### PR TITLE
Backward compatibility

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Feature.kt
@@ -139,7 +139,7 @@ data class Feature(val scenarios: List<Scenario> = emptyList(), private var serv
 
     fun generateBackwardCompatibilityTestScenarios(): List<Scenario> =
         scenarios.flatMap { scenario ->
-            scenario.copy(examples = emptyList()).generateTestScenarios()
+            scenario.copy(examples = emptyList()).generateBackwardCompatibilityScenarios()
         }
 
     fun assertMatchesMockKafkaMessage(kafkaMessage: KafkaMessage) {

--- a/core/src/main/kotlin/in/specmatic/core/HttpHeadersPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpHeadersPattern.kt
@@ -82,6 +82,11 @@ data class HttpHeadersPattern(val pattern: Map<String, Pattern> = emptyMap(), va
             newBasedOn(pattern, row, resolver)
         }.map { HttpHeadersPattern(it.mapKeys { withoutOptionality(it.key) }) }
 
+    fun newBasedOn(resolver: Resolver): List<HttpHeadersPattern> =
+            allOrNothingCombinationIn(pattern) { pattern ->
+                newBasedOn(pattern, resolver)
+            }.map { HttpHeadersPattern(it.mapKeys { withoutOptionality(it.key) }) }
+
     fun encompasses(other: HttpHeadersPattern, thisResolver: Resolver, otherResolver: Resolver): Result {
         val myRequiredKeys = pattern.keys.filter { !isOptional(it) }
         val otherRequiredKeys = other.pattern.keys.filter { !isOptional(it) }

--- a/core/src/main/kotlin/in/specmatic/core/URLPathPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/URLPathPattern.kt
@@ -16,6 +16,9 @@ data class URLPathPattern(override val pattern: Pattern, override val key: Strin
     override fun newBasedOn(row: Row, resolver: Resolver): List<URLPathPattern> =
             pattern.newBasedOn(row, resolver).map { URLPathPattern(it, key) }
 
+    override fun newBasedOn(resolver: Resolver): List<URLPathPattern> =
+            pattern.newBasedOn(resolver).map { URLPathPattern(it, key) }
+
     override fun parse(value: String, resolver: Resolver): Value = pattern.parse(value, resolver)
 
     override fun encompasses(otherPattern: Pattern, thisResolver: Resolver, otherResolver: Resolver, typeStack: TypeStack): Result {

--- a/core/src/main/kotlin/in/specmatic/core/pattern/AnyPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/AnyPattern.kt
@@ -38,6 +38,9 @@ data class AnyPattern(override val pattern: List<Pattern>, val key: String? = nu
     override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> =
             pattern.flatMap { it.newBasedOn(row, resolver) }
 
+    override fun newBasedOn(resolver: Resolver): List<Pattern> =
+            pattern.flatMap { it.newBasedOn(resolver) }
+
     override fun parse(value: String, resolver: Resolver): Value =
         pattern.asSequence().map {
             try { it.parse(value, resolver) } catch(e: Throwable) { null }

--- a/core/src/main/kotlin/in/specmatic/core/pattern/AnythingPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/AnythingPattern.kt
@@ -18,6 +18,10 @@ object AnythingPattern: Pattern {
         return listOf(this)
     }
 
+    override fun newBasedOn(resolver: Resolver): List<Pattern> {
+        return listOf(this)
+    }
+
     override fun parse(value: String, resolver: Resolver): Value {
         return StringValue(value)
     }

--- a/core/src/main/kotlin/in/specmatic/core/pattern/BooleanPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/BooleanPattern.kt
@@ -20,6 +20,7 @@ object BooleanPattern : Pattern, ScalarType {
         randomBoolean()
 
     override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> = listOf(this)
+    override fun newBasedOn(resolver: Resolver): List<Pattern> = listOf(this)
     override fun parse(value: String, resolver: Resolver): Value = when {
         value !in (listOf("true", "false")) -> throw ContractException(resultReport(mismatchResult(BooleanPattern, value)))
         else -> BooleanValue(value.toBoolean())

--- a/core/src/main/kotlin/in/specmatic/core/pattern/DateTimePattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/DateTimePattern.kt
@@ -21,6 +21,8 @@ object DateTimePattern : Pattern, ScalarType {
 
     override fun newBasedOn(row: Row, resolver: Resolver): List<DateTimePattern> = listOf(this)
 
+    override fun newBasedOn(resolver: Resolver): List<DateTimePattern> = listOf(this)
+
     override fun parse(value: String, resolver: Resolver): StringValue =
             attempt {
                 DateTimeFormatter.ISO_DATE_TIME.parse(value)

--- a/core/src/main/kotlin/in/specmatic/core/pattern/DeferredPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/DeferredPattern.kt
@@ -25,6 +25,10 @@ data class DeferredPattern(override val pattern: String, val key: String? = null
         return resolver.getPattern(pattern).newBasedOn(row, resolver)
     }
 
+    override fun newBasedOn(resolver: Resolver): List<Pattern> {
+        return resolver.getPattern(pattern).newBasedOn(resolver)
+    }
+
     override fun encompasses(otherPattern: Pattern, thisResolver: Resolver, otherResolver: Resolver, typeStack: TypeStack): Result {
         return thisResolver.getPattern(pattern).encompasses(resolvedHop(otherPattern, otherResolver), thisResolver, otherResolver, typeStack)
     }

--- a/core/src/main/kotlin/in/specmatic/core/pattern/DictionaryPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/DictionaryPattern.kt
@@ -56,6 +56,14 @@ data class DictionaryPattern(val keyPattern: Pattern, val valuePattern: Pattern,
         }
     }
 
+    override fun newBasedOn(resolver: Resolver): List<Pattern> {
+        val newValuePatterns = valuePattern.newBasedOn(resolver)
+
+        return newValuePatterns.map {
+            DictionaryPattern(keyPattern, it)
+        }
+    }
+
     override fun parse(value: String, resolver: Resolver): Value = parsedJSON(value)
 
     override fun encompasses(otherPattern: Pattern, thisResolver: Resolver, otherResolver: Resolver, typeStack: TypeStack): Result =

--- a/core/src/main/kotlin/in/specmatic/core/pattern/EmptyStringPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/EmptyStringPattern.kt
@@ -15,6 +15,7 @@ object EmptyStringPattern : Pattern {
 
     override fun generate(resolver: Resolver): Value = StringValue("")
     override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> = listOf(this)
+    override fun newBasedOn(resolver: Resolver): List<Pattern> = listOf(this)
     override fun parse(value: String, resolver: Resolver): Value {
         return when {
             value.isEmpty() -> EmptyString

--- a/core/src/main/kotlin/in/specmatic/core/pattern/ExactValuePattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/ExactValuePattern.kt
@@ -31,6 +31,7 @@ data class ExactValuePattern(override val pattern: Value, override val typeAlias
 
     override fun generate(resolver: Resolver) = pattern
     override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> = listOf(this)
+    override fun newBasedOn(resolver: Resolver): List<Pattern> = listOf(this)
     override fun parse(value: String, resolver: Resolver): Value = pattern.type().parse(value, resolver)
 
     override val typeName: String = pattern.displayableValue()

--- a/core/src/main/kotlin/in/specmatic/core/pattern/JSONArrayPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/JSONArrayPattern.kt
@@ -76,6 +76,11 @@ data class JSONArrayPattern(override val pattern: List<Pattern> = emptyList(), o
         val resolverWithNullType = withNullPattern(resolver)
         return newBasedOn(pattern, row, resolverWithNullType).map { JSONArrayPattern(it) }
     }
+
+    override fun newBasedOn(resolver: Resolver): List<JSONArrayPattern> {
+        val resolverWithNullType = withNullPattern(resolver)
+        return newBasedOn(pattern, resolverWithNullType).map { JSONArrayPattern(it) }
+    }
     override fun parse(value: String, resolver: Resolver): Value = parsedJSON(value)
     override fun encompasses(otherPattern: Pattern, thisResolver: Resolver, otherResolver: Resolver, typeStack: TypeStack): Result {
         val thisResolverWithNullType = withNullPattern(thisResolver)
@@ -123,6 +128,16 @@ fun newBasedOn(jsonPattern: List<Pattern>, row: Row, resolver: Resolver): List<L
     val values = jsonPattern.mapIndexed { index, pattern ->
         attempt(breadCrumb = "[$index]") {
             pattern.newBasedOn(row, resolver)
+        }
+    }
+
+    return listCombinations(values)
+}
+
+fun newBasedOn(jsonPattern: List<Pattern>, resolver: Resolver): List<List<Pattern>> {
+    val values = jsonPattern.mapIndexed { index, pattern ->
+        attempt(breadCrumb = "[$index]") {
+            pattern.newBasedOn(resolver)
         }
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/JSONObjectPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/JSONObjectPattern.kt
@@ -22,7 +22,7 @@ fun toJSONObjectPattern(map: Map<String, Pattern>): JSONObjectPattern {
 val ignoreUnexpectedKeys = { _: Map<String, Any>, _: Map<String, Any> -> null }
 
 data class JSONObjectPattern(override val pattern: Map<String, Pattern> = emptyMap(), private val unexpectedKeyCheck: UnexpectedKeyCheck = ::validateUnexpectedKeys, override val typeAlias: String? = null) : Pattern {
-    override fun equals(other: Any?): Boolean = when(other) {
+    override fun equals(other: Any?): Boolean = when (other) {
         is JSONObjectPattern -> this.pattern == other.pattern
         else -> false
     }
@@ -44,11 +44,11 @@ data class JSONObjectPattern(override val pattern: Map<String, Pattern> = emptyM
 
     override fun matches(sampleData: Value?, resolver: Resolver): Result {
         val resolverWithNullType = withNullPattern(resolver)
-        if(sampleData !is JSONObjectValue)
+        if (sampleData !is JSONObjectValue)
             return mismatchResult("JSON object", sampleData)
 
         val missingKey = resolverWithNullType.findMissingKey(pattern, sampleData.jsonObject, unexpectedKeyCheck)
-        if(missingKey != null)
+        if (missingKey != null)
             return missingKeyToResult(missingKey, "key")
 
         mapZip(pattern, sampleData.jsonObject).forEach { (key, patternValue, sampleValue) ->
@@ -69,6 +69,13 @@ data class JSONObjectPattern(override val pattern: Map<String, Pattern> = emptyM
         val resolverWithNullType = withNullPattern(resolver)
         return forEachKeyCombinationIn(pattern.minus("..."), row) { pattern ->
             newBasedOn(pattern, row, resolverWithNullType)
+        }.map { toJSONObjectPattern(it) }
+    }
+
+    override fun newBasedOn(resolver: Resolver): List<JSONObjectPattern> {
+        val resolverWithNullType = withNullPattern(resolver)
+        return allOrNothingCombinationIn(pattern.minus("...")) { pattern ->
+            newBasedOn(pattern, resolverWithNullType)
         }.map { toJSONObjectPattern(it) }
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/ListPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/ListPattern.kt
@@ -43,6 +43,11 @@ data class ListPattern(override val pattern: Pattern, override val typeAlias: St
         val resolverWithEmptyType = withEmptyType(pattern, resolver)
         return attempt(breadCrumb = "[]") { pattern.newBasedOn(row, resolverWithEmptyType).map { ListPattern(it) } }
     }
+
+    override fun newBasedOn(resolver: Resolver): List<Pattern> {
+        val resolverWithEmptyType = withEmptyType(pattern, resolver)
+        return attempt(breadCrumb = "[]") { pattern.newBasedOn(resolverWithEmptyType).map { ListPattern(it) } }
+    }
     override fun parse(value: String, resolver: Resolver): Value = parsedJSON(value)
 
     override fun patternSet(resolver: Resolver): List<Pattern> {

--- a/core/src/main/kotlin/in/specmatic/core/pattern/LookupRowPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/LookupRowPattern.kt
@@ -24,6 +24,13 @@ data class LookupRowPattern(override val pattern: Pattern, override val key: Str
         }
     }
 
+    override fun newBasedOn(resolver: Resolver): List<Pattern> {
+        return when(key) {
+            null -> pattern.newBasedOn(resolver)
+            else -> newBasedOn(pattern, resolver)
+        }
+    }
+
     override fun parse(value: String, resolver: Resolver): Value = pattern.parse(value, resolver)
 
     override fun encompasses(otherPattern: Pattern, thisResolver: Resolver, otherResolver: Resolver, typeStack: TypeStack): Result {

--- a/core/src/main/kotlin/in/specmatic/core/pattern/NullPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/NullPattern.kt
@@ -20,6 +20,7 @@ object NullPattern : Pattern, ScalarType {
 
     override fun generate(resolver: Resolver): Value = NullValue
     override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> = listOf(this)
+    override fun newBasedOn(resolver: Resolver): List<Pattern> = listOf(this)
 
     override fun parse(value: String, resolver: Resolver): Value =
         when(value.trim()) {

--- a/core/src/main/kotlin/in/specmatic/core/pattern/NumberPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/NumberPattern.kt
@@ -20,6 +20,7 @@ object NumberPattern : Pattern, ScalarType {
 
     private fun randomNumber(bound: Int) = Random().nextInt(bound)
     override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> = listOf(this)
+    override fun newBasedOn(resolver: Resolver): List<Pattern> = listOf(this)
     override fun parse(value: String, resolver: Resolver): Value {
         return NumberValue(convertToNumber(value))
     }

--- a/core/src/main/kotlin/in/specmatic/core/pattern/Pattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/Pattern.kt
@@ -17,6 +17,7 @@ interface Pattern {
 
     fun generate(resolver: Resolver): Value
     fun newBasedOn(row: Row, resolver: Resolver): List<Pattern>
+    fun newBasedOn(resolver: Resolver): List<Pattern>
     fun parse(value: String, resolver: Resolver): Value
 
     fun patternSet(resolver: Resolver): List<Pattern> = listOf(this)

--- a/core/src/main/kotlin/in/specmatic/core/pattern/PatternInStringPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/PatternInStringPattern.kt
@@ -25,6 +25,9 @@ data class PatternInStringPattern(override val pattern: Pattern = StringPattern,
     override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> =
             pattern.newBasedOn(row, resolver).map { PatternInStringPattern(it) }
 
+    override fun newBasedOn(resolver: Resolver): List<Pattern> =
+            pattern.newBasedOn(resolver).map { PatternInStringPattern(it) }
+
     override fun parse(value: String, resolver: Resolver): Value = StringValue(pattern.parse(value, resolver).toStringValue())
 
     override fun patternSet(resolver: Resolver): List<PatternInStringPattern> =

--- a/core/src/main/kotlin/in/specmatic/core/pattern/RestPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/RestPattern.kt
@@ -13,6 +13,7 @@ data class RestPattern(override val pattern: Pattern, override val typeAlias: St
 
     override fun generate(resolver: Resolver): Value = listPattern.generate(resolver)
     override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> = pattern.newBasedOn(row, resolver).map { RestPattern(it) }
+    override fun newBasedOn(resolver: Resolver): List<Pattern> = pattern.newBasedOn(resolver).map { RestPattern(it) }
     override fun parse(value: String, resolver: Resolver): Value = listPattern.parse(value, resolver)
 
     override fun patternSet(resolver: Resolver): List<Pattern> =

--- a/core/src/main/kotlin/in/specmatic/core/pattern/StringPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/StringPattern.kt
@@ -32,6 +32,7 @@ object StringPattern : Pattern, ScalarType {
     override fun generate(resolver: Resolver): Value = StringValue(randomString())
 
     override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> = listOf(this)
+    override fun newBasedOn(resolver: Resolver): List<Pattern> = listOf(this)
     override fun parse(value: String, resolver: Resolver): Value = StringValue(value)
     override val typeName: String = "string"
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/URLPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/URLPattern.kt
@@ -26,6 +26,8 @@ data class URLPattern(val scheme: URLScheme = URLScheme.HTTPS, override val type
 
     override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> = listOf(this)
 
+    override fun newBasedOn(resolver: Resolver): List<Pattern> = listOf(this)
+
     override fun parse(value: String, resolver: Resolver): StringValue = StringValue(URI.create(value).toString())
 
     override fun encompasses(otherPattern: Pattern, thisResolver: Resolver, otherResolver: Resolver, typeStack: TypeStack): Result {

--- a/core/src/main/kotlin/in/specmatic/core/pattern/XMLPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/XMLPattern.kt
@@ -47,17 +47,17 @@ data class XMLPattern(override val pattern: XMLTypeData = XMLTypeData(realName =
     }
 
     private fun matchesRequiredNode(
-        xmlValues: List<XMLValue>,
-        sampleData: List<Value>,
-        resolver: Resolver
+            xmlValues: List<XMLValue>,
+            sampleData: List<Value>,
+            resolver: Resolver
     ): ConsumeResult<Value, Value> = if (xmlValues.isEmpty())
         ConsumeResult(Failure("Didn't get enough values", breadCrumb = this.pattern.name), sampleData)
     else
         ConsumeResult(matches(xmlValues.first(), resolver), xmlValues.drop(1))
 
     private fun matchesMultipleNodes(
-        xmlValues: List<XMLValue>,
-        resolver: Resolver
+            xmlValues: List<XMLValue>,
+            resolver: Resolver
     ): ConsumeResult<Value, Value> {
         val remainder = xmlValues.dropWhile {
             matches(it, resolver) is Success
@@ -67,9 +67,9 @@ data class XMLPattern(override val pattern: XMLTypeData = XMLTypeData(realName =
             ConsumeResult(matches(remainder.first(), resolver), remainder)
         } else if (remainder.isNotEmpty()) {
             val provisionalError = ProvisionalError<Value>(
-                matches(remainder.first(), resolver) as Failure,
-                this,
-                remainder.first()
+                    matches(remainder.first(), resolver) as Failure,
+                    this,
+                    remainder.first()
             )
             ConsumeResult(Success(), remainder, provisionalError)
         } else {
@@ -78,8 +78,8 @@ data class XMLPattern(override val pattern: XMLTypeData = XMLTypeData(realName =
     }
 
     private fun matchesOptionalNode(
-        xmlValues: List<XMLValue>,
-        resolver: Resolver
+            xmlValues: List<XMLValue>,
+            resolver: Resolver
     ): ConsumeResult<Value, Value> = if (xmlValues.isEmpty())
         ConsumeResult(Success())
     else {
@@ -117,24 +117,24 @@ data class XMLPattern(override val pattern: XMLTypeData = XMLTypeData(realName =
     }
 
     private fun matchNodes(
-        sampleData: XMLNode,
-        resolver: Resolver
+            sampleData: XMLNode,
+            resolver: Resolver
     ): Result {
         val results = pattern.nodes.scanIndexed(
-            ConsumeResult<XMLValue, Value>(
-                Success(),
-                sampleData.childNodes
-            )
+                ConsumeResult<XMLValue, Value>(
+                        Success(),
+                        sampleData.childNodes
+                )
         ) { index, consumeResult, type ->
             when (val resolvedType = resolvedHop(type, resolver)) {
                 is ListPattern -> ConsumeResult(
-                    resolvedType.matches(
-                        this.listOf(
-                            consumeResult.remainder.subList(index, pattern.nodes.indices.last),
-                            resolver
-                        ), resolver
-                    ),
-                    emptyList()
+                        resolvedType.matches(
+                                this.listOf(
+                                        consumeResult.remainder.subList(index, pattern.nodes.indices.last),
+                                        resolver
+                                ), resolver
+                        ),
+                        emptyList()
                 )
                 else -> {
                     try {
@@ -144,8 +144,8 @@ data class XMLPattern(override val pattern: XMLTypeData = XMLTypeData(realName =
                                     childNode.isPatternToken() -> childNode.trimmed()
                                     else -> {
                                         attempt(
-                                            "Couldn't read value ${childNode.string} as type ${resolvedType.pattern}",
-                                            breadCrumb = breadCrumbIfXMLTag(resolvedType)
+                                                "Couldn't read value ${childNode.string} as type ${resolvedType.pattern}",
+                                                breadCrumb = breadCrumbIfXMLTag(resolvedType)
                                         ) { resolvedType.parse(childNode.string, resolver) }
                                     }
                                 }
@@ -187,11 +187,11 @@ data class XMLPattern(override val pattern: XMLTypeData = XMLTypeData(realName =
                     results.find {
                         it.provisionalError != null
                     }?.provisionalError?.result
-                        ?: if(results.last().remainder.size == 1) {
-                            Failure("Unexpected value found: ${results.last().remainder.first().toStringValue()}")
-                        }else {
-                            Failure("Unexpected values found: ${results.last().remainder.joinToString(", ") { it.toStringValue() }}")
-                        }
+                            ?: if (results.last().remainder.size == 1) {
+                                Failure("Unexpected value found: ${results.last().remainder.first().toStringValue()}")
+                            } else {
+                                Failure("Unexpected values found: ${results.last().remainder.joinToString(", ") { it.toStringValue() }}")
+                            }
                 }
                 else -> null
             }
@@ -203,29 +203,29 @@ data class XMLPattern(override val pattern: XMLTypeData = XMLTypeData(realName =
     private fun matchNamespaces(sampleData: XMLNode): Result {
         if (pattern.attributes.any { it.key == "xmlns" || it.key.startsWith("xmlns:") }) {
             val patternXmlnsValues =
-                pattern.attributes.entries.filter { it.key == "xmlns" || it.key.startsWith("xmlns:") }
-                    .map { (_, attributePattern) ->
-                        when (attributePattern) {
-                            is ExactValuePattern -> attributePattern.pattern.toStringValue()
-                            else -> attributePattern.pattern.toString()
-                        }
-                    }.toSet()
+                    pattern.attributes.entries.filter { it.key == "xmlns" || it.key.startsWith("xmlns:") }
+                            .map { (_, attributePattern) ->
+                                when (attributePattern) {
+                                    is ExactValuePattern -> attributePattern.pattern.toStringValue()
+                                    else -> attributePattern.pattern.toString()
+                                }
+                            }.toSet()
             val sampleXmlnsValues =
-                sampleData.attributes.entries.filter { it.key == "xmlns" || it.key.startsWith("xmlns:") }
-                    .map { (_, attributeValue) ->
-                        attributeValue.toStringValue()
-                    }.toSet()
+                    sampleData.attributes.entries.filter { it.key == "xmlns" || it.key.startsWith("xmlns:") }
+                            .map { (_, attributeValue) ->
+                                attributeValue.toStringValue()
+                            }.toSet()
 
             val missing = patternXmlnsValues - sampleXmlnsValues
             if (missing.isNotEmpty())
                 Failure(
-                    "In node named ${pattern.name}, the following namespaces were missing: $missing",
+                        "In node named ${pattern.name}, the following namespaces were missing: $missing",
                 )
 
             val extra = sampleXmlnsValues - patternXmlnsValues
             if (extra.isNotEmpty())
                 return Failure(
-                    "In node named ${pattern.name}, the following unexpected namespaces were found: $extra",
+                        "In node named ${pattern.name}, the following unexpected namespaces were found: $extra",
                 )
         }
 
@@ -241,9 +241,9 @@ data class XMLPattern(override val pattern: XMLTypeData = XMLTypeData(realName =
         }
 
         val missingKey = resolver.findMissingKey(
-            ignoreXMLNamespaces(patternAttributesWithoutXmlns),
-            ignoreXMLNamespaces(sampleAttributesWithoutXmlns),
-            ::validateUnexpectedKeys
+                ignoreXMLNamespaces(patternAttributesWithoutXmlns),
+                ignoreXMLNamespaces(sampleAttributesWithoutXmlns),
+                ::validateUnexpectedKeys
         )
         if (missingKey != null)
             return missingKeyToResult(missingKey, "attribute")
@@ -259,27 +259,27 @@ data class XMLPattern(override val pattern: XMLTypeData = XMLTypeData(realName =
     }
 
     private fun matchAttributes(
-        patternAttributesWithoutXmlns: Map<String, Pattern>,
-        sampleAttributesWithoutXmlns: Map<String, StringValue>,
-        resolver: Resolver
+            patternAttributesWithoutXmlns: Map<String, Pattern>,
+            sampleAttributesWithoutXmlns: Map<String, StringValue>,
+            resolver: Resolver
     ): Result =
-        mapZip(
-            ignoreXMLNamespaces(patternAttributesWithoutXmlns),
-            ignoreXMLNamespaces(sampleAttributesWithoutXmlns)
-        ).asSequence().map { (key, patternValue, sampleValue) ->
-            try {
-                val resolvedValue: Value = when {
-                    sampleValue.isPatternToken() -> sampleValue.trimmed()
-                    else -> patternValue.parse(sampleValue.string, resolver)
-                }
-                resolver.matchesPattern(key, patternValue, resolvedValue)
-            } catch (e: ContractException) {
-                e.failure()
-            }.breadCrumb(key)
-        }.find { it is Failure } ?: Success()
+            mapZip(
+                    ignoreXMLNamespaces(patternAttributesWithoutXmlns),
+                    ignoreXMLNamespaces(sampleAttributesWithoutXmlns)
+            ).asSequence().map { (key, patternValue, sampleValue) ->
+                try {
+                    val resolvedValue: Value = when {
+                        sampleValue.isPatternToken() -> sampleValue.trimmed()
+                        else -> patternValue.parse(sampleValue.string, resolver)
+                    }
+                    resolver.matchesPattern(key, patternValue, resolvedValue)
+                } catch (e: ContractException) {
+                    e.failure()
+                }.breadCrumb(key)
+            }.find { it is Failure } ?: Success()
 
     private fun <ValueType> ignoreXMLNamespaces(attributes: Map<String, ValueType>): Map<String, ValueType> =
-        attributes.filterNot { it.key.toLowerCase().startsWith("xmlns:") }
+            attributes.filterNot { it.key.toLowerCase().startsWith("xmlns:") }
 
     private fun expectingEmpty(sampleData: XMLNode, type: Pattern, resolver: Resolver): Boolean {
         val resolvedPatternSet = type.patternSet(resolver).map { resolvedHop(it, resolver) }
@@ -308,9 +308,9 @@ data class XMLPattern(override val pattern: XMLTypeData = XMLTypeData(realName =
                 when {
                     pattern is ListPattern -> (pattern.generate(resolver) as XMLNode).childNodes
                     pattern is XMLPattern && pattern.occurMultipleTimes() -> 0.until(randomNumber(RANDOM_NUMBER_CEILING))
-                        .map {
-                            pattern.generate(resolver)
-                        }
+                            .map {
+                                pattern.generate(resolver)
+                            }
                     else -> listOf(pattern.generate(resolver))
                 }
             }
@@ -340,7 +340,7 @@ data class XMLPattern(override val pattern: XMLTypeData = XMLTypeData(realName =
                             throw ContractException("Node ${pattern.name} is empty but an example with this name exists")
 
                         val parsedData =
-                            dereferenced.pattern.nodes[0].parse(row.getField(dereferenced.pattern.name), resolver)
+                                dereferenced.pattern.nodes[0].parse(row.getField(dereferenced.pattern.name), resolver)
                         val matchResult = dereferenced.pattern.nodes[0].matches(parsedData, resolver)
 
                         if (matchResult is Failure)
@@ -379,6 +379,41 @@ data class XMLPattern(override val pattern: XMLTypeData = XMLTypeData(realName =
         }
     }
 
+    override fun newBasedOn(resolver: Resolver): List<XMLPattern> {
+        return allOrNothingCombinationIn(pattern.attributes) { attributePattern ->
+            attempt(breadCrumb = this.pattern.name) {
+                newBasedOn(attributePattern, resolver).map {
+                    it.mapKeys { entry -> withoutOptionality(entry.key) }
+                }
+            }
+        }.flatMap { newAttributes ->
+            val newNodesList = listCombinations(pattern.nodes.map { childPattern ->
+                attempt(breadCrumb = this.pattern.name) {
+                    when (childPattern) {
+                        is XMLPattern -> {
+                            val dereferenced: XMLPattern = childPattern.dereferenceType(resolver)
+
+                            when {
+                                dereferenced.occurMultipleTimes() -> {
+                                    childPattern.newBasedOn(resolver)
+                                }
+                                dereferenced.isOptional() -> {
+                                    childPattern.newBasedOn(resolver).plus(null)
+                                }
+                                else -> childPattern.newBasedOn(resolver)
+                            }
+                        }
+                        else -> childPattern.newBasedOn(resolver)
+                    }
+                }
+            })
+
+            newNodesList.map { newNodes ->
+                XMLPattern(XMLTypeData(pattern.name, pattern.realName, newAttributes, newNodes))
+            }
+        }
+    }
+
     private fun dereferenceType(resolver: Resolver): XMLPattern {
         if (!hasType()) {
             return this
@@ -388,10 +423,10 @@ data class XMLPattern(override val pattern: XMLTypeData = XMLTypeData(realName =
         val resolved = resolver.getPattern("($qontractType)") as XMLPattern
         val qontractAttributes = this.pattern.attributes.filterKeys { it.startsWith(SPECMATIC_XML_ATTRIBUTE_PREFIX) }
         return resolved.copy(
-            pattern = resolved.pattern.copy(
-                name = this.pattern.name,
-                attributes = resolved.pattern.attributes.plus(qontractAttributes)
-            )
+                pattern = resolved.pattern.copy(
+                        name = this.pattern.name,
+                        attributes = resolved.pattern.attributes.plus(qontractAttributes)
+                )
         )
     }
 
@@ -406,26 +441,26 @@ data class XMLPattern(override val pattern: XMLTypeData = XMLTypeData(realName =
     }
 
     override fun encompasses(
-        otherPattern: Pattern,
-        thisResolver: Resolver,
-        otherResolver: Resolver,
-        typeStack: TypeStack
+            otherPattern: Pattern,
+            thisResolver: Resolver,
+            otherResolver: Resolver,
+            typeStack: TypeStack
     ): Result {
         val otherResolvedPattern = resolvedHop(otherPattern, otherResolver)
 
         return when (otherResolvedPattern) {
             is ExactValuePattern -> otherResolvedPattern.fitsWithin(
-                listOf(this),
-                otherResolver,
-                thisResolver,
-                typeStack
+                    listOf(this),
+                    otherResolver,
+                    thisResolver,
+                    typeStack
             )
             is XMLPattern -> nodeNamesShouldBeEqual(otherResolvedPattern).ifSuccess {
                 mapEncompassesMap(
-                    pattern.attributes.filterNot { it.key.startsWith(SPECMATIC_XML_ATTRIBUTE_PREFIX) },
-                    otherResolvedPattern.pattern.attributes.filterNot { it.key.startsWith(SPECMATIC_XML_ATTRIBUTE_PREFIX) },
-                    thisResolver,
-                    otherResolver
+                        pattern.attributes.filterNot { it.key.startsWith(SPECMATIC_XML_ATTRIBUTE_PREFIX) },
+                        otherResolvedPattern.pattern.attributes.filterNot { it.key.startsWith(SPECMATIC_XML_ATTRIBUTE_PREFIX) },
+                        thisResolver,
+                        otherResolver
                 )
             }.ifSuccess {
                 thisOccurrenceEncompassesTheOther(this, otherResolvedPattern)
@@ -439,37 +474,37 @@ data class XMLPattern(override val pattern: XMLTypeData = XMLTypeData(realName =
                 val adaptedOthers = adapt(others, otherResolver)
 
                 val results =
-                    these.runningFold(ConsumeResult<Pattern, Pattern>(adaptedOthers)) { consumeResult, thisOne ->
-                        val unmatched = consumeResult.remainder.dropWhile { otherOne ->
-                            val result = encompassResult(thisOne, otherOne, thisResolver, otherResolver, typeStack)
-                            result is Success
-                        }
+                        these.runningFold(ConsumeResult<Pattern, Pattern>(adaptedOthers)) { consumeResult, thisOne ->
+                            val unmatched = consumeResult.remainder.dropWhile { otherOne ->
+                                val result = encompassResult(thisOne, otherOne, thisResolver, otherResolver, typeStack)
+                                result is Success
+                            }
 
-                        if (unmatched.size == consumeResult.remainder.size) {
-                            val failure = encompassResult(
-                                thisOne,
-                                unmatched.first(),
-                                thisResolver,
-                                otherResolver,
-                                typeStack
-                            ) as Failure
-                            ConsumeResult(failure, unmatched)
-                        } else {
-                            val provisionalError: ProvisionalError<Pattern>? =
-                                unmatched.firstOrNull()?.let { unmatchedPattern ->
-                                    val failure = encompassResult(
+                            if (unmatched.size == consumeResult.remainder.size) {
+                                val failure = encompassResult(
                                         thisOne,
-                                        unmatchedPattern,
+                                        unmatched.first(),
                                         thisResolver,
                                         otherResolver,
                                         typeStack
-                                    ) as Failure
-                                    ProvisionalError(failure, thisOne, unmatchedPattern)
-                                }
+                                ) as Failure
+                                ConsumeResult(failure, unmatched)
+                            } else {
+                                val provisionalError: ProvisionalError<Pattern>? =
+                                        unmatched.firstOrNull()?.let { unmatchedPattern ->
+                                            val failure = encompassResult(
+                                                    thisOne,
+                                                    unmatchedPattern,
+                                                    thisResolver,
+                                                    otherResolver,
+                                                    typeStack
+                                            ) as Failure
+                                            ProvisionalError(failure, thisOne, unmatchedPattern)
+                                        }
 
-                            ConsumeResult(Success(), unmatched, provisionalError)
+                                ConsumeResult(Success(), unmatched, provisionalError)
+                            }
                         }
-                    }
 
                 val failureResult = results.find { it.result is Failure }?.result
 
@@ -489,19 +524,19 @@ data class XMLPattern(override val pattern: XMLTypeData = XMLTypeData(realName =
     }
 
     private fun encompassResult(
-        thisOne: Pattern,
-        otherOne: Pattern,
-        thisResolver: Resolver,
-        otherResolver: Resolver,
-        typeStack: TypeStack
+            thisOne: Pattern,
+            otherOne: Pattern,
+            thisResolver: Resolver,
+            otherResolver: Resolver,
+            typeStack: TypeStack
     ): Result {
         return try {
             val otherOneAdjustedForExactValue = when {
                 otherOne is ExactValuePattern && otherOne.pattern is StringValue -> ExactValuePattern(
-                    thisOne.parse(
-                        otherOne.pattern.string,
-                        thisResolver
-                    )
+                        thisOne.parse(
+                                otherOne.pattern.string,
+                                thisResolver
+                        )
                 )
                 else -> otherOne
             }
@@ -550,16 +585,16 @@ data class XMLPattern(override val pattern: XMLTypeData = XMLTypeData(realName =
                 throw ContractException("A list specification inside an XML definition must refer to an XML type. But $typeName is not an XML type.")
 
             val multipleOccursAttribute =
-                mapOf(OCCURS_ATTRIBUTE_NAME to ExactValuePattern(StringValue(MULTIPLE_ATTRIBUTE_VALUE)))
+                    mapOf(OCCURS_ATTRIBUTE_NAME to ExactValuePattern(StringValue(MULTIPLE_ATTRIBUTE_VALUE)))
 
             return listOf(
-                type.copy(
-                    pattern = type.pattern.copy(
-                        attributes = type.pattern.attributes.plus(
-                            multipleOccursAttribute
-                        )
+                    type.copy(
+                            pattern = type.pattern.copy(
+                                    attributes = type.pattern.attributes.plus(
+                                            multipleOccursAttribute
+                                    )
+                            )
                     )
-                )
             )
         }
 

--- a/core/src/test/kotlin/in/specmatic/core/TestBackwardCompatibilityKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/TestBackwardCompatibilityKtTest.kt
@@ -6,7 +6,7 @@ import kotlin.test.assertEquals
 
 internal class TestBackwardCompatibilityKtTest {
     @Test
-    fun `contract backward compatibility should break when one has an optional key and the other does not` () {
+    fun `contract backward compatibility should break when one has an optional key and the other does not`() {
         val gherkin1 = """
 Feature: Older contract API
 
@@ -20,7 +20,7 @@ Then status 200
     """.trim()
 
         val gherkin2 = """
-Feature: Older contract API
+Feature: Newer contract API
 
 Scenario: api call
 Given json Value
@@ -43,7 +43,43 @@ Then status 200
     }
 
     @Test
-    fun `contract backward compatibility should not break when both have an optional keys` () {
+    fun `contract backward compatibility should break when there is incompatibility one level down`() {
+        val gherkin1 = """
+Feature: Old contract
+  Scenario: Test Scenario
+    Given type RequestBody
+    | address? | (Address?) |
+    And type Address
+    | street | (string) |
+    When POST /
+    And request-body (RequestBody)
+    Then status 200
+    """.trim()
+
+        val gherkin2 = """
+Feature: New contract
+  Scenario: Test Scenario
+    Given type RequestBody
+    | address? | (Address?) |
+    And type Address
+    | street | (number) |
+    When POST /
+    And request-body (RequestBody)
+    Then status 200
+    """.trim()
+
+        val olderContract = parseGherkinStringToFeature(gherkin1)
+        val newerContract = parseGherkinStringToFeature(gherkin2)
+
+        val result: Results = testBackwardCompatibilityInParallel(olderContract, newerContract)
+
+        println(result.report())
+
+        assertEquals(1, result.failureCount)
+    }
+
+    @Test
+    fun `contract backward compatibility should not break when both have an optional keys`() {
         val gherkin1 = """
 Feature: API contract
 
@@ -82,7 +118,7 @@ Then status 200
     }
 
     @Test
-    fun `contract backward compatibility should break when a new fact is added` () {
+    fun `contract backward compatibility should break when a new fact is added`() {
         val gherkin1 = """
 Feature: Older contract API
 
@@ -132,7 +168,7 @@ Then status 200
 
         val results: Results = testBackwardCompatibilityInParallel(contract, contract)
 
-        if(results.failureCount > 0)
+        if (results.failureCount > 0)
             println(results.report())
 
         assertEquals(1, results.successCount)
@@ -154,7 +190,7 @@ Then status 200
 
         val results: Results = testBackwardCompatibilityInParallel(contract, contract)
 
-        if(results.failureCount > 0)
+        if (results.failureCount > 0)
             println(results.report())
 
         assertEquals(2, results.successCount)
@@ -176,7 +212,7 @@ Then status 200
 
         val results: Results = testBackwardCompatibilityInParallel(contract, contract)
 
-        if(results.failureCount > 0)
+        if (results.failureCount > 0)
             println(results.report())
 
         assertEquals(2, results.successCount)
@@ -200,7 +236,7 @@ Then status 200
 
         val results: Results = testBackwardCompatibilityInParallel(contract, contract)
 
-        if(results.failureCount > 0)
+        if (results.failureCount > 0)
             println(results.report())
 
         assertEquals(2, results.successCount)
@@ -222,7 +258,7 @@ And response-body (number?)
 
         val results: Results = testBackwardCompatibilityInParallel(contract, contract)
 
-        if(results.failureCount > 0)
+        if (results.failureCount > 0)
             println(results.report())
 
         assertEquals(1, results.successCount)
@@ -246,7 +282,7 @@ And response-body (Number)
 
         val results: Results = testBackwardCompatibilityInParallel(contract, contract)
 
-        if(results.failureCount > 0)
+        if (results.failureCount > 0)
             println(results.report())
 
         assertEquals(1, results.successCount)
@@ -397,7 +433,7 @@ And response-body (number)
 
         val results: Results = testBackwardCompatibilityInParallel(contract, contract)
 
-        if(results.failureCount > 0)
+        if (results.failureCount > 0)
             println(results.report())
 
         assertEquals(1, results.successCount)
@@ -422,7 +458,7 @@ And response-body (number)
 
         val results: Results = testBackwardCompatibilityInParallel(contract, contract)
 
-        if(results.failureCount > 0)
+        if (results.failureCount > 0)
             println(results.report())
 
         assertEquals(1, results.successCount)
@@ -457,7 +493,7 @@ And response-body (number)
 
         val results: Results = testBackwardCompatibilityInParallel(parseGherkinStringToFeature(gherkin1), parseGherkinStringToFeature(gherkin2))
 
-        if(results.failureCount > 0)
+        if (results.failureCount > 0)
             println(results.report())
 
         assertEquals(0, results.successCount)
@@ -488,7 +524,7 @@ Then status 200
 
         val results: Results = testBackwardCompatibilityInParallel(parseGherkinStringToFeature(gherkin1), parseGherkinStringToFeature(gherkin2))
 
-        if(results.failureCount > 0)
+        if (results.failureCount > 0)
             println(results.report())
 
         assertThat(results.successCount).isZero()
@@ -518,7 +554,7 @@ Then status 200
 
         val results: Results = testBackwardCompatibilityInParallel(parseGherkinStringToFeature(gherkin1), parseGherkinStringToFeature(gherkin2))
 
-        if(results.failureCount > 0)
+        if (results.failureCount > 0)
             println(results.report())
 
         assertThat(results.successCount).isOne()


### PR DESCRIPTION
**What**:

Removing combinations based backward compatibility test on optional fields and values

**Why**:

It was leading to out of memory exceptions when specification has too many optional fields

**How**:

One request with all optional fields set to null and another request with all optional fields being sent in older spec

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #209 

<!-- feel free to add additional comments -->
