### PR TITLE
Generative test fixes

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpRequestPattern.kt
@@ -400,14 +400,19 @@ data class HttpRequestPattern(
                         }
 
                         if(resolver.generativeTestingEnabled) {
-                            val rowWithRequestBodyAsIs = listOf(ExactValuePattern(value))
+                            val requestBodyAsIs = ExactValuePattern(value)
+                            val rowWithRequestBodyAsIs = listOf(requestBodyAsIs)
 
                             val requestsFromFlattenedRow: List<Pattern> =
                                 resolver.withCyclePrevention(body) { cyclePreventedResolver ->
                                     body.newBasedOn(row.flattenRequestBodyIntoRow(), cyclePreventedResolver)
                                 }
 
-                            requestsFromFlattenedRow.plus(rowWithRequestBodyAsIs)
+                            if(requestsFromFlattenedRow.none { it.encompasses(requestBodyAsIs, resolver, resolver, emptySet()) is Result.Success}) {
+                                requestsFromFlattenedRow.plus(rowWithRequestBodyAsIs)
+                            } else {
+                                requestsFromFlattenedRow
+                            }
                         } else {
                             listOf(ExactValuePattern(value))
                         }

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
@@ -414,6 +414,8 @@ Background:
                 object : TestExecutor {
                     override fun execute(request: HttpRequest): HttpResponse {
                         flags["${request.path} executed"] = true
+                        println("====REQUEST")
+                        println(request.toLogString())
                         val headers: HashMap<String, String> = object : HashMap<String, String>() {
                             init {
                                 put("Content-Type", "application/json")
@@ -434,9 +436,9 @@ Background:
             System.clearProperty(Flags.negativeTestingFlag)
         }
 
-        assertThat(results.results.size).isEqualTo(5)
+        assertThat(results.results.size).isEqualTo(9)
         assertThat(results.results.filterIsInstance<Result.Success>().size).isEqualTo(1)
-        assertThat(results.results.filterIsInstance<Result.Failure>().size).isEqualTo(4)
+        assertThat(results.results.filterIsInstance<Result.Failure>().size).isEqualTo(8)
     }
 
     @Test

--- a/core/src/test/kotlin/in/specmatic/core/HttpRequestPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/HttpRequestPatternTest.kt
@@ -417,4 +417,14 @@ internal class HttpRequestPatternTest {
             assertThat(reportText.indexOf(""">> REQUEST.MULTIPART-FORMDATA.data2""")).isLessThan(reportText.indexOf(""">> REQUEST.MULTIPART-FORMDATA.data1"""))
         }
     }
+
+    @Test
+    fun `should not generate test request for generative tests more than once`()  {
+        val pattern = HttpRequestPattern(method = "POST", urlMatcher = toURLMatcherWithOptionalQueryParams("http://helloworld.com/data"), body = JSONObjectPattern(mapOf("id" to NumberPattern())))
+
+        val row: Row = Row(listOf("(REQUEST-BODY)"), listOf("""{ "id": 10 }"""))
+        val patterns = pattern.newBasedOn(row, Resolver(generativeTestingEnabled = true))
+
+        assertThat(patterns).hasSize(1)
+    }
 }

--- a/core/src/test/kotlin/in/specmatic/core/HttpRequestPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/HttpRequestPatternTest.kt
@@ -422,7 +422,7 @@ internal class HttpRequestPatternTest {
     fun `should not generate test request for generative tests more than once`()  {
         val pattern = HttpRequestPattern(method = "POST", urlMatcher = toURLMatcherWithOptionalQueryParams("http://helloworld.com/data"), body = JSONObjectPattern(mapOf("id" to NumberPattern())))
 
-        val row: Row = Row(listOf("(REQUEST-BODY)"), listOf("""{ "id": 10 }"""))
+        val row = Row(listOf("(REQUEST-BODY)"), listOf("""{ "id": 10 }"""))
         val patterns = pattern.newBasedOn(row, Resolver(generativeTestingEnabled = true))
 
         assertThat(patterns).hasSize(1)

--- a/core/src/test/kotlin/in/specmatic/core/pattern/AnyPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/AnyPatternTest.kt
@@ -193,6 +193,9 @@ internal class AnyPatternTest {
     fun `values for negative tests`() {
         val negativeTypes = AnyPattern(listOf(NullPattern, StringPattern())).negativeBasedOn(Row(), Resolver())
 
-        assertThat(negativeTypes).hasSize(2)
+        val expectedTypes = listOf(NumberPattern(), BooleanPattern)
+
+        assertThat(negativeTypes).containsAll(expectedTypes)
+        assertThat(negativeTypes).hasSize(expectedTypes.size)
     }
 }

--- a/core/src/test/kotlin/in/specmatic/core/pattern/AnyPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/AnyPatternTest.kt
@@ -188,4 +188,11 @@ internal class AnyPatternTest {
         val parsedValue = type.parse("22B Baker Street", Resolver(isNegative = true))
         assertThat(parsedValue.toStringLiteral()).isEqualTo("22B Baker Street")
     }
+
+    @Test
+    fun `values for negative tests`() {
+        val negativeTypes = AnyPattern(listOf(NullPattern, StringPattern())).negativeBasedOn(Row(), Resolver())
+
+        assertThat(negativeTypes).hasSize(2)
+    }
 }


### PR DESCRIPTION
**What**:

This fixes two bugs in generative testing.

1. Negative pattern generation would not generate the right patterns for nullable values
2. With generative test on, positive cases were often sent twice.

**How**:

For 1: AnyPattern has been fixed.
For 2: The vanilla positive case for the body is now checked against other generated body patterns and only added if not already found.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [x] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #123

<!-- feel free to add additional comments -->
