### PR TITLE
waiting for process to complete after listening on streams

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/git/SystemGit.kt
+++ b/core/src/main/kotlin/in/specmatic/core/git/SystemGit.kt
@@ -55,9 +55,9 @@ class SystemGit(private val workingDirectory: String = ".", private val prefix: 
 private fun executeCommandWithWorkingDirectory(prefix: String, workingDirectory: String, command: Array<String>): String {
     information.forDebugging("${prefix}Executing: ${command.joinToString(" ")}")
     val process = Runtime.getRuntime().exec(command, null, File(workingDirectory))
-    process.waitFor()
     val out = process.inputStream.bufferedReader().readText()
     val err = process.errorStream.bufferedReader().readText()
+    process.waitFor()
 
     if (process.exitValue() != 0) throw NonZeroExitError(err.ifEmpty { out })
 


### PR DESCRIPTION
**What**:

Compatible Command hangs on git show when file size is larger than ~60KB or roughly 1000 lines of Gherkin

**Why**:

Process.waitFor is placed after the the inputStream and errorStream reads

**How**:

Moving Process.waitFor after consuming streams

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/qontract/qontract-documentation - NA
- [ ] Tests
- [x] Sonar Quality Gate