### PR TITLE
open api params without examples when there are response examples

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -182,7 +182,7 @@ class OpenApiSpecification(private val openApiFile: String, private val openApi:
                     val specmaticExampleRows: List<Row> = responseExamples.map { (exampleName, _) ->
                         val requestExamples =
                             operation.parameters.orEmpty()
-                                .filter { parameter -> parameter.examples.any { it.key == exampleName } }
+                                .filter { parameter -> parameter.examples.orEmpty().any { it.key == exampleName } }
                                 .map { it.name to it.examples[exampleName]!!.value }.toMap()
 
                         requestExamples.map { (key, value) -> key to value.toString() }.toList().isNotEmpty()

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -49,6 +49,10 @@ paths:
             application/json:
               schema:
                 type: string
+              examples:
+                200_OKAY:
+                  value: hello
+                  summary: response example without any matching parameters with examples
         '404':
           description: Not Found
           content:


### PR DESCRIPTION
**What**:

Allowing OpenApi parameters without examples when there are responses with examples

**Why**:

Specmatic throws Null Pointer Exception when there are response examples and parameters without examples. When there are no response examples this problem does not occur because Specmatic only looks for param examples when there are examples for response to see if it can correlate them through naming convention.

**How**:

Handling null access issue with parameters with no examples.

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/qontract/qontract-documentation - NA
- [x] Tests
- [x] Sonar Quality Gate