### PR TITLE
Fix soap action

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/WsdlSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/WsdlSpecification.kt
@@ -57,11 +57,11 @@ class WsdlSpecification(private val wsdlFile: WSDLContent) : IncludedSpecificati
     private fun matchesRequest(parameters: Pair<ScenarioInfo, List<ScenarioInfo>>): MatchingResult<Pair<ScenarioInfo, List<ScenarioInfo>>> {
         val (specmaticScenarioInfo, wsdlScenarioInfos) = parameters
 
-        val matchingScenarioInfos = wsdlScenarioInfos.filter {
-            it.httpRequestPattern.matches(
+        val matchingScenarioInfos = wsdlScenarioInfos.filter { scenarioInfo ->
+            scenarioInfo.httpRequestPattern.matches(
                 specmaticScenarioInfo.httpRequestPattern.generate(
-                    Resolver()
-                ), Resolver()
+                    Resolver(newPatterns = scenarioInfo.patterns)
+                ), Resolver(newPatterns = scenarioInfo.patterns)
             ).isSuccess()
         }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/XMLPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/XMLPattern.kt
@@ -128,6 +128,9 @@ data class XMLPattern(override val pattern: XMLTypeData = XMLTypeData(realName =
             sampleData: XMLNode,
             resolver: Resolver
     ): Result {
+        if(sampleData.name.lowercase() == "body" && sampleData.firstNode() is XMLNode && sampleData.firstNode()?.name?.lowercase() == "fault")
+            return Success()
+
         val results = pattern.nodes.scanIndexed(
                 ConsumeResult<XMLValue, Value>(
                         Success(),
@@ -136,13 +139,13 @@ data class XMLPattern(override val pattern: XMLTypeData = XMLTypeData(realName =
         ) { index, consumeResult, type ->
             when (val resolvedType = resolvedHop(type, resolver)) {
                 is ListPattern -> ConsumeResult(
-                        resolvedType.matches(
-                                this.listOf(
-                                        consumeResult.remainder.subList(index, pattern.nodes.indices.last),
-                                        resolver
-                                ), resolver
-                        ),
-                        emptyList()
+                    resolvedType.matches(
+                        this.listOf(
+                            consumeResult.remainder.subList(index, pattern.nodes.indices.last),
+                            resolver
+                        ), resolver
+                    ),
+                    emptyList()
                 )
                 else -> {
                     try {

--- a/core/src/main/kotlin/in/specmatic/core/wsdl/parser/operation/SOAPRequest.kt
+++ b/core/src/main/kotlin/in/specmatic/core/wsdl/parser/operation/SOAPRequest.kt
@@ -6,7 +6,10 @@ data class SOAPRequest(val path: String, val operationName: String, val soapActi
     fun statements(): List<String> {
         val pathStatement = listOf("When POST $path")
         val soapActionHeaderStatement = when {
-            soapAction.isNotBlank() -> listOf("""And request-header SOAPAction "$soapAction"""")
+            soapAction.isNotBlank() -> listOf(
+                """And enum SoapAction (string) values "$soapAction",$soapAction""",
+                """And request-header SOAPAction (SoapAction)"""
+            )
             else -> emptyList()
         }
 

--- a/core/src/test/kotlin/in/specmatic/conversions/WSDLConversionTests.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/WSDLConversionTests.kt
@@ -74,7 +74,8 @@ class WSDLConversionTests {
 
             Scenario: SimpleOperation
                 When POST /SOAPService/SimpleSOAP
-                And request-header SOAPAction "http://specmatic.in/SOAPService/SimpleOperation"
+                And enum SoapAction (string) values "http://specmatic.in/SOAPService/SimpleOperation",http://specmatic.in/SOAPService/SimpleOperation
+                And request-header SOAPAction (SoapAction)
                 And request-body
                 ""${'"'}
                 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soapenv:Header specmatic_occurs="optional"/><soapenv:Body><SimpleRequest>(string)</SimpleRequest></soapenv:Body></soapenv:Envelope>
@@ -157,7 +158,8 @@ class WSDLConversionTests {
 
             Scenario: SimpleOperation
                 When POST /SOAPService/SimpleSOAP
-                And request-header SOAPAction "http://specmatic.in/SOAPService/SimpleOperation"
+                And enum SoapAction (string) values "http://specmatic.in/SOAPService/SimpleOperation",http://specmatic.in/SOAPService/SimpleOperation
+                And request-header SOAPAction (SoapAction)
                 And request-body
                 ""${'"'}
                 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soapenv:Header specmatic_occurs="optional"/><soapenv:Body><SimpleRequest>(string)</SimpleRequest></soapenv:Body></soapenv:Envelope>
@@ -249,7 +251,8 @@ class WSDLConversionTests {
                     </SPECMATIC_TYPE>
                     ""${'"'}
                     When POST /SOAPService/SimpleSOAP
-                    And request-header SOAPAction "http://specmatic.in/SOAPService/SimpleOperation"
+                    And enum SoapAction (string) values "http://specmatic.in/SOAPService/SimpleOperation",http://specmatic.in/SOAPService/SimpleOperation
+                    And request-header SOAPAction (SoapAction)
                     And request-body
                     ""${'"'}
                     <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
@@ -345,7 +348,8 @@ class WSDLConversionTests {
                     </SPECMATIC_TYPE>
                     ""${'"'}
                     When POST /SOAPService/SimpleSOAP
-                    And request-header SOAPAction "http://specmatic.in/SOAPService/SimpleOperation"
+                    And enum SoapAction (string) values "http://specmatic.in/SOAPService/SimpleOperation",http://specmatic.in/SOAPService/SimpleOperation
+                    And request-header SOAPAction (SoapAction)
                     And request-body
                     ""${'"'}
                     <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
@@ -446,7 +450,8 @@ class WSDLConversionTests {
                     </SPECMATIC_TYPE>
                     ""${'"'}
                     When POST /SOAPService/SimpleSOAP
-                    And request-header SOAPAction "http://specmatic.in/SOAPService/SimpleOperation"
+                    And enum SoapAction (string) values "http://specmatic.in/SOAPService/SimpleOperation",http://specmatic.in/SOAPService/SimpleOperation
+                    And request-header SOAPAction (SoapAction)
                     And request-body
                     ""${'"'}
                     <soapenv:Envelope xmlns:SOAPService="http://specmatic.in/SOAPService/" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
@@ -542,7 +547,8 @@ class WSDLConversionTests {
                     </SPECMATIC_TYPE>
                     ""${'"'}
                     When POST /SOAPService/SimpleSOAP
-                    And request-header SOAPAction "http://specmatic.in/SOAPService/SimpleOperation"
+                    And enum SoapAction (string) values "http://specmatic.in/SOAPService/SimpleOperation",http://specmatic.in/SOAPService/SimpleOperation
+                    And request-header SOAPAction (SoapAction)
                     And request-body
                     ""${'"'}
                     <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
@@ -584,7 +590,8 @@ class WSDLConversionTests {
                         </SPECMATIC_TYPE>
                         ""${'"'}
                         When POST /SOAPService/SimpleSOAP
-                        And request-header SOAPAction "http://specmatic.in/SOAPService/SimpleOperation"
+                        And enum SoapAction (string) values "http://specmatic.in/SOAPService/SimpleOperation",http://specmatic.in/SOAPService/SimpleOperation
+                        And request-header SOAPAction (SoapAction)
                         And request-body
                         ""${'"'}
                         <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
@@ -698,7 +705,8 @@ class WSDLConversionTests {
                         </SPECMATIC_TYPE>
                         ""${'"'}
                         When POST /SOAPService/SimpleSOAP
-                        And request-header SOAPAction "http://specmatic.in/SOAPService/SimpleOperation"
+                        And enum SoapAction (string) values "http://specmatic.in/SOAPService/SimpleOperation",http://specmatic.in/SOAPService/SimpleOperation
+                        And request-header SOAPAction (SoapAction)
                         And request-body
                         ""${'"'}
                         <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
@@ -746,7 +754,8 @@ class WSDLConversionTests {
                         </SPECMATIC_TYPE>
                         ""${'"'}
                         When POST /SOAPService/SimpleSOAP
-                        And request-header SOAPAction "http://specmatic.in/SOAPService/SimpleOperation"
+                        And enum SoapAction (string) values "http://specmatic.in/SOAPService/SimpleOperation",http://specmatic.in/SOAPService/SimpleOperation
+                        And request-header SOAPAction (SoapAction)
                         And request-body
                         ""${'"'}
                         <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
@@ -833,7 +842,8 @@ class WSDLConversionTests {
             
                 Scenario: SimpleOperation
                     When POST /SOAPService/SimpleSOAP
-                    And request-header SOAPAction "http://specmatic.in/SOAPService/SimpleOperation"
+                    And enum SoapAction (string) values "http://specmatic.in/SOAPService/SimpleOperation",http://specmatic.in/SOAPService/SimpleOperation
+                    And request-header SOAPAction (SoapAction)
                     Then status 200
                     And response-body
                     ""${'"'}
@@ -904,7 +914,8 @@ class WSDLConversionTests {
             
                 Scenario: SimpleOperation
                     When POST /SOAPService/SimpleSOAP
-                    And request-header SOAPAction "http://specmatic.in/SOAPService/SimpleOperation"
+                    And enum SoapAction (string) values "http://specmatic.in/SOAPService/SimpleOperation",http://specmatic.in/SOAPService/SimpleOperation
+                    And request-header SOAPAction (SoapAction)
                     And request-body
                     ""${'"'}
                     <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soapenv:Header specmatic_occurs="optional"/><soapenv:Body/></soapenv:Envelope>
@@ -996,7 +1007,8 @@ class WSDLConversionTests {
                     </SPECMATIC_TYPE>
                     ""${'"'}
                     When POST /SOAPService/SimpleSOAP
-                    And request-header SOAPAction "http://specmatic.in/SOAPService/SimpleOperation"
+                    And enum SoapAction (string) values "http://specmatic.in/SOAPService/SimpleOperation",http://specmatic.in/SOAPService/SimpleOperation
+                    And request-header SOAPAction (SoapAction)
                     And request-body
                     ""${'"'}
                     <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
@@ -1108,7 +1120,8 @@ class WSDLConversionTests {
                     </SPECMATIC_TYPE>
                     ""${'"'}
                     When POST /SOAPService/SimpleSOAP
-                    And request-header SOAPAction "http://specmatic.in/SOAPService/SimpleOperation"
+                    And enum SoapAction (string) values "http://specmatic.in/SOAPService/SimpleOperation",http://specmatic.in/SOAPService/SimpleOperation
+                    And request-header SOAPAction (SoapAction)
                     And request-body
                     ""${'"'}
                     <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
@@ -1214,7 +1227,8 @@ class WSDLConversionTests {
             
                 Scenario: SimpleOperation
                     When POST /SOAPService/SimpleSOAP
-                    And request-header SOAPAction "http://specmatic.in/SOAPService/SimpleOperation"
+                    And enum SoapAction (string) values "http://specmatic.in/SOAPService/SimpleOperation",http://specmatic.in/SOAPService/SimpleOperation
+                    And request-header SOAPAction (SoapAction)
                     And request-body
                     ""${'"'}
                     <soapenv:Envelope xmlns:SOAPService="http://specmatic.in/SOAPService/" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soapenv:Header specmatic_occurs="optional"/><soapenv:Body><SOAPService:SimpleRequest>(string)</SOAPService:SimpleRequest></soapenv:Body></soapenv:Envelope>
@@ -1292,7 +1306,8 @@ class WSDLConversionTests {
             
                 Scenario: SimpleOperation
                     When POST /SOAPService/SimpleSOAP
-                    And request-header SOAPAction "http://specmatic.in/SOAPService/SimpleOperation"
+                    And enum SoapAction (string) values "http://specmatic.in/SOAPService/SimpleOperation",http://specmatic.in/SOAPService/SimpleOperation
+                    And request-header SOAPAction (SoapAction)
                     And request-body
                     ""${'"'}
                     <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soapenv:Header specmatic_occurs="optional"/><soapenv:Body><SimpleRequest>(string)</SimpleRequest></soapenv:Body></soapenv:Envelope>

--- a/core/src/test/kotlin/in/specmatic/conversions/WsdlKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/WsdlKtTest.kt
@@ -155,7 +155,10 @@ Scenario: test request returns test response
             object : TestExecutor {
                 override fun execute(request: HttpRequest): HttpResponse {
                     assertThat(request.path).matches("""/SOAPService/SimpleSOAP""")
-                    assertThat(request.headers["SOAPAction"]).isEqualTo(""""http://specmatic.in/SOAPService/SimpleOperation"""")
+                    assertThat(listOf(
+                        """http://specmatic.in/SOAPService/SimpleOperation""",
+                        """"http://specmatic.in/SOAPService/SimpleOperation""""))
+                        .contains(request.headers["SOAPAction"])
                     val responseBody = when {
                         request.bodyString.contains("test request") -> """<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soapenv:Header/><soapenv:Body><SimpleResponse>test response</SimpleResponse></soapenv:Body></soapenv:Envelope>"""
                         else -> """<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soapenv:Header/><soapenv:Body><SimpleResponse>WSDL</SimpleResponse></soapenv:Body></soapenv:Envelope>"""

--- a/core/src/test/kotlin/in/specmatic/core/wsdl/parser/operation/SOAPOperationTypeInfoTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/wsdl/parser/operation/SOAPOperationTypeInfoTest.kt
@@ -13,7 +13,8 @@ internal class SOAPOperationTypeInfoTest {
         val expectedSOAPPayload = """
             Scenario: customer
               When POST /get
-              And request-header SOAPAction "/getDetails"
+              And enum SoapAction (string) values "/getDetails",/getDetails
+              And request-header SOAPAction (SoapAction)
               And request-body
               ""${'"'}
               <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soapenv:Header $OCCURS_ATTRIBUTE_NAME="optional"/><soapenv:Body/></soapenv:Envelope>

--- a/core/src/test/kotlin/in/specmatic/core/wsdl/parser/operation/SOAPRequestTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/wsdl/parser/operation/SOAPRequestTest.kt
@@ -12,10 +12,11 @@ internal class SOAPRequestTest {
         val soapRequest = SOAPRequest("/customer", "add", "/add", EmptySOAPPayload(SOAPMessageType.Input))
 
         val statements = soapRequest.statements()
-        assertThat(statements).hasSize(3)
+        assertThat(statements).hasSize(4)
 
         assertThat(statements).contains("When POST /customer")
-        assertThat(statements).contains("And request-header SOAPAction \"/add\"")
+        assertThat(statements).contains("And enum SoapAction (string) values \"/add\",/add",)
+        assertThat(statements).contains("And request-header SOAPAction (SoapAction)")
         assertThat(statements).contains("And request-body\n" +
                 "\"\"\"\n" +
                 "<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><soapenv:Header $OCCURS_ATTRIBUTE_NAME=\"optional\"/><soapenv:Body/></soapenv:Envelope>\n" +

--- a/core/src/test/resources/wsdl/hello.spec
+++ b/core/src/test/resources/wsdl/hello.spec
@@ -2,7 +2,8 @@ Feature: simpleService
 
     Scenario: SimpleOperation
         When POST /SOAPService/SimpleSOAP
-        And request-header SOAPAction "http://specmatic.in/SOAPService/SimpleOperation"
+        And enum SoapAction (string) values "http://specmatic.in/SOAPService/SimpleOperation",http://specmatic.in/SOAPService/SimpleOperation
+        And request-header SOAPAction (SoapAction)
         And request-body
         """
         <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soapenv:Header specmatic_occurs="optional"/><soapenv:Body><SimpleRequest>(string)</SimpleRequest></soapenv:Body></soapenv:Envelope>

--- a/core/src/test/resources/wsdl/stockquote.spec
+++ b/core/src/test/resources/wsdl/stockquote.spec
@@ -14,7 +14,8 @@ Feature: StockQuoteService
         </SPECMATIC_TYPE>
         """
         When POST /stockquote
-        And request-header SOAPAction "http://example.com/GetLastTradePrice"
+        And enum SoapAction (string) values "http://example.com/GetLastTradePrice",http://example.com/GetLastTradePrice
+        And request-header SOAPAction (SoapAction)
         And request-body
         """
         <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soapenv:Header specmatic_occurs="optional"/><soapenv:Body><TradePriceRequest specmatic_type="GetLastTradePrice_SOAPPayload_Input"/></soapenv:Body></soapenv:Envelope>

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=0.72.0
+version=0.73.0


### PR DESCRIPTION
**What**:

1. The value of the SOAPAction header previously was expected to be enclosed in quotes. It now can be "/soapAction" or just /soapAction.
2. We have basic support now for SOAP faults. WSDL-validation of faults is not yet in place, and will follow.

**Why**:

These have been missing pieces for some time.

**Checklist**:


- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

