### PR TITLE
#582 adding tests for branch support in specmatic json

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/utilities/ContractSource.kt
+++ b/core/src/main/kotlin/in/specmatic/core/utilities/ContractSource.kt
@@ -19,12 +19,11 @@ sealed class ContractSource {
 
 data class GitRepo(
     val gitRepositoryURL: String,
-    val gitBranch: String?,
+    val branchName: String?,
     override val testContracts: List<String>,
     override val stubContracts: List<String>
 ) : ContractSource() {
     val repoName = gitRepositoryURL.split("/").last().removeSuffix(".git")
-    val branchName = gitBranch
     override fun pathDescriptor(path: String): String {
         return "${repoName}:${path}"
     }
@@ -95,16 +94,16 @@ data class GitRepo(
         sourceGit.fetch()
         return sourceGit.revisionsBehindCount() > 0
     }
-    private fun cloneRepo(reposBaseDir:File, gitRepo: GitRepo) : File {
+    private fun cloneRepo(reposBaseDir: File, gitRepo: GitRepo): File {
         logger.log("Couldn't find local contracts, cloning $gitRepositoryURL into ${reposBaseDir.path}")
         reposBaseDir.mkdirs()
-        val out = clone(reposBaseDir, gitRepo)
+        val repositoryDirectory = clone(reposBaseDir, gitRepo)
 
-        when(branchName) {
+        when (branchName) {
             null -> logger.log("No branch specified, using default branch")
-            else -> checkout(out, branchName)
+            else -> checkout(repositoryDirectory, branchName)
         }
-        return out
+        return repositoryDirectory
     }
 
     private fun localRepoDir(workingDirectory: String): File = File(workingDirectory).resolve("repos")


### PR DESCRIPTION
**What**:

Adding unit tests for branch support in specmatic json

**Why**:

To verify existing functionality when branch is not mentioned

**How**:

Unit tests for both scenarios where the branch name is provided and when it is not

**Checklist**:

- [x] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [x] Sonar Quality Gate
