### PR TITLE
Fixing: bundle command fails to pick qontracts & stub data in mono repo

### DIFF
--- a/application/src/main/kotlin/application/BundleCommand.kt
+++ b/application/src/main/kotlin/application/BundleCommand.kt
@@ -1,3 +1,5 @@
+@file:JvmName("BundleCommand_Jvm")
+
 package application
 
 import org.springframework.beans.factory.annotation.Autowired
@@ -70,7 +72,7 @@ class Zipper {
     fun compress(zipFilePath: String, zipperEntries: List<ZipperEntry>) {
         FileOutputStream(zipFilePath).use { zipFile ->
             ZipOutputStream(zipFile).use { zipOut ->
-                for(zipperEntry in zipperEntries) {
+                for (zipperEntry in zipperEntries) {
                     val entry = ZipEntry(zipperEntry.path)
                     zipOut.putNextEntry(entry)
                     zipOut.write(zipperEntry.bytes)

--- a/application/src/test/kotlin/application/BundleCommandTest.kt
+++ b/application/src/test/kotlin/application/BundleCommandTest.kt
@@ -128,4 +128,23 @@ internal class BundleCommandTest {
         verify(exactly = 1) { file.isDirectory }
         verify(exactly = 1) { fileOperations.files(stubDataDir) }
     }
+
+    @Test
+    fun `bundle command should pick git repo and mono repo sources path`() {
+        val contractPaths = listOf(
+                ContractPathData("cloneDir", "cloneDir/a/1.qontract"),
+                ContractPathData("cloneDir", "cloneDir/b/1.qontract"),
+                ContractPathData(".", "./c/1.qontract"),
+        )
+        every { qontractConfig.contractStubPathData() }.returns(contractPaths)
+
+        mockkStatic("application.BundleCommand_Jvm")
+        every { pathDataToEntryPath(any(), any()) }.returns(emptyList())
+
+        CommandLine(bundleCommand, factory).execute()
+
+        verify(exactly = 1) {pathDataToEntryPath(ContractPathData("cloneDir", "cloneDir/a/1.qontract"), fileOperations)}
+        verify(exactly = 1) {pathDataToEntryPath(ContractPathData("cloneDir", "cloneDir/b/1.qontract"), fileOperations)}
+        verify(exactly = 1) {pathDataToEntryPath(ContractPathData(".", "./c/1.qontract"), fileOperations)}
+    }
 }

--- a/application/src/test/kotlin/application/FakeGit.kt
+++ b/application/src/test/kotlin/application/FakeGit.kt
@@ -76,4 +76,8 @@ abstract class FakeGit: GitCommand {
     override fun inGitRootOf(contractPath: String): GitCommand {
         TODO("Not yet implemented")
     }
+
+    override fun repoName(): String {
+        TODO("Not yet implemented")
+    }
 }

--- a/application/src/test/kotlin/application/FakeGit.kt
+++ b/application/src/test/kotlin/application/FakeGit.kt
@@ -77,7 +77,4 @@ abstract class FakeGit: GitCommand {
         TODO("Not yet implemented")
     }
 
-    override fun repoName(): String {
-        TODO("Not yet implemented")
-    }
 }

--- a/application/src/test/kotlin/application/QontractConfigTest.kt
+++ b/application/src/test/kotlin/application/QontractConfigTest.kt
@@ -1,0 +1,23 @@
+package application
+
+import io.mockk.every
+import io.mockk.mockkStatic
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import run.qontract.core.utilities.ContractPathData
+import run.qontract.core.utilities.contractFilePathsFrom
+
+internal class QontractConfigTest {
+
+    @Test
+    fun `should return contractStubPathData`() {
+        val contractPathData = ContractPathData("aaa", "bbbb")
+        mockkStatic("run.qontract.core.utilities.Utilities")
+        every {
+            contractFilePathsFrom(any(), any(), any())
+        }.returns(listOf(contractPathData))
+
+        val paths = QontractConfig().contractStubPathData()
+        assertThat(paths.equals(listOf(contractPathData))).isTrue
+    }
+}

--- a/application/src/test/kotlin/run/qontract/core/utilities/UtilitiesTest.kt
+++ b/application/src/test/kotlin/run/qontract/core/utilities/UtilitiesTest.kt
@@ -11,8 +11,6 @@ import run.qontract.core.pattern.parsedJSON
 import run.qontract.core.value.JSONObjectValue
 import run.qontract.core.value.XMLNode
 import java.io.File
-import java.nio.file.Files
-import java.nio.file.Paths
 
 internal class UtilitiesTest {
     @Test

--- a/application/src/test/kotlin/run/qontract/core/utilities/UtilitiesTest.kt
+++ b/application/src/test/kotlin/run/qontract/core/utilities/UtilitiesTest.kt
@@ -47,17 +47,13 @@ internal class UtilitiesTest {
 
     @Test
     fun `contractFilePathsFrom sources with mono repo`() {
-        val sources = listOf(GitMonoRepo(listOf(), listOf("../a/1.qontract", "../b/1.qontract", "../c/1.qontract")))
+        val sources = listOf(GitMonoRepo(listOf(), listOf("a/1.qontract", "b/1.qontract", "c/1.qontract")))
 
         mockkStatic("run.qontract.core.utilities.Utilities")
         every { loadSources(".") }.returns(sources)
 
         mockkConstructor(SystemGit::class)
         every { anyConstructed<SystemGit>().gitRoot() }.returns("/path/to/monorepo")
-
-        every { anyConstructed<SystemGit>().relativeGitPath("../a/1.qontract") }.returns(Pair(SystemGit(), "a/1.qontract"))
-        every { anyConstructed<SystemGit>().relativeGitPath("../b/1.qontract") }.returns(Pair(SystemGit(), "b/1.qontract"))
-        every { anyConstructed<SystemGit>().relativeGitPath("../c/1.qontract") }.returns(Pair(SystemGit(), "c/1.qontract"))
 
         sources[0].stubContracts.forEach {
             File(it).parentFile.mkdirs()
@@ -66,14 +62,14 @@ internal class UtilitiesTest {
 
         val contractPaths = contractFilePathsFrom(".", ".qontract") { source -> source.stubContracts }
         val expectedContractPaths = listOf(
-                ContractPathData(".qontract/repos/monorepo", ".qontract/repos/monorepo/a/1.qontract"),
-                ContractPathData(".qontract/repos/monorepo", ".qontract/repos/monorepo/b/1.qontract"),
-                ContractPathData(".qontract/repos/monorepo", ".qontract/repos/monorepo/c/1.qontract"),
+                ContractPathData("/path/to/monorepo", "/path/to/monorepo/a/1.qontract"),
+                ContractPathData("/path/to/monorepo", "/path/to/monorepo/b/1.qontract"),
+                ContractPathData("/path/to/monorepo", "/path/to/monorepo/c/1.qontract"),
         )
 
         assertThat(contractPaths == expectedContractPaths).isTrue
 
-        listOf("../a", "../b", "../c").forEach { File(it).deleteRecursively() }
+        listOf("a", "b", "c").forEach { File(it).deleteRecursively() }
         File(".qontract").deleteRecursively()
     }
 

--- a/application/src/test/kotlin/run/qontract/core/utilities/UtilitiesTest.kt
+++ b/application/src/test/kotlin/run/qontract/core/utilities/UtilitiesTest.kt
@@ -1,8 +1,18 @@
 package run.qontract.core.utilities
 
+import io.mockk.every
+import io.mockk.mockkConstructor
+import io.mockk.mockkStatic
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import run.qontract.core.git.SystemGit
+import run.qontract.core.git.clone
+import run.qontract.core.pattern.parsedJSON
+import run.qontract.core.value.JSONObjectValue
 import run.qontract.core.value.XMLNode
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Paths
 
 internal class UtilitiesTest {
     @Test
@@ -14,7 +24,114 @@ internal class UtilitiesTest {
 
         val xmlValue = XMLNode(xml)
 
-        assertThat(xmlValue.nodes.size).isOne()
+        assertThat(xmlValue.nodes.size).isOne
         assertThat(xmlValue.toStringValue().trim()).isEqualTo("""<line1><line2>data</line2></line1>""")
     }
+
+    @Test
+    fun `contractFilePathsFrom sources with git repo`() {
+        val sources = listOf(GitRepo("https://repo1", listOf(), listOf("a/1.qontract", "b/1.qontract", "c/1.qontract")))
+
+        mockkStatic("run.qontract.core.utilities.Utilities")
+        every { loadSources("/configFilePath") }.returns(sources)
+
+        mockkStatic("run.qontract.core.git.GitOperations")
+        every { clone(any(), any()) }.returns(File("cloneDir"))
+
+        val contractPaths = contractFilePathsFrom("/configFilePath", ".qontract") { source -> source.stubContracts }
+        val expectedContractPaths = listOf(
+                ContractPathData("cloneDir", "cloneDir/a/1.qontract"),
+                ContractPathData("cloneDir", "cloneDir/b/1.qontract"),
+                ContractPathData("cloneDir", "cloneDir/c/1.qontract"),
+        )
+        assertThat(contractPaths == expectedContractPaths).isTrue
+    }
+
+    @Test
+    fun `contractFilePathsFrom sources with mono repo`() {
+        val sources = listOf(GitMonoRepo(listOf(), listOf("../a/1.qontract", "../b/1.qontract", "../c/1.qontract")))
+
+        mockkStatic("run.qontract.core.utilities.Utilities")
+        every { loadSources(".") }.returns(sources)
+
+        mockkConstructor(SystemGit::class)
+        every { anyConstructed<SystemGit>().repoName() }.returns("monorepo")
+
+        every { anyConstructed<SystemGit>().relativeGitPath("../a/1.qontract") }.returns(Pair(SystemGit(), "a/1.qontract"))
+        every { anyConstructed<SystemGit>().relativeGitPath("../b/1.qontract") }.returns(Pair(SystemGit(), "b/1.qontract"))
+        every { anyConstructed<SystemGit>().relativeGitPath("../c/1.qontract") }.returns(Pair(SystemGit(), "c/1.qontract"))
+
+        sources[0].stubContracts.forEach {
+            File(it).parentFile.mkdirs()
+            File(it).createNewFile()
+        }
+
+        val contractPaths = contractFilePathsFrom(".", ".qontract") { source -> source.stubContracts }
+        val expectedContractPaths = listOf(
+                ContractPathData(".qontract/repos/monorepo", ".qontract/repos/monorepo/a/1.qontract"),
+                ContractPathData(".qontract/repos/monorepo", ".qontract/repos/monorepo/b/1.qontract"),
+                ContractPathData(".qontract/repos/monorepo", ".qontract/repos/monorepo/c/1.qontract"),
+        )
+
+        assertThat(contractPaths == expectedContractPaths).isTrue
+
+        listOf("../a", "../b", "../c").forEach { File(it).deleteRecursively() }
+        File(".qontract").deleteRecursively()
+    }
+
+    @Test
+    fun `load sources with git repo`() {
+        val qontractJson = "{\"sources\": [{\"provider\": \"git\",\"repository\": \"https://repo1\",\"stub\": [\"a/1.qontract\",\"b/1.qontract\",\"c/1.qontract\"]}]}"
+        val configJson = parsedJSON(qontractJson) as JSONObjectValue
+        val sources = loadSources(configJson)
+        val expectedSources = listOf(GitRepo("https://repo1", listOf(), listOf("a/1.qontract", "b/1.qontract", "c/1.qontract")))
+        assertThat(sources == expectedSources).isTrue
+    }
+
+    @Test
+    fun `load sources with multiple git repos`() {
+        val qontractJson = "{\"sources\": [{\"provider\": \"git\",\"repository\": \"https://repo1\",\"stub\": [\"a/1.qontract\",\"b/1.qontract\"]}," +
+                "{\"provider\": \"git\",\"repository\": \"https://repo2\",\"stub\": [\"c/1.qontract\"]}]}"
+        val configJson = parsedJSON(qontractJson) as JSONObjectValue
+        val sources = loadSources(configJson)
+        val expectedSources = listOf(
+                GitRepo("https://repo1", listOf(), listOf("a/1.qontract", "b/1.qontract")),
+                GitRepo("https://repo2", listOf(), listOf("c/1.qontract"))
+        )
+        assertThat(sources == expectedSources).isTrue
+    }
+
+    @Test
+    fun `load sources with mono repo`() {
+        val qontractJson = "{\"sources\": [{\"provider\": \"git\",\"stub\": [\"a/1.qontract\",\"b/1.qontract\",\"c/1.qontract\"]}]}"
+        val configJson = parsedJSON(qontractJson) as JSONObjectValue
+        val sources = loadSources(configJson)
+        val expectedSources = listOf(GitMonoRepo(listOf(), listOf("a/1.qontract", "b/1.qontract", "c/1.qontract")))
+        assertThat(sources == expectedSources).isTrue
+    }
+
+    @Test
+    fun `load sources with multiple mono repos`() {
+        val qontractJson = "{\"sources\": [{\"provider\": \"git\",\"stub\": [\"a/1.qontract\",\"b/1.qontract\"]}," +
+                "{\"provider\": \"git\",\"stub\": [\"c/1.qontract\"]}]}"
+        val configJson = parsedJSON(qontractJson) as JSONObjectValue
+        val sources = loadSources(configJson)
+        val expectedSources = listOf(GitMonoRepo(listOf(), listOf("a/1.qontract", "b/1.qontract")),
+                GitMonoRepo(listOf(), listOf("c/1.qontract")))
+        assertThat(sources == expectedSources).isTrue
+    }
+
+    @Test
+    fun `load sources with git and mono repos`() {
+        val qontractJson = "{\"sources\": [{\"provider\": \"git\",\"repository\": \"https://repo1\",\"stub\": [\"a/1.qontract\",\"b/1.qontract\"]}," +
+                "{\"provider\": \"git\",\"stub\": [\"c/1.qontract\"]}]}"
+        val configJson = parsedJSON(qontractJson) as JSONObjectValue
+        val sources = loadSources(configJson)
+        val expectedSources = listOf(
+                GitRepo("https://repo1", listOf(), listOf("a/1.qontract", "b/1.qontract")),
+                GitMonoRepo(listOf(), listOf("c/1.qontract"))
+        )
+        assertThat(sources == expectedSources).isTrue
+    }
+
 }

--- a/application/src/test/kotlin/run/qontract/core/utilities/UtilitiesTest.kt
+++ b/application/src/test/kotlin/run/qontract/core/utilities/UtilitiesTest.kt
@@ -53,7 +53,7 @@ internal class UtilitiesTest {
         every { loadSources(".") }.returns(sources)
 
         mockkConstructor(SystemGit::class)
-        every { anyConstructed<SystemGit>().repoName() }.returns("monorepo")
+        every { anyConstructed<SystemGit>().gitRoot() }.returns("/path/to/monorepo")
 
         every { anyConstructed<SystemGit>().relativeGitPath("../a/1.qontract") }.returns(Pair(SystemGit(), "a/1.qontract"))
         every { anyConstructed<SystemGit>().relativeGitPath("../b/1.qontract") }.returns(Pair(SystemGit(), "b/1.qontract"))

--- a/core/src/main/kotlin/run/qontract/core/git/GitCommand.kt
+++ b/core/src/main/kotlin/run/qontract/core/git/GitCommand.kt
@@ -21,5 +21,4 @@ interface GitCommand {
     fun relativeGitPath(newerContractPath: String): Pair<GitCommand, String>
     fun fileIsInGitDir(newerContractPath: String): Boolean
     fun inGitRootOf(contractPath: String): GitCommand
-    fun repoName(): String
 }

--- a/core/src/main/kotlin/run/qontract/core/git/GitCommand.kt
+++ b/core/src/main/kotlin/run/qontract/core/git/GitCommand.kt
@@ -21,4 +21,5 @@ interface GitCommand {
     fun relativeGitPath(newerContractPath: String): Pair<GitCommand, String>
     fun fileIsInGitDir(newerContractPath: String): Boolean
     fun inGitRootOf(contractPath: String): GitCommand
+    fun repoName(): String
 }

--- a/core/src/main/kotlin/run/qontract/core/git/GitOperations.kt
+++ b/core/src/main/kotlin/run/qontract/core/git/GitOperations.kt
@@ -1,3 +1,5 @@
+@file:JvmName("GitOperations")
+
 package run.qontract.core.git
 
 import io.ktor.http.*

--- a/core/src/main/kotlin/run/qontract/core/git/SystemGit.kt
+++ b/core/src/main/kotlin/run/qontract/core/git/SystemGit.kt
@@ -11,9 +11,9 @@ class SystemGit(private val workingDirectory: String = ".", private val prefix: 
     override fun commit(): SystemGit = this.also { execute("git", "commit", "-m", "Updated contract") }
     override fun push(): SystemGit = this.also { execute("git", "push") }
     override fun pull(): SystemGit = this.also { execute("git", "pull") }
-    override fun resetHard(): SystemGit = this.also { execute("git",  "reset", "--hard", "HEAD") }
-    override fun resetMixed(): SystemGit = this.also { execute("git",  "reset", "--mixed", "HEAD") }
-    override fun mergeAbort(): SystemGit = this.also { execute("git",  "merge", "--aborg") }
+    override fun resetHard(): SystemGit = this.also { execute("git", "reset", "--hard", "HEAD") }
+    override fun resetMixed(): SystemGit = this.also { execute("git", "reset", "--mixed", "HEAD") }
+    override fun mergeAbort(): SystemGit = this.also { execute("git", "merge", "--aborg") }
     override fun checkout(branchName: String): SystemGit = this.also { execute("git", "checkout", branchName) }
     override fun merge(branchName: String): SystemGit = this.also { execute("git", "merge", branchName) }
     override fun clone(gitRepositoryURI: String, cloneDirectory: File): SystemGit = this.also { execute("git", "clone", gitRepositoryURI, cloneDirectory.absolutePath) }
@@ -21,7 +21,7 @@ class SystemGit(private val workingDirectory: String = ".", private val prefix: 
     override fun show(treeish: String, relativePath: String): String = execute("git", "show", "${treeish}:${relativePath}")
     override fun workingDirectoryIsGitRepo(): Boolean = try {
         execute("git", "rev-parse", "--is-inside-work-tree").trim() == "true"
-    } catch(e: Throwable) {
+    } catch (e: Throwable) {
         false.also {
             println("This must not be a git dir, got error ${e.javaClass.name}: ${exceptionCauseMessage(e)}")
         }
@@ -30,7 +30,7 @@ class SystemGit(private val workingDirectory: String = ".", private val prefix: 
     override fun getChangedFiles(): List<String> {
         val result = execute("git", "status", "--porcelain=1").trim()
 
-        if(result.isEmpty())
+        if (result.isEmpty())
             return emptyList()
 
         return result.lines().map { it.trim().split(" ", limit = 2)[1] }
@@ -49,6 +49,11 @@ class SystemGit(private val workingDirectory: String = ".", private val prefix: 
     }
 
     override fun inGitRootOf(contractPath: String): GitCommand = SystemGit(File(contractPath).parentFile.absolutePath)
+
+    override fun repoName(): String {
+        val result = execute("git", "config", "--get", "remote.origin.url").trim()
+        return result.substring(result.lastIndexOf('/') + 1)
+    }
 }
 
 private fun executeCommandWithWorkingDirectory(prefix: String, workingDirectory: String, command: Array<String>): String {
@@ -58,13 +63,13 @@ private fun executeCommandWithWorkingDirectory(prefix: String, workingDirectory:
     val out = process.inputStream.bufferedReader().readText()
     val err = process.errorStream.bufferedReader().readText()
 
-    if(process.exitValue() != 0) throw NonZeroExitError(err.ifEmpty { out })
+    if (process.exitValue() != 0) throw NonZeroExitError(err.ifEmpty { out })
 
     return out
 }
 
 fun exitErrorMessageContains(exception: NonZeroExitError, snippets: List<String>): Boolean {
-    return when(val message = exception.localizedMessage ?: exception.message) {
+    return when (val message = exception.localizedMessage ?: exception.message) {
         null -> false
         else -> snippets.all { snippet -> snippet in message }
     }

--- a/core/src/main/kotlin/run/qontract/core/git/SystemGit.kt
+++ b/core/src/main/kotlin/run/qontract/core/git/SystemGit.kt
@@ -49,11 +49,6 @@ class SystemGit(private val workingDirectory: String = ".", private val prefix: 
     }
 
     override fun inGitRootOf(contractPath: String): GitCommand = SystemGit(File(contractPath).parentFile.absolutePath)
-
-    override fun repoName(): String {
-        val result = execute("git", "config", "--get", "remote.origin.url").trim()
-        return result.substring(result.lastIndexOf('/') + 1)
-    }
 }
 
 private fun executeCommandWithWorkingDirectory(prefix: String, workingDirectory: String, command: Array<String>): String {

--- a/core/src/main/kotlin/run/qontract/core/utilities/ContractSource.kt
+++ b/core/src/main/kotlin/run/qontract/core/utilities/ContractSource.kt
@@ -39,17 +39,16 @@ data class GitRepo(val gitRepositoryURL: String, override val testContracts: Lis
 
         try {
             println("Checking ${sourceDir.path}")
-            if(!sourceDir.exists())
+            if (!sourceDir.exists())
                 sourceDir.mkdirs()
 
-            if(!sourceGit.workingDirectoryIsGitRepo()) {
+            if (!sourceGit.workingDirectoryIsGitRepo()) {
                 println("Found it, not a git dir, recreating...")
                 sourceDir.deleteRecursively()
                 sourceDir.mkdirs()
                 println("Cloning ${this.gitRepositoryURL} into ${sourceDir.absolutePath}")
                 sourceGit.clone(this.gitRepositoryURL, sourceDir.absoluteFile)
-            }
-            else {
+            } else {
                 println("Git repo already exists at ${sourceDir.path}, so ignoring it and moving on")
             }
         } catch (e: Throwable) {
@@ -58,14 +57,14 @@ data class GitRepo(val gitRepositoryURL: String, override val testContracts: Lis
     }
 }
 
-data class GitMonoRepo(override val testContracts: List<String>, override val stubContracts: List<String>) : ContractSource() {
+data class GitMonoRepo(override val testContracts: List<String>, override var stubContracts: List<String>) : ContractSource() {
     override fun pathDescriptor(path: String): String = path
     override fun install(workingDirectory: File) {
         println("Checking list of mono repo paths...")
 
         val contracts = testContracts + stubContracts
 
-        for(path in contracts) {
+        for (path in contracts) {
             val existenceMessage = when {
                 File(path).exists() -> "$path exists"
                 else -> "$path NOT FOUND!"
@@ -75,10 +74,13 @@ data class GitMonoRepo(override val testContracts: List<String>, override val st
         }
     }
 
-    override fun directoryRelativeTo(workingDirectory: File): File = File("..")
+    override fun directoryRelativeTo(workingDirectory: File) =
+            workingDirectory.resolve(SystemGit().repoName())
+
     override fun getLatest(sourceGit: SystemGit) {
         // In mono repos, we can't pull latest arbitrarily
     }
+
     override fun pushUpdates(sourceGit: SystemGit) {
         // In mono repos, we can't push arbitrarily
     }

--- a/core/src/main/kotlin/run/qontract/core/utilities/Utilities.kt
+++ b/core/src/main/kotlin/run/qontract/core/utilities/Utilities.kt
@@ -255,12 +255,8 @@ fun contractFilePathsFrom(configFilePath: String, workingDirectory: String, sele
     println("Loading config file $configFilePath")
     val sources = loadSources(configFilePath)
 
-    return sources.flatMap { source ->
-        val reposBaseDir = File(workingDirectory).resolve("repos")
-        if (!reposBaseDir.exists())
-            reposBaseDir.mkdirs()
-
-        source.loadContracts(reposBaseDir, selector)
+    return sources.flatMap {
+        it.loadContracts(selector, workingDirectory)
     }.also {
         println("Contract file paths #######")
         println(it)


### PR DESCRIPTION
Fixing: bundle command fails to pick contracts & stub data in mono repo (Issue#132)

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: 
Fixes #132 , makes sure the bundle command picks the contracts and stub data from within the mono repo, and places it under the base dir with the same name as the mono repo and under the same path as it is within the mono repo.

<!-- Why are these changes necessary? -->

**Why**:
Currently, the bundle command is generating the zip file which is missing sources referring to the path within a mono repo.

<!-- How were these changes implemented? -->

**How**:
When the source belongs to a mono repo, ensuring contract file paths are picked correctly, relative to the mono repo root directory.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Tests
- [x] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #132 

<!-- feel free to add additional comments -->
