### PR TITLE
Return multiple reasons for failure

### DIFF
--- a/application/src/main/kotlin/application/BundleCommand.kt
+++ b/application/src/main/kotlin/application/BundleCommand.kt
@@ -41,9 +41,6 @@ class StubBundle(private val _bundlePath: String?, private val config: Specmatic
 
             val stubFiles: List<Pair<String, String>> = stubFilesIn(base, File(customImplicitStubBase), File(stubRelativePath))
 
-//            val stubDataDir = stubDataDir(File(pathData.path))
-//            val stubFiles = stubFilesIn(stubDataDir, fileOperations)
-
             return stubFiles.map { (virtualPath, actualPath) ->
                 val relativeEntryPath = File(virtualPath).relativeTo(base)
                 ZipperEntry("${base.name}/${relativeEntryPath.path}", fileOperations.readBytes(actualPath))

--- a/application/src/main/kotlin/application/InstallCommand.kt
+++ b/application/src/main/kotlin/application/InstallCommand.kt
@@ -1,12 +1,11 @@
 package application
 
-import picocli.CommandLine
 import `in`.specmatic.core.APPLICATION_NAME_LOWER_CASE
 import `in`.specmatic.core.Configuration.Companion.globalConfigFileName
 import `in`.specmatic.core.pattern.ContractException
-import `in`.specmatic.core.toReport
 import `in`.specmatic.core.utilities.exitWithMessage
 import `in`.specmatic.core.utilities.loadSources
+import picocli.CommandLine
 import java.io.File
 import java.util.concurrent.Callable
 

--- a/application/src/main/kotlin/application/SubscribeCommand.kt
+++ b/application/src/main/kotlin/application/SubscribeCommand.kt
@@ -1,13 +1,12 @@
 package application
 
-import picocli.CommandLine
 import `in`.specmatic.core.CONTRACT_EXTENSION
 import `in`.specmatic.core.Configuration.Companion.globalConfigFileName
-import `in`.specmatic.core.git.SystemGit
 import `in`.specmatic.core.git.NonZeroExitError
+import `in`.specmatic.core.git.SystemGit
 import `in`.specmatic.core.pattern.ContractException
-import `in`.specmatic.core.toReport
 import `in`.specmatic.core.utilities.*
+import picocli.CommandLine
 import java.io.File
 import java.util.concurrent.Callable
 import kotlin.system.exitProcess

--- a/core/src/main/kotlin/in/specmatic/core/CheckOnlyPatternKeys.kt
+++ b/core/src/main/kotlin/in/specmatic/core/CheckOnlyPatternKeys.kt
@@ -4,8 +4,12 @@ import `in`.specmatic.core.pattern.isMissingKey
 
 internal object CheckOnlyPatternKeys: KeyErrorCheck {
     override fun validate(pattern: Map<String, Any>, actual: Map<String, Any>): KeyError? {
+        return validateList(pattern, actual).firstOrNull()
+    }
+
+    override fun validateList(pattern: Map<String, Any>, actual: Map<String, Any>): List<KeyError> {
         return pattern.minus("...").keys.find { key ->
             isMissingKey(actual, key)
-        }?.toMissingKeyError()
+        }?.toMissingKeyError()?.let { listOf(it) } ?: emptyList()
     }
 }

--- a/core/src/main/kotlin/in/specmatic/core/FailureReport.kt
+++ b/core/src/main/kotlin/in/specmatic/core/FailureReport.kt
@@ -7,7 +7,9 @@ class FailureReport(val contractPath: String?, val scenarioMessage: String?, val
 
         val matchFailureDetails = matchFailureDetails()
 
-        val reportDetails = "$scenarioDetails${System.lineSeparator()}${System.lineSeparator()}${matchFailureDetails.prependIndent("  ")}"
+        val reportDetails: String = scenario?.let {
+            "$scenarioDetails${System.lineSeparator()}${System.lineSeparator()}${matchFailureDetails.prependIndent("  ")}"
+        } ?: matchFailureDetails
 
         val report = contractLine?.let {
             val reportIndent = if(contractLine.isNotEmpty()) "  " else ""
@@ -27,21 +29,24 @@ class FailureReport(val contractPath: String?, val scenarioMessage: String?, val
 
     private fun matchFailureDetails(matchFailureDetails: MatchFailureDetails): String {
         return matchFailureDetails.let { (breadCrumbs, errorMessages) ->
-            val breadCrumbString =
-                breadCrumbs
-                    .filter { it.isNotBlank() }
-                    .joinToString(".") { it.trim() }
-                    .let {
-                        when {
-                            it.isNotBlank() -> ">> $it"
-                            else -> ""
-                        }
-                    }
+            val breadCrumbString = breadCrumbString(breadCrumbs)
 
             val errorMessagesString = errorMessages.map { it.trim() }.filter { it.isNotEmpty() }.joinToString("\n")
 
-            "$breadCrumbString${System.lineSeparator()}${System.lineSeparator()}$errorMessagesString".trim()
+            "$breadCrumbString${System.lineSeparator()}${System.lineSeparator()}${errorMessagesString.prependIndent("   ")}".trim()
         }
+    }
+
+    private fun breadCrumbString(breadCrumbs: List<String>): String {
+        return breadCrumbs
+            .filter { it.isNotBlank() }
+            .joinToString(".") { it.trim() }
+            .let {
+                when {
+                    it.isNotBlank() -> ">> $it"
+                    else -> ""
+                }
+            }
     }
 
     private fun contractPathDetails(): String? {

--- a/core/src/main/kotlin/in/specmatic/core/FailureReport.kt
+++ b/core/src/main/kotlin/in/specmatic/core/FailureReport.kt
@@ -1,0 +1,63 @@
+package `in`.specmatic.core
+
+class FailureReport(val contractPath: String?, val scenarioMessage: String?, val scenario: Scenario?, val matchFailureDetailList: List<MatchFailureDetails>): Report {
+    override fun toText(): String {
+        val contractLine = contractPathDetails()
+        val scenarioDetails = scenarioDetails(scenario) ?: ""
+
+        val matchFailureDetails = matchFailureDetails()
+
+        val reportDetails = "$scenarioDetails${System.lineSeparator()}${System.lineSeparator()}${matchFailureDetails.prependIndent("  ")}"
+
+        val report = contractLine?.let {
+            val reportIndent = if(contractLine.isNotEmpty()) "  " else ""
+            "$contractLine${reportDetails.prependIndent(reportIndent)}"
+        } ?: reportDetails
+
+        return report.trim()
+    }
+
+    override fun toString(): String = toText()
+
+    private fun matchFailureDetails(): String {
+        return matchFailureDetailList.joinToString("\n\n") {
+            matchFailureDetails(it)
+        }
+    }
+
+    private fun matchFailureDetails(matchFailureDetails: MatchFailureDetails): String {
+        return matchFailureDetails.let { (breadCrumbs, errorMessages) ->
+            val breadCrumbString =
+                breadCrumbs
+                    .filter { it.isNotBlank() }
+                    .joinToString(".") { it.trim() }
+                    .let {
+                        when {
+                            it.isNotBlank() -> ">> $it"
+                            else -> ""
+                        }
+                    }
+
+            val errorMessagesString = errorMessages.map { it.trim() }.filter { it.isNotEmpty() }.joinToString("\n")
+
+            "$breadCrumbString${System.lineSeparator()}${System.lineSeparator()}$errorMessagesString".trim()
+        }
+    }
+
+    private fun contractPathDetails(): String? {
+        if(contractPath == null || contractPath.isBlank())
+            return null
+
+        return "Error from contract $contractPath\n\n"
+    }
+
+    private fun scenarioDetails(scenario: Scenario?): String? {
+        return scenario?.let {
+            val scenarioLine = """${scenarioMessage ?: "In scenario"} "${scenario.name}""""
+            val urlLine =
+                "API: ${scenario.httpRequestPattern.method} ${scenario.httpRequestPattern.urlMatcher?.path} -> ${scenario.httpResponsePattern.status}"
+
+            "$scenarioLine${System.lineSeparator()}$urlLine"
+        }
+    }
+}

--- a/core/src/main/kotlin/in/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpRequestPattern.kt
@@ -111,11 +111,6 @@ data class HttpRequestPattern(
     fun matchFormFields(parameters: Triple<HttpRequest, Resolver, List<Failure>>): MatchingResult<Triple<HttpRequest, Resolver, List<Failure>>> {
         val (httpRequest, resolver) = parameters
 
-        val keys: List<String> =
-            formFieldsPattern.keys.filter { key -> isOptional(key) && withoutOptionality(key) !in httpRequest.formFields }
-        if (keys.isNotEmpty())
-            return MatchFailure(Failure(message = "Fields $keys not found", breadCrumb = FORM_FIELDS_BREADCRUMB))
-
         val keyError = resolver.findKeyError(formFieldsPattern, httpRequest.formFields)
         if (keyError != null)
             return MatchFailure(keyError.missingKeyToResult("form field", resolver.mismatchMessages))

--- a/core/src/main/kotlin/in/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpRequestPattern.kt
@@ -41,15 +41,6 @@ data class HttpRequestPattern(
     fun matchesSignature(other: HttpRequestPattern): Boolean =
         urlMatcher!!.path == other.urlMatcher!!.path && method.equals(method)
 
-    private fun summarize(parameters: Triple<HttpRequest, Resolver, List<Failure>>): MatchingResult<Triple<HttpRequest, Resolver, List<Failure>>> {
-        val (_, _, failures) = parameters
-
-        return if(failures.isNotEmpty())
-            MatchFailure(Failure.fromFailures(failures))
-        else
-            MatchSuccess(parameters)
-    }
-
     private fun matchMultiPartFormData(parameters: Triple<HttpRequest, Resolver, List<Failure>>): MatchingResult<Triple<HttpRequest, Resolver, List<Failure>>> {
         val (httpRequest, resolver, failures) = parameters
 

--- a/core/src/main/kotlin/in/specmatic/core/HttpResponsePattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpResponsePattern.kt
@@ -50,7 +50,7 @@ data class HttpResponsePattern(val headersPattern: HttpHeadersPattern = HttpHead
 
         return when (response.status) {
             status -> MatchSuccess(parameters)
-            else -> MatchFailure(mismatchResult("status $status", "status ${response.status}").copyWithDetails(breadCrumb = "STATUS", failureReason = FailureReason.StatusMismatch))
+            else -> MatchFailure(mismatchResult("status $status", "status ${response.status}").copy(breadCrumb = "STATUS", failureReason = FailureReason.StatusMismatch))
         }
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/HttpResponsePattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpResponsePattern.kt
@@ -50,7 +50,7 @@ data class HttpResponsePattern(val headersPattern: HttpHeadersPattern = HttpHead
 
         return when (response.status) {
             status -> MatchSuccess(parameters)
-            else -> MatchFailure(mismatchResult("status $status", "status ${response.status}").copy(breadCrumb = "STATUS", failureReason = FailureReason.StatusMismatch))
+            else -> MatchFailure(mismatchResult("status $status", "status ${response.status}").copyWithDetails(breadCrumb = "STATUS", failureReason = FailureReason.StatusMismatch))
         }
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/KeyCheck.kt
+++ b/core/src/main/kotlin/in/specmatic/core/KeyCheck.kt
@@ -16,7 +16,14 @@ class KeyCheck(val patternKeyCheck: KeyErrorCheck = CheckOnlyPatternKeys,
         pattern: Map<String, Any>,
         actual: Map<String, Any>
     ): KeyError? {
-        return patternKeyCheck.validate(pattern, actual) ?: unexpectedKeyCheck.validate(pattern, actual)
+        return validateAll(pattern, actual).firstOrNull()
+    }
+
+    fun validateAll(
+        pattern: Map<String, Any>,
+        actual: Map<String, Any>
+    ): List<KeyError> {
+        return patternKeyCheck.validateList(pattern, actual).plus(unexpectedKeyCheck.validateList(pattern, actual))
     }
 
 }

--- a/core/src/main/kotlin/in/specmatic/core/KeyError.kt
+++ b/core/src/main/kotlin/in/specmatic/core/KeyError.kt
@@ -18,7 +18,3 @@ data class UnexpectedKeyError(override val name: String) : KeyError() {
     override fun missingKeyToResult(keyLabel: String, mismatchMessages: MismatchMessages): Failure =
         Failure(mismatchMessages.unexpectedKey(keyLabel, name))
 }
-
-internal fun String.toMissingKeyError(): MissingKeyError {
-    return MissingKeyError(this)
-}

--- a/core/src/main/kotlin/in/specmatic/core/KeyErrorCheck.kt
+++ b/core/src/main/kotlin/in/specmatic/core/KeyErrorCheck.kt
@@ -2,4 +2,5 @@ package `in`.specmatic.core
 
 interface KeyErrorCheck {
     fun validate(pattern: Map<String, Any>, actual: Map<String, Any>): KeyError?
+    fun validateList(pattern: Map<String, Any>, actual: Map<String, Any>): List<KeyError>
 }

--- a/core/src/main/kotlin/in/specmatic/core/RailwayOrientedProgramming.kt
+++ b/core/src/main/kotlin/in/specmatic/core/RailwayOrientedProgramming.kt
@@ -26,3 +26,12 @@ infix fun <T> MatchingResult<T>.toResult(f: (Result) -> Result) =
 fun <T> handleError(error: Result.Failure): MatchingResult<T> = MatchFailure(error)
 
 fun returnResult(result: Result) = result
+
+fun <T> summarize(parameters: Triple<T, Resolver, List<Result.Failure>>): MatchingResult<Triple<T, Resolver, List<Result.Failure>>> {
+    val (_, _, failures) = parameters
+
+    return if(failures.isNotEmpty())
+        MatchFailure(Result.Failure.fromFailures(failures))
+    else
+        MatchSuccess(parameters)
+}

--- a/core/src/main/kotlin/in/specmatic/core/Report.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Report.kt
@@ -1,0 +1,6 @@
+package `in`.specmatic.core
+
+interface Report {
+    override fun toString(): String
+    fun toText(): String
+}

--- a/core/src/main/kotlin/in/specmatic/core/Resolver.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Resolver.kt
@@ -27,7 +27,11 @@ data class Resolver(
     }
 
     fun findKeyError(pattern: Map<String, Any>, actual: Map<String, Any>): KeyError? {
-        return findKeyErrorCheck.validate(pattern, actual)
+        return findKeyErrorList(pattern, actual).firstOrNull()
+    }
+
+    fun findKeyErrorList(pattern: Map<String, Any>, actual: Map<String, Any>): List<KeyError> {
+        return findKeyErrorCheck.validate(pattern, actual)?.let { listOf(it) } ?: emptyList()
     }
 
     fun matchesPattern(factKey: String?, pattern: Pattern, sampleValue: Value): Result {

--- a/core/src/main/kotlin/in/specmatic/core/Resolver.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Resolver.kt
@@ -31,7 +31,7 @@ data class Resolver(
     }
 
     fun findKeyErrorList(pattern: Map<String, Any>, actual: Map<String, Any>): List<KeyError> {
-        return findKeyErrorCheck.validate(pattern, actual)?.let { listOf(it) } ?: emptyList()
+        return findKeyErrorCheck.validateAll(pattern, actual)
     }
 
     fun matchesPattern(factKey: String?, pattern: Pattern, sampleValue: Value): Result {

--- a/core/src/main/kotlin/in/specmatic/core/Result.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Result.kt
@@ -47,7 +47,13 @@ sealed class Result {
         }
     }
 
-    data class Failure(val message: String="", var cause: Failure? = null, val breadCrumb: String = "", val failureReason: FailureReason? = null) : Result() {
+    data class FailureCause(val message: String="", var cause: Failure? = null)
+
+    data class Failure(val causes: List<FailureCause> = emptyList(), val breadCrumb: String = "", val failureReason: FailureReason? = null) : Result() {
+        constructor(message: String="", cause: Failure? = null, breadCrumb: String = "", failureReason: FailureReason? = null): this(listOf(FailureCause(message, cause)), breadCrumb, failureReason)
+        val message = causes.first().message
+        val cause = causes.first().cause
+
         override fun ifSuccess(function: () -> Result) = this
         override fun withBindings(bindings: Map<String, String>, response: HttpResponse): Result {
             return this

--- a/core/src/main/kotlin/in/specmatic/core/Result.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Result.kt
@@ -143,7 +143,19 @@ fun Result.breadCrumb(breadCrumb: String): Result =
         else -> this
     }
 
-data class MatchFailureDetails(val breadCrumbs: List<String> = emptyList(), val errorMessages: List<String> = emptyList(), val path: String? = null)
+data class MatchFailureDetails(val breadCrumbs: List<String> = emptyList(), val errorMessages: List<String> = emptyList(), val path: String? = null) {
+    private fun breadCrumbString(breadCrumbs: List<String>) {
+        breadCrumbs
+            .filter { it.isNotBlank() }
+            .joinToString(".") { it.trim() }
+            .let {
+                when {
+                    it.isNotBlank() -> ">> $it"
+                    else -> ""
+                }
+            }
+    }
+}
 
 interface MismatchMessages {
     fun mismatchMessage(expected: String, actual: String): String

--- a/core/src/main/kotlin/in/specmatic/core/Result.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Result.kt
@@ -34,6 +34,8 @@ sealed class Result {
 
     abstract fun ifSuccess(function: () -> Result): Result
     abstract fun withBindings(bindings: Map<String, String>, response: HttpResponse): Result
+    abstract fun breadCrumb(breadCrumb: String): Result
+    abstract fun failureReason(failureReason: FailureReason?): Result
 
     abstract fun shouldBeIgnored(): Boolean
 
@@ -79,7 +81,10 @@ sealed class Result {
         }
 
         fun reason(errorMessage: String) = Failure(errorMessage, this)
-        fun breadCrumb(breadCrumb: String) = Failure(cause = this, breadCrumb = breadCrumb)
+        override fun breadCrumb(breadCrumb: String) = Failure(cause = this, breadCrumb = breadCrumb)
+        override fun failureReason(failureReason: FailureReason?): Result {
+            return this.copy(failureReason = failureReason)
+        }
 
         fun toFailureReport(scenarioMessage: String? = null): FailureReport {
             return FailureReport(contractPath, scenarioMessage, scenario, toMatchFailureDetailList())
@@ -123,6 +128,14 @@ sealed class Result {
         override fun ifSuccess(function: () -> Result) = function()
         override fun withBindings(bindings: Map<String, String>, response: HttpResponse): Result {
             return this.copy(variables = response.export(bindings))
+        }
+
+        override fun breadCrumb(breadCrumb: String): Result {
+            return this
+        }
+
+        override fun failureReason(failureReason: FailureReason?): Result {
+            return this
         }
 
         override fun shouldBeIgnored(): Boolean = false

--- a/core/src/main/kotlin/in/specmatic/core/Result.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Result.kt
@@ -52,6 +52,16 @@ sealed class Result {
     data class Failure(val causes: List<FailureCause> = emptyList(), val failureReason: FailureReason? = null) : Result() {
         constructor(message: String="", cause: Failure? = null, breadCrumb: String = "", failureReason: FailureReason? = null): this(listOf(FailureCause(message, cause, breadCrumb)), failureReason)
 
+        companion object {
+            fun fromFailures(failures: List<Failure>): Failure {
+                val allCauses = failures.flatMap {
+                    it.causes
+                }
+
+                return Failure(allCauses)
+            }
+        }
+
         fun copyWithDetails(breadCrumb: String, failureReason: FailureReason): Failure {
             val newCauses = causes.map {
                 it.copy(breadCrumb = breadCrumb)
@@ -60,9 +70,9 @@ sealed class Result {
             return this.copy(causes = newCauses, failureReason = failureReason)
         }
 
-        val message = causes.first().message
-        val cause = causes.first().cause
-        val breadCrumb: String = causes.first().breadCrumb
+        val message = causes.firstOrNull()?.message ?: ""
+        val cause = causes.firstOrNull()?.cause
+        val breadCrumb: String = causes.firstOrNull()?.breadCrumb ?: ""
 
         override fun ifSuccess(function: () -> Result) = this
         override fun withBindings(bindings: Map<String, String>, response: HttpResponse): Result {

--- a/core/src/main/kotlin/in/specmatic/core/Result.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Result.kt
@@ -47,12 +47,22 @@ sealed class Result {
         }
     }
 
-    data class FailureCause(val message: String="", var cause: Failure? = null)
+    data class FailureCause(val message: String="", var cause: Failure? = null, val breadCrumb: String = "")
 
-    data class Failure(val causes: List<FailureCause> = emptyList(), val breadCrumb: String = "", val failureReason: FailureReason? = null) : Result() {
-        constructor(message: String="", cause: Failure? = null, breadCrumb: String = "", failureReason: FailureReason? = null): this(listOf(FailureCause(message, cause)), breadCrumb, failureReason)
+    data class Failure(val causes: List<FailureCause> = emptyList(), val failureReason: FailureReason? = null) : Result() {
+        constructor(message: String="", cause: Failure? = null, breadCrumb: String = "", failureReason: FailureReason? = null): this(listOf(FailureCause(message, cause, breadCrumb)), failureReason)
+
+        fun copyWithDetails(breadCrumb: String, failureReason: FailureReason): Failure {
+            val newCauses = causes.map {
+                it.copy(breadCrumb = breadCrumb)
+            }
+
+            return this.copy(causes = newCauses, failureReason = failureReason)
+        }
+
         val message = causes.first().message
         val cause = causes.first().cause
+        val breadCrumb: String = causes.first().breadCrumb
 
         override fun ifSuccess(function: () -> Result) = this
         override fun withBindings(bindings: Map<String, String>, response: HttpResponse): Result {

--- a/core/src/main/kotlin/in/specmatic/core/SuccessReport.kt
+++ b/core/src/main/kotlin/in/specmatic/core/SuccessReport.kt
@@ -1,0 +1,9 @@
+package `in`.specmatic.core
+
+object SuccessReport: Report {
+    override fun toString(): String = toText()
+
+    override fun toText(): String {
+        return ""
+    }
+}

--- a/core/src/main/kotlin/in/specmatic/core/UnexpectedKeyCheck.kt
+++ b/core/src/main/kotlin/in/specmatic/core/UnexpectedKeyCheck.kt
@@ -1,0 +1,6 @@
+package `in`.specmatic.core
+
+interface UnexpectedKeyCheck {
+    fun validate(pattern: Map<String, Any>, actual: Map<String, Any>): UnexpectedKeyError?
+    fun validateList(pattern: Map<String, Any>, actual: Map<String, Any>): List<UnexpectedKeyError>
+}

--- a/core/src/main/kotlin/in/specmatic/core/ValidateUnexpectedKeys.kt
+++ b/core/src/main/kotlin/in/specmatic/core/ValidateUnexpectedKeys.kt
@@ -2,17 +2,17 @@ package `in`.specmatic.core
 
 import `in`.specmatic.core.pattern.withoutOptionality
 
-interface UnexpectedKeyCheck {
-    fun validate(pattern: Map<String, Any>, actual: Map<String, Any>): UnexpectedKeyError?
-}
-
 object ValidateUnexpectedKeys: UnexpectedKeyCheck {
     override fun validate(pattern: Map<String, Any>, actual: Map<String, Any>): UnexpectedKeyError? {
+        return validateList(pattern, actual).firstOrNull()
+    }
+
+    override fun validateList(pattern: Map<String, Any>, actual: Map<String, Any>): List<UnexpectedKeyError> {
         val patternKeys = pattern.minus("...").keys.map { withoutOptionality(it) }
         val actualKeys = actual.keys.map { withoutOptionality(it) }
 
         return actualKeys.minus(patternKeys.toSet()).firstOrNull()?.let {
-            UnexpectedKeyError(it)
-        }
+            listOf(UnexpectedKeyError(it))
+        } ?: emptyList()
     }
 }

--- a/core/src/main/kotlin/in/specmatic/core/ValidateUnexpectedKeys.kt
+++ b/core/src/main/kotlin/in/specmatic/core/ValidateUnexpectedKeys.kt
@@ -11,8 +11,8 @@ object ValidateUnexpectedKeys: UnexpectedKeyCheck {
         val patternKeys = pattern.minus("...").keys.map { withoutOptionality(it) }
         val actualKeys = actual.keys.map { withoutOptionality(it) }
 
-        return actualKeys.minus(patternKeys.toSet()).firstOrNull()?.let {
-            listOf(UnexpectedKeyError(it))
-        } ?: emptyList()
+        return actualKeys.minus(patternKeys.toSet()).map {
+            UnexpectedKeyError(it)
+        }
     }
 }

--- a/core/src/main/kotlin/in/specmatic/core/pattern/BooleanPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/BooleanPattern.kt
@@ -3,7 +3,6 @@ package `in`.specmatic.core.pattern
 import `in`.specmatic.core.Resolver
 import `in`.specmatic.core.Result
 import `in`.specmatic.core.mismatchResult
-import `in`.specmatic.core.toReport
 import `in`.specmatic.core.value.BooleanValue
 import `in`.specmatic.core.value.JSONArrayValue
 import `in`.specmatic.core.value.Value

--- a/core/src/main/kotlin/in/specmatic/core/pattern/ContractException.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/ContractException.kt
@@ -3,7 +3,6 @@ package `in`.specmatic.core.pattern
 import `in`.specmatic.core.FailureReport
 import `in`.specmatic.core.Result
 import `in`.specmatic.core.Scenario
-import `in`.specmatic.core.toReport
 
 data class ContractException(val errorMessage: String = "", val breadCrumb: String = "", val exceptionCause: ContractException? = null, val scenario: Scenario? = null) : Exception(errorMessage) {
     constructor(failureReport: FailureReport): this(failureReport.toText())

--- a/core/src/main/kotlin/in/specmatic/core/pattern/Grammar.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/Grammar.kt
@@ -18,12 +18,6 @@ internal fun withoutOptionality(key: String): String {
 internal fun isOptional(key: String): Boolean =
     key.endsWith(DEFAULT_OPTIONAL_SUFFIX) || key.endsWith(XML_ATTR_OPTIONAL_SUFFIX)
 
-internal fun isMissingKey(jsonObject: Map<String, Any?>, key: String) =
-    when {
-        isOptional(key) -> false
-        else -> key !in jsonObject && "$key?" !in jsonObject && "$key:" !in jsonObject
-    }
-
 internal fun containsKey(jsonObject: Map<String, Any?>, key: String) =
     when {
         isOptional(key) -> withoutOptionality(key) in jsonObject

--- a/core/src/main/kotlin/in/specmatic/core/pattern/IgnoreUnexpectedKeys.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/IgnoreUnexpectedKeys.kt
@@ -5,4 +5,7 @@ import `in`.specmatic.core.UnexpectedKeyError
 
 object IgnoreUnexpectedKeys: UnexpectedKeyCheck {
     override fun validate(pattern: Map<String, Any>, actual: Map<String, Any>): UnexpectedKeyError? = null
+    override fun validateList(pattern: Map<String, Any>, actual: Map<String, Any>): List<UnexpectedKeyError> {
+        return emptyList()
+    }
 }

--- a/core/src/main/kotlin/in/specmatic/core/pattern/JSONObjectPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/JSONObjectPattern.kt
@@ -52,12 +52,14 @@ data class JSONObjectPattern(override val pattern: Map<String, Pattern> = emptyM
 
         val results: List<Result.Failure> = mapZip(pattern, sampleData.jsonObject).map { (key, patternValue, sampleValue) ->
             resolverWithNullType.matchesPattern(key, patternValue, sampleValue).breadCrumb(key)
-        }.filterIsInstance<Result.Failure>().plus(keyErrors)
+        }.filterIsInstance<Result.Failure>()
 
-        return if(results.isEmpty())
+        val failures = keyErrors.plus(results)
+
+        return if(failures.isEmpty())
             Result.Success()
         else
-            Result.Failure.fromFailures(results)
+            Result.Failure.fromFailures(failures)
     }
 
     override fun generate(resolver: Resolver): JSONObjectValue {

--- a/core/src/test/kotlin/in/specmatic/TestUtilities.kt
+++ b/core/src/test/kotlin/in/specmatic/TestUtilities.kt
@@ -15,6 +15,15 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assert.assertFalse
 import java.io.File
 
+fun toReport(result: Result, scenarioMessage: String? = null): String {
+    return when (result) {
+        is Result.Failure -> {
+            result.toFailureReport(scenarioMessage)
+        }
+        else -> SuccessReport
+    }.toString()
+}
+
 object Utils {
     fun readTextResource(path: String) =
         File(

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
@@ -841,24 +841,24 @@ Background:
             """
             In scenario "create a pet. Response: pet response"
             API: POST /pets -> 201
-            
+
               >> RESPONSE.BODY.breed
               
-              ${ContractAndResponseMismatch.mismatchMessage("""("labrador" or "retriever" or "null")""", "string: \"malinois\"")}
-            
+                 ${ContractAndResponseMismatch.mismatchMessage("""("labrador" or "retriever" or "null")""", "string: \"malinois\"")}
+
             In scenario "create a pet. Response: pet response"
             API: POST /pets -> 201
-            
+
               >> RESPONSE.BODY.breed
               
-              ${ContractAndResponseMismatch.mismatchMessage("""("labrador" or "retriever" or "null")""", "string: \"malinois\"")}
-            
+                 ${ContractAndResponseMismatch.mismatchMessage("""("labrador" or "retriever" or "null")""", "string: \"malinois\"")}
+
             In scenario "create a pet. Response: pet response"
             API: POST /pets -> 201
-            
+
               >> RESPONSE.BODY.breed
               
-              ${ContractAndResponseMismatch.mismatchMessage("""("labrador" or "retriever" or "null")""", "string: \"malinois\"")}
+                 ${ContractAndResponseMismatch.mismatchMessage("""("labrador" or "retriever" or "null")""", "string: \"malinois\"")}
             """.trimIndent()
         )
     }
@@ -918,21 +918,21 @@ Background:
             
               >> RESPONSE.BODY.rating
               
-              ${ContractAndResponseMismatch.mismatchMessage("(1 or 2)", "number: 3")}
+                 ${ContractAndResponseMismatch.mismatchMessage("(1 or 2)", "number: 3")}
             
             In scenario "create a pet. Response: pet response"
             API: POST /pets -> 201
             
               >> RESPONSE.BODY.rating
               
-              ${ContractAndResponseMismatch.mismatchMessage("(1 or 2)", "number: 3")}
+                 ${ContractAndResponseMismatch.mismatchMessage("(1 or 2)", "number: 3")}
             
             In scenario "create a pet. Response: pet response"
             API: POST /pets -> 201
             
               >> RESPONSE.BODY.rating
               
-              ${ContractAndResponseMismatch.mismatchMessage("(1 or 2)", "number: 3")}
+                 ${ContractAndResponseMismatch.mismatchMessage("(1 or 2)", "number: 3")}
             """.trimIndent()
         )
     }
@@ -989,24 +989,24 @@ Background:
             """
             In scenario "create a pet. Response: pet response"
             API: POST /pets -> 201
-            
+
               >> RESPONSE.BODY.name
               
-              ${ContractAndResponseMismatch.mismatchMessage("string with minLength 6", "string: \"small\"")}
-            
+                 ${ContractAndResponseMismatch.mismatchMessage("string with minLength 6", "string: \"small\"")}
+
             In scenario "create a pet. Response: pet response"
             API: POST /pets -> 201
-            
+
               >> RESPONSE.BODY.name
               
-              ${ContractAndResponseMismatch.mismatchMessage("string with minLength 6", "string: \"small\"")}
-            
+                 ${ContractAndResponseMismatch.mismatchMessage("string with minLength 6", "string: \"small\"")}
+
             In scenario "create a pet. Response: pet response"
             API: POST /pets -> 201
-            
+
               >> RESPONSE.BODY.name
               
-              ${ContractAndResponseMismatch.mismatchMessage("string with minLength 6", "string: \"small\"")}
+                 ${ContractAndResponseMismatch.mismatchMessage("string with minLength 6", "string: \"small\"")}
             """.trimIndent()
         )
     }

--- a/core/src/test/kotlin/in/specmatic/core/CheckOnlyPatternKeysTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/CheckOnlyPatternKeysTest.kt
@@ -1,7 +1,7 @@
 package `in`.specmatic.core
 
-import `in`.specmatic.core.pattern.IgnoreUnexpectedKeys
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 internal class CheckOnlyPatternKeysTest {
@@ -57,5 +57,25 @@ internal class CheckOnlyPatternKeysTest {
         val missing = CheckOnlyPatternKeys.validate(expected, actual)
 
         assertThat(missing).isEqualTo(null)
+    }
+
+    @Nested
+    inner class ReturnAllErrors {
+        val expected = mapOf("hello" to "value", "world" to "value")
+        val actual = mapOf("hello_world" to "value")
+        val missingList: List<KeyError> = CheckOnlyPatternKeys.validateList(expected, actual)
+
+        @Test
+        fun `should return as many errors as the number of missing keys`() {
+            assertThat(missingList).hasSize(2)
+        }
+
+        @Test
+        fun `the errors should refer to the missing keys`() {
+            val keys = missingList.map { it.name }
+
+            assertThat(keys).contains("hello")
+            assertThat(keys).contains("world")
+        }
     }
 }

--- a/core/src/test/kotlin/in/specmatic/core/ContractAsTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/ContractAsTest.kt
@@ -89,7 +89,7 @@ class ContractAsTest {
             
               >> RESPONSE.HEADERS.length
               
-              ${ContractAndResponseMismatch.mismatchMessage("number", "string: \"abc\"")}
+                 ${ContractAndResponseMismatch.mismatchMessage("number", "string: \"abc\"")}
             """.trimIndent()
         )
     }

--- a/core/src/test/kotlin/in/specmatic/core/FailureReportTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/FailureReportTest.kt
@@ -1,0 +1,36 @@
+package `in`.specmatic.core
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class FailureReportTest {
+    @Test
+    fun `breadcrumbs should be flush left and descriptions indented`() {
+        val personIdDetails = MatchFailureDetails(listOf("person", "id"), listOf("error"))
+        val report = FailureReport(null, null, null, listOf(personIdDetails))
+
+        assertThat(report.toText()).isEqualTo("""
+            >> person.id
+
+               error
+        """.trimIndent())
+    }
+
+    @Test
+    fun `with multiple errors all breadcrumbs should be flush left and all descriptions indented`() {
+        val personIdDetails = MatchFailureDetails(listOf("person", "id"), listOf("error"))
+        val personNameDetails = MatchFailureDetails(listOf("person", "name"), listOf("error"))
+
+        val report = FailureReport(null, null, null, listOf(personIdDetails, personNameDetails))
+
+        assertThat(report.toText()).isEqualTo("""
+            >> person.id
+
+               error
+
+            >> person.name
+
+               error
+        """.trimIndent())
+    }
+}

--- a/core/src/test/kotlin/in/specmatic/core/FeatureTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/FeatureTest.kt
@@ -68,7 +68,7 @@ class FeatureTest {
             In scenario "Get balance info"
             API: GET /balance -> 200
             
-              >> REQUEST.HEADERS
+              >> REQUEST.HEADERS.x-loginId
               
                  Expected header named "x-loginId" was missing
               """.trimIndent())

--- a/core/src/test/kotlin/in/specmatic/core/FeatureTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/FeatureTest.kt
@@ -670,7 +670,10 @@ Feature: Contract for /balance API
     fun `returns error for form fields`() {
         val requestPattern = HttpRequestPattern(HttpHeadersPattern(), null, null, EmptyStringPattern, mapOf("Data" to NumberPattern()))
         val request = HttpRequest().copy(formFields = mapOf("Data" to "hello"))
-        assertTrue(requestPattern.matchFormFields(Triple(request, Resolver(), emptyList())) is MatchFailure)
+        val result: MatchingResult<Triple<HttpRequest, Resolver, List<Result.Failure>>> = requestPattern.matchFormFields(Triple(request, Resolver(), emptyList()))
+        result as MatchSuccess<Triple<HttpRequest, Resolver, List<Result.Failure>>>
+        val failures = result.value.third
+        assertThat(failures).hasSize(1)
     }
 
     @Test

--- a/core/src/test/kotlin/in/specmatic/core/FeatureTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/FeatureTest.kt
@@ -70,7 +70,7 @@ class FeatureTest {
             
               >> REQUEST.HEADERS
               
-              Expected header named "x-loginId" was missing
+                 Expected header named "x-loginId" was missing
               """.trimIndent())
     }
 
@@ -148,7 +148,7 @@ class FeatureTest {
             
               >> REQUEST.BODY.calls_made
               
-              Expected an array of length 3, actual length 2
+                 Expected an array of length 3, actual length 2
             """.trimIndent())
     }
 
@@ -173,7 +173,7 @@ class FeatureTest {
             
               >> REQUEST.BODY.calls_made.[2]
               
-              Expected number, actual was string: "test"
+                 Expected number, actual was string: "test"
             """.trimIndent())
     }
 
@@ -216,7 +216,7 @@ class FeatureTest {
             
               >> REQUEST.URL.QUERY-PARAMS.account-id
               
-              Expected number, actual was string: "abc"
+                 Expected number, actual was string: "abc"
             """.trimIndent())
     }
 

--- a/core/src/test/kotlin/in/specmatic/core/FeatureTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/FeatureTest.kt
@@ -663,14 +663,14 @@ Feature: Contract for /balance API
     fun `successfully matches valid form fields`() {
         val requestPattern = HttpRequestPattern(HttpHeadersPattern(), null, null, EmptyStringPattern, mapOf("Data" to NumberPattern()))
         val request = HttpRequest().copy(formFields = mapOf("Data" to "10"))
-        assertTrue(requestPattern.matchFormFields(request to Resolver()) is MatchSuccess)
+        assertTrue(requestPattern.matchFormFields(Triple(request, Resolver(), emptyList())) is MatchSuccess)
     }
 
     @Test
     fun `returns error for form fields`() {
         val requestPattern = HttpRequestPattern(HttpHeadersPattern(), null, null, EmptyStringPattern, mapOf("Data" to NumberPattern()))
         val request = HttpRequest().copy(formFields = mapOf("Data" to "hello"))
-        assertTrue(requestPattern.matchFormFields(request to Resolver()) is MatchFailure)
+        assertTrue(requestPattern.matchFormFields(Triple(request, Resolver(), emptyList())) is MatchFailure)
     }
 
     @Test

--- a/core/src/test/kotlin/in/specmatic/core/HttpRequestPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/HttpRequestPatternTest.kt
@@ -324,4 +324,17 @@ internal class HttpRequestPatternTest {
                 Success::class.java)
         }
     }
+
+    @Test
+    fun `optional form field can be omitted from request`() {
+        val request = HttpRequest(method = "POST", path = "/", formFields = mapOf("hello" to """10"""))
+
+        val result = HttpRequestPattern(
+            method = "POST",
+            urlMatcher = URLMatcher(emptyMap(), emptyList(), "/"),
+            formFieldsPattern = mapOf("hello" to NumberPattern(), "world?" to NumberPattern())
+        ).matches(request, Resolver())
+
+        assertThat(result).isInstanceOf(Success::class.java)
+    }
 }

--- a/core/src/test/kotlin/in/specmatic/core/HttpRequestPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/HttpRequestPatternTest.kt
@@ -51,7 +51,7 @@ internal class HttpRequestPatternTest {
             .updateBody("""{"unmatchedKey": "unmatchedValue"}""")
         httpRequestPattern.matches(httpRequest, Resolver()).let {
             assertThat(it).isInstanceOf(Failure::class.java)
-            assertThat((it as Failure).toMatchFailureDetails()).isEqualTo(MatchFailureDetails(listOf("REQUEST", "BODY"), listOf("Expected key named \"name\" was missing")))
+            assertThat((it as Failure).toMatchFailureDetails()).isEqualTo(MatchFailureDetails(listOf("REQUEST", "BODY", "name"), listOf("Expected key named \"name\" was missing")))
         }
     }
 

--- a/core/src/test/kotlin/in/specmatic/core/HttpRequestPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/HttpRequestPatternTest.kt
@@ -337,4 +337,15 @@ internal class HttpRequestPatternTest {
 
         assertThat(result).isInstanceOf(Success::class.java)
     }
+
+    @Test
+    fun `match errors across the request including header and body will be returned`()  {
+        val type = HttpRequestPattern(method = "POST", urlMatcher = toURLMatcherWithOptionalQueryParams("http://helloworld.com/data"), headersPattern = HttpHeadersPattern(mapOf("X-Data" to NumberPattern())), body = JSONObjectPattern(mapOf("id" to NumberPattern())))
+        val request = HttpRequest("POST", "/data", headers = mapOf("X-Data" to "abc123"), body = parsedJSON("""{"id": "abc123"}"""))
+
+        val result = type.matches(request, Resolver())
+        val reportText = result.reportString()
+        assertThat(reportText).contains(">> REQUEST.HEADERS.X-Data")
+        assertThat(reportText).contains(">> REQUEST.BODY.id")
+    }
 }

--- a/core/src/test/kotlin/in/specmatic/core/HttpStubTests.kt
+++ b/core/src/test/kotlin/in/specmatic/core/HttpStubTests.kt
@@ -418,7 +418,7 @@ Scenario: JSON API to get account details with fact check
                     
                       >> RESPONSE.BODY.[0].rating
                       
-                      ${ContractAndStubMismatchMessages.mismatchMessage("(1 or 2 or 3)", "number: 4")}
+                         ${ContractAndStubMismatchMessages.mismatchMessage("(1 or 2 or 3)", "number: 4")}
                 """.trimIndent()
                 )
             }

--- a/core/src/test/kotlin/in/specmatic/core/KeyCheckTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/KeyCheckTest.kt
@@ -12,6 +12,10 @@ internal class KeyCheckTest {
                 return MissingKeyError("test")
             }
 
+            override fun validateList(pattern: Map<String, Any>, actual: Map<String, Any>): List<KeyError> {
+                return listOf(MissingKeyError("test"))
+            }
+
         }).validate(emptyMap(), emptyMap())
 
         assertThat(result?.name).isEqualTo("test")
@@ -24,9 +28,17 @@ internal class KeyCheckTest {
                 return null
             }
 
+            override fun validateList(pattern: Map<String, Any>, actual: Map<String, Any>): List<KeyError> {
+                return emptyList()
+            }
+
         }, unexpectedKeyCheck = object: UnexpectedKeyCheck {
             override fun validate(pattern: Map<String, Any>, actual: Map<String, Any>): UnexpectedKeyError {
                 return UnexpectedKeyError("test")
+            }
+
+            override fun validateList(pattern: Map<String, Any>, actual: Map<String, Any>): List<UnexpectedKeyError> {
+                return listOf(UnexpectedKeyError("test"))
             }
 
         }).validate(emptyMap(), emptyMap())
@@ -41,9 +53,17 @@ internal class KeyCheckTest {
                 return null
             }
 
+            override fun validateList(pattern: Map<String, Any>, actual: Map<String, Any>): List<KeyError> {
+                return emptyList()
+            }
+
         }, unexpectedKeyCheck = object: UnexpectedKeyCheck {
             override fun validate(pattern: Map<String, Any>, actual: Map<String, Any>): UnexpectedKeyError {
                 return UnexpectedKeyError("test")
+            }
+
+            override fun validateList(pattern: Map<String, Any>, actual: Map<String, Any>): List<UnexpectedKeyError> {
+                return listOf(UnexpectedKeyError("test"))
             }
 
         }).withUnexpectedKeyCheck(IgnoreUnexpectedKeys)
@@ -60,9 +80,17 @@ internal class KeyCheckTest {
                 return null
             }
 
+            override fun validateList(pattern: Map<String, Any>, actual: Map<String, Any>): List<KeyError> {
+                return emptyList()
+            }
+
         }, unexpectedKeyCheck = object: UnexpectedKeyCheck {
             override fun validate(pattern: Map<String, Any>, actual: Map<String, Any>): UnexpectedKeyError {
                 return UnexpectedKeyError("test")
+            }
+
+            override fun validateList(pattern: Map<String, Any>, actual: Map<String, Any>): List<UnexpectedKeyError> {
+                return listOf(UnexpectedKeyError("test"))
             }
 
         }).disableOverrideUnexpectedKeycheck().withUnexpectedKeyCheck(IgnoreUnexpectedKeys)

--- a/core/src/test/kotlin/in/specmatic/core/ResultKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/ResultKtTest.kt
@@ -2,11 +2,31 @@ package `in`.specmatic.core
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import java.util.function.Consumer
 
 internal class ResultKtTest {
     @Test
     fun `add response body to result variables`() {
         val result = Result.Success().withBindings(mapOf("data" to "response-body"), HttpResponse.OK("10")) as Result.Success
         assertThat(result.variables).isEqualTo(mapOf("data" to "10"))
+    }
+
+    @Test
+    fun `result report for failure with multiple causes`() {
+        val result = Result.Failure(
+            causes = listOf(
+                Result.FailureCause("", cause = Result.Failure("Failure 1", breadCrumb = "id")),
+                Result.FailureCause("", cause = Result.Failure("Failure 2", breadCrumb = "height"))
+            ), breadCrumb = "person"
+        )
+
+        assertThat(result.reportString()).satisfies(Consumer {
+            assertThat(it).contains("person.id")
+            assertThat(it).contains("person.height")
+            assertThat(it).contains("Failure 1")
+            assertThat(it).contains("Failure 2")
+
+            println(result.reportString())
+        })
     }
 }

--- a/core/src/test/kotlin/in/specmatic/core/URLMatcherKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/URLMatcherKtTest.kt
@@ -1,0 +1,30 @@
+package `in`.specmatic.core
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+internal class URLMatcherKtTest {
+    @Nested
+    inner class ReturnMultipleErrors {
+        val urlMatcher = toURLMatcherWithOptionalQueryParams("http://example.com/?hello=(number)")
+        val result = urlMatcher.matches(HttpRequest("GET", "/", queryParams = mapOf("hello" to "world", "hi" to "all")), Resolver()) as Result.Failure
+        val resultText = result.toReport().toText()
+
+        @Test
+        fun `should return as many errors as there are value mismatches`() {
+            assertThat(result.toMatchFailureDetailList()).hasSize(2)
+        }
+
+        @Test
+        fun `keys with errors should be present in the error list`() {
+            assertThat(resultText).contains(">> QUERY-PARAMS.hello")
+            assertThat(resultText).contains(">> QUERY-PARAMS.hi")
+        }
+
+        @Test
+        fun `key presence errors should appear before value errors`() {
+            assertThat(resultText.indexOf(">> QUERY-PARAMS.hi")).isLessThan(resultText.indexOf(">> QUERY-PARAMS.hello"))
+        }
+    }
+}

--- a/core/src/test/kotlin/in/specmatic/core/ValidateUnexpectedKeysTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/ValidateUnexpectedKeysTest.kt
@@ -2,6 +2,7 @@ package `in`.specmatic.core
 
 import `in`.specmatic.core.pattern.NullPattern
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 internal class ValidateUnexpectedKeysTest {
@@ -32,5 +33,25 @@ internal class ValidateUnexpectedKeysTest {
 
         val error = ValidateUnexpectedKeys.validate(expected, actual)
         assertThat(error).isNull()
+    }
+
+    @Nested
+    inner class AllUnexpectedErrors {
+        private val expected = mapOf("hello" to NullPattern)
+        private val actual = mapOf("hello_there" to NullPattern, "hello_world" to NullPattern)
+        private val errorList: List<UnexpectedKeyError> = ValidateUnexpectedKeys.validateList(expected, actual)
+
+        @Test
+        fun `returns as many errors as unexpected keys`() {
+            assertThat(errorList).hasSize(2)
+        }
+
+        @Test
+        fun `errors should refer to the unexpected keys`() {
+            val names = errorList.map { it.name }
+
+            assertThat(names).contains("hello_there")
+            assertThat(names).contains("hello_world")
+        }
     }
 }

--- a/core/src/test/kotlin/in/specmatic/core/pattern/AnyPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/AnyPatternTest.kt
@@ -39,14 +39,14 @@ internal class AnyPatternTest {
         val result2 = pattern2.matches(value, resolver)
 
         assertThat(result2.toReport().toText().trimIndent()).isEqualTo("""Expected string, actual was json object: {
-      "firstname": "Jane",
-      "lastname": "Doe"
-  }""")
+       "firstname": "Jane",
+       "lastname": "Doe"
+   }""")
 
         assertThat(result1.toReport().toText().trimIndent()).isEqualTo("""Expected string, actual was json object: {
-      "firstname": "Jane",
-      "lastname": "Doe"
-  }""")
+       "firstname": "Jane",
+       "lastname": "Doe"
+   }""")
     }
 
     @Test

--- a/core/src/test/kotlin/in/specmatic/core/pattern/AnyPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/AnyPatternTest.kt
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import `in`.specmatic.core.Resolver
 import `in`.specmatic.core.Result
-import `in`.specmatic.core.toReport
 import `in`.specmatic.core.utilities.withNullPattern
 import `in`.specmatic.core.value.JSONObjectValue
 import `in`.specmatic.core.value.NumberValue

--- a/core/src/test/kotlin/in/specmatic/core/pattern/JSONObjectPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/JSONObjectPatternTest.kt
@@ -7,6 +7,7 @@ import `in`.specmatic.core.value.*
 import `in`.specmatic.shouldMatch
 import `in`.specmatic.shouldNotMatch
 import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Nested
 import java.util.function.Consumer
 
 internal class JSONObjectPatternTest {
@@ -338,5 +339,30 @@ internal class JSONObjectPatternTest {
                   Expected number, actual was string: "10"
             """.trimIndent().trim())
         })
+    }
+
+    @Nested
+    inner class MatchReturnsAllKeyErrors {
+        val type = JSONObjectPattern(mapOf("id" to NumberPattern(), "address" to StringPattern()))
+        val json = parsedJSON("""{"person_id": "abc123"}""")
+        val error: Result = type.matches(json, Resolver())
+
+        @Test
+        fun `return as many errors as the number of key errors`() {
+            error as Result.Failure
+
+            assertThat(error.toMatchFailureDetailList()).hasSize(3)
+        }
+
+        @Test
+        fun `errors should refer to the missing keys`() {
+            error as Result.Failure
+
+            println(error.toFailureReport().toText())
+
+            assertThat(error.toFailureReport().toText()).contains(">> id")
+            assertThat(error.toFailureReport().toText()).contains(">> address")
+            assertThat(error.toFailureReport().toText()).contains(">> person_id")
+        }
     }
 }

--- a/core/src/test/kotlin/in/specmatic/core/pattern/JSONObjectPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/JSONObjectPatternTest.kt
@@ -366,8 +366,8 @@ internal class JSONObjectPatternTest {
 
         @Test
         fun `key errors appear before value errors`() {
-            assertThat(reportText.indexOf(">> person_address")).isGreaterThan(reportText.indexOf("id"))
-            assertThat(reportText.indexOf(">> address")).isGreaterThan(reportText.indexOf("id"))
+            assertThat(reportText.indexOf(">> person_address")).isLessThan(reportText.indexOf(">> id"))
+            assertThat(reportText.indexOf(">> address")).isLessThan(reportText.indexOf(">> id"))
         }
     }
 }

--- a/core/src/test/kotlin/in/specmatic/core/pattern/JSONObjectPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/JSONObjectPatternTest.kt
@@ -331,12 +331,12 @@ internal class JSONObjectPatternTest {
 
             assertThat(it.toFailureReport().toString()).isEqualTo("""
                 >> id
-                  
-                  Expected number, actual was string: "abc123"
-                  
-                  >> address.flat
-                  
-                  Expected number, actual was string: "10"
+
+                   Expected number, actual was string: "abc123"
+
+                >> address.flat
+
+                   Expected number, actual was string: "10"
             """.trimIndent().trim())
         })
     }

--- a/core/src/test/kotlin/in/specmatic/core/pattern/JSONObjectPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/JSONObjectPatternTest.kt
@@ -344,8 +344,9 @@ internal class JSONObjectPatternTest {
     @Nested
     inner class MatchReturnsAllKeyErrors {
         val type = JSONObjectPattern(mapOf("id" to NumberPattern(), "address" to StringPattern()))
-        val json = parsedJSON("""{"person_id": "abc123"}""")
-        val error: Result = type.matches(json, Resolver())
+        val json = parsedJSON("""{"id": "10", "person_address": "abc123"}""")
+        val error: Result.Failure = type.matches(json, Resolver()) as Result.Failure
+        val reportText = error.toFailureReport().toText()
 
         @Test
         fun `return as many errors as the number of key errors`() {
@@ -356,13 +357,17 @@ internal class JSONObjectPatternTest {
 
         @Test
         fun `errors should refer to the missing keys`() {
-            error as Result.Failure
+            println(reportText)
 
-            println(error.toFailureReport().toText())
+            assertThat(reportText).contains(">> id")
+            assertThat(reportText).contains(">> address")
+            assertThat(reportText).contains(">> person_address")
+        }
 
-            assertThat(error.toFailureReport().toText()).contains(">> id")
-            assertThat(error.toFailureReport().toText()).contains(">> address")
-            assertThat(error.toFailureReport().toText()).contains(">> person_id")
+        @Test
+        fun `key errors appear before value errors`() {
+            assertThat(reportText.indexOf(">> person_address")).isGreaterThan(reportText.indexOf("id"))
+            assertThat(reportText.indexOf(">> address")).isGreaterThan(reportText.indexOf("id"))
         }
     }
 }

--- a/core/src/test/kotlin/in/specmatic/core/pattern/JSONObjectPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/JSONObjectPatternTest.kt
@@ -318,4 +318,25 @@ internal class JSONObjectPatternTest {
             println(it)
         })
     }
+
+    @Test
+    fun `an error for failure n levels deep should have a path with all the levels`() {
+        val type = JSONObjectPattern(mapOf("id" to NumberPattern(), "address" to JSONObjectPattern(mapOf("flat" to NumberPattern()))))
+        val json = parsedJSON("""{"id": "abc123", "address": {"flat": "10"}}""")
+
+        assertThat(type.matches(json, Resolver())).satisfies(Consumer {
+            it as Result.Failure
+            assertThat(it.causes).hasSize(2)
+
+            assertThat(it.toFailureReport().toString()).isEqualTo("""
+                >> id
+                  
+                  Expected number, actual was string: "abc123"
+                  
+                  >> address.flat
+                  
+                  Expected number, actual was string: "10"
+            """.trimIndent().trim())
+        })
+    }
 }

--- a/core/src/test/kotlin/in/specmatic/core/pattern/JSONObjectPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/JSONObjectPatternTest.kt
@@ -7,6 +7,7 @@ import `in`.specmatic.core.value.*
 import `in`.specmatic.shouldMatch
 import `in`.specmatic.shouldNotMatch
 import org.junit.jupiter.api.Assertions.*
+import java.util.function.Consumer
 
 internal class JSONObjectPatternTest {
     @Test
@@ -303,5 +304,18 @@ internal class JSONObjectPatternTest {
         assertThat(combinations).contains(personWithAddressWithoutStreet)
         assertThat(combinations).contains(personWithAddressSetToNull)
         assertThat(combinations).contains(personWithoutAddress)
+    }
+
+    @Test
+    fun `returns as many errors as contract-invalid values in a JSON object`() {
+        val type = JSONObjectPattern(mapOf("id" to NumberPattern(), "height" to NumberPattern()))
+        val json = parsedJSON("""{"id": "abc123", "height": "5 feet 7"}""")
+
+        assertThat(type.matches(json, Resolver())).satisfies(Consumer {
+            it as Result.Failure
+            assertThat(it.causes).hasSize(2)
+
+            println(it)
+        })
     }
 }

--- a/core/src/test/kotlin/in/specmatic/core/pattern/ListPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/ListPatternTest.kt
@@ -9,6 +9,8 @@ import `in`.specmatic.core.Result
 import `in`.specmatic.core.testBackwardCompatibility
 import `in`.specmatic.core.value.NullValue
 import `in`.specmatic.shouldNotMatch
+import org.junit.jupiter.api.Nested
+import org.junit.runner.notification.Failure
 
 internal class ListPatternTest {
     @Test
@@ -83,5 +85,27 @@ Feature: Recursive test
         val result = testBackwardCompatibility(feature, feature)
         println(result.report())
         assertThat(result.success()).isTrue()
+    }
+
+    @Nested
+    inner class ReturnAllErrors {
+        val listType = ListPattern(NumberPattern())
+        val list = parsedJSON("""["elementA", 2, "elementC"]""")
+        val result: Result.Failure = listType.matches(list, Resolver()) as Result.Failure
+        val resultText = result.toFailureReport().toText()
+
+        @Test
+        fun `should return all errors in a list`() {
+            assertThat(result.toMatchFailureDetailList()).hasSize(2)
+        }
+
+        @Test
+        fun `should refer to all errors in the report`() {
+            println(resultText)
+            assertThat(resultText).contains("[0]")
+            assertThat(resultText).contains("elementA")
+            assertThat(resultText).contains("[2]")
+            assertThat(resultText).contains("elementC")
+        }
     }
 }

--- a/core/src/test/kotlin/in/specmatic/core/pattern/LookupRowPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/LookupRowPatternTest.kt
@@ -1,11 +1,10 @@
 package `in`.specmatic.core.pattern
 
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Test
 import `in`.specmatic.core.Resolver
 import `in`.specmatic.core.Result
-import `in`.specmatic.core.toReport
 import `in`.specmatic.core.value.NumberValue
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
 
 internal class LookupRowPatternTest {
     @Test
@@ -31,7 +30,7 @@ internal class LookupRowPatternTest {
         val lookupRowPattern = LookupRowPattern(StringPattern(), "name")
         val result = lookupRowPattern.encompasses(lookupRowPattern, Resolver(), Resolver())
 
-        println(toReport(result))
+        println(result.toReport())
         assertThat(result).isInstanceOf(Result.Success::class.java)
     }
 

--- a/core/src/test/kotlin/in/specmatic/core/pattern/PatternInStringPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/PatternInStringPatternTest.kt
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.fail
 import `in`.specmatic.core.Resolver
 import `in`.specmatic.core.Result
-import `in`.specmatic.core.toReport
 import `in`.specmatic.core.value.StringValue
 import `in`.specmatic.shouldMatch
 

--- a/core/src/test/kotlin/in/specmatic/core/pattern/TabularPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/TabularPatternTest.kt
@@ -318,11 +318,11 @@ Feature: test feature
 
         assertThat(result.toReport().toString()).isEqualTo(
             """>> REQUEST.BODY.name
-  
-  Expected string, actual was json object: {
-      "firstname": "Jane",
-      "lastname": "Doe"
-  }"""
+
+   Expected string, actual was json object: {
+       "firstname": "Jane",
+       "lastname": "Doe"
+   }"""
         )
     }
 

--- a/core/src/test/kotlin/in/specmatic/core/pattern/TabularPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/TabularPatternTest.kt
@@ -316,7 +316,7 @@ Feature: test feature
         val resolver = feature.scenarios.single().resolver
         val result = feature.scenarios.single().httpRequestPattern.matches(request, resolver)
 
-        assertThat(toReport(result)).isEqualTo(
+        assertThat(result.toReport().toString()).isEqualTo(
             """>> REQUEST.BODY.name
   
   Expected string, actual was json object: {

--- a/core/src/test/kotlin/in/specmatic/core/pattern/XMLPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/XMLPatternTest.kt
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import `in`.specmatic.core.Resolver
 import `in`.specmatic.core.Result
-import `in`.specmatic.core.toReport
 import `in`.specmatic.core.value.*
 import `in`.specmatic.core.wsdl.parser.message.MULTIPLE_ATTRIBUTE_VALUE
 import `in`.specmatic.core.wsdl.parser.message.OCCURS_ATTRIBUTE_NAME
@@ -181,7 +180,7 @@ internal class XMLPatternTest {
             val value = parsedValue("""<name/>""")
 
             val result = type.matches(value, Resolver())
-            println(toReport(result))
+            println(result.toReport())
             assertThat(result).isInstanceOf(Result.Success::class.java)
         }
 

--- a/core/src/test/kotlin/in/specmatic/mock/ScenarioStubKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/mock/ScenarioStubKtTest.kt
@@ -877,10 +877,10 @@ paths:
             assertThat((it as NoMatchingScenario).report(request).trim()).isEqualTo("""
                 In scenario "hello world. Response: Says hello"
                 API: GET /hello/(id:number) -> 200
-                
+
                   >> REQUEST.HEADERS.X-Value
                   
-                  ${ContractAndStubMismatchMessages.mismatchMessage("number", """string: "data" """.trim())}
+                     ${ContractAndStubMismatchMessages.mismatchMessage("number", """string: "data" """.trim())}
                 """.trimIndent())
         })
     }

--- a/core/src/test/kotlin/in/specmatic/stub/ApiKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/stub/ApiKtTest.kt
@@ -370,15 +370,15 @@ Feature: Math API
         assertThat(stubInfo.single().second).isEmpty()
 
         val expectedOnStandardOutput =
-            """
-            sample.json didn't match math.$CONTRACT_EXTENSION
-                In scenario "Square of a number"
-                API: POST /square -> 200
-              
-                  >> RESPONSE.BODY
-              
-                  ${ContractAndStubMismatchMessages.mismatchMessage("number", """string: "not a number"""")}
-            """.trimIndent()
+"""
+sample.json didn't match math.$CONTRACT_EXTENSION
+    In scenario "Square of a number"
+    API: POST /square -> 200
+  
+      >> RESPONSE.BODY
+  
+         ${ContractAndStubMismatchMessages.mismatchMessage("number", """string: "not a number"""")}
+""".trim()
 
         assertThat(stdout).contains(expectedOnStandardOutput)
     }
@@ -440,7 +440,7 @@ Feature: Math API
   
       >> REQUEST.BODY
   
-      ${ContractAndStubMismatchMessages.unexpectedKey("key", "unexpected")}""")
+         ${ContractAndStubMismatchMessages.unexpectedKey("key", "unexpected")}""")
     }
 
     @Test
@@ -466,8 +466,8 @@ sample.json didn't match math.$CONTRACT_EXTENSION
   
       >> RESPONSE.BODY
   
-      ${ContractAndStubMismatchMessages.unexpectedKey("key", "unexpected")}
-      """.trimIndent())
+         ${ContractAndStubMismatchMessages.unexpectedKey("key", "unexpected")}
+  """.trimIndent())
     }
 
     @Test

--- a/core/src/test/kotlin/in/specmatic/stub/ApiKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/stub/ApiKtTest.kt
@@ -438,7 +438,7 @@ Feature: Math API
     In scenario "Square of a number"
     API: POST /square -> 200
   
-      >> REQUEST.BODY
+      >> REQUEST.BODY.unexpected
   
          ${ContractAndStubMismatchMessages.unexpectedKey("key", "unexpected")}""")
     }
@@ -464,7 +464,7 @@ sample.json didn't match math.$CONTRACT_EXTENSION
     In scenario "Square of a number"
     API: POST /square -> 200
   
-      >> RESPONSE.BODY
+      >> RESPONSE.BODY.unexpected
   
          ${ContractAndStubMismatchMessages.unexpectedKey("key", "unexpected")}
   """.trimIndent())

--- a/core/src/test/kotlin/in/specmatic/stub/HttpStubKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/stub/HttpStubKtTest.kt
@@ -164,7 +164,7 @@ Scenario: Square of a number
         val strictResponse = stubResponse(request, listOf(feature), listOf(stubData), true)
         assertResponseFailure(strictResponse, """STRICT MODE ON
 
->> REQUEST.URL.QUERY-PARAMS
+>> REQUEST.URL.QUERY-PARAMS.status
 
    ${StubAndRequestMismatchMessages.expectedKeyWasMissing("query param", "status")}""")
     }

--- a/core/src/test/kotlin/in/specmatic/stub/HttpStubKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/stub/HttpStubKtTest.kt
@@ -67,7 +67,7 @@ Feature: POST API
             In scenario "Test"
             API: POST / -> 200
             
-              >> REQUEST.BODY
+              >> REQUEST.BODY.undeclared
               
                  ${ContractAndRequestsMismatch.unexpectedKey("key", "undeclared")}
             """.trimIndent())
@@ -131,7 +131,7 @@ Scenario: Square of a number
             In scenario "Square of a number"
             API: POST /number -> 200
             
-              >> REQUEST.BODY
+              >> REQUEST.BODY.unexpected
               
                  ${ContractAndRequestsMismatch.unexpectedKey("key", "unexpected")}
             """.trimIndent())

--- a/core/src/test/kotlin/in/specmatic/stub/HttpStubKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/stub/HttpStubKtTest.kt
@@ -37,8 +37,8 @@ Feature: Test
         assertResponseFailure(stubResponse, """STRICT MODE ON
 
 >> REQUEST.BODY
-  
-  Expected number, actual was "Hello"""")
+
+   Expected number, actual was "Hello"""")
     }
 
     private fun assertResponseFailure(stubResponse: HttpStubResponse, errorMessage: String) {
@@ -69,7 +69,7 @@ Feature: POST API
             
               >> REQUEST.BODY
               
-              ${ContractAndRequestsMismatch.unexpectedKey("key", "undeclared")}
+                 ${ContractAndRequestsMismatch.unexpectedKey("key", "undeclared")}
             """.trimIndent())
     }
 
@@ -133,7 +133,7 @@ Scenario: Square of a number
             
               >> REQUEST.BODY
               
-              ${ContractAndRequestsMismatch.unexpectedKey("key", "unexpected")}
+                 ${ContractAndRequestsMismatch.unexpectedKey("key", "unexpected")}
             """.trimIndent())
     }
 
@@ -165,8 +165,8 @@ Scenario: Square of a number
         assertResponseFailure(strictResponse, """STRICT MODE ON
 
 >> REQUEST.URL.QUERY-PARAMS
-  
-  ${StubAndRequestMismatchMessages.expectedKeyWasMissing("query param", "status")}""")
+
+   ${StubAndRequestMismatchMessages.expectedKeyWasMissing("query param", "status")}""")
     }
 
     @Test

--- a/junit5-support/src/main/kotlin/in/specmatic/test/ResultAssert.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/ResultAssert.kt
@@ -1,8 +1,7 @@
 package `in`.specmatic.test
 
-import org.assertj.core.api.AbstractAssert
 import `in`.specmatic.core.Result
-import `in`.specmatic.core.toReport
+import org.assertj.core.api.AbstractAssert
 
 class ResultAssert(result: Result) : AbstractAssert<ResultAssert, Result>(result, ResultAssert::class.java) {
     companion object {

--- a/junit5-support/src/main/kotlin/in/specmatic/test/ResultAssert.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/ResultAssert.kt
@@ -13,8 +13,10 @@ class ResultAssert(result: Result) : AbstractAssert<ResultAssert, Result>(result
     fun isSuccess() {
         isNotNull
 
-        if(actual is Result.Failure) {
-            failWithMessage(actual.toFailureReport("Testing scenario").toText())
+        actual.let {
+            if(it is Result.Failure) {
+                failWithMessage(it.toFailureReport("Testing scenario").toText())
+            }
         }
     }
 }

--- a/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
@@ -120,7 +120,7 @@ open class SpecmaticJUnitSupport {
                 val result: Result = invoker.execute(testScenario, timeout)
 
                 when {
-                    shouldBeIgnored(result) -> {
+                    result.shouldBeIgnored() -> {
                         val message = "Test FAILED, ignoring since the scenario is tagged @WIP${System.lineSeparator()}${result.toReport().toText().prependIndent("  ")}"
                         throw TestAbortedException(message)
                     }

--- a/release.sh
+++ b/release.sh
@@ -1,14 +1,12 @@
 #!/bin/sh
 
-set -e
-
 BRANCH=`git rev-parse --abbrev-ref HEAD`
 
 if [ $BRANCH != "main" ]
 then
-	echo Current branch is $BRANCH
+	echo Current branch is $BRANCH.
 	echo
-	echo You should only release from main
+	echo You should only release from main.
 	exit 1
 fi
 
@@ -19,11 +17,21 @@ then
 	exit 1
 fi
 
+OUTPUT=`git rev-parse $1 2>&1`
+
+if [ $? = "0" ]
+then
+	echo This tag already exists, most likely because a release with this version has already been done.
+	exit 1
+fi
+
+set -e
+
 ACTUAL_VERSION=`cat version.properties | sed s/version=//g`
 
 if [ "$1" != $ACTUAL_VERSION ]
 then
-	echo The specified version $1 does not match the actual version $ACTUAL_VERSION
+	echo The specified version $1 does not match the actual version $ACTUAL_VERSION.
 	exit 1
 fi
 

--- a/release.sh
+++ b/release.sh
@@ -2,6 +2,16 @@
 
 set -e
 
+BRANCH=`git rev-parse --abbrev-ref HEAD`
+
+if [ $BRANCH != "main" ]
+then
+	echo Current branch is $BRANCH
+	echo
+	echo You should only release from main
+	exit 1
+fi
+
 if [ -z "$1" ]
 then
 	echo Provide the version to be published as the first argument.


### PR DESCRIPTION
**What**:

All errors in a stub / actual request and response are returned together by Specmatic, instead one at a time.

Ideally this would be done for contract test, stub and backward compatibility errors. But that's a large exercise. For this PR, we have started off with stub and request matching in JSON. We will finish contract and backward compatibility next, and then approach XML/SOAP.

**Why**:

For the longest time, Specmatic has returned errors one at a time. For example, if there are two keys in the contract that are missing in a stub request payload, Specmatic identifies just one of the missing keys. When this missing key is added to the stub request, Specmatic highlights the second.

It would be so much better if both errors were identified in one go.

This would save on time taken to start the stub or run the component test to figure out where the contract mismatches lie.

**How**:

I have modified the Result class to hold multiple causes instead of one, and the reporting code as needed.
