### PR TITLE
Streaming response

### DIFF
--- a/core/src/main/kotlin/in/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/in/specmatic/stub/HttpStub.kt
@@ -86,11 +86,16 @@ class HttpStub(private val features: List<Feature>, _httpStubs: List<HttpStubDat
                         else -> serveStubResponse(httpRequest)
                     }
 
-                    if(httpRequest.headers["Content-Type"] == "text/event-stream") {
+                    if(httpRequest.path!!.startsWith("""/features/default""")) {
                         val channel = produce { // this: ProducerScope<SseEvent> ->
                             var n = 0
+                            send(SseEvent("""{"status":"discover"}""", "ack"))
+                            delay(1000)
+                            send(SseEvent("""[{"id":"8b6002e8-e97a-4ebe-8cae-ac68fb123121","key":"T03","l":true,"version":5,"type":"BOOLEAN","value":false}]"""
+                                , "features", "ef0c67ba"))
+                            delay(1000)
                             while (true) {
-                                send(SseEvent("demo$n"))
+                                send(SseEvent("""{"status":"closed"}""", "bye"))
                                 delay(1000)
                                 n++
                             }

--- a/core/src/main/kotlin/in/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/in/specmatic/stub/HttpStub.kt
@@ -30,6 +30,9 @@ import io.ktor.server.engine.*
 import io.ktor.server.netty.*
 import io.ktor.util.asStream
 import io.ktor.util.toMap
+import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.channels.broadcast
+import kotlinx.coroutines.channels.produce
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import java.io.ByteArrayOutputStream
@@ -83,8 +86,25 @@ class HttpStub(private val features: List<Feature>, _httpStubs: List<HttpStubDat
                         else -> serveStubResponse(httpRequest)
                     }
 
-                    respondToKtorHttpResponse(call, httpStubResponse.response, httpStubResponse.delayInSeconds)
-                    httpLogMessage.addResponse(httpStubResponse)
+                    if(httpRequest.headers["Content-Type"] == "text/event-stream") {
+                        val channel = produce { // this: ProducerScope<SseEvent> ->
+                            var n = 0
+                            while (true) {
+                                send(SseEvent("demo$n"))
+                                delay(1000)
+                                n++
+                            }
+                        }.broadcast()
+                        val events = channel.openSubscription()
+                        try {
+                            call.respondSse(events)
+                        } finally {
+                            events.cancel()
+                        }
+                    } else {
+                        respondToKtorHttpResponse(call, httpStubResponse.response, httpStubResponse.delayInSeconds)
+                        httpLogMessage.addResponse(httpStubResponse)
+                    }
                 }
                 catch(e: ContractException) {
                     val response = badRequest(e.report())
@@ -481,4 +501,25 @@ fun stringToMockScenario(text: Value): ScenarioStub {
             }
 
     return mockFromJSON(mockSpec)
+}
+
+data class SseEvent(val data: String, val event: String? = null, val id: String? = null)
+
+suspend fun ApplicationCall.respondSse(events: ReceiveChannel<SseEvent>) {
+    response.cacheControl(CacheControl.NoCache(null))
+    respondTextWriter(contentType = ContentType.Text.EventStream) {
+        for (event in events) {
+            if (event.id != null) {
+                write("id: ${event.id}\n")
+            }
+            if (event.event != null) {
+                write("event: ${event.event}\n")
+            }
+            for (dataLine in event.data.lines()) {
+                write("data: $dataLine\n")
+            }
+            write("\n")
+            flush()
+        }
+    }
 }


### PR DESCRIPTION
**What**:

SSE support without upgrading to KTOR 2

**Why**:

Testing response to see if will work with FeatureHub

**How**:

GET FeatureHub URL - ```curl -v http://localhost:9000/features/default/<feature id string>```

POST to ```http://localhost:9000/_specmatic/sse-expectations```
```{"data":"<string>","event":"<string>","id":"<string>"}```

Examples:
```{"data":"{\"status\":\"discover\"}","event":"ack"}```
```{"data":"{\"feature\":\"test\"}","event":"features","id":"1"}```
```{"data":"{\"status\":\"closed\"}","event":"bye"}```

Event sent to Expectations is sent to the SSE client

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/qontract/qontract-documentation
- [ ] Tests
- [ ] Sonar Quality Gate

