### PR TITLE
Case insensitive header match

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/CheckOnlyPatternKeys.kt
+++ b/core/src/main/kotlin/in/specmatic/core/CheckOnlyPatternKeys.kt
@@ -1,6 +1,8 @@
 package `in`.specmatic.core
 
+import `in`.specmatic.core.pattern.Pattern
 import `in`.specmatic.core.pattern.isOptional
+import `in`.specmatic.core.value.StringValue
 
 internal object CheckOnlyPatternKeys: KeyErrorCheck {
     override fun validate(pattern: Map<String, Any>, actual: Map<String, Any>): KeyError? {
@@ -10,6 +12,15 @@ internal object CheckOnlyPatternKeys: KeyErrorCheck {
     override fun validateList(pattern: Map<String, Any>, actual: Map<String, Any>): List<KeyError> {
         return pattern.minus("...").keys.filter { key ->
             isMissingKey(actual, key)
+        }.map { it.toMissingKeyError() }
+    }
+
+    override fun validateListCaseInsensitive(
+        pattern: Map<String, Pattern>,
+        actual: Map<String, StringValue>
+    ): List<KeyError> {
+        return pattern.minus("...").keys.filter { key ->
+            isMissingKeyCaseInsensitive(actual, key)
         }.map { it.toMissingKeyError() }
     }
 }
@@ -22,4 +33,15 @@ internal fun isMissingKey(jsonObject: Map<String, Any?>, key: String) =
     when {
         isOptional(key) -> false
         else -> key !in jsonObject && "$key?" !in jsonObject && "$key:" !in jsonObject
+    }
+
+internal fun isMissingKeyCaseInsensitive(jsonObject: Map<String, Any?>, key: String) =
+    when {
+        isOptional(key) -> false
+        else -> {
+            val objectWithLowerCaseKeys = jsonObject.mapKeys { it.key.lowercase() }
+            val lowerCaseKey = key.lowercase()
+
+            lowerCaseKey !in objectWithLowerCaseKeys && "$lowerCaseKey?" !in objectWithLowerCaseKeys && "$lowerCaseKey:" !in objectWithLowerCaseKeys
+        }
     }

--- a/core/src/main/kotlin/in/specmatic/core/KeyCheck.kt
+++ b/core/src/main/kotlin/in/specmatic/core/KeyCheck.kt
@@ -1,5 +1,8 @@
 package `in`.specmatic.core
 
+import `in`.specmatic.core.pattern.Pattern
+import `in`.specmatic.core.value.StringValue
+
 class KeyCheck(val patternKeyCheck: KeyErrorCheck = CheckOnlyPatternKeys,
                var unexpectedKeyCheck: UnexpectedKeyCheck = ValidateUnexpectedKeys,
                private val overrideUnexpectedKeyCheck: OverrideUnexpectedKeyCheck? = ::overrideUnexpectedKeyCheck
@@ -24,6 +27,10 @@ class KeyCheck(val patternKeyCheck: KeyErrorCheck = CheckOnlyPatternKeys,
         actual: Map<String, Any>
     ): List<KeyError> {
         return patternKeyCheck.validateList(pattern, actual).plus(unexpectedKeyCheck.validateList(pattern, actual))
+    }
+
+    fun validateAllCaseInsensitive(pattern: Map<String, Pattern>, actual: Map<String, StringValue>): List<KeyError> {
+        return patternKeyCheck.validateListCaseInsensitive(pattern, actual).plus(unexpectedKeyCheck.validateListCaseInsensitive(pattern, actual))
     }
 
 }

--- a/core/src/main/kotlin/in/specmatic/core/KeyErrorCheck.kt
+++ b/core/src/main/kotlin/in/specmatic/core/KeyErrorCheck.kt
@@ -1,6 +1,10 @@
 package `in`.specmatic.core
 
+import `in`.specmatic.core.pattern.Pattern
+import `in`.specmatic.core.value.StringValue
+
 interface KeyErrorCheck {
     fun validate(pattern: Map<String, Any>, actual: Map<String, Any>): KeyError?
     fun validateList(pattern: Map<String, Any>, actual: Map<String, Any>): List<KeyError>
+    fun validateListCaseInsensitive(pattern: Map<String, Pattern>, actual: Map<String, StringValue>): List<KeyError>
 }

--- a/core/src/main/kotlin/in/specmatic/core/Resolver.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Resolver.kt
@@ -86,4 +86,8 @@ data class Resolver(
             }
         }
     }
+
+    fun findKeyErrorListCaseInsensitive(pattern: Map<String, Pattern>, actual: Map<String, StringValue>): List<KeyError> {
+        return findKeyErrorCheck.validateAllCaseInsensitive(pattern, actual)
+    }
 }

--- a/core/src/main/kotlin/in/specmatic/core/UnexpectedKeyCheck.kt
+++ b/core/src/main/kotlin/in/specmatic/core/UnexpectedKeyCheck.kt
@@ -1,6 +1,10 @@
 package `in`.specmatic.core
 
+import `in`.specmatic.core.pattern.Pattern
+import `in`.specmatic.core.value.StringValue
+
 interface UnexpectedKeyCheck {
     fun validate(pattern: Map<String, Any>, actual: Map<String, Any>): UnexpectedKeyError?
     fun validateList(pattern: Map<String, Any>, actual: Map<String, Any>): List<UnexpectedKeyError>
+    fun validateListCaseInsensitive(pattern: Map<String, Pattern>, actual: Map<String, StringValue>): List<UnexpectedKeyError>
 }

--- a/core/src/main/kotlin/in/specmatic/core/ValidateUnexpectedKeys.kt
+++ b/core/src/main/kotlin/in/specmatic/core/ValidateUnexpectedKeys.kt
@@ -1,6 +1,8 @@
 package `in`.specmatic.core
 
+import `in`.specmatic.core.pattern.Pattern
 import `in`.specmatic.core.pattern.withoutOptionality
+import `in`.specmatic.core.value.StringValue
 
 object ValidateUnexpectedKeys: UnexpectedKeyCheck {
     override fun validate(pattern: Map<String, Any>, actual: Map<String, Any>): UnexpectedKeyError? {
@@ -14,5 +16,15 @@ object ValidateUnexpectedKeys: UnexpectedKeyCheck {
         return actualKeys.minus(patternKeys.toSet()).map {
             UnexpectedKeyError(it)
         }
+    }
+
+    override fun validateListCaseInsensitive(
+        pattern: Map<String, Pattern>,
+        actual: Map<String, StringValue>
+    ): List<UnexpectedKeyError> {
+        val patternKeys = pattern.minus("...").keys.map { withoutOptionality(it).lowercase() }.toSet()
+        val actualKeys = actual.keys.map { withoutOptionality(it) }
+
+        return actualKeys.filter { it.lowercase() !in patternKeys }.map { UnexpectedKeyError(it) }
     }
 }

--- a/core/src/main/kotlin/in/specmatic/core/pattern/IgnoreUnexpectedKeys.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/IgnoreUnexpectedKeys.kt
@@ -2,10 +2,18 @@ package `in`.specmatic.core.pattern
 
 import `in`.specmatic.core.UnexpectedKeyCheck
 import `in`.specmatic.core.UnexpectedKeyError
+import `in`.specmatic.core.value.StringValue
 
 object IgnoreUnexpectedKeys: UnexpectedKeyCheck {
     override fun validate(pattern: Map<String, Any>, actual: Map<String, Any>): UnexpectedKeyError? = null
     override fun validateList(pattern: Map<String, Any>, actual: Map<String, Any>): List<UnexpectedKeyError> {
+        return emptyList()
+    }
+
+    override fun validateListCaseInsensitive(
+        pattern: Map<String, Pattern>,
+        actual: Map<String, StringValue>
+    ): List<UnexpectedKeyError> {
         return emptyList()
     }
 }

--- a/core/src/test/kotlin/in/specmatic/core/KeyCheckTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/KeyCheckTest.kt
@@ -1,6 +1,10 @@
 package `in`.specmatic.core
 
 import `in`.specmatic.core.pattern.IgnoreUnexpectedKeys
+import `in`.specmatic.core.pattern.Pattern
+import `in`.specmatic.core.value.StringValue
+import io.mockk.every
+import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -14,6 +18,13 @@ internal class KeyCheckTest {
 
             override fun validateList(pattern: Map<String, Any>, actual: Map<String, Any>): List<KeyError> {
                 return listOf(MissingKeyError("test"))
+            }
+
+            override fun validateListCaseInsensitive(
+                pattern: Map<String, Pattern>,
+                actual: Map<String, StringValue>
+            ): List<KeyError> {
+                TODO("Not yet implemented")
             }
 
         }).validate(emptyMap(), emptyMap())
@@ -32,6 +43,13 @@ internal class KeyCheckTest {
                 return emptyList()
             }
 
+            override fun validateListCaseInsensitive(
+                pattern: Map<String, Pattern>,
+                actual: Map<String, StringValue>
+            ): List<KeyError> {
+                TODO("Not yet implemented")
+            }
+
         }, unexpectedKeyCheck = object: UnexpectedKeyCheck {
             override fun validate(pattern: Map<String, Any>, actual: Map<String, Any>): UnexpectedKeyError {
                 return UnexpectedKeyError("test")
@@ -39,6 +57,13 @@ internal class KeyCheckTest {
 
             override fun validateList(pattern: Map<String, Any>, actual: Map<String, Any>): List<UnexpectedKeyError> {
                 return listOf(UnexpectedKeyError("test"))
+            }
+
+            override fun validateListCaseInsensitive(
+                pattern: Map<String, Pattern>,
+                actual: Map<String, StringValue>
+            ): List<UnexpectedKeyError> {
+                TODO("Not yet implemented")
             }
 
         }).validate(emptyMap(), emptyMap())
@@ -57,6 +82,13 @@ internal class KeyCheckTest {
                 return emptyList()
             }
 
+            override fun validateListCaseInsensitive(
+                pattern: Map<String, Pattern>,
+                actual: Map<String, StringValue>
+            ): List<KeyError> {
+                TODO("Not yet implemented")
+            }
+
         }, unexpectedKeyCheck = object: UnexpectedKeyCheck {
             override fun validate(pattern: Map<String, Any>, actual: Map<String, Any>): UnexpectedKeyError {
                 return UnexpectedKeyError("test")
@@ -64,6 +96,13 @@ internal class KeyCheckTest {
 
             override fun validateList(pattern: Map<String, Any>, actual: Map<String, Any>): List<UnexpectedKeyError> {
                 return listOf(UnexpectedKeyError("test"))
+            }
+
+            override fun validateListCaseInsensitive(
+                pattern: Map<String, Pattern>,
+                actual: Map<String, StringValue>
+            ): List<UnexpectedKeyError> {
+                TODO("Not yet implemented")
             }
 
         }).withUnexpectedKeyCheck(IgnoreUnexpectedKeys)
@@ -84,6 +123,13 @@ internal class KeyCheckTest {
                 return emptyList()
             }
 
+            override fun validateListCaseInsensitive(
+                pattern: Map<String, Pattern>,
+                actual: Map<String, StringValue>
+            ): List<KeyError> {
+                TODO("Not yet implemented")
+            }
+
         }, unexpectedKeyCheck = object: UnexpectedKeyCheck {
             override fun validate(pattern: Map<String, Any>, actual: Map<String, Any>): UnexpectedKeyError {
                 return UnexpectedKeyError("test")
@@ -93,10 +139,37 @@ internal class KeyCheckTest {
                 return listOf(UnexpectedKeyError("test"))
             }
 
+            override fun validateListCaseInsensitive(
+                pattern: Map<String, Pattern>,
+                actual: Map<String, StringValue>
+            ): List<UnexpectedKeyError> {
+                TODO("Not yet implemented")
+            }
+
         }).disableOverrideUnexpectedKeycheck().withUnexpectedKeyCheck(IgnoreUnexpectedKeys)
 
         val result = checker.validate(emptyMap(), emptyMap())
 
         assertThat(result?.name).isEqualTo("test")
+    }
+
+    @Test
+    fun `should invoke case insensitive matchers`() {
+        val keyErrorCheck = mockk<KeyErrorCheck>()
+
+        every {
+            keyErrorCheck.validateListCaseInsensitive(any(), any())
+        }.returns(listOf(MissingKeyError("key1")))
+
+        val unexpectedKeyCheck = mockk<UnexpectedKeyCheck>()
+
+        every {
+            unexpectedKeyCheck.validateListCaseInsensitive(any(), any())
+        }.returns(listOf(UnexpectedKeyError("key2")))
+
+        val errors = KeyCheck(keyErrorCheck, unexpectedKeyCheck).validateAllCaseInsensitive(emptyMap(), emptyMap())
+
+        assertThat(errors[0].name).isEqualTo("key1")
+        assertThat(errors[1].name).isEqualTo("key2")
     }
 }

--- a/core/src/test/kotlin/in/specmatic/core/ValidateUnexpectedKeysTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/ValidateUnexpectedKeysTest.kt
@@ -1,6 +1,9 @@
 package `in`.specmatic.core
 
 import `in`.specmatic.core.pattern.NullPattern
+import `in`.specmatic.core.pattern.Pattern
+import `in`.specmatic.core.pattern.StringPattern
+import `in`.specmatic.core.value.StringValue
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -52,6 +55,25 @@ internal class ValidateUnexpectedKeysTest {
 
             assertThat(names).contains("hello_there")
             assertThat(names).contains("hello_world")
+        }
+    }
+
+    @Nested
+    inner class AllUnexpectedErrorsCaseInsensitive {
+        private val expected = mapOf("hello" to StringPattern())
+        private val actual = mapOf("HELLO" to StringValue("friend"), "hello_there" to StringValue("friend"))
+        private val errorList: List<UnexpectedKeyError> = ValidateUnexpectedKeys.validateListCaseInsensitive(expected, actual)
+
+        @Test
+        fun `returns as many errors as unexpected keys`() {
+            assertThat(errorList).hasSize(1)
+        }
+
+        @Test
+        fun `errors should refer to the unexpected keys`() {
+            val names = errorList.map { it.name }
+
+            assertThat(names).contains("hello_there")
         }
     }
 }


### PR DESCRIPTION
**What**:

Header matching has been made case insensitive

**Why**:

According to RFC 2616, HTTP header names are case insensitive.

**How**:

The header matching code in HttpHeadersPattern has been modified to match header names case insensitively.

**Checklist**:

- [x] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation n/a
- [/] Tests
- [/] Sonar Quality Gate

