### PR TITLE
Leading trailing slash

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Feature.kt
@@ -571,12 +571,14 @@ data class Feature(
 
     fun toOpenAPIURLPrefixMap(urls: List<String>, mappedURLType: MappedURLType): Map<String, String> {
         val normalisedURL = urls.map { url ->
-            url.removeSuffix("/").removePrefix("http://").removePrefix("https://").split("/").joinToString("/") {
-                if(it.toIntOrNull() != null)
-                    "1"
-                else
-                    it
-            }.let { if(it.startsWith("/")) it else "/$it"}
+            val path =
+                url.removeSuffix("/").removePrefix("http://").removePrefix("https://").split("/").joinToString("/") {
+                    if (it.toIntOrNull() != null)
+                        "1"
+                    else
+                        it
+                }
+            path.let { if(it.startsWith("/")) it else "/$it"}.let { if(url.endsWith("/") && ! it.endsWith("/")) "$it/" else it }
         }.distinct()
 
         val minLength = normalisedURL.map {

--- a/core/src/main/kotlin/in/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Feature.kt
@@ -578,7 +578,7 @@ data class Feature(
                     else
                         it
                 }
-            path.let { if(it.startsWith("/")) it else "/$it"}.let { if(url.endsWith("/") && ! it.endsWith("/")) "$it/" else it }
+            path.let { if(it.startsWith("/")) it else "/$it"}
         }.distinct()
 
         val minLength = normalisedURL.map {

--- a/core/src/main/kotlin/in/specmatic/core/URLMatcher.kt
+++ b/core/src/main/kotlin/in/specmatic/core/URLMatcher.kt
@@ -113,7 +113,11 @@ data class URLMatcher(val queryPattern: Map<String, Pattern>, val pathPattern: L
                         else urlPathPattern.pattern.generate(cyclePreventedResolver)
                     }
                 }
-            }.joinToString("/")).let { if(path.endsWith("/") && ! it.endsWith("/")) "$it/" else it }
+            }.joinToString("/")).let {
+                if(path.endsWith("/") && ! it.endsWith("/")) "$it/" else it
+            }.let {
+                if(path.startsWith("/") && ! it.startsWith("/")) "$/it" else it
+            }
         }
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/URLMatcher.kt
+++ b/core/src/main/kotlin/in/specmatic/core/URLMatcher.kt
@@ -104,7 +104,7 @@ data class URLMatcher(val queryPattern: Map<String, Pattern>, val pathPattern: L
 
     fun generatePath(resolver: Resolver): String {
         return attempt(breadCrumb = "PATH") {
-            "/" + pathPattern.mapIndexed { index, urlPathPattern ->
+            ("/" + pathPattern.mapIndexed { index, urlPathPattern ->
                 attempt(breadCrumb = "[$index]") {
                     val key = urlPathPattern.key
                     resolver.withCyclePrevention(urlPathPattern.pattern) { cyclePreventedResolver ->
@@ -113,7 +113,7 @@ data class URLMatcher(val queryPattern: Map<String, Pattern>, val pathPattern: L
                         else urlPathPattern.pattern.generate(cyclePreventedResolver)
                     }
                 }
-            }.joinToString("/")
+            }.joinToString("/")).let { if(path.endsWith("/") && ! it.endsWith("/")) "$it/" else it }
         }
     }
 


### PR DESCRIPTION
**What**:

Handle trailing slashes correctly

**Why**:

Specmatic removes trailing slashes in URL paths. This is not right.

**How**:

Specmatic now takes care not to remove the trailing slash.

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

