### PR TITLE
added support for ephemeral stubs

### DIFF
--- a/core/src/main/kotlin/in/specmatic/mock/ScenarioStub.kt
+++ b/core/src/main/kotlin/in/specmatic/mock/ScenarioStub.kt
@@ -4,7 +4,7 @@ import `in`.specmatic.core.*
 import `in`.specmatic.core.pattern.ContractException
 import `in`.specmatic.core.value.*
 
-data class ScenarioStub(val request: HttpRequest = HttpRequest(), val response: HttpResponse = HttpResponse(0, emptyMap()), val kafkaMessage: KafkaMessage? = null, val delayInSeconds: Int? = null) {
+data class ScenarioStub(val request: HttpRequest = HttpRequest(), val response: HttpResponse = HttpResponse(0, emptyMap()), val kafkaMessage: KafkaMessage? = null, val delayInSeconds: Int? = null, val stubToken: String? = null) {
     fun toJSON(): JSONObjectValue {
         val mockInteraction = mutableMapOf<String, Value>()
         if(kafkaMessage != null) {
@@ -22,6 +22,7 @@ const val MOCK_KAFKA_MESSAGE = "kafka-message"
 const val MOCK_HTTP_REQUEST = "http-request"
 const val MOCK_HTTP_RESPONSE = "http-response"
 const val DELAY_IN_SECONDS = "delay-in-seconds"
+const val STUB_TOKEN = "http-stub-token"
 
 val MOCK_HTTP_REQUEST_ALL_KEYS = listOf("mock-http-request", MOCK_HTTP_REQUEST)
 val MOCK_HTTP_RESPONSE_ALL_KEYS = listOf("mock-http-response", MOCK_HTTP_RESPONSE)
@@ -43,8 +44,9 @@ fun mockFromJSON(mockSpec: Map<String, Value>): ScenarioStub {
             val mockResponse = HttpResponse.fromJSON(getJSONObjectValue(MOCK_HTTP_RESPONSE_ALL_KEYS, mockSpec))
 
             val delayInSeconds = getIntOrNull(DELAY_IN_SECONDS, mockSpec)
+            val stubToken: String? = getStringOrNull(STUB_TOKEN, mockSpec)
 
-            ScenarioStub(request = mockRequest, response = mockResponse, delayInSeconds = delayInSeconds)
+            ScenarioStub(request = mockRequest, response = mockResponse, delayInSeconds = delayInSeconds, stubToken = stubToken)
         }
     }
 }
@@ -86,3 +88,13 @@ fun getIntOrNull(key: String, mapData: Map<String, Value>): Int? {
         return data.number.toInt()
     }
 }
+
+fun getStringOrNull(key: String, mapData: Map<String, Value>): String? {
+    val data = mapData[key]
+
+    return data?.let {
+        if(data !is StringValue) throw ContractException("$key should be a number")
+        return data.string
+    }
+}
+

--- a/core/src/main/kotlin/in/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/in/specmatic/stub/HttpStub.kt
@@ -13,10 +13,7 @@ import `in`.specmatic.core.value.EmptyString
 import `in`.specmatic.core.value.StringValue
 import `in`.specmatic.core.value.Value
 import `in`.specmatic.core.value.toXMLNode
-import `in`.specmatic.mock.NoMatchingScenario
-import `in`.specmatic.mock.ScenarioStub
-import `in`.specmatic.mock.mockFromJSON
-import `in`.specmatic.mock.validateMock
+import `in`.specmatic.mock.*
 import `in`.specmatic.test.HttpClient
 import io.ktor.http.*
 import io.ktor.http.content.*
@@ -27,10 +24,11 @@ import io.ktor.server.plugins.cors.*
 import io.ktor.server.plugins.doublereceive.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
-import io.ktor.util.asStream
-import io.ktor.util.toMap
-import kotlinx.coroutines.*
+import io.ktor.util.*
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.*
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
 import java.io.ByteArrayOutputStream
 import java.io.Writer
 import java.nio.charset.Charset
@@ -38,28 +36,6 @@ import java.util.*
 import kotlin.text.toCharArray
 
 data class HttpStubResponse(val response: HttpResponse, val delayInSeconds: Int? = null, val contractPath: String = "")
-
-class SSEBuffer(private val buffer: MutableList<SseEvent> = mutableListOf()) {
-    fun add(event: SseEvent) {
-        val bufferIndex = event.bufferIndex ?: return
-
-        if(bufferIndex == -1) {
-            buffer.add(event)
-        } else if(bufferIndex >= 0) {
-            buffer[bufferIndex] = event
-        }
-    }
-
-    fun replace(event: SseEvent, index: Int) {
-        buffer[index] = event
-    }
-
-    fun write(writer: Writer) {
-        for(event in buffer) {
-            writeEvent(event, writer)
-        }
-    }
-}
 
 class HttpStub(
     private val features: List<Feature>,
@@ -90,6 +66,8 @@ class HttpStub(
     ) : this(parseGherkinStringToFeature(gherkinData), scenarioStubs, host, port, log)
 
     private val threadSafeHttpStubs = ThreadSafeListOfStubs(_httpStubs.toMutableList())
+    private val threadSafeHttpStubQueue = ThreadSafeListOfStubs(_httpStubs.toMutableList())
+
     val endPoint = endPointFromHostAndPort(host, port, keyData)
 
     override val client = HttpClient(this.endPoint)
@@ -134,6 +112,7 @@ class HttpStub(
                         isExpectationCreation(httpRequest) -> handleExpectationCreationRequest(httpRequest)
                         isSseExpectationCreation(httpRequest) -> handleSseExpectationCreationRequest(httpRequest)
                         isStateSetupRequest(httpRequest) -> handleStateSetupRequest(httpRequest)
+                        isFlushEphemeralStubsRequest(httpRequest) -> handleFlushEphemeralStubsRequest(httpRequest)
                         else -> serveStubResponse(httpRequest)
                     }
 
@@ -198,6 +177,18 @@ class HttpStub(
                 this.port = port
             }
         }
+    }
+
+    private fun handleFlushEphemeralStubsRequest(httpRequest: HttpRequest): HttpStubResponse {
+        val token = httpRequest.path?.removePrefix("/_specmatic/admin/$STUB_TOKEN/")
+
+        threadSafeHttpStubQueue.removeWithToken(token)
+
+        return HttpStubResponse(HttpResponse.OK)
+    }
+
+    private fun isFlushEphemeralStubsRequest(httpRequest: HttpRequest): Boolean {
+        return httpRequest.method?.toLowerCasePreservingASCIIRules() == "delete" && httpRequest.path?.startsWith("/_specmatic/admin/$STUB_TOKEN") == true
     }
 
     private fun close(
@@ -268,6 +259,7 @@ class HttpStub(
             httpRequest,
             features,
             threadSafeHttpStubs,
+            threadSafeHttpStubQueue,
             strictMode,
             passThroughTargetBase,
             httpClientFactory
@@ -383,7 +375,13 @@ class HttpStub(
                 val failureResults = Results(failures).withoutFluff()
                 throw NoMatchingScenario(failureResults, cachedMessage = failureResults.report(stub.request))
             }
-            else -> threadSafeHttpStubs.addToStub(firstResult, stub)
+            else -> {
+                if(stub.stubToken != null) {
+                    threadSafeHttpStubQueue.addToStub(firstResult, stub)
+                } else {
+                    threadSafeHttpStubs.addToStub(firstResult, stub)
+                }
+            }
         }
 
         return firstResult.second
@@ -528,12 +526,13 @@ fun getHttpResponse(
     httpRequest: HttpRequest,
     features: List<Feature>,
     threadSafeStubs: ThreadSafeListOfStubs,
+    threadSafeStubQueue: ThreadSafeListOfStubs,
     strictMode: Boolean,
     passThroughTargetBase: String = "",
     httpClientFactory: HttpClientFactory? = null
 ): HttpStubResponse {
     return try {
-        val (matchResults, stubResponse) = stubbedResponse(threadSafeStubs, httpRequest)
+        val (matchResults, stubResponse) = stubbedResponse(threadSafeStubs, threadSafeStubQueue, httpRequest)
 
         stubResponse
             ?: if (httpClientFactory != null && passThroughTargetBase.isNotBlank()) {
@@ -578,9 +577,26 @@ object StubAndRequestMismatchMessages : MismatchMessages {
 
 private fun stubbedResponse(
     threadSafeStubs: ThreadSafeListOfStubs,
+    threadSafeStubQueue: ThreadSafeListOfStubs,
     httpRequest: HttpRequest
 ): Pair<List<Pair<Result, HttpStubData>>, HttpStubResponse?> {
-    val matchResults = threadSafeStubs.matchResults { stubs ->
+
+    val (mock, matchResults) = stubThatMatchesRequest(threadSafeStubQueue, threadSafeStubs, httpRequest)
+
+    val stubResponse = mock?.let {
+        val softCastResponse = it.softCastResponseToXML(httpRequest).response
+        HttpStubResponse(softCastResponse, it.delayInSeconds, it.contractPath)
+    }
+
+    return Pair(matchResults, stubResponse)
+}
+
+private fun stubThatMatchesRequest(
+    threadSafeStubQueue: ThreadSafeListOfStubs,
+    threadSafeStubs: ThreadSafeListOfStubs,
+    httpRequest: HttpRequest
+): Pair<HttpStubData?, List<Pair<Result, HttpStubData>>> {
+    val queueMatchResults: List<Pair<Result, HttpStubData>> = threadSafeStubQueue.matchResults { stubs ->
         stubs.map {
             val (requestPattern, _, resolver) = it
             Pair(
@@ -592,14 +608,27 @@ private fun stubbedResponse(
         }
     }
 
-    val mock = matchResults.find { (result, _) -> result is Result.Success }?.second
-
-    val stubResponse = mock?.let {
-        val softCastResponse = it.softCastResponseToXML(httpRequest).response
-        HttpStubResponse(softCastResponse, it.delayInSeconds, it.contractPath)
+    val queueMock = queueMatchResults.findLast { (result, _) -> result is Result.Success }
+    if(queueMock != null) {
+        threadSafeStubQueue.remove(queueMock.second)
+        return Pair(queueMock.second, queueMatchResults)
     }
 
-    return Pair(matchResults, stubResponse)
+    val listMatchResults: List<Pair<Result, HttpStubData>> = threadSafeStubs.matchResults { stubs ->
+        stubs.map {
+            val (requestPattern, _, resolver) = it
+            Pair(
+                requestPattern.matches(
+                    httpRequest,
+                    resolver.disableOverrideUnexpectedKeycheck().copy(mismatchMessages = StubAndRequestMismatchMessages)
+                ), it
+            )
+        }
+    }
+
+    val mock = listMatchResults.find { (result, _) -> result is Result.Success }
+
+    return Pair(mock?.second, listMatchResults)
 }
 
 object ContractAndRequestsMismatch : MismatchMessages {
@@ -794,7 +823,7 @@ suspend fun ApplicationCall.respondSse(events: ReceiveChannel<SseEvent>, sseBuff
     }
 }
 
-private fun writeEvent(event: SseEvent, writer: Writer) {
+fun writeEvent(event: SseEvent, writer: Writer) {
     if (event.id != null) {
         writer.write("id: ${event.id}\n")
     }

--- a/core/src/main/kotlin/in/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/in/specmatic/stub/HttpStub.kt
@@ -112,7 +112,7 @@ class HttpStub(
                         isExpectationCreation(httpRequest) -> handleExpectationCreationRequest(httpRequest)
                         isSseExpectationCreation(httpRequest) -> handleSseExpectationCreationRequest(httpRequest)
                         isStateSetupRequest(httpRequest) -> handleStateSetupRequest(httpRequest)
-                        isFlushEphemeralStubsRequest(httpRequest) -> handleFlushEphemeralStubsRequest(httpRequest)
+                        isFlushTransientStubsRequest(httpRequest) -> handleFlushTransientStubsRequest(httpRequest)
                         else -> serveStubResponse(httpRequest)
                     }
 
@@ -179,7 +179,7 @@ class HttpStub(
         }
     }
 
-    private fun handleFlushEphemeralStubsRequest(httpRequest: HttpRequest): HttpStubResponse {
+    private fun handleFlushTransientStubsRequest(httpRequest: HttpRequest): HttpStubResponse {
         val token = httpRequest.path?.removePrefix("/_specmatic/admin/$STUB_TOKEN/")
 
         threadSafeHttpStubQueue.removeWithToken(token)
@@ -187,7 +187,7 @@ class HttpStub(
         return HttpStubResponse(HttpResponse.OK)
     }
 
-    private fun isFlushEphemeralStubsRequest(httpRequest: HttpRequest): Boolean {
+    private fun isFlushTransientStubsRequest(httpRequest: HttpRequest): Boolean {
         return httpRequest.method?.toLowerCasePreservingASCIIRules() == "delete" && httpRequest.path?.startsWith("/_specmatic/admin/$STUB_TOKEN") == true
     }
 

--- a/core/src/main/kotlin/in/specmatic/stub/SSEBuffer.kt
+++ b/core/src/main/kotlin/in/specmatic/stub/SSEBuffer.kt
@@ -1,0 +1,25 @@
+package `in`.specmatic.stub
+
+import java.io.Writer
+
+class SSEBuffer(private val buffer: MutableList<SseEvent> = mutableListOf()) {
+    fun add(event: SseEvent) {
+        val bufferIndex = event.bufferIndex ?: return
+
+        if(bufferIndex == -1) {
+            buffer.add(event)
+        } else if(bufferIndex >= 0) {
+            buffer[bufferIndex] = event
+        }
+    }
+
+    fun replace(event: SseEvent, index: Int) {
+        buffer[index] = event
+    }
+
+    fun write(writer: Writer) {
+        for(event in buffer) {
+            writeEvent(event, writer)
+        }
+    }
+}

--- a/core/src/main/kotlin/in/specmatic/stub/StubData.kt
+++ b/core/src/main/kotlin/in/specmatic/stub/StubData.kt
@@ -15,7 +15,8 @@ data class HttpStubData(
     val resolver: Resolver,
     val delayInSeconds: Int? = null,
     val responsePattern: HttpResponsePattern,
-    val contractPath: String = ""
+    val contractPath: String = "",
+    val stubToken: String? = null
 ) : StubData {
     fun softCastResponseToXML(httpRequest: HttpRequest): HttpStubData = when {
         response.externalisedResponseCommand.isNotEmpty() -> invokeExternalCommand(httpRequest).copy(contractPath = contractPath)

--- a/core/src/main/kotlin/in/specmatic/stub/ThreadSafeListOfStubs.kt
+++ b/core/src/main/kotlin/in/specmatic/stub/ThreadSafeListOfStubs.kt
@@ -14,7 +14,23 @@ class ThreadSafeListOfStubs(private val httpStubs: MutableList<HttpStubData>) {
         synchronized(this) {
             result.second.let {
                 if(it != null)
-                    httpStubs.add(0, it.copy(delayInSeconds = stub.delayInSeconds))
+                    httpStubs.add(0, it.copy(delayInSeconds = stub.delayInSeconds, stubToken = stub.stubToken))
+            }
+        }
+    }
+
+    fun remove(element: HttpStubData) {
+        synchronized(this) {
+            httpStubs.remove(element)
+        }
+    }
+
+    fun removeWithToken(token: String?) {
+        synchronized(this) {
+            httpStubs.mapIndexed { index, httpStubData ->
+                if (httpStubData.stubToken == token) index else null
+            }.filterNotNull().reversed().map { index ->
+                httpStubs.removeAt(index)
             }
         }
     }

--- a/core/src/test/kotlin/in/specmatic/TestUtilities.kt
+++ b/core/src/test/kotlin/in/specmatic/TestUtilities.kt
@@ -95,6 +95,7 @@ fun stubResponse(httpRequest: HttpRequest, features: List<Feature>, threadSafeSt
         httpRequest,
         features,
         ThreadSafeListOfStubs(threadSafeStubs.toMutableList()),
+        ThreadSafeListOfStubs(mutableListOf()),
         strictMode
     )
 }

--- a/core/src/test/kotlin/in/specmatic/stub/HttpStubKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/stub/HttpStubKtTest.kt
@@ -47,7 +47,7 @@ paths:
         """.trimIndent(), "").toFeature()
 
         HttpStub(contract).use { stub ->
-            stub.createStub("""
+            stub.setExpectation("""
                 {
                     "http-request": {
                         "method": "GET",
@@ -90,7 +90,7 @@ paths:
         """.trimIndent(), "").toFeature()
 
         HttpStub(contract).use { stub ->
-            stub.createStub("""
+            stub.setExpectation("""
                 {
                     "http-request": {
                         "method": "GET",
@@ -144,7 +144,7 @@ paths:
         """.trimIndent(), "").toFeature()
 
         HttpStub(contract).use { stub ->
-            stub.createStub("""
+            stub.setExpectation("""
                 {
                     "http-request": {
                         "method": "POST",
@@ -161,7 +161,7 @@ paths:
                 }
             """.trimIndent())
 
-            stub.createStub("""
+            stub.setExpectation("""
                 {
                     "http-request": {
                         "method": "POST",
@@ -219,7 +219,7 @@ paths:
         """.trimIndent(), "").toFeature()
 
         HttpStub(contract).use { stub ->
-            stub.createStub("""
+            stub.setExpectation("""
                 {
                     "http-request": {
                         "method": "POST",
@@ -236,7 +236,7 @@ paths:
                 }
             """.trimIndent())
 
-            stub.createStub("""
+            stub.setExpectation("""
                 {
                     "http-request": {
                         "method": "POST",

--- a/core/src/test/kotlin/in/specmatic/stub/HttpStubKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/stub/HttpStubKtTest.kt
@@ -26,7 +26,7 @@ import java.util.function.Consumer
 
 internal class HttpStubKtTest {
     @Test
-    fun `flush ephemeral stub`() {
+    fun `flush transient stub`() {
         val contract = OpenApiSpecification.fromYAML("""
 openapi: 3.0.0
 info:
@@ -69,7 +69,7 @@ paths:
     }
 
     @Test
-    fun `ephemeral stub`() {
+    fun `transient stub`() {
         val contract = OpenApiSpecification.fromYAML("""
 openapi: 3.0.0
 info:
@@ -113,7 +113,7 @@ paths:
     }
 
     @Test
-    fun `ephemeral stub matches in reverse order`() {
+    fun `transient stub matches in reverse order`() {
         val contract = OpenApiSpecification.fromYAML("""
 openapi: 3.0.0
 info:
@@ -188,7 +188,7 @@ paths:
     }
 
     @Test
-    fun `ephemeral match precedes non-ephemeral stub match`() {
+    fun `transient match precedes non-transient stub match`() {
         val contract = OpenApiSpecification.fromYAML("""
 openapi: 3.0.0
 info:
@@ -230,7 +230,7 @@ paths:
                     },
                     "http-response": {
                         "status": 200,
-                        "body": "ephemeral"
+                        "body": "transient"
                     },
                     "http-stub-token": "123"
                 }
@@ -247,20 +247,20 @@ paths:
                     },
                     "http-response": {
                         "status": 200,
-                        "body": "non-ephemeral"
+                        "body": "non-transient"
                     }
                 }
             """.trimIndent())
 
             val request = HttpRequest("POST", "/data", body = parsedJSON("""{"item": "123"}"""))
             val firstResponse = stub.client.execute(request)
-            assertThat(firstResponse.body.toStringLiteral()).isEqualTo("ephemeral")
+            assertThat(firstResponse.body.toStringLiteral()).isEqualTo("transient")
 
             val secondResponse = stub.client.execute(request)
-            assertThat(secondResponse.body.toStringLiteral()).isEqualTo("non-ephemeral")
+            assertThat(secondResponse.body.toStringLiteral()).isEqualTo("non-transient")
 
             val thirdResponse = stub.client.execute(request)
-            assertThat(thirdResponse.body.toStringLiteral()).isEqualTo("non-ephemeral")
+            assertThat(thirdResponse.body.toStringLiteral()).isEqualTo("non-transient")
         }
     }
 


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Added ephemeral stubs. If a token by the name of http-stub-token is provided, Specmatic takes this to be an ephemeral stub and stores it in a queue. This queue is looked up first when matching an incoming request. A match is removed from this queue before being returned.

A flush API has been added to clear out ephemeral stubs.

**Why**:

This is needed for stubbing out APIs where a sequence of calls to a single API is needed and the requests cannot be distinguished one from another.

**How**:

See the What section.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #123

<!-- feel free to add additional comments -->
