### PR TITLE
Temp fix for xml namespaces

### DIFF
--- a/core/src/main/kotlin/run/qontract/core/pattern/Grammar.kt
+++ b/core/src/main/kotlin/run/qontract/core/pattern/Grammar.kt
@@ -4,7 +4,7 @@ import run.qontract.core.utilities.jsonStringToValueArray
 import run.qontract.core.utilities.jsonStringToValueMap
 import run.qontract.core.value.*
 
-private const val XML_ATTR_OPTIONAL_SUFFIX = ":optional"
+const val XML_ATTR_OPTIONAL_SUFFIX = ".opt"
 private const val DEFAULT_OPTIONAL_SUFFIX = "?"
 
 internal fun withoutOptionality(key: String): String {

--- a/core/src/main/kotlin/run/qontract/core/pattern/Pattern.kt
+++ b/core/src/main/kotlin/run/qontract/core/pattern/Pattern.kt
@@ -4,6 +4,7 @@ import run.qontract.core.Resolver
 import run.qontract.core.Result
 import run.qontract.core.value.StringValue
 import run.qontract.core.value.Value
+import run.qontract.core.value.XMLNode
 
 interface Pattern {
     fun matches(sampleData: Value?, resolver: Resolver): Result

--- a/core/src/main/kotlin/run/qontract/core/pattern/XMLTypeData.kt
+++ b/core/src/main/kotlin/run/qontract/core/pattern/XMLTypeData.kt
@@ -1,6 +1,7 @@
 package run.qontract.core.pattern
 
-data class XMLTypeData(val name: String = "", val attributes: Map<String, Pattern> = emptyMap(), val nodes: List<Pattern> = emptyList()) {
+data class XMLTypeData(val name: String = "", val realName: String, val attributes: Map<String, Pattern> = emptyMap(), val nodes: List<Pattern> = emptyList()) {
+
     fun isEmpty(): Boolean {
         return name.isEmpty() && attributes.isEmpty() && nodes.isEmpty()
     }

--- a/core/src/main/kotlin/run/qontract/core/utilities/Utilities.kt
+++ b/core/src/main/kotlin/run/qontract/core/utilities/Utilities.kt
@@ -67,6 +67,7 @@ fun readFile(filePath: String): String {
 
 fun parseXML(xmlData: String): Document {
     val builderFactory = DocumentBuilderFactory.newInstance()
+    builderFactory.isNamespaceAware = true
     val builder = builderFactory.newDocumentBuilder()
     builder.setErrorHandler(null)
     return removeWhiteSpace(builder.parse(InputSource(StringReader(xmlData))))

--- a/core/src/test/kotlin/run/qontract/core/TestBackwardCompatibilityKtTest.kt
+++ b/core/src/test/kotlin/run/qontract/core/TestBackwardCompatibilityKtTest.kt
@@ -495,4 +495,34 @@ Then status 200
         assertThat(results.failureCount).isZero()
         assertThat(results.success()).isTrue()
     }
+
+    @Test
+    fun `two xml contracts should be backward compatibility when the only thing changing is namespace prefixes`() {
+        val gherkin1 = """
+Feature: Contract API
+
+Scenario: api call
+When POST /data
+  And request-body <ns1:customer xmlns:ns1="http://example.com/customer"><name>(string)</name></ns1:customer>
+Then status 200
+    """.trim()
+
+        val gherkin2 = """
+Feature: Contract API
+
+Scenario: api call
+When POST /data
+  And request-body <ns2:customer xmlns:ns2="http://example.com/customer"><name>(string)</name></ns2:customer>
+Then status 200
+    """.trim()
+
+        val results: Results = testBackwardCompatibility(Feature(gherkin1), Feature(gherkin2))
+
+        if(results.failureCount > 0)
+            println(results.report())
+
+        assertThat(results.successCount).isOne()
+        assertThat(results.failureCount).isZero()
+        assertThat(results.success()).isTrue()
+    }
 }

--- a/core/src/test/kotlin/run/qontract/core/pattern/XMLPatternTest.kt
+++ b/core/src/test/kotlin/run/qontract/core/pattern/XMLPatternTest.kt
@@ -27,6 +27,22 @@ internal class XMLPatternTest {
     }
 
     @Test
+    fun `generate a value with namespace intact`() {
+        val itemsType = parsedPattern("<ns1:items xmlns:ns1=\"http://example.com/items\">(string)</ns1:items>")
+
+        val xmlValue = itemsType.generate(Resolver()) as XMLNode
+
+        assertThat(xmlValue.name).isEqualTo("items")
+        assertThat(xmlValue.realName).isEqualTo("ns1:items")
+
+        assertThat(xmlValue.attributes.size).isOne()
+        assertThat(xmlValue.attributes.get("xmlns:ns1")).isEqualTo(StringValue("http://example.com/items"))
+
+        assertThat(xmlValue.nodes.size).isOne()
+        assertThat(xmlValue.nodes.first()).isInstanceOf(StringValue::class.java)
+    }
+
+    @Test
     fun `should fail to match nulls gracefully`() {
         NullValue shouldNotMatch XMLPattern("<data></data>")
     }

--- a/core/src/test/kotlin/run/qontract/core/pattern/XMLPatternTest.kt
+++ b/core/src/test/kotlin/run/qontract/core/pattern/XMLPatternTest.kt
@@ -300,14 +300,14 @@ internal class XMLPatternTest {
 
     @Test
     fun `optional attribute encompasses non optional`() {
-        val bigger = XMLPattern("""<number val:optional="(number)">(number)</number>""")
+        val bigger = XMLPattern("""<number val$XML_ATTR_OPTIONAL_SUFFIX="(number)">(number)</number>""")
         val smaller = XMLPattern("""<number val="(number)">(number)</number>""")
         assertThat(bigger.encompasses(smaller, Resolver(), Resolver())).isInstanceOf(Result.Success::class.java)
     }
 
     @Test
     fun `optional attribute should pick up example value`() {
-        val type = XMLPattern("""<number val:optional="(number)"></number>""")
+        val type = XMLPattern("""<number val$XML_ATTR_OPTIONAL_SUFFIX="(number)"></number>""")
         val example = Row(listOf("val"), listOf("10"))
 
         val newTypes = type.newBasedOn(example, Resolver())
@@ -319,7 +319,7 @@ internal class XMLPatternTest {
 
     @Test
     fun `optional attribute without examples should generate two tests`() {
-        val type = XMLPattern("""<number val:optional="(number)"></number>""")
+        val type = XMLPattern("""<number val$XML_ATTR_OPTIONAL_SUFFIX="(number)"></number>""")
 
         val newTypes = type.newBasedOn(Row(), Resolver())
         assertThat(newTypes.size).isEqualTo(2)
@@ -340,7 +340,7 @@ internal class XMLPatternTest {
 
     @Test
     fun `sanity test that double optional gets handled right`() {
-        val type = XMLPattern("""<number val:optional:optional="(number)"></number>""")
+        val type = XMLPattern("""<number val$XML_ATTR_OPTIONAL_SUFFIX$XML_ATTR_OPTIONAL_SUFFIX="(number)"></number>""")
 
         val newTypes = type.newBasedOn(Row(), Resolver())
         assertThat(newTypes.size).isEqualTo(2)
@@ -349,7 +349,7 @@ internal class XMLPatternTest {
 
         for(newType in newTypes) {
             when {
-                newType.pattern.attributes.containsKey("val:optional") -> flags.add("with")
+                newType.pattern.attributes.containsKey("val$XML_ATTR_OPTIONAL_SUFFIX") -> flags.add("with")
                 else -> flags.add("without")
             }
         }

--- a/core/src/test/kotlin/run/qontract/core/value/XMLNodeTest.kt
+++ b/core/src/test/kotlin/run/qontract/core/value/XMLNodeTest.kt
@@ -9,7 +9,7 @@ internal class XMLNodeTest {
         val xmlData = "<data>data</data>"
         val node = XMLNode(xmlData)
 
-        assertThat(node).isEqualTo(XMLNode("data", emptyMap(), listOf(StringValue("data"))))
+        assertThat(node).isEqualTo(XMLNode("data", "data", emptyMap(), listOf(StringValue("data"))))
         assertThat(node.toStringValue()).isEqualTo("<data>data</data>")
     }
 }

--- a/core/src/test/kotlin/run/qontract/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/run/qontract/stub/HttpStubTest.kt
@@ -15,6 +15,7 @@ import run.qontract.core.Feature
 import run.qontract.core.HttpRequest
 import run.qontract.core.HttpResponse
 import run.qontract.core.QONTRACT_RESULT_HEADER
+import run.qontract.core.pattern.XML_ATTR_OPTIONAL_SUFFIX
 import run.qontract.core.pattern.parsedValue
 import run.qontract.core.value.NumberValue
 import run.qontract.core.value.StringValue
@@ -334,7 +335,7 @@ Then status 200
         val gherkin = """Feature: Number
 Scenario: Accept a number
 When POST /number
-And request-body <data number:optional="(number)"/>
+And request-body <data number$XML_ATTR_OPTIONAL_SUFFIX="(number)"/>
 Then status 200
         """.trim()
 
@@ -353,7 +354,7 @@ Then status 200
         val gherkin = """Feature: Number
 Scenario: Accept a number
 When POST /number
-And request-body <data number:optional="(number)"/>
+And request-body <data number$XML_ATTR_OPTIONAL_SUFFIX="(number)"/>
 Then status 200
         """.trim()
 

--- a/junit5-support/src/main/kotlin/run/qontract/test/QontractJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/run/qontract/test/QontractJUnitSupport.kt
@@ -17,8 +17,6 @@ import run.qontract.stub.testKafkaMessages
 import java.io.File
 import kotlin.system.exitProcess
 
-val pass = Unit
-
 open class QontractJUnitSupport {
     companion object {
         const val CONTRACT_PATHS = "contractPaths"


### PR DESCRIPTION
**What**: This will ignore namespaces, which is a quick fix that allows for namespace prefixes to flip flop without breaking stub expectations.

The ideal fix to come will validate the relevant namespaces referred to by the XML namespace prefixes.

**Why**:

We need a quick fix for this to enable some developers to use XML support. We will design and implement proper namespace support as well, and remove this feature.

**How**:
n/a

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/qontract/qontract-documentation
n/a

- [x] Tests
- [x] Sonar Quality Gate

**Issue ID**:
n/a Temp fix, does not address an issue