### PR TITLE
Filter out specified test names

### DIFF
--- a/application/src/main/kotlin/application/TestCommand.kt
+++ b/application/src/main/kotlin/application/TestCommand.kt
@@ -26,6 +26,7 @@ import `in`.specmatic.test.SpecmaticJUnitSupport.Companion.PORT
 import `in`.specmatic.test.SpecmaticJUnitSupport.Companion.SUGGESTIONS_PATH
 import `in`.specmatic.test.SpecmaticJUnitSupport.Companion.ENV_NAME
 import `in`.specmatic.test.SpecmaticJUnitSupport.Companion.FILTER_NAME
+import `in`.specmatic.test.SpecmaticJUnitSupport.Companion.FILTER_NOT_NAME
 import `in`.specmatic.test.SpecmaticJUnitSupport.Companion.TEST_BASE_URL
 import `in`.specmatic.test.SpecmaticJUnitSupport.Companion.TIMEOUT
 import `in`.specmatic.test.SpecmaticJUnitSupport.Companion.VARIABLES_FILE_NAME
@@ -72,6 +73,9 @@ class TestCommand : Callable<Unit> {
 
     @Option(names = ["--filter-name"], description = ["Run only tests with this value in their name"], defaultValue = "")
     var filterName: String = ""
+
+    @Option(names = ["--filter-not-name"], description = ["Run only tests with this value in their name"], defaultValue = "")
+    var filterNotName: String = ""
 
     @Option(names = ["--env"], description = ["Environment name"])
     var envName: String = ""
@@ -141,6 +145,10 @@ class TestCommand : Callable<Unit> {
 
         if(filterName.isNotBlank()) {
             System.setProperty(FILTER_NAME, filterName)
+        }
+
+        if(filterNotName.isNotBlank()) {
+            System.setProperty(FILTER_NOT_NAME, filterName)
         }
 
         System.setProperty("kafkaBootstrapServers", kafkaBootstrapServers)

--- a/application/src/main/kotlin/application/TestCommand.kt
+++ b/application/src/main/kotlin/application/TestCommand.kt
@@ -74,7 +74,7 @@ class TestCommand : Callable<Unit> {
     @Option(names = ["--filter-name"], description = ["Run only tests with this value in their name"], defaultValue = "")
     var filterName: String = ""
 
-    @Option(names = ["--filter-not-name"], description = ["Run only tests with this value in their name"], defaultValue = "")
+    @Option(names = ["--filter-not-name"], description = ["Run only tests which do not have this value in their name"], defaultValue = "")
     var filterNotName: String = ""
 
     @Option(names = ["--env"], description = ["Environment name"])

--- a/application/src/test/kotlin/in/specmatic/test/TestsFilterTest.kt
+++ b/application/src/test/kotlin/in/specmatic/test/TestsFilterTest.kt
@@ -2,9 +2,10 @@ package `in`.specmatic.test
 
 import `in`.specmatic.conversions.OpenApiSpecification
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 
-class SpecmaticJUnitSupportKtTest {
+class TestsFilterTest {
     val contract = OpenApiSpecification.fromYAML("""
 openapi: 3.0.0
 info:
@@ -51,18 +52,18 @@ paths:
                 type: number
         """.trimIndent(), "").toFeature()
 
-    val contractTests = contract.generateContractTests(emptyList())
+    private val contractTests = contract.generateContractTests(emptyList())
 
     @Test
     fun `should select tests containing the value of filterName in testDescription`() {
-        val selected = selectTestsToRun(contractTests, "TEST1")
+        val selected = TestsFilter("TEST1").selectTestsToRun(contractTests)
         assertThat(selected).hasSize(1)
         assertThat(selected.first().testDescription()).contains("TEST1")
     }
 
     @Test
     fun `should select tests whose testDescriptions contain any of the multiple comma separate values in filterName`() {
-        val selected = selectTestsToRun(contractTests, "TEST1, TEST2")
+        val selected = TestsFilter("TEST1, TEST2").selectTestsToRun(contractTests)
         assertThat(selected).hasSize(2)
         assertThat(selected.map { it.testDescription() }).allMatch {
             it.contains("TEST1") || it.contains("TEST2")
@@ -71,7 +72,7 @@ paths:
 
     @Test
     fun `should omit tests containing the value of filterNotName in testDescription`() {
-        val selected = selectTestsToRun(contractTests, filterNotName = "TEST1")
+        val selected = TestsFilter(filterNotName = "TEST1").selectTestsToRun(contractTests)
         assertThat(selected).hasSize(2)
         assertThat(selected.map { it.testDescription() }).allMatch {
             it.contains("TEST2") || it.contains("TEST3")
@@ -80,7 +81,8 @@ paths:
 
     @Test
     fun `should omit tests whose testDescriptions contain any of the multiple comma separate values in filterNotName`() {
-        val selected = selectTestsToRun(contractTests, filterNotName = "TEST1, TEST2")
+        val selected = TestsFilter(filterNotName = "TEST1, TEST2").selectTestsToRun(contractTests)
+        println(contractTests.map { it.testDescription() })
         assertThat(selected).hasSize(1)
         assertThat(selected.first().testDescription()).contains("TEST3")
     }

--- a/junit5-support/src/main/kotlin/in/specmatic/test/TestsFilter.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/TestsFilter.kt
@@ -1,0 +1,23 @@
+package `in`.specmatic.test
+
+data class TestsFilter(private val filterNames: List<String>, private val filterNotNames: List<String>) {
+    constructor(filterName: String? = null, filterNotName: String? = null) :
+            this(
+                filterName?.split(",")?.map { it.trim() } ?: emptyList(),
+                filterNotName?.split(",")?.map { it.trim() } ?: emptyList())
+
+    fun selectTestsToRun(
+        testScenarios: List<ContractTest>
+    ): List<ContractTest> {
+        val filteredByNames = if(filterNames.isNotEmpty()) testScenarios.filter { test ->
+            filterNames.any { test.testDescription().contains(it) }
+        } else testScenarios
+
+        val filterByNotNames = if(filterNotNames.isNotEmpty()) filteredByNames.filterNot { test ->
+            filterNotNames.isNotEmpty() && filterNotNames.any { test.testDescription().contains(it) }
+        } else testScenarios
+
+
+        return filterByNotNames
+    }
+}

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=0.65.0
+version=0.65.1


### PR DESCRIPTION
**What**:

Omit tests containing the specified name

**Why**:

You might need to run all except a few tests that require for example a dependency to be down, which at the moment needs to be simulated in Java using a separate property file, loaded by Spring at application start. This necessitates another class, that need not run all the contract tests. But this test would fail if the application is up, so it should be omitted from the main test class.


**How**:

We've added a filterNotName property, as well as a --filter-not-name command-line parameter.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #123

<!-- feel free to add additional comments -->
