### PR TITLE
Xml Backward Compatibility

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/pattern/JSONArrayPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/JSONArrayPattern.kt
@@ -175,17 +175,22 @@ fun allOrNothingListCombinations(values: List<List<Pattern?>>): List<List<Patter
     val mandatoryKeysWithOptionalChildren = mandatoryKeys.filter { it.size > 1 }
 
     val keyLists = if (optionalKeys.isNotEmpty()) {
+        val nonNullOptionals = optionalKeysWithoutOptionalChildren.map { it.filter { it != null } }.flatten()
         val allOptionals = if (optionalKeysWithOptionalChildren.isNotEmpty()) {
-            optionalKeysWithoutOptionalChildren.map { it.filter { it != null } }.flatten()
-                    .plus(optionalKeysWithOptionalChildren.map { it[0] })
-        } else optionalKeysWithoutOptionalChildren.map { it.filter { it != null } }.flatten()
+            listOf(nonNullOptionals.plus(optionalKeysWithOptionalChildren.map { it[0] }),
+                    nonNullOptionals.plus(optionalKeysWithOptionalChildren.map { it[1] }))
+        } else listOf(nonNullOptionals)
         if (mandatoryKeysWithOptionalChildren.isNotEmpty()) {
             val mandatoryFirstValues = mandatoryKeysWithOptionalChildren.map { it[0] }
             val mandatorySecondValues = mandatoryKeysWithOptionalChildren.map { it[1] }
             listOf(mandatoryFirstValues, mandatorySecondValues).map {
-                listOf(mandatoryKeysWithoutOptionalChildren.plus(it).plus(allOptionals), mandatoryKeysWithoutOptionalChildren.plus(it))
+                allOptionals.map { optionals ->
+                    listOf(mandatoryKeysWithoutOptionalChildren.plus(it).plus(optionals), mandatoryKeysWithoutOptionalChildren.plus(it))
+                }.flatten()
             }.flatten()
-        } else listOf(mandatoryKeysWithoutOptionalChildren.plus(allOptionals), mandatoryKeysWithoutOptionalChildren)
+        } else allOptionals.map { optionals ->
+            listOf(mandatoryKeysWithoutOptionalChildren.plus(optionals))
+        }.flatten().plus(listOf(mandatoryKeysWithoutOptionalChildren))
     } else {
         if (mandatoryKeysWithOptionalChildren.isNotEmpty()) {
             val mandatoryFirstValues = mandatoryKeysWithOptionalChildren.map { it[0] }

--- a/core/src/main/kotlin/in/specmatic/core/pattern/JSONArrayPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/JSONArrayPattern.kt
@@ -32,10 +32,10 @@ data class JSONArrayPattern(override val pattern: List<Pattern> = emptyList(), o
 
     @Throws(Exception::class)
     override fun matches(sampleData: Value?, resolver: Resolver): Result {
-        if(sampleData !is JSONArrayValue)
+        if (sampleData !is JSONArrayValue)
             return Result.Failure("Value is not a JSON array")
 
-        if(sampleData.list.isEmpty())
+        if (sampleData.list.isEmpty())
             return Result.Success()
 
         val resolverWithNumberType = withNumberType(withNullPattern(resolver))
@@ -81,6 +81,7 @@ data class JSONArrayPattern(override val pattern: List<Pattern> = emptyList(), o
         val resolverWithNullType = withNullPattern(resolver)
         return newBasedOn(pattern, resolverWithNullType).map { JSONArrayPattern(it) }
     }
+
     override fun parse(value: String, resolver: Resolver): Value = parsedJSON(value)
     override fun encompasses(otherPattern: Pattern, thisResolver: Resolver, otherResolver: Resolver, typeStack: TypeStack): Result {
         val thisResolverWithNullType = withNullPattern(thisResolver)
@@ -105,8 +106,8 @@ data class JSONArrayPattern(override val pattern: List<Pattern> = emptyList(), o
 
                     results.find {
                         it.result is Result.Failure
-                    }?.let {
-                        result -> result.result.breadCrumb("[${result.index}]")
+                    }?.let { result ->
+                        result.result.breadCrumb("[${result.index}]")
                     } ?: Result.Success()
                 }
             } catch (e: ContractException) {
@@ -145,7 +146,7 @@ fun newBasedOn(jsonPattern: List<Pattern>, resolver: Resolver): List<List<Patter
 }
 
 fun listCombinations(values: List<List<Pattern?>>): List<List<Pattern>> {
-    if(values.isEmpty())
+    if (values.isEmpty())
         return listOf(emptyList())
 
     val lastValueTypes: List<Pattern?> = values.last()
@@ -153,7 +154,7 @@ fun listCombinations(values: List<List<Pattern?>>): List<List<Pattern>> {
 
     return subLists.flatMap { subList ->
         lastValueTypes.map { lastValueType ->
-            if(lastValueType != null)
+            if (lastValueType != null)
                 subList.plus(lastValueType)
             else
                 subList
@@ -162,33 +163,39 @@ fun listCombinations(values: List<List<Pattern?>>): List<List<Pattern>> {
 }
 
 fun allOrNothingListCombinations(values: List<List<Pattern?>>): List<List<Pattern>> {
-    if(values.isEmpty())
+    if (values.isEmpty())
         return listOf(emptyList())
 
-    val optionalKeys = values.filter { it.size == 2 }
+    val optionalKeys = values.filter { it.contains(null) }
     val optionalKeysSetToNonNullValues = optionalKeys.map { it.filter { it != null } }.flatten()
 
-    val mandatoryKeys = values.filter { it.size == 1 }.flatten()
+    val mandatoryKeys = values.filter { !it.contains(null) }
+    val mandatoryKeysWithoutOptionalChildren = mandatoryKeys.filter { it.size == 1 }.flatten()
+    val mandatoryKeysWithOptionalChildren = mandatoryKeys.filter { it.size > 1 }
 
-    val keyLists = if (values.any{ it.size == 2}) {
-        listOf(mandatoryKeys.plus(optionalKeysSetToNonNullValues), mandatoryKeys)
+    val keyLists = if (!optionalKeys.isEmpty()) {
+        listOf(mandatoryKeysWithoutOptionalChildren.plus(optionalKeysSetToNonNullValues), mandatoryKeysWithoutOptionalChildren)
     } else {
-        listOf(mandatoryKeys)
+        listOf(mandatoryKeysWithoutOptionalChildren)
     }
 
-    return keyLists as List<List<Pattern>>
+    return if (!mandatoryKeysWithOptionalChildren.isEmpty()) {
+        mandatoryKeysWithOptionalChildren.flatten().map { pattern ->
+            keyLists.map { it.plus(pattern) }
+        }.flatten() as List<List<Pattern>>
+    } else keyLists as List<List<Pattern>>
 }
 
 fun generate(jsonPattern: List<Pattern>, resolver: Resolver): List<Value> =
-    jsonPattern.mapIndexed { index, pattern ->
-        when (pattern) {
-            is RestPattern -> attempt(breadCrumb = "[$index...${jsonPattern.lastIndex}]") {
-                val list = pattern.generate(resolver) as ListValue
-                list.list
+        jsonPattern.mapIndexed { index, pattern ->
+            when (pattern) {
+                is RestPattern -> attempt(breadCrumb = "[$index...${jsonPattern.lastIndex}]") {
+                    val list = pattern.generate(resolver) as ListValue
+                    list.list
+                }
+                else -> attempt(breadCrumb = "[$index]") { listOf(pattern.generate(resolver)) }
             }
-            else -> attempt(breadCrumb = "[$index]") { listOf(pattern.generate(resolver)) }
-        }
-    }.flatten()
+        }.flatten()
 
 const val RANDOM_NUMBER_CEILING = 10
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/XMLPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/XMLPattern.kt
@@ -34,6 +34,10 @@ data class XMLPattern(override val pattern: XMLTypeData = XMLTypeData(realName =
     constructor(node: XMLNode, typeAlias: String? = null) : this(toTypeData(node), typeAlias)
     constructor(xmlString: String, typeAlias: String? = null) : this(toXMLNode(parseXML(xmlString)), typeAlias)
 
+    fun toPrettyString(): String {
+        return pattern.toGherkinishNode().toPrettyStringValue()
+    }
+
     override fun matches(sampleData: List<Value>, resolver: Resolver): ConsumeResult<Value, Value> {
         val xmlValues = sampleData.filterIsInstance<XMLValue>()
         if (xmlValues.size != sampleData.size)
@@ -395,12 +399,12 @@ data class XMLPattern(override val pattern: XMLTypeData = XMLTypeData(realName =
 
                             when {
                                 dereferenced.occurMultipleTimes() -> {
-                                    childPattern.newBasedOn(resolver)
+                                    dereferenced.newBasedOn(resolver)
                                 }
                                 dereferenced.isOptional() -> {
-                                    childPattern.newBasedOn(resolver).plus(null)
+                                    dereferenced.newBasedOn(resolver).plus(null)
                                 }
-                                else -> childPattern.newBasedOn(resolver)
+                                else -> dereferenced.newBasedOn(resolver)
                             }
                         }
                         else -> childPattern.newBasedOn(resolver)
@@ -425,6 +429,7 @@ data class XMLPattern(override val pattern: XMLTypeData = XMLTypeData(realName =
         return resolved.copy(
                 pattern = resolved.pattern.copy(
                         name = this.pattern.name,
+                        realName = this.pattern.realName,
                         attributes = resolved.pattern.attributes.plus(qontractAttributes)
                 )
         )

--- a/core/src/test/kotlin/in/specmatic/core/pattern/XMLPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/XMLPatternTest.kt
@@ -171,6 +171,8 @@ internal class XMLPatternTest {
                 println(type)
             }
 
+            assertThat(testTypes.size).isEqualTo(2)
+
             assertThat(testTypes).contains("""
                 <person>
                   <name>(string)</name>
@@ -185,6 +187,56 @@ internal class XMLPatternTest {
                 <person>
                   <name>(string)</name>
                   <address specmatic_type="Address"/>
+                </person>
+                """.trimIndent())
+        }
+
+        @Test
+        fun `creates three combinations per optional field with optional children`() {
+            val personType = XMLPattern("""
+                <person>
+                    <name>(string)</name>
+                    <address specmatic_occurs="optional" specmatic_type="Address" />
+                </person>
+            """.trimIndent())
+
+            val addressType = XMLPattern("""
+                <SPECMATIC_TYPE>
+                    <flat_no specmatic_occurs="optional">(string)</flat_no>
+                    <street specmatic_occurs="optional">(string)</street>
+                </SPECMATIC_TYPE>
+            """.trimIndent())
+
+            val resolver = Resolver(newPatterns = mapOf("(Address)" to addressType))
+
+            val testTypes = personType.newBasedOn(resolver).map { it.toPrettyString() }
+
+            for (type in testTypes) {
+                println(type)
+            }
+
+            assertThat(testTypes.size).isEqualTo(3)
+
+            assertThat(testTypes).contains("""
+                <person>
+                  <name>(string)</name>
+                  <address specmatic_occurs="optional" specmatic_type="Address">
+                    <flat_no specmatic_occurs="optional">(string)</flat_no>
+                    <street specmatic_occurs="optional">(string)</street>
+                  </address>
+                </person>
+                """.trimIndent())
+
+            assertThat(testTypes).contains("""
+                <person>
+                  <name>(string)</name>
+                  <address specmatic_occurs="optional" specmatic_type="Address"/>
+                </person>
+                """.trimIndent())
+
+            assertThat(testTypes).contains("""
+                <person>
+                  <name>(string)</name>
                 </person>
                 """.trimIndent())
         }

--- a/core/src/test/kotlin/in/specmatic/core/pattern/XMLPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/XMLPatternTest.kt
@@ -167,6 +167,10 @@ internal class XMLPatternTest {
 
             val testTypes = personType.newBasedOn(resolver).map { it.toPrettyString() }
 
+            for(type in testTypes) {
+                println(type)
+            }
+
             assertThat(testTypes).contains("""
                 <person>
                   <name>(string)</name>

--- a/core/src/test/kotlin/in/specmatic/core/pattern/XMLPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/XMLPatternTest.kt
@@ -28,7 +28,7 @@ internal class XMLPatternTest {
             val resolver = Resolver(newPatterns = mapOf("(Item)" to itemType))
             val xmlValue = itemsType.generate(resolver) as XMLNode
 
-            for(node in xmlValue.childNodes.map { it as XMLNode }) {
+            for (node in xmlValue.childNodes.map { it as XMLNode }) {
                 assertThat(node.childNodes.size == 1)
                 assertThat(node.childNodes[0]).isInstanceOf(StringValue::class.java)
             }
@@ -102,7 +102,7 @@ internal class XMLPatternTest {
         }
 
         @Test
-        fun `list type should match multiple xml values of the same type` () {
+        fun `list type should match multiple xml values of the same type`() {
             val numberInfoPattern = XMLPattern("<number>(number)</number>")
             val resolver = Resolver(newPatterns = mapOf("(NumberInfo)" to numberInfoPattern))
             val answerPattern = XMLPattern("<answer>(NumberInfo*)</answer>")
@@ -148,7 +148,7 @@ internal class XMLPatternTest {
     @Nested
     inner class BackwardCompatibility {
         @Test
-        fun temp() {
+        fun `creates two combinations per mandatory field with optional children`() {
             val personType = XMLPattern("""
                 <person>
                     <name>(string)</name>
@@ -167,7 +167,7 @@ internal class XMLPatternTest {
 
             val testTypes = personType.newBasedOn(resolver).map { it.toPrettyString() }
 
-            for(type in testTypes) {
+            for (type in testTypes) {
                 println(type)
             }
 
@@ -184,8 +184,9 @@ internal class XMLPatternTest {
             assertThat(testTypes).contains("""
                 <person>
                   <name>(string)</name>
-                  <address specmatic_type="Address" />
-                </person>""".trimIndent())
+                  <address specmatic_type="Address"/>
+                </person>
+                """.trimIndent())
         }
 
         @Test
@@ -219,7 +220,7 @@ internal class XMLPatternTest {
         }
 
         @Test
-        fun `sanity check for pattern encompassing` () {
+        fun `sanity check for pattern encompassing`() {
             val numberInfoPattern = XMLPattern("<number>(number)</number>")
             val resolver = Resolver()
 
@@ -227,7 +228,7 @@ internal class XMLPatternTest {
         }
 
         @Test
-        fun `sanity check for pattern encompassing with raw values` () {
+        fun `sanity check for pattern encompassing with raw values`() {
             val numberInfoPattern = XMLPattern("<number>100</number>")
             val resolver = Resolver()
 
@@ -235,7 +236,7 @@ internal class XMLPatternTest {
         }
 
         @Test
-        fun `sanity check for xml with number type encompassing another with raw number` () {
+        fun `sanity check for xml with number type encompassing another with raw number`() {
             val pattern1 = XMLPattern("<number>(number)</number>")
             val pattern2 = XMLPattern("<number>100</number>")
             val resolver = Resolver()
@@ -244,16 +245,16 @@ internal class XMLPatternTest {
         }
 
         @Test
-        fun `pattern by name should encompass another pattern of the same structure` () {
+        fun `pattern by name should encompass another pattern of the same structure`() {
             val numberInfoPattern = XMLPattern("<number>(number)</number>")
             val resolver = Resolver(newPatterns = mapOf("(Number)" to XMLPattern("<number>(number)</number>")))
 
             assertThat(resolver.getPattern("(Number)").encompasses(numberInfoPattern, resolver, resolver)).isInstanceOf(
-                Result.Success::class.java)
+                    Result.Success::class.java)
         }
 
         @Test
-        fun `sanity check for nested pattern encompassing` () {
+        fun `sanity check for nested pattern encompassing`() {
             val answersPattern = XMLPattern("<answer><number>(number)</number><name>(string)</name></answer>")
             val resolver = Resolver()
 
@@ -261,7 +262,7 @@ internal class XMLPatternTest {
         }
 
         @Test
-        fun `pattern should not encompass another with different order` () {
+        fun `pattern should not encompass another with different order`() {
             val answersPattern1 = XMLPattern("<answer><number>(number)</number><name>(string)</name></answer>")
             val answersPattern2 = XMLPattern("<answer><name>(string)</name><number>(number)</number></answer>")
             val resolver = Resolver()
@@ -270,7 +271,7 @@ internal class XMLPatternTest {
         }
 
         @Test
-        fun `repeating pattern should not encompass another with a different repeating type` () {
+        fun `repeating pattern should not encompass another with a different repeating type`() {
             val answersPattern1 = XMLPattern("<answers>(Number*)</answers>")
             val answersPattern2 = XMLPattern("<answers>(Number*)</answers>")
             val resolver1 = Resolver(newPatterns = mapOf("(Number)" to parsedPattern("<number>(number)</number>")))
@@ -280,7 +281,7 @@ internal class XMLPatternTest {
         }
 
         @Test
-        fun `node with finite number of children should not encompass repeating pattern with similar type` () {
+        fun `node with finite number of children should not encompass repeating pattern with similar type`() {
             val answersPattern1 = XMLPattern("<answers><number>(number)</number><number>(number)</number></answers>")
             val answersPattern2 = XMLPattern("<answer>(Number*)</answer>")
             val resolver = Resolver(newPatterns = mapOf("(Number)" to parsedPattern("<number>(number)</number>")))
@@ -460,7 +461,7 @@ internal class XMLPatternTest {
 
             val flags = mutableListOf<String>()
 
-            for(newType in newTypes) {
+            for (newType in newTypes) {
                 when {
                     newType.pattern.attributes.containsKey("val") -> flags.add("with")
                     else -> flags.add("without")
@@ -481,7 +482,7 @@ internal class XMLPatternTest {
 
             val flags = mutableListOf<String>()
 
-            for(newType in newTypes) {
+            for (newType in newTypes) {
                 when {
                     newType.pattern.attributes.containsKey("val$XML_ATTR_OPTIONAL_SUFFIX") -> flags.add("with")
                     else -> flags.add("without")
@@ -626,7 +627,7 @@ internal class XMLPatternTest {
         @Test
         fun `xml with optional node generates one sample with the node and one without`() {
             val nameType = XMLPattern("<name><nameid $isOptional>(number)</nameid></name>")
-            val newValues = nameType.newBasedOn(Row(), Resolver()).map { it.generate(Resolver())}
+            val newValues = nameType.newBasedOn(Row(), Resolver()).map { it.generate(Resolver()) }
 
             assertThat(newValues).anySatisfy {
                 assertThat(it.name).isEqualTo("name")
@@ -649,7 +650,7 @@ internal class XMLPatternTest {
             val nameIdType = XMLPattern("<nameid>(number)</nameid>")
             val resolver = Resolver(newPatterns = mapOf("(Nameid)" to nameIdType))
 
-            val newValues = nameType.newBasedOn(Row(), resolver).map { it.generate(resolver)}
+            val newValues = nameType.newBasedOn(Row(), resolver).map { it.generate(resolver) }
 
             assertThat(newValues).anySatisfy {
                 assertThat(it.name).isEqualTo("name")
@@ -672,7 +673,7 @@ internal class XMLPatternTest {
             val nameIdType = XMLPattern("<nameid>(number)</nameid>")
             val resolver = Resolver(newPatterns = mapOf("(Nameid)" to nameIdType))
             val row = Row(listOf("nameid"), listOf("10"))
-            val newValues = nameType.newBasedOn(row, resolver).map { it.generate(resolver)}
+            val newValues = nameType.newBasedOn(row, resolver).map { it.generate(resolver) }
 
             assertThat(newValues.isNotEmpty())
 
@@ -716,7 +717,7 @@ internal class XMLPatternTest {
         @Test
         fun `xml with a node that occurs multiple times generates multiple nodes`() {
             val nameType = XMLPattern("<name><title $occursMultipleTimes>(number)</title></name>")
-            val newValues = nameType.newBasedOn(Row(), Resolver()).map { it.generate(Resolver())}
+            val newValues = nameType.newBasedOn(Row(), Resolver()).map { it.generate(Resolver()) }
 
             assertThat(newValues.isNotEmpty())
 
@@ -735,7 +736,7 @@ internal class XMLPatternTest {
             val nameType = XMLPattern("<name><nameid $occursMultipleTimes $TYPE_ATTRIBUTE_NAME=\"Nameid\" /></name>")
             val nameIdType = XMLPattern("<nameid>(number)</nameid>")
             val resolver = Resolver(newPatterns = mapOf("(Nameid)" to nameIdType))
-            val newValues = nameType.newBasedOn(Row(), resolver).map { it.generate(resolver)}
+            val newValues = nameType.newBasedOn(Row(), resolver).map { it.generate(resolver) }
 
             assertThat(newValues.isNotEmpty())
 
@@ -755,7 +756,7 @@ internal class XMLPatternTest {
             val nameIdType = XMLPattern("<nameid>(number)</nameid>")
             val resolver = Resolver(newPatterns = mapOf("(Nameid)" to nameIdType))
             val row = Row(listOf("nameid"), listOf("10"))
-            val newValues = nameType.newBasedOn(row, resolver).map { it.generate(resolver)}
+            val newValues = nameType.newBasedOn(row, resolver).map { it.generate(resolver) }
 
             assertThat(newValues.isNotEmpty())
 
@@ -853,7 +854,7 @@ internal class XMLPatternTest {
         val gherkinStatement = xml.toGherkinStatement("TypeName")
 
         assertThat(gherkinStatement).isEqualTo(
-            """And type TypeName
+                """And type TypeName
 ""${'"'}
 <account>
   <id>(number)</id>

--- a/core/src/test/kotlin/in/specmatic/core/pattern/XMLPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/XMLPatternTest.kt
@@ -148,6 +148,43 @@ internal class XMLPatternTest {
     @Nested
     inner class BackwardCompatibility {
         @Test
+        fun temp() {
+            val personType = XMLPattern("""
+                <person>
+                    <name>(string)</name>
+                    <address specmatic_type="Address" />
+                </person>
+            """.trimIndent())
+
+            val addressType = XMLPattern("""
+                <SPECMATIC_TYPE>
+                    <flat_no specmatic_occurs="optional">(string)</flat_no>
+                    <street specmatic_occurs="optional">(string)</street>
+                </SPECMATIC_TYPE>
+            """.trimIndent())
+
+            val resolver = Resolver(newPatterns = mapOf("(Address)" to addressType))
+
+            val testTypes = personType.newBasedOn(resolver).map { it.toPrettyString() }
+
+            assertThat(testTypes).contains("""
+                <person>
+                  <name>(string)</name>
+                  <address specmatic_type="Address">
+                    <flat_no specmatic_occurs="optional">(string)</flat_no>
+                    <street specmatic_occurs="optional">(string)</street>
+                  </address>
+                </person>
+                """.trimIndent())
+
+            assertThat(testTypes).contains("""
+                <person>
+                  <name>(string)</name>
+                  <address specmatic_type="Address" />
+                </person>""".trimIndent())
+        }
+
+        @Test
         fun `optional node text type should encompass text type`() {
             val resolver = Resolver()
 


### PR DESCRIPTION
**What**:
* creates two combinations per mandatory field with optional children
* creates three combinations per optional field with optional children

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/qontract/qontract-documentation - N/A
- [x] Tests
- [x] Sonar Quality Gate

**Issue ID**:
Closes: #209

