### PR TITLE
Fix regression changes for OpenApiSpecification introduced in 0.60.0

### DIFF
--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
@@ -1729,10 +1729,6 @@ Feature: Foo API
 
         assertThat(flags["/v1/foo/CAC10D70-0000-0000-000030AA DELETE executed"]).isEqualTo(1)
         assertThat(flags.keys.filter { it.matches(Regex("""$pattern DELETE executed""")) }.size).isEqualTo(1)
-        assertThat(flags.keys.filter { it.matches(Regex("""$pattern GET executed""")) }.size).isNotNull
-        assertThat(flags.keys.filter { it.matches(Regex("""$pattern POST executed""")) }.size).isNotNull
-        assertThat(flags.keys.filter { it.matches(Regex("""$pattern PUT executed""")) }.size).isNotNull
-        assertThat(flags.keys.filter { it.matches(Regex("""$pattern PATCH executed""")) }.size).isNotNull
         assertThat(flags.size).isEqualTo(1)
         assertTrue(results.success(), results.report())
     }

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
@@ -1682,7 +1682,7 @@ Scenario: zero should return not found
                 setOf("message", "another_message"),
             )
         )
-        assertThat(queryParameters.map { it.values.toList() }).containsAll(listOf(listOf("Hari", "hello"), listOf("hello")))
+        assertThat(queryParameters.map { it.values.toList() }).containsAll(listOf(listOf("hello", "Hari"), listOf("hello")))
     }
 
     @Test

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
@@ -1701,20 +1701,25 @@ Feature: Foo API
       | baz |
         """.trimIndent()
 
-        val feature = parseGherkinStringToFeature(openAPISpec, sourceSpecPath)
-
         val flags = mutableListOf<String>()
 
-        feature.executeTests(
-            object : TestExecutor {
-                override fun execute(request: HttpRequest): HttpResponse {
-                    flags.add("test executed")
-                    return HttpResponse.OK
-                }
+        try {
+            val feature = parseGherkinStringToFeature(openAPISpec, sourceSpecPath)
 
-                override fun setServerState(serverState: Map<String, Value>) {}
-            }
-        )
+            feature.executeTests(
+                object : TestExecutor {
+                    override fun execute(request: HttpRequest): HttpResponse {
+                        flags.add("test executed")
+                        return HttpResponse.OK
+                    }
+
+                    override fun setServerState(serverState: Map<String, Value>) {}
+                }
+            )
+
+        } catch(e: Throwable) {
+
+        }
 
         assertThat(flags).doesNotContain("test executed")
     }

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
@@ -1686,6 +1686,40 @@ Scenario: zero should return not found
     }
 
     @Test
+    fun `should validate enum values in URL path params`() {
+        val openAPISpec = """
+Feature: Foo API
+
+  Background:
+    Given openapi openapi/enum_in_path.yaml
+
+  Scenario Outline: Delete foo
+    When GET /v1/foo/(data:string)
+    Then status 200
+    Examples:
+      | id  |
+      | baz |
+        """.trimIndent()
+
+        val feature = parseGherkinStringToFeature(openAPISpec, sourceSpecPath)
+
+        val flags = mutableListOf<String>()
+
+        feature.executeTests(
+            object : TestExecutor {
+                override fun execute(request: HttpRequest): HttpResponse {
+                    flags.add("test executed")
+                    return HttpResponse.OK
+                }
+
+                override fun setServerState(serverState: Map<String, Value>) {}
+            }
+        )
+
+        assertThat(flags).doesNotContain("test executed")
+    }
+
+    @Test
     fun `should delete 'foo' using regex pattern and {min,max}Length parameters`() {
         val flags = mutableMapOf<String, Int>().withDefault { 0 }
 

--- a/core/src/test/resources/openapi/enum_in_path.yaml
+++ b/core/src/test/resources/openapi/enum_in_path.yaml
@@ -1,0 +1,28 @@
+openapi: 3.0.3
+info:
+  version: '1.0'
+  title: Foo API Definition
+  description: Example API to reproduce Specmatic 0.60.0 issue.
+servers:
+  - url: http://api.example.com/v1
+    description: Optional server description, e.g. Main (production) server
+paths:
+  /v1/foo/{data}:
+    get:
+      summary: Get 'foo' data
+      description: Gets data on foo
+      parameters:
+        - in: path
+          name: data
+          schema:
+            type: string
+            enum: [bar,none]
+          required: true
+          description: type of 'foo' data required
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            text/plain:
+              schema:
+                type: string

--- a/core/src/test/resources/openapi/regexParameters.yaml
+++ b/core/src/test/resources/openapi/regexParameters.yaml
@@ -1,0 +1,30 @@
+openapi: 3.0.3
+info:
+  version: '1.0'
+  title: Foo API Definition
+  description: Example API to reproduce Specmatic 0.60.0 issue.
+servers:
+  - url: http://api.example.com/v1
+    description: Optional server description, e.g. Main (production) server
+paths:
+  /v1/foo/{id}:
+    delete:
+      summary: Delete 'foo'
+      description: Deletes a specific product and returns status code 204.
+      operationId: foo.delete
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+            pattern: '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-000030[aA]{2}$'
+            # the regex above limits the length;
+            # however, some tools might require explicit settings:
+            minLength: 27
+            maxLength: 27
+          example: CAC10D70-0000-0000-000030AA
+          required: true
+          description: ID of the requested 'foo'
+      responses:
+        '204':
+          description: Successful operation


### PR DESCRIPTION
**What**:

Fix regression changes for handling parameters introduced in 0.60.0

**Why**:

This fix will restore correct string parameter handling if both `pattern` and `minLength`/`maxLength` are specified for them.

**How**:

- Partially rollback 1a73c8e to the previous version.
- Provide new test case.

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation N/A
- [x] Tests
- [ ] Sonar Quality Gate N/A

**Issue ID**:
Closes: #607