### PR TITLE
Verify optional keys even when their values are not optional

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/pattern/TabularPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/TabularPattern.kt
@@ -170,14 +170,16 @@ fun <ValueType> patternValues(patternCollection: Map<String, List<ValueType>>): 
     val singleValues = patternCollection.filter { entry -> !optionalValues(entry) }
 
     val singleValuesSetToValues = singleValues.map { entry ->
-        Pair(entry.key, entry.value.first())
-    }.toMap()
+        entry.value.map {
+            Pair(entry.key, it)
+        }
+    }.flatten().toMap()
 
-    return if (patternCollection.any { entry -> entry.value.size > 1 }) {
+    return if (patternCollection.any { entry -> optionalValues(entry) }) {
         listOf(optionalValuesSetToNull.plus(singleValuesSetToValues),
                 optionalValuesSetToValue.plus(singleValuesSetToValues))
     } else {
-        listOf(singleValuesSetToValues)
+       listOf(singleValuesSetToValues)
     }
 }
 


### PR DESCRIPTION
**What**: When optional keys have mandatory values, only the first possibility for the key was considered. It is now changed to consider all possibilities.

**Why**:

**How**:

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the README.md OR link to PR on https://github.com/qontract/qontract-documentation
- [x] Tests
- [x] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #217 

<!-- feel free to add additional comments -->
