### PR TITLE
Chain ContractException with its cause

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Scenario.kt
@@ -207,7 +207,8 @@ data class Scenario(
             )
                 code()
         } catch (e: Throwable) {
-            throw ContractException("Couldn't match state values. Expected $expectedValue in key $key, actual value is $actualValue")
+            throw ContractException("Couldn't match state values. Expected $expectedValue in key $key" +
+                ", actual value is $actualValue", exceptionCause = e)
         }
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/ContractException.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/ContractException.kt
@@ -5,11 +5,19 @@ import `in`.specmatic.core.Result
 import `in`.specmatic.core.Scenario
 import `in`.specmatic.core.ScenarioDetailsForResult
 
-data class ContractException(val errorMessage: String = "", val breadCrumb: String = "", val exceptionCause: ContractException? = null, val scenario: ScenarioDetailsForResult? = null) : Exception(errorMessage) {
+data class ContractException(
+    val errorMessage: String = "",
+    val breadCrumb: String = "",
+    val exceptionCause: Throwable? = null,
+    val scenario: ScenarioDetailsForResult? = null,
+) : Exception(errorMessage, exceptionCause) {
     constructor(failureReport: FailureReport): this(failureReport.toText())
 
     fun failure(): Result.Failure =
-        Result.Failure(errorMessage, exceptionCause?.failure(), breadCrumb).also { result ->
+        Result.Failure(errorMessage,
+            if (exceptionCause is ContractException) exceptionCause.failure() else null,
+            breadCrumb
+        ).also { result ->
             if(scenario != null) result.updateScenario(scenario)
         }
 
@@ -24,7 +32,7 @@ fun <ReturnType> attempt(errorMessage: String = "", breadCrumb: String = "", f: 
         throw ContractException(errorMessage, breadCrumb, contractException)
     }
     catch(throwable: Throwable) {
-        throw ContractException("$errorMessage\nException thrown: $throwable", breadCrumb)
+        throw ContractException("$errorMessage\nException thrown: $throwable", breadCrumb, throwable)
     }
 }
 
@@ -33,7 +41,7 @@ fun <ReturnType> attempt(f: ()->ReturnType): ReturnType {
         return f()
     }
     catch(throwable: Throwable) {
-        throw ContractException("Exception thrown: ${throwable.localizedMessage}")
+        throw ContractException("Exception thrown: ${throwable.localizedMessage}", exceptionCause = throwable)
     }
 }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/Grammar.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/Grammar.kt
@@ -185,7 +185,7 @@ fun parsedPattern(rawContent: String, key: String? = null, typeAlias: String? = 
                         maxLength = restrictions["maxLength"]?.toIntOrNull()
                     )
                 } catch (e: IllegalArgumentException) {
-                    throw ContractException(e.message?:"")
+                    throw ContractException(e.message?:"", exceptionCause = e)
                 }
             }
             isNumberPatternWithRestrictions(it) -> {
@@ -200,7 +200,7 @@ fun parsedPattern(rawContent: String, key: String? = null, typeAlias: String? = 
                         maxLength = restrictions["maxLength"]?.toIntOrNull()
                     )
                 } catch (e: IllegalArgumentException) {
-                    throw ContractException(e.message?:"")
+                    throw ContractException(e.message?:"", exceptionCause = e)
                 }
             }
             isPatternToken(it) -> when {
@@ -250,12 +250,14 @@ fun parsedJSON(content: String, mismatchMessages: MismatchMessages = DefaultMism
             it.startsWith("{") -> try {
                 JSONObjectValue(jsonStringToValueMap(it))
             } catch (e: Throwable) {
-                throw ContractException("Could not parse json object, got error: ${e.localizedMessage ?: e.message}")
+                throw ContractException("Could not parse json object, got error: ${e.localizedMessage ?: e.message}",
+                    exceptionCause = e)
             }
             it.startsWith("[") -> try {
                 JSONArrayValue(jsonStringToValueArray(it))
             } catch (e: Throwable) {
-                throw ContractException("Could not parse json array, got error: ${e.localizedMessage ?: e.message}")
+                throw ContractException("Could not parse json array, got error: ${e.localizedMessage ?: e.message}",
+                    exceptionCause = e)
             }
             else -> throw ContractException(mismatchMessages.mismatchMessage("json value", stringInErrorMessage(content)))
         }
@@ -274,7 +276,8 @@ fun parsedJSONObject(content: String, mismatchMessages: MismatchMessages = Defau
             it.startsWith("{") -> try {
                 JSONObjectValue(jsonStringToValueMap(it))
             } catch (e: Throwable) {
-                throw ContractException("Could not parse json object, got error: ${e.localizedMessage ?: e.message}")
+                throw ContractException("Could not parse json object, got error: ${e.localizedMessage ?: e.message}",
+                    exceptionCause = e)
             }
             else -> throw ContractException(mismatchMessages.mismatchMessage("json object", stringInErrorMessage(content)))
         }
@@ -287,7 +290,8 @@ fun parsedJSONArray(content: String, mismatchMessages: MismatchMessages = Defaul
             it.startsWith("[") -> try {
                 JSONArrayValue(jsonStringToValueArray(it))
             } catch (e: Throwable) {
-                throw ContractException("Could not parse json array, got error: ${e.localizedMessage ?: e.message}")
+                throw ContractException("Could not parse json array, got error: ${e.localizedMessage ?: e.message}",
+                    exceptionCause = e)
             }
             else -> throw ContractException(mismatchMessages.mismatchMessage("json array", stringInErrorMessage(content)))
         }

--- a/core/src/main/kotlin/in/specmatic/core/utilities/ExternalCommand.kt
+++ b/core/src/main/kotlin/in/specmatic/core/utilities/ExternalCommand.kt
@@ -24,7 +24,8 @@ class ExternalCommand(
 
             out
         } catch (otherExceptions: Exception) {
-            throw ContractException("""Error running $commandWithParameters: ${otherExceptions.message}""")
+            throw ContractException("""Error running $commandWithParameters: ${otherExceptions.message}""",
+                exceptionCause = otherExceptions)
         }
     }
 }

--- a/core/src/main/kotlin/in/specmatic/core/utilities/Utilities.kt
+++ b/core/src/main/kotlin/in/specmatic/core/utilities/Utilities.kt
@@ -154,7 +154,8 @@ fun loadConfigJSON(configFile: File): JSONObjectValue {
     val configJson = try {
         parsedJSON(configFile.readText())
     } catch (e: Throwable) {
-        throw ContractException("Error reading the $globalConfigFileName: ${exceptionCauseMessage(e)}")
+        throw ContractException("Error reading the $globalConfigFileName: ${exceptionCauseMessage(e)}",
+            exceptionCause = e)
     }
 
     if (configJson !is JSONObjectValue)


### PR DESCRIPTION
- Otherwise traceability into the root causes of exceptions is lost.

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Chains `ContractException` with its cause.

<!-- Why are these changes necessary? -->

**Why**: To fix #614 and make it possible to perform root cause analysis on exceptions.

<!-- How were these changes implemented? -->

**How**: Follows standard practice of chaining an exception with its cause by passing the exception cause to the super class.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [X] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #614 

<!-- feel free to add additional comments -->
