### PR TITLE
Proxy generator now generates OpenAPI contracts

### DIFF
--- a/application/src/main/kotlin/application/ProxyCommand.kt
+++ b/application/src/main/kotlin/application/ProxyCommand.kt
@@ -25,7 +25,7 @@ class ProxyCommand : Callable<Unit> {
     var port: Int = 9000
 
     @Parameters(description = ["Store data from the proxy interactions into this dir"], index = "0")
-    lateinit var proxyQontractDataDir: String
+    lateinit var proxySpecmaticDataDir: String
 
     @Option(names = ["--httpsKeyStore"], description = ["Run the proxy on https using a key in this store"])
     var keyStoreFile = ""
@@ -45,12 +45,12 @@ class ProxyCommand : Callable<Unit> {
     var proxy: Proxy? = null
 
     override fun call() {
-        validatedProxySettings(targetBaseURL, proxyQontractDataDir)
+        validatedProxySettings(targetBaseURL, proxySpecmaticDataDir)
 
         val certInfo = CertInfo(keyStoreFile, keyStoreDir, keyStorePassword, keyStoreAlias, keyPassword)
         val keyStoreData = certInfo.getHttpsCert()
 
-        proxy = Proxy(host, port, targetBaseURL, proxyQontractDataDir, keyStoreData)
+        proxy = Proxy(host, port, targetBaseURL, proxySpecmaticDataDir, keyStoreData)
         addShutdownHook()
 
         val protocol = keyStoreData?.let { "https" } ?: "http"
@@ -59,11 +59,11 @@ class ProxyCommand : Callable<Unit> {
         while(true) sleep(10000)
     }
 
-    private fun validatedProxySettings(unknownProxyTarget: String?, proxyQontractDataDir: String?) {
-        if(unknownProxyTarget == null && proxyQontractDataDir == null) return
+    private fun validatedProxySettings(unknownProxyTarget: String?, proxySpecmaticDataDir: String?) {
+        if(unknownProxyTarget == null && proxySpecmaticDataDir == null) return
 
-        if(unknownProxyTarget != null && proxyQontractDataDir != null) {
-            val dataDirFile = File(proxyQontractDataDir)
+        if(unknownProxyTarget != null && proxySpecmaticDataDir != null) {
+            val dataDirFile = File(proxySpecmaticDataDir)
             if(!dataDirFile.exists()) {
                 try {
                     dataDirFile.mkdirs()
@@ -72,7 +72,7 @@ class ProxyCommand : Callable<Unit> {
                 }
             } else {
                 if(dataDirFile.listFiles()?.isNotEmpty() == true) {
-                    exitWithMessage("This data directory $proxyQontractDataDir must be empty if it exists")
+                    exitWithMessage("This data directory $proxySpecmaticDataDir must be empty if it exists")
                 }
             }
         }

--- a/core/src/main/kotlin/in/specmatic/proxy/Proxy.kt
+++ b/core/src/main/kotlin/in/specmatic/proxy/Proxy.kt
@@ -1,5 +1,6 @@
 package `in`.specmatic.proxy
 
+import `in`.specmatic.conversions.OpenApiSpecification
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
 import io.ktor.server.netty.*
@@ -11,6 +12,7 @@ import `in`.specmatic.stub.httpResponseLog
 import `in`.specmatic.stub.ktorHttpRequestToHttpRequest
 import `in`.specmatic.stub.respondToKtorHttpResponse
 import `in`.specmatic.test.HttpClient
+import io.swagger.v3.core.util.Yaml
 import java.io.Closeable
 import java.net.URI
 import java.net.URL
@@ -118,15 +120,16 @@ class Proxy(host: String, port: Int, baseURL: String, private val proxyQontractD
         server.stop(0, 0)
 
         val gherkin = toGherkinFeature("New feature", stubs)
+        val featureFileName = "proxy_generated.yaml"
+        val openApi = parseGherkinStringToFeature(gherkin).toOpenApi()
 
         if(stubs.isEmpty()) {
             println("No stubs were recorded. No contract will be written.")
         } else {
             proxyQontractDataDir.createDirectory()
 
-            val featureFileName = "proxy_generated.$CONTRACT_EXTENSION"
             println("Writing contract to $featureFileName")
-            proxyQontractDataDir.writeText(featureFileName, gherkin)
+            proxyQontractDataDir.writeText(featureFileName, Yaml.pretty(openApi))
 
             stubs.mapIndexed { index, namedStub ->
                 val fileName = "stub$index.json"

--- a/core/src/test/kotlin/in/specmatic/proxy/ProxyTest.kt
+++ b/core/src/test/kotlin/in/specmatic/proxy/ProxyTest.kt
@@ -1,5 +1,6 @@
 package `in`.specmatic.proxy
 
+import `in`.specmatic.conversions.OpenApiSpecification
 import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.springframework.http.client.SimpleClientHttpRequestFactory
@@ -41,7 +42,7 @@ internal class ProxyTest {
             override fun writeText(path: String, content: String) {
                 receivedPaths.add(path)
 
-                if(path.endsWith(".$CONTRACT_EXTENSION"))
+                if(path.endsWith(".yaml"))
                     receivedContract = content
                 else
                     receivedStub = content
@@ -61,10 +62,10 @@ internal class ProxyTest {
             }
         }
 
-        assertThat(receivedContract?.trim()).startsWith("Feature:")
-        assertThatCode { parseGherkinStringToFeature(receivedContract ?: "") }.doesNotThrowAnyException()
+        assertThat(receivedContract?.trim()).startsWith("openapi:")
+        assertThatCode { OpenApiSpecification.fromYAML(receivedContract!!, "") }.doesNotThrowAnyException()
         assertThatCode { parsedJSON(receivedStub ?: "") }.doesNotThrowAnyException()
-        assertThat(receivedPaths.toList()).isEqualTo(listOf("proxy_generated.$CONTRACT_EXTENSION", "stub0.json"))
+        assertThat(receivedPaths.toList()).isEqualTo(listOf("proxy_generated.yaml", "stub0.json"))
     }
 
     @Test
@@ -87,7 +88,7 @@ internal class ProxyTest {
             override fun writeText(path: String, content: String) {
                 receivedPaths.add(path)
 
-                if(path.endsWith(".$CONTRACT_EXTENSION"))
+                if(path.endsWith(".yaml"))
                     receivedContract = content
                 else
                     receivedStub = content
@@ -104,9 +105,9 @@ internal class ProxyTest {
             }
         }
 
-        assertThat(receivedContract?.trim()).startsWith("Feature:")
-        assertThatCode { parseGherkinStringToFeature(receivedContract ?: "") }.doesNotThrowAnyException()
+        assertThat(receivedContract?.trim()).startsWith("openapi:")
+        assertThatCode { OpenApiSpecification.fromYAML(receivedContract!!, "") }.doesNotThrowAnyException()
         assertThatCode { parsedJSON(receivedStub ?: "") }.doesNotThrowAnyException()
-        assertThat(receivedPaths.toList()).isEqualTo(listOf("proxy_generated.$CONTRACT_EXTENSION", "stub0.json"))
+        assertThat(receivedPaths.toList()).isEqualTo(listOf("proxy_generated.yaml", "stub0.json"))
     }
 }


### PR DESCRIPTION
**What**:

The proxy command now generates OpenAPI contracts instead of Gherkin.

**Why**:

We have moved away from Gherkin to OpenAPI, and all the generator commands should start generating OpenAPI contracts. The proxy command is the first of these to be updated to do so.

**How**:

The Proxy class now generates OpenAPI on shutdown.