### PR TITLE
adding ability to omit query param in examples

### DIFF
--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
@@ -1611,7 +1611,7 @@ Scenario: zero should return not found
         val result = executeTest(feature.scenarios.first(), object : TestExecutor {
             override fun execute(request: HttpRequest): HttpResponse {
                 executed = true
-                return if (request.queryParams.containsKey("id")) HttpResponse.OK
+                return if (request.queryParams.keys.containsAll(listOf("name", "message"))) HttpResponse.OK
                 else HttpResponse.ERROR_400
             }
 
@@ -1636,8 +1636,9 @@ Scenario: zero should return not found
   When GET /hello
   Then status 200
   Examples:
-      | id   |
-      | OMIT |
+      | message | name |
+      | hello   | Hari |
+      | hello   | OMIT |
         """.trimIndent()
 
         val feature = parseGherkinStringToFeature(openAPISpec, sourceSpecPath)
@@ -1648,7 +1649,14 @@ Scenario: zero should return not found
             object : TestExecutor {
                 override fun execute(request: HttpRequest): HttpResponse {
                     executed = true
-                    return if (!request.queryParams.containsKey("id")) HttpResponse.OK
+                    return if (request.queryParams.size == 2 && request.queryParams.values.containsAll(
+                            listOf(
+                                "hello",
+                                "Hari"
+                            )
+                        )
+                    ) HttpResponse.OK
+                    else if (request.queryParams.size == 1 && request.queryParams.values.containsAll(listOf("hello"))) HttpResponse.OK
                     else HttpResponse.ERROR_400
                 }
 
@@ -1658,6 +1666,7 @@ Scenario: zero should return not found
         )
 
         assertThat(results.success()).isTrue
+        assertThat(results.successCount).isEqualTo(2)
         assertThat(executed).isTrue
     }
 

--- a/core/src/test/resources/openapi/helloWithQueryParams.yaml
+++ b/core/src/test/resources/openapi/helloWithQueryParams.yaml
@@ -20,22 +20,18 @@ paths:
             type: string
           required: true
           description: Greeting Message
-          examples:
-            200_OKAY:
-              value: 'hello'
-            200_OKAY_id_only:
-              value: 'hello'
         - in: query
           name: name
           schema:
             type: string
           required: true
           description: Name of person to greet
-          examples:
-            200_OKAY:
-              value: 'Hari'
-            200_OKAY_id_only:
-              value: OMIT
+        - in: query
+          name: another_message
+          schema:
+            type: string
+          required: true
+          description: additional message
       responses:
         '200':
           description: Says hello
@@ -43,11 +39,6 @@ paths:
             application/json:
               schema:
                 type: string
-              examples:
-                200_OKAY:
-                  value: 'hello Hari'
-                200_OKAY_id_only:
-                  value: 'hello'
         '404':
           description: Not Found
           content:

--- a/core/src/test/resources/openapi/helloWithQueryParams.yaml
+++ b/core/src/test/resources/openapi/helloWithQueryParams.yaml
@@ -15,11 +15,27 @@ paths:
       description: Optional extended description in CommonMark or HTML.
       parameters:
         - in: query
-          name: id
+          name: message
           schema:
-            type: integer
+            type: string
           required: true
-          description: Numeric ID
+          description: Greeting Message
+          examples:
+            200_OKAY:
+              value: 'hello'
+            200_OKAY_id_only:
+              value: 'hello'
+        - in: query
+          name: name
+          schema:
+            type: string
+          required: true
+          description: Name of person to greet
+          examples:
+            200_OKAY:
+              value: 'Hari'
+            200_OKAY_id_only:
+              value: OMIT
       responses:
         '200':
           description: Says hello
@@ -27,6 +43,11 @@ paths:
             application/json:
               schema:
                 type: string
+              examples:
+                200_OKAY:
+                  value: 'hello Hari'
+                200_OKAY_id_only:
+                  value: 'hello'
         '404':
           description: Not Found
           content:


### PR DESCRIPTION
**What**:

Adding "OMIT" keyword. When OMIT is mentioned as data in the examples for a query parameter, that query parameter will not be sent as part of the request for that example.

**Why**:

In APIs designs that involve inter parameter dependency between query parameters, certain query parameter combinations require that the remaining options not be sent. Example: param1 and param2 combination are contradictory in nature to param3 and param4, sending all 4 parameters may not be a valid option. In such cases where API Design is suboptimal, there is a necessity explicitly omit param3 and param4 when sending param1 and param2 and vice versa.

**How**:

Specmatic completely omit sending the query parameter that has been omitted in the example.

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [x] Sonar Quality Gate

**Issue ID**:
Closes: #499 

