### PR TITLE
Support for regex match of request body stub

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Feature.kt
@@ -350,7 +350,7 @@ data class Feature(
             scenarioStub.request,
             scenarioStub.response,
             mismatchMessages
-        ).copy(delayInSeconds = scenarioStub.delayInSeconds)
+        ).copy(delayInSeconds = scenarioStub.delayInSeconds, requestBodyRegex = scenarioStub.requestBodyRegex?.let { Regex(it) })
 
     fun clearServerState() {
         serverState = emptyMap()

--- a/core/src/main/kotlin/in/specmatic/mock/ScenarioStub.kt
+++ b/core/src/main/kotlin/in/specmatic/mock/ScenarioStub.kt
@@ -24,7 +24,7 @@ const val MOCK_HTTP_RESPONSE = "http-response"
 const val DELAY_IN_SECONDS = "delay-in-seconds"
 const val TRANSIENT_MOCK = "http-stub"
 const val TRANSIENT_MOCK_ID = "$TRANSIENT_MOCK-id"
-const val REQUEST_BODY_REGEX = "requestBodyRegex"
+const val REQUEST_BODY_REGEX = "bodyRegex"
 
 val MOCK_HTTP_REQUEST_ALL_KEYS = listOf("mock-http-request", MOCK_HTTP_REQUEST)
 val MOCK_HTTP_RESPONSE_ALL_KEYS = listOf("mock-http-response", MOCK_HTTP_RESPONSE)

--- a/core/src/main/kotlin/in/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/in/specmatic/stub/HttpStub.kt
@@ -391,12 +391,12 @@ class HttpStub(
         return firstResult.second
     }
 
-    private fun parseRegex(requestBodyRegex: String?): Regex? {
-        return requestBodyRegex?.let {
+    private fun parseRegex(regex: String?): Regex? {
+        return regex?.let {
             try {
                 Regex(it)
             } catch(e: Throwable) {
-                throw ContractException("Couldn't parse regex", exceptionCause = e)
+                throw ContractException("Couldn't parse regex $regex", exceptionCause = e)
             }
         }
     }

--- a/core/src/main/kotlin/in/specmatic/stub/StubData.kt
+++ b/core/src/main/kotlin/in/specmatic/stub/StubData.kt
@@ -16,7 +16,8 @@ data class HttpStubData(
     val delayInSeconds: Int? = null,
     val responsePattern: HttpResponsePattern,
     val contractPath: String = "",
-    val stubToken: String? = null
+    val stubToken: String? = null,
+    val requestBodyRegex: Regex? = null
 ) : StubData {
     fun softCastResponseToXML(httpRequest: HttpRequest): HttpStubData = when {
         response.externalisedResponseCommand.isNotEmpty() -> invokeExternalCommand(httpRequest).copy(contractPath = contractPath)

--- a/core/src/main/kotlin/in/specmatic/stub/api.kt
+++ b/core/src/main/kotlin/in/specmatic/stub/api.kt
@@ -213,7 +213,7 @@ fun stubMatchErrorMessage(
 }
 
 fun loadContractStubs(features: List<Pair<String, Feature>>, stubData: List<Pair<String, ScenarioStub>>): List<Pair<Feature, List<ScenarioStub>>> {
-    val contractInfoFromStubs = stubData.mapNotNull { (stubFile, stub) ->
+    val contractInfoFromStubs: List<Pair<Feature, List<ScenarioStub>>> = stubData.mapNotNull { (stubFile, stub) ->
         val matchResults = features.map { (qontractFile, feature) ->
             try {
                 val kafkaMessage = stub.kafkaMessage

--- a/core/src/test/kotlin/in/specmatic/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/in/specmatic/stub/HttpStubTest.kt
@@ -716,7 +716,7 @@ paths:
                         "method": "POST",
                         "path": "/",
                         "body": "(string)",
-                        "requestBodyRegex": "^hello (.*)$"
+                        "bodyRegex": "^hello (.*)$"
                     },
                     "http-response": {
                         "status": 200,

--- a/core/src/test/kotlin/in/specmatic/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/in/specmatic/stub/HttpStubTest.kt
@@ -1,5 +1,6 @@
 package `in`.specmatic.stub
 
+import `in`.specmatic.conversions.OpenApiSpecification
 import `in`.specmatic.core.*
 import `in`.specmatic.core.pattern.XML_ATTR_OPTIONAL_SUFFIX
 import `in`.specmatic.core.pattern.parsedValue
@@ -611,7 +612,7 @@ Scenario: Square of a number
 
             assertThat(response.status).isEqualTo(200)
             assertThat(response.body.toStringLiteral()).isEqualTo("it worked")
-            assertThat(response.headers[QONTRACT_SOURCE_HEADER]).isEqualTo("proxy")
+            assertThat(response.headers[SPECMATIC_SOURCE_HEADER]).isEqualTo("proxy")
         }
     }
 
@@ -643,7 +644,7 @@ Scenario: Square of a number
             val client = HttpClient(stub.endPoint)
             val response = client.execute(HttpRequest(method = "POST", path = "/", body = NumberValue(10)))
 
-            assertThat(response.headers[QONTRACT_SOURCE_HEADER]).isEqualTo("proxy")
+            assertThat(response.headers[SPECMATIC_SOURCE_HEADER]).isEqualTo("proxy")
         }
     }
 
@@ -678,6 +679,66 @@ Scenario: Square of a number
 
             assertThat(response.status).isEqualTo(200)
             assertThat(response.body.toStringLiteral()).isEqualTo("success")
+        }
+    }
+
+    @Test
+    fun `should stub out a request with body string matching a regex`() {
+        val contract = OpenApiSpecification.fromYAML(
+            """
+openapi: 3.0.1
+info:
+  title: Data API
+  version: "1"
+paths:
+  /:
+    post:
+      summary: Data
+      parameters: []
+      requestBody:
+        content:
+          text/plain:
+            schema:
+              type: string
+      responses:
+        "200":
+          description: Data
+          content:
+            text/plain:
+              schema:
+                type: string
+""".trim(), "").toFeature()
+
+        HttpStub(contract).use { stub ->
+            val stubData = """
+                {
+                    "http-request": {
+                        "method": "POST",
+                        "path": "/",
+                        "body": "(string)",
+                        "requestBodyRegex": "^hello (.*)$"
+                    },
+                    "http-response": {
+                        "status": 200,
+                        "body": "Hi!"
+                    }
+                }
+            """.trimIndent()
+
+            val stubRequest = HttpRequest("POST", "/_specmatic/expectations", emptyMap(), StringValue(stubData))
+            val stubResponse = stub.client.execute(stubRequest)
+
+            assertThat(stubResponse.status).isEqualTo(200)
+
+            HttpRequest("POST", "/", emptyMap(), StringValue("hello world")).let { actualRequest ->
+                val actualResponse = stub.client.execute(actualRequest)
+                assertThat(actualResponse.body.toStringLiteral()).isEqualTo("Hi!")
+            }
+
+            HttpRequest("POST", "/", emptyMap(), StringValue("hi world")).let { actualRequest ->
+                val actualResponse = stub.client.execute(actualRequest)
+                assertThat(actualResponse.headers).containsEntry("X-Specmatic-Type", "random")
+            }
         }
     }
 }


### PR DESCRIPTION
**What**:

Added support for regex matching of the request body in a stub.

You can specify a regex in a stub file, and the request body string is matched against it.

**Why**:

When a part of the string varies while the rest remains the same (e.g. a timestamp in the string that changes with each test), we can now use a regex to match the string. Previously the only options were an exact match or match everything, whereas this scenario requires both exact match (only for the parts of the string that do not change) and a variable match (only for the part of the string that changes).

**How**:

`http-request` in the stub body now takes a key `requestBodyRegex` which will be matched against an incoming request body.

**Checklist**:

- [/] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [/] Tests
- [ ] Sonar Quality Gate
