### PR TITLE
Allow invalid request examples

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -249,7 +249,8 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
                                             ObjectMapper().readValue(valueString, Map::class.java).values.first()
                                                 .toString()
                                         } else valueString
-                                    })
+                                    },
+                                name = exampleName)
                             else -> Row()
                         }
                     }
@@ -279,7 +280,8 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
                             scenarioBreadCrumb(scenarioDetails) {
                                 httpRequestPattern.newBasedOn(
                                     row,
-                                    Resolver(newPatterns = this.patterns).copy(mismatchMessages = Scenario.ContractAndRowValueMismatch)
+                                    Resolver(newPatterns = this.patterns).copy(mismatchMessages = Scenario.ContractAndRowValueMismatch),
+                                    httpResponsePattern.status
                                 )
                             }
                         }

--- a/core/src/main/kotlin/in/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Scenario.kt
@@ -261,6 +261,7 @@ data class Scenario(
     }
 
     private fun newBasedOn(row: Row, generativeTestingEnabled: Boolean = false): List<Scenario> {
+        val ignoreFailure = this.ignoreFailure || row.name.startsWith("[WIP]")
         val resolver = Resolver(expectedFacts, false, patterns).copy(mismatchMessages = ContractAndRowValueMismatch, generativeTestingEnabled = generativeTestingEnabled)
 
         val newExpectedServerState = newExpectedServerStateBasedOn(row, expectedFacts, fixtures, resolver)

--- a/core/src/main/kotlin/in/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Scenario.kt
@@ -269,7 +269,7 @@ data class Scenario(
             null -> scenarioBreadCrumb(this) {
                 attempt {
                     when (isNegative) {
-                        false -> httpRequestPattern.newBasedOn(row, resolver)
+                        false -> httpRequestPattern.newBasedOn(row, resolver, httpResponsePattern.status)
                         else -> httpRequestPattern.negativeBasedOn(row, resolver.copy(isNegative = true))
                     }.map { newHttpRequestPattern ->
                         Scenario(

--- a/core/src/main/kotlin/in/specmatic/core/pattern/Row.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/Row.kt
@@ -12,7 +12,8 @@ data class Row(
     val columnNames: List<String> = emptyList(),
     val values: List<String> = emptyList(),
     val variables: Map<String, String> = emptyMap(),
-    val references: Map<String, References> = emptyMap()
+    val references: Map<String, References> = emptyMap(),
+    val name: String = ""
 ) {
     private val cells = columnNames.zip(values.map { it }).toMap().toMutableMap()
 

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
@@ -1848,6 +1848,77 @@ components:
     }
 
     @Test
+    fun `a test marked WIP should setup the scenario to ignore failure`() {
+        val contract = OpenApiSpecification.fromYAML("""
+openapi: "3.0.3"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  description: A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification
+  termsOfService: http://swagger.io/terms/
+  contact:
+    name: Swagger API Team
+    email: apiteam@swagger.io
+    url: http://swagger.io
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+servers:
+  - url: http://petstore.swagger.io/api
+paths:
+  /pets:
+    post:
+      summary: create a pet
+      description: Creates a new pet in the store. Duplicates are allowed
+      operationId: addPet
+      requestBody:
+        description: Pet to add to the store
+        required: true
+        content:
+          application/json:
+            schema:
+              ${'$'}ref: '#/components/schemas/NewPet'
+            examples:
+              "[WIP] SUCCESS":
+                value:
+                  name: 'Archie'
+      responses:
+        '200':
+          description: new pet record
+          content:
+            application/json:
+              schema:
+                ${'$'}ref: '#/components/schemas/Pet'
+              examples:
+                "[WIP] SUCCESS":
+                  value:
+                    id: 10
+                    name: Archie
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        name:
+          type: string
+        id:
+          type: integer
+    NewPet:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+""".trimIndent(), "").toFeature()
+
+        assertThat(contract.generateContractTestScenarios(emptyList()).single().ignoreFailure).isTrue
+    }
+
+    @Test
     fun `400 response in the contract should be used to match a 400 status response in a negative test even when a default response has been declared`() {
         val openAPISpec = """
             Feature: With default

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
@@ -8,6 +8,7 @@ import `in`.specmatic.core.log.logger
 import `in`.specmatic.core.pattern.ContractException
 import `in`.specmatic.core.pattern.parsedJSONObject
 import `in`.specmatic.core.value.JSONObjectValue
+import `in`.specmatic.core.value.NumberValue
 import `in`.specmatic.core.value.StringValue
 import `in`.specmatic.core.value.Value
 import `in`.specmatic.mock.ScenarioStub
@@ -1734,6 +1735,113 @@ Scenario: zero should return not found
             println(results.report())
 
             assertThat(results.success()).isTrue
+        } finally {
+            System.clearProperty(Flags.negativeTestingFlag)
+        }
+    }
+
+    @Test
+    fun `contract-invalid test should be allowed for 400 request`() {
+        val contract = OpenApiSpecification.fromYAML("""
+openapi: "3.0.3"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  description: A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification
+  termsOfService: http://swagger.io/terms/
+  contact:
+    name: Swagger API Team
+    email: apiteam@swagger.io
+    url: http://swagger.io
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+servers:
+  - url: http://petstore.swagger.io/api
+paths:
+  /pets:
+    post:
+      summary: create a pet
+      description: Creates a new pet in the store. Duplicates are allowed
+      operationId: addPet
+      requestBody:
+        description: Pet to add to the store
+        required: true
+        content:
+          application/json:
+            schema:
+              ${'$'}ref: '#/components/schemas/NewPet'
+            examples:
+              SUCCESS:
+                value:
+                  name: 'Archie'
+              INVALID:
+                value:
+                  name: 10
+      responses:
+        '200':
+          description: new pet record
+          content:
+            application/json:
+              schema:
+                ${'$'}ref: '#/components/schemas/Pet'
+              examples:
+                SUCCESS:
+                  value:
+                    id: 10
+                    name: Archie
+        '400':
+          description: invalid request
+          content:
+            application/json:
+              examples:
+                INVALID:
+                  value:
+                    message: Name must be a strings
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        name:
+          type: string
+        id:
+          type: integer
+    NewPet:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+""".trimIndent(), "").toFeature()
+
+        var contractInvalidValueReceived = false
+
+        try {
+            contract.executeTests(object : TestExecutor {
+                override fun execute(request: HttpRequest): HttpResponse {
+                    val jsonBody = request.body as JSONObjectValue
+
+                    if(jsonBody.jsonObject["name"] is NumberValue)
+                        contractInvalidValueReceived = true
+
+                    return HttpResponse(422, body = parsedJSONObject("""{"message": "invalid request"}"""))
+                }
+
+                override fun setServerState(serverState: Map<String, Value>) {
+                }
+            })
+
+            assertThat(contractInvalidValueReceived).isTrue
         } finally {
             System.clearProperty(Flags.negativeTestingFlag)
         }


### PR DESCRIPTION
**What**:

Examples can now be marked WIP. A WIP example is similar to a WIP scenario, in that if the example fails, it gets logged but is not considered a failure but Specmatic. JUnit will ignore the failure, the return value on the command-line will be 0 (if the failing test from the WIP example is the only failure) and the failure will not break any build.

**Why**:

There are times when we wish to add an example that should trigger a 400 but instead triggers a 500 (or even a 200 response), and commit this contract to a repo even if the resulting contract test fails. We wish to keep the example so that the feedback is not lost, but cannot afford to break the build as the developer needs time to fix the problem.

**How**:

- The Row class now accepts a name.
- When generating a test from a row, Specmatic now checks if it is a WIP row, if so sets the ignoreFailures flag on the test.
- Specmatic does not validate an example if it is for a 400 or 422 response. This works only for examples inside a yaml file.

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [/] Tests
- [/] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #123

<!-- feel free to add additional comments -->
