### PR TITLE
Specmatic stub restart fix

### DIFF
--- a/application/src/test/kotlin/application/FakeGit.kt
+++ b/application/src/test/kotlin/application/FakeGit.kt
@@ -87,4 +87,8 @@ abstract class FakeGit: GitCommand {
     override fun exists(treeish: String, relativePath: String): Boolean {
         TODO("Not yet implemented")
     }
+
+    override fun statusPorcelain(): String {
+        TODO("Not yet implemented")
+    }
 }

--- a/core/src/main/kotlin/in/specmatic/core/git/GitCommand.kt
+++ b/core/src/main/kotlin/in/specmatic/core/git/GitCommand.kt
@@ -25,4 +25,5 @@ interface GitCommand {
     fun shallowClone(gitRepositoryURI: String, cloneDirectory: File): SystemGit
     fun exists(treeish: String, relativePath: String): Boolean
     fun getCurrentBranch(): String
+    fun statusPorcelain(): String
 }

--- a/core/src/main/kotlin/in/specmatic/core/git/SystemGit.kt
+++ b/core/src/main/kotlin/in/specmatic/core/git/SystemGit.kt
@@ -61,6 +61,10 @@ class SystemGit(override val workingDirectory: String = ".", private val prefix:
         return execute(Configuration.gitCommand, "git", "diff", "--name-only", "master")
     }
 
+    override fun statusPorcelain(): String {
+        return execute(Configuration.gitCommand, "status", "--porcelain")
+    }
+
 
     override fun shallowClone(gitRepositoryURI: String, cloneDirectory: File): SystemGit =
         this.also {

--- a/core/src/main/kotlin/in/specmatic/core/utilities/Utilities.kt
+++ b/core/src/main/kotlin/in/specmatic/core/utilities/Utilities.kt
@@ -12,6 +12,7 @@ import org.xml.sax.InputSource
 import `in`.specmatic.core.log.consoleLog
 import `in`.specmatic.core.*
 import `in`.specmatic.core.Configuration.Companion.globalConfigFileName
+import `in`.specmatic.core.git.GitCommand
 import `in`.specmatic.core.git.SystemGit
 import `in`.specmatic.core.log.logger
 import `in`.specmatic.core.pattern.ContractException
@@ -273,6 +274,10 @@ fun contractFilePathsFrom(configFilePath: String, workingDirectory: String, sele
     logger.debug(contractPathData.joinToString(System.lineSeparator()) { it.path }.prependIndent("  "))
 
     return contractPathData
+}
+
+fun getSystemGit(path: String) : GitCommand {
+    return SystemGit(path)
 }
 
 class UncaughtExceptionHandler: Thread.UncaughtExceptionHandler {

--- a/core/src/test/kotlin/utilities/UtilitiesTest.kt
+++ b/core/src/test/kotlin/utilities/UtilitiesTest.kt
@@ -1,8 +1,5 @@
 package utilities
 
-import io.mockk.every
-import io.mockk.mockkConstructor
-import io.mockk.mockkStatic
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import `in`.specmatic.core.CONTRACT_EXTENSION
@@ -13,7 +10,7 @@ import `in`.specmatic.core.pattern.parsedJSON
 import `in`.specmatic.core.utilities.*
 import `in`.specmatic.core.value.JSONObjectValue
 import `in`.specmatic.core.value.toXMLNode
-import io.mockk.mockk
+import io.mockk.*
 import java.io.File
 
 internal class UtilitiesTest {
@@ -32,6 +29,7 @@ internal class UtilitiesTest {
 
     @Test
     fun `contractFilePathsFrom sources with git repo when git repo already exists and is clean`() {
+        clearAllMocks()
         val sources = listOf(GitRepo("https://repo1", listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION")))
 
         val mockGitCommand = mockk<GitCommand>()

--- a/core/src/test/kotlin/utilities/UtilitiesTest.kt
+++ b/core/src/test/kotlin/utilities/UtilitiesTest.kt
@@ -6,12 +6,14 @@ import io.mockk.mockkStatic
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import `in`.specmatic.core.CONTRACT_EXTENSION
+import `in`.specmatic.core.git.GitCommand
 import `in`.specmatic.core.git.SystemGit
 import `in`.specmatic.core.git.clone
 import `in`.specmatic.core.pattern.parsedJSON
 import `in`.specmatic.core.utilities.*
 import `in`.specmatic.core.value.JSONObjectValue
 import `in`.specmatic.core.value.toXMLNode
+import io.mockk.mockk
 import java.io.File
 
 internal class UtilitiesTest {
@@ -29,20 +31,43 @@ internal class UtilitiesTest {
     }
 
     @Test
-    fun `contractFilePathsFrom sources with git repo`() {
+    fun `contractFilePathsFrom sources with git repo when git repo already exists and is clean`() {
         val sources = listOf(GitRepo("https://repo1", listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION")))
 
+        val mockGitCommand = mockk<GitCommand>()
+        every { mockGitCommand.statusPorcelain() }.returns("")
         mockkStatic("in.specmatic.core.utilities.Utilities")
         every { loadSources("/configFilePath") }.returns(sources)
+        every { getSystemGit(any()) }.returns(mockGitCommand)
+
+        val contractPaths = contractFilePathsFrom("/configFilePath", ".$CONTRACT_EXTENSION") { source -> source.stubContracts }
+        val expectedContractPaths = listOf(
+                ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/a/1.$CONTRACT_EXTENSION"),
+                ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/b/1.$CONTRACT_EXTENSION"),
+                ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/c/1.$CONTRACT_EXTENSION"),
+        )
+        assertThat(contractPaths == expectedContractPaths).isTrue
+    }
+
+    @Test
+    fun `contractFilePathsFrom sources with git repo when git repo already exists and is not clean`() {
+        val sources = listOf(GitRepo("https://repo1", listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION")))
+
+        val mockGitCommand = mockk<GitCommand>()
+        every { mockGitCommand.statusPorcelain() }.returns("someDir/someFile")
+        mockkStatic("in.specmatic.core.utilities.Utilities")
+        every { loadSources("/configFilePath") }.returns(sources)
+        every { getSystemGit(any()) }.returns(mockGitCommand)
 
         mockkStatic("in.specmatic.core.git.GitOperations")
         every { clone(any(), any()) }.returns(File("cloneDir"))
 
+
         val contractPaths = contractFilePathsFrom("/configFilePath", ".$CONTRACT_EXTENSION") { source -> source.stubContracts }
         val expectedContractPaths = listOf(
-                ContractPathData("cloneDir", "cloneDir/a/1.$CONTRACT_EXTENSION"),
-                ContractPathData("cloneDir", "cloneDir/b/1.$CONTRACT_EXTENSION"),
-                ContractPathData("cloneDir", "cloneDir/c/1.$CONTRACT_EXTENSION"),
+            ContractPathData("cloneDir", "cloneDir/a/1.$CONTRACT_EXTENSION"),
+            ContractPathData("cloneDir", "cloneDir/b/1.$CONTRACT_EXTENSION"),
+            ContractPathData("cloneDir", "cloneDir/c/1.$CONTRACT_EXTENSION"),
         )
         assertThat(contractPaths == expectedContractPaths).isTrue
     }

--- a/core/src/test/kotlin/utilities/UtilitiesTest.kt
+++ b/core/src/test/kotlin/utilities/UtilitiesTest.kt
@@ -29,8 +29,8 @@ internal class UtilitiesTest {
 
     @Test
     fun `contractFilePathsFrom sources with git repo when git repo already exists and is clean`() {
-        clearAllMocks()
         val sources = listOf(GitRepo("https://repo1", listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION")))
+        File(".spec/repos").mkdirs()
 
         val mockGitCommand = mockk<GitCommand>()
         every { mockGitCommand.statusPorcelain() }.returns("")


### PR DESCRIPTION
Fixed bug wherein the specmatic stub restarts itself when tests are run parallelly from the same folder. The stub restarts because the .specmacti/repos folder is deleted and recreated when tests are run.