### PR TITLE
Xml issues

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/pattern/JSONArrayPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/JSONArrayPattern.kt
@@ -161,6 +161,24 @@ fun listCombinations(values: List<List<Pattern?>>): List<List<Pattern>> {
     }
 }
 
+fun allOrNothingListCombinations(values: List<List<Pattern?>>): List<List<Pattern>> {
+    if(values.isEmpty())
+        return listOf(emptyList())
+
+    val optionalKeys = values.filter { it.size == 2 }
+    val optionalKeysSetToNonNullValues = optionalKeys.map { it.filter { it != null } }.flatten()
+
+    val mandatoryKeys = values.filter { it.size == 1 }.flatten()
+
+    val keyLists = if (values.any{ it.size == 2}) {
+        listOf(mandatoryKeys.plus(optionalKeysSetToNonNullValues), mandatoryKeys)
+    } else {
+        listOf(mandatoryKeys)
+    }
+
+    return keyLists as List<List<Pattern>>
+}
+
 fun generate(jsonPattern: List<Pattern>, resolver: Resolver): List<Value> =
     jsonPattern.mapIndexed { index, pattern ->
         when (pattern) {

--- a/core/src/main/kotlin/in/specmatic/core/pattern/XMLPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/XMLPattern.kt
@@ -387,10 +387,8 @@ data class XMLPattern(override val pattern: XMLTypeData = XMLTypeData(realName =
                 }
             }
         }.flatMap { newAttributes ->
-            val newNodesList = listCombinations(pattern.nodes.map { childPattern ->
+            val newNodesList = allOrNothingListCombinations(pattern.nodes.map { childPattern ->
                 attempt(breadCrumb = this.pattern.name) {
-                    /*
-                    TODO: Why do we have to add the null when XMLPattern is optional?
                     when (childPattern) {
                         is XMLPattern -> {
                             val dereferenced: XMLPattern = childPattern.dereferenceType(resolver)
@@ -406,8 +404,7 @@ data class XMLPattern(override val pattern: XMLTypeData = XMLTypeData(realName =
                             }
                         }
                         else -> childPattern.newBasedOn(resolver)
-                    }*/
-                    childPattern.newBasedOn(resolver)
+                    }
                 }
             })
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/XMLPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/XMLPattern.kt
@@ -389,6 +389,8 @@ data class XMLPattern(override val pattern: XMLTypeData = XMLTypeData(realName =
         }.flatMap { newAttributes ->
             val newNodesList = listCombinations(pattern.nodes.map { childPattern ->
                 attempt(breadCrumb = this.pattern.name) {
+                    /*
+                    TODO: Why do we have to add the null when XMLPattern is optional?
                     when (childPattern) {
                         is XMLPattern -> {
                             val dereferenced: XMLPattern = childPattern.dereferenceType(resolver)
@@ -404,7 +406,8 @@ data class XMLPattern(override val pattern: XMLTypeData = XMLTypeData(realName =
                             }
                         }
                         else -> childPattern.newBasedOn(resolver)
-                    }
+                    }*/
+                    childPattern.newBasedOn(resolver)
                 }
             })
 

--- a/core/src/test/kotlin/in/specmatic/core/TestBackwardCompatibilityKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/TestBackwardCompatibilityKtTest.kt
@@ -597,4 +597,66 @@ Then status 200
         assertThat(results.failureCount).isZero()
         assertThat(results.success()).isTrue()
     }
+
+    @Test
+    fun `two xml contracts should not be backward compatibility when optional key is made mandatory in request`() {
+        val gherkin1 = """
+Feature: Contract API
+
+Scenario: api call
+When POST /data
+  And request-body <ns1:customer xmlns:ns1="http://example.com/customer"><name specmatic_occurs="optional">(string)</name></ns1:customer>
+Then status 200
+    """.trim()
+
+        val gherkin2 = """
+Feature: Contract API
+
+Scenario: api call
+When POST /data
+  And request-body <ns2:customer xmlns:ns2="http://example.com/customer"><name>(string)</name></ns2:customer>
+Then status 200
+    """.trim()
+
+        val results: Results = testBackwardCompatibility(parseGherkinStringToFeature(gherkin1), parseGherkinStringToFeature(gherkin2))
+
+        if (results.failureCount > 0)
+            println(results.report())
+
+        assertThat(results.successCount).isOne()
+        assertThat(results.failureCount).isOne()
+        assertThat(results.success()).isFalse()
+    }
+
+    @Test
+    fun `two xml contracts should not be backward compatibility when mandatory key is made optional in response`() {
+        val gherkin1 = """
+Feature: Contract API
+
+Scenario: api call
+When POST /data
+  And request-body "test"
+Then status 200
+  And response-body <ns1:customer xmlns:ns1="http://example.com/customer"><name>(string)</name></ns1:customer>
+    """.trim()
+
+        val gherkin2 = """
+Feature: Contract API
+
+Scenario: api call
+When POST /data
+  And request-body "test"
+Then status 200
+  And response-body <ns1:customer xmlns:ns1="http://example.com/customer"><name specmatic_occurs="optional">(string)</name></ns1:customer>
+    """.trim()
+
+        val results: Results = testBackwardCompatibility(parseGherkinStringToFeature(gherkin1), parseGherkinStringToFeature(gherkin2))
+
+        if (results.failureCount > 0)
+            println(results.report())
+
+        assertThat(results.successCount).isZero()
+        assertThat(results.failureCount).isOne()
+        assertThat(results.success()).isFalse()
+    }
 }


### PR DESCRIPTION
**What**:

Fixing slow XML Compatibility

**Why**:

When there are several optional keys in XML, compatibility generates all combinations of optional keys. This leads to Out of Memory.

**How**:

Replace combinations by sending all optionals or not sending them.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the README.md OR link to PR on https://github.com/qontract/qontract-documentation
- [x] Tests
- [x] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #209 

<!-- feel free to add additional comments -->
