### PR TITLE
Run stub on a random free port if the default port is in use

### DIFF
--- a/application/src/main/kotlin/application/PortUtil.kt
+++ b/application/src/main/kotlin/application/PortUtil.kt
@@ -1,0 +1,38 @@
+package application
+
+import `in`.specmatic.core.log.logger
+import java.io.IOException
+import java.net.InetAddress
+import java.net.ServerSocket
+
+
+fun portIsInUse(host: String, port: Int): Boolean {
+    return try {
+        val ipAddress = InetAddress.getByName(host)
+        ServerSocket(port, 1, ipAddress).use {
+            false
+        }
+    } catch (e: IOException) {
+        true
+    }
+}
+
+fun findRandomFreePort(): Int {
+    logger.log("Checking for a free port")
+    var port = 0
+    var serverSocket: ServerSocket? = null
+
+    try {
+        serverSocket = ServerSocket(0)
+        port = serverSocket.localPort
+    } finally {
+        serverSocket?.close()
+    }
+
+    if (port > 0) {
+        logger.log("Free port found: $port")
+        return port
+    }
+    throw RuntimeException("Could not find a free port")
+}
+

--- a/application/src/main/kotlin/application/StubCommand.kt
+++ b/application/src/main/kotlin/application/StubCommand.kt
@@ -10,7 +10,11 @@ import `in`.specmatic.stub.HttpClientFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationContext
 import picocli.CommandLine.*
+import java.io.IOException
+import java.net.InetAddress
+import java.net.ServerSocket
 import java.util.concurrent.Callable
+
 
 @Command(name = "stub",
         mixinStandardHelpOptions = true,
@@ -173,10 +177,48 @@ class StubCommand : Callable<Unit> {
 
         val certInfo = CertInfo(keyStoreFile, keyStoreDir, keyStorePassword, keyStoreAlias, keyPassword)
 
+        port = when (isDefaultPort(port)) {
+            true -> if (portIsInUse(host, port)) findRandomFreePort() else port
+            false -> port
+        }
         httpStub = httpStubEngine.runHTTPStub(stubData, host, port, certInfo, strictMode, passThroughTargetBase, httpClientFactory, workingDirectory)
         kafkaStub = kafkaStubEngine.runKafkaStub(stubData, kafkaHost, kafkaPort.toInt(), startKafka)
 
         LogTail.storeSnapshot()
+    }
+
+    private fun isDefaultPort(port:Int): Boolean {
+        return DEFAULT_HTTP_STUB_PORT == port.toString()
+    }
+
+    private fun portIsInUse(host:String, port: Int): Boolean {
+        return try {
+            val ipAddress = InetAddress.getByName(host)
+            ServerSocket(port, 1, ipAddress).use {
+                false
+            }
+        } catch (e: IOException) {
+            true
+        }
+    }
+
+    private fun findRandomFreePort(): Int {
+        logger.log("Checking for a free port")
+        var port = 0
+        var serverSocket: ServerSocket? = null
+
+        try {
+            serverSocket = ServerSocket(0)
+            port = serverSocket.localPort
+        } finally {
+            serverSocket?.close()
+        }
+
+        if (port > 0) {
+            logger.log("Free port found: $port")
+            return port
+        }
+        throw RuntimeException("Could not find a free port")
     }
 
     private fun restartServer() {

--- a/application/src/main/kotlin/application/StubCommand.kt
+++ b/application/src/main/kotlin/application/StubCommand.kt
@@ -10,9 +10,6 @@ import `in`.specmatic.stub.HttpClientFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationContext
 import picocli.CommandLine.*
-import java.io.IOException
-import java.net.InetAddress
-import java.net.ServerSocket
 import java.util.concurrent.Callable
 
 
@@ -189,36 +186,6 @@ class StubCommand : Callable<Unit> {
 
     private fun isDefaultPort(port:Int): Boolean {
         return DEFAULT_HTTP_STUB_PORT == port.toString()
-    }
-
-    private fun portIsInUse(host:String, port: Int): Boolean {
-        return try {
-            val ipAddress = InetAddress.getByName(host)
-            ServerSocket(port, 1, ipAddress).use {
-                false
-            }
-        } catch (e: IOException) {
-            true
-        }
-    }
-
-    private fun findRandomFreePort(): Int {
-        logger.log("Checking for a free port")
-        var port = 0
-        var serverSocket: ServerSocket? = null
-
-        try {
-            serverSocket = ServerSocket(0)
-            port = serverSocket.localPort
-        } finally {
-            serverSocket?.close()
-        }
-
-        if (port > 0) {
-            logger.log("Free port found: $port")
-            return port
-        }
-        throw RuntimeException("Could not find a free port")
     }
 
     private fun restartServer() {

--- a/application/src/test/kotlin/application/PortUtilTest.kt
+++ b/application/src/test/kotlin/application/PortUtilTest.kt
@@ -1,0 +1,24 @@
+package application
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.net.InetAddress
+import java.net.ServerSocket
+
+internal class PortUtilTest {
+    @Test
+    fun `should correctly determine if a port is free`() {
+        val host = "0.0.0.0"
+        val randomFreePort = findRandomFreePort()
+        assertThat(portIsInUse(host, randomFreePort)).isFalse
+    }
+
+    @Test
+    fun `should correctly determine if a port is in use`() {
+        val host = "0.0.0.0"
+        val randomFreePort = findRandomFreePort()
+        ServerSocket(randomFreePort, 1, InetAddress.getByName(host)).use {
+            assertThat(portIsInUse(host, randomFreePort)).isTrue
+        }
+    }
+}


### PR DESCRIPTION

**What**:

Run stub on a random free port if the default port 9000 is in use.

**Why**:

This is to avoid issues in CI builds where the default port 9000 may not be always available.

**How**:
Check if the specified port happens to be the default port 9000.
If yes, then we check if port 9000 is available.
If it is not available, we find a random free port and run the stub on it.

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation N/A
- [x] Tests
- [x] Sonar Quality Gate

