### PR TITLE
Added support for additionalProperties false

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -581,7 +581,7 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
             is DateSchema -> DatePattern
             is BooleanSchema -> BooleanPattern
             is ObjectSchema -> {
-                if (schema.additionalProperties != null) {
+                if (schema.additionalProperties is Schema<*>) {
                     toDictionaryPattern(schema, typeStack, patternName)
                 } else if (schema.xml?.name != null) {
                     toXMLPattern(schema, typeStack = typeStack)
@@ -630,7 +630,7 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
             else -> {
                 if (schema.nullable == true && schema.additionalProperties == null && schema.`$ref` == null) {
                     NullPattern
-                } else if (schema.additionalProperties != null) {
+                } else if (schema.additionalProperties is Schema<*>) {
                     toDictionaryPattern(schema, typeStack, patternName)
                 } else {
                     when (schema.`$ref`) {

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -3265,8 +3265,7 @@ components:
                 type: integer
 """.trimIndent()
 
-        println(openAPI)
-        val feature = OpenApiSpecification.fromYAML(openAPI, "").toFeature()
+                val feature = OpenApiSpecification.fromYAML(openAPI, "").toFeature()
 
         val request = HttpRequest("POST", "/data", body = parsedValue("""{"data": [{"id": 10}]}"""))
         val response = HttpResponse.OK
@@ -3304,8 +3303,7 @@ paths:
           description: API
 """.trimIndent()
 
-        println(openAPI)
-        val feature = OpenApiSpecification.fromYAML(openAPI, "").toFeature()
+                val feature = OpenApiSpecification.fromYAML(openAPI, "").toFeature()
 
         val request = HttpRequest("GET", "/permissions/state/ALLOW")
         val response = HttpResponse.OK
@@ -3347,8 +3345,7 @@ components:
         - DENY
 """.trimIndent()
 
-        println(openAPI)
-        val feature = OpenApiSpecification.fromYAML(openAPI, "").toFeature()
+                val feature = OpenApiSpecification.fromYAML(openAPI, "").toFeature()
 
         val request = HttpRequest("GET", "/permissions/state/ALLOW")
         val response = HttpResponse.OK
@@ -3394,8 +3391,7 @@ components:
           type: string
 """.trimIndent()
 
-        println(openAPI)
-        val feature = OpenApiSpecification.fromYAML(openAPI, "").toFeature()
+                val feature = OpenApiSpecification.fromYAML(openAPI, "").toFeature()
 
         val request =
             HttpRequest("POST", "/data", body = parsedValue("""{"10": {"name": "Jill"}, "20": {"name": "Jack"}}"""))
@@ -3438,8 +3434,7 @@ paths:
           description: API
 """.trimIndent()
 
-        println(openAPI)
-        val feature = OpenApiSpecification.fromYAML(openAPI, "").toFeature()
+                val feature = OpenApiSpecification.fromYAML(openAPI, "").toFeature()
 
         val request =
             HttpRequest("POST", "/data", body = parsedValue("""{"10": {"name": "Jill"}, "20": {"name": "Jack"}}"""))
@@ -3489,8 +3484,7 @@ components:
           type: string
 """.trimIndent()
 
-        println(openAPI)
-        val feature = OpenApiSpecification.fromYAML(openAPI, "").toFeature()
+                val feature = OpenApiSpecification.fromYAML(openAPI, "").toFeature()
 
         val request = HttpRequest(
             "POST",
@@ -3552,8 +3546,7 @@ components:
           type: string
 """.trimIndent()
 
-    println(openAPI)
-    val feature = OpenApiSpecification.fromYAML(openAPI, "").toFeature()
+        val feature = OpenApiSpecification.fromYAML(openAPI, "").toFeature()
 
     val request = HttpRequest(
       "POST",
@@ -3597,8 +3590,7 @@ paths:
           description: API
 """.trimIndent()
 
-        println(openAPI)
-        val feature = OpenApiSpecification.fromYAML(openAPI, "").toFeature()
+                val feature = OpenApiSpecification.fromYAML(openAPI, "").toFeature()
 
         val request =
             HttpRequest("POST", "/data", body = parsedValue("""{"10": "Jill", "20": "Jack"}"""))
@@ -3610,6 +3602,58 @@ paths:
 
         assertThat(stub.requestType.method).isEqualTo("POST")
         assertThat(stub.response.status).isEqualTo(200)
+    }
+
+    @Nested
+    inner class WhenAdditionalPropertiesIsFalse {
+        val openAPI =
+            """
+---
+openapi: 3.0.1
+info:
+  title: API
+  version: 1
+paths:
+  /data:
+    post:
+      summary: API
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: integer
+              additionalProperties: false
+      responses:
+        200:
+          description: API
+""".trimIndent()
+
+        val feature = OpenApiSpecification.fromYAML(openAPI, "").toFeature()
+
+        @Test
+        fun `an object with no additional properties should match the specification`() {
+            val request =
+                HttpRequest("POST", "/data", body = parsedValue("""{"id": 10}"""))
+            val response = HttpResponse.OK
+
+            val stub: HttpStubData = feature.matchingStub(request, response)
+            assertThat(stub.requestType.matches(request, Resolver())).isInstanceOf(Result.Success::class.java)
+        }
+
+        @Test
+        fun `an object with additional properties should not match the specification`() {
+            val invalidRequest =
+                HttpRequest("POST", "/data", body = parsedValue("""{"id": 10, "name": "Jill"}"""))
+            val response = HttpResponse.OK
+
+            assertThatThrownBy { feature.matchingStub(invalidRequest, response) }
+                .isInstanceOf(NoMatchingScenario::class.java)
+                .hasMessageContaining("REQUEST.BODY.name")
+        }
     }
 
     @Test


### PR DESCRIPTION
**What**:

So far Specmatic expects additionalProperties to be a Schema<*>. It can also be false to indicate that no additional properties are allowed, and Specmatic threw an exception when trying to cast additionalProperties to Schema<*>.

This is now fixed.

**How**:

additionalProperties used to be cast to Schema<*> if it was not null. Wherever this was happening, it now checks explicitly for the Schema<*> type.

Specmatic's behaviour at this point is to disallow extra unexpected properties. Specmatic exhibits this behaviour even if additionalProperties is not set to false (though according to OpenAPI the absence of additionalProperties indicates that additional properties are allowed).

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

Fixes: #646