### PR TITLE
Resolving external openapi references

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Feature.kt
@@ -44,7 +44,7 @@ fun parseContractFileToFeature(file: File, hook: Hook = PassThroughHook()): Feat
     logger.debug("Parsing contract file ${file.path}, absolute path ${file.absolutePath}")
 
     return when (file.extension) {
-        "yaml" -> OpenApiSpecification.fromFile(file.path).toFeature()
+        "yaml" -> OpenApiSpecification.fromYAML(hook.readContract(file.path), file.path).toFeature()
         "wsdl" -> wsdlContentToFeature(checkExists(file).readText(), file.canonicalPath)
         in CONTRACT_EXTENSIONS -> parseGherkinStringToFeature(checkExists(file).readText().trim(), file.canonicalPath)
         else -> throw ContractException("File extension of ${file.path} not recognized")

--- a/core/src/main/kotlin/in/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Feature.kt
@@ -44,7 +44,7 @@ fun parseContractFileToFeature(file: File, hook: Hook = PassThroughHook()): Feat
     logger.debug("Parsing contract file ${file.path}, absolute path ${file.absolutePath}")
 
     return when (file.extension) {
-        "yaml" -> OpenApiSpecification.fromYAML(hook.readContract(file.path), file.path).toFeature()
+        "yaml" -> OpenApiSpecification.fromFile(file.path).toFeature()
         "wsdl" -> wsdlContentToFeature(checkExists(file).readText(), file.canonicalPath)
         in CONTRACT_EXTENSIONS -> parseGherkinStringToFeature(checkExists(file).readText().trim(), file.canonicalPath)
         else -> throw ContractException("File extension of ${file.path} not recognized")

--- a/core/src/test/resources/openapi/common.yaml
+++ b/core/src/test/resources/openapi/common.yaml
@@ -1,0 +1,22 @@
+openapi: 3.0.1
+components:
+  schemas:
+    NewPet:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+        tag:
+          type: string
+          nullable: true
+  parameters:
+    limitParam:
+      name: limit
+      in: query
+      description: maximum number of results to return
+      required: false
+      schema:
+        type: integer
+        format: int3

--- a/core/src/test/resources/openapi/petstore-expanded.yaml
+++ b/core/src/test/resources/openapi/petstore-expanded.yaml
@@ -27,13 +27,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: limit
-          in: query
-          description: maximum number of results to return
-          required: false
-          schema:
-            type: integer
-            format: int32
+        - $ref: './common.yaml#/components/parameters/limitParam'
       responses:
         '200':
           description: pet response
@@ -153,7 +147,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/NewPet'
+              $ref: './common.yaml#/components/schemas/NewPet'
       responses:
         '201':
           description: pet response
@@ -241,17 +235,6 @@ components:
         rating:
           type: integer
           enum: [ 1, 2 ]
-
-    NewPet:
-      type: object
-      required:
-        - name
-      properties:
-        name:
-          type: string
-        tag:
-          type: string
-          nullable: true
 
     Tag:
       type: string


### PR DESCRIPTION
**What**: OpenAPI allows referencing components in an external openapi file https://swagger.io/docs/specification/using-ref/ This is helpful in reusing snippets by keeping them in a common location.

**Why**: Specmatic only support $ref to locally defined components. External references are not supported.

**How**: Setting swagger parser isResolve to true - https://github.com/swagger-api/swagger-parser#1-resolve

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/qontract/qontract-documentation
- [x] Tests
- [x] Sonar Quality Gate

Pending - Backward Compatibility Testing
- [ ] Spec file changes
- [ ] Common yaml changes