### PR TITLE
Contract tests should match responses against the default response

### DIFF
--- a/application/src/main/kotlin/application/test/ColorPrinter.kt
+++ b/application/src/main/kotlin/application/test/ColorPrinter.kt
@@ -6,11 +6,11 @@ import org.junit.platform.launcher.TestIdentifier
 
 class ColorPrinter: ContractExecutionPrinter {
     override fun printFinalSummary(testSummary: TestSummary) {
-        val (_, aborted, failure) = testSummary
+        val (_, partialSuccesses, aborted) = testSummary
 
         val color = when {
-            failure > 0 -> Ansi.ansi().fgBrightRed()
-            aborted > 0 -> Ansi.ansi().fgYellow()
+            aborted > 0 -> Ansi.ansi().fgBrightRed()
+            partialSuccesses > 0 -> Ansi.ansi().fgYellow()
             else -> Ansi.ansi().fgGreen()
         }
 

--- a/application/src/main/kotlin/application/test/ContractExecutionListener.kt
+++ b/application/src/main/kotlin/application/test/ContractExecutionListener.kt
@@ -85,14 +85,15 @@ class ContractExecutionListener : TestExecutionListener {
     override fun testPlanExecutionFinished(testPlan: TestPlan?) {
         org.fusesource.jansi.AnsiConsole.systemInstall()
 
-        if(SpecmaticJUnitSupport.taintedSuccesses.isNotEmpty()) {
+        if(SpecmaticJUnitSupport.partialSuccesses.isNotEmpty()) {
             println()
-            colorPrinter.printFailureTitle("Tainted Successes (successes where the response matched the default):")
+            colorPrinter.printFailureTitle("Partial Successes:")
             println()
 
-            SpecmaticJUnitSupport.taintedSuccesses.forEach { result ->
+            SpecmaticJUnitSupport.partialSuccesses.filter { it.partialSuccessMessage != null} .forEach { result ->
                 println("  " + (result.scenario?.testDescription() ?: "Unknown Scenario"))
-                println(result.taint.joinToString("\n") { "    $it" })
+                println("    " + result.partialSuccessMessage!!)
+                println()
             }
 
             println()
@@ -108,7 +109,7 @@ class ContractExecutionListener : TestExecutionListener {
             println()
         }
 
-        colorPrinter.printFinalSummary(TestSummary(success, SpecmaticJUnitSupport.taintedSuccesses.size, aborted, failure))
+        colorPrinter.printFinalSummary(TestSummary(success, SpecmaticJUnitSupport.partialSuccesses.size, aborted, failure))
     }
 
     fun exitProcess() {

--- a/application/src/main/kotlin/application/test/ContractExecutionListener.kt
+++ b/application/src/main/kotlin/application/test/ContractExecutionListener.kt
@@ -1,6 +1,7 @@
 package application.test
 
 import `in`.specmatic.core.log.logger
+import `in`.specmatic.test.SpecmaticJUnitSupport
 import org.junit.platform.engine.TestExecutionResult
 import org.junit.platform.launcher.TestExecutionListener
 import org.junit.platform.launcher.TestIdentifier
@@ -84,14 +85,30 @@ class ContractExecutionListener : TestExecutionListener {
     override fun testPlanExecutionFinished(testPlan: TestPlan?) {
         org.fusesource.jansi.AnsiConsole.systemInstall()
 
+        if(SpecmaticJUnitSupport.taintedSuccesses.isNotEmpty()) {
+            println()
+            colorPrinter.printFailureTitle("Tainted Successes (successes where the response matched the default):")
+            println()
+
+            SpecmaticJUnitSupport.taintedSuccesses.forEach { result ->
+                println("  " + (result.scenario?.testDescription() ?: "Unknown Scenario"))
+                println(result.taint.joinToString("\n") { "    $it" })
+            }
+
+            println()
+
+        }
+
+
+
         if (failedLog.isNotEmpty()) {
             println()
-            colorPrinter.printFailureTitle("Unsuccessful scenarios:")
+            colorPrinter.printFailureTitle("Unsuccessful Scenarios:")
             println(failedLog.joinToString(System.lineSeparator()) { it.prependIndent("  ") })
             println()
         }
 
-        colorPrinter.printFinalSummary(TestSummary(success, aborted, failure))
+        colorPrinter.printFinalSummary(TestSummary(success, SpecmaticJUnitSupport.taintedSuccesses.size, aborted, failure))
     }
 
     fun exitProcess() {

--- a/application/src/main/kotlin/application/test/TestSummary.kt
+++ b/application/src/main/kotlin/application/test/TestSummary.kt
@@ -1,10 +1,10 @@
 package application.test
 
-data class TestSummary(val success: Int, val taintedSuccess: Int, val aborted: Int, val failure: Int) {
+data class TestSummary(val success: Int, val partialSuccesses: Int, val aborted: Int, val failure: Int) {
     val message: String
         get() {
             val total = success + aborted + failure
-            val taintedNote = if(taintedSuccess > 0) " (of which $taintedSuccess are tainted)" else ""
-            return "Tests run: $total, Successes: ${success}$taintedNote, Failures: $failure, Aborted: $aborted"
+            val partialSuccessNote = if(partialSuccesses > 0) " (of which $partialSuccesses are partial)" else ""
+            return "Tests run: $total, Successes: ${success}$partialSuccessNote, Failures: $failure, Errors: $aborted"
         }
 }

--- a/application/src/main/kotlin/application/test/TestSummary.kt
+++ b/application/src/main/kotlin/application/test/TestSummary.kt
@@ -1,6 +1,10 @@
 package application.test
 
-data class TestSummary(val success: Int, val aborted: Int, val failure: Int) {
-    val message: String = "Tests run: ${success + aborted + failure}, Failures: $failure, Aborted: $aborted"
-    val total: Int = success + aborted + failure
+data class TestSummary(val success: Int, val taintedSuccess: Int, val aborted: Int, val failure: Int) {
+    val message: String
+        get() {
+            val total = success + aborted + failure
+            val taintedNote = if(taintedSuccess > 0) " (of which $taintedSuccess are tainted)" else ""
+            return "Tests run: $total, Successes: ${success}$taintedNote, Failures: $failure, Aborted: $aborted"
+        }
 }

--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -313,8 +313,6 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
         status: String,
         headersMap: Map<String, Pattern>
     ): List<Triple<ApiResponse, MediaType, HttpResponsePattern>> {
-        if(status == "default") return emptyList()
-
         if(response.content == null) {
             val responsePattern = HttpResponsePattern(
                 headersPattern = HttpHeadersPattern(headersMap),
@@ -327,7 +325,7 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
         return response.content.map { (contentType, mediaType) ->
             val responsePattern = HttpResponsePattern(
                 headersPattern = HttpHeadersPattern(headersMap),
-                status = status.toInt(),
+                status = if(status == "default") 1000 else status.toInt(),
                 body = when (contentType) {
                     "application/xml" -> toXMLPattern(mediaType)
                     else -> toSpecmaticPattern(mediaType)

--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -316,7 +316,7 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
         if(response.content == null) {
             val responsePattern = HttpResponsePattern(
                 headersPattern = HttpHeadersPattern(headersMap),
-                status = status.toInt()
+                status = status.toIntOrNull() ?: DEFAULT_RESPONSE_CODE
             )
 
             return listOf(Triple(response, MediaType(), responsePattern))

--- a/core/src/main/kotlin/in/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Feature.kt
@@ -34,7 +34,7 @@ class BadRequestOrDefault(private val badRequestResponses: Map<Int, HttpResponse
     fun matches(httpResponse: HttpResponse, resolver: Resolver): Result =
         when(httpResponse.status) {
             in badRequestResponses -> badRequestResponses.getValue(httpResponse.status).matches(httpResponse, resolver)
-            else -> defaultResponse?.matches(httpResponse, resolver)?.tainted("The response matched the default response, but the contract should declare a ${httpResponse.status} response.") ?: Result.Failure("Neither is the status code declared nor is there a default response.")
+            else -> defaultResponse?.matches(httpResponse, resolver)?.partialSuccess("The response matched the default response, but the contract should declare a ${httpResponse.status} response.") ?: Result.Failure("Neither is the status code declared nor is there a default response.")
         }
 
     fun supports(httpResponse: HttpResponse): Boolean =

--- a/core/src/main/kotlin/in/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Feature.kt
@@ -251,32 +251,10 @@ data class Feature(
     private fun failureResults(results: List<Pair<HttpStubData?, Result>>): Results =
         Results(results.map { it.second }.filterIsInstance<Result.Failure>().toMutableList())
 
-    fun generateContractTests(suggestions: List<Scenario>): List<ContractTest> {
-        val negativeScenarios =
-            scenarios.filter { it.isA2xxScenario() }.map { it.negativeBasedOn(suggestions, has4xx(it)) }.flatMap {
-                it.generateTestScenarios(testVariables, testBaseURLs)
-            }
-        val positiveScenarios = scenarios.filter { it.isA2xxScenario() || it.examples.isNotEmpty() || it.isGherkinScenario}.map { it.newBasedOn(suggestions) }.flatMap {
-            it.generateTestScenarios(testVariables, testBaseURLs)
-        }
-        val negativeScenariosToConsider = negativeScenarios.filter { negativeSecenario ->
-            positiveScenarios.filter { it.isA2xxScenario() }.none {
-                it.httpRequestPattern.matches(
-                    negativeSecenario.httpRequestPattern.generate(Resolver()),
-                    Resolver()
-                ) is Result.Success
-            }
-        }
-
-        val testScenarios = if (enableNegativeTesting)
-            positiveScenarios + negativeScenariosToConsider
-        else
-            positiveScenarios
-
-        return testScenarios.map {
+    fun generateContractTests(suggestions: List<Scenario>): List<ContractTest> =
+        generateContractTestScenarios(suggestions).map {
             ScenarioTest(it)
         }
-    }
 
     private fun has4xx(scenario: Scenario): Boolean {
         return scenarios.any {
@@ -291,7 +269,9 @@ data class Feature(
                 it.generateTestScenarios(testVariables, testBaseURLs)
             }
         val positiveScenarios =
-            scenarios.filter { it.isA2xxScenario() || it.examples.isNotEmpty() || it.isGherkinScenario }.map { it.newBasedOn(suggestions) }.flatMap {
+            scenarios.filter { it.isA2xxScenario() || it.examples.isNotEmpty() || it.isGherkinScenario }.map {
+                it.newBasedOn(suggestions)
+            }.flatMap {
                 it.generateTestScenarios(testVariables, testBaseURLs)
             }
         val negativeScenariosToConsider = negativeScenarios.filter { negativeSecenario ->

--- a/core/src/main/kotlin/in/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Feature.kt
@@ -34,7 +34,7 @@ class BadRequestOrDefault(private val badRequestResponses: Map<Int, HttpResponse
     fun matches(httpResponse: HttpResponse, resolver: Resolver): Result =
         when(httpResponse.status) {
             in badRequestResponses -> badRequestResponses.getValue(httpResponse.status).matches(httpResponse, resolver)
-            else -> defaultResponse?.matches(httpResponse, resolver) ?: Result.Failure("Neither is the status code declared nor is there a default response.")
+            else -> defaultResponse?.matches(httpResponse, resolver)?.tainted("HTTP response with status ${httpResponse.status} matched the default response, but ideally a status ${httpResponse.status} should be explicitly declared") ?: Result.Failure("Neither is the status code declared nor is there a default response.")
         }
 
     fun supports(httpResponse: HttpResponse): Boolean =

--- a/core/src/main/kotlin/in/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Feature.kt
@@ -34,7 +34,7 @@ class BadRequestOrDefault(private val badRequestResponses: Map<Int, HttpResponse
     fun matches(httpResponse: HttpResponse, resolver: Resolver): Result =
         when(httpResponse.status) {
             in badRequestResponses -> badRequestResponses.getValue(httpResponse.status).matches(httpResponse, resolver)
-            else -> defaultResponse?.matches(httpResponse, resolver)?.tainted("HTTP response with status ${httpResponse.status} matched the default response, but ideally a status ${httpResponse.status} should be explicitly declared") ?: Result.Failure("Neither is the status code declared nor is there a default response.")
+            else -> defaultResponse?.matches(httpResponse, resolver)?.tainted("The response matched the default response, but the contract should declare a ${httpResponse.status} response.") ?: Result.Failure("Neither is the status code declared nor is there a default response.")
         }
 
     fun supports(httpResponse: HttpResponse): Boolean =

--- a/core/src/main/kotlin/in/specmatic/core/HttpResponse.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpResponse.kt
@@ -32,6 +32,9 @@ data class HttpResponse(
                 else -> HttpStatusCode.fromValue(status).description
             }
 
+    fun specmaticResultHeaderValue(): String =
+        this.headers.getOrDefault(SPECMATIC_RESULT_HEADER, "success")
+
     fun updateBodyWith(content: Value): HttpResponse {
         return copy(body = content, headers = headers.minus(CONTENT_TYPE).plus(CONTENT_TYPE to content.httpContentType))
     }

--- a/core/src/main/kotlin/in/specmatic/core/HttpResponsePattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpResponsePattern.kt
@@ -48,6 +48,9 @@ data class HttpResponsePattern(val headersPattern: HttpHeadersPattern = HttpHead
     fun matchesMock(response: HttpResponse, resolver: Resolver) = matches(response, resolver)
 
     private fun matchStatus(parameters: Pair<HttpResponse, Resolver>): MatchingResult<Pair<HttpResponse, Resolver>> {
+        if(status == 1000)
+            return MatchSuccess(parameters)
+
         val (response, _) = parameters
 
         val body = response.body

--- a/core/src/main/kotlin/in/specmatic/core/HttpResponsePattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpResponsePattern.kt
@@ -5,6 +5,8 @@ import `in`.specmatic.core.value.JSONObjectValue
 import `in`.specmatic.core.value.StringValue
 import `in`.specmatic.stub.softCastValueToXML
 
+const val DEFAULT_RESPONSE_CODE = 1000
+
 data class HttpResponsePattern(val headersPattern: HttpHeadersPattern = HttpHeadersPattern(), val status: Int = 0, val body: Pattern = EmptyStringPattern) {
     constructor(response: HttpResponse) : this(HttpHeadersPattern(response.headers.mapValues { stringToPattern(it.value, it.key) }), response.status, response.body.exactMatchElseType())
 
@@ -48,7 +50,7 @@ data class HttpResponsePattern(val headersPattern: HttpHeadersPattern = HttpHead
     fun matchesMock(response: HttpResponse, resolver: Resolver) = matches(response, resolver)
 
     private fun matchStatus(parameters: Pair<HttpResponse, Resolver>): MatchingResult<Pair<HttpResponse, Resolver>> {
-        if(status == 1000)
+        if(status == DEFAULT_RESPONSE_CODE)
             return MatchSuccess(parameters)
 
         val (response, _) = parameters

--- a/core/src/main/kotlin/in/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Scenario.kt
@@ -38,7 +38,6 @@ data class Scenario(
     val bindings: Map<String, String> = emptyMap(),
     val isGherkinScenario: Boolean = false,
     val isNegative: Boolean = false,
-    val is4xxDefined: Boolean = false,
     val badRequestOrDefault: BadRequestOrDefault? = null
 ) {
     constructor(scenarioInfo: ScenarioInfo) : this(
@@ -251,7 +250,6 @@ data class Scenario(
                             bindings,
                             isGherkinScenario,
                             isNegative,
-                            is4xxDefined,
                             badRequestOrDefault
                         )
                     }
@@ -272,8 +270,7 @@ data class Scenario(
                         references,
                         bindings,
                         isGherkinScenario,
-                        isNegative,
-                        is4xxDefined
+                        isNegative
                     )
                 }
             }
@@ -476,8 +473,7 @@ data class Scenario(
             scenario.references,
             bindings,
             isGherkinScenario,
-            isNegative,
-            is4xxDefined
+            isNegative
         )
 
     fun newBasedOn(suggestions: List<Scenario>) =
@@ -498,7 +494,6 @@ data class Scenario(
         bindings,
         this.isGherkinScenario,
         isNegative = true,
-        is4xxDefined = is4xxDefined,
         badRequestOrDefault
     )
 }

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
@@ -5,6 +5,7 @@ import `in`.specmatic.core.*
 import `in`.specmatic.core.log.Verbose
 import `in`.specmatic.core.log.logger
 import `in`.specmatic.core.pattern.ContractException
+import `in`.specmatic.core.pattern.parsedJSONObject
 import `in`.specmatic.core.value.Value
 import `in`.specmatic.stub.HttpStub
 import `in`.specmatic.stub.createStubFromContracts
@@ -1370,6 +1371,22 @@ Scenario: zero should return not found
 
         assertThat(result).isInstanceOf(Result.Success::class.java)
         assertThat(executed).isTrue
+    }
+
+    @Test
+    fun `default response should be used to match an unexpected response status code and body`() {
+        val openAPISpec = """
+            Feature: With default
+            
+            Background:
+              Given openapi openapi/with_default.yaml            
+        """.trimIndent()
+
+        val feature = parseGherkinStringToFeature(openAPISpec, sourceSpecPath)
+
+        val result = feature.matches(HttpRequest("GET", "/hello/10"), HttpResponse(500, body = parsedJSONObject("""{"data": "information"}""")))
+
+        assertThat(result).isTrue
     }
 }
 

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
@@ -6,6 +6,8 @@ import `in`.specmatic.core.log.Verbose
 import `in`.specmatic.core.log.logger
 import `in`.specmatic.core.pattern.ContractException
 import `in`.specmatic.core.pattern.parsedJSONObject
+import `in`.specmatic.core.value.JSONObjectValue
+import `in`.specmatic.core.value.StringValue
 import `in`.specmatic.core.value.Value
 import `in`.specmatic.stub.HttpStub
 import `in`.specmatic.stub.createStubFromContracts
@@ -1374,12 +1376,12 @@ Scenario: zero should return not found
     }
 
     @Test
-    fun `default response should be used to match an unexpected response status code and body`() {
+    fun `default response should be used to match an unexpected response status code and body in stub`() {
         val openAPISpec = """
             Feature: With default
             
             Background:
-              Given openapi openapi/with_default.yaml            
+              Given openapi openapi/with_default.yaml
         """.trimIndent()
 
         val feature = parseGherkinStringToFeature(openAPISpec, sourceSpecPath)
@@ -1387,6 +1389,76 @@ Scenario: zero should return not found
         val result = feature.matches(HttpRequest("GET", "/hello/10"), HttpResponse(500, body = parsedJSONObject("""{"data": "information"}""")))
 
         assertThat(result).isTrue
+    }
+
+    @Test
+    fun `default response should be used to match an unexpected response status code and body in a negative test`() {
+        val openAPISpec = """
+            Feature: With default
+            
+            Background:
+              Given openapi openapi/post_with_default.yaml
+        """.trimIndent()
+
+        val feature = parseGherkinStringToFeature(openAPISpec, sourceSpecPath)
+
+        try {
+            System.setProperty(Flags.negativeTestingFlag, "true")
+
+            val results: Results = feature.copy(enableNegativeTesting = true).executeTests(object : TestExecutor {
+                override fun execute(request: HttpRequest): HttpResponse {
+                    val jsonBody = request.body as JSONObjectValue
+                    if(jsonBody.jsonObject.get("id")?.toStringLiteral()?.toIntOrNull() != null)
+                        return HttpResponse(200, body = StringValue("it worked"))
+
+                    return HttpResponse(400, body = parsedJSONObject("""{"data": "information"}"""))
+                }
+
+                override fun setServerState(serverState: Map<String, Value>) {
+                }
+            })
+
+            println(results.report())
+
+            assertThat(results.success()).isTrue
+        } finally {
+            System.clearProperty(Flags.negativeTestingFlag)
+        }
+    }
+
+    @Test
+    fun `400 response in the contract should be used to match a 400 status response in a negative test even when a default response has been declared`() {
+        val openAPISpec = """
+            Feature: With default
+            
+            Background:
+              Given openapi openapi/post_with_default_and_400.yaml
+        """.trimIndent()
+
+        val feature = parseGherkinStringToFeature(openAPISpec, sourceSpecPath)
+
+        try {
+            System.setProperty(Flags.negativeTestingFlag, "true")
+
+            val results: Results = feature.copy(enableNegativeTesting = true).executeTests(object : TestExecutor {
+                override fun execute(request: HttpRequest): HttpResponse {
+                    val jsonBody = request.body as JSONObjectValue
+                    if(jsonBody.jsonObject.get("id")?.toStringLiteral()?.toIntOrNull() != null)
+                        return HttpResponse(200, body = StringValue("it worked"))
+
+                    return HttpResponse(400, body = parsedJSONObject("""{"error_in_400": "message"}"""))
+                }
+
+                override fun setServerState(serverState: Map<String, Value>) {
+                }
+            })
+
+            println(results.report())
+
+            assertThat(results.success()).isTrue
+        } finally {
+            System.clearProperty(Flags.negativeTestingFlag)
+        }
     }
 }
 

--- a/core/src/test/resources/openapi/post_with_default.yaml
+++ b/core/src/test/resources/openapi/post_with_default.yaml
@@ -1,0 +1,41 @@
+openapi: 3.0.0
+info:
+  title: Sample API
+  description: Optional multiline or single-line description in [CommonMark](http://commonmark.org/help/) or HTML.
+  version: 0.1.9
+servers:
+  - url: http://api.example.com/v1
+    description: Optional server description, e.g. Main (production) server
+  - url: http://staging-api.example.com
+    description: Optional server description, e.g. Internal staging server for testing
+paths:
+  /hello:
+    post:
+      summary: hello world
+      description: Optional extended description in CommonMark or HTML.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - id
+              properties:
+                id:
+                  type: integer
+      responses:
+        default:
+          description: All errors
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: string
+        '200':
+          description: Says hello
+          content:
+            text/plain:
+              schema:
+                type: string

--- a/core/src/test/resources/openapi/post_with_default_and_400.yaml
+++ b/core/src/test/resources/openapi/post_with_default_and_400.yaml
@@ -1,0 +1,50 @@
+openapi: 3.0.0
+info:
+  title: Sample API
+  description: Optional multiline or single-line description in [CommonMark](http://commonmark.org/help/) or HTML.
+  version: 0.1.9
+servers:
+  - url: http://api.example.com/v1
+    description: Optional server description, e.g. Main (production) server
+  - url: http://staging-api.example.com
+    description: Optional server description, e.g. Internal staging server for testing
+paths:
+  /hello:
+    post:
+      summary: hello world
+      description: Optional extended description in CommonMark or HTML.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - id
+              properties:
+                id:
+                  type: integer
+      responses:
+        default:
+          description: All errors
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: string
+        '400':
+          description: All errors
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error_in_400:
+                    type: string
+        '200':
+          description: Says hello
+          content:
+            text/plain:
+              schema:
+                type: string

--- a/core/src/test/resources/openapi/with_default.yaml
+++ b/core/src/test/resources/openapi/with_default.yaml
@@ -1,0 +1,38 @@
+openapi: 3.0.0
+info:
+  title: Sample API
+  description: Optional multiline or single-line description in [CommonMark](http://commonmark.org/help/) or HTML.
+  version: 0.1.9
+servers:
+  - url: http://api.example.com/v1
+    description: Optional server description, e.g. Main (production) server
+  - url: http://staging-api.example.com
+    description: Optional server description, e.g. Internal staging server for testing
+paths:
+  /hello/{id}:
+    get:
+      summary: hello world
+      description: Optional extended description in CommonMark or HTML.
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
+          description: Numeric ID
+      responses:
+        default:
+          description: All errors
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: string
+        '200':
+          description: Says hello
+          content:
+            text/plain:
+              schema:
+                type: string

--- a/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
@@ -33,6 +33,7 @@ open class SpecmaticJUnitSupport {
         const val FILTER_NAME = "filterName"
 
         val testsNames = mutableListOf<String>()
+        val taintedSuccesses: MutableList<Result.Success> = mutableListOf()
     }
 
     private fun getEnvConfig(envName: String?): JSONObjectValue {
@@ -118,6 +119,10 @@ open class SpecmaticJUnitSupport {
                 testsNames.add(testScenario.testDescription())
 
                 val result: Result = invoker.execute(testScenario, timeout)
+
+                if(result is Result.Success && result.taint.isNotEmpty()) {
+                    taintedSuccesses.add(result)
+                }
 
                 when {
                     result.shouldBeIgnored() -> {

--- a/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
@@ -33,7 +33,7 @@ open class SpecmaticJUnitSupport {
         const val FILTER_NAME = "filterName"
 
         val testsNames = mutableListOf<String>()
-        val taintedSuccesses: MutableList<Result.Success> = mutableListOf()
+        val partialSuccesses: MutableList<Result.Success> = mutableListOf()
     }
 
     private fun getEnvConfig(envName: String?): JSONObjectValue {
@@ -120,8 +120,8 @@ open class SpecmaticJUnitSupport {
 
                 val result: Result = invoker.execute(testScenario, timeout)
 
-                if(result is Result.Success && result.taint.isNotEmpty()) {
-                    taintedSuccesses.add(result)
+                if(result is Result.Success && result.isPartialSuccess()) {
+                    partialSuccesses.add(result)
                 }
 
                 when {


### PR DESCRIPTION
**What**:

If a default response exists, Specmatic should match a response against it when running negative contract tests.

For example, if a 4xx is not declared, but a 4xx response is received to a mal-formed request, and a default response has been declared, Specmatic should check if the responses matches the default declaration.

If the responses matches the default response, it should consider tell JUnit that the test was a success. However it should log that the test was a Partial Success, and print a list of partial success at the end.

**Why**:

If a default response has been declared, we should certainly use it. However we do not want to encourage the use of the default response as as shortcut. An explicit declaration of the relevant status code makes for a clearer contract.

**How**:

HttpResponsePattern now has handling for a default response code. Negative test scenario objects are given all the 4xx responses and the default response during contruction.
