### PR TITLE
Backward Compatibility Optional Parents with Optional Children

### DIFF
--- a/core/src/test/kotlin/in/specmatic/core/TestBackwardCompatibilityKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/TestBackwardCompatibilityKtTest.kt
@@ -222,7 +222,7 @@ Feature: New contract
 
         println(result.report())
 
-        assertEquals(1, result.successCount)
+        assertEquals(2, result.successCount)
         assertEquals(1, result.failureCount)
     }
 

--- a/core/src/test/kotlin/in/specmatic/core/TestBackwardCompatibilityKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/TestBackwardCompatibilityKtTest.kt
@@ -190,6 +190,84 @@ Feature: New contract
     }
 
     @Test
+    fun `contract backward compatibility should break when optional key is made mandatory inside an optional parent`() {
+        val gherkin1 = """
+Feature: Old contract
+  Scenario: Test Scenario
+    Given type RequestBody
+    | address? | (Address) |
+    And type Address
+    | street? | (string) |
+    When POST /
+    And request-body (RequestBody)
+    Then status 200
+    """.trim()
+
+        val gherkin2 = """
+Feature: New contract
+  Scenario: Test Scenario
+    Given type RequestBody
+    | address? | (Address) |
+    And type Address
+    | street | (string) |
+    When POST /
+    And request-body (RequestBody)
+    Then status 200
+    """.trim()
+
+        val olderContract = parseGherkinStringToFeature(gherkin1)
+        val newerContract = parseGherkinStringToFeature(gherkin2)
+
+        val result: Results = testBackwardCompatibility(olderContract, newerContract)
+
+        println(result.report())
+
+        assertEquals(1, result.successCount)
+        assertEquals(1, result.failureCount)
+    }
+
+    @Test
+    fun `contract backward compatibility should break when optional key is made mandatory inside an optional parent two levels down`() {
+        val gherkin1 = """
+Feature: Old contract
+  Scenario: Test Scenario
+    Given type RequestBody
+    | person | (Person) |
+    And type Person
+    | address? | (Address) |
+    And type Address
+    | street? | (string) |
+    When POST /
+    And request-body (RequestBody)
+    Then status 200
+    """.trim()
+
+        val gherkin2 = """
+Feature: Old contract
+  Scenario: Test Scenario
+    Given type RequestBody
+    | person | (Person) |
+    And type Person
+    | address? | (Address) |
+    And type Address
+    | street | (string) |
+    When POST /
+    And request-body (RequestBody)
+    Then status 200
+    """.trim()
+
+        val olderContract = parseGherkinStringToFeature(gherkin1)
+        val newerContract = parseGherkinStringToFeature(gherkin2)
+
+        val result: Results = testBackwardCompatibility(olderContract, newerContract)
+
+        println(result.report())
+
+        assertEquals(1, result.successCount)
+        assertEquals(1, result.failureCount)
+    }
+
+    @Test
     fun `contract backward compatibility should break when mandatory key is made optional one level down in response`() {
         val gherkin1 = """
 Feature: Old contract

--- a/core/src/test/kotlin/in/specmatic/core/TestBackwardCompatibilityKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/TestBackwardCompatibilityKtTest.kt
@@ -306,6 +306,48 @@ Feature: New contract
     }
 
     @Test
+    fun `contract backward compatibility should break when mandatory key is made optional two levels down in response`() {
+        val gherkin1 = """
+Feature: Old contract
+  Scenario: Test Scenario
+    Given type ResponseBody
+    | person | (Person) |
+    And type Person
+    | address? | (Address) |
+    And type Address
+    | street | (string) |
+    When POST /
+    And request-body "test"
+    Then status 200
+    And response-body (ResponseBody)
+    """.trim()
+
+        val gherkin2 = """
+Feature: New contract
+  Scenario: Test Scenario
+    Given type ResponseBody
+    | person | (Person) |
+    And type Person
+    | address? | (Address) |
+    And type Address
+    | street? | (string) |
+    When POST /
+    And request-body "test"
+    Then status 200
+    And response-body (ResponseBody) 
+    """.trim()
+
+        val olderContract = parseGherkinStringToFeature(gherkin1)
+        val newerContract = parseGherkinStringToFeature(gherkin2)
+
+        val result: Results = testBackwardCompatibility(olderContract, newerContract)
+
+        println(result.report())
+
+        assertEquals(1, result.failureCount)
+    }
+
+    @Test
     fun `contract backward compatibility should not break when both have an optional keys`() {
         val gherkin1 = """
 Feature: API contract


### PR DESCRIPTION
**What**: JSON Backward Compatibility on optional Parents with optional Children

**Why**: At the moment we are excluding the entire parent if it is optional or including only one version of the optional parent with its optional child. So any changes to the child (Data Type, Optional) will not be considered in backward compatibility.

**How**: When there is an optional parent with optional child, there combinations are generated, one with all its optional children, one without optional children and the parent itself is null.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/qontract/qontract-documentation - N/A
- [x] Tests
- [x] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #225 

