### PR TITLE
Support dictionary with allOf, oneOf values

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -779,7 +779,7 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
         schema: Schema<*>, typeStack: List<String>, patternName: String
     ): DictionaryPattern {
         val valueSchema = schema.additionalProperties as Schema<Any>
-        val valueSchemaTypeName = if (valueSchema.`$ref` == null) valueSchema.types.first() else valueSchema.`$ref`
+        val valueSchemaTypeName = valueSchema.`$ref` ?: valueSchema.types?.first() ?: "";
         return DictionaryPattern(
             StringPattern(), toSpecmaticPattern(valueSchema, typeStack, valueSchemaTypeName, false)
         )

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -3494,6 +3494,69 @@ components:
         assertThat(stub.response.status).isEqualTo(200)
 
     }
+  @Test
+  fun `support dictionary object type with composed oneOf value`() {
+    val openAPI =
+      """
+---
+openapi: 3.0.1
+info:
+  title: API
+  version: 1
+paths:
+  /data:
+    post:
+      summary: API
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                myValues:
+                  type: object
+                  additionalProperties:
+                    oneOf:
+                    - ${"$"}ref: Person
+                    - ${"$"}ref: Alien
+      responses:
+        200:
+          description: API
+components:
+  schemas:
+    Person:
+      type: object
+      properties:
+        name:
+          type: string
+    Alien:
+      type: object
+      properties:
+        moniker:
+          type: string
+        homePlanet:
+          type: string
+""".trimIndent()
+
+    println(openAPI)
+    val feature = OpenApiSpecification.fromYAML(openAPI, "").toFeature()
+
+    val request = HttpRequest(
+      "POST",
+      "/data",
+      body = parsedValue("""{"myValues": {"10": {"name": "Jill"}, "20": {"moniker": "Vin", "homePlanet": "Scadrial"}}}""")
+    )
+    val response = HttpResponse.OK
+
+    val stub: HttpStubData = feature.matchingStub(request, response)
+
+    println(stub.requestType)
+
+    assertThat(stub.requestType.method).isEqualTo("POST")
+    assertThat(stub.response.status).isEqualTo(200)
+
+  }
 
     @Test
     fun `support dictionary object type in request body with inline fixed keys`() {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Adds support for dictionary of oneOf or allOf value schemas. Without this fixed a NullPointerException is produced. NOTE: #585 must be fully fixed ( PR #586 merged) before this can be fully fixed.

<!-- Why are these changes necessary? -->

**Why**: Fixes issue #587 

<!-- How were these changes implemented? -->

**How**: Updated existing support in `OpenApiSpecification.toDictionaryPattern()`

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [ X] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #587 

<!-- feel free to add additional comments -->
NOTE: #585 must be fully fixed ( PR #586 merged) before this can be fully fixed.