### PR TITLE
Allow command install to be set in a specific directory even in a Git directory + handle the branch in install command

### DIFF
--- a/application/src/main/kotlin/application/InstallCommand.kt
+++ b/application/src/main/kotlin/application/InstallCommand.kt
@@ -11,8 +11,11 @@ import java.util.concurrent.Callable
 
 @CommandLine.Command(name = "install", description = ["Clone the git repositories declared in the manifest"], mixinStandardHelpOptions = true)
 class InstallCommand: Callable<Unit> {
+
+    @CommandLine.Option(names = ["--targetDirectory"], description = ["Directory in which the git repository will be cloned"])
+    var targetDirectory: String = System.getProperty("user.home")
     override fun call() {
-        val userHome = File(System.getProperty("user.home"))
+        val userHome = File(targetDirectory)
         val workingDirectory = userHome.resolve(".$APPLICATION_NAME_LOWER_CASE/repos")
 
         val sources = try { loadSources(globalConfigFileName) } catch(e: ContractException) { exitWithMessage(e.failure().toReport().toText()) }

--- a/application/src/test/kotlin/application/FakeGit.kt
+++ b/application/src/test/kotlin/application/FakeGit.kt
@@ -99,4 +99,7 @@ abstract class FakeGit: GitCommand {
     override fun revisionsBehindCount(): Int {
         TODO("Not yet implemented")
     }
+    override fun getRemoteUrl(name: String): String {
+        TODO("Not yet implemented")
+    }
 }

--- a/core/src/main/kotlin/in/specmatic/core/git/GitCommand.kt
+++ b/core/src/main/kotlin/in/specmatic/core/git/GitCommand.kt
@@ -28,4 +28,5 @@ interface GitCommand {
     fun statusPorcelain(): String
     fun fetch(): String
     fun revisionsBehindCount(): Int
+    fun getRemoteUrl(name: String = "origin"): String
 }

--- a/core/src/main/kotlin/in/specmatic/core/git/SystemGit.kt
+++ b/core/src/main/kotlin/in/specmatic/core/git/SystemGit.kt
@@ -122,6 +122,8 @@ class SystemGit(override val workingDirectory: String = ".", private val prefix:
     fun getChangesFromMainBranch(mainBranch: String): List<String> {
         return execute(Configuration.gitCommand, "diff", "--name-only", mainBranch).split(System.lineSeparator())
     }
+
+    override fun getRemoteUrl(name: String): String = execute(Configuration.gitCommand, "remote", "get-url", name)
 }
 
 fun exitErrorMessageContains(exception: NonZeroExitError, snippets: List<String>): Boolean {

--- a/core/src/main/kotlin/in/specmatic/core/utilities/ContractSource.kt
+++ b/core/src/main/kotlin/in/specmatic/core/utilities/ContractSource.kt
@@ -117,7 +117,7 @@ data class GitRepo(
             if (!sourceDir.exists())
                 sourceDir.mkdirs()
 
-            if (!sourceGit.workingDirectoryIsGitRepo() || (sourceGit.workingDirectoryIsGitRepo() && sourceGit.getRemoteUrl() != this.gitRepositoryURL && sourceDir.listFiles()?.isEmpty()!!)) {
+            if (!sourceGit.workingDirectoryIsGitRepo() || isEmptyNestedGitDirectory(sourceGit, sourceDir)) {
                 println("Found it, not a git dir, recreating...")
                 sourceDir.deleteRecursively()
                 sourceDir.mkdirs()
@@ -130,6 +130,9 @@ data class GitRepo(
             println("Could not clone ${this.gitRepositoryURL}\n${e.javaClass.name}: ${exceptionCauseMessage(e)}")
         }
     }
+
+    private fun isEmptyNestedGitDirectory(sourceGit: SystemGit, sourceDir: File) =
+        (sourceGit.workingDirectoryIsGitRepo() && sourceGit.getRemoteUrl() != this.gitRepositoryURL && sourceDir.listFiles()?.isEmpty()!!)
 }
 
 data class GitMonoRepo(override val testContracts: List<String>, override val stubContracts: List<String>) : ContractSource() {

--- a/core/src/main/kotlin/in/specmatic/core/utilities/ContractSource.kt
+++ b/core/src/main/kotlin/in/specmatic/core/utilities/ContractSource.kt
@@ -117,12 +117,12 @@ data class GitRepo(
             if (!sourceDir.exists())
                 sourceDir.mkdirs()
 
-            if (!sourceGit.workingDirectoryIsGitRepo()) {
+            if (!sourceGit.workingDirectoryIsGitRepo() || (sourceGit.workingDirectoryIsGitRepo() && sourceGit.getRemoteUrl() != this.gitRepositoryURL && sourceDir.listFiles()?.isEmpty()!!)) {
                 println("Found it, not a git dir, recreating...")
                 sourceDir.deleteRecursively()
                 sourceDir.mkdirs()
-                println("Cloning ${this.gitRepositoryURL} into ${sourceDir.absolutePath}")
-                sourceGit.clone(this.gitRepositoryURL, sourceDir.absoluteFile)
+                println("Cloning ${this.gitRepositoryURL} into ${sourceDir.canonicalPath}")
+                this.cloneRepo(sourceDir.canonicalFile.parentFile, this)
             } else {
                 println("Git repo already exists at ${sourceDir.path}, so ignoring it and moving on")
             }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: I added the feature to allow the user to specify where the install command should place the files from the OpenApi repository, allowing it to be placed inside another directory which is also a git directory (nested repository)
I added the feature to change the branch by using the one specified in the `specmatic.json` whe using the command install

<!-- Why are these changes necessary? -->

**Why**: Install by default was installing in the home directory which can be an issue while working with docker container and k8s pods, or even with a CI tool a bit too old like bamboo

<!-- How were these changes implemented? -->

**How**: 
- I added an option to the command `install` which is called `--targetDirectory` wich by default is home if not specified
- I used the clone command from the `GitRepo.kt` instead of the `sourceGit.clone(....)` to handle the branch specified in the `specmatic.json`
- I check that if the directory is a git directory but the remote is not the same and the sub direcotries are empty or the directory is not a git directory then clone from the repo

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [ ] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: /

<!-- feel free to add additional comments -->
