### PR TITLE
Bug fix: initial stubs provided to HttpStub contructor were added to transient stubs

### DIFF
--- a/core/src/main/kotlin/in/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/in/specmatic/stub/HttpStub.kt
@@ -66,7 +66,17 @@ class HttpStub(
     ) : this(parseGherkinStringToFeature(gherkinData), scenarioStubs, host, port, log)
 
     private val threadSafeHttpStubs = ThreadSafeListOfStubs(_httpStubs.toMutableList())
-    private val threadSafeHttpStubQueue = ThreadSafeListOfStubs(_httpStubs.toMutableList())
+    private val threadSafeHttpStubQueue = ThreadSafeListOfStubs(mutableListOf())
+
+    val stubCount: Int
+        get() {
+            return threadSafeHttpStubs.size
+        }
+
+    val transientStubCount: Int
+        get() {
+            return threadSafeHttpStubQueue.size
+        }
 
     val endPoint = endPointFromHostAndPort(host, port, keyData)
 

--- a/core/src/main/kotlin/in/specmatic/stub/ThreadSafeListOfStubs.kt
+++ b/core/src/main/kotlin/in/specmatic/stub/ThreadSafeListOfStubs.kt
@@ -4,6 +4,11 @@ import `in`.specmatic.core.Result
 import `in`.specmatic.mock.ScenarioStub
 
 class ThreadSafeListOfStubs(private val httpStubs: MutableList<HttpStubData>) {
+    val size: Int
+        get() {
+            return httpStubs.size
+        }
+
     fun matchResults(fn: (List<HttpStubData>) -> List<Pair<Result, HttpStubData>>): List<Pair<Result, HttpStubData>> {
         synchronized(this) {
             return fn(httpStubs.toList())

--- a/core/src/test/kotlin/in/specmatic/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/in/specmatic/stub/HttpStubTest.kt
@@ -743,7 +743,7 @@ paths:
     }
 
     @Test
-    fun `stubbed values should not populate the queue`() {
+    fun `persistent stubs should not populate the transient stub queue`() {
         val contract = OpenApiSpecification.fromYAML(
             """
 openapi: 3.0.1

--- a/core/src/test/kotlin/in/specmatic/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/in/specmatic/stub/HttpStubTest.kt
@@ -741,4 +741,46 @@ paths:
             }
         }
     }
+
+    @Test
+    fun `stubbed values should not populate the queue`() {
+        val contract = OpenApiSpecification.fromYAML(
+            """
+openapi: 3.0.1
+info:
+  title: Data API
+  version: "1"
+paths:
+  /:
+    post:
+      summary: Data
+      parameters: []
+      requestBody:
+        content:
+          text/plain:
+            schema:
+              type: string
+      responses:
+        "200":
+          description: Data
+          content:
+            text/plain:
+              schema:
+                type: string
+""".trim(), "").toFeature()
+
+        HttpStub(contract, listOf(ScenarioStub(
+            HttpRequest(
+                method = "POST",
+                path = "/",
+                body = StringValue("(string)")
+            ),
+            HttpResponse(
+                status = 200,
+                body = "Hi!"
+            )))).use { stub ->
+            assertThat(stub.stubCount).isEqualTo(1)
+            assertThat(stub.transientStubCount).isEqualTo(0)
+        }
+    }
 }


### PR DESCRIPTION
**What**:

The stubs passed to the constructor of HttpStub were being used to initialise the queue holding transient stubs. This PR just fixes the construction of the queue.

**Checklist**:

- [ ] (n/a) Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [x] Sonar Quality Gate

