### PR TITLE
Bug fix for specmatic not fetching latest contracts

### DIFF
--- a/application/src/test/kotlin/application/BundleCommandTestE2E.kt
+++ b/application/src/test/kotlin/application/BundleCommandTestE2E.kt
@@ -8,11 +8,7 @@ import io.ktor.utils.io.streams.*
 import io.mockk.clearAllMocks
 import org.assertj.core.api.Assertions.assertThat
 import org.eclipse.jgit.api.Git
-import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.BeforeAll
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
-import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.*
 import org.junit.jupiter.api.io.TempDir
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -97,7 +93,6 @@ internal class BundleCommandTestE2E {
         @JvmStatic
         fun tearDown() {
             Configuration.globalConfigFileName = configFilename
-            cleanupSpecmaticDirectories(File("."))
         }
 
         fun cleanupSpecmaticDirectories(dir: File) {
@@ -124,6 +119,11 @@ internal class BundleCommandTestE2E {
     @BeforeEach
     fun setupEachTest() {
         clearAllMocks()
+    }
+
+    @AfterEach
+    fun teardownEachTest() {
+        cleanupSpecmaticDirectories(File("."))
     }
 
     @Test

--- a/application/src/test/kotlin/application/FakeGit.kt
+++ b/application/src/test/kotlin/application/FakeGit.kt
@@ -91,4 +91,12 @@ abstract class FakeGit: GitCommand {
     override fun statusPorcelain(): String {
         TODO("Not yet implemented")
     }
+
+    override fun fetch(): String {
+        TODO("Not yet implemented")
+    }
+
+    override fun revisionsBehindCount(): Int {
+        TODO("Not yet implemented")
+    }
 }

--- a/core/src/main/kotlin/in/specmatic/core/git/GitCommand.kt
+++ b/core/src/main/kotlin/in/specmatic/core/git/GitCommand.kt
@@ -26,4 +26,6 @@ interface GitCommand {
     fun exists(treeish: String, relativePath: String): Boolean
     fun getCurrentBranch(): String
     fun statusPorcelain(): String
+    fun fetch(): String
+    fun revisionsBehindCount(): Int
 }

--- a/core/src/main/kotlin/in/specmatic/core/git/SystemGit.kt
+++ b/core/src/main/kotlin/in/specmatic/core/git/SystemGit.kt
@@ -65,6 +65,14 @@ class SystemGit(override val workingDirectory: String = ".", private val prefix:
         return execute(Configuration.gitCommand, "status", "--porcelain")
     }
 
+    override fun fetch(): String {
+        return execute(Configuration.gitCommand, "fetch")
+    }
+
+    override fun revisionsBehindCount(): Int {
+        return execute(Configuration.gitCommand, "rev-list", "--count", "HEAD..@{u}").trim().toInt()
+    }
+
 
     override fun shallowClone(gitRepositoryURI: String, cloneDirectory: File): SystemGit =
         this.also {

--- a/core/src/main/kotlin/in/specmatic/core/utilities/ContractSource.kt
+++ b/core/src/main/kotlin/in/specmatic/core/utilities/ContractSource.kt
@@ -69,6 +69,7 @@ data class GitRepo(
                 val contractsRepoDir =  this.directoryRelativeTo(reposBaseDir)
                 when {
                     !contractsRepoDir.exists() -> cloneRepo(reposBaseDir, this)
+                    contractsRepoDir.exists() && isBehind(contractsRepoDir) -> cloneRepo(reposBaseDir, this)
                     contractsRepoDir.exists() && isClean(contractsRepoDir) -> {
                         logger.log("Couldn't find local contracts but ${contractsRepoDir.path} already exists and is clean and has contracts")
                         contractsRepoDir
@@ -89,6 +90,12 @@ data class GitRepo(
     private fun isClean(contractsRepoDir: File): Boolean {
         val sourceGit = getSystemGit(contractsRepoDir.path)
         return sourceGit.statusPorcelain().isEmpty()
+    }
+
+    private fun isBehind(contractsRepoDir: File): Boolean {
+        val sourceGit = getSystemGit(contractsRepoDir.path)
+        sourceGit.fetch()
+        return sourceGit.revisionsBehindCount() > 0
     }
     private fun cloneRepo(reposBaseDir:File, gitRepo: GitRepo) : File {
         logger.log("Couldn't find local contracts, cloning $gitRepositoryURL into ${reposBaseDir.path}")


### PR DESCRIPTION

**What**:
Bug fix for specmatic not fetching latest contracts.
If a contract file is updated and checked into the git repo, then next time we run specmatic stub/test, it does not fetch the latest version of the contract file.

**Why**:
This is a regression of the changes implemented for the stub auto restart fix.
If the local .specmatic folder is clean and unchanged, specmatic doesn't do anything further ..and hence the updated contracts are not fetched.

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

