### PR TITLE
Check for redeclared api

### DIFF
--- a/application/src/main/kotlin/application/ContractToCheck.kt
+++ b/application/src/main/kotlin/application/ContractToCheck.kt
@@ -1,0 +1,18 @@
+package application
+
+import `in`.specmatic.core.Feature
+import `in`.specmatic.core.git.GitCommand
+import java.io.File
+
+class ContractToCheck(private val contractFile: CanonicalFile, private val git: GitCommand) {
+    constructor(contractFilePath: String, git: GitCommand): this(CanonicalFile(contractFilePath), git)
+
+    fun fetchAllOtherContracts(): List<Pair<Feature, String>> =
+        listOfAllContractFiles(File(git.gitRoot())).filterNot {
+            it.path == contractFile.path
+        }.mapNotNull {
+            loadContractData(it)
+        }
+
+    fun getPathsInContract(): List<String>? = urlPaths(contractFile.readText())
+}

--- a/application/src/main/kotlin/application/ReclaredAPICommand.kt
+++ b/application/src/main/kotlin/application/ReclaredAPICommand.kt
@@ -31,8 +31,13 @@ class ReDeclaredAPICommand: Callable<Unit> {
     fun file(@CommandLine.Parameters(paramLabel = "contractPath") contractFilePath: String): Int {
         val redeclarations = findReDeclaredContracts(ContractToCheck(contractFilePath, SystemGit()))
 
+        if(redeclarations.isNotEmpty()) {
+            logger.log("Some APIs in $contractFilePath have been declared in other files as well.")
+            logger.newLine()
+        }
+
         redeclarations.forEach { (newPath, contracts) ->
-            logger.log("Path $newPath already exists in the following contracts:")
+            logger.log(newPath)
             logger.log(contracts.joinToString("\n") { "- $it" })
         }
 
@@ -48,8 +53,13 @@ class ReDeclaredAPICommand: Callable<Unit> {
 
         val redeclarations = findReDeclarationsAmongstContracts(contracts)
 
+        if(redeclarations.isNotEmpty()) {
+            logger.log("Some APIs have been declared in multiple files.")
+            logger.newLine()
+        }
+
         redeclarations.forEach { (newPath, contracts) ->
-            logger.log("Path $newPath already exists in the following contracts:")
+            logger.log(newPath)
             logger.log(contracts.joinToString("\n") { "- $it" })
             logger.newLine()
         }

--- a/application/src/main/kotlin/application/ReclaredAPICommand.kt
+++ b/application/src/main/kotlin/application/ReclaredAPICommand.kt
@@ -34,15 +34,11 @@ class ReDeclaredAPICommand: Callable<Unit> {
             git.show(newerVersion, relativeContractFile.path)
         }
 
-        val newContract = OpenApiSpecification.fromYAML(newerContractYaml, "")
-        val newContractPaths = newContract.toFeature().scenarios.map { it.httpRequestPattern.urlMatcher!!.path }
+        val newContractPaths = urlPaths(newerContractYaml)
 
         val newPaths = if(git.exists(olderVersion, relativeContractFile.path)) {
             val olderContractYaml = git.show(olderVersion, relativeContractFile.path)
-
-            val oldContract = OpenApiSpecification.fromYAML(olderContractYaml, "")
-            val oldContractPaths = oldContract.toFeature().scenarios.map { it.httpRequestPattern.urlMatcher!!.path }
-
+            val oldContractPaths = urlPaths(olderContractYaml)
             newContractPaths.filter { it !in oldContractPaths }
         } else {
             newContractPaths
@@ -64,6 +60,12 @@ class ReDeclaredAPICommand: Callable<Unit> {
             println("Path $newPath already exists in the following contracts:")
             println(contracts.joinToString("\n") { "- $it" })
         }
+    }
+
+    private fun urlPaths(newerContractYaml: String): List<String> {
+        val newContract = OpenApiSpecification.fromYAML(newerContractYaml, "")
+        val newContractPaths = newContract.toFeature().scenarios.map { it.httpRequestPattern.urlMatcher!!.path }
+        return newContractPaths
     }
 
     private fun listOfAllContractFiles(dir: File): List<File> {

--- a/application/src/main/kotlin/application/ReclaredAPICommand.kt
+++ b/application/src/main/kotlin/application/ReclaredAPICommand.kt
@@ -8,6 +8,39 @@ import picocli.CommandLine
 import java.io.File
 import java.util.concurrent.Callable
 
+class ContractToCheck(private val contractFile: CanonicalFile, val git: GitCommand) {
+    constructor(contractFilePath: String, git: GitCommand): this(CanonicalFile(contractFilePath), git)
+
+    fun fetchAllOtherContracts() =
+        listOfAllContractFiles(File(git.gitRoot())).filterNot { it.path == contractFile.path }
+            .map { Pair(OpenApiSpecification.fromYAML(it.readText(), it.path).toFeature(), it.path) }
+
+    fun getNewPathsInContract(
+        olderVersion: String,
+        newerVersion: String,
+    ): List<String> {
+        val gitRoot = File(git.gitRoot())
+
+        val relativeContractFile = contractFile.relativeTo(gitRoot)
+
+        val newerContractYaml = if (newerVersion.isBlank()) {
+            contractFile.readText()
+        } else {
+            git.show(newerVersion, relativeContractFile.path)
+        }
+
+        val newContractPaths = urlPaths(newerContractYaml)
+
+        return if (git.exists(olderVersion, relativeContractFile.path)) {
+            val olderContractYaml = git.show(olderVersion, relativeContractFile.path)
+            val oldContractPaths = urlPaths(olderContractYaml)
+            newContractPaths.filter { it !in oldContractPaths }
+        } else {
+            newContractPaths
+        }
+    }
+}
+
 @CommandLine.Command(name = "redeclared",
     mixinStandardHelpOptions = true,
     description = ["Checks if new APIs in this file have been re-declared"])
@@ -22,24 +55,33 @@ class ReDeclaredAPICommand: Callable<Unit> {
     lateinit var newerVersion: String
 
     override fun call() {
-        val contractFile = CanonicalFile(contractFilePath)
-
-        val newPaths = getNewPaths(contractFile, olderVersion, newerVersion, SystemGit())
-        val contracts: List<Pair<Feature, String>> = fetchAllContracts(contractFile, SystemGit())
-
-        val newPathToContractMap = newPathToContractMap(newPaths, contracts)
+        val newPathToContractMap = findRedeclaredContracts(ContractToCheck(contractFilePath, SystemGit()), olderVersion, newerVersion)
 
         newPathToContractMap.forEach { (newPath, contracts) ->
             println("Path $newPath already exists in the following contracts:")
             println(contracts.joinToString("\n") { "- $it" })
         }
     }
+
 }
 
-private fun newPathToContractMap(
+data class Redeclaration(val apiURLPath: String, val contractsContainingAPI: List<String>)
+
+fun findRedeclaredContracts(
+    contractToCheck: ContractToCheck,
+    olderVersion: String,
+    newerVersion: String,
+): List<Redeclaration> {
+    val newPaths = contractToCheck.getNewPathsInContract(olderVersion, newerVersion)
+    val contracts: List<Pair<Feature, String>> = contractToCheck.fetchAllOtherContracts()
+
+    return newPathToContractMap(newPaths, contracts)
+}
+
+fun newPathToContractMap(
     newPaths: List<String>,
     contracts: List<Pair<Feature, String>>
-): List<Pair<String, List<String>>> {
+): List<Redeclaration> {
     val newPathToContractMap = newPaths.map { newPath ->
         val matchingContracts = contracts.filter { (feature, _) ->
             feature.scenarios.map { it.httpRequestPattern.urlMatcher!!.path }.any { scenarioPath ->
@@ -47,59 +89,14 @@ private fun newPathToContractMap(
             }
         }.map { it.second }
 
-        Pair(newPath, matchingContracts)
+        Redeclaration(newPath, matchingContracts)
     }
     return newPathToContractMap
-}
-
-private fun fetchAllContracts(
-    contractFile: CanonicalFile,
-    git: GitCommand
-) =
-    listOfAllContractFiles(File(git.gitRoot())).filterNot { it.path == contractFile.path }
-        .map { Pair(OpenApiSpecification.fromYAML(it.readText(), it.path).toFeature(), it.path) }
-
-fun getNewPaths(
-    contractFile: CanonicalFile,
-    olderVersion: String,
-    newerVersion: String,
-    git: GitCommand
-): List<String> {
-    val gitRoot = File(git.gitRoot())
-
-    val relativeContractFile = contractFile.relativeTo(gitRoot)
-
-    val newerContractYaml = if (newerVersion.isBlank()) {
-        contractFile.readText()
-    } else {
-        git.show(newerVersion, relativeContractFile.path)
-    }
-
-    val newContractPaths = urlPaths(newerContractYaml)
-
-    return if (git.exists(olderVersion, relativeContractFile.path)) {
-        val olderContractYaml = git.show(olderVersion, relativeContractFile.path)
-        val oldContractPaths = urlPaths(olderContractYaml)
-        newContractPaths.filter { it !in oldContractPaths }
-    } else {
-        newContractPaths
-    }
 }
 
 fun urlPaths(newerContractYaml: String): List<String> {
     val newContract = OpenApiSpecification.fromYAML(newerContractYaml, "")
     return newContract.toFeature().scenarios.map { it.httpRequestPattern.urlMatcher!!.path }
-}
-
-fun listOfAllContractFiles(dir: File): List<File> {
-    val fileGroups = dir.listFiles()!!.groupBy { it.isDirectory }
-
-    val files = (fileGroups[false] ?: emptyList()).map { it.canonicalFile }
-    val dirs = (fileGroups[true] ?: emptyList()).filter { it.name != ".git" }.map { it.canonicalFile }
-
-    val dirFiles = dirs.flatMap { listOfAllContractFiles(it) }
-
-    return files.plus(dirFiles)
 }
 
 open class CanonicalFile(val file: File) {
@@ -108,4 +105,15 @@ open class CanonicalFile(val file: File) {
     constructor (path: String) : this(File(path).canonicalFile)
     fun readText(): String = file.readText()
     fun relativeTo(parentDir: File): File = file.relativeTo(parentDir)
+}
+
+fun listOfAllContractFiles(dir: File): List<File> {
+    val fileGroups = dir.listFiles()!!.groupBy { it.isDirectory }
+
+    val files = (fileGroups[false] ?: emptyList()).filter { it.extension == "yaml" }.map { it.canonicalFile }
+    val dirs = (fileGroups[true] ?: emptyList()).filter { it.name != ".git" }.map { it.canonicalFile }
+
+    val dirFiles = dirs.flatMap { listOfAllContractFiles(it) }
+
+    return files.plus(dirFiles)
 }

--- a/application/src/main/kotlin/application/ReclaredAPICommand.kt
+++ b/application/src/main/kotlin/application/ReclaredAPICommand.kt
@@ -1,0 +1,79 @@
+package application
+
+import `in`.specmatic.conversions.OpenApiSpecification
+import `in`.specmatic.core.Feature
+import `in`.specmatic.core.git.SystemGit
+import picocli.CommandLine
+import java.io.File
+import java.util.concurrent.Callable
+
+@CommandLine.Command(name = "redeclared",
+    mixinStandardHelpOptions = true,
+    description = ["Checks if new APIs in this file have been re-declared"])
+class ReDeclaredAPICommand: Callable<Unit> {
+    @CommandLine.Parameters(index = "0", description = ["Contract to validate"])
+    lateinit var contractFilePath: String
+
+    @CommandLine.Option(names = ["--older"], description = ["Older version"], defaultValue = "HEAD")
+    lateinit var olderVersion: String
+
+    @CommandLine.Option(names = ["--newer"], description = ["Newer version"], defaultValue = "")
+    lateinit var newerVersion: String
+
+    override fun call() {
+        val git = SystemGit()
+
+        val gitRoot = File(git.gitRoot()).canonicalFile
+        val contractFile = File(contractFilePath).canonicalFile
+
+        val relativeContractFile = contractFile.relativeTo(gitRoot)
+
+        val newerContractYaml = if(newerVersion.isBlank()) {
+            contractFile.readText()
+        } else {
+            git.show(newerVersion, relativeContractFile.path)
+        }
+
+        val newContract = OpenApiSpecification.fromYAML(newerContractYaml, "")
+        val newContractPaths = newContract.toFeature().scenarios.map { it.httpRequestPattern.urlMatcher!!.path }
+
+        val newPaths = if(git.exists(olderVersion, relativeContractFile.path)) {
+            val olderContractYaml = git.show(olderVersion, relativeContractFile.path)
+
+            val oldContract = OpenApiSpecification.fromYAML(olderContractYaml, "")
+            val oldContractPaths = oldContract.toFeature().scenarios.map { it.httpRequestPattern.urlMatcher!!.path }
+
+            newContractPaths.filter { it !in oldContractPaths }
+        } else {
+            newContractPaths
+        }
+
+        val contracts: List<Pair<Feature, String>> = listOfAllContractFiles(gitRoot).filterNot { it.path == contractFile.path }.map { Pair(OpenApiSpecification.fromYAML(it.readText(), it.path).toFeature(), it.path) }
+
+        val newPathToContract = newPaths.map { newPath ->
+            val matchingContracts = contracts.filter { (feature, _) ->
+                feature.scenarios.map { it.httpRequestPattern.urlMatcher!!.path }.any { scenarioPath ->
+                    scenarioPath == newPath
+                }
+            }.map { it.second }
+
+            Pair(newPath, matchingContracts)
+        }
+
+        newPathToContract.forEach { (newPath, contracts) ->
+            println("Path $newPath already exists in the following contracts:")
+            println(contracts.joinToString("\n") { "- $it" })
+        }
+    }
+
+    private fun listOfAllContractFiles(dir: File): List<File> {
+        val fileGroups = dir.listFiles()!!.groupBy { it.isDirectory }
+
+        val files = (fileGroups[false] ?: emptyList()).map { it.canonicalFile }
+        val dirs = (fileGroups[true] ?: emptyList()).filter { it.name != ".git" }.map { it.canonicalFile }
+
+        val dirFiles = dirs.flatMap { listOfAllContractFiles(it) }
+
+        return files.plus(dirFiles)
+    }
+}

--- a/application/src/main/kotlin/application/SpecmaticCommand.kt
+++ b/application/src/main/kotlin/application/SpecmaticCommand.kt
@@ -9,7 +9,7 @@ import java.util.concurrent.Callable
         name = "specmatic",
         mixinStandardHelpOptions = true,
         versionProvider = VersionProvider::class,
-        subcommands = [BundleCommand::class, CompareCommand::class, CompatibleCommand::class, GraphCommand::class, ToOpenAPICommand::class, ImportCommand::class, InstallCommand::class, ProxyCommand::class, PushCommand::class, SamplesCommand::class, StubCommand::class, SubscribeCommand::class, TestCommand::class]
+        subcommands = [BundleCommand::class, CompareCommand::class, CompatibleCommand::class, GraphCommand::class, ToOpenAPICommand::class, ImportCommand::class, InstallCommand::class, ProxyCommand::class, PushCommand::class, ReDeclaredAPICommand::class, SamplesCommand::class, StubCommand::class, SubscribeCommand::class, TestCommand::class]
 )
 class SpecmaticCommand : Callable<Int> {
     override fun call(): Int {

--- a/application/src/test/kotlin/application/FakeGit.kt
+++ b/application/src/test/kotlin/application/FakeGit.kt
@@ -77,4 +77,7 @@ abstract class FakeGit: GitCommand {
         TODO("Not yet implemented")
     }
 
+    override fun exists(treeish: String, relativePath: String): Boolean {
+        TODO("Not yet implemented")
+    }
 }

--- a/application/src/test/kotlin/application/ReDeclaredAPICommandTest.kt
+++ b/application/src/test/kotlin/application/ReDeclaredAPICommandTest.kt
@@ -155,6 +155,24 @@ internal class ReDeclaredAPICommandTest {
             assertThat(newPaths).hasSize(1)
             assertThat(newPaths).contains("/pet/(id:number)")
         }
+
+        @Test
+        fun `from committed file`() {
+            val contractFile = mockk<CanonicalFile>()
+            every { contractFile.relativeTo(any()) } returns File(".")
+
+            val git = mockk<GitCommand>()
+            every { git.gitRoot() } returns "/git/root"
+            every { git.exists("HEAD", any()) } returns true
+            every { git.show("HEAD", any()) } returns oldContractYaml
+            every { git.show("newerCommit", any()) } returns newContractYaml
+
+            val contractToCheck = ContractToCheck(contractFile, git)
+
+            val newPaths = contractToCheck.getNewPathsInContract("HEAD", "newerCommit")
+            assertThat(newPaths).hasSize(1)
+            assertThat(newPaths).contains("/pet/(id:number)")
+        }
     }
 
     @Test

--- a/application/src/test/kotlin/application/ReDeclaredAPICommandTest.kt
+++ b/application/src/test/kotlin/application/ReDeclaredAPICommandTest.kt
@@ -1,0 +1,154 @@
+package application
+
+import `in`.specmatic.core.git.GitCommand
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.io.File
+
+internal class ReDeclaredAPICommandTest {
+    @Nested
+    inner class GetNewPaths {
+        val oldContractYaml = """
+            openapi: "3.0.0"
+            info:
+              version: 1.0.0
+              title: Swagger Petstore
+              description: A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification
+              termsOfService: http://swagger.io/terms/
+              contact:
+                name: Swagger API Team
+                email: apiteam@swagger.io
+                url: http://swagger.io
+              license:
+                name: Apache 2.0
+                url: https://www.apache.org/licenses/LICENSE-2.0.html
+            servers:
+              - url: http://petstore.swagger.io/api
+            paths:
+              /pets:
+                post:
+                  description: Creates a new pet in the store. Duplicates are allowed
+                  operationId: addPet
+                  requestBody:
+                    description: Pet to add to the store
+                    required: true
+                    content:
+                      application/json:
+                        schema:
+                          ${'$'}ref: '#/components/schemas/NewPet'
+                  responses:
+                    '201':
+                      description: pet response
+                      content:
+                        text/plain:
+                          schema:
+                            type: string
+            components:
+              schemas:
+                NewPet:
+                  type: object
+                  required:
+                    - name
+                    - tag
+                  properties:
+                    name:
+                      type: string
+                      nullable: false
+                    tag:
+                      type: string
+                      nullable: false
+                    optional:
+                      type: string
+                      nullable: true
+        """.trimIndent()
+
+        val newContractYaml = """
+            openapi: "3.0.0"
+            info:
+              version: 1.0.0
+              title: Swagger Petstore
+              description: A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification
+              termsOfService: http://swagger.io/terms/
+              contact:
+                name: Swagger API Team
+                email: apiteam@swagger.io
+                url: http://swagger.io
+              license:
+                name: Apache 2.0
+                url: https://www.apache.org/licenses/LICENSE-2.0.html
+            servers:
+              - url: http://petstore.swagger.io/api
+            paths:
+              /pet/{id}:
+                get:
+                  description: Get pet details
+                  operationId: getPetDetails
+                  parameters:
+                    - in: path
+                      name: id
+                      schema:
+                        type: integer
+                      required: true
+                      description: Numeric ID
+                  responses:
+                    '201':
+                      description: pet response
+                      content:
+                        application/json:
+                          schema:
+                            ${'$'}ref: '#/components/schemas/NewPet'
+              /pets:
+                post:
+                  description: Creates a new pet in the store. Duplicates are allowed
+                  operationId: addPet
+                  requestBody:
+                    description: Pet to add to the store
+                    required: true
+                    content:
+                      application/json:
+                        schema:
+                          ${'$'}ref: '#/components/schemas/NewPet'
+                  responses:
+                    '201':
+                      description: pet response
+                      content:
+                        text/plain:
+                          schema:
+                            type: string
+            components:
+              schemas:
+                NewPet:
+                  type: object
+                  required:
+                    - name
+                    - tag
+                  properties:
+                    name:
+                      type: string
+                      nullable: false
+                    tag:
+                      type: string
+                      nullable: false
+                    optional:
+                      type: string
+                      nullable: true
+        """.trimIndent()
+        @Test
+        fun `from uncommitted file`() {
+            val contractFile = mockk<CanonicalFile>()
+            every { contractFile.readText() } returns newContractYaml
+            every { contractFile.relativeTo(any()) } returns File(".")
+
+            val git = mockk<GitCommand>()
+            every { git.gitRoot() } returns "/git/root"
+            every { git.exists("HEAD", any()) } returns true
+            every { git.show("HEAD", any()) } returns oldContractYaml
+
+            val newPaths = getNewPaths(contractFile, "HEAD", "", git)
+            println(newPaths)
+        }
+    }
+}

--- a/core/src/main/kotlin/in/specmatic/core/git/GitCommand.kt
+++ b/core/src/main/kotlin/in/specmatic/core/git/GitCommand.kt
@@ -23,4 +23,5 @@ interface GitCommand {
     fun fileIsInGitDir(newerContractPath: String): Boolean
     fun inGitRootOf(contractPath: String): GitCommand
     fun shallowClone(gitRepositoryURI: String, cloneDirectory: File): SystemGit
+    fun exists(treeish: String, relativePath: String): Boolean
 }

--- a/core/src/main/kotlin/in/specmatic/core/git/SystemGit.kt
+++ b/core/src/main/kotlin/in/specmatic/core/git/SystemGit.kt
@@ -48,6 +48,15 @@ class SystemGit(override val workingDirectory: String = ".", private val prefix:
     override fun merge(branchName: String): SystemGit = this.also { execute(Configuration.gitCommand, "merge", branchName) }
     override fun clone(gitRepositoryURI: String, cloneDirectory: File): SystemGit =
         this.also { executeWithAuth("clone", gitRepositoryURI, cloneDirectory.absolutePath) }
+    fun exists(treeish: String, relativePath: String): Boolean {
+        return try {
+            show(treeish, relativePath)
+            true
+        } catch(e: NonZeroExitError) {
+            false
+        }
+    }
+
 
     override fun shallowClone(gitRepositoryURI: String, cloneDirectory: File): SystemGit =
         this.also {

--- a/core/src/main/kotlin/in/specmatic/core/git/SystemGit.kt
+++ b/core/src/main/kotlin/in/specmatic/core/git/SystemGit.kt
@@ -48,7 +48,7 @@ class SystemGit(override val workingDirectory: String = ".", private val prefix:
     override fun merge(branchName: String): SystemGit = this.also { execute(Configuration.gitCommand, "merge", branchName) }
     override fun clone(gitRepositoryURI: String, cloneDirectory: File): SystemGit =
         this.also { executeWithAuth("clone", gitRepositoryURI, cloneDirectory.absolutePath) }
-    fun exists(treeish: String, relativePath: String): Boolean {
+    override fun exists(treeish: String, relativePath: String): Boolean {
         return try {
             show(treeish, relativePath)
             true


### PR DESCRIPTION
**What**:

The redeclared command checks looks for APIs that occur in more than one file.

**Why**:

Ideally any API should be declared in a single file. But sometimes developers may add an API elsewhere. This command is a first attempt at detecting multiple declarations of an API.

**How**:

There are two variants to this command.

1. redeclared file: Given a newly added or modified file, are the APIs in it declared in any other files in the repo.
2. redeclared entire-repo: Which APIs have been declared multiple times, and in which APIs are they found?
