### PR TITLE
Ignore non-openapi specifications

### DIFF
--- a/core/src/main/kotlin/in/specmatic/stub/api.kt
+++ b/core/src/main/kotlin/in/specmatic/stub/api.kt
@@ -112,7 +112,7 @@ fun loadContractStubsFromImplicitPaths(contractPaths: List<String>): List<Pair<F
     }
 }
 
-private fun isYAML(contractPath: String) = contractPath.trim().endsWith(".yaml")
+fun isYAML(contractPath: String): Boolean = contractPath.trim().endsWith(".yaml")
 
 private fun logIgnoredFiles(implicitDataDir: File) {
     val ignoredFiles = implicitDataDir.listFiles()?.toList()?.filter { it.extension != "json" }?.filter { it.isFile } ?: emptyList()
@@ -153,22 +153,6 @@ fun loadContractStubsFromFiles(contractPaths: List<String>, dataDirPaths: List<S
 
     return loadContractStubs(features, mockData)
 }
-
-fun loadIfOpenAPISpecification(path: String): Pair<String, Feature>? {
-    return if(isYAML(path)) {
-        if (isOpenAPI(path))
-            Pair(path, parseContractFileToFeature(path, CommandHook(HookName.stub_load_contract)))
-        else {
-            logger.log("Ignoring $path as it is not an OpenAPI specification")
-            null
-        }
-    } else {
-        Pair(path, parseContractFileToFeature(path, CommandHook(HookName.stub_load_contract)))
-    }
-}
-
-private fun isOpenAPI(path: String): Boolean =
-    Yaml().load<MutableMap<String, Any?>>(File(path).reader()).contains("openapi")
 
 private fun printDataFiles(dataFiles: List<File>) {
     if (dataFiles.isNotEmpty()) {
@@ -330,4 +314,20 @@ fun implicitContractDataDir(contractPath: String, customBase: String? = null): F
         }
     }
 }
+
+fun loadIfOpenAPISpecification(path: String): Pair<String, Feature>? {
+    return if(isYAML(path)) {
+        if (isOpenAPI(path))
+            Pair(path, parseContractFileToFeature(path, CommandHook(HookName.stub_load_contract)))
+        else {
+            logger.log("Ignoring $path as it is not an OpenAPI specification")
+            null
+        }
+    } else {
+        Pair(path, parseContractFileToFeature(path, CommandHook(HookName.stub_load_contract)))
+    }
+}
+
+fun isOpenAPI(path: String): Boolean =
+    Yaml().load<MutableMap<String, Any?>>(File(path).reader()).contains("openapi")
 

--- a/core/src/main/kotlin/in/specmatic/stub/api.kt
+++ b/core/src/main/kotlin/in/specmatic/stub/api.kt
@@ -316,16 +316,14 @@ fun implicitContractDataDir(contractPath: String, customBase: String? = null): F
 }
 
 fun loadIfOpenAPISpecification(path: String): Pair<String, Feature>? {
-    return if(isYAML(path)) {
-        if (isOpenAPI(path))
-            Pair(path, parseContractFileToFeature(path, CommandHook(HookName.stub_load_contract)))
-        else {
-            logger.log("Ignoring $path as it is not an OpenAPI specification")
-            null
-        }
-    } else {
-        Pair(path, parseContractFileToFeature(path, CommandHook(HookName.stub_load_contract)))
-    }
+    if (!isYAML(path))
+        return Pair(path, parseContractFileToFeature(path, CommandHook(HookName.stub_load_contract)))
+
+    if (isOpenAPI(path))
+        return Pair(path, parseContractFileToFeature(path, CommandHook(HookName.stub_load_contract)))
+
+    logger.log("Ignoring $path as it is not an OpenAPI specification")
+    return null
 }
 
 fun isOpenAPI(path: String): Boolean =

--- a/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
@@ -12,6 +12,8 @@ import `in`.specmatic.core.utilities.*
 import `in`.specmatic.core.value.JSONArrayValue
 import `in`.specmatic.core.value.JSONObjectValue
 import `in`.specmatic.core.value.Value
+import `in`.specmatic.stub.isOpenAPI
+import `in`.specmatic.stub.isYAML
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.DynamicTest
 import org.junit.jupiter.api.TestFactory
@@ -341,6 +343,9 @@ open class SpecmaticJUnitSupport {
         suggestionsData: String,
         config: TestConfig
     ): List<ContractTest> {
+        if(isYAML(path) && !isOpenAPI(path))
+            return emptyList()
+
         val contractFile = File(path)
         val feature = parseContractFileToFeature(contractFile.path, CommandHook(HookName.test_load_contract)).copy(testVariables = config.variables, testBaseURLs = config.baseURLs)
 


### PR DESCRIPTION
**What**:

Ignore non-openapi specifications in specmatic.json when running http stubs or tests.

**Why**:

When a non-HTTP specification (such as an AsyncAPI specification for a Kafka dependency) is found in specmatic.json, the HTTP stub and test functionality should ignore. It crashes today with an exception. This PR fixes the issue.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

