### PR TITLE
Support oneOf multiple sub-schemas

### DIFF
--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -5300,7 +5300,7 @@ paths:
     }
 
     @Test
-    fun `nullable ref in yaml`() {
+    fun `nullable oneOf ref in yaml`() {
         val openAPIText = """
             ---
             openapi: "3.0.1"
@@ -5317,12 +5317,13 @@ paths:
                       application/json:
                         schema:
                           required:
-                          - "address"
+                          - "location"
                           properties:
-                            address:
+                            location:
                               oneOf:
                               - nullable: true
                               - ${'$'}ref: '#/components/schemas/Address'
+                              - ${'$'}ref: '#/components/schemas/LatLong'
                   responses:
                     "200":
                       description: "Test"
@@ -5338,6 +5339,15 @@ paths:
                   properties:
                     street:
                       type: "string"
+                LatLong:
+                  required:
+                  - "latitude"
+                  - "longitude"
+                  properties:
+                    latitude:
+                      type: "number"
+                    longitude:
+                      type: "number"
         """.trimIndent()
 
         val feature = OpenApiSpecification.fromYAML(openAPIText, "").toFeature()
@@ -5347,7 +5357,7 @@ paths:
                 HttpRequest(
                     "POST",
                     "/user",
-                    body = parsedJSON("""{"address": {"street": "Baker Street"}}""")
+                    body = parsedJSON("""{"location": {"street": "Baker Street"}}""")
                 ), HttpResponse.OK("success")
             ).response.headers["X-Specmatic-Result"]
         ).isEqualTo("success")
@@ -5357,7 +5367,17 @@ paths:
                 HttpRequest(
                     "POST",
                     "/user",
-                    body = parsedJSON("""{"address": null}""")
+                    body = parsedJSON("""{"location": {"latitude": 51.523160, "longitude": -0.158070}}""")
+                ), HttpResponse.OK("success")
+            ).response.headers["X-Specmatic-Result"]
+        ).isEqualTo("success")
+
+        assertThat(
+            feature.matchingStub(
+                HttpRequest(
+                    "POST",
+                    "/user",
+                    body = parsedJSON("""{"location": null}""")
                 ), HttpResponse.OK("success")
             ).response.headers["X-Specmatic-Result"]
         ).isEqualTo("success")


### PR DESCRIPTION
- Previously only supported the first sub-schema under oneOf (plus a nullable sub-schema)

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Adds support for selecting any one of multiple sub-schemas under oneOf. Currently only the first found sub-schema is supported.

<!-- Why are these changes necessary? -->

**Why**: Fixes issue #585 

<!-- How were these changes implemented? -->

**How**: Made existing oneOf support more complete in OpenApiSpecification.kt

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [X] Tests 
- [ ] Sonar Quality Gate N/A

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #585

<!-- feel free to add additional comments -->
