### PR TITLE
Prevent sending a header by marking it as omit in open api…

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/HttpHeadersPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpHeadersPattern.kt
@@ -153,7 +153,7 @@ data class HttpHeadersPattern(
     }
 
     fun newBasedOn(row: Row, resolver: Resolver): List<HttpHeadersPattern> =
-        forEachKeyCombinationIn(pattern, row) { pattern ->
+        forEachKeyCombinationIn(row.withoutOmittedKeys(pattern), row) { pattern ->
             newBasedOn(pattern, row, resolver)
         }.map { HttpHeadersPattern(it.mapKeys { withoutOptionality(it.key) }) }
 

--- a/core/src/test/resources/openapi/helloWithExamples.yaml
+++ b/core/src/test/resources/openapi/helloWithExamples.yaml
@@ -27,6 +27,21 @@ paths:
             404_NOT_FOUND:
               value: 0
               summary: value that returns 404
+            400_BAD_REQUEST:
+              value: 1
+        - in: header
+          name: traceId
+          schema:
+            type: string
+          required: false
+          description: trace id
+          examples:
+            200_OKAY:
+              value: "test-trace-id"
+            404_NOT_FOUND:
+              value: "test-trace-id"
+            400_BAD_REQUEST:
+              value: "(OMIT)"
       responses:
         '200':
           description: Says hello
@@ -54,3 +69,7 @@ paths:
             application/json:
               schema:
                 type: string
+              examples:
+                400_BAD_REQUEST:
+                  value: trace id missing
+                  summary: response that matches 400_BAD_REQUEST


### PR DESCRIPTION
**What**:

Prevent sending header in the request by marking it as "(OMIT)" in example value

**Why**:

Currently when there is no example in OpenAPI, the header value is auto generated and sent as part of contract test. Certain test cases require a header to be completely not sent at all.

Example: A test case to verify if the server returns a 400 BAD REQUEST if a mandatory header such as traceId is missing will require us to deliberately not send the header as part of the generated test.

**How**:

Leveraging "(OMIT)" keyword which when provided as the example value for a header will prevent that header from being sent.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation - Pending
- [x] Tests
- [x] Sonar Quality Gate
