### PR TITLE
Lenient matching of the paths in a Gherkin wrapper against the wrapped specification

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/ApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/ApiSpecification.kt
@@ -1,0 +1,17 @@
+package `in`.specmatic.conversions
+
+import `in`.specmatic.core.Resolver
+import `in`.specmatic.core.URLPathPattern
+
+interface ApiSpecification {
+    fun exactValuePatternsAreEqual(
+        openapiURLPart: URLPathPattern,
+        wrapperURLPart: URLPathPattern
+    ): Boolean
+
+    fun patternMatchesExact(
+        wrapperURLPart: URLPathPattern,
+        openapiURLPart: URLPathPattern,
+        resolver: Resolver,
+    ): Boolean
+}

--- a/core/src/main/kotlin/in/specmatic/core/ScenarioInfo.kt
+++ b/core/src/main/kotlin/in/specmatic/core/ScenarioInfo.kt
@@ -1,8 +1,7 @@
 package `in`.specmatic.core
 
-import `in`.specmatic.core.pattern.Examples
-import `in`.specmatic.core.pattern.KafkaMessagePattern
-import `in`.specmatic.core.pattern.Pattern
+import `in`.specmatic.conversions.ApiSpecification
+import `in`.specmatic.core.pattern.*
 import `in`.specmatic.core.value.Value
 
 data class ScenarioInfo(
@@ -21,4 +20,42 @@ data class ScenarioInfo(
 ) {
     fun matchesSignature(other: ScenarioInfo) = httpRequestPattern.matchesSignature(other.httpRequestPattern) &&
             httpResponsePattern.status == other.httpResponsePattern.status
+
+    fun matchesGherkinWrapperPath(scenarioInfos: List<ScenarioInfo>, apiSpecification: ApiSpecification): List<ScenarioInfo> =
+        scenarioInfos.filter { openApiScenarioInfo ->
+            val pathPatternFromOpenApi = openApiScenarioInfo.httpRequestPattern.urlMatcher!!.pathPattern
+            val pathPatternFromWrapper = this.httpRequestPattern.urlMatcher!!.pathPattern
+
+            if(pathPatternFromOpenApi.size != pathPatternFromWrapper.size)
+                return@filter false
+
+            val resolver = Resolver(newPatterns = openApiScenarioInfo.patterns)
+            val zipped = pathPatternFromOpenApi.zip(pathPatternFromWrapper)
+
+            zipped.all { (openapiURLPart: URLPathPattern, wrapperURLPart: URLPathPattern) ->
+                val openapiType = if(openapiURLPart.pattern is ExactValuePattern) "exact" else "pattern"
+                val wrapperType = if(wrapperURLPart.pattern is ExactValuePattern) "exact" else "pattern"
+
+                when(Pair(openapiType, wrapperType)) {
+                    Pair("exact", "exact") -> apiSpecification.exactValuePatternsAreEqual(openapiURLPart, wrapperURLPart)
+                    Pair("exact", "pattern") -> false
+                    Pair("pattern", "exact") -> {
+                        attempt("Error matching url ${this.httpRequestPattern.urlMatcher.path} to the specification") {
+                            apiSpecification.patternMatchesExact(
+                                wrapperURLPart,
+                                openapiURLPart,
+                                resolver
+                            )
+                        }
+                    }
+                    Pair("pattern", "pattern") -> {
+                        val valueFromOpenapi = openapiURLPart.pattern.generate(Resolver(newPatterns = openApiScenarioInfo.patterns))
+                        val valueFromWrapper = wrapperURLPart.pattern.generate(Resolver(newPatterns = this.patterns))
+
+                        valueFromOpenapi.javaClass == valueFromWrapper.javaClass
+                    }
+                    else -> false
+                }
+            }
+        }
 }

--- a/core/src/main/kotlin/in/specmatic/core/URLMatcher.kt
+++ b/core/src/main/kotlin/in/specmatic/core/URLMatcher.kt
@@ -143,7 +143,7 @@ data class URLMatcher(val queryPattern: Map<String, Pattern>, val pathPattern: L
                                     is Failure -> throw ContractException(result.toFailureReport())
                                 }
                             }
-                            else -> attempt("Format error in example of \"$key\"") {
+                            else -> attempt("Format error in example of path parameter \"$key\"") {
                                 val value = urlPathPattern.parse(rowValue, resolver)
 
                                 val matchResult = urlPathPattern.matches(value, resolver)

--- a/core/src/main/kotlin/in/specmatic/core/URLMatcher.kt
+++ b/core/src/main/kotlin/in/specmatic/core/URLMatcher.kt
@@ -144,9 +144,15 @@ data class URLMatcher(val queryPattern: Map<String, Pattern>, val pathPattern: L
                                 }
                             }
                             else -> attempt("Format error in example of \"$key\"") {
+                                val value = urlPathPattern.parse(rowValue, resolver)
+
+                                val matchResult = urlPathPattern.matches(value, resolver)
+                                if(matchResult is Failure)
+                                    throw ContractException("""Could not run contract test, the example value ${value.toStringLiteral()} provided "id" does not match the contract.""")
+
                                 URLPathPattern(
                                     ExactValuePattern(
-                                        urlPathPattern.parse(rowValue, resolver)
+                                        value
                                     )
                                 )
                             }

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
@@ -2439,9 +2439,9 @@ components:
                 Then status 200
                 
                 Examples:
-                | id  |
-                | 123 |
-                | 234 |
+                | id         |
+                | 1234567890 |
+                | 0987654321 |
         """.trimIndent())
 
         var testCount = 0

--- a/core/src/test/resources/openapi/hello_with_constraints.yaml
+++ b/core/src/test/resources/openapi/hello_with_constraints.yaml
@@ -1,0 +1,52 @@
+openapi: 3.0.0
+info:
+  title: Sample API
+  description: Optional multiline or single-line description in [CommonMark](http://commonmark.org/help/) or HTML.
+  version: 0.1.9
+servers:
+  - url: http://api.example.com/v1
+    description: Optional server description, e.g. Main (production) server
+  - url: http://staging-api.example.com
+    description: Optional server description, e.g. Internal staging server for testing
+paths:
+  /hello/{id}:
+    get:
+      summary: hello world
+      description: Optional extended description in CommonMark or HTML.
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+            minLength: 10
+            maxLength: 20
+          required: true
+          description: Numeric ID
+      responses:
+        '200':
+          description: Says hello
+          content:
+            application/json:
+              schema:
+                type: string
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                type: string
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: string
+
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+
+security:
+  - BearerAuth: []

--- a/core/src/test/resources/openapi/hello_with_constraints.yaml
+++ b/core/src/test/resources/openapi/hello_with_constraints.yaml
@@ -17,11 +17,11 @@ paths:
         - in: path
           name: id
           schema:
-            type: integer
+            type: string
             minLength: 10
             maxLength: 20
           required: true
-          description: Numeric ID
+          description: Alphanumeric ID
       responses:
         '200':
           description: Says hello


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

The path in Gherkin wrapper scenarios are matched leniently against paths in the wrapped OpenAPI specification. For example, /order/(id:string) in the wrapper will match /order/{id} in the OpenAPI specification, where id is a string with minLength 20.

**Why**:

It's not possible to express constraints like minLength or maxLength in Gherkin yet. In fact in a wrapper, it's usually not necessary as the path is only provided for the purpose of identifying the corresponding operation in the OpenAPI specification.

**How**:

1. For a path param in an OpenAPI specification, e.g. /order/{id} where id is a string with minLength 10
- when the wrapper is a type, consider it a match with the specification if the two types are the same, ignoring any constraints, e.g. /order/(id:string) would match the specification
- when the wrapper has a specific value, consider it a match with the specification if the specification's type matches the wrapper's value, e.g. /order/1234567890 would match the specification, but /order/123 would not.
2. For all path parameters, take the id from the Gherkin instead of the specification, as the Gherkin will have examples matching the id, and once the specification has been loaded (which it is by the time we are doing the match), the id from the specification is of no more use.

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

**Issue ID**:
Closes: #607

