### PR TITLE
Add branch support to git sources

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/in/specmatic/core/SpecmaticConfig.kt
@@ -73,6 +73,7 @@ enum class SourceProvider { git }
 data class Source(
     val provider: SourceProvider,
     val repository: String? = null,
+    val branch: String? = null,
     val test: List<String>? = null,
     val stub: List<String>? = null
 )

--- a/core/src/main/kotlin/in/specmatic/core/git/GitOperations.kt
+++ b/core/src/main/kotlin/in/specmatic/core/git/GitOperations.kt
@@ -34,9 +34,20 @@ fun clone(workingDirectory: File, gitRepo: GitRepo): File {
     return cloneDirectory
 }
 
+fun checkout(workingDirectory: File, branchName: String) {
+    logger.log("Checking out branch: ${branchName}")
+    try {
+        SystemGit(workingDirectory.path).checkout(branchName);
+    } catch(exception: Exception) {
+        logger.debug("Could not checkout branch ${branchName}")
+        logger.debug(exception.localizedMessage ?: exception.message ?: "")
+        logger.debug(exception.stackTraceToString())
+    }
+}
+
 private fun clone(gitRepositoryURI: String, cloneDirectory: File) {
     try {
-        SystemGit(cloneDirectory.parent, "-", AzureAuthCredentials).shallowClone(gitRepositoryURI, cloneDirectory)
+        SystemGit(cloneDirectory.parent, "-", AzureAuthCredentials).clone(gitRepositoryURI, cloneDirectory)
     } catch(exception: Exception) {
         logger.debug("Falling back to jgit after trying shallow clone")
         logger.debug(exception.localizedMessage ?: exception.message ?: "")

--- a/core/src/main/kotlin/in/specmatic/core/utilities/Utilities.kt
+++ b/core/src/main/kotlin/in/specmatic/core/utilities/Utilities.kt
@@ -174,7 +174,7 @@ fun loadSources(specmaticConfigJson: SpecmaticConfigJson): List<ContractSource> 
 
                 when (source.repository) {
                     null -> GitMonoRepo(testPaths, stubPaths)
-                    else -> GitRepo(source.repository, testPaths, stubPaths)
+                    else -> GitRepo(source.repository, source.branch, testPaths, stubPaths)
                 }
             }
         }
@@ -194,13 +194,14 @@ fun loadSources(configJson: JSONObjectValue): List<ContractSource> {
         when(nativeString(source.jsonObject, "provider")) {
             "git" -> {
                 val repositoryURL = nativeString(source.jsonObject, "repository")
+                val branch = nativeString(source.jsonObject, "branch")
 
                 val stubPaths = jsonArray(source, "stub")
                 val testPaths = jsonArray(source, "test")
 
                 when (repositoryURL) {
                     null -> GitMonoRepo(testPaths, stubPaths)
-                    else -> GitRepo(repositoryURL, testPaths, stubPaths)
+                    else -> GitRepo(repositoryURL, branch, testPaths, stubPaths)
                 }
             }
             else -> throw ContractException("Provider ${nativeString(source.jsonObject, "provider")} not recognised in $globalConfigFileName")

--- a/core/src/test/kotlin/utilities/UtilitiesTest.kt
+++ b/core/src/test/kotlin/utilities/UtilitiesTest.kt
@@ -32,7 +32,7 @@ internal class UtilitiesTest {
 
     @Test
     fun `contractFilePathsFrom sources when contracts repo dir does not exist`() {
-        val sources = listOf(GitRepo("https://repo1", listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION")))
+        val sources = listOf(GitRepo("https://repo1", null, listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION")))
         File(".spec").deleteRecursively()
 
         mockkStatic("in.specmatic.core.utilities.Utilities")
@@ -53,7 +53,7 @@ internal class UtilitiesTest {
 
     @Test
     fun `contractFilePathsFrom sources when contracts repo dir exists and is clean`() {
-        val sources = listOf(GitRepo("https://repo1", listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION")))
+        val sources = listOf(GitRepo("https://repo1", null, listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION")))
         File(".spec").deleteRecursively()
         File(".spec/repos/repo1").mkdirs()
 
@@ -77,7 +77,7 @@ internal class UtilitiesTest {
 
     @Test
     fun `contractFilePathsFrom sources when contracts repo dir exists and is not clean`() {
-        val sources = listOf(GitRepo("https://repo1", listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION")))
+        val sources = listOf(GitRepo("https://repo1", null, listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION")))
         File(".spec").deleteRecursively()
         File(".spec/repos/repo1").mkdirs()
 
@@ -104,7 +104,7 @@ internal class UtilitiesTest {
 
     @Test
     fun `contractFilePathsFrom sources when contracts repo dir exists and is behind remote`() {
-        val sources = listOf(GitRepo("https://repo1", listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION")))
+        val sources = listOf(GitRepo("https://repo1", null, listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION")))
         File(".spec").deleteRecursively()
         File(".spec/repos/repo1").mkdirs()
 
@@ -165,7 +165,7 @@ internal class UtilitiesTest {
         val qontractJson = "{\"sources\": [{\"provider\": \"git\",\"repository\": \"https://repo1\",\"stub\": [\"a/1.$CONTRACT_EXTENSION\",\"b/1.$CONTRACT_EXTENSION\",\"c/1.$CONTRACT_EXTENSION\"]}]}"
         val configJson = parsedJSON(qontractJson) as JSONObjectValue
         val sources = loadSources(configJson)
-        val expectedSources = listOf(GitRepo("https://repo1", listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION")))
+        val expectedSources = listOf(GitRepo("https://repo1", null, listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION")))
         assertThat(sources == expectedSources).isTrue
     }
 
@@ -176,8 +176,8 @@ internal class UtilitiesTest {
         val configJson = parsedJSON(qontractJson) as JSONObjectValue
         val sources = loadSources(configJson)
         val expectedSources = listOf(
-                GitRepo("https://repo1", listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION")),
-                GitRepo("https://repo2", listOf(), listOf("c/1.$CONTRACT_EXTENSION"))
+                GitRepo("https://repo1",null, listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION")),
+                GitRepo("https://repo2",null, listOf(), listOf("c/1.$CONTRACT_EXTENSION"))
         )
         assertThat(sources == expectedSources).isTrue
     }
@@ -229,7 +229,7 @@ internal class UtilitiesTest {
         val configJson = parsedJSON(qontractJson) as JSONObjectValue
         val sources = loadSources(configJson)
         val expectedSources = listOf(
-                GitRepo("https://repo1", listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION")),
+                GitRepo("https://repo1", null, listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION")),
                 GitMonoRepo(listOf(), listOf("c/1.$CONTRACT_EXTENSION"))
         )
         assertThat(sources == expectedSources).isTrue


### PR DESCRIPTION
**Changes made**:

What was added is branch support in the repository sources:
```json
{
    "sources": [
      {
        "provider": "git",
        "repository": "https://github.com/znsio/specmatic-order-contracts.git",
        "branch": "feature/my-amazing-api-wip",
        "test": [
          "in/specmatic/examples/store/api_order_v1.yaml"
        ]
      }
    ]
  }
```

This will clone & checkout the repo on that branch before loading contracts & spec files.

**Why**:
Sometimes when working with a contracts repository, in a consumer we want to be able to load a WIP API contract from a feature branch. Currently, we cannot specify a branch. the default one is used.

**How**:
- Added a "branch" field to "Specmatic.json" config file, then used it to call the checkout method from SystemGit.
- Changed the git clone from shallow to regular to load branches
- Fixed the previous tests with the new branch parameter set to null

When no branch is specified, the default behavior hasn't changed.

<!-- Have you done all of these things?  -->

**Checklist**:
*TODO*
- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [ ] Tests
- [ ] Sonar Quality Gate

_If you don't see any problem with this change, i'll gladly add tests & documentation 😁_

