### PR TITLE
allowing args for external command in stub json

### DIFF
--- a/core/src/main/kotlin/in/specmatic/stub/StubData.kt
+++ b/core/src/main/kotlin/in/specmatic/stub/StubData.kt
@@ -43,7 +43,7 @@ data class HttpStubData(
 
     private fun executeExternalCommand(command: String, envParam: String): String {
         information.forDebugging("Executing: $command with EnvParam: $envParam")
-        return ExternalCommand(arrayOf(command), ".", arrayOf(envParam)).executeAsSeparateProcess()
+        return ExternalCommand(command.split(" ").toTypedArray(), ".", arrayOf(envParam)).executeAsSeparateProcess()
     }
 }
 

--- a/core/src/test/kotlin/in/specmatic/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/in/specmatic/stub/HttpStubTest.kt
@@ -96,7 +96,7 @@ Scenario: Multiply a number by 3
 
         HttpStub(gherkin).use { fake ->
             val mockData =
-                """{"http-request": {"method": "GET", "path": "/multiply/(value:number)"}, "http-response": {"status": 200, "body": 10, "externalisedResponseCommand": "${testResourcesDir.absolutePathString()}/response.sh"}}"""
+                """{"http-request": {"method": "GET", "path": "/multiply/(value:number)"}, "http-response": {"status": 200, "body": 10, "externalisedResponseCommand": "${testResourcesDir.absolutePathString()}/response.sh 3"}}"""
             val stubSetupURL = "${fake.endPoint}/_specmatic/expectations"
             val headers = HttpHeaders()
             headers.contentType = MediaType.APPLICATION_JSON

--- a/core/src/test/resources/response.sh
+++ b/core/src/test/resources/response.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 
+multiplier=$1
 value=${SPECMATIC_REQUEST:20:1}
 
 cat << EOF
 {
     "status": 200,
-    "body": $((value * 3)),
+    "body": $((value * multiplier)),
     "status-text": "OK",
     "headers": {
         "X-Specmatic-Result": "success",


### PR DESCRIPTION
**What**:

Allowing users to pass command line arguments to the external command in stub json.

**Why**:

Users may want to control certain aspects about how the external command generates the response from within the stub json.

**How**:

Treating external command as space delimited list of strings.

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/qontract/qontract-documentation - NA
- [x] Tests
- [x] Sonar Quality Gate

