### PR TITLE
Support component cycles in stub generation

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -601,15 +601,12 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
                                 typeStack.contains(
                                     componentName
                                 ) && referredSchema.instanceOf(ObjectSchema::class)
-                            when {
-                                cyclicReference -> DeferredPattern("(${patternName})")
-                                else -> {
-                                    val componentType = resolveReference(component, typeStack)
-                                    val typeName = "(${componentNameFromReference(component)})"
-                                    patterns[typeName] = componentType
-                                    DeferredPattern(typeName)
-                                }
+                            val typeName = "(${componentNameFromReference(component)})"
+                            if (!cyclicReference) {
+                                val componentType = resolveReference(component, typeStack)
+                                patterns[typeName] = componentType
                             }
+                            DeferredPattern(typeName)
                         }
                     }
                 }

--- a/core/src/main/kotlin/in/specmatic/core/Resolver.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Resolver.kt
@@ -82,7 +82,7 @@ data class Resolver(
             val subStack = cyclePreventionStack.subList(index, cyclePreventionStack.size)
             if (subStack.stream().noneMatch { nullable(it) }) {
                 // Terminate what would otherwise be an infinite cycle.
-                throw PatternCycleException("Invalid pattern cycle", cyclePreventionStack.plus(pattern))
+                throw ContractException("Invalid pattern cycle: ${cyclePreventionStack.plus(pattern)}", isCycle = true)
             }
         }
     }

--- a/core/src/main/kotlin/in/specmatic/core/Resolver.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Resolver.kt
@@ -77,7 +77,7 @@ data class Resolver(
 
     private fun validateNoCycle(pattern: Pattern) {
         val index = cyclePreventionStack.indexOf(pattern)
-        if (index > 0) {
+        if (index >= 0) {
             // Nullables are allowed since they will eventually terminate any cycle (only consider substack with cycle)
             val subStack = cyclePreventionStack.subList(index, cyclePreventionStack.size)
             if (subStack.stream().noneMatch { nullable(it) }) {

--- a/core/src/main/kotlin/in/specmatic/core/Resolver.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Resolver.kt
@@ -82,7 +82,7 @@ data class Resolver(
             val subStack = cyclePreventionStack.subList(index, cyclePreventionStack.size)
             if (subStack.stream().noneMatch { nullable(it) }) {
                 // Terminate what would otherwise be an infinite cycle.
-                throw ContractException("Invalid cycle for non-nullable $pattern. Stack so far: $cyclePreventionStack")
+                throw PatternCycleException("Invalid pattern cycle", cyclePreventionStack.plus(pattern))
             }
         }
     }

--- a/core/src/main/kotlin/in/specmatic/core/pattern/ContractException.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/ContractException.kt
@@ -5,7 +5,13 @@ import `in`.specmatic.core.Result
 import `in`.specmatic.core.Scenario
 import `in`.specmatic.core.ScenarioDetailsForResult
 
-data class ContractException(val errorMessage: String = "", val breadCrumb: String = "", val exceptionCause: ContractException? = null, val scenario: ScenarioDetailsForResult? = null) : Exception(errorMessage) {
+data class ContractException(
+    val errorMessage: String = "",
+    val breadCrumb: String = "",
+    val exceptionCause: ContractException? = null,
+    val scenario: ScenarioDetailsForResult? = null,
+    val isCycle: Boolean = exceptionCause?.isCycle?: false,
+) : Exception(errorMessage) {
     constructor(failureReport: FailureReport): this(failureReport.toText())
 
     fun failure(): Result.Failure =

--- a/core/src/main/kotlin/in/specmatic/core/pattern/JSONObjectPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/JSONObjectPattern.kt
@@ -112,13 +112,14 @@ fun generate(jsonPattern: Map<String, Pattern>, resolver: Resolver): Map<String,
             attempt(breadCrumb = key) {
                 try {
                     Optional.of(resolverWithNullType.generate(key, pattern))
-                } catch (e: PatternCycleException) {
-                    if (optionalProps.contains(key)) {
-                        // Handle cycle by marking this property as removable
-                        Optional.empty()
+                } catch (e: ContractException) {
+                    if (!e.isCycle || !optionalProps.contains(key)) {
+                        // Give other patterns in the cycle a chance to check for optional properties
+                        throw e
                     }
-                    // Property is required, so must throw exception
-                    else throw ContractException(e.message!!, key)
+
+                    // Handle cycle by marking this property as removable
+                    Optional.empty()
                 }
             }
         }

--- a/core/src/main/kotlin/in/specmatic/core/pattern/PatternCycleException.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/PatternCycleException.kt
@@ -1,0 +1,3 @@
+package `in`.specmatic.core.pattern
+
+data class PatternCycleException(val msg: String, val cycle: List<Pattern>,) : Exception("$msg. cycle=$cycle")

--- a/core/src/main/kotlin/in/specmatic/core/pattern/PatternCycleException.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/PatternCycleException.kt
@@ -1,3 +1,0 @@
-package `in`.specmatic.core.pattern
-
-data class PatternCycleException(val msg: String, val cycle: List<Pattern>,) : Exception("$msg. cycle=$cycle")

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
@@ -1021,7 +1021,7 @@ Background:
     }
 
     @Test
-    fun `should validate and generate with indirect non-nullable cyclic reference in open api`() {
+    fun `should validate and generate with indirect required non-nullable cyclic reference in open api`() {
         val feature = parseGherkinStringToFeature(
             """
 Feature: Hello world
@@ -1046,10 +1046,11 @@ Background:
         assertThat(resp.isSuccessful).isFalse
         assertThat(resp.code()).isEqualTo(400)
         val body = resp.body()?.string()
-        assertThat(body).contains("Invalid cycle")
+        assertThat(body).contains("Invalid pattern cycle")
     }
 
     @Test
+    @RepeatedTest(10) // Try to exercise all outcomes of AnyPattern.generate() which randomly selects from its options
     fun `should validate and generate with indirect nullable cyclic reference in open api`() {
         val feature = parseGherkinStringToFeature(
             """

--- a/core/src/test/resources/openapi/circular-reference-non-nullable.yaml
+++ b/core/src/test/resources/openapi/circular-reference-non-nullable.yaml
@@ -22,6 +22,8 @@ components:
         # indirect cycle via an intermediate node
         intermediate-node:
           $ref: '#/components/schemas/CycleIntermediateNode'
+      required:
+        - intermediate-node
 
     CycleIntermediateNode:
       type: object
@@ -29,3 +31,5 @@ components:
         # Completes an indirect cycle back to the root
         indirect-cycle:
           $ref: '#/components/schemas/CycleRoot'
+      required:
+        - indirect-cycle

--- a/core/src/test/resources/openapi/circular-reference-non-nullable.yaml
+++ b/core/src/test/resources/openapi/circular-reference-non-nullable.yaml
@@ -1,9 +1,9 @@
 openapi: 3.0.1
 info:
-  title: Demonstrate circular reference bug in specmatic
+  title: Tests circular references
   version: "1.0"
 paths:
-  /demo/circular-reference:
+  /demo/circular-reference-non-nullable:
     get:
       responses:
         "200":
@@ -19,14 +19,9 @@ components:
     CycleRoot:
       type: object
       properties:
-        # A direct cycle works
-        direct-cycle:
-          $ref: '#/components/schemas/CycleRoot'
-
-        # An indirect cycle via an intermediate node does NOT work
+        # indirect cycle via an intermediate node
         intermediate-node:
           $ref: '#/components/schemas/CycleIntermediateNode'
-
 
     CycleIntermediateNode:
       type: object

--- a/core/src/test/resources/openapi/circular-reference-nullable.yaml
+++ b/core/src/test/resources/openapi/circular-reference-nullable.yaml
@@ -1,0 +1,39 @@
+openapi: 3.0.1
+info:
+  title: Tests circular references
+  version: "1.0"
+paths:
+  /demo/circular-reference-nullable:
+    get:
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NullableCycleHolder'
+
+components:
+  schemas:
+
+    # Holder to ensure at a response body is returned, even if it is empty
+    NullableCycleHolder:
+      type: object
+      properties:
+        contents:
+          $ref: '#/components/schemas/NullableCycleRoot'
+
+    NullableCycleRoot:
+      type: object
+      nullable: true
+      properties:
+        # indirect cycle via an intermediate node
+        intermediate-node:
+          $ref: '#/components/schemas/NullableCycleIntermediateNode'
+
+    NullableCycleIntermediateNode:
+      type: object
+      properties:
+        # Completes an indirect cycle back to the root
+        indirect-cycle:
+          $ref: '#/components/schemas/NullableCycleRoot'

--- a/core/src/test/resources/openapi/circular-reference-nullable.yaml
+++ b/core/src/test/resources/openapi/circular-reference-nullable.yaml
@@ -22,6 +22,8 @@ components:
       properties:
         contents:
           $ref: '#/components/schemas/NullableCycleRoot'
+      required:
+        - contents
 
     NullableCycleRoot:
       type: object
@@ -30,6 +32,8 @@ components:
         # indirect cycle via an intermediate node
         intermediate-node:
           $ref: '#/components/schemas/NullableCycleIntermediateNode'
+      required:
+        - intermediate-node
 
     NullableCycleIntermediateNode:
       type: object
@@ -37,3 +41,5 @@ components:
         # Completes an indirect cycle back to the root
         indirect-cycle:
           $ref: '#/components/schemas/NullableCycleRoot'
+      required:
+        - indirect-cycle

--- a/core/src/test/resources/openapi/circular-reference-optional-non-nullable.yaml
+++ b/core/src/test/resources/openapi/circular-reference-optional-non-nullable.yaml
@@ -1,0 +1,33 @@
+openapi: 3.0.1
+info:
+  title: Tests optional circular references
+  version: "1.0"
+paths:
+  /demo/circular-reference-optional-non-nullable:
+    get:
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OptionalCycleRoot'
+
+components:
+  schemas:
+
+    OptionalCycleRoot:
+      type: object
+      properties:
+        # indirect cycle via an intermediate node
+        intermediate-node:
+          $ref: '#/components/schemas/OptionalCycleIntermediateNode'
+      required:
+        - intermediate-node
+
+    OptionalCycleIntermediateNode:
+      type: object
+      properties:
+        # Completes an optional indirect cycle back to the root
+        indirect-cycle:
+          $ref: '#/components/schemas/OptionalCycleRoot'


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Fixes #591 and StackOverflowError produced when generating stubs for spec containing component cycles.

<!-- Why are these changes necessary? -->

**Why**: Avoids serious StackOverflowError and better supports the OpenApi specification

<!-- How were these changes implemented? -->

**How**: Resolver keeps a stack of patterns visited in order to avoid infinite processing cycle.
- Otherwise StackOverflowError thrown
- Uses correct pattern for the referred-to component that would introduce a cycle (previously would use the referring component's pattern). See OpenApiSpecification.toSpecmaticPattern()
- Test enhanced to test stub generation for direct cycle, indirect cycles through another component, and cycles through arrays.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [X] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #591 

<!-- feel free to add additional comments -->
Related to #583 , but this issue deals with stub generation logic.