### PR TITLE
Test command changes

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -45,7 +45,6 @@ dependencies {
         exclude group: 'ch.qos.logback', module: 'logback-classic'
     }
     implementation 'info.picocli:picocli:4.5.1'
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     implementation 'org.jetbrains.kotlin:kotlin-reflect'
     implementation "io.ktor:ktor-client-core-jvm:${ktor_version}"
     implementation "io.ktor:ktor-network-tls:$ktor_version"

--- a/application/src/main/kotlin/application/InstallCommand.kt
+++ b/application/src/main/kotlin/application/InstallCommand.kt
@@ -1,7 +1,7 @@
 package application
 
 import picocli.CommandLine
-import run.qontract.core.Constants.Companion.QONTRACT_CONFIG_IN_CURRENT_DIRECTORY
+import run.qontract.core.Constants.Companion.DEFAULT_QONTRACT_CONFIG_IN_CURRENT_DIRECTORY
 import run.qontract.core.utilities.loadSources
 import java.io.File
 import java.util.concurrent.Callable
@@ -12,7 +12,7 @@ class InstallCommand: Callable<Unit> {
         val userHome = File(System.getProperty("user.home"))
         val workingDirectory = userHome.resolve(".qontract/repos")
 
-        val sources = loadSources(QONTRACT_CONFIG_IN_CURRENT_DIRECTORY)
+        val sources = loadSources(DEFAULT_QONTRACT_CONFIG_IN_CURRENT_DIRECTORY)
 
         for(source in sources) {
             println("Installing $source")

--- a/application/src/main/kotlin/application/PushCommand.kt
+++ b/application/src/main/kotlin/application/PushCommand.kt
@@ -1,7 +1,7 @@
 package application
 
 import picocli.CommandLine
-import run.qontract.core.Constants.Companion.QONTRACT_CONFIG_IN_CURRENT_DIRECTORY
+import run.qontract.core.Constants.Companion.DEFAULT_QONTRACT_CONFIG_IN_CURRENT_DIRECTORY
 import run.qontract.core.Feature
 import run.qontract.core.git.SystemGit
 import run.qontract.core.git.NonZeroExitError
@@ -24,7 +24,7 @@ class PushCommand: Callable<Unit> {
     override fun call() {
         val userHome = File(System.getProperty("user.home"))
         val workingDirectory = userHome.resolve(".qontract/repos")
-        val manifestFile = File(QONTRACT_CONFIG_IN_CURRENT_DIRECTORY)
+        val manifestFile = File(DEFAULT_QONTRACT_CONFIG_IN_CURRENT_DIRECTORY)
         val manifestData = loadConfigJSON(manifestFile)
         val sources = loadSources(manifestData)
 

--- a/application/src/main/kotlin/application/QontractApplication.kt
+++ b/application/src/main/kotlin/application/QontractApplication.kt
@@ -1,8 +1,11 @@
 package application
 
+import org.junit.platform.launcher.Launcher
+import org.junit.platform.launcher.core.LauncherFactory
 import org.springframework.boot.Banner
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.context.annotation.Bean
 import picocli.CommandLine
 import run.qontract.core.utilities.UncaughtExceptionHandler
 import java.io.ByteArrayInputStream
@@ -40,4 +43,5 @@ open class QontractApplication {
             logManager.readConfiguration(ByteArrayInputStream(out.toByteArray()))
         }
     }
+
 }

--- a/application/src/main/kotlin/application/QontractBeans.kt
+++ b/application/src/main/kotlin/application/QontractBeans.kt
@@ -1,0 +1,12 @@
+package application
+
+import org.junit.platform.launcher.Launcher
+import org.junit.platform.launcher.core.LauncherFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+open class QontractBeans {
+    @Bean
+    public open fun junitLauncher(): Launcher = LauncherFactory.create()
+}

--- a/application/src/main/kotlin/application/QontractConfig.kt
+++ b/application/src/main/kotlin/application/QontractConfig.kt
@@ -11,6 +11,10 @@ class QontractConfig {
         return contractFilePathsFrom(QONTRACT_CONFIG_IN_CURRENT_DIRECTORY, WORKING_DIRECTORY) { source -> source.stubContracts }.map { it.path }
     }
 
+    fun contractTestPaths(): List<String> {
+        return contractFilePathsFrom(QONTRACT_CONFIG_IN_CURRENT_DIRECTORY, WORKING_DIRECTORY) { source -> source.testContracts }.map { it.path }
+    }
+
     fun contractStubPathData(): List<ContractPathData> {
         return contractFilePathsFrom(QONTRACT_CONFIG_IN_CURRENT_DIRECTORY, WORKING_DIRECTORY) { source -> source.stubContracts }
     }

--- a/application/src/main/kotlin/application/QontractConfig.kt
+++ b/application/src/main/kotlin/application/QontractConfig.kt
@@ -1,22 +1,22 @@
 package application
 
 import org.springframework.stereotype.Component
-import run.qontract.core.Constants.Companion.QONTRACT_CONFIG_IN_CURRENT_DIRECTORY
+import run.qontract.core.Constants.Companion.DEFAULT_QONTRACT_CONFIG_IN_CURRENT_DIRECTORY
 import run.qontract.core.utilities.ContractPathData
 import run.qontract.core.utilities.contractFilePathsFrom
 
 @Component
 class QontractConfig {
     fun contractStubPaths(): List<String> {
-        return contractFilePathsFrom(QONTRACT_CONFIG_IN_CURRENT_DIRECTORY, WORKING_DIRECTORY) { source -> source.stubContracts }.map { it.path }
+        return contractFilePathsFrom(DEFAULT_QONTRACT_CONFIG_IN_CURRENT_DIRECTORY, WORKING_DIRECTORY) { source -> source.stubContracts }.map { it.path }
     }
 
     fun contractTestPaths(): List<String> {
-        return contractFilePathsFrom(QONTRACT_CONFIG_IN_CURRENT_DIRECTORY, WORKING_DIRECTORY) { source -> source.testContracts }.map { it.path }
+        return contractFilePathsFrom(DEFAULT_QONTRACT_CONFIG_IN_CURRENT_DIRECTORY, WORKING_DIRECTORY) { source -> source.testContracts }.map { it.path }
     }
 
     fun contractStubPathData(): List<ContractPathData> {
-        return contractFilePathsFrom(QONTRACT_CONFIG_IN_CURRENT_DIRECTORY, WORKING_DIRECTORY) { source -> source.stubContracts }
+        return contractFilePathsFrom(DEFAULT_QONTRACT_CONFIG_IN_CURRENT_DIRECTORY, WORKING_DIRECTORY) { source -> source.stubContracts }
     }
 
     companion object {

--- a/application/src/main/kotlin/application/StubCommand.kt
+++ b/application/src/main/kotlin/application/StubCommand.kt
@@ -7,16 +7,11 @@ import run.qontract.consoleLog
 import run.qontract.core.*
 import run.qontract.core.Constants.Companion.DEFAULT_HTTP_STUB_HOST
 import run.qontract.core.Constants.Companion.DEFAULT_HTTP_STUB_PORT
-import run.qontract.core.Constants.Companion.QONTRACT_CONFIG_IN_CURRENT_DIRECTORY
+import run.qontract.core.Constants.Companion.DEFAULT_QONTRACT_CONFIG_IN_CURRENT_DIRECTORY
 import run.qontract.core.pattern.ContractException
 import run.qontract.core.utilities.exceptionCauseMessage
 import run.qontract.mock.NoMatchingScenario
 import run.qontract.stub.*
-import java.io.File
-import java.nio.file.FileSystems
-import java.nio.file.Path
-import java.nio.file.StandardWatchEventKinds
-import java.nio.file.WatchKey
 import java.util.concurrent.Callable
 
 @Command(name = "stub",
@@ -92,7 +87,7 @@ class StubCommand : Callable<Unit> {
     private fun loadConfig() {
         when(contractPaths.isEmpty()) {
             true -> {
-                println("No contractPaths specified. Falling back to $QONTRACT_CONFIG_IN_CURRENT_DIRECTORY")
+                println("No contractPaths specified. Falling back to $DEFAULT_QONTRACT_CONFIG_IN_CURRENT_DIRECTORY")
                 contractPaths = qontractConfig.contractStubPaths()
             }
         }

--- a/application/src/main/kotlin/application/SubscribeCommand.kt
+++ b/application/src/main/kotlin/application/SubscribeCommand.kt
@@ -1,7 +1,7 @@
 package application
 
 import picocli.CommandLine
-import run.qontract.core.Constants.Companion.QONTRACT_CONFIG_IN_CURRENT_DIRECTORY
+import run.qontract.core.Constants.Companion.DEFAULT_QONTRACT_CONFIG_IN_CURRENT_DIRECTORY
 import run.qontract.core.git.SystemGit
 import run.qontract.core.git.NonZeroExitError
 import run.qontract.core.utilities.exceptionCauseMessage
@@ -16,7 +16,7 @@ class SubscribeCommand: Callable<Unit> {
     override fun call() {
         val userHome = File(System.getProperty("user.home"))
         val workingDirectory = userHome.resolve(".qontract/repos")
-        val manifestFile = File(QONTRACT_CONFIG_IN_CURRENT_DIRECTORY)
+        val manifestFile = File(DEFAULT_QONTRACT_CONFIG_IN_CURRENT_DIRECTORY)
         val manifestData = loadConfigJSON(manifestFile)
         val sources = loadSources(manifestData)
 

--- a/application/src/main/kotlin/application/TestCommand.kt
+++ b/application/src/main/kotlin/application/TestCommand.kt
@@ -6,7 +6,6 @@ import org.junit.platform.engine.discovery.DiscoverySelectors.selectClass
 import org.junit.platform.launcher.Launcher
 import org.junit.platform.launcher.LauncherDiscoveryRequest
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder
-import org.junit.platform.launcher.core.LauncherFactory
 import org.springframework.beans.factory.annotation.Autowired
 import picocli.CommandLine
 import picocli.CommandLine.Command
@@ -34,7 +33,7 @@ class TestCommand : Callable<Unit> {
     lateinit var junitLauncher: Launcher
 
     @CommandLine.Parameters(arity = "0..*", description = ["Contract file paths"])
-    var contractPaths: List<String> = mutableListOf()
+    var contractPaths: List<String> = emptyList()
 
     @Option(names = ["--host"], description = ["The host to bind to, e.g. localhost or some locally bound IP"], defaultValue = "localhost")
     lateinit var host: String
@@ -70,7 +69,7 @@ class TestCommand : Callable<Unit> {
     var junitReportDirName: String? = null
 
     override fun call() = try {
-        loadConfig()
+        contractPaths = loadContractPaths()
 
         if(port == 0) {
             port = when {
@@ -122,12 +121,13 @@ class TestCommand : Callable<Unit> {
         println(exceptionCauseMessage(e))
     }
 
-    private fun loadConfig() {
-        when(contractPaths.isEmpty()) {
-            true -> {
+    private fun loadContractPaths(): List<String> {
+        return when {
+            contractPaths.isEmpty() -> {
                 println("No contractPaths specified. Falling back to ${Constants.DEFAULT_QONTRACT_CONFIG_IN_CURRENT_DIRECTORY}")
-                contractPaths = qontractConfig.contractTestPaths()
+                qontractConfig.contractTestPaths()
             }
+            else -> contractPaths
         }
     }
 }

--- a/application/src/main/kotlin/application/TestCommand.kt
+++ b/application/src/main/kotlin/application/TestCommand.kt
@@ -12,6 +12,12 @@ import picocli.CommandLine.Command
 import picocli.CommandLine.Option
 import run.qontract.core.Constants
 import run.qontract.core.utilities.*
+import run.qontract.test.QontractJUnitSupport.Companion.CONTRACT_PATHS
+import run.qontract.test.QontractJUnitSupport.Companion.HOST
+import run.qontract.test.QontractJUnitSupport.Companion.INLINE_SUGGESTIONS
+import run.qontract.test.QontractJUnitSupport.Companion.PORT
+import run.qontract.test.QontractJUnitSupport.Companion.SUGGESTIONS_PATH
+import run.qontract.test.QontractJUnitSupport.Companion.TIMEOUT
 import java.io.PrintWriter
 import java.nio.file.Paths
 import java.util.concurrent.Callable
@@ -40,9 +46,6 @@ class TestCommand : Callable<Unit> {
 
     @Option(names = ["--https"], description = ["Use https instead of the default http"], required = false)
     var useHttps: Boolean = false
-
-    @Option(names = ["--checkBackwardCompatibility", "--check", "-c"], description = ["Identify versions of the contract prior to the one specified, and verify backward compatibility from the earliest to the latest"])
-    var checkBackwardCompatibility: Boolean = false
 
     @Option(names = ["--timeout"], description = ["Specify a timeout for the test requests"], required = false, defaultValue = "60")
     var timeout: Int = 60
@@ -81,14 +84,13 @@ class TestCommand : Callable<Unit> {
             else -> "http"
         }
 
-        System.setProperty("contractPaths", contractPaths.joinToString(","))
+        System.setProperty(CONTRACT_PATHS, contractPaths.joinToString(","))
 
-        System.setProperty("host", host)
-        System.setProperty("port", port.toString())
-        System.setProperty("timeout", timeout.toString())
-        System.setProperty("suggestionsPath", suggestionsPath)
-        System.setProperty("suggestions", suggestions)
-        System.setProperty("checkBackwardCompatibility", checkBackwardCompatibility.toString())
+        System.setProperty(HOST, host)
+        System.setProperty(PORT, port.toString())
+        System.setProperty(TIMEOUT, timeout.toString())
+        System.setProperty(SUGGESTIONS_PATH, suggestionsPath)
+        System.setProperty(INLINE_SUGGESTIONS, suggestions)
         System.setProperty("protocol", protocol)
 
         System.setProperty("kafkaBootstrapServers", kafkaBootstrapServers)
@@ -124,7 +126,7 @@ class TestCommand : Callable<Unit> {
     private fun loadConfig() {
         when(contractPaths.isEmpty()) {
             true -> {
-                println("No contractPaths specified. Falling back to ${Constants.QONTRACT_CONFIG_IN_CURRENT_DIRECTORY}")
+                println("No contractPaths specified. Falling back to ${Constants.DEFAULT_QONTRACT_CONFIG_IN_CURRENT_DIRECTORY}")
                 contractPaths = qontractConfig.contractTestPaths()
             }
         }

--- a/application/src/main/kotlin/application/test/ContractExecutionListener.kt
+++ b/application/src/main/kotlin/application/test/ContractExecutionListener.kt
@@ -23,7 +23,8 @@ class ContractExecutionListener : TestExecutionListener {
                 false -> {
                     failure++
 
-                    val message = testExecutionResult?.throwable?.get()?.message?.replace("\n", "\n\t")?.trimIndent() ?: ""
+                    val message = testExecutionResult?.throwable?.get()?.message?.replace("\n", "\n\t")?.trimIndent()
+                            ?: ""
 
                     val reason = "Reason: $message"
                     println("$reason\n\n")
@@ -44,10 +45,10 @@ ${reason.prependIndent("  ")}"""
     override fun testPlanExecutionFinished(testPlan: TestPlan?) {
         println("Tests run: ${success + failure}, Failures: $failure")
 
-        if(failedLog.isNotEmpty()) {
+        if (failedLog.isNotEmpty()) {
             println()
             println("Failed scenarios:")
-            println(failedLog.distinct().joinToString(System.lineSeparator()) { it.prependIndent("  ")})
+            println(failedLog.distinct().joinToString(System.lineSeparator()) { it.prependIndent("  ") })
         }
     }
 

--- a/application/src/test/kotlin/application/TestCommandTest.kt
+++ b/application/src/test/kotlin/application/TestCommandTest.kt
@@ -1,0 +1,83 @@
+package application
+
+import application.test.ContractExecutionListener
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.platform.launcher.Launcher
+import org.junit.platform.launcher.LauncherDiscoveryRequest
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import picocli.CommandLine
+import run.qontract.test.QontractJUnitSupport.Companion.CONTRACT_PATHS
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, classes = arrayOf(QontractApplication::class, TestCommand::class))
+internal class TestCommandTest {
+    @MockkBean
+    lateinit var qontractConfig: QontractConfig
+
+    @MockkBean
+    lateinit var junitLauncher: Launcher
+
+    @Autowired
+    lateinit var factory: CommandLine.IFactory
+
+    @Autowired
+    lateinit var testCommand: TestCommand
+
+    private val contractsToBeRunAsTests = arrayListOf("/config/path/to/contract_1.qontract",
+            "/config/path/to/another_contract_1.qontract")
+
+    @BeforeEach
+    fun `clean up test command`() {
+        testCommand.contractPaths = arrayListOf()
+        testCommand.junitReportDirName = null
+    }
+
+    @Test
+    fun `when contract files are not given it should load from qontract config`() {
+        every { qontractConfig.contractTestPaths() }.returns(contractsToBeRunAsTests)
+
+        CommandLine(testCommand, factory).execute()
+
+        verify(exactly = 1) { qontractConfig.contractTestPaths() }
+        assertThat(System.getProperty(CONTRACT_PATHS)).isEqualTo(contractsToBeRunAsTests.joinToString(","))
+    }
+
+    @Test
+    fun `when contract files are given it should not load from qontract config`() {
+        CommandLine(testCommand, factory).execute(contractsToBeRunAsTests[0], contractsToBeRunAsTests[1])
+        verify(exactly = 0) { qontractConfig.contractTestPaths() }
+        assertThat(System.getProperty(CONTRACT_PATHS)).isEqualTo(contractsToBeRunAsTests.joinToString(","))
+    }
+
+    @Test
+    fun `it should execute junit test with execution listener`() {
+        every { junitLauncher.discover(any()) }.returns(mockk())
+        every { junitLauncher.registerTestExecutionListeners(any<ContractExecutionListener>()) }.returns(mockk())
+
+        CommandLine(testCommand, factory).execute("api_1.qontract")
+
+        verify(exactly = 1) { junitLauncher.discover(any()) }
+        verify(exactly = 1) { junitLauncher.registerTestExecutionListeners(any<ContractExecutionListener>()) }
+        verify(exactly = 1) { junitLauncher.execute(any<LauncherDiscoveryRequest>()) }
+    }
+
+    @Test
+    fun `when junit report directory is set it should also register legacy XML test execution listener`() {
+        every { junitLauncher.discover(any()) }.returns(mockk())
+        every { junitLauncher.registerTestExecutionListeners(any<ContractExecutionListener>()) }.returns(mockk())
+        every { junitLauncher.registerTestExecutionListeners(any<org.junit.platform.reporting.legacy.xml.LegacyXmlReportGeneratingListener>()) }.returns(mockk())
+
+        CommandLine(testCommand, factory).execute("api_1.qontract", "--junitReportDir", "reports/junit")
+
+        verify(exactly = 1) { junitLauncher.discover(any()) }
+        verify { junitLauncher.registerTestExecutionListeners(any<ContractExecutionListener>()) }
+        verify { junitLauncher.registerTestExecutionListeners(any<org.junit.platform.reporting.legacy.xml.LegacyXmlReportGeneratingListener>()) }
+        verify(exactly = 1) { junitLauncher.execute(any<LauncherDiscoveryRequest>()) }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,6 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
 }
 compileKotlin {
     kotlinOptions {

--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,7 @@ sonarqube {
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.coverage.jacoco.xmlReportPaths", "${rootDir}/build/reports/jacoco/codeCoverageReport/codeCoverageReport.xml"
         property "sonar.coverage.exclusions", "**/application/src/**,**/junit5-support/src/**"
+        property "sonar.exclusions", "**/*Bean?."
     }
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -31,7 +31,6 @@ def testcontainers_version = "1.14.3"
 
 dependencies {
     implementation 'io.cucumber:gherkin:15.0.2'
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     implementation 'org.jetbrains.kotlin:kotlin-reflect'
     implementation "io.ktor:ktor-server-netty:$ktor_version"
     implementation "io.ktor:ktor-server-core:$ktor_version"
@@ -39,7 +38,7 @@ dependencies {
     implementation "io.ktor:ktor-client-apache:$ktor_version"
     implementation "io.ktor:ktor-client-features:$ktor_version"
 
-    implementation 'org.jetbrains.kotlinx:kotlinx-serialization-runtime:0.20.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.0.0-RC'
     implementation "org.eclipse.jgit:org.eclipse.jgit:$jgit_version"
     implementation "org.eclipse.jgit:org.eclipse.jgit.ssh.apache:$jgit_version"
 

--- a/core/src/main/kotlin/run/qontract/core/Constants.kt
+++ b/core/src/main/kotlin/run/qontract/core/Constants.kt
@@ -2,8 +2,8 @@ package run.qontract.core
 
 class Constants {
     companion object {
-        const val QONTRACT_CONFIG_FILE_NAME = "qontract.json"
-        const val QONTRACT_CONFIG_IN_CURRENT_DIRECTORY = "./$QONTRACT_CONFIG_FILE_NAME"
+        const val DEFAULT_QONTRACT_CONFIG_FILE_NAME = "qontract.json"
+        const val DEFAULT_QONTRACT_CONFIG_IN_CURRENT_DIRECTORY = "./$DEFAULT_QONTRACT_CONFIG_FILE_NAME"
         private const val ALL_IPV4_ADDRESS_ON_LOCAL_MACHINE = "0.0.0.0"
         const val DEFAULT_HTTP_STUB_HOST = ALL_IPV4_ADDRESS_ON_LOCAL_MACHINE
         const val DEFAULT_HTTP_STUB_PORT = "9000"

--- a/core/src/main/kotlin/run/qontract/core/git/GitOperations.kt
+++ b/core/src/main/kotlin/run/qontract/core/git/GitOperations.kt
@@ -4,7 +4,7 @@ import io.ktor.http.*
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.transport.CredentialsProvider
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider
-import run.qontract.core.Constants.Companion.QONTRACT_CONFIG_IN_CURRENT_DIRECTORY
+import run.qontract.core.Constants.Companion.DEFAULT_QONTRACT_CONFIG_IN_CURRENT_DIRECTORY
 import run.qontract.core.pattern.parsedJSONStructure
 import run.qontract.core.utilities.GitRepo
 import run.qontract.core.utilities.getTransportCallingCallback
@@ -74,7 +74,7 @@ fun loadFromPath(json: Value?, path: List<String>): Value? {
 }
 
 fun getBearerToken(): String? {
-    val qontractConfigFile = File(QONTRACT_CONFIG_IN_CURRENT_DIRECTORY)
+    val qontractConfigFile = File(DEFAULT_QONTRACT_CONFIG_IN_CURRENT_DIRECTORY)
 
     return when {
         qontractConfigFile.exists() ->
@@ -82,7 +82,7 @@ fun getBearerToken(): String? {
                 readBearerFromEnvVariable(qontractConfig) ?: readBearerFromFile(qontractConfig)
             }
         else -> null.also {
-            println("$QONTRACT_CONFIG_IN_CURRENT_DIRECTORY not found")
+            println("$DEFAULT_QONTRACT_CONFIG_IN_CURRENT_DIRECTORY not found")
             println("Current working directory is ${File(".").absolutePath}")
         }
     }

--- a/core/src/main/kotlin/run/qontract/core/utilities/JSONSerialisation.kt
+++ b/core/src/main/kotlin/run/qontract/core/utilities/JSONSerialisation.kt
@@ -1,33 +1,29 @@
 package run.qontract.core.utilities
 
-import kotlinx.serialization.ImplicitReflectionSerializer
-import kotlinx.serialization.UnstableDefault
+import kotlinx.serialization.*
 import kotlinx.serialization.json.*
-import kotlinx.serialization.stringify
+
 import run.qontract.core.pattern.*
 import run.qontract.core.value.*
 
-@OptIn(UnstableDefault::class)
-val indentedJson = Json(JsonConfiguration(prettyPrint = true))
+val indentedJson = Json {
+    prettyPrint = true
+}
 
-@OptIn(UnstableDefault::class)
-val lenientJson = Json(JsonConfiguration(isLenient = true))
+val lenientJson = Json {
+    isLenient = true
+}
 
-@OptIn(ImplicitReflectionSerializer::class, UnstableDefault::class)
 fun valueArrayToJsonString(value: List<Value>): String {
     val data = valueListToElements(value)
 
-    return indentedJson.stringify(data)
+    return indentedJson.encodeToString(data)
 }
 
 fun toMap(value: Value?) = jsonStringToValueMap(value.toString())
 
-@OptIn(ImplicitReflectionSerializer::class, UnstableDefault::class)
-internal fun prettifyJsonString(content: String): String = indentedJson.stringify(lenientJson.parseJson(content))
-
-@OptIn(UnstableDefault::class)
 fun stringToPatternMap(stringContent: String): Map<String, Pattern>  {
-    val data = lenientJson.parseJson(stringContent).jsonObject.toMap()
+    val data = lenientJson.parseToJsonElement(stringContent).jsonObject.toMap()
     try {
         return convertToMapPattern(data)
     }
@@ -38,9 +34,8 @@ fun stringToPatternMap(stringContent: String): Map<String, Pattern>  {
     }
 }
 
-@OptIn(UnstableDefault::class)
 fun jsonStringToValueMap(stringContent: String): Map<String, Value>  {
-    val data = lenientJson.parseJson(stringContent).jsonObject.toMap()
+    val data = lenientJson.parseToJsonElement(stringContent).jsonObject.toMap()
     return convertToMapValue(data)
 }
 
@@ -56,12 +51,12 @@ fun toPattern(jsonElement: JsonElement): Pattern {
         is JsonNull -> NullPattern
         is JsonObject -> toJSONObjectPattern(jsonElement.toMap().mapValues { toPattern(it.value) })
         is JsonArray -> JSONArrayPattern(jsonElement.toList().map { toPattern(it) })
-        is JsonLiteral -> toLiteralPattern(jsonElement)
+        is JsonPrimitive -> toLiteralPattern(jsonElement)
         else -> throw ContractException("Unknown value type: ${jsonElement.javaClass.name}")
     }
 }
 
-fun toLiteralPattern(jsonElement: JsonLiteral): Pattern =
+fun toLiteralPattern(jsonElement: JsonPrimitive): Pattern =
     when {
         jsonElement.isString -> parsedPattern(jsonElement.content)
         jsonElement.booleanOrNull != null -> ExactValuePattern(BooleanValue(jsonElement.boolean))
@@ -76,11 +71,11 @@ private fun toValue(jsonElement: JsonElement): Value =
         is JsonNull -> NullValue
         is JsonObject -> JSONObjectValue(jsonElement.toMap().mapValues { toValue(it.value) })
         is JsonArray -> JSONArrayValue(jsonElement.toList().map { toValue(it) })
-        is JsonLiteral -> toLiteralValue(jsonElement)
+        is JsonPrimitive -> toLiteralValue(jsonElement)
         else -> throw ContractException("Unknown value type: ${jsonElement.javaClass.name}")
     }
 
-fun toLiteralValue(jsonElement: JsonLiteral): Value =
+fun toLiteralValue(jsonElement: JsonPrimitive): Value =
     when {
         jsonElement.isString -> StringValue(jsonElement.content)
         jsonElement.booleanOrNull != null -> BooleanValue(jsonElement.boolean)
@@ -96,16 +91,14 @@ fun convertToArrayValue(data: List<JsonElement>): List<Value> =
 fun convertToArrayPattern(data: List<JsonElement>): List<Pattern> =
     data.map { toPattern(it) }
 
-@OptIn(ImplicitReflectionSerializer::class, UnstableDefault::class)
 fun valueMapToPrettyJsonString(value: Map<String, Value>): String {
     val data = mapToStringElement(value)
-    return indentedJson.stringify(data)
+    return indentedJson.encodeToString(data)
 }
 
-@OptIn(ImplicitReflectionSerializer::class, UnstableDefault::class)
 fun valueMapToPlainJsonString(value: Map<String, Value>): String {
     val data = mapToStringElement(value)
-    return lenientJson.stringify(data)
+    return lenientJson.encodeToString(data)
 }
 
 fun mapToStringElement(data: Map<String, Value>): Map<String, JsonElement> {
@@ -116,9 +109,9 @@ private fun valueToJsonElement(value: Value): JsonElement {
     return when (value) {
         is JSONArrayValue -> valueListToElements(value.list)
         is JSONObjectValue -> JsonObject(mapToStringElement(value.jsonObject))
-        is NumberValue -> JsonLiteral(value.number)
-        is BooleanValue -> JsonLiteral(value.booleanValue)
-        is StringValue -> JsonLiteral(value.string)
+        is NumberValue -> JsonPrimitive(value.number)
+        is BooleanValue -> JsonPrimitive(value.booleanValue)
+        is StringValue -> JsonPrimitive(value.string)
         else -> JsonNull
     }
 }
@@ -127,14 +120,12 @@ fun valueListToElements(values: List<Value>): JsonArray {
     return JsonArray(values.map { valueToJsonElement(it) })
 }
 
-@OptIn(UnstableDefault::class)
 fun jsonStringToValueArray(value: String): List<Value> {
-    val data = lenientJson.parseJson(value).jsonArray.toList()
+    val data = lenientJson.parseToJsonElement(value).jsonArray.toList()
     return convertToArrayValue(data)
 }
 
-@OptIn(UnstableDefault::class)
 fun stringTooPatternArray(value: String): List<Pattern> {
-    val data = lenientJson.parseJson(value).jsonArray.toList()
+    val data = lenientJson.parseToJsonElement(value).jsonArray.toList()
     return convertToArrayPattern(data)
 }

--- a/core/src/main/kotlin/run/qontract/core/utilities/Utilities.kt
+++ b/core/src/main/kotlin/run/qontract/core/utilities/Utilities.kt
@@ -12,7 +12,7 @@ import org.w3c.dom.Node.ELEMENT_NODE
 import org.w3c.dom.Node.TEXT_NODE
 import org.xml.sax.InputSource
 import run.qontract.consoleLog
-import run.qontract.core.Constants.Companion.QONTRACT_CONFIG_IN_CURRENT_DIRECTORY
+import run.qontract.core.Constants.Companion.DEFAULT_QONTRACT_CONFIG_IN_CURRENT_DIRECTORY
 import run.qontract.core.Resolver
 import run.qontract.core.git.SystemGit
 import run.qontract.core.git.clone
@@ -144,11 +144,11 @@ fun loadConfigJSON(configFile: File): JSONObjectValue {
         parsedJSONStructure(configFile.readText())
 
     } catch (e: Throwable) {
-        exitWithMessage("Error reading the $QONTRACT_CONFIG_IN_CURRENT_DIRECTORY: ${exceptionCauseMessage(e)}")
+        exitWithMessage("Error reading the $DEFAULT_QONTRACT_CONFIG_IN_CURRENT_DIRECTORY: ${exceptionCauseMessage(e)}")
     }
 
     if (configJson !is JSONObjectValue)
-        exitWithMessage("The contents of $QONTRACT_CONFIG_IN_CURRENT_DIRECTORY must be a json object")
+        exitWithMessage("The contents of $DEFAULT_QONTRACT_CONFIG_IN_CURRENT_DIRECTORY must be a json object")
 
     return configJson
 }
@@ -176,7 +176,7 @@ fun loadSources(configJson: JSONObjectValue): List<ContractSource> {
                     else -> GitRepo(repositoryURL, testPaths, stubPaths)
                 }
             }
-            else -> throw ContractException("Provider ${nativeString(source.jsonObject, "provider")} not recognised in $QONTRACT_CONFIG_IN_CURRENT_DIRECTORY")
+            else -> throw ContractException("Provider ${nativeString(source.jsonObject, "provider")} not recognised in $DEFAULT_QONTRACT_CONFIG_IN_CURRENT_DIRECTORY")
         }
     }
 }
@@ -229,7 +229,7 @@ fun exitIfDoesNotExist(label: String, filePath: String) {
 
 // Used by QontractJUnitSupport users for loading contracts to stub or mock
 fun contractStubPaths(): List<ContractPathData> =
-        contractFilePathsFrom(QONTRACT_CONFIG_IN_CURRENT_DIRECTORY, ".qontract") { source -> source.stubContracts }
+        contractFilePathsFrom(DEFAULT_QONTRACT_CONFIG_IN_CURRENT_DIRECTORY, ".qontract") { source -> source.stubContracts }
 
 fun interface ContractsSelectorPredicate {
     fun select(source: ContractSource): List<String>

--- a/junit5-support/build.gradle
+++ b/junit5-support/build.gradle
@@ -22,10 +22,9 @@ def junit_version = "5.6.2"
 dependencies {
     implementation project(':core')
     implementation "org.junit.jupiter:junit-jupiter-engine:${junit_version}"
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     implementation 'org.jetbrains.kotlin:kotlin-reflect'
     implementation 'org.jetbrains.kotlin:kotlin-maven-serialization'
-    implementation 'org.jetbrains.kotlinx:kotlinx-serialization-runtime:0.20.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-serialization-core:1.0.0-RC'
     implementation 'org.assertj:assertj-core:3.17.2'
     implementation 'org.junit.jupiter:junit-jupiter-api:5.6.2'
 

--- a/junit5-support/src/main/kotlin/run/qontract/test/QontractJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/run/qontract/test/QontractJUnitSupport.kt
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.DynamicTest
 import org.junit.jupiter.api.TestFactory
 import org.opentest4j.TestAbortedException
 import run.qontract.core.*
-import run.qontract.core.Constants.Companion.QONTRACT_CONFIG_FILE_NAME
+import run.qontract.core.Constants.Companion.DEFAULT_QONTRACT_CONFIG_FILE_NAME
 import run.qontract.core.pattern.ContractException
 import run.qontract.core.pattern.Examples
 import run.qontract.core.pattern.parsedValue
@@ -18,16 +18,28 @@ import kotlin.system.exitProcess
 val pass = Unit
 
 open class QontractJUnitSupport {
+    companion object {
+        const val CONTRACT_PATHS = "contractPaths"
+        const val WORKING_DIRECTORY = "workingDirectory"
+        const val CONFIG_FILE_NAME = "manifestFile"
+        const val TIMEOUT = "timeout"
+        private const val DEFAULT_TIMEOUT = "60"
+        const val INLINE_SUGGESTIONS = "suggestions"
+        const val SUGGESTIONS_PATH = "suggestionsPath"
+        const val HOST = "host"
+        const val PORT = "port"
+    }
+    
     @TestFactory
     fun contractAsTest(): Collection<DynamicTest> {
-        val contractPaths = System.getProperty("contractPaths")
-        val givenWorkingDirectory = System.getProperty("workingDirectory")
-        val givenConfigFile = System.getProperty("manifestFile")
+        val contractPaths = System.getProperty(CONTRACT_PATHS)
+        val givenWorkingDirectory = System.getProperty(WORKING_DIRECTORY)
+        val givenConfigFile = System.getProperty(CONFIG_FILE_NAME)
 
-        val timeout = System.getProperty("timeout", "60").toInt()
+        val timeout = System.getProperty(TIMEOUT, DEFAULT_TIMEOUT).toInt()
 
-        val suggestionsData = System.getProperty("suggestions") ?: ""
-        val suggestionsPath = System.getProperty("suggestionsPath") ?: ""
+        val suggestionsData = System.getProperty(INLINE_SUGGESTIONS) ?: ""
+        val suggestionsPath = System.getProperty(SUGGESTIONS_PATH) ?: ""
 
         val workingDirectory = File(valueOrDefault(givenWorkingDirectory, ".qontract", "Working was not specified specified"))
         val workingDirectoryWasCreated = workingDirectory.exists()
@@ -38,7 +50,7 @@ open class QontractJUnitSupport {
                     contractPaths.split(",").flatMap { loadTestScenarios(it, suggestionsPath, suggestionsData) }
                 }
                 else -> {
-                    val configFile = valueOrDefault(givenConfigFile, QONTRACT_CONFIG_FILE_NAME, "Neither contract nor config were specified")
+                    val configFile = valueOrDefault(givenConfigFile, DEFAULT_QONTRACT_CONFIG_FILE_NAME, "Neither contract nor config were specified")
 
                     exitIfDoesNotExist("config file", configFile)
 
@@ -98,8 +110,8 @@ open class QontractJUnitSupport {
     }
 
     private fun runHttpTest(timeout: Int, testScenario: Scenario): Result {
-        val host = System.getProperty("host")
-        val port = System.getProperty("port")
+        val host = System.getProperty(HOST)
+        val port = System.getProperty(PORT)
         val protocol = System.getProperty("protocol") ?: "http"
 
         return executeTest(protocol, host, port, timeout, testScenario)

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=0.17.1
+version=0.17.2-SNAPSHOT-1


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Test Command should be able to take one or more contract files as arguments. When contract files are not provided, it should get the contracts to run as test in qontract.json

<!-- Why are these changes necessary? -->

**Why**: To make Test Command consistent with Stub Command to enable running multiple Contracts as Tests.

<!-- How were these changes implemented? -->

**How**: Reuse the config file reading and contract install code

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/qontract/qontract-documentation N/A
- [x] Tests
- [x] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #64 

<!-- feel free to add additional comments -->

I have also changed
1. junitReportDir option name
2. Removed workingDirectory option
3. Removed backwardCompatibility check in test command
