### PR TITLE
Improved error message for oneOf

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/FailureReport.kt
+++ b/core/src/main/kotlin/in/specmatic/core/FailureReport.kt
@@ -40,7 +40,7 @@ class FailureReport(val contractPath: String?, val scenarioMessage: String?, val
     private fun breadCrumbString(breadCrumbs: List<String>): String {
         return breadCrumbs
             .filter { it.isNotBlank() }
-            .joinToString(".") { it.trim() }.replace(".(as ", " (as ")
+            .joinToString(".") { it.trim() }.replace(".(~~~", " (when ")
             .let {
                 when {
                     it.isNotBlank() -> ">> $it"

--- a/core/src/main/kotlin/in/specmatic/core/FailureReport.kt
+++ b/core/src/main/kotlin/in/specmatic/core/FailureReport.kt
@@ -40,7 +40,7 @@ class FailureReport(val contractPath: String?, val scenarioMessage: String?, val
     private fun breadCrumbString(breadCrumbs: List<String>): String {
         return breadCrumbs
             .filter { it.isNotBlank() }
-            .joinToString(".") { it.trim() }
+            .joinToString(".") { it.trim() }.replace(".(as ", " (as ")
             .let {
                 when {
                     it.isNotBlank() -> ">> $it"

--- a/core/src/main/kotlin/in/specmatic/core/pattern/AnyPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/AnyPattern.kt
@@ -44,7 +44,7 @@ data class AnyPattern(
             Pair(it.pattern, it.result as Result.Failure)
         }.map { (pattern, failure) ->
             pattern.typeAlias?.let {
-                failure.breadCrumb(" (as ${withoutPatternDelimiters(it)})")
+                failure.breadCrumb("(~~~${withoutPatternDelimiters(it)} object)")
             } ?:
             failure
         }


### PR DESCRIPTION
**What**:

When a JSON object is supposed to match against one of several schemas, as given in the specification as a oneOf of multiple possible schemas, the error message was quite opaque and confusing.

Now it will show each error with breadcrumb, and indicate which type it's for.

For example, an error message that looked like this:

```
In scenario "Create New User. Response: User Created"
API: POST /user -> 200

  >> REQUEST.BODY

      Contract expected (json object or json object) but stub contained JSON object {
          "email": "YPALR",
          "lastName": "NJIHV",
          "firstName": "RHYQL",
          "id": 612,
          "invalidkey": "data"
      }
```

...would now look like this:

```
In scenario "Create New User. Response: User Created"
API: POST /user -> 200

   >> REQUEST.BODY (when Employee object).email

      Key named email in the stub was not in the contract

   >> REQUEST.BODY (when Employee object).invalidkey

      Key named invalidkey in the stub was not in the contract

   >> REQUEST.BODY (when Customer object).invalidkey

      Key named invalidkey in the stub was not in the contract
```

**Why**:

The error message is confusing as it stands today. It is expressed very vaguely, and doesn't have enough detail about what exactly has not matched. It's ok for one level of depth, but if the error is nested several levels down, it is hard to find what has not matched.

With this change, there is pin-pointed feedback about what the mismatch was between the given JSON object and each of the oneOf object schemas that's it's supposed to match.

**Checklist**:

- [ ] (n/a) Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests

