### PR TITLE
Support Xml response with type: string

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -628,6 +628,9 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
     }
 
     private fun toXMLPattern(mediaType: MediaType): Pattern {
+        if (mediaType.schema is StringSchema)
+            return toSpecmaticPattern(mediaType.schema, emptyList())
+
         return toXMLPattern(mediaType.schema, typeStack = emptyList())
     }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Avoids `ContractException(errorMessage=Node not recognized as XML type: string, breadCrumb=, exceptionCause=null, scenario=null)`

<!-- Why are these changes necessary? -->

**Why**: Fixes #597 .

<!-- How were these changes implemented? -->

**How**: Uses string pattern when type: string

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [X] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #597 

<!-- feel free to add additional comments -->
