### PR TITLE
Ensure that DateTimePattern is stringified as its pattern

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/pattern/DateTimePattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/DateTimePattern.kt
@@ -47,6 +47,8 @@ object DateTimePattern : Pattern, ScalarType {
     override val typeName: String = "datetime"
 
     override val pattern = "(datetime)"
+
+    override fun toString() = pattern
 }
 
 fun currentDate() = StringValue(LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME))

--- a/core/src/test/kotlin/in/specmatic/core/URLMatcherTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/URLMatcherTest.kt
@@ -237,4 +237,10 @@ internal class URLMatcherTest {
         val result = matcher.matches(URI("/"), mapOf("name" to "Archie"), Resolver())
         assertThat(result.isSuccess()).isFalse()
     }
+
+    @Test
+    fun `should stringify date time query param to date time pattern`() {
+        val urlMatcher = URLMatcher(mapOf("before" to DateTimePattern), pathToPattern("/pets"), "/pets")
+        assertThat(urlMatcher.toString()).isEqualTo("/pets?before=(datetime)")
+    }
 }


### PR DESCRIPTION
**What**: DateTimePattern is casted to string by it's own JVM identifier, but it should be the `pattern`.

**Why**: Several places seem to be replacing the `(datetime)` pattern with an actually value


**Checklist**:

- [x] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation N/A
- [x] Tests
- [x] Sonar Quality Gate

**Issue ID**:
Closes: #580 

I've been trying to find a nice place to test this, but it seems to fall a bit between the cracks of the test-suite. Any pointers on where it would be appropriate to add tests would be very appreciated. 


