### PR TITLE
#574 converting header keys to lower case while loading stub data

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpRequestPattern.kt
@@ -6,6 +6,7 @@ import `in`.specmatic.core.Result.Success
 import `in`.specmatic.core.pattern.*
 import `in`.specmatic.core.value.JSONObjectValue
 import `in`.specmatic.core.value.StringValue
+import io.ktor.util.*
 
 private const val MULTIPART_FORMDATA_BREADCRUMB = "MULTIPART-FORMDATA"
 private const val FORM_FIELDS_BREADCRUMB = "FORM-FIELDS"
@@ -228,8 +229,8 @@ data class HttpRequestPattern(
                 requestType.copy(
                     headersPattern = HttpHeadersPattern(
                         toTypeMap(
-                            request.headers,
-                            headersPattern.pattern,
+                            toLowerCaseKeys(request.headers) as Map<String, String>,
+                            toLowerCaseKeys(headersPattern.pattern) as Map<String, Pattern>,
                             resolver
                         )
                     )
@@ -264,6 +265,9 @@ data class HttpRequestPattern(
             }
         }
     }
+
+    private fun toLowerCaseKeys(map: Map<String, Any?>) =
+        map.map { (key, value) -> key.toLowerCasePreservingASCIIRules() to value }.toMap()
 
     private fun toTypeMap(
         values: Map<String, String>,

--- a/core/src/test/kotlin/in/specmatic/core/HttpRequestPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/HttpRequestPatternTest.kt
@@ -350,6 +350,15 @@ internal class HttpRequestPatternTest {
         assertThat(reportText).contains(">> REQUEST.BODY.id")
     }
 
+    @Test
+    fun `should lower case header keys while loading stub data`()  {
+        val type = HttpRequestPattern(method = "POST", urlMatcher = toURLMatcherWithOptionalQueryParams("http://helloworld.com/data"), headersPattern = HttpHeadersPattern(mapOf("x-data" to StringPattern())), body = JSONObjectPattern(mapOf("id" to NumberPattern())))
+        val request = HttpRequest("POST", "/data", headers = mapOf("X-Data" to "abc123"), body = parsedJSON("""{"id": "abc123"}"""))
+
+        val httpRequestPattern = type.generate(request, Resolver())
+        assertThat(httpRequestPattern.headersPattern.pattern["x-data"].toString()).isEqualTo("abc123")
+    }
+
     @Nested
     inner class FormFieldMatchReturnsAllErrors {
         val request = HttpRequest(method = "POST", path = "/", formFields = mapOf("hello" to "abc123"))


### PR DESCRIPTION
**What**:

Converting header names in stub data to lower case.

**Why**:

While headers are case insensitive in rest of the places, the stub data being loaded is loaded with case headers in case sensitive manner. This leads to stub data mismatch. Please see #574.

**How**:

At load time converting header names to lower case.

**Checklist**:

- [ NA] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [x] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #574 

<!-- feel free to add additional comments -->
