### PR TITLE
fixing bug - stub and test commands falling back on qontract.json fai…

### DIFF
--- a/application/src/main/kotlin/application/StubCommand.kt
+++ b/application/src/main/kotlin/application/StubCommand.kt
@@ -40,7 +40,7 @@ class StubCommand : Callable<Unit> {
     private lateinit var context: ApplicationContext
 
     @Autowired
-    lateinit var qontractConfig: QontractConfig
+    private var qontractConfig: QontractConfig = QontractConfig()
 
     @Parameters(arity = "0..*", description = ["Contract file paths"])
     var contractPaths: List<String> = mutableListOf()

--- a/core/src/main/kotlin/run/qontract/core/utilities/ContractSource.kt
+++ b/core/src/main/kotlin/run/qontract/core/utilities/ContractSource.kt
@@ -119,7 +119,7 @@ data class GitMonoRepo(override val testContracts: List<String>, override val st
         val monoRepoBaseDir = File(SystemGit().gitRoot())
         val configFileLocation = File(configFilePath).parentFile
 
-        return stubContracts.map {
+        return selector.select(this).map {
             ContractPathData(monoRepoBaseDir.canonicalPath, configFileLocation.resolve(it).canonicalPath)
         }
     }


### PR DESCRIPTION
Fixing: bug introduced - stub and test commands falling back on qontract.json failing to pick relevant contracts

What:
Fixes #132 , makes sure the bundle command picks the contracts and stub data from within the mono repo, and places it under the base dir with the same name as the mono repo and under the same path as it is within the mono repo.

Why:
Currently, the bundle command is generating the zip file which is missing sources referring to the path within a mono repo.

How:
When the source belongs to a mono repo, ensuring contract file paths are picked correctly, relative to the mono repo root directory.

Checklist:
- [x] Tests

Issue ID:
Closes: #132