### PR TITLE
reading openapi string regular expression pattern

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
 
     implementation 'io.swagger.parser.v3:swagger-parser:2.1.3'
+    implementation 'com.github.mifmif:generex:1.0.2'
 
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit_version"
 

--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -484,7 +484,7 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
     ): Pattern {
         val pattern = when (schema) {
             is StringSchema -> when (schema.enum) {
-                null -> StringPattern(minLength = schema.minLength, maxLength = schema.maxLength)
+                null -> StringPattern(minLength = schema.minLength, maxLength = schema.maxLength, regexPattern = schema.pattern)
                 else -> toEnum(schema, patternName) { enumValue -> StringValue(enumValue.toString()) }
             }
             is IntegerSchema -> when (schema.enum) {

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
@@ -883,17 +883,19 @@ Background:
         """.trimIndent(), sourceSpecPath
         )
 
-        val petResponse = HttpStub(feature).use {
+        HttpStub(feature).use {
             val restTemplate = RestTemplate()
-            restTemplate.postForObject(
-                URI.create("http://localhost:9000/pets"),
-                NewPet("Scooby", "golden"),
-                Pet::class.java
-            )
+            try {
+                restTemplate.postForObject(
+                    URI.create("http://localhost:9000/pets"),
+                    NewPet("Scooby", "golden"),
+                    Pet::class.java
+                )
+                throw AssertionError("Should not allow upper case alphabets in name")
+            } catch (e: HttpClientErrorException) {
+                assertThat(e.statusCode).isEqualTo(BAD_REQUEST)
+            }
         }
-
-        assertThat(petResponse).isInstanceOf(Pet::class.java)
-        assertThat(petResponse).isNotNull
     }
 
     @Test

--- a/core/src/test/kotlin/in/specmatic/core/pattern/StringPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/StringPatternTest.kt
@@ -66,6 +66,19 @@ internal class StringPatternTest {
         assertThat(result.reportString()).isEqualTo("""Expected string with maxLength 3, actual was "test"""")
     }
 
+    @Test
+    fun `should not match when String is not as per regular expression`() {
+        val result = StringPattern(regexPattern = "^[a-z]*$").matches(StringValue("Test"), Resolver())
+        assertThat(result.isSuccess()).isFalse
+        assertThat(result.reportString()).isEqualTo("""Expected string that matches regex /^[a-z]*$/, actual was "Test"""")
+    }
+
+    @Test
+    fun `should match when String is as per regular expression`() {
+        val result = StringPattern(regexPattern = "^[a-z]*$").matches(StringValue("test"), Resolver())
+        assertThat(result.isSuccess()).isTrue
+    }
+
     companion object {
         @JvmStatic
         fun lengthTestValues(): Stream<Arguments> {
@@ -86,10 +99,22 @@ internal class StringPatternTest {
 
     @ParameterizedTest
     @MethodSource("lengthTestValues")
-    fun `generate string value of appropriate length matching minLength and maxLength parameters`(min: Int?, max: Int?, length: Int) {
+    fun `generate string value of appropriate length matching minLength and maxLength parameters`(
+        min: Int?,
+        max: Int?,
+        length: Int
+    ) {
         val result = StringPattern(minLength = min, maxLength = max).generate(Resolver()) as StringValue
 
         assertThat(result.string.length).isEqualTo(length)
+    }
+
+    @Test
+    fun `generate string value as per regex pattern`() {
+        val result =
+            StringPattern(regexPattern = "^[0-8]*$", minLength = 8, maxLength = 11).generate(Resolver()) as StringValue
+        assertThat(Regex("^[0-8]*$").matches(result.toStringLiteral())).isTrue
+        assertThat(result.toStringLiteral().length).isBetween(8, 11)
     }
 
     @Test

--- a/core/src/test/resources/openapi/common.yaml
+++ b/core/src/test/resources/openapi/common.yaml
@@ -8,6 +8,7 @@ components:
       properties:
         name:
           type: string
+          pattern: '^[a-z]*$'
         tag:
           type: string
           nullable: true

--- a/core/src/test/resources/openapi/petstore-expanded.yaml
+++ b/core/src/test/resources/openapi/petstore-expanded.yaml
@@ -223,6 +223,7 @@ components:
               type: string
               minLength: 6
               maxLength: 12
+              pattern: '^[a-z]*$'
             tag:
               $ref: '#/components/schemas/Tag'
             id:


### PR DESCRIPTION
**What**:

String Pattern should consider the regular expression in OpenAPI while matching and generating values 

**Why**:

* Contract Tests
  * Request - Values generated should be according to regular expression since application may be expecting it
  * Response - Verification of Strings against regular expression makes tests even more thorough
* Stubs
  * Request - Verification of Strings against regular expression makes the stub behave exactly as per spec
  * Response - Generating values as per regular expression emulates the Provider even better

**How**:

* Matching leverage Kotlin libraries
* Generating is done with [generex](https://github.com/mifmif/Generex)

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

