### PR TITLE
Avoid combinatorial explosion during test generation

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/Flags.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Flags.kt
@@ -5,6 +5,7 @@ import org.apache.commons.lang3.BooleanUtils
 object Flags {
     private const val customResponseName = "CUSTOM_RESPONSE"
     const val negativeTestingFlag = "SPECMATIC_GENERATIVE_TESTS"
+    const val maxTestRequestCombinationsFlag = "MAX_TEST_REQUEST_COMBINATIONS"
 
     private fun flagValue(flagName: String): String? {
         return System.getenv(flagName) ?: System.getProperty(flagName)
@@ -16,5 +17,9 @@ object Flags {
 
     fun generativeTestingEnabled(): Boolean {
         return BooleanUtils.toBoolean(flagValue(negativeTestingFlag) ?: "false")
+    }
+
+    fun maxTestRequestCombinations(): Int {
+        return (flagValue(maxTestRequestCombinationsFlag) ?: "64").toInt()
     }
 }

--- a/core/src/main/kotlin/in/specmatic/core/Flags.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Flags.kt
@@ -20,6 +20,6 @@ object Flags {
     }
 
     fun maxTestRequestCombinations(): Int {
-        return (flagValue(maxTestRequestCombinationsFlag) ?: "64").toInt()
+        return flagValue(maxTestRequestCombinationsFlag)?.toInt() ?: Int.MAX_VALUE
     }
 }

--- a/core/src/main/kotlin/in/specmatic/core/pattern/CombinationSpec.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/CombinationSpec.kt
@@ -1,0 +1,83 @@
+package `in`.specmatic.core.pattern
+
+import kotlin.math.min
+
+/**
+ * Provides utility access to all combinations of multiple sets of candidate values. Represented as the cartesian
+ * product of all sets where each combination is represented as a numerical index from 0 to (MAX_COMBOS - 1).
+ *
+ * Supports sequential iteration over all combinations, which is used to test as many combinations as possible.
+ *
+ * Supports translating a combination of candidate values to an index, which is used to first test priority combinations
+ * (and to remember these when later iterating remaining combinations to not double-include these priority combinations)
+ *
+ * See <a href="https://softwareengineering.stackexchange.com/questions/228478/testing-all-combinations"> this
+ * stackoverflow article</a> accepted answer. A notable difference is that our representation is reversed such that
+ * a sequential iteration produces all combinations with the first candidate value of the first set before producing
+ * all combinations using the second candidate value of the first set, and so on for each subsequent value and set.
+ */
+class CombinationSpec<ValueType>(
+    keyToCandidatesOrig: Map<String, List<ValueType>>,
+    private val maxCombinations: Int,
+) {
+    init {
+        if (maxCombinations < 1) throw IllegalArgumentException("maxCombinations must be > 0 and <= ${Int.MAX_VALUE}")
+    }
+    // Omit entries without any candidate values
+    private val keyToCandidates = keyToCandidatesOrig.filterValues { it.isNotEmpty() }
+    private val indexToKeys = keyToCandidates.keys.toList()
+    private val indexToCandidates = keyToCandidates.values
+    private val maxCandidateCount = indexToCandidates.maxOfOrNull { it.size } ?: 0
+    private val allCombosCount = indexToCandidates.map { it.size.toLong()}.reduceOrNull{ acc, cnt -> acc * cnt} ?: 0
+    private val reversedIndexToKeys = indexToKeys.reversed()
+    private val reversedIndexToCandidates = indexToCandidates.reversed()
+    private val lastCombination = min(maxCombinations, min(allCombosCount, Int.MAX_VALUE.toLong()).toInt()) - 1
+    private val prioritizedComboIndexes = calculatePrioritizedComboIndexes()
+
+    val selectedCombinations = toSelectedCombinations()
+
+    private fun calculatePrioritizedComboIndexes(): List<Int> {
+        // Prioritizes using each candidate value as early as possible so uses first candidate of each set,
+        // then second candidate, and so on.
+        val prioritizedCombos = (0 until maxCandidateCount).map { lockStepOffset ->
+            val fullComboIndex = indexToCandidates.foldIndexed(0) {index, acc, candidates ->
+                // Lower-cardinality sets run out of candidates first so are reused round-robin until other sets finish
+                val candidateOffset = lockStepOffset % candidates.size
+
+                toComboIndex(candidates.size, candidateOffset, acc)
+            }
+            // val combo = toCombo(finalComboIndex)
+            fullComboIndex
+        }
+        return prioritizedCombos
+    }
+
+    // Combo index is based on each candidate set size and offset, plus any index accumulated so far
+    private fun toComboIndex(candidateSetSize: Int, candidateOffset: Int, comboIndexSoFar: Int) =
+        (comboIndexSoFar * candidateSetSize) + candidateOffset
+
+    private fun toSelectedCombinations(): List<Map<String, ValueType>> {
+        val prioritizedCombos = prioritizedComboIndexes.map { toCombo(it) }
+        val remainingCombos = (0 .. lastCombination)
+            .filterNot { prioritizedComboIndexes.contains(it) }
+            .map { toCombo(it) }
+
+        val combined = prioritizedCombos.plus(remainingCombos)
+
+        val combinedAndTrimmed = if (combined.size > maxCombinations)
+            combined.subList(0, maxCombinations)
+        else combined
+
+        return combinedAndTrimmed
+    }
+    private fun toCombo(comboIndex: Int): Map<String, ValueType> {
+        var subIndex = comboIndex
+
+        return reversedIndexToCandidates.mapIndexed{ reversedIndex, candidates ->
+            val candidateOffset = subIndex % candidates.size
+            subIndex /= candidates.size
+            reversedIndexToKeys[reversedIndex] to  candidates[candidateOffset]
+        }.toMap()
+    }
+
+}

--- a/core/src/main/kotlin/in/specmatic/core/pattern/TabularPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/TabularPattern.kt
@@ -235,15 +235,8 @@ fun <ValueType> patternList(patternCollection: Map<String, List<ValueType>>): Li
     if (patternCollection.isEmpty())
         return listOf(emptyMap())
 
-    val key = patternCollection.keys.first()
-
-    return (patternCollection[key] ?: throw ContractException("key $key should not be empty in $patternCollection"))
-        .flatMap { pattern ->
-            val subLists = patternList(patternCollection - key)
-            subLists.map { generatedPatternMap ->
-                generatedPatternMap.plus(Pair(key, pattern))
-            }
-        }
+    val spec = CombinationSpec(patternCollection, Flags.maxTestRequestCombinations())
+    return spec.selectedCombinations;
 }
 
 fun <ValueType> patternValues(patternCollection: Map<String, List<ValueType>>): List<Map<String, ValueType>> {

--- a/core/src/test/kotlin/in/specmatic/core/FeatureKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/FeatureKtTest.kt
@@ -1,5 +1,6 @@
 package `in`.specmatic.core
 
+import `in`.specmatic.conversions.OpenApiSpecification
 import org.assertj.core.api.Assertions.assertThat
 import `in`.specmatic.core.pattern.*
 import `in`.specmatic.core.value.JSONObjectValue
@@ -571,6 +572,72 @@ paths:
         @Test
         fun `parsing OpenAPI spec should preserve the bindings declared in the gherkin spec`() {
             assertThat(feature.scenarios.first().bindings.contains("data"))
+        }
+    }
+
+    @Test
+    fun test() {
+        val contract = OpenApiSpecification.fromYAML("""
+openapi: 3.0.0
+info:
+  title: Sample API
+  version: 0.1.9
+paths:
+  /data:
+    post:
+      summary: hello world
+      description: test
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                data1:
+                  type: string
+                data2:
+                  type: string
+              required:
+                - data1
+                - data2
+      responses:
+        '200':
+          description: Says hello
+          content:
+            text/plain:
+              schema:
+                type: number
+        """.trimIndent(), "").toFeature()
+
+        val withGenerativeTestsEnabled = contract.copy(generativeTestingEnabled = true)
+
+        val tests: List<Scenario> = withGenerativeTestsEnabled.generateContractTestScenarios(emptyList())
+
+        val expectedRequestTypes: List<Pair<String, String>> = listOf(
+            Pair("(string)", "(string)"),
+            Pair("(string)", "(null)"),
+            Pair("(string)", "(number)"),
+            Pair("(string)", "(boolean)"),
+            Pair("(null)", "(string)"),
+            Pair("(number)", "(string)"),
+            Pair("(boolean)", "(string)")
+        )
+
+        val actualRequestTypes: List<Pair<String, String>> = tests.map {
+            val bodyType = it.httpRequestPattern.body as JSONObjectPattern
+            bodyType.pattern["data2"].toString()to bodyType.pattern["data1"].toString()
+        }
+
+        actualRequestTypes.forEach { keyTypesInRequest ->
+            assertThat(expectedRequestTypes).contains(keyTypesInRequest)
+        }
+
+        assertThat(actualRequestTypes.size).isEqualTo(expectedRequestTypes.size)
+
+        tests.forEach {
+            println(it.testDescription())
+            println(it.httpRequestPattern.body.toString())
+            println()
         }
     }
 

--- a/core/src/test/kotlin/in/specmatic/core/FeatureKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/FeatureKtTest.kt
@@ -576,7 +576,7 @@ paths:
     }
 
     @Test
-    fun test() {
+    fun `should generate all required negative tests`() {
         val contract = OpenApiSpecification.fromYAML("""
 openapi: 3.0.0
 info:

--- a/core/src/test/kotlin/in/specmatic/core/pattern/CombinationSpecTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/CombinationSpecTest.kt
@@ -1,0 +1,134 @@
+package `in`.specmatic.core.pattern
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+class CombinationSpecTest {
+
+  @Test
+  fun `error when maxCombinations less than 1`() {
+    assertThatThrownBy{ CombinationSpec<Int>(mapOf(), 0) }.hasMessageContaining("must be > 0")
+    assertThatThrownBy{ CombinationSpec<Int>(mapOf(), -1) }.hasMessageContaining("must be > 0")
+  }
+
+  @Test
+  fun `empty list when no candidate sets supplied`() {
+    assertThat(CombinationSpec<Long>(mapOf(), 50).selectedCombinations).isEmpty()
+  }
+
+  @Test
+  fun `combination omitted when candidate set empty`() {
+    val spec = CombinationSpec(mapOf("k1" to listOf(), "k2" to listOf(21, 22)), 50)
+    assertThat(spec.selectedCombinations).containsExactly(mapOf("k2" to 21), mapOf("k2" to 22),)
+  }
+
+  @Test
+  fun `produces all combos and orders and prioritized first`() {
+    val spec = CombinationSpec<Long>(
+      mapOf(
+        "k1" to listOf(12, 14),
+        "k2" to listOf(25, 22, 28, 27),
+        "k3" to listOf(39, 33, 31),
+      ),
+      50,
+    )
+    assertThat(spec.selectedCombinations).containsExactly(
+      // Prioritized first
+      mapOf("k1" to 12, "k2" to 25, "k3" to 39),
+      mapOf("k1" to 14, "k2" to 22, "k3" to 33),
+      mapOf("k1" to 12, "k2" to 28, "k3" to 31),
+      mapOf("k1" to 14, "k2" to 27, "k3" to 39),
+
+      // Remaining combos
+//      mapOf("k1" to 12, "k2" to 25, "k3" to 39), // Already included in prioritized list
+      mapOf("k1" to 12, "k2" to 25, "k3" to 33),
+      mapOf("k1" to 12, "k2" to 25, "k3" to 31),
+      mapOf("k1" to 12, "k2" to 22, "k3" to 39),
+      mapOf("k1" to 12, "k2" to 22, "k3" to 33),
+      mapOf("k1" to 12, "k2" to 22, "k3" to 31),
+      mapOf("k1" to 12, "k2" to 28, "k3" to 39),
+      mapOf("k1" to 12, "k2" to 28, "k3" to 33),
+//      mapOf("k1" to 12, "k2" to 28, "k3" to 31), // Already included in prioritized list
+      mapOf("k1" to 12, "k2" to 27, "k3" to 39),
+      mapOf("k1" to 12, "k2" to 27, "k3" to 33),
+      mapOf("k1" to 12, "k2" to 27, "k3" to 31),
+      mapOf("k1" to 14, "k2" to 25, "k3" to 39),
+      mapOf("k1" to 14, "k2" to 25, "k3" to 33),
+      mapOf("k1" to 14, "k2" to 25, "k3" to 31),
+      mapOf("k1" to 14, "k2" to 22, "k3" to 39),
+//      mapOf("k1" to 14, "k2" to 22, "k3" to 33), // Already included in prioritized list
+      mapOf("k1" to 14, "k2" to 22, "k3" to 31),
+      mapOf("k1" to 14, "k2" to 28, "k3" to 39),
+      mapOf("k1" to 14, "k2" to 28, "k3" to 33),
+      mapOf("k1" to 14, "k2" to 28, "k3" to 31),
+//      mapOf("k1" to 14, "k2" to 27, "k3" to 39), // Already included in prioritized list
+      mapOf("k1" to 14, "k2" to 27, "k3" to 33),
+      mapOf("k1" to 14, "k2" to 27, "k3" to 31),
+    )
+  }
+
+  @Test
+  fun `restricts combos when count too high and orders with prioritized first`() {
+    val spec = CombinationSpec<Long>(
+      mapOf(
+        "k1" to listOf(12, 14),
+        "k2" to listOf(25, 22, 28, 27),
+        "k3" to listOf(39, 33, 31),
+      ),
+      23,
+    )
+    assertThat(spec.selectedCombinations).containsExactly(
+      // Prioritized first
+      mapOf("k1" to 12, "k2" to 25, "k3" to 39),
+      mapOf("k1" to 14, "k2" to 22, "k3" to 33),
+      mapOf("k1" to 12, "k2" to 28, "k3" to 31),
+      mapOf("k1" to 14, "k2" to 27, "k3" to 39),
+
+      // Remaining combos
+//      mapOf("k1" to 12, "k2" to 25, "k3" to 39),
+      mapOf("k1" to 12, "k2" to 25, "k3" to 33),
+      mapOf("k1" to 12, "k2" to 25, "k3" to 31),
+      mapOf("k1" to 12, "k2" to 22, "k3" to 39),
+      mapOf("k1" to 12, "k2" to 22, "k3" to 33),
+      mapOf("k1" to 12, "k2" to 22, "k3" to 31),
+      mapOf("k1" to 12, "k2" to 28, "k3" to 39),
+      mapOf("k1" to 12, "k2" to 28, "k3" to 33),
+//      mapOf("k1" to 12, "k2" to 28, "k3" to 31), // Already included in prioritized list
+      mapOf("k1" to 12, "k2" to 27, "k3" to 39),
+      mapOf("k1" to 12, "k2" to 27, "k3" to 33),
+      mapOf("k1" to 12, "k2" to 27, "k3" to 31),
+      mapOf("k1" to 14, "k2" to 25, "k3" to 39),
+      mapOf("k1" to 14, "k2" to 25, "k3" to 33),
+      mapOf("k1" to 14, "k2" to 25, "k3" to 31),
+      mapOf("k1" to 14, "k2" to 22, "k3" to 39),
+//      mapOf("k1" to 14, "k2" to 22, "k3" to 33), // Already included in prioritized list
+      mapOf("k1" to 14, "k2" to 22, "k3" to 31),
+      mapOf("k1" to 14, "k2" to 28, "k3" to 39),
+      mapOf("k1" to 14, "k2" to 28, "k3" to 33),
+      mapOf("k1" to 14, "k2" to 28, "k3" to 31),
+//      mapOf("k1" to 14, "k2" to 27, "k3" to 39), // Already included in prioritized list
+      mapOf("k1" to 14, "k2" to 27, "k3" to 33),
+//      mapOf("k1" to 14, "k2" to 27, "k3" to 31), // Omitted to not exceed maxCombinations count
+    )
+  }
+
+  @Test
+  fun `restricts combos even when prioritized count is too high`() {
+    val spec = CombinationSpec<Long>(
+      mapOf(
+        "k1" to listOf(12, 14),
+        "k2" to listOf(25, 22, 28, 27),
+        "k3" to listOf(39, 33, 31),
+      ),
+      3,
+    )
+    assertThat(spec.selectedCombinations).containsExactly(
+      // Prioritized first
+      mapOf("k1" to 12, "k2" to 25, "k3" to 39),
+      mapOf("k1" to 14, "k2" to 22, "k3" to 33),
+      mapOf("k1" to 12, "k2" to 28, "k3" to 31),
+    )
+  }
+
+}

--- a/core/src/test/kotlin/in/specmatic/core/pattern/JSONObjectPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/JSONObjectPatternTest.kt
@@ -113,6 +113,22 @@ internal class JSONObjectPatternTest {
     }
 
     @Test
+    fun `Should avoid combinatorial explosion when many request properties with many possible values`() {
+        val resolver = Resolver(
+            newPatterns = (1..6).map { paramIndex ->
+                "(enum${paramIndex})" to AnyPattern((0..9).map { possibleValueIndex ->
+                    ExactValuePattern(StringValue("${paramIndex}${possibleValueIndex}"))
+                }.toList())
+            }.toMap()
+        )
+
+        val objPattern = parsedPattern("""{"p1": "(enum1)", "p2": "(enum2)", "p3": "(enum3)", "p4": "(enum4)", "p5": "(enum5)", "p6": "(enum6)"}""")
+
+        val newPatterns = objPattern.newBasedOn(Row(), resolver)
+        assertThat(newPatterns).hasSize(64)
+    }
+
+    @Test
     fun `When generating a new pattern based on a row, a concrete pattern value in the object should not become a concrete value`() {
         val resolver = Resolver()
 

--- a/core/src/test/kotlin/in/specmatic/core/pattern/JSONObjectPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/JSONObjectPatternTest.kt
@@ -124,7 +124,13 @@ internal class JSONObjectPatternTest {
 
         val objPattern = parsedPattern("""{"p1": "(enum1)", "p2": "(enum2)", "p3": "(enum3)", "p4": "(enum4)", "p5": "(enum5)", "p6": "(enum6)"}""")
 
-        val newPatterns = objPattern.newBasedOn(Row(), resolver)
+
+        System.setProperty("MAX_TEST_REQUEST_COMBINATIONS", "64")
+        val newPatterns = try {
+            objPattern.newBasedOn(Row(), resolver)
+        } finally {
+            System.clearProperty("MAX_TEST_REQUEST_COMBINATIONS")
+        }
         assertThat(newPatterns).hasSize(64)
     }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Avoids combinatorial explosion during test generation

<!-- Why are these changes necessary? -->

**Why**: Fixes #625 . Without this wait-time and used memory become unacceptable even in basic cases, since the previous implementation produces the cartesian product of each request property's possible values.

<!-- How were these changes implemented? -->

**How**: Introduces CombinationSpec to support producing as many test combinations as possible up to a configured max, while also ensuring every candidate value is tested in at least one test combination.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [X] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #625 

<!-- feel free to add additional comments -->
