### PR TITLE
Format contract test descriptions for better devex

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -305,13 +305,6 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
                                 get() = httpRequestPattern.urlMatcher?.path ?: ""
                             override val status: Int
                                 get() = httpResponsePattern.status
-                            override val requestTestDescription: String
-                                get() = httpRequestPattern.testDescription()
-
-                            override val exampleName: String?
-                                get() = null
-                            override val isNegative: Boolean
-                                get() = false
 
                             override fun testDescription(): String {
                                 TODO("Not yet implemented")

--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -307,6 +307,9 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
                                 get() = httpResponsePattern.status
                             override val requestTestDescription: String
                                 get() = httpRequestPattern.testDescription()
+
+                            override val exampleName: String?
+                                get() = null
                         }
 
                         specmaticExampleRows.forEach { row ->

--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -310,6 +310,12 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
 
                             override val exampleName: String?
                                 get() = null
+                            override val isNegative: Boolean
+                                get() = false
+
+                            override fun testDescription(): String {
+                                TODO("Not yet implemented")
+                            }
                         }
 
                         specmaticExampleRows.forEach { row ->

--- a/core/src/main/kotlin/in/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Feature.kt
@@ -274,7 +274,7 @@ data class Feature(
 
     fun generateContractTests(suggestions: List<Scenario>): List<ContractTest> =
         generateContractTestScenarios(suggestions).map {
-            ScenarioTest(it, Flags.generativeTestingEnabled())
+            ScenarioTest(it, generativeTestingEnabled)
         }
 
     private fun getBadRequestsOrDefault(scenario: Scenario): BadRequestOrDefault? {
@@ -313,7 +313,7 @@ data class Feature(
             it.isA2xxScenario()
         }.map { scenario ->
             val negativeScenario = scenario.negativeBasedOn(getBadRequestsOrDefault(scenario))
-            val negativeTestScenarios = negativeScenario.generateTestScenarios(testVariables, testBaseURLs)
+            val negativeTestScenarios = negativeScenario.generateTestScenarios(testVariables, testBaseURLs, true)
 
             negativeTestScenarios.filterNot { negativeTestScenario ->
                 val sampleRequest = negativeTestScenario.httpRequestPattern.generate(negativeTestScenario.resolver)

--- a/core/src/main/kotlin/in/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpRequestPattern.kt
@@ -399,7 +399,7 @@ data class HttpRequestPattern(
                                 throw ContractException(result.toFailureReport())
                         }
 
-                        if(Flags.generativeTestingEnabled()) {
+                        if(resolver.generativeTestingEnabled) {
                             val rowWithRequestBodyAsIs = listOf(ExactValuePattern(value))
 
                             val requestsFromFlattenedRow: List<Pattern> =
@@ -413,7 +413,7 @@ data class HttpRequestPattern(
                         }
                     } else {
 
-                        if(Flags.generativeTestingEnabled()) {
+                        if(resolver.generativeTestingEnabled) {
                             val vanilla = resolver.withCyclePrevention(body) { cyclePreventedResolver ->
                                 body.newBasedOn(Row(), cyclePreventedResolver)
                             }

--- a/core/src/main/kotlin/in/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpRequestPattern.kt
@@ -556,7 +556,8 @@ data class HttpRequestPattern(
                             val jsonValues = jsonObjectToValues(value)
                             val jsonValeuRow = Row(
                                 columnNames = jsonValues.map { it.first }.toList(),
-                                values = jsonValues.map { it.second }.toList())
+                                values = jsonValues.map { it.second }.toList(),
+                                name = row.name)
 
                             body.negativeBasedOn(jsonValeuRow, resolver)
                         } else {

--- a/core/src/main/kotlin/in/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Scenario.kt
@@ -32,14 +32,33 @@ interface ScenarioDetailsForResult {
     val method: String
     val path: String
     val requestTestDescription: String
+    val exampleName: String?
+
     fun testDescription(): String {
         val scenarioDescription = StringBuilder()
+
+        val prefix = exampleName?.let {
+            exampleNamePrefix(it)
+        } ?: ""
+
+        scenarioDescription.append(prefix)
+
         scenarioDescription.append("Scenario: ")
-        when {
-            name.isNotEmpty() -> scenarioDescription.append("$name ")
+
+        if(name.isNotEmpty()) {
+            scenarioDescription.append("$name ")
         }
 
         return scenarioDescription.append(requestTestDescription).toString()
+    }
+
+    fun exampleNamePrefix(it: String) = if (it.startsWith("[WIP]")) {
+        val withoutWIP = it.removePrefix("[WIP]").trim()
+        "[WIP] [$withoutWIP] "
+    } else if (it.isNotBlank()) {
+        "[$it] "
+    } else {
+        ""
     }
 }
 
@@ -58,6 +77,7 @@ data class Scenario(
     val isGherkinScenario: Boolean = false,
     val isNegative: Boolean = false,
     val badRequestOrDefault: BadRequestOrDefault? = null,
+    override val exampleName: String? = null
 ): ScenarioDetailsForResult {
     constructor(scenarioInfo: ScenarioInfo) : this(
         scenarioInfo.scenarioName,
@@ -288,7 +308,8 @@ data class Scenario(
                             bindings,
                             isGherkinScenario,
                             isNegative,
-                            badRequestOrDefault
+                            badRequestOrDefault,
+                            row.name
                         )
                     }
                 }
@@ -488,10 +509,16 @@ data class Scenario(
 
     override fun testDescription(): String {
         val scenarioDescription = StringBuilder()
+
+        val prefix = exampleName?.let {
+            exampleNamePrefix(it)
+        } ?: ""
+
+        scenarioDescription.append(prefix)
+
         scenarioDescription.append("Scenario: ")
-        when {
-            name.isNotEmpty() -> scenarioDescription.append("$name ")
-        }
+
+        if(name.isNotEmpty()) scenarioDescription.append("$name ")
 
         return if (kafkaMessagePattern != null)
             scenarioDescription.append(kafkaMessagePattern.topic).toString()
@@ -534,7 +561,8 @@ data class Scenario(
         bindings,
         this.isGherkinScenario,
         isNegative = true,
-        badRequestOrDefault
+        badRequestOrDefault,
+        exampleName
     )
 }
 

--- a/core/src/main/kotlin/in/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Scenario.kt
@@ -31,9 +31,6 @@ interface ScenarioDetailsForResult {
     val name: String
     val method: String
     val path: String
-    val requestTestDescription: String
-    val exampleName: String?
-    val isNegative: Boolean
 
     fun testDescription(): String
 }
@@ -51,9 +48,9 @@ data class Scenario(
     val references: Map<String, References> = emptyMap(),
     val bindings: Map<String, String> = emptyMap(),
     val isGherkinScenario: Boolean = false,
-    override val isNegative: Boolean = false,
+    val isNegative: Boolean = false,
     val badRequestOrDefault: BadRequestOrDefault? = null,
-    override val exampleName: String? = null,
+    val exampleName: String? = null,
     val generativeTestingEnabled: Boolean = false
 ): ScenarioDetailsForResult {
     constructor(scenarioInfo: ScenarioInfo) : this(
@@ -70,8 +67,6 @@ data class Scenario(
         scenarioInfo.bindings
     )
 
-    override val requestTestDescription: String
-        get() = httpRequestPattern.testDescription()
     override val method: String
         get() {
             return httpRequestPattern.method ?: ""

--- a/core/src/main/kotlin/in/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Scenario.kt
@@ -54,9 +54,9 @@ interface ScenarioDetailsForResult {
 
     fun exampleNamePrefix(it: String) = if (it.startsWith("[WIP]")) {
         val withoutWIP = it.removePrefix("[WIP]").trim()
-        "[WIP] [$withoutWIP] "
+        "[WIP] $withoutWIP | "
     } else if (it.isNotBlank()) {
-        "[$it] "
+        "$it | "
     } else {
         ""
     }

--- a/core/src/main/kotlin/in/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Scenario.kt
@@ -489,31 +489,14 @@ data class Scenario(
         val method = this.httpRequestPattern.method
         val path = this.httpRequestPattern.urlMatcher?.path ?: ""
         val responseStatus = this.httpResponsePattern.status
-        val exampleIdentifier = exampleName?.trim() ?: ""
+        val exampleIdentifier = if(exampleName.isNullOrBlank()) "" else { " | ${exampleName.trim()}" }
 
         val generativePrefix = if(this.generativeTestingEnabled)
             if(this.isNegative) "-ve " else "+ve "
         else
             ""
 
-        return "$generativePrefix Scenario: $method $path -> $responseStatus | $exampleIdentifier"
-
-//        val scenarioDescription = StringBuilder()
-//
-//        val prefix = exampleName?.let {
-//            exampleIdentifier(it)
-//        } ?: ""
-//
-//        scenarioDescription.append(prefix)
-//
-//        scenarioDescription.append("Scenario: ")
-//
-//        if(name.isNotEmpty()) scenarioDescription.append("$name ")
-//
-//        return if (kafkaMessagePattern != null)
-//            scenarioDescription.append(kafkaMessagePattern.topic).toString()
-//        else
-//            scenarioDescription.append(httpRequestPattern.testDescription()).toString()
+        return "$generativePrefix Scenario: $method $path -> $responseStatus$exampleIdentifier"
     }
 
     fun newBasedOn(scenario: Scenario): Scenario =

--- a/core/src/main/kotlin/in/specmatic/core/pattern/Row.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/Row.kt
@@ -24,7 +24,7 @@ data class Row(
 
         val values: List<Pair<String, String>> = jsonObjectToValues(jsonValue)
 
-        return Row(columnNames = values.map { it.first }, values = values.map { it.second })
+        return Row(columnNames = values.map { it.first }, values = values.map { it.second }, name = name)
     }
 
     fun stringForOpenAPIError(): String {

--- a/core/src/test/kotlin/in/specmatic/core/FeatureTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/FeatureTest.kt
@@ -20,6 +20,56 @@ import java.util.stream.Stream
 
 class FeatureTest {
     @Test
+    fun `test descriptions with no tags should contain no tag separators`() {
+        val contract = OpenApiSpecification.fromYAML("""
+openapi: 3.0.0
+info:
+  title: Sample Product API
+  description: Optional multiline or single-line description in [CommonMark](http://commonmark.org/help/) or HTML.
+  version: 0.1.9
+servers:
+  - url: http://localhost:8080
+    description: Local
+paths:
+  /products:
+    post:
+      summary: Add Product
+      description: Add Product
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+                - sku
+              properties:
+                name:
+                  type: string
+                sku:
+                  type: string
+      responses:
+        '200':
+          description: Returns Product With Id
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                properties:
+                  id:
+                    type: integer
+""".trimIndent(), "").toFeature()
+
+        val scenarios: List<Scenario> = contract.generateContractTestScenarios(emptyList())
+
+        assertThat(scenarios.map { it.testDescription() }).allSatisfy {
+            assertThat(it).doesNotContain("|")
+        }
+    }
+
+    @Test
     fun `test descriptions with generative tests on should contain the type`() {
         val contract = OpenApiSpecification.fromYAML("""
 openapi: 3.0.0

--- a/core/src/test/kotlin/in/specmatic/core/FeatureTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/FeatureTest.kt
@@ -17,6 +17,117 @@ import java.util.*
 import java.util.stream.Stream
 
 class FeatureTest {
+    @Test
+    fun `test output should contain example name`() {
+val contract = OpenApiSpecification.fromYAML("""
+openapi: 3.0.0
+info:
+  title: Sample Product API
+  description: Optional multiline or single-line description in [CommonMark](http://commonmark.org/help/) or HTML.
+  version: 0.1.9
+servers:
+  - url: http://localhost:8080
+    description: Local
+paths:
+  /products:
+    post:
+      summary: Add Product
+      description: Add Product
+      requestBody:
+        content:
+          application/json:
+            examples:
+              SUCCESS:
+                value:
+                  name: abc
+                  sku: "123"
+            schema:
+              type: object
+              required:
+                - name
+                - sku
+              properties:
+                name:
+                  type: string
+                sku:
+                  type: string
+      responses:
+        '200':
+          description: Returns Product With Id
+          content:
+            application/json:
+              examples:
+                SUCCESS:
+                  value:
+                    id: 10
+              schema:
+                type: object
+                required:
+                  - id
+                properties:
+                  id:
+                    type: integer
+""".trimIndent(), "").toFeature()
+
+        val scenario: Scenario = contract.generateContractTestScenarios(emptyList()).first()
+        assertThat(scenario.testDescription()).contains("[SUCCESS]")
+    }
+
+    @Test
+    fun `test output should contain example name and preserve WIP tag`() {
+        val contract = OpenApiSpecification.fromYAML("""
+openapi: 3.0.0
+info:
+  title: Sample Product API
+  description: Optional multiline or single-line description in [CommonMark](http://commonmark.org/help/) or HTML.
+  version: 0.1.9
+servers:
+  - url: http://localhost:8080
+    description: Local
+paths:
+  /products:
+    post:
+      summary: Add Product
+      description: Add Product
+      requestBody:
+        content:
+          application/json:
+            examples:
+              "[WIP] SUCCESS":
+                value:
+                  name: abc
+                  sku: "123"
+            schema:
+              type: object
+              required:
+                - name
+                - sku
+              properties:
+                name:
+                  type: string
+                sku:
+                  type: string
+      responses:
+        '200':
+          description: Returns Product With Id
+          content:
+            application/json:
+              examples:
+                "[WIP] SUCCESS":
+                  value:
+                    id: 10
+              schema:
+                type: object
+                required:
+                  - id
+                properties:
+                  id:
+                    type: integer
+""".trimIndent(), "").toFeature()
+
+        val scenario: Scenario = contract.generateContractTestScenarios(emptyList()).first()
+        assertThat(scenario.testDescription()).contains("[WIP] [SUCCESS]")
+    }
     @DisplayName("Single Feature Contract")
     @ParameterizedTest
     @MethodSource("singleFeatureContractSource")

--- a/core/src/test/kotlin/in/specmatic/core/FeatureTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/FeatureTest.kt
@@ -70,7 +70,7 @@ paths:
 """.trimIndent(), "").toFeature()
 
         val scenario: Scenario = contract.generateContractTestScenarios(emptyList()).first()
-        assertThat(scenario.testDescription()).contains("[SUCCESS]")
+        assertThat(scenario.testDescription()).contains("SUCCESS | ")
     }
 
     @Test
@@ -126,7 +126,7 @@ paths:
 """.trimIndent(), "").toFeature()
 
         val scenario: Scenario = contract.generateContractTestScenarios(emptyList()).first()
-        assertThat(scenario.testDescription()).contains("[WIP] [SUCCESS]")
+        assertThat(scenario.testDescription()).contains("[WIP] SUCCESS | ")
     }
     @DisplayName("Single Feature Contract")
     @ParameterizedTest

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=0.63.3
+version=0.63.4-SNAPSHOT


### PR DESCRIPTION
**What**:

The test description now contains only those details identify the API, and the kind of test running against it, namely:
1. API endpoint (method, path)
2. Response http status code
3. Example name
4. Whether the test is positive or negative, if generative tests is switched on

For example: `Scenario: POST /orders/{id} -> 200 | SUCCESS`

If generative tests were on, it would look like this: `+ve Scenario: POST /orders/{id} -> 200 | SUCCESS`

**Why**:

When making the tests pass or debugging failing tests, or even demonstrating issues in a failing contract tests, the developer looks for the above key details. Anything else is noise. Making these details prominent will make it much easier to spot or filter on the specific contract test being worked on.

**How**:

This PR cleans up and improves the way a test description is created.

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

