### PR TITLE
Fixed url paths not covered in api coverage report

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/SpringRequestMapping.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/SpringRequestMapping.kt
@@ -1,0 +1,3 @@
+package `in`.specmatic.conversions
+
+public fun convertPathParameterStyle(path: String) = path.replace(Regex("""\((.*?):.*?\)"""), "{$1}")

--- a/core/src/main/kotlin/in/specmatic/core/URLMatcher.kt
+++ b/core/src/main/kotlin/in/specmatic/core/URLMatcher.kt
@@ -221,7 +221,7 @@ data class URLMatcher(val queryPattern: Map<String, Pattern>, val pathPattern: L
     fun toOpenApiPath(): String {
         val pathParamsWithPattern =
             this.path.split("/").filter { it.startsWith("(") }.map { it.replace("(", "").replace(")", "").split(":") }
-        return this.path.replace("(", "{").replace(""":[a-z,A-Z]*\)""".toRegex(), "}")
+        return this.path.replace("(", "{").replace(""":[a-z,A-Z]*?\)""".toRegex(), "}")
     }
 
     fun pathParameters(): List<URLPathPattern> {

--- a/core/src/main/kotlin/in/specmatic/test/ScenarioTest.kt
+++ b/core/src/main/kotlin/in/specmatic/test/ScenarioTest.kt
@@ -6,7 +6,7 @@ import `in`.specmatic.core.executeTest
 
 class ScenarioTest(val scenario: Scenario, private val generativeTestingEnabled: Boolean = false) : ContractTest {
     override fun testResultRecord(result: Result): TestResultRecord {
-        return TestResultRecord(scenario.path.replace(Regex("""\((.*):.*\)"""), "{$1}"), scenario.method, scenario.status, result.testResult())
+        return TestResultRecord(scenario.path.replace(Regex("""\((.*?):.*?\)"""), "{$1}"), scenario.method, scenario.status, result.testResult())
     }
 
     override fun generateTestScenarios(

--- a/core/src/main/kotlin/in/specmatic/test/ScenarioTest.kt
+++ b/core/src/main/kotlin/in/specmatic/test/ScenarioTest.kt
@@ -1,12 +1,13 @@
 package `in`.specmatic.test
 
+import `in`.specmatic.conversions.convertPathParameterStyle
 import `in`.specmatic.core.Result
 import `in`.specmatic.core.Scenario
 import `in`.specmatic.core.executeTest
 
 class ScenarioTest(val scenario: Scenario, private val generativeTestingEnabled: Boolean = false) : ContractTest {
     override fun testResultRecord(result: Result): TestResultRecord {
-        return TestResultRecord(scenario.path.replace(Regex("""\((.*?):.*?\)"""), "{$1}"), scenario.method, scenario.status, result.testResult())
+        return TestResultRecord(convertPathParameterStyle(scenario.path), scenario.method, scenario.status, result.testResult())
     }
 
     override fun generateTestScenarios(

--- a/core/src/main/kotlin/in/specmatic/test/ScenarioTestGenerationFailure.kt
+++ b/core/src/main/kotlin/in/specmatic/test/ScenarioTestGenerationFailure.kt
@@ -1,12 +1,13 @@
 package `in`.specmatic.test
 
+import `in`.specmatic.conversions.convertPathParameterStyle
 import `in`.specmatic.core.utilities.exceptionCauseMessage
 import `in`.specmatic.core.Scenario
 import `in`.specmatic.core.Result
 
 class ScenarioTestGenerationFailure(val scenario: Scenario, val e: Throwable) : ContractTest {
     override fun testResultRecord(result: Result): TestResultRecord {
-        return TestResultRecord(scenario.path.replace(Regex("""\((.*?):.*?\)"""), "{$1}"), scenario.method, scenario.httpResponsePattern.status, result.testResult())
+        return TestResultRecord(convertPathParameterStyle(scenario.path), scenario.method, scenario.httpResponsePattern.status, result.testResult())
     }
 
     override fun generateTestScenarios(testVariables: Map<String, String>, testBaseURLs: Map<String, String>): List<ContractTest> {

--- a/core/src/main/kotlin/in/specmatic/test/ScenarioTestGenerationFailure.kt
+++ b/core/src/main/kotlin/in/specmatic/test/ScenarioTestGenerationFailure.kt
@@ -6,7 +6,7 @@ import `in`.specmatic.core.Result
 
 class ScenarioTestGenerationFailure(val scenario: Scenario, val e: Throwable) : ContractTest {
     override fun testResultRecord(result: Result): TestResultRecord {
-        return TestResultRecord(scenario.path.replace(Regex("""\((.*):.*\)"""), "{$1}"), scenario.method, scenario.httpResponsePattern.status, result.testResult())
+        return TestResultRecord(scenario.path.replace(Regex("""\((.*?):.*?\)"""), "{$1}"), scenario.method, scenario.httpResponsePattern.status, result.testResult())
     }
 
     override fun generateTestScenarios(testVariables: Map<String, String>, testBaseURLs: Map<String, String>): List<ContractTest> {

--- a/core/src/test/kotlin/in/specmatic/conversions/SpringRequestMappingKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/SpringRequestMappingKtTest.kt
@@ -1,0 +1,13 @@
+package `in`.specmatic.conversions
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class SpringRequestMappingKtTest {
+    @Test
+    fun `convert common brackets to braces when designating path parameters in url`(): Unit {
+        val path = "/(country:string)/state/(state:number)";
+        assertEquals("/{country}/state/{state}", convertPathParameterStyle(path))
+    }
+}
+

--- a/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
@@ -1,5 +1,6 @@
 package `in`.specmatic.test
 
+import `in`.specmatic.conversions.convertPathParameterStyle
 import `in`.specmatic.core.*
 import `in`.specmatic.core.Configuration.Companion.globalConfigFileName
 import `in`.specmatic.core.log.ignoreLog
@@ -110,7 +111,7 @@ class TestReport(private val testReportRecords: MutableList<TestResultRecord> = 
         logger.newLine()
 
         val recordsWithFixedURLs = testReportRecords.map {
-            it.copy(path = it.path.replace(Regex("""\((.*?):.*?\)"""), "{$1}"))
+            it.copy(path = convertPathParameterStyle(it.path))
         }
 
         val coveredAPIRows = recordsWithFixedURLs.groupBy {
@@ -147,7 +148,6 @@ class TestReport(private val testReportRecords: MutableList<TestResultRecord> = 
 
         logger.log(APICoverageReport(coveredAPIRows, missedAPIRows).toLogString())
     }
-
 }
 
 open class SpecmaticJUnitSupport {

--- a/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
@@ -110,7 +110,7 @@ class TestReport(private val testReportRecords: MutableList<TestResultRecord> = 
         logger.newLine()
 
         val recordsWithFixedURLs = testReportRecords.map {
-            it.copy(path = it.path.replace(Regex("""\((.*):.*\)"""), "{$1}"))
+            it.copy(path = it.path.replace(Regex("""\((.*?):.*?\)"""), "{$1}"))
         }
 
         val coveredAPIRows = recordsWithFixedURLs.groupBy {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What:** Url path with multiple path parameters is not parsed correctly due to regex pattern matching error during parsing (requires non-greedy matching)

<!-- Why are these changes necessary? -->

**Why:** Api Coverage is incorrect due to wrong path string manipulation. All apis with multiple path params are marked as not covered

<!-- How were these changes implemented? -->

**How:** Simple modification of the regex used for path conversion to be non greedy using `?` operator

<!-- Have you done all of these things?  -->

**Checklist**: 

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation : N/A
- [x] Tests
- [ ] Sonar Quality Gate : N/A

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
N/A

<!-- feel free to add additional comments -->
