### PR TITLE
Api coverage report cleanup

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -59,8 +59,6 @@ dependencies {
 
     implementation 'org.apache.ant:ant-junit:1.10.12'
 
-    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.4.1"
-
     implementation(project(':core'))
     implementation(project(':junit5-support'))
 

--- a/junit5-support/src/main/kotlin/in/specmatic/test/reports/OpenApiCoverageReportProcessor.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/reports/OpenApiCoverageReportProcessor.kt
@@ -43,7 +43,8 @@ class OpenApiCoverageReportProcessor(private val openApiCoverageReportInput: Ope
             val coverageThresholdNotMetMessage =
                 "Total API coverage: ${openAPICoverageReport.totalCoveragePercentage}% is less than the specified minimum threshold of ${successCriteria.minThresholdPercentage}%."
             val missedEndpointsCountExceededMessage =
-                "Total missed endpoints count: ${openAPICoverageReport.missedEndpointsCount} is greater than the maximum threshold of ${successCriteria.maxMissedEndpointsInSpec}."
+                "Total missed endpoints count: ${openAPICoverageReport.missedEndpointsCount} is greater than the maximum threshold of ${successCriteria.maxMissedEndpointsInSpec}.\n(Note: Specmatic will consider an endpoint as 'covered' only if it is documented in the open api spec with atleast one example for each operation and response code.\nIf it is present in the spec, but does not have an example, Specmatic will still report the particular operation and response code as 'missing in spec'.)"
+
             val minCoverageThresholdCriteriaMet = openAPICoverageReport.totalCoveragePercentage >= successCriteria.minThresholdPercentage
             val maxMissingEndpointsExceededCriteriaMet = openAPICoverageReport.missedEndpointsCount <= successCriteria.maxMissedEndpointsInSpec
             val coverageReportSuccessCriteriaMet = minCoverageThresholdCriteriaMet && maxMissingEndpointsExceededCriteriaMet


### PR DESCRIPTION
**What**:

- Removed unneeded import of dependency: 'org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.4.1' as it is available via core.
- Added a message indicating that specmatic will report an endpoint as 'missed in spec' when there are no examples defined, when the success criteria fails due to exceeding the max number of missed endpoints.

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [ ] Tests
- [ ] Sonar Quality Gate
