### PR TITLE
Support array of enum in query param

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -869,7 +869,11 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
 
         val queryParameters = parameters.filterIsInstance(QueryParameter::class.java).joinToString("&") {
             val specmaticPattern = if(it.schema.type == "array") {
-                CsvPattern(toSpecmaticPattern(schema = it.schema.items, typeStack = emptyList()))
+                var innerPattern = toSpecmaticPattern(schema = it.schema.items, typeStack = emptyList())
+                if (innerPattern is AnyPattern) {
+                    innerPattern = StringPattern("");
+                }
+                CsvPattern(innerPattern)
             } else {
                 toSpecmaticPattern(schema = it.schema, typeStack = emptyList(), patternName = it.name)
             }

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
@@ -1291,7 +1291,7 @@ Background:
         )
 
         assertThat(flags["/pets POST executed"]).isEqualTo(1)
-        assertThat(flags["/pets GET executed"]).isEqualTo(12)
+        assertThat(flags["/pets GET executed"]).isEqualTo(24)
         assertThat(flags["/petIds GET executed"]).isEqualTo(4)
         assertThat(flags["/pets/0 GET executed"]).isEqualTo(1)
         assertThat(flags.keys.filter { it.matches(Regex("""\/pets\/[0-9]+ GET executed""")) }.size).isEqualTo(2)

--- a/core/src/test/resources/openapi/petstore-expanded.yaml
+++ b/core/src/test/resources/openapi/petstore-expanded.yaml
@@ -70,6 +70,17 @@ paths:
             enum:
               - labrador
               - retriever
+        - name: rating
+          in: query
+          description: ratings to filter by
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - 1
+                - 2
         - in: header
           name: X-Request-ID
           schema:


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Fixes #589 and URISyntaxException when defining a query param as an array of enum.

<!-- Why are these changes necessary? -->

**Why**: Query param with array of enum should be supported without error.

<!-- How were these changes implemented? -->

**How**: OpenApiSpecification.toSpecmaticPath() already detected the array, so this was enhanced to further detect an array of enum. I'm not confident if the approach taken is best, so please modify as appropriate.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [x] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #589 

<!-- feel free to add additional comments -->
