### PR TITLE
Fix to discriminator implementation

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -854,6 +854,8 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
     ) = schema.properties.orEmpty().map { (propertyName, propertyType) ->
         if (discriminatorPropertyName == propertyName)
             propertyName to ExactValuePattern(StringValue(patternName))
+        else if(schema.discriminator?.propertyName == propertyName)
+            propertyName to ExactValuePattern(StringValue(patternName))
         else {
             val optional = !requiredFields.contains(propertyName)
             toSpecmaticParamName(optional, propertyName) to toSpecmaticPattern(propertyType, typeStack)

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -5663,12 +5663,12 @@ paths:
                   properties:
                     pet_type:
                       type: string
-                  discriminator:
-                    propertyName: pet_type
                 Pet_Polymorphic:
                   oneOf:
                     - ${'$'}ref: '#/components/schemas/Cat'
                     - ${'$'}ref: '#/components/schemas/Dog'
+                  discriminator:
+                    propertyName: pet_type
                 Dog:
                   allOf:
                   - ${'$'}ref: '#/components/schemas/Pet'

--- a/core/src/test/resources/openapi/circular-reference-polymorphic.yaml
+++ b/core/src/test/resources/openapi/circular-reference-polymorphic.yaml
@@ -26,8 +26,6 @@ components:
 
     MyBase:
       type: object
-      discriminator:
-        propertyName: '@type'
       properties:
         '@type':
           type: string
@@ -36,6 +34,8 @@ components:
       oneOf:
         - $ref: '#/components/schemas/MySub1'
         - $ref: '#/components/schemas/MySub2'
+      discriminator:
+        propertyName: '@type'
 
     MySub1:
       allOf:


### PR DESCRIPTION
**What**:

The discriminator currently is read from the object itself. However, according to the OpenAPI documentation, the discriminator property is in the same schema object that contains oneOf or anyOf.

Reference: https://swagger.io/docs/specification/data-models/inheritance-and-polymorphism/

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate
