### PR TITLE
Select multiple tests to run using filterName

### DIFF
--- a/application/src/test/kotlin/in/specmatic/test/SpecmaticJUnitSupportKtTest.kt
+++ b/application/src/test/kotlin/in/specmatic/test/SpecmaticJUnitSupportKtTest.kt
@@ -1,0 +1,74 @@
+package `in`.specmatic.test
+
+import `in`.specmatic.conversions.OpenApiSpecification
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class SpecmaticJUnitSupportKtTest {
+    val contract = OpenApiSpecification.fromYAML("""
+openapi: 3.0.0
+info:
+  title: Sample API
+  version: 0.1.9
+paths:
+  /data:
+    post:
+      summary: hello world
+      description: test
+      requestBody:
+        content:
+          application/json:
+            examples:
+              INCLUDE1:
+                value:
+                  data: abc
+              INCLUDE2:
+                value:
+                  data: abc
+              EXCLUDE:
+                value:
+                  data: abc
+            schema:
+              type: object
+              properties:
+                data:
+                  type: string
+              required:
+                - data
+      responses:
+        '200':
+          description: Says hello
+          content:
+            text/plain:
+              examples:
+                INCLUDE1:
+                  value: 10
+                INCLUDE2:
+                  value: 10
+                EXCLUDE:
+                  value: 10
+              schema:
+                type: number
+        """.trimIndent(), "").toFeature()
+
+    val contractTests = contract.generateContractTests(emptyList())
+    @Test
+    fun `should select tests containing the value of filterName in testDescription`() {
+        val selected = selectTestsToRun("INCLUDE1", contractTests)
+        assertThat(selected).hasSize(1)
+        assertThat(selected.first().testDescription()).contains("INCLUDE1")
+//        assertThat(selected.map { it.testDescription() }).allMatch {
+//            it.contains("INCLUDE1")
+//        }
+    }
+
+    @Test
+    fun `should select tests whose testDescriptions contain any of the multiple comma separate values in filterName`() {
+        val selected = selectTestsToRun("INCLUDE1, INCLUDE2", contractTests)
+        assertThat(selected).hasSize(2)
+        assertThat(selected.map { it.testDescription() }).allMatch {
+            it.contains("INCLUDE1") || it.contains("INCLUDE2")
+        }
+    }
+}

--- a/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
@@ -280,12 +280,7 @@ open class SpecmaticJUnitSupport {
                 }
             }
 
-            if(filterName != null) {
-                testScenarios.filter {
-                    it.testDescription().contains(filterName)
-                }
-            } else
-                testScenarios
+            selectTestsToRun(filterName, testScenarios)
         } catch(e: ContractException) {
             return loadExceptionAsTestError(e)
         } catch(e: Throwable) {
@@ -409,4 +404,18 @@ private fun asJSONObjectValue(value: Value, errorMessage: String): Map<String, V
         throw ContractException(errorMessage)
 
     return value.jsonObject
+}
+
+fun selectTestsToRun(
+    filterName: String?,
+    testScenarios: List<ContractTest>
+): List<ContractTest> {
+    return if (!filterName.isNullOrBlank()) {
+        val filterNames = filterName.split(",").map { it.trim() }
+
+        testScenarios.filter { test ->
+            filterNames.any { test.testDescription().contains(it) }
+        }
+    } else
+        testScenarios
 }


### PR DESCRIPTION
**What**:

filterName (--filter-name from the command-line) can now be a comma separate value. If it is comma separated, each value separate by the commas will be used to filter the tests generated from the contract.

For example:
```java
System.setProperty("filterName", "TEST1, "TEST2");
```

This will now run all tests which have either TEST1 or TEST2 in the name.

**Why**:

This can be useful if you wish to run only passing contract tests in the build, while the other tests are still being worked on.

**How**:

This PR adds a function to filter tests which splits by comma.

**Checklist**:

- [/] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [/] Tests
- [ ] Sonar Quality Gate
