### PR TITLE
resolvingly only refs to deferred pattern

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -421,7 +421,7 @@ class OpenApiSpecification(private val openApiFile: String, private val openApi:
     ) = schema.properties.orEmpty().map { (propertyName, propertyType) ->
         val optional = !requiredFields.contains(propertyName)
         if (patternName.isNotEmpty()) {
-            if (typeStack.contains(patternName)) toSpecmaticParamName(
+            if (typeStack.contains(patternName) && propertyType.`$ref`.orEmpty().endsWith(patternName)) toSpecmaticParamName(
                 optional,
                 propertyName
             ) to DeferredPattern("(${patternName})")


### PR DESCRIPTION
**What**:

OpenApi nested Types with same name as one of its ancestors should only be considered a cyclic reference if it is a $ref. 

**Why**:

Nested Types which have the same name need not be the same type as its ancestor.

**How**:

In addition to checking whether we have already encountered the pattern name and resolved it earlier we also need to check if it is a $ref.

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/qontract/qontract-documentation - NA
- [x] Tests
- [x] Sonar Quality Gate

