### PR TITLE
Support oneOf w/ discriminator

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -807,6 +807,10 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
             ) toSpecmaticParamName(
                 optional, propertyName
             ) to DeferredPattern("(${patternName})")
+            else if (schema.discriminator?.propertyName == propertyName){
+                // Ensure discriminator property exactly matches component and not just any string
+                propertyName to ExactValuePattern(StringValue(patternName))
+            }
             else {
                 val specmaticPattern = toSpecmaticPattern(
                     propertyType, typeStack.plus(patternName), patternName

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -5567,6 +5567,118 @@ paths:
         }.satisfies(Consumer { it.instanceOf(NoMatchingScenario::class) })
     }
 
+  // See https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/#allof
+    @Test
+    fun `oneOf with discriminator in yaml`() {
+        val openAPIText = """
+            ---
+            openapi: "3.0.1"
+            info:
+              title: "Test"
+              version: "1"
+            paths:
+              /pets:
+                patch:
+                  requestBody:
+                    content:
+                      application/json:
+                        schema:
+                          ${'$'}ref: "#/components/schemas/Pet_Polymorphic"
+                  responses:
+                    "200":
+                      description: "updated"
+                      content:
+                        text/plain:
+                          schema:
+                            type: "string"
+            components:
+              schemas:
+                Pet:
+                  type: object
+                  required:
+                  - pet_type
+                  properties:
+                    pet_type:
+                      type: string
+                  discriminator:
+                    propertyName: pet_type
+                Pet_Polymorphic:
+                  oneOf:
+                    - ${'$'}ref: '#/components/schemas/Cat'
+                    - ${'$'}ref: '#/components/schemas/Dog'
+                Dog:
+                  allOf:
+                  - ${'$'}ref: '#/components/schemas/Pet'
+                  - type: object
+                    properties:
+                      bark:
+                        type: boolean
+                      breed:
+                        type: string
+                        enum: [Dingo, Husky]
+                Cat:
+                  allOf:
+                  - ${'$'}ref: '#/components/schemas/Pet'
+                  - type: object
+                    properties:
+                      hunts:
+                        type: boolean
+                      age:
+                        type: integer
+        """.trimIndent()
+      val feature = OpenApiSpecification.fromYAML(openAPIText, "").toFeature()
+
+      assertThat(
+          feature.matchingStub(
+              HttpRequest(
+                  "PATCH",
+                  "/pets",
+                  body = parsedJSON("""{"pet_type": "Cat", "age": 3}""")
+              ), HttpResponse.OK("success")
+          ).response.headers["X-Specmatic-Result"]
+      ).isEqualTo("success")
+
+      assertThat(
+          feature.matchingStub(
+              HttpRequest(
+                  "PATCH",
+                  "/pets",
+                  body = parsedJSON("""{"pet_type": "Dog", "bark": true}""")
+              ), HttpResponse.OK("success")
+          ).response.headers["X-Specmatic-Result"]
+      ).isEqualTo("success")
+
+      assertThat(
+          feature.matchingStub(
+              HttpRequest(
+                  "PATCH",
+                  "/pets",
+                  body = parsedJSON("""{"pet_type": "Dog", "bark": false, "breed": "Dingo"}""")
+              ), HttpResponse.OK("success")
+          ).response.headers["X-Specmatic-Result"]
+      ).isEqualTo("success")
+
+      assertThatThrownBy {
+        feature.matchingStub(
+          HttpRequest(
+            "PATCH",
+            "/pets",
+            body = parsedJSON("""{"age": 3}""")
+          ), HttpResponse.OK("success")
+        )
+      }.isInstanceOf(NoMatchingScenario::class.java)
+
+      assertThatThrownBy {
+        feature.matchingStub(
+          HttpRequest(
+            "PATCH",
+            "/pets",
+            body = parsedJSON("""{"pet_type": "Cat", "bark": true}""")
+          ), HttpResponse.OK("success")
+        )
+      }.isInstanceOf(NoMatchingScenario::class.java)
+    }
+
     @Test
     fun `should read WIP tag in OpenAPI paths`() {
         val contractString = """


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Adds support for discriminator per [OAS spec](https://spec.openapis.org/oas/latest.html#discriminator-object). NOTE unit test depends on #585 having been fixed.

<!-- Why are these changes necessary? -->

**Why**: To fix issue #593 and add discriminator support per OAS spec.

<!-- How were these changes implemented? -->

**How**: Enhanced existing allOf support

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [X] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #593

<!-- feel free to add additional comments -->
NOTE unit test depends on #585 having been fixed
