### PR TITLE
Support path param as enum

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -862,8 +862,9 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
 
         var specmaticPath = openApiPath
         parameters.filterIsInstance(PathParameter::class.java).map {
+            val pattern = if (it.schema.enum != null) StringPattern("") else toSpecmaticPattern(it.schema, emptyList())
             specmaticPath = specmaticPath.replace(
-                "{${it.name}}", "(${it.name}:${toSpecmaticPattern(it.schema, emptyList()).typeName})"
+                "{${it.name}}", "(${it.name}:${pattern.typeName})"
             )
         }
 

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -3264,7 +3264,89 @@ components:
 
     }
 
-    @Test
+  @Test
+  fun `support path parameter as enum inline`() {
+    val openAPI =
+      """
+---
+openapi: 3.0.1
+info:
+  title: API
+  version: 1
+paths:
+  /permissions/state/{state}:
+    get:
+      parameters:
+      - name: state
+        in: path
+        schema:
+          type: string
+          enum:
+          - ALLOW
+          - DENY
+      responses:
+        200:
+          description: API
+""".trimIndent()
+
+    println(openAPI)
+    val feature = OpenApiSpecification.fromYAML(openAPI, "").toFeature()
+
+    val request = HttpRequest("GET", "/permissions/state/ALLOW")
+    val response = HttpResponse.OK
+
+    val stub: HttpStubData = feature.matchingStub(request, response)
+
+    println(stub.requestType)
+
+    assertThat(stub.requestType.method).isEqualTo("GET")
+    assertThat(stub.response.status).isEqualTo(200)
+  }
+
+  @Test
+  fun `support path parameter as enum reference`() {
+    val openAPI =
+      """
+---
+openapi: 3.0.1
+info:
+  title: API
+  version: 1
+paths:
+  /permissions/state/{state}:
+    get:
+      parameters:
+      - ${'$'}ref: '#/components/parameters/stateParam'
+      responses:
+        200:
+          description: API
+components:
+  parameters:
+    stateParam:
+      name: state
+      in: path
+      schema:
+        type: string
+        enum:
+        - ALLOW
+        - DENY
+""".trimIndent()
+
+    println(openAPI)
+    val feature = OpenApiSpecification.fromYAML(openAPI, "").toFeature()
+
+    val request = HttpRequest("GET", "/permissions/state/ALLOW")
+    val response = HttpResponse.OK
+
+    val stub: HttpStubData = feature.matchingStub(request, response)
+
+    println(stub.requestType)
+
+    assertThat(stub.requestType.method).isEqualTo("GET")
+    assertThat(stub.response.status).isEqualTo(200)
+  }
+
+  @Test
     fun `support dictionary object type in request body with data structure as reference`() {
         val openAPI =
             """


### PR DESCRIPTION
- Without this a URISyntaxException is produced.

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Adds support for path param as enum, similar to existing support for query param as enum.

<!-- Why are these changes necessary? -->

**Why**: Fixes #595 .

<!-- How were these changes implemented? -->

**How**: Enhanced existing logic near where query params are similarly handled.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [X] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #595 

<!-- feel free to add additional comments -->
