### PR TITLE
Add Bearer prefix to Authentication header when using bearer security scheme

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/APIKeyInHeaderSecurityScheme.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/APIKeyInHeaderSecurityScheme.kt
@@ -3,12 +3,13 @@ package `in`.specmatic.conversions
 import `in`.specmatic.core.HttpRequest
 import `in`.specmatic.core.HttpRequestPattern
 import `in`.specmatic.core.Resolver
+import `in`.specmatic.core.Result
 import `in`.specmatic.core.pattern.Row
 import `in`.specmatic.core.pattern.StringPattern
 
 class APIKeyInHeaderSecurityScheme(val name: String) : OpenAPISecurityScheme {
-    override fun matches(httpRequest: HttpRequest): Boolean {
-        return httpRequest.headers.containsKey(name)
+    override fun matches(httpRequest: HttpRequest): Result {
+        return if (httpRequest.headers.containsKey(name)) Result.Success() else Result.Failure("API-key named $name was not present as a header")
     }
 
     override fun removeParam(httpRequest: HttpRequest): HttpRequest {

--- a/core/src/main/kotlin/in/specmatic/conversions/APIKeyInQueryParamSecurityScheme.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/APIKeyInQueryParamSecurityScheme.kt
@@ -3,12 +3,13 @@ package `in`.specmatic.conversions
 import `in`.specmatic.core.HttpRequest
 import `in`.specmatic.core.HttpRequestPattern
 import `in`.specmatic.core.Resolver
+import `in`.specmatic.core.Result
 import `in`.specmatic.core.pattern.*
 import `in`.specmatic.core.value.StringValue
 
 class APIKeyInQueryParamSecurityScheme(val name: String) : OpenAPISecurityScheme {
-    override fun matches(httpRequest: HttpRequest): Boolean {
-        return httpRequest.queryParams.containsKey(name)
+    override fun matches(httpRequest: HttpRequest): Result {
+        return if (httpRequest.queryParams.containsKey(name)) Result.Success() else Result.Failure("API-key named $name was not present in query string")
     }
 
     override fun removeParam(httpRequest: HttpRequest): HttpRequest {

--- a/core/src/main/kotlin/in/specmatic/conversions/BearerSecurityScheme.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/BearerSecurityScheme.kt
@@ -9,7 +9,9 @@ import org.apache.http.HttpHeaders.AUTHORIZATION
 
 class BearerSecurityScheme : OpenAPISecurityScheme {
     override fun matches(httpRequest: HttpRequest): Boolean {
-        return httpRequest.headers.containsKey(AUTHORIZATION)
+        return httpRequest.headers.let {
+            it.containsKey(AUTHORIZATION) && it[AUTHORIZATION]!!.lowercase().startsWith("bearer")
+        }
     }
 
     override fun removeParam(httpRequest: HttpRequest): HttpRequest {

--- a/core/src/main/kotlin/in/specmatic/conversions/BearerSecurityScheme.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/BearerSecurityScheme.kt
@@ -3,15 +3,20 @@ package `in`.specmatic.conversions
 import `in`.specmatic.core.HttpRequest
 import `in`.specmatic.core.HttpRequestPattern
 import `in`.specmatic.core.Resolver
+import `in`.specmatic.core.Result
 import `in`.specmatic.core.pattern.Row
 import `in`.specmatic.core.pattern.StringPattern
 import org.apache.http.HttpHeaders.AUTHORIZATION
 
 class BearerSecurityScheme : OpenAPISecurityScheme {
-    override fun matches(httpRequest: HttpRequest): Boolean {
-        return httpRequest.headers.let {
-            it.containsKey(AUTHORIZATION) && it[AUTHORIZATION]!!.lowercase().startsWith("bearer")
+    override fun matches(httpRequest: HttpRequest): Result {
+        httpRequest.headers.let {
+            if (!it.containsKey(AUTHORIZATION))
+                return Result.Failure("$AUTHORIZATION header is missing in request")
+            if (!it[AUTHORIZATION]!!.lowercase().startsWith("bearer"))
+                return Result.Failure("$AUTHORIZATION header must be prefixed with \"Bearer\"")
         }
+        return Result.Success()
     }
 
     override fun removeParam(httpRequest: HttpRequest): HttpRequest {

--- a/core/src/main/kotlin/in/specmatic/conversions/BearerSecurityScheme.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/BearerSecurityScheme.kt
@@ -3,7 +3,8 @@ package `in`.specmatic.conversions
 import `in`.specmatic.core.HttpRequest
 import `in`.specmatic.core.HttpRequestPattern
 import `in`.specmatic.core.Resolver
-import `in`.specmatic.core.pattern.*
+import `in`.specmatic.core.pattern.Row
+import `in`.specmatic.core.pattern.StringPattern
 import org.apache.http.HttpHeaders.AUTHORIZATION
 
 class BearerSecurityScheme : OpenAPISecurityScheme {
@@ -16,7 +17,11 @@ class BearerSecurityScheme : OpenAPISecurityScheme {
     }
 
     override fun addTo(httpRequest: HttpRequest): HttpRequest {
-        return httpRequest.copy(headers = httpRequest.headers.plus(AUTHORIZATION to StringPattern().generate(Resolver()).toStringLiteral()))
+        return httpRequest.copy(
+            headers = httpRequest.headers.plus(
+                AUTHORIZATION to "Bearer " + StringPattern().generate(Resolver()).toStringLiteral(),
+            ),
+        )
     }
 
     override fun addTo(requestPattern: HttpRequestPattern, row: Row): HttpRequestPattern {

--- a/core/src/main/kotlin/in/specmatic/conversions/OpenAPISecurityScheme.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenAPISecurityScheme.kt
@@ -2,6 +2,7 @@ package `in`.specmatic.conversions
 
 import `in`.specmatic.core.HttpRequest
 import `in`.specmatic.core.HttpRequestPattern
+import `in`.specmatic.core.Result
 import `in`.specmatic.core.pattern.ExactValuePattern
 import `in`.specmatic.core.pattern.Row
 import `in`.specmatic.core.pattern.isPatternToken
@@ -9,7 +10,7 @@ import `in`.specmatic.core.pattern.parsedPattern
 import `in`.specmatic.core.value.StringValue
 
 interface OpenAPISecurityScheme {
-    fun matches(httpRequest: HttpRequest): Boolean
+    fun matches(httpRequest: HttpRequest): Result
     fun removeParam(httpRequest: HttpRequest): HttpRequest
     fun addTo(httpRequest: HttpRequest): HttpRequest
     fun addTo(requestPattern: HttpRequestPattern, row: Row): HttpRequestPattern

--- a/core/src/test/kotlin/in/specmatic/conversions/BearerSecuritySchemeTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/BearerSecuritySchemeTest.kt
@@ -1,0 +1,20 @@
+package `in`.specmatic.conversions
+
+import `in`.specmatic.core.HttpRequest
+import org.apache.http.HttpHeaders.AUTHORIZATION
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class BearerSecuritySchemeTest {
+    @Test
+    fun `authentication header starts with Bearer when using Bearer secuirty scheme`() {
+        val scheme = BearerSecurityScheme()
+        val request = scheme.addTo(
+            HttpRequest(
+                method = "POST",
+                path = "/customer",
+            ),
+        )
+        assertThat(request.headers[AUTHORIZATION]).startsWith("Bearer ")
+    }
+}

--- a/core/src/test/kotlin/in/specmatic/conversions/BearerSecuritySchemeTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/BearerSecuritySchemeTest.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test
 
 class BearerSecuritySchemeTest {
     @Test
-    fun `authentication header starts with Bearer when using Bearer secuirty scheme`() {
+    fun `authentication header starts with Bearer when using Bearer security scheme`() {
         val scheme = BearerSecurityScheme()
         val request = scheme.addTo(
             HttpRequest(
@@ -16,5 +16,25 @@ class BearerSecuritySchemeTest {
             ),
         )
         assertThat(request.headers[AUTHORIZATION]).startsWith("Bearer ")
+    }
+
+    @Test
+    fun `Bearer security scheme matches requests with authorization header set`() {
+        val scheme = BearerSecurityScheme()
+
+        val requestWithBearer = HttpRequest(method = "POST", path = "/customer", headers = mapOf(AUTHORIZATION to "Bearer foo"))
+        assertThat(scheme.matches(requestWithBearer).isSuccess()).isTrue
+
+        val requestWithoutHeader = HttpRequest(method = "POST", path = "/customer")
+        with(scheme.matches(requestWithoutHeader)) {
+            assertThat(isSuccess()).isFalse
+            assertThat(this.reportString()).contains("Authorization header is missing in request")
+        }
+
+        val requestWithoutBearer = HttpRequest(method = "POST", path = "/customer", headers = mapOf(AUTHORIZATION to "foo"))
+        with(scheme.matches(requestWithoutBearer)) {
+            assertThat(isSuccess()).isFalse
+            assertThat(this.reportString()).contains("must be prefixed")
+        }
     }
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Add `Bearer` prefix to the `Authorization` header when API is using `Bearer` based authentication.

<!-- Why are these changes necessary? -->

**Why**: When setting up an authentication scheme using `bearer` as `scheme` the requests made when contract testing should contain a `Bearer` prefix in the generated `Authentication` header.

Many frameworks, `ktor` included, requires the `Bearer` prefix to be there to correctly delegate to the specified auth handler. Without it `ktor` automatically rejects the request with a `401 Unauthorized` when the `Authorization` header simply is `Authorization: WFPSL`.

<!-- How were these changes implemented? -->

**How**: Add a `Bearer` prefix to the `Authorization` header.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

