### PR TITLE
fix: correctly filter schema scenarios already defined in external spec

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Feature.kt
@@ -1655,7 +1655,7 @@ fun scenarioInfos(
     }
 
     return specmaticScenarioInfos.plus(scenarioInfosBelongingToIncludedSpecifications.filter { scenarioInfo ->
-        !specmaticScenarioInfos.any {
+        specmaticScenarioInfos.none {
             it.httpResponsePattern.status == scenarioInfo.httpResponsePattern.status
                     && it.httpRequestPattern.matchesSignature(scenarioInfo.httpRequestPattern)
         }

--- a/core/src/main/kotlin/in/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Feature.kt
@@ -1657,6 +1657,7 @@ fun scenarioInfos(
     return specmaticScenarioInfos.plus(scenarioInfosBelongingToIncludedSpecifications.filter { scenarioInfo ->
         !specmaticScenarioInfos.any {
             it.httpResponsePattern.status == scenarioInfo.httpResponsePattern.status
+                    && it.httpRequestPattern.matchesSignature(scenarioInfo.httpRequestPattern)
         }
     })
 }

--- a/core/src/main/kotlin/in/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Scenario.kt
@@ -76,6 +76,9 @@ data class Scenario(
         serviceType = scenarioInfo.serviceType
     )
 
+    val apiIdentifier: String
+        get() = "$method $path $status"
+
     override val method: String
         get() {
             return httpRequestPattern.method ?: ""

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.google.common.net.HttpHeaders.AUTHORIZATION
 import `in`.specmatic.core.*
 import `in`.specmatic.core.HttpRequest
 import `in`.specmatic.core.log.Verbose
@@ -17,7 +16,6 @@ import `in`.specmatic.core.value.NumberValue
 import `in`.specmatic.core.value.StringValue
 import `in`.specmatic.core.value.Value
 import `in`.specmatic.stub.HttpStub
-import `in`.specmatic.stub.createStubFromContracts
 import `in`.specmatic.test.TestExecutor
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.OkHttpClient
@@ -60,7 +58,6 @@ import kotlin.collections.joinToString
 import kotlin.collections.last
 import kotlin.collections.listOf
 import kotlin.collections.map
-import kotlin.collections.mapOf
 import kotlin.collections.mapValues
 import kotlin.collections.mutableListOf
 import kotlin.collections.mutableMapOf
@@ -1204,6 +1201,16 @@ Background:
         val openapiSpec = OpenApiSpecification.fromFile("openapi/petstore-expanded.yaml")
 
         assertThat(feature.scenarios).hasSameSizeAs(openapiSpec.toScenarioInfos())
+
+        val apiIdentifiersFromGherkinSpec = feature.scenarios.map {
+            it.apiIdentifier
+        }.sorted().distinct()
+
+        val apiIdentifiersDirectlyFromSpecification = feature.scenarios.map {
+            it.apiIdentifier
+        }.sorted().distinct()
+
+        assertThat(apiIdentifiersFromGherkinSpec).isEqualTo(apiIdentifiersDirectlyFromSpecification)
     }
     @Test
     fun `should create petstore tests`() {

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
@@ -1344,6 +1344,27 @@ Background:
     }
 
     @Test
+    fun `should filter out schema scenarios already defined in spec`() {
+        val feature = parseGherkinStringToFeature(
+            """
+            Feature: Hello world
+            
+            Background:
+              Given openapi openapi/petstore-expanded.yaml
+              
+              Scenario Outline: get by tag
+                When GET /pets
+                Then status 200
+                Examples:
+                  | tag     |
+                  | testing |
+        """.trimIndent(), sourceSpecPath
+        )
+        val openapiSpec = OpenApiSpecification.fromFile("openapi/petstore-expanded.yaml")
+
+        assertThat(feature.scenarios).hasSameSizeAs(openapiSpec.toScenarioInfos())
+    }
+    @Test
     fun `should create petstore tests`() {
         val systemPropertiesMap = System.getProperties().map { it.key.toString() to it.value.toString() }.toMap()
         printMap("System Properties", systemPropertiesMap)


### PR DESCRIPTION
**What**:

This should fix the overly aggressive filter in Feature scenarios, that removes any Schema scenario that has the same return status value as a scenario defined in external spec file. 

**Why**:

See #711 

**How**:

Filter now consider both the status and request pattern match

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation N/A
- [x] Tests
- [ ] Sonar Quality Gate 

**Issue ID**:
Closes: #711 

