### PR TITLE
Fixes #71: Makes sure that qontract exits cleanly when qontracts are either non-existent or invalid

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -77,6 +77,7 @@ dependencies {
         exclude group: 'ch.qos.logback', module: 'logback-classic'
     }
     testImplementation 'org.assertj:assertj-core:3.17.2'
+    testImplementation 'com.ginsberg:junit5-system-exit:1.0.0'
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junit_version"
     testImplementation "org.junit.jupiter:junit-jupiter-params:$junit_version"
 }

--- a/application/src/main/kotlin/application/RealFileReader.kt
+++ b/application/src/main/kotlin/application/RealFileReader.kt
@@ -16,4 +16,8 @@ class RealFileReader: FileReader {
     fun files(stubDataDir: String): List<File> {
         return File(stubDataDir).listFiles()?.toList() ?: emptyList()
     }
+
+    fun isFile(fileName: String): Boolean = File(fileName).isFile
+
+    fun extensionIsNot(fileName: String, extension: String): Boolean = File(fileName).extension != extension
 }

--- a/application/src/test/kotlin/application/RealFileReaderTest.kt
+++ b/application/src/test/kotlin/application/RealFileReaderTest.kt
@@ -1,0 +1,53 @@
+package application
+
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.io.TempDir
+import run.qontract.core.QONTRACT_EXTENSION
+import java.io.File
+import java.nio.file.Path
+
+internal class RealFileReaderTest {
+
+    @Test
+    fun `given an existing file, it is found to be a valid file`(@TempDir tempDir: Path) {
+        val existentFile = tempDir.resolve("contract.qontract")
+        val qontractFilePath = existentFile.toAbsolutePath().toString()
+        File(qontractFilePath).writeText("some content")
+
+        val reader = RealFileReader()
+
+        assertTrue(reader.isFile(qontractFilePath))
+    }
+
+    @Test
+    fun `given an invalid file, it is not found to be a valid file`(@TempDir tempDir: Path) {
+        val nonExistentFile = tempDir.resolve("contract.qontract")
+        val qontractFilePath = nonExistentFile.toAbsolutePath().toString()
+
+        val reader = RealFileReader()
+
+        assertFalse(reader.isFile(qontractFilePath))
+    }
+
+    @Test
+    fun `given a contract with a matching extension, it is found to be valid`(@TempDir tempDir: Path) {
+        val validExtensionContract = tempDir.resolve("contract.qontract")
+        val qontractFilePath = validExtensionContract.toAbsolutePath().toString()
+
+        val reader = RealFileReader()
+
+        assertFalse(reader.extensionIsNot(qontractFilePath, QONTRACT_EXTENSION))
+    }
+
+    @Test
+    fun `given a contract with a mismatched extension, it is found to be invalid`(@TempDir tempDir: Path) {
+        val validExtensionContract = tempDir.resolve("contract.txt")
+        val qontractFilePath = validExtensionContract.toAbsolutePath().toString()
+
+        val reader = RealFileReader()
+
+        assertTrue(reader.extensionIsNot(qontractFilePath, QONTRACT_EXTENSION))
+    }
+}

--- a/application/src/test/kotlin/application/RealFileReaderTest.kt
+++ b/application/src/test/kotlin/application/RealFileReaderTest.kt
@@ -1,8 +1,8 @@
 package application
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
-import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.io.TempDir
 import run.qontract.core.QONTRACT_EXTENSION
 import java.io.File
@@ -18,7 +18,7 @@ internal class RealFileReaderTest {
 
         val reader = RealFileReader()
 
-        assertTrue(reader.isFile(qontractFilePath))
+        assertThat(reader.isFile(qontractFilePath)).isTrue
     }
 
     @Test
@@ -28,7 +28,7 @@ internal class RealFileReaderTest {
 
         val reader = RealFileReader()
 
-        assertFalse(reader.isFile(qontractFilePath))
+        assertThat(reader.isFile(qontractFilePath)).isFalse
     }
 
     @Test
@@ -38,7 +38,7 @@ internal class RealFileReaderTest {
 
         val reader = RealFileReader()
 
-        assertFalse(reader.extensionIsNot(qontractFilePath, QONTRACT_EXTENSION))
+        assertThat(reader.extensionIsNot(qontractFilePath, QONTRACT_EXTENSION)).isFalse
     }
 
     @Test
@@ -48,6 +48,6 @@ internal class RealFileReaderTest {
 
         val reader = RealFileReader()
 
-        assertTrue(reader.extensionIsNot(qontractFilePath, QONTRACT_EXTENSION))
+        assertThat(reader.extensionIsNot(qontractFilePath, QONTRACT_EXTENSION)).isTrue
     }
 }

--- a/application/src/test/kotlin/application/StubCommandTest.kt
+++ b/application/src/test/kotlin/application/StubCommandTest.kt
@@ -1,15 +1,21 @@
 package application
 
+import com.ginsberg.junit.exit.ExpectSystemExitWithStatus
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE
 import picocli.CommandLine
 import picocli.CommandLine.IFactory
+import run.qontract.core.QONTRACT_EXTENSION
+import java.io.File
+import java.nio.file.Path
 
 @SpringBootTest(webEnvironment = NONE, classes = arrayOf(QontractApplication::class, StubCommand::class))
 internal class StubCommandTest {
@@ -28,7 +34,7 @@ internal class StubCommandTest {
     @MockkBean
     lateinit var watchMaker: WatchMaker
 
-    @MockkBean
+    @MockkBean(relaxUnitFun = true)
     lateinit var watcher: Watcher
 
     @BeforeEach
@@ -39,7 +45,9 @@ internal class StubCommandTest {
     @Test
     fun `when contract files are not given it should load from qontract config`() {
         every { watchMaker.make(listOf("/config/path/to/contract.qontract")) }.returns(watcher)
-        every { qontractConfig.contractStubPaths() }.returns(arrayListOf("/config/path/to/contract.qontract"));
+        every { qontractConfig.contractStubPaths() }.returns(arrayListOf("/config/path/to/contract.qontract"))
+        every { reader.isFile("/config/path/to/contract.qontract") }.returns(true)
+        every { reader.extensionIsNot("/config/path/to/contract.qontract", QONTRACT_EXTENSION) }.returns(false)
 
         CommandLine(stubCommand, factory).execute()
 
@@ -50,11 +58,50 @@ internal class StubCommandTest {
     @Test
     fun `when contract files are given it should not load from qontract config`() {
         every { watchMaker.make(listOf("/parameter/path/to/contract.qontract")) }.returns(watcher)
-        every { qontractConfig.contractStubPaths() }.returns(arrayListOf("/config/path/to/contract.qontract"));
+        every { qontractConfig.contractStubPaths() }.returns(arrayListOf("/config/path/to/contract.qontract"))
+        every { reader.isFile("/parameter/path/to/contract.qontract") }.returns(true)
+        every { reader.extensionIsNot("/parameter/path/to/contract.qontract", QONTRACT_EXTENSION) }.returns(false)
 
         CommandLine(stubCommand, factory).execute("/parameter/path/to/contract.qontract")
 
         verify(exactly = 0) { qontractConfig.contractStubPaths() }
         verify(exactly = 1) { watchMaker.make(listOf("/parameter/path/to/contract.qontract")) }
+    }
+
+    @Test
+    fun `when a contract with the correct extension is given it should be loaded`(@TempDir tempDir: Path) {
+        val validQontract = tempDir.resolve("contract.qontract")
+
+        val qontractFilePath = validQontract.toAbsolutePath().toString()
+        File(qontractFilePath).writeText("""
+            Feature: Is a dummy feature
+        """.trimIndent())
+
+        every { watchMaker.make(listOf(qontractFilePath)) }.returns(watcher)
+        every { qontractConfig.contractStubPaths() }.returns(arrayListOf("/config/path/to/contract.qontract"))
+        every { reader.isFile(qontractFilePath) }.returns(true)
+        every { reader.extensionIsNot(qontractFilePath, QONTRACT_EXTENSION) }.returns(false)
+
+        val execute = CommandLine(stubCommand, factory).execute(qontractFilePath)
+
+        assertThat(execute).isEqualTo(0)
+    }
+
+    @Test
+    @ExpectSystemExitWithStatus(1)
+    fun `when a contract with the incorrect extension command should exit with non-zero`(@TempDir tempDir: Path) {
+        val invalidQontract = tempDir.resolve("contract.contract")
+
+        val qontractFilePath = invalidQontract.toAbsolutePath().toString()
+        File(qontractFilePath).writeText("""
+            Feature: Is a dummy feature
+        """.trimIndent())
+
+        every { watchMaker.make(listOf(qontractFilePath)) }.returns(watcher)
+        every { qontractConfig.contractStubPaths() }.returns(arrayListOf("/config/path/to/contract.qontract"))
+        every { reader.isFile(qontractFilePath) }.returns(true)
+        every { reader.extensionIsNot(qontractFilePath, QONTRACT_EXTENSION) }.returns(true)
+
+        CommandLine(stubCommand, factory).execute(qontractFilePath)
     }
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Fixes #71 , makes sure that qontract exits cleanly when qontracts are either non-existent or invalid (e.g. with an improper extension)
<!-- Why are these changes necessary? -->

**Why**:
Currently, qontract, when given an invalid file, hangs. We want to make sure that the program exits, so as to enforce convention, such as file extensions. We also want to make sure that the exit code is a valid non-zero exit code, so that integrations or validations in shell scripts work as well.
<!-- How were these changes implemented? -->

**How**:
We've added some convenience methods to RealFileReader & used them in the StubCommand, as a way to enforce the "whys"
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the README.md OR link to PR on https://github.com/qontract/qontract-documentation
- [x] Tests
- [x] Sonar Quality Gate

Link to docs PR https://github.com/qontract/qontract-documentation/pull/5
<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #71 

<!-- feel free to add additional comments -->
