### PR TITLE
adding ability to invoke a hook script before running contract test

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/CommandHook.kt
+++ b/core/src/main/kotlin/in/specmatic/core/CommandHook.kt
@@ -5,7 +5,8 @@ import `in`.specmatic.core.utilities.ExternalCommand
 import java.io.File
 
 enum class HookName {
-    stub_load_contract
+    stub_load_contract,
+    test_load_contract
 }
 
 class CommandHook(private val name: HookName): Hook {

--- a/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
@@ -342,7 +342,7 @@ open class SpecmaticJUnitSupport {
         config: TestConfig
     ): List<ContractTest> {
         val contractFile = File(path)
-        val feature = parseContractFileToFeature(contractFile.path).copy(testVariables = config.variables, testBaseURLs = config.baseURLs)
+        val feature = parseContractFileToFeature(contractFile.path, CommandHook(HookName.test_load_contract)).copy(testVariables = config.variables, testBaseURLs = config.baseURLs)
 
         val suggestions = when {
             suggestionsPath.isNotEmpty() -> suggestionsFromFile(suggestionsPath)


### PR DESCRIPTION
**What**:

Adding ability add a hook script before running contract test

**Why**:

To allow transformation of API specifications just like what is currently supported for stubs.

**How**:

Introduced hook parameter ```test_load_contract``` in specmatic.json.

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [ ] Tests
- [x] Sonar Quality Gate
