### PR TITLE
Polymorphic stackoverflow prevention

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -525,6 +525,9 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
         val preExistingResult = patterns.get("($patternName)")
         val pattern = if (preExistingResult != null && !patternName.isNullOrBlank())
             preExistingResult
+        else if (typeStack.filter { it == patternName }.size > 1) {
+            DeferredPattern("($patternName)")
+        }
         else when (schema) {
             is StringSchema -> when (schema.enum) {
                 null -> StringPattern(minLength = schema.minLength, maxLength = schema.maxLength)
@@ -575,7 +578,7 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
                         val (componentName, schemaToProcess) =
                             if (componentSchema.`$ref` != null) resolveReferenceToSchema(componentSchema.`$ref`)
                             else patternName to componentSchema
-                        toSpecmaticPattern(schemaToProcess, typeStack.plus(patternName), componentName)
+                        toSpecmaticPattern(schemaToProcess, typeStack.plus(componentName), componentName)
                     }
 
                     val nullable = if(schema.oneOf.any { nullableEmptyObject(it) }) listOf(NullPattern) else emptyList()

--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -522,7 +522,10 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
     fun toSpecmaticPattern(
         schema: Schema<*>, typeStack: List<String>, patternName: String = "", jsonInFormData: Boolean = false
     ): Pattern {
-        val pattern = when (schema) {
+        val preExistingResult = patterns.get("($patternName)")
+        val pattern = if (preExistingResult != null && !patternName.isNullOrBlank())
+            preExistingResult
+        else when (schema) {
             is StringSchema -> when (schema.enum) {
                 null -> StringPattern(minLength = schema.minLength, maxLength = schema.maxLength)
                 else -> toEnum(schema, patternName) { enumValue -> StringValue(enumValue.toString()) }
@@ -566,19 +569,18 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
                         toSchemaProperties(schemaToProcess, requiredFields, patternName, typeStack)
                     }.fold(emptyMap<String, Pattern>()) { acc, entry -> acc.plus(entry) }
                     val jsonObjectPattern = toJSONObjectPattern(schemaProperties, "(${patternName})")
-                    patterns["(${patternName})"] = jsonObjectPattern
-                    jsonObjectPattern
+                    cacheComponentPattern(patternName, jsonObjectPattern)
                 } else if (schema.oneOf != null) {
-                    val nonNullableSchemaPatterns = schema.oneOf
-                        .filter { it.nullable != true }
-                        .map { toSpecmaticPattern(it, typeStack, patternName) }
-
-                    if (nonNullableSchemaPatterns.isEmpty())
-                        throw UnsupportedOperationException("Specmatic supports oneOf for at least one non-nullable ref")
+                    val candidatePatterns = schema.oneOf.map { componentSchema ->
+                        val (componentName, schemaToProcess) =
+                            if (componentSchema.`$ref` != null) resolveReferenceToSchema(componentSchema.`$ref`)
+                            else patternName to componentSchema
+                        toSpecmaticPattern(schemaToProcess, typeStack.plus(patternName), componentName)
+                    }
 
                     val nullable = if(nullableOneOf(schema)) listOf(NullPattern) else emptyList()
 
-                    AnyPattern(nonNullableSchemaPatterns.plus(nullable))
+                    AnyPattern(candidatePatterns.plus(nullable))
                 } else if (schema.anyOf != null) {
                     throw UnsupportedOperationException("Specmatic does not support anyOf")
                 } else {
@@ -597,16 +599,13 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
                             val component: String = schema.`$ref`
 
                             val (componentName, referredSchema) = resolveReferenceToSchema(component)
-                            val cyclicReference =
-                                typeStack.contains(
-                                    componentName
-                                ) && referredSchema.instanceOf(ObjectSchema::class)
-                            val typeName = "(${componentNameFromReference(component)})"
+                            val cyclicReference = typeStack.contains(componentName)
                             if (!cyclicReference) {
-                                val componentType = resolveReference(component, typeStack)
-                                patterns[typeName] = componentType
+                                val componentPattern = toSpecmaticPattern(referredSchema,
+                                    typeStack.plus(componentName), componentName)
+                                cacheComponentPattern(componentName, componentPattern)
                             }
-                            DeferredPattern(typeName)
+                            DeferredPattern("(${componentName})")
                         }
                     }
                 }
@@ -629,6 +628,20 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
                 else -> AnyPattern(listOf(NullPattern, pattern))
             }
         }
+    }
+
+    private fun <T : Pattern> cacheComponentPattern(componentName: String, pattern: T): T {
+        if (!componentName.isNullOrBlank() && pattern !is DeferredPattern) {
+            val typeName = "(${componentName})"
+            val prev = patterns.get(typeName)
+            if (pattern != prev) {
+                if (prev != null) {
+                    logger.debug("Replacing cached component pattern. name=$componentName, prev=$prev, new=$pattern")
+                }
+                patterns[typeName] = pattern
+            }
+        }
+        return pattern
     }
 
     private fun nullableOneOf(schema: ComposedSchema): Boolean {
@@ -744,8 +757,10 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
 
                     val nodeName = componentSchema.xml?.name ?: name ?: componentName
 
-                    if (typeName !in typeStack) this.patterns[typeName] =
-                        toXMLPattern(componentSchema, componentName, typeStack.plus(typeName))
+                    if (typeName !in typeStack) {
+                        val componentPattern = toXMLPattern(componentSchema, componentName, typeStack.plus(typeName))
+                        cacheComponentPattern(componentName, componentPattern)
+                    }
 
                     val xmlRefType = XMLTypeData(
                         nodeName, nodeName, mapOf(
@@ -788,36 +803,17 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
         val requiredFields = schema.required.orEmpty()
         val schemaProperties = toSchemaProperties(schema, requiredFields, patternName, typeStack)
         val jsonObjectPattern = toJSONObjectPattern(schemaProperties, "(${patternName})")
-        patterns["(${patternName})"] = jsonObjectPattern
-        return jsonObjectPattern
+        return cacheComponentPattern(patternName, jsonObjectPattern)
     }
 
     private fun toSchemaProperties(
         schema: Schema<*>, requiredFields: List<String>, patternName: String, typeStack: List<String>
     ) = schema.properties.orEmpty().map { (propertyName, propertyType) ->
-        val optional = !requiredFields.contains(propertyName)
-        if (patternName.isNotEmpty()) {
-            if (typeStack.contains(patternName) && (propertyType.`$ref`.orEmpty()
-                    .endsWith(patternName) || (propertyType is ArraySchema && propertyType.items?.`$ref`?.endsWith(
-                    patternName
-                ) == true))
-            ) toSpecmaticParamName(
-                optional, propertyName
-            ) to DeferredPattern("(${patternName})")
-            else if (schema.discriminator?.propertyName == propertyName){
-                // Ensure discriminator property exactly matches component and not just any string
-                propertyName to ExactValuePattern(StringValue(patternName))
-            }
-            else {
-                val specmaticPattern = toSpecmaticPattern(
-                    propertyType, typeStack.plus(patternName), patternName
-                )
-                toSpecmaticParamName(optional, propertyName) to specmaticPattern
-            }
-        } else {
-            toSpecmaticParamName(optional, propertyName) to toSpecmaticPattern(
-                propertyType, typeStack
-            )
+        if (schema.discriminator?.propertyName == propertyName)
+            propertyName to ExactValuePattern(StringValue(patternName))
+        else {
+            val optional = !requiredFields.contains(propertyName)
+            toSpecmaticParamName(optional, propertyName) to toSpecmaticPattern(propertyType, typeStack)
         }
     }.toMap()
 
@@ -827,16 +823,13 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
                 null -> NullPattern
                 else -> ExactValuePattern(toSpecmaticValue(enumValue))
             }
-        }.toList(), typeAlias = patternName).also { if (patternName.isNotEmpty()) patterns["(${patternName})"] = it }
+        }.toList(), typeAlias = patternName).also {
+            cacheComponentPattern(patternName, it)
+        }
 
     private fun toSpecmaticParamName(optional: Boolean, name: String) = when (optional) {
         true -> "${name}?"
         false -> name
-    }
-
-    private fun resolveReference(component: String, typeStack: List<String>): Pattern {
-        val (componentName, referredSchema) = resolveReferenceToSchema(component)
-        return toSpecmaticPattern(referredSchema, typeStack, patternName = componentName)
     }
 
     private fun resolveReferenceToSchema(component: String): Pair<String, Schema<Any>> {

--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -601,15 +601,12 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
                                 typeStack.contains(
                                     componentName
                                 ) && referredSchema.instanceOf(ObjectSchema::class)
-                            when {
-                                cyclicReference -> DeferredPattern("(${patternName})")
-                                else -> {
-                                    val componentType = resolveReference(component, typeStack)
-                                    val typeName = "(${componentNameFromReference(component)})"
-                                    patterns[typeName] = componentType
-                                    DeferredPattern(typeName)
-                                }
+                            val typeName = "(${componentNameFromReference(component)})"
+                            if (!cyclicReference) {
+                                val componentType = resolveReference(component, typeStack)
+                                patterns[typeName] = componentType
                             }
+                            DeferredPattern(typeName)
                         }
                     }
                 }

--- a/core/src/main/kotlin/in/specmatic/core/HttpHeadersPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpHeadersPattern.kt
@@ -124,7 +124,7 @@ data class HttpHeadersPattern(
         return attempt(breadCrumb = "HEADERS") {
             pattern.mapValues { (key, pattern) ->
                 attempt(breadCrumb = key) {
-                    resolver.generate(key, pattern).toStringLiteral()
+                    resolver.withCyclePrevention(pattern) { it. generate(key, pattern)}.toStringLiteral()
                 }
             }
         }.map { (key, value) -> withoutOptionality(key) to value }.toMap()

--- a/core/src/main/kotlin/in/specmatic/core/HttpResponsePattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpResponsePattern.kt
@@ -53,7 +53,9 @@ data class HttpResponsePattern(val headersPattern: HttpHeadersPattern = HttpHead
 
     fun newBasedOn(row: Row, resolver: Resolver): List<HttpResponsePattern> =
         attempt(breadCrumb = "RESPONSE") {
-            body.newBasedOn(row, resolver).flatMap { newBody ->
+            resolver.withCyclePrevention(body) { cyclePreventedResolver ->
+                body.newBasedOn(row, cyclePreventedResolver)
+            }.flatMap { newBody ->
                 headersPattern.newBasedOn(row, resolver).map { newHeadersPattern ->
                     HttpResponsePattern(newHeadersPattern, status, newBody)
                 }

--- a/core/src/main/kotlin/in/specmatic/core/HttpResponsePattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpResponsePattern.kt
@@ -12,7 +12,7 @@ data class HttpResponsePattern(val headersPattern: HttpHeadersPattern = HttpHead
 
     fun generateResponse(resolver: Resolver): HttpResponse {
         return attempt(breadCrumb = "RESPONSE") {
-            val value = softCastValueToXML(body.generate(resolver))
+            val value = softCastValueToXML(resolver.withCyclePrevention(body, body::generate))
             val headers = headersPattern.generate(resolver).plus(SPECMATIC_RESULT_HEADER to "success").let { headers ->
                 when {
                     !headers.containsKey("Content-Type") -> headers.plus("Content-Type" to value.httpContentType)

--- a/core/src/main/kotlin/in/specmatic/core/MultiPartFormDataPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/MultiPartFormDataPattern.kt
@@ -31,7 +31,7 @@ data class MultiPartContentPattern(override val name: String, val content: Patte
             }
 
     override fun generate(resolver: Resolver): MultiPartFormDataValue =
-            MultiPartContentValue(name, content.generate(resolver), specifiedContentType = contentType)
+            MultiPartContentValue(name, resolver.withCyclePrevention(content, content::generate), specifiedContentType = contentType)
 
     override fun matches(value: MultiPartFormDataValue, resolver: Resolver): Result {
         if(withoutOptionality(name) != value.name)
@@ -80,7 +80,7 @@ data class MultiPartFilePattern(override val name: String, val filename: Pattern
     }
 
     override fun generate(resolver: Resolver): MultiPartFormDataValue =
-            MultiPartFileValue(name, filename.generate(resolver).toStringLiteral(), contentType ?: "", contentEncoding)
+            MultiPartFileValue(name, resolver.withCyclePrevention(filename, filename::generate).toStringLiteral(), contentType ?: "", contentEncoding)
 
     override fun matches(value: MultiPartFormDataValue, resolver: Resolver): Result {
         return when {

--- a/core/src/main/kotlin/in/specmatic/core/Resolver.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Resolver.kt
@@ -79,11 +79,11 @@ data class Resolver(
      * returnNullOnCycle=true in which case null is returned. Null is never returned if returnNullOnCycle=false.
      */
     fun <T> withCyclePrevention(pattern: Pattern, returnNullOnCycle: Boolean = false, toResult: (r: Resolver) -> T) : T? {
-        val index = cyclePreventionStack.indexOf(pattern)
+        val count = cyclePreventionStack.filter { it == pattern }.size
         val newCyclePreventionStack = cyclePreventionStack.plus(pattern)
 
         try {
-            if (index >= 0)
+            if (count > 1)
                 // Terminate what would otherwise be an infinite cycle.
                 throw ContractException("Invalid pattern cycle: ${newCyclePreventionStack}", isCycle = true)
 

--- a/core/src/main/kotlin/in/specmatic/core/Resolver.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Resolver.kt
@@ -13,7 +13,8 @@ data class Resolver(
     val context: Map<String, String> = emptyMap(),
     val mismatchMessages: MismatchMessages = DefaultMismatchMessages,
     val isNegative: Boolean = false,
-    val generativeTestingEnabled: Boolean = false
+    val generativeTestingEnabled: Boolean = false,
+    val cyclePreventionStack: List<Pattern> = listOf(),
 ) {
     constructor(facts: Map<String, Value> = emptyMap(), mockMode: Boolean = false, newPatterns: Map<String, Pattern> = emptyMap()) : this(CheckFacts(facts), mockMode, newPatterns)
     constructor() : this(emptyMap(), false)
@@ -68,6 +69,33 @@ data class Resolver(
             }
             else -> throw ContractException("$patternValue is not a type")
         }
+
+    fun <T> withCyclePrevention(pattern: Pattern, toResult: (r: Resolver) -> T) : T {
+        return withCyclePrevention(pattern, false, toResult)!!
+    }
+
+    /**
+     * Returns non-null if no cycle. If there is a cycle then ContractException(cycle=true) is thrown - unless
+     * returnNullOnCycle=true in which case null is returned. Null is never returned if returnNullOnCycle=false.
+     */
+    fun <T> withCyclePrevention(pattern: Pattern, returnNullOnCycle: Boolean = false, toResult: (r: Resolver) -> T) : T? {
+        val index = cyclePreventionStack.indexOf(pattern)
+        val newCyclePreventionStack = cyclePreventionStack.plus(pattern)
+
+        try {
+            if (index >= 0)
+                // Terminate what would otherwise be an infinite cycle.
+                throw ContractException("Invalid pattern cycle: ${newCyclePreventionStack}", isCycle = true)
+
+            return toResult(copy(cyclePreventionStack = newCyclePreventionStack))
+        } catch (e: ContractException) {
+            if (!e.isCycle || !returnNullOnCycle)
+                throw e
+
+            // Returns null if (and only if) a cycle has been detected and returnNullOnCycle=true
+            return null
+        }
+    }
 
     fun generate(factKey: String, pattern: Pattern): Value {
         if (!factStore.has(factKey))

--- a/core/src/main/kotlin/in/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Scenario.kt
@@ -550,7 +550,10 @@ fun newExpectedServerStateBasedOn(
 
                     when {
                         fixtures.containsKey(fieldValue) -> fixtures.getValue(fieldValue)
-                        isPatternToken(fieldValue) -> resolver.getPattern(fieldValue).generate(resolver)
+                        isPatternToken(fieldValue) -> {
+                            val fieldPattern = resolver.getPattern(fieldValue)
+                            resolver.withCyclePrevention(fieldPattern, fieldPattern::generate)
+                        }
                         else -> StringValue(fieldValue)
                     }
                 }

--- a/core/src/main/kotlin/in/specmatic/core/URLPathPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/URLPathPattern.kt
@@ -10,8 +10,13 @@ data class URLPathPattern(override val pattern: Pattern, override val key: Strin
     override fun matches(sampleData: Value?, resolver: Resolver): Result =
             resolver.matchesPattern(key, pattern, sampleData ?: NullValue)
 
-    override fun generate(resolver: Resolver): Value =
-            if(key != null) resolver.generate(key, pattern) else pattern.generate(resolver)
+    override fun generate(resolver: Resolver): Value {
+        return resolver.withCyclePrevention(pattern) { cyclePreventedResolver ->
+            if (key != null)
+                cyclePreventedResolver.generate(key, pattern)
+            else pattern.generate(cyclePreventedResolver)
+        }
+    }
 
     override fun newBasedOn(row: Row, resolver: Resolver): List<URLPathPattern> =
             pattern.newBasedOn(row, resolver).map { URLPathPattern(it, key) }

--- a/core/src/main/kotlin/in/specmatic/core/URLPathPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/URLPathPattern.kt
@@ -19,10 +19,14 @@ data class URLPathPattern(override val pattern: Pattern, override val key: Strin
     }
 
     override fun newBasedOn(row: Row, resolver: Resolver): List<URLPathPattern> =
-            pattern.newBasedOn(row, resolver).map { URLPathPattern(it, key) }
+        resolver.withCyclePrevention(pattern) { cyclePreventedResolver ->
+            pattern.newBasedOn(row, cyclePreventedResolver).map { URLPathPattern(it, key) }
+        }
 
     override fun newBasedOn(resolver: Resolver): List<URLPathPattern> =
-            pattern.newBasedOn(resolver).map { URLPathPattern(it, key) }
+        resolver.withCyclePrevention(pattern) { cyclePreventedResolver ->
+            pattern.newBasedOn(cyclePreventedResolver).map { URLPathPattern(it, key) }
+        }
 
     override fun negativeBasedOn(row: Row, resolver: Resolver): List<Pattern> {
         return newBasedOn(row, resolver)

--- a/core/src/main/kotlin/in/specmatic/core/pattern/ContractException.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/ContractException.kt
@@ -5,7 +5,6 @@ import `in`.specmatic.core.Result
 import `in`.specmatic.core.Scenario
 import `in`.specmatic.core.ScenarioDetailsForResult
 
-<<<<<<< HEAD
 fun isCycle(throwable: Throwable?): Boolean = when(throwable) {
     is ContractException -> throwable.isCycle
     else -> false

--- a/core/src/main/kotlin/in/specmatic/core/pattern/ContractException.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/ContractException.kt
@@ -5,12 +5,17 @@ import `in`.specmatic.core.Result
 import `in`.specmatic.core.Scenario
 import `in`.specmatic.core.ScenarioDetailsForResult
 
+fun isCycle(throwable: Throwable?): Boolean = when(throwable) {
+    is ContractException -> throwable.isCycle
+    else -> false
+}
+
 data class ContractException(
     val errorMessage: String = "",
     val breadCrumb: String = "",
     val exceptionCause: ContractException? = null,
     val scenario: ScenarioDetailsForResult? = null,
-    val isCycle: Boolean = exceptionCause?.isCycle?: false,
+    val isCycle: Boolean = isCycle(exceptionCause)
 ) : Exception(errorMessage) {
     constructor(failureReport: FailureReport): this(failureReport.toText())
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/ContractException.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/ContractException.kt
@@ -5,7 +5,13 @@ import `in`.specmatic.core.Result
 import `in`.specmatic.core.Scenario
 import `in`.specmatic.core.ScenarioDetailsForResult
 
-data class ContractException(val errorMessage: String = "", val breadCrumb: String = "", val exceptionCause: ContractException? = null, val scenario: ScenarioDetailsForResult? = null) : Exception(errorMessage) {
+data class ContractException(
+    val errorMessage: String = "",
+    val breadCrumb: String = "",
+    val exceptionCause: ContractException? = null,
+    val scenario: ScenarioDetailsForResult? = null,
+    val isCycle: Boolean = exceptionCause?.isCycle?: false,
+) : Exception(errorMessage) {
     constructor(failureReport: FailureReport): this(failureReport.toText())
 
     fun failure(): Result.Failure =

--- a/core/src/main/kotlin/in/specmatic/core/pattern/CsvPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/CsvPattern.kt
@@ -28,7 +28,7 @@ class CsvPattern(override val pattern: Pattern) : Pattern {
         val max = (2..5).random()
 
         return StringValue((1..max).map {
-            pattern.generate(resolver)
+            resolver.withCyclePrevention(pattern, pattern::generate)
         }.joinToString(",") { it.toStringLiteral() })
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/DeferredPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/DeferredPattern.kt
@@ -26,11 +26,17 @@ data class DeferredPattern(override val pattern: String, val key: String? = null
     }
 
     override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> {
-        return resolver.getPattern(pattern).newBasedOn(row, resolver)
+        val resolvedPattern = resolvePattern(resolver)
+        return resolver.withCyclePrevention(resolvedPattern) { cyclePreventedResolver ->
+            resolvedPattern.newBasedOn(row, cyclePreventedResolver)
+        }
     }
 
     override fun newBasedOn(resolver: Resolver): List<Pattern> {
-        return resolver.getPattern(pattern).newBasedOn(resolver)
+        val resolvedPattern = resolvePattern(resolver)
+        return resolver.withCyclePrevention(resolvedPattern) { cyclePreventedResolver ->
+            resolvedPattern.newBasedOn(cyclePreventedResolver)
+        }
     }
 
     override fun negativeBasedOn(row: Row, resolver: Resolver): List<Pattern> {

--- a/core/src/main/kotlin/in/specmatic/core/pattern/DictionaryPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/DictionaryPattern.kt
@@ -44,8 +44,8 @@ data class DictionaryPattern(val keyPattern: Pattern, val valuePattern: Pattern,
 
     override fun generate(resolver: Resolver): Value {
         return JSONObjectValue((1..randomNumber(RANDOM_NUMBER_CEILING)).fold(emptyMap()) { obj, _ ->
-            val key = keyPattern.generate(resolver).toStringLiteral()
-            val value = valuePattern.generate(resolver)
+            val key = resolver.withCyclePrevention(keyPattern, keyPattern::generate).toStringLiteral()
+            val value = resolver.withCyclePrevention(valuePattern, valuePattern::generate)
 
             obj.plus(key to value)
         })

--- a/core/src/main/kotlin/in/specmatic/core/pattern/DictionaryPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/DictionaryPattern.kt
@@ -52,7 +52,9 @@ data class DictionaryPattern(val keyPattern: Pattern, val valuePattern: Pattern,
     }
 
     override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> {
-        val newValuePatterns = valuePattern.newBasedOn(Row(), resolver)
+        val newValuePatterns = resolver.withCyclePrevention(valuePattern) { cyclePreventedResolver ->
+            valuePattern.newBasedOn(Row(), cyclePreventedResolver)
+        }
 
         return newValuePatterns.map {
             DictionaryPattern(keyPattern, it)
@@ -60,7 +62,9 @@ data class DictionaryPattern(val keyPattern: Pattern, val valuePattern: Pattern,
     }
 
     override fun newBasedOn(resolver: Resolver): List<Pattern> {
-        val newValuePatterns = valuePattern.newBasedOn(resolver)
+        val newValuePatterns = resolver.withCyclePrevention(valuePattern) { cyclePreventedResolver ->
+            valuePattern.newBasedOn(cyclePreventedResolver)
+        }
 
         return newValuePatterns.map {
             DictionaryPattern(keyPattern, it)

--- a/core/src/main/kotlin/in/specmatic/core/pattern/JSONArrayPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/JSONArrayPattern.kt
@@ -136,7 +136,9 @@ data class JSONArrayPattern(override val pattern: List<Pattern> = emptyList(), o
 fun newBasedOn(jsonPattern: List<Pattern>, row: Row, resolver: Resolver): List<List<Pattern>> {
     val values = jsonPattern.mapIndexed { index, pattern ->
         attempt(breadCrumb = "[$index]") {
-            pattern.newBasedOn(row, resolver)
+            resolver.withCyclePrevention(pattern) { cyclePreventedResolver ->
+                pattern.newBasedOn(row, cyclePreventedResolver)
+            }
         }
     }
 
@@ -146,7 +148,9 @@ fun newBasedOn(jsonPattern: List<Pattern>, row: Row, resolver: Resolver): List<L
 fun newBasedOn(jsonPattern: List<Pattern>, resolver: Resolver): List<List<Pattern>> {
     val values = jsonPattern.mapIndexed { index, pattern ->
         attempt(breadCrumb = "[$index]") {
-            pattern.newBasedOn(resolver)
+            resolver.withCyclePrevention(pattern) { cyclePreventedResolver ->
+                pattern.newBasedOn(cyclePreventedResolver)
+            }
         }
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/JSONArrayPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/JSONArrayPattern.kt
@@ -195,12 +195,15 @@ private fun keyCombinations(values: List<List<Pattern?>>,
 
 fun generate(jsonPattern: List<Pattern>, resolver: Resolver): List<Value> =
         jsonPattern.mapIndexed { index, pattern ->
-            when (pattern) {
-                is RestPattern -> attempt(breadCrumb = "[$index...${jsonPattern.lastIndex}]") {
-                    val list = pattern.generate(resolver) as ListValue
-                    list.list
+            resolver.withCyclePrevention(pattern) { cyclePreventedResolver ->
+                when (pattern) {
+                    is RestPattern -> attempt(breadCrumb = "[$index...${jsonPattern.lastIndex}]") {
+                        val list = pattern.generate(cyclePreventedResolver) as ListValue
+                        list.list
+                    }
+
+                    else -> attempt(breadCrumb = "[$index]") { listOf(pattern.generate(cyclePreventedResolver)) }
                 }
-                else -> attempt(breadCrumb = "[$index]") { listOf(pattern.generate(resolver)) }
             }
         }.flatten()
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/KafkaMessagePattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/KafkaMessagePattern.kt
@@ -64,8 +64,12 @@ data class KafkaMessagePattern(val topic: String = "", val key: Pattern = EmptyS
     }
 
     fun newBasedOn(row: Row, resolver: Resolver): List<KafkaMessagePattern> {
-        val newKeys = key.newBasedOn(row, resolver)
-        val newValues = value.newBasedOn(row, resolver)
+        val newKeys = resolver.withCyclePrevention(key) { cyclePreventedResolver ->
+            key.newBasedOn(row, cyclePreventedResolver)
+        }
+        val newValues = resolver.withCyclePrevention(key) { cyclePreventedResolver ->
+            value.newBasedOn(row, cyclePreventedResolver)
+        }
 
         return newKeys.flatMap { newKey ->
             newValues.map { newValue ->

--- a/core/src/main/kotlin/in/specmatic/core/pattern/KafkaMessagePattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/KafkaMessagePattern.kt
@@ -75,5 +75,6 @@ data class KafkaMessagePattern(val topic: String = "", val key: Pattern = EmptyS
     }
 
     fun generate(resolver: Resolver): KafkaMessage =
+            // Cycle prevention not needed because StringValue expected for both key and value
             KafkaMessage(topic, key.generate(resolver) as StringValue, value.generate(resolver) as StringValue)
 }

--- a/core/src/main/kotlin/in/specmatic/core/pattern/ListPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/ListPattern.kt
@@ -47,12 +47,20 @@ data class ListPattern(override val pattern: Pattern, override val typeAlias: St
 
     override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> {
         val resolverWithEmptyType = withEmptyType(pattern, resolver)
-        return attempt(breadCrumb = "[]") { pattern.newBasedOn(row, resolverWithEmptyType).map { ListPattern(it) } }
+        return attempt(breadCrumb = "[]") {
+            resolverWithEmptyType.withCyclePrevention(pattern) { cyclePreventedResolver ->
+                pattern.newBasedOn(row, cyclePreventedResolver).map { ListPattern(it) }
+            }
+        }
     }
 
     override fun newBasedOn(resolver: Resolver): List<Pattern> {
         val resolverWithEmptyType = withEmptyType(pattern, resolver)
-        return attempt(breadCrumb = "[]") { pattern.newBasedOn(resolverWithEmptyType).map { ListPattern(it) } }
+        return attempt(breadCrumb = "[]") {
+            resolverWithEmptyType.withCyclePrevention(pattern) { cyclePreventedResolver ->
+                pattern.newBasedOn(cyclePreventedResolver).map { ListPattern(it) }
+            }
+        }
     }
 
     override fun negativeBasedOn(row: Row, resolver: Resolver): List<Pattern> = listOf(NullPattern)

--- a/core/src/main/kotlin/in/specmatic/core/pattern/ListPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/ListPattern.kt
@@ -39,6 +39,7 @@ data class ListPattern(override val pattern: Pattern, override val typeAlias: St
 
     override fun generate(resolver: Resolver): Value {
         val resolverWithEmptyType = withEmptyType(pattern, resolver)
+        // Cycle prevention handled in listOf, so not duplicating it here.
         return pattern.listOf(0.until(randomNumber(3)).mapIndexed{ index, _ ->
             attempt(breadCrumb = "[$index (random)]") { pattern.generate(resolverWithEmptyType) }
         }, resolverWithEmptyType)
@@ -102,7 +103,7 @@ data class ListPattern(override val pattern: Pattern, override val typeAlias: St
 
     override fun listOf(valueList: List<Value>, resolver: Resolver): Value {
         val resolverWithEmptyType = withEmptyType(pattern, resolver)
-        return pattern.listOf(valueList, resolverWithEmptyType)
+        return resolverWithEmptyType.withCyclePrevention(pattern) { pattern.listOf(valueList, it) }
     }
 
     override val typeName: String = "list of ${pattern.typeName}"

--- a/core/src/main/kotlin/in/specmatic/core/pattern/LookupRowPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/LookupRowPattern.kt
@@ -12,9 +12,13 @@ data class LookupRowPattern(override val pattern: Pattern, override val key: Str
     override fun matches(sampleData: Value?, resolver: Resolver): Result =
             resolver.matchesPattern(key, pattern, sampleData ?: EmptyString)
 
-    override fun generate(resolver: Resolver): Value = when(key){
-        null -> pattern.generate(resolver)
-        else -> resolver.generate(key, pattern)
+    override fun generate(resolver: Resolver): Value {
+        return resolver.withCyclePrevention(pattern) { cyclePreventedResolver ->
+            when (key) {
+                null -> pattern.generate(cyclePreventedResolver)
+                else -> cyclePreventedResolver.generate(key, pattern)
+            }
+        }
     }
 
     override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> {

--- a/core/src/main/kotlin/in/specmatic/core/pattern/LookupRowPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/LookupRowPattern.kt
@@ -23,15 +23,21 @@ data class LookupRowPattern(override val pattern: Pattern, override val key: Str
 
     override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> {
         return when(key) {
-            null -> pattern.newBasedOn(row, resolver)
+            null -> resolver.withCyclePrevention(pattern) { cyclePreventedResolver ->
+                pattern.newBasedOn(row, cyclePreventedResolver)
+            }
+            // Cycle prevention handled in helper method
             else -> newBasedOn(row, key, pattern, resolver)
         }
     }
 
     override fun newBasedOn(resolver: Resolver): List<Pattern> {
         return when(key) {
-            null -> pattern.newBasedOn(resolver)
-            else -> newBasedOn(pattern, resolver)
+            null -> resolver.withCyclePrevention(pattern) { cyclePreventedResolver ->
+                pattern.newBasedOn(cyclePreventedResolver)
+            }
+            // Cycle prevention handled in helper method
+            else -> newBasedOn(key, pattern, resolver)
         }
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/Pattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/Pattern.kt
@@ -16,7 +16,7 @@ interface Pattern {
     }
 
     fun generate(resolver: Resolver): Value
-    fun generateWithAll(resolver: Resolver) = generate(resolver)
+    fun generateWithAll(resolver: Resolver) = resolver.withCyclePrevention(this, this::generate)
     fun newBasedOn(row: Row, resolver: Resolver): List<Pattern>
     fun negativeBasedOn(row: Row, resolver: Resolver): List<Pattern>
     fun newBasedOn(resolver: Resolver): List<Pattern>

--- a/core/src/main/kotlin/in/specmatic/core/pattern/PatternInStringPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/PatternInStringPattern.kt
@@ -25,10 +25,14 @@ data class PatternInStringPattern(override val pattern: Pattern = StringPattern(
     }
 
     override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> =
-            pattern.newBasedOn(row, resolver).map { PatternInStringPattern(it) }
+        resolver.withCyclePrevention(pattern) { cyclePreventedResolver ->
+            pattern.newBasedOn(row, cyclePreventedResolver).map { PatternInStringPattern(it) }
+        }
 
     override fun newBasedOn(resolver: Resolver): List<Pattern> =
-            pattern.newBasedOn(resolver).map { PatternInStringPattern(it) }
+        resolver.withCyclePrevention(pattern) { cyclePreventedResolver ->
+            pattern.newBasedOn(cyclePreventedResolver).map { PatternInStringPattern(it) }
+        }
 
     override fun negativeBasedOn(row: Row, resolver: Resolver): List<Pattern> {
         return listOf(NullPattern)

--- a/core/src/main/kotlin/in/specmatic/core/pattern/PatternInStringPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/PatternInStringPattern.kt
@@ -20,7 +20,9 @@ data class PatternInStringPattern(override val pattern: Pattern = StringPattern(
         return pattern.matches(value, resolver)
     }
 
-    override fun generate(resolver: Resolver): Value = StringValue(pattern.generate(resolver).toStringLiteral())
+    override fun generate(resolver: Resolver): Value {
+        return StringValue(resolver.withCyclePrevention(pattern, pattern::generate).toStringLiteral())
+    }
 
     override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> =
             pattern.newBasedOn(row, resolver).map { PatternInStringPattern(it) }

--- a/core/src/main/kotlin/in/specmatic/core/pattern/RestPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/RestPattern.kt
@@ -12,7 +12,7 @@ data class RestPattern(override val pattern: Pattern, override val typeAlias: St
     override fun matches(sampleData: Value?, resolver: Resolver): Result =
             listPattern.matches(sampleData, resolver)
 
-    override fun generate(resolver: Resolver): Value = listPattern.generate(resolver)
+    override fun generate(resolver: Resolver): Value = resolver.withCyclePrevention(listPattern, listPattern::generate)
     override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> = pattern.newBasedOn(row, resolver).map { RestPattern(it) }
     override fun newBasedOn(resolver: Resolver): List<Pattern> = pattern.newBasedOn(resolver).map { RestPattern(it) }
     override fun negativeBasedOn(row: Row, resolver: Resolver): List<Pattern> {

--- a/core/src/main/kotlin/in/specmatic/core/pattern/RestPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/RestPattern.kt
@@ -13,8 +13,16 @@ data class RestPattern(override val pattern: Pattern, override val typeAlias: St
             listPattern.matches(sampleData, resolver)
 
     override fun generate(resolver: Resolver): Value = resolver.withCyclePrevention(listPattern, listPattern::generate)
-    override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> = pattern.newBasedOn(row, resolver).map { RestPattern(it) }
-    override fun newBasedOn(resolver: Resolver): List<Pattern> = pattern.newBasedOn(resolver).map { RestPattern(it) }
+    override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> {
+        return resolver.withCyclePrevention(pattern) { cyclePreventedResolver ->
+            pattern.newBasedOn(row, cyclePreventedResolver).map { RestPattern(it) }
+        }
+    }
+    override fun newBasedOn(resolver: Resolver): List<Pattern> {
+        return resolver.withCyclePrevention(pattern) { cyclePreventedResolver ->
+            pattern.newBasedOn(cyclePreventedResolver).map { RestPattern(it) }
+        }
+    }
     override fun negativeBasedOn(row: Row, resolver: Resolver): List<Pattern> {
         return listOf(this)
     }

--- a/core/src/main/kotlin/in/specmatic/core/pattern/TabularPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/TabularPattern.kt
@@ -53,7 +53,7 @@ data class TabularPattern(
     override fun generate(resolver: Resolver): JSONObjectValue {
         val resolverWithNullType = withNullPattern(resolver)
         return JSONObjectValue(pattern.mapKeys { entry -> withoutOptionality(entry.key) }.mapValues { (key, pattern) ->
-            attempt(breadCrumb = key) { resolverWithNullType.generate(key, pattern) }
+            attempt(breadCrumb = key) { resolverWithNullType.withCyclePrevention(pattern) {it.generate(key, pattern)} }
         })
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/TabularPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/TabularPattern.kt
@@ -166,7 +166,7 @@ fun negativeBasedOn(patternMap: Map<String, Pattern>, row: Row, resolver: Resolv
 fun newBasedOn(patternMap: Map<String, Pattern>, resolver: Resolver): List<Map<String, Pattern>> {
     val patternCollection = patternMap.mapValues { (key, pattern) ->
         attempt(breadCrumb = key) {
-            newBasedOn(pattern, resolver)
+            newBasedOn(key, pattern, resolver)
         }
     }
 
@@ -185,7 +185,13 @@ fun newBasedOn(row: Row, key: String, pattern: Pattern, resolver: Resolver): Lis
 
                 attempt(breadCrumb = key) {
                     when (val result = pattern.encompasses(rowPattern, resolver, resolver)) {
-                        is Result.Success -> rowPattern.newBasedOn(row, resolver)
+                        is Result.Success -> {
+                            resolver.withCyclePrevention(rowPattern, isOptional(key)) { cyclePreventedResolver ->
+                                rowPattern.newBasedOn(row, cyclePreventedResolver)
+                            }?:
+                            // Handle cycle (represented by null value) by using empty list for optional properties
+                            listOf()
+                        }
                         is Result.Failure -> throw ContractException(result.toFailureReport())
                     }
                 }
@@ -214,12 +220,20 @@ fun newBasedOn(row: Row, key: String, pattern: Pattern, resolver: Resolver): Lis
 //                fromExamples
 //            }
         }
-        else -> pattern.newBasedOn(row, resolver)
+        else -> resolver.withCyclePrevention(pattern, isOptional(key)) { cyclePreventedResolver ->
+            pattern.newBasedOn(row, cyclePreventedResolver)
+        }?:
+        // Handle cycle (represented by null value) by using empty list for optional properties
+        listOf()
     }
 }
 
-fun newBasedOn(pattern: Pattern, resolver: Resolver): List<Pattern> {
-    return pattern.newBasedOn(resolver)
+fun newBasedOn(key: String, pattern: Pattern, resolver: Resolver): List<Pattern> {
+    return resolver.withCyclePrevention(pattern, isOptional(key)) { cyclePreventedResolver ->
+        pattern.newBasedOn(cyclePreventedResolver)
+    }?:
+    // Handle cycle (represented by null value) by using empty list for optional properties
+    listOf()
 }
 
 fun key(pattern: Pattern, key: String): String {
@@ -266,7 +280,9 @@ private fun <ValueType> keyCombinations(
     patternCollection: Map<String, List<ValueType>>,
     optionalSelector: (String, List<ValueType>) -> Pair<String, ValueType>
 ): Map<String, ValueType> {
-    return patternCollection.map { (key, value) ->
+    return patternCollection
+        .filterValues { it.isNotEmpty() }
+        .map { (key, value) ->
         optionalSelector(key, value)
     }.toMap()
 }

--- a/core/src/main/kotlin/in/specmatic/core/pattern/XMLPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/XMLPattern.kt
@@ -337,17 +337,23 @@ data class XMLPattern(override val pattern: XMLTypeData = XMLTypeData(realName =
                                 is XMLPattern -> {
                                     val dereferenced: XMLPattern = childPattern.dereferenceType(resolver)
 
-                                    when {
-                                        dereferenced.occurMultipleTimes() -> {
-                                            dereferenced.newBasedOn(row, resolver)
+                                    resolver.withCyclePrevention(dereferenced) { cyclePreventedResolver ->
+                                        when {
+                                            dereferenced.occurMultipleTimes() -> {
+                                                dereferenced.newBasedOn(row, cyclePreventedResolver)
+                                            }
+
+                                            dereferenced.isOptional() -> {
+                                                dereferenced.newBasedOn(row, cyclePreventedResolver).plus(null)
+                                            }
+
+                                            else -> dereferenced.newBasedOn(row, cyclePreventedResolver)
                                         }
-                                        dereferenced.isOptional() -> {
-                                            dereferenced.newBasedOn(row, resolver).plus(null)
-                                        }
-                                        else -> dereferenced.newBasedOn(row, resolver)
                                     }
                                 }
-                                else -> childPattern.newBasedOn(row, resolver)
+                                else -> resolver.withCyclePrevention(childPattern) { cyclePreventedResolver ->
+                                    childPattern.newBasedOn(row, cyclePreventedResolver)
+                                }
                             }
                         }
                     })
@@ -374,17 +380,23 @@ data class XMLPattern(override val pattern: XMLTypeData = XMLTypeData(realName =
                         is XMLPattern -> {
                             val dereferenced: XMLPattern = childPattern.dereferenceType(resolver)
 
-                            when {
-                                dereferenced.occurMultipleTimes() -> {
-                                    dereferenced.newBasedOn(resolver)
+                            resolver.withCyclePrevention(dereferenced) { cyclePreventedResolver ->
+                                when {
+                                    dereferenced.occurMultipleTimes() -> {
+                                        dereferenced.newBasedOn(cyclePreventedResolver)
+                                    }
+
+                                    dereferenced.isOptional() -> {
+                                        dereferenced.newBasedOn(cyclePreventedResolver).plus(null)
+                                    }
+
+                                    else -> dereferenced.newBasedOn(cyclePreventedResolver)
                                 }
-                                dereferenced.isOptional() -> {
-                                    dereferenced.newBasedOn(resolver).plus(null)
-                                }
-                                else -> dereferenced.newBasedOn(resolver)
                             }
                         }
-                        else -> childPattern.newBasedOn(resolver)
+                        else -> resolver.withCyclePrevention(childPattern) { cyclePreventedResolver ->
+                            childPattern.newBasedOn(cyclePreventedResolver)
+                        }
                     }
                 }
             })

--- a/core/src/main/kotlin/in/specmatic/core/pattern/XMLPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/XMLPattern.kt
@@ -271,7 +271,11 @@ data class XMLPattern(override val pattern: XMLTypeData = XMLTypeData(realName =
         val newAttributes = nonQontractAttributes.mapKeys { entry ->
             withoutOptionality(entry.key)
         }.mapValues { (key, pattern) ->
-            attempt(breadCrumb = "$name.$key") { resolver.generate(key, pattern) }
+            attempt(breadCrumb = "$name.$key") {
+                resolver.withCyclePrevention(pattern) { cyclePreventedResolver ->
+                    cyclePreventedResolver.generate(key, pattern)
+                }
+            }
         }.mapValues {
             StringValue(it.value.toStringLiteral())
         }
@@ -280,13 +284,15 @@ data class XMLPattern(override val pattern: XMLTypeData = XMLTypeData(realName =
             resolvedHop(it, resolver)
         }.map { pattern ->
             attempt(breadCrumb = name) {
-                when {
-                    pattern is ListPattern -> (pattern.generate(resolver) as XMLNode).childNodes
-                    pattern is XMLPattern && pattern.occurMultipleTimes() -> 0.until(randomNumber(RANDOM_NUMBER_CEILING))
-                        .map {
-                            pattern.generate(resolver)
-                        }
-                    else -> listOf(pattern.generate(resolver))
+                resolver.withCyclePrevention(pattern) { cyclePreventedResolver ->
+                    when {
+                        pattern is ListPattern -> (pattern.generate(cyclePreventedResolver) as XMLNode).childNodes
+                        pattern is XMLPattern && pattern.occurMultipleTimes() ->
+                            0.until(randomNumber(RANDOM_NUMBER_CEILING))
+                                .map { pattern.generate(cyclePreventedResolver) }
+
+                        else -> listOf(pattern.generate(cyclePreventedResolver))
+                    }
                 }
             }
         }.flatten().map {

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
@@ -1989,47 +1989,6 @@ Scenario: zero should return not found
             System.clearProperty(Flags.negativeTestingFlag)
         }
     }
-
-    @Test
-    fun `test cycle in optional key to circular ref`() {
-        val feature = OpenApiSpecification.fromYAML("""
-            openapi: "3.0.0"
-            info:
-              version: 1.0.0
-              title: Swagger Petstore
-            paths:
-              /data:
-                get:
-                  description: Get data
-                  responses:
-                    '200':
-                      description: data
-                      content:
-                        application/json:
-                          schema:
-                            ${'$'}ref: '#/components/schemas/TopLevel'
-            components:
-              schemas:
-                TopLevel:
-                  type: object
-                  required:
-                  properties:
-                    key:
-                      type:
-                        schema:
-                          ${'$'}ref: '#/components/schemas/TopLevel'
-        """.trimIndent(), "").toFeature()
-
-        val resp = HttpStub(feature).use {
-            val request =
-                Request.Builder().url("http://localhost:9000/data")
-                    .addHeader("Content-Type", "application/json")
-                    .get().build()
-            it.client.execute(HttpRequest("GET", "/data")).body as JSONObjectValue
-        }
-
-        assertThat(resp.jsonObject).isEmpty()
-    }
 }
 
 data class CycleRoot(

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
@@ -1989,6 +1989,47 @@ Scenario: zero should return not found
             System.clearProperty(Flags.negativeTestingFlag)
         }
     }
+
+    @Test
+    fun `test cycle in optional key to circular ref`() {
+        val feature = OpenApiSpecification.fromYAML("""
+            openapi: "3.0.0"
+            info:
+              version: 1.0.0
+              title: Swagger Petstore
+            paths:
+              /data:
+                get:
+                  description: Get data
+                  responses:
+                    '200':
+                      description: data
+                      content:
+                        application/json:
+                          schema:
+                            ${'$'}ref: '#/components/schemas/TopLevel'
+            components:
+              schemas:
+                TopLevel:
+                  type: object
+                  required:
+                  properties:
+                    key:
+                      type:
+                        schema:
+                          ${'$'}ref: '#/components/schemas/TopLevel'
+        """.trimIndent(), "").toFeature()
+
+        val resp = HttpStub(feature).use {
+            val request =
+                Request.Builder().url("http://localhost:9000/data")
+                    .addHeader("Content-Type", "application/json")
+                    .get().build()
+            it.client.execute(HttpRequest("GET", "/data")).body as JSONObjectValue
+        }
+
+        assertThat(resp.jsonObject).isEmpty()
+    }
 }
 
 data class CycleRoot(

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
@@ -10,7 +10,6 @@ import `in`.specmatic.core.pattern.parsedJSONObject
 import `in`.specmatic.core.value.JSONObjectValue
 import `in`.specmatic.core.value.StringValue
 import `in`.specmatic.core.value.Value
-import `in`.specmatic.mock.ScenarioStub
 import `in`.specmatic.stub.HttpStub
 import `in`.specmatic.stub.createStubFromContracts
 import `in`.specmatic.test.TestExecutor
@@ -1022,18 +1021,94 @@ Background:
     }
 
     @Test
-    fun `should validate with indirect cyclic reference in open api`() {
+    fun `should validate and generate with indirect required non-nullable cyclic reference in open api`() {
         val feature = parseGherkinStringToFeature(
             """
 Feature: Hello world
 
 Background:
-  Given openapi openapi/circular-reference.yaml
+  Given openapi openapi/circular-reference-non-nullable.yaml
         """.trimIndent(), sourceSpecPath
         )
 
         val result = testBackwardCompatibility(feature, feature)
         assertThat(result.success()).isTrue()
+
+        val resp = HttpStub(feature).use {
+            val request =
+                Request.Builder().url("http://localhost:9000/demo/circular-reference-non-nullable")
+                    .addHeader("Content-Type", "application/json")
+                    .get().build()
+            val call = OkHttpClient().newCall(request)
+            call.execute()
+        }
+
+        assertThat(resp.isSuccessful).isFalse
+        assertThat(resp.code()).isEqualTo(400)
+        val body = resp.body()?.string()
+        assertThat(body).contains("Invalid pattern cycle")
+    }
+
+    @Test
+    @RepeatedTest(10) // Try to exercise all outcomes of AnyPattern.generate() which randomly selects from its options
+    fun `should validate and generate with indirect optional non-nullable cyclic reference in open api`() {
+        val feature = parseGherkinStringToFeature(
+            """
+Feature: Hello world
+
+Background:
+  Given openapi openapi/circular-reference-optional-non-nullable.yaml
+        """.trimIndent(), sourceSpecPath
+        )
+
+        val result = testBackwardCompatibility(feature, feature)
+        assertThat(result.success()).isTrue()
+
+        val resp = HttpStub(feature).use {
+            val request =
+                Request.Builder().url("http://localhost:9000/demo/circular-reference-optional-non-nullable")
+                    .addHeader("Content-Type", "application/json")
+                    .get().build()
+            val call = OkHttpClient().newCall(request)
+            call.execute()
+        }
+
+        val body = resp.body()?.string()
+        assertThat(resp.isSuccessful).withFailMessage("Response unexpectedly failed. body=$body").isTrue
+        assertThat(resp.code()).isEqualTo(200)
+        val deserialized = ObjectMapper().readValue(body, OptionalCycleRoot::class.java)
+        assertThat(deserialized).isNotNull
+    }
+
+    @Test
+    @RepeatedTest(10) // Try to exercise all outcomes of AnyPattern.generate() which randomly selects from its options
+    fun `should validate and generate with indirect nullable cyclic reference in open api`() {
+        val feature = parseGherkinStringToFeature(
+            """
+Feature: Hello world
+
+Background:
+  Given openapi openapi/circular-reference-nullable.yaml
+        """.trimIndent(), sourceSpecPath
+        )
+
+        val result = testBackwardCompatibility(feature, feature)
+        assertThat(result.success()).isTrue()
+
+        val resp = HttpStub(feature).use {
+            val request =
+                Request.Builder().url("http://localhost:9000/demo/circular-reference-nullable")
+                    .addHeader("Content-Type", "application/json")
+                    .get().build()
+            val call = OkHttpClient().newCall(request)
+            call.execute()
+        }
+
+        val body = resp.body()?.string()
+        assertThat(resp.isSuccessful).withFailMessage("Response unexpectedly failed. body=$body").isTrue
+        assertThat(resp.code()).isEqualTo(200)
+        val deserialized = ObjectMapper().readValue(body, NullableCycleHolder::class.java)
+        assertThat(deserialized).isNotNull
     }
 
     //TODO:
@@ -1776,12 +1851,30 @@ Scenario: zero should return not found
 }
 
 data class CycleRoot(
-    @JsonProperty("direct-cycle") val directCycle: CycleRoot,
     @JsonProperty("intermediate-node") val intermediateNode: CycleIntermediateNode,
 )
 
 data class CycleIntermediateNode(
     @JsonProperty("indirect-cycle") val indirectCycle: CycleRoot,
+)
+
+data class OptionalCycleRoot(
+    @JsonProperty("intermediate-node") val intermediateNode: OptionalCycleIntermediateNode,
+)
+
+data class OptionalCycleIntermediateNode(
+    @JsonProperty("indirect-cycle") val indirectCycle: OptionalCycleRoot?,
+)
+
+data class NullableCycleHolder(
+    @JsonProperty("contents") val contents: NullableCycleRoot?,
+)
+data class NullableCycleRoot(
+    @JsonProperty("intermediate-node") val intermediateNode: NullableCycleIntermediateNode,
+)
+
+data class NullableCycleIntermediateNode(
+    @JsonProperty("indirect-cycle") val indirectCycle: NullableCycleRoot?,
 )
 
 data class Pet(

--- a/core/src/test/kotlin/in/specmatic/core/CyclePrevention.kt
+++ b/core/src/test/kotlin/in/specmatic/core/CyclePrevention.kt
@@ -35,9 +35,7 @@ class CyclePrevention {
                   type: object
                   properties:
                     key:
-                      type:
-                        schema:
-                          ${'$'}ref: '#/components/schemas/TopLevel'
+                      ${'$'}ref: '#/components/schemas/TopLevel'
         """.trimIndent(), "").toFeature()
 
         val response = HttpStub(feature).use {
@@ -77,12 +75,11 @@ class CyclePrevention {
                     - key
                   properties:
                     key:
-                      type:
-                        oneOf:
-                          - type: object
-                            properties: {}
-                            nullable: true
-                          - ${'$'}ref: '#/components/schemas/NextLevel'
+                      oneOf:
+                        - type: object
+                          properties: {}
+                          nullable: true
+                        - ${'$'}ref: '#/components/schemas/NextLevel'
         """.trimIndent(), "").toFeature()
 
         val response = HttpStub(feature).use {
@@ -120,12 +117,11 @@ class CyclePrevention {
                   type: object
                   properties:
                     key:
-                      type:
-                        oneOf:
-                          - type: object
-                            properties: {}
-                            nullable: true
-                          - ${'$'}ref: '#/components/schemas/TopLevel'
+                      oneOf:
+                        - type: object
+                          properties: {}
+                          nullable: true
+                        - ${'$'}ref: '#/components/schemas/TopLevel'`
         """.trimIndent(), "").toFeature()
 
         val response = HttpStub(feature).use {
@@ -165,9 +161,7 @@ class CyclePrevention {
                   - key
                   properties:
                     key:
-                      type:
-                        schema:
-                          ${'$'}ref: '#/components/schemas/TopLevel'
+                      ${'$'}ref: '#/components/schemas/TopLevel'
         """.trimIndent(), ""
         ).toFeature()
 
@@ -207,16 +201,13 @@ class CyclePrevention {
                     - key1
                   properties:
                     key1:
-                      type:
-                        schema:
-                          ${'$'}ref: '#/components/schemas/NextLevel'
+                      ${'$'}ref: '#/components/schemas/NextLevel'
                 NextLevel:
                   type: object
                   properties:
                     key2:
                       type:
-                        schema:
-                          ${'$'}ref: '#/components/schemas/TopLevel'
+                        ${'$'}ref: '#/components/schemas/TopLevel'
         """.trimIndent(), "").toFeature()
 
         val response = HttpStub(feature).use {
@@ -256,21 +247,18 @@ class CyclePrevention {
                     - key1
                   properties:
                     key1:
-                      type:
-                        schema:
-                          ${'$'}ref: '#/components/schemas/NextLevel'
+                      ${'$'}ref: '#/components/schemas/NextLevel'
                 NextLevel:
                   type: object
                   required:
                     - key2
                   properties:
                     key2:
-                      type:
-                        oneOf:
-                          - type: object
-                            properties: {}
-                            nullable: true
-                          - ${'$'}ref: '#/components/schemas/TopLevel'
+                      oneOf:
+                        - type: object
+                          properties: {}
+                          nullable: true
+                        - ${'$'}ref: '#/components/schemas/TopLevel'
         """.trimIndent(), "").toFeature()
 
         val response = HttpStub(feature).use {
@@ -310,9 +298,7 @@ class CyclePrevention {
                     - key1
                   properties:
                     key1:
-                      type:
-                        schema:
-                          ${'$'}ref: '#/components/schemas/NextLevel'
+                      ${'$'}ref: '#/components/schemas/NextLevel'
                 NextLevel:
                   type: object
                   properties:
@@ -361,18 +347,14 @@ class CyclePrevention {
                   - key1
                   properties:
                     key1:
-                      type:
-                        schema:
-                          ${'$'}ref: '#/components/schemas/NextLevel'
+                      ${'$'}ref: '#/components/schemas/NextLevel'
                 NextLevel:
                   type: object
                   required:
                   - key2
                   properties:
                     key2:
-                      type:
-                        schema:
-                          ${'$'}ref: '#/components/schemas/TopLevel'
+                      ${'$'}ref: '#/components/schemas/TopLevel'
         """.trimIndent(), "").toFeature()
 
         val response = HttpStub(feature).use {

--- a/core/src/test/kotlin/in/specmatic/core/CyclePrevention.kt
+++ b/core/src/test/kotlin/in/specmatic/core/CyclePrevention.kt
@@ -79,7 +79,7 @@ class CyclePrevention {
                         - type: object
                           properties: {}
                           nullable: true
-                        - ${'$'}ref: '#/components/schemas/NextLevel'
+                        - ${'$'}ref: '#/components/schemas/TopLevel'
         """.trimIndent(), "").toFeature()
 
         val response = HttpStub(feature).use {
@@ -91,7 +91,7 @@ class CyclePrevention {
     }
 
     @Test
-    @RepeatedTest(5)
+//    @RepeatedTest(5)
     fun `test cycle in optional key to nullable ref`() {
 //        key? -> circular-ref-value?
 
@@ -121,7 +121,7 @@ class CyclePrevention {
                         - type: object
                           properties: {}
                           nullable: true
-                        - ${'$'}ref: '#/components/schemas/TopLevel'`
+                        - ${'$'}ref: '#/components/schemas/TopLevel'
         """.trimIndent(), "").toFeature()
 
         val response = HttpStub(feature).use {

--- a/core/src/test/kotlin/in/specmatic/core/CyclePrevention.kt
+++ b/core/src/test/kotlin/in/specmatic/core/CyclePrevention.kt
@@ -1,0 +1,384 @@
+package `in`.specmatic.core
+
+import `in`.specmatic.conversions.OpenApiSpecification
+import `in`.specmatic.core.Result.Success
+import `in`.specmatic.stub.HttpStub
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.RepeatedTest
+import org.junit.jupiter.api.Test
+
+class CyclePrevention {
+    @Test
+    @RepeatedTest(5)
+    fun `test cycle in optional key to circular ref`() {
+//        key? -> circular-ref-value
+
+        val feature = OpenApiSpecification.fromYAML("""
+            openapi: "3.0.0"
+            info:
+              version: 1.0.0
+              title: Data API
+            paths:
+              /data:
+                get:
+                  description: Get data
+                  responses:
+                    '200':
+                      description: data
+                      content:
+                        application/json:
+                          schema:
+                            ${'$'}ref: '#/components/schemas/TopLevel'
+            components:
+              schemas:
+                TopLevel:
+                  type: object
+                  properties:
+                    key:
+                      type:
+                        schema:
+                          ${'$'}ref: '#/components/schemas/TopLevel'
+        """.trimIndent(), "").toFeature()
+
+        val response = HttpStub(feature).use {
+            it.client.execute(HttpRequest("GET", "/data"))
+        }
+
+        assertThat(feature.scenarios.first().let { it.httpResponsePattern.matches(response, it.resolver) }).isInstanceOf(
+            Success::class.java)
+    }
+
+    @Test
+    @RepeatedTest(5)
+    fun `test cycle in required key to nullable ref`() {
+//        key -> circular-ref-value?
+
+        val feature = OpenApiSpecification.fromYAML("""
+            openapi: "3.0.0"
+            info:
+              version: 1.0.0
+              title: Data API
+            paths:
+              /data:
+                get:
+                  description: Get data
+                  responses:
+                    '200':
+                      description: data
+                      content:
+                        application/json:
+                          schema:
+                            ${'$'}ref: '#/components/schemas/TopLevel'
+            components:
+              schemas:
+                TopLevel:
+                  type: object
+                  required:
+                    - key
+                  properties:
+                    key:
+                      type:
+                        oneOf:
+                          - type: object
+                            properties: {}
+                            nullable: true
+                          - ${'$'}ref: '#/components/schemas/NextLevel'
+        """.trimIndent(), "").toFeature()
+
+        val response = HttpStub(feature).use {
+            it.client.execute(HttpRequest("GET", "/data"))
+        }
+
+        assertThat(feature.scenarios.first().let { it.httpResponsePattern.matches(response, it.resolver) }).isInstanceOf(
+            Success::class.java)
+    }
+
+    @Test
+    @RepeatedTest(5)
+    fun `test cycle in optional key to nullable ref`() {
+//        key? -> circular-ref-value?
+
+        val feature = OpenApiSpecification.fromYAML("""
+            openapi: "3.0.0"
+            info:
+              version: 1.0.0
+              title: Data API
+            paths:
+              /data:
+                get:
+                  description: Get data
+                  responses:
+                    '200':
+                      description: data
+                      content:
+                        application/json:
+                          schema:
+                            ${'$'}ref: '#/components/schemas/TopLevel'
+            components:
+              schemas:
+                TopLevel:
+                  type: object
+                  properties:
+                    key:
+                      type:
+                        oneOf:
+                          - type: object
+                            properties: {}
+                            nullable: true
+                          - ${'$'}ref: '#/components/schemas/TopLevel'
+        """.trimIndent(), "").toFeature()
+
+        val response = HttpStub(feature).use {
+            it.client.execute(HttpRequest("GET", "/data"))
+        }
+
+        assertThat(feature.scenarios.first().let { it.httpResponsePattern.matches(response, it.resolver) }).isInstanceOf(
+            Success::class.java)
+    }
+
+    @Test
+    fun `test cycle in key to circular ref`() {
+//        key -> circular-ref-value
+
+        val feature = OpenApiSpecification.fromYAML(
+            """
+            openapi: "3.0.0"
+            info:
+              version: 1.0.0
+              title: Data API
+            paths:
+              /data:
+                get:
+                  description: Get data
+                  responses:
+                    '200':
+                      description: data
+                      content:
+                        application/json:
+                          schema:
+                            ${'$'}ref: '#/components/schemas/TopLevel'
+            components:
+              schemas:
+                TopLevel:
+                  type: object
+                  required:
+                  - key
+                  properties:
+                    key:
+                      type:
+                        schema:
+                          ${'$'}ref: '#/components/schemas/TopLevel'
+        """.trimIndent(), ""
+        ).toFeature()
+
+        val response = HttpStub(feature).use {
+            it.client.execute(HttpRequest("GET", "/data"))
+        }
+
+        assertThat(response.status).isEqualTo(400)
+    }
+
+    @Test
+    @RepeatedTest(5)
+    fun `test cycle in required key to optional key to circular ref`() {
+//        key1 -> { key2? -> circular-ref-value }
+
+        val feature = OpenApiSpecification.fromYAML("""
+            openapi: "3.0.0"
+            info:
+              version: 1.0.0
+              title: Data API
+            paths:
+              /data:
+                get:
+                  description: Get data
+                  responses:
+                    '200':
+                      description: data
+                      content:
+                        application/json:
+                          schema:
+                            ${'$'}ref: '#/components/schemas/TopLevel'
+            components:
+              schemas:
+                TopLevel:
+                  type: object
+                  required:
+                    - key1
+                  properties:
+                    key1:
+                      type:
+                        schema:
+                          ${'$'}ref: '#/components/schemas/NextLevel'
+                NextLevel:
+                  type: object
+                  properties:
+                    key2:
+                      type:
+                        schema:
+                          ${'$'}ref: '#/components/schemas/TopLevel'
+        """.trimIndent(), "").toFeature()
+
+        val response = HttpStub(feature).use {
+            it.client.execute(HttpRequest("GET", "/data"))
+        }
+
+        assertThat(feature.scenarios.first().let { it.httpResponsePattern.matches(response, it.resolver) }).isInstanceOf(
+            Success::class.java)
+    }
+
+    @Test
+    @RepeatedTest(5)
+    fun `test cycle in required key to required key to nullable circular ref`() {
+//        key1 -> { key2 -> circular-ref-value? }
+
+        val feature = OpenApiSpecification.fromYAML("""
+            openapi: "3.0.0"
+            info:
+              version: 1.0.0
+              title: Data API
+            paths:
+              /data:
+                get:
+                  description: Get data
+                  responses:
+                    '200':
+                      description: data
+                      content:
+                        application/json:
+                          schema:
+                            ${'$'}ref: '#/components/schemas/TopLevel'
+            components:
+              schemas:
+                TopLevel:
+                  type: object
+                  required:
+                    - key1
+                  properties:
+                    key1:
+                      type:
+                        schema:
+                          ${'$'}ref: '#/components/schemas/NextLevel'
+                NextLevel:
+                  type: object
+                  required:
+                    - key2
+                  properties:
+                    key2:
+                      type:
+                        oneOf:
+                          - type: object
+                            properties: {}
+                            nullable: true
+                          - ${'$'}ref: '#/components/schemas/TopLevel'
+        """.trimIndent(), "").toFeature()
+
+        val response = HttpStub(feature).use {
+            it.client.execute(HttpRequest("GET", "/data"))
+        }
+
+        assertThat(feature.scenarios.first().let { it.httpResponsePattern.matches(response, it.resolver) }).isInstanceOf(
+            Success::class.java)
+    }
+
+    @Test
+    @RepeatedTest(5)
+    fun `test cycle in required key to optional key to nullable circular ref`() {
+//        key1 -> { key2? -> circular-ref-value? }
+
+        val feature = OpenApiSpecification.fromYAML("""
+            openapi: "3.0.0"
+            info:
+              version: 1.0.0
+              title: Data API
+            paths:
+              /data:
+                get:
+                  description: Get data
+                  responses:
+                    '200':
+                      description: data
+                      content:
+                        application/json:
+                          schema:
+                            ${'$'}ref: '#/components/schemas/TopLevel'
+            components:
+              schemas:
+                TopLevel:
+                  type: object
+                  required:
+                    - key1
+                  properties:
+                    key1:
+                      type:
+                        schema:
+                          ${'$'}ref: '#/components/schemas/NextLevel'
+                NextLevel:
+                  type: object
+                  properties:
+                    key2:
+                      type:
+                        oneOf:
+                          - type: object
+                            properties: {}
+                            nullable: true
+                          - ${'$'}ref: '#/components/schemas/TopLevel'
+        """.trimIndent(), "").toFeature()
+
+        val response = HttpStub(feature).use {
+            it.client.execute(HttpRequest("GET", "/data"))
+        }
+
+        assertThat(feature.scenarios.first().let { it.httpResponsePattern.matches(response, it.resolver) }).isInstanceOf(
+            Success::class.java)
+    }
+
+    @Test
+    fun `test cycle in required key to required key to circular ref`() {
+//        key1 -> { key2 -> circular-ref-value }
+
+        val feature = OpenApiSpecification.fromYAML("""
+            openapi: "3.0.0"
+            info:
+              version: 1.0.0
+              title: Data API
+            paths:
+              /data:
+                get:
+                  description: Get data
+                  responses:
+                    '200':
+                      description: data
+                      content:
+                        application/json:
+                          schema:
+                            ${'$'}ref: '#/components/schemas/TopLevel'
+            components:
+              schemas:
+                TopLevel:
+                  type: object
+                  required:
+                  - key1
+                  properties:
+                    key1:
+                      type:
+                        schema:
+                          ${'$'}ref: '#/components/schemas/NextLevel'
+                NextLevel:
+                  type: object
+                  required:
+                  - key2
+                  properties:
+                    key2:
+                      type:
+                        schema:
+                          ${'$'}ref: '#/components/schemas/TopLevel'
+        """.trimIndent(), "").toFeature()
+
+        val response = HttpStub(feature).use {
+            it.client.execute(HttpRequest("GET", "/data"))
+        }
+
+        assertThat(response.status).isEqualTo(400)
+    }
+}

--- a/core/src/test/kotlin/in/specmatic/core/URLMatcherTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/URLMatcherTest.kt
@@ -91,8 +91,10 @@ internal class URLMatcherTest {
     fun `should generate path when url has only path parameters`() {
         val urlPattern = toURLMatcherWithOptionalQueryParams(URI("/pets/(petid:number)/owner/(owner:string)"))
         val resolver = mockk<Resolver>().also {
-            every { it.generate("petid", DeferredPattern("(number)", "petid")) } returns NumberValue(123)
-            every { it.generate("owner", DeferredPattern("(string)", "owner")) } returns StringValue("hari")
+            every { it.withCyclePrevention<StringValue>(ExactValuePattern(StringValue("pets")), any())} returns StringValue("pets")
+            every { it.withCyclePrevention<NumberValue>(DeferredPattern("(number)", "petid"), any())} returns NumberValue(123)
+            every { it.withCyclePrevention<StringValue>(ExactValuePattern(StringValue("owner")), any())} returns StringValue("owner")
+            every { it.withCyclePrevention<StringValue>(DeferredPattern("(string)", "owner"), any())} returns StringValue("hari")
         }
         urlPattern.generatePath(resolver).let{
             assertThat(it).isEqualTo("/pets/123/owner/hari")
@@ -103,8 +105,9 @@ internal class URLMatcherTest {
     fun `should generate query`() {
         val urlPattern = toURLMatcherWithOptionalQueryParams(URI("/pets?petid=(number)&owner=(string)"))
         val resolver = mockk<Resolver>().also {
-            every { it.generate("petid", DeferredPattern("(number)", "petid")) } returns NumberValue(123)
-            every { it.generate("owner", DeferredPattern("(string)", "owner")) } returns StringValue("hari")
+            every { it.withCyclePrevention<StringValue>(ExactValuePattern(StringValue("pets")), any())} returns StringValue("pets")
+            every { it.withCyclePrevention<NumberValue>(DeferredPattern("(number)", "petid"), any())} returns NumberValue(123)
+            every { it.withCyclePrevention<StringValue>(DeferredPattern("(string)", "owner"), any())} returns StringValue("hari")
         }
         urlPattern.generateQuery(resolver).let {
             assertThat(it).isEqualTo(hashMapOf("petid" to "123", "owner" to "hari"))

--- a/core/src/test/kotlin/in/specmatic/stub/HttpStubKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/stub/HttpStubKtTest.kt
@@ -533,7 +533,7 @@ Feature: POST API
         val errors: Vector<String> = Vector()
 
         HttpStub(feature).use { stub ->
-            usingMultipleThreads(30) { stubNumber ->
+            usingMultipleThreads(20) { stubNumber ->
                 `set an expectation and exercise it`(stubNumber, stub)?.let {
                     errors.add(it)
                 }

--- a/core/src/test/resources/openapi/circular-reference-non-nullable.yaml
+++ b/core/src/test/resources/openapi/circular-reference-non-nullable.yaml
@@ -1,9 +1,9 @@
 openapi: 3.0.1
 info:
-  title: Demonstrate circular reference bug in specmatic
+  title: Tests circular references
   version: "1.0"
 paths:
-  /demo/circular-reference:
+  /demo/circular-reference-non-nullable:
     get:
       responses:
         "200":
@@ -19,14 +19,11 @@ components:
     CycleRoot:
       type: object
       properties:
-        # A direct cycle works
-        direct-cycle:
-          $ref: '#/components/schemas/CycleRoot'
-
-        # An indirect cycle via an intermediate node does NOT work
+        # indirect cycle via an intermediate node
         intermediate-node:
           $ref: '#/components/schemas/CycleIntermediateNode'
-
+      required:
+        - intermediate-node
 
     CycleIntermediateNode:
       type: object
@@ -34,3 +31,5 @@ components:
         # Completes an indirect cycle back to the root
         indirect-cycle:
           $ref: '#/components/schemas/CycleRoot'
+      required:
+        - indirect-cycle

--- a/core/src/test/resources/openapi/circular-reference-nullable.yaml
+++ b/core/src/test/resources/openapi/circular-reference-nullable.yaml
@@ -1,0 +1,45 @@
+openapi: 3.0.1
+info:
+  title: Tests circular references
+  version: "1.0"
+paths:
+  /demo/circular-reference-nullable:
+    get:
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NullableCycleHolder'
+
+components:
+  schemas:
+
+    # Holder to ensure at a response body is returned, even if it is empty
+    NullableCycleHolder:
+      type: object
+      properties:
+        contents:
+          $ref: '#/components/schemas/NullableCycleRoot'
+      required:
+        - contents
+
+    NullableCycleRoot:
+      type: object
+      nullable: true
+      properties:
+        # indirect cycle via an intermediate node
+        intermediate-node:
+          $ref: '#/components/schemas/NullableCycleIntermediateNode'
+      required:
+        - intermediate-node
+
+    NullableCycleIntermediateNode:
+      type: object
+      properties:
+        # Completes an indirect cycle back to the root
+        indirect-cycle:
+          $ref: '#/components/schemas/NullableCycleRoot'
+      required:
+        - indirect-cycle

--- a/core/src/test/resources/openapi/circular-reference-optional-non-nullable.yaml
+++ b/core/src/test/resources/openapi/circular-reference-optional-non-nullable.yaml
@@ -1,0 +1,33 @@
+openapi: 3.0.1
+info:
+  title: Tests optional circular references
+  version: "1.0"
+paths:
+  /demo/circular-reference-optional-non-nullable:
+    get:
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OptionalCycleRoot'
+
+components:
+  schemas:
+
+    OptionalCycleRoot:
+      type: object
+      properties:
+        # indirect cycle via an intermediate node
+        intermediate-node:
+          $ref: '#/components/schemas/OptionalCycleIntermediateNode'
+      required:
+        - intermediate-node
+
+    OptionalCycleIntermediateNode:
+      type: object
+      properties:
+        # Completes an optional indirect cycle back to the root
+        indirect-cycle:
+          $ref: '#/components/schemas/OptionalCycleRoot'

--- a/core/src/test/resources/openapi/circular-reference-polymorphic.yaml
+++ b/core/src/test/resources/openapi/circular-reference-polymorphic.yaml
@@ -1,0 +1,55 @@
+openapi: 3.0.1
+info:
+  title: Tests circular references in polymorphic relationships
+  version: "1.0"
+paths:
+  /demo/circular-reference-polymorphic:
+    get:
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MyBaseHolder'
+
+components:
+  schemas:
+
+    MyBaseHolder:
+      type: object
+      properties:
+        myBase:
+          $ref: '#/components/schemas/MyBase_Polymorphic'
+      required:
+        - myBase
+
+    MyBase:
+      type: object
+      discriminator:
+        propertyName: '@type'
+      properties:
+        '@type':
+          type: string
+
+    MyBase_Polymorphic:
+      oneOf:
+        - $ref: '#/components/schemas/MySub1'
+        - $ref: '#/components/schemas/MySub2'
+
+    MySub1:
+      allOf:
+        - $ref: '#/components/schemas/MyBase'
+        - type: object
+          properties:
+            aMyBase:
+              $ref: '#/components/schemas/MyBase_Polymorphic'
+
+    MySub2:
+      allOf:
+        - $ref: '#/components/schemas/MyBase'
+        - type: object
+          properties:
+            myVal:
+              type: string
+


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: More complete stackoverflow prevention than has been implemented so far

<!-- Why are these changes necessary? -->

**Why**: Fixes #591. I kept running into new scenarios that produced StackOverflowError, so I felt it was time for a more complete refactor after taking the time to fully understand the OpenApiSpecification class logic. Additionally, cycle prevention logic is needed in stub and test generation logic and has been included here (used to be in #592 which is now closed in favor of this PR)

<!-- How were these changes implemented? -->

**How**:
 Pattern discovery (OpenApiSpecification)
- Return previously calculated component patterns rather than calculating them again.
- Standardize how the component pattern cache is populated by factoring into a dedicated method.
- Simplify toSchemaProperties() logic to remove logic that is redundant to existing toSpecmaticPattern() logic.
- Ensure typeStack is populated with proper component pattern names in all the correct recursive calls.

Stub generation (`Pattern.generate()`) and test generation (`Pattern.newBasedOn()`)
- For stub and test generation, `Resolver.withCyclePrevention()` is introduced as a wrapper for any call that resolves deferred patterns to actual patterns.  This is an approach generally applicable for bot test and stub generation.
- Ensures Resolver remains immutable via `Resolver.withCyclePrevention()` which produces a new Resolver with a cyclePreventionStack with an addition entry for the current pattern.
- `Resolver.withCyclePrevention()` has a simple overload which will throw ContractException(cycle=true) if a cycle is found, but there is also a second overload that allows returning null to give the caller an opportunity to gracefully handle the detected cycle. This is done for nullable components (see AnyPattern) and optional properties (see JSONObjectPattern).

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [X] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #591 

<!-- feel free to add additional comments -->
