### PR TITLE
Minor fixes

### DIFF
--- a/application/src/main/kotlin/application/QontractApplicationRunner.kt
+++ b/application/src/main/kotlin/application/QontractApplicationRunner.kt
@@ -13,7 +13,10 @@ class QontractApplicationRunner(specmaticCommand: SpecmaticCommand, factory: Com
 
     @Throws(Exception::class)
     override fun run(vararg args: String) {
-        exitCode = CommandLine(myCommand, factory).execute(*args)
+        val cmd = CommandLine(myCommand, factory)
+        cmd.subcommands.getValue("generate-completion").commandSpec.usageMessage().hidden(true)
+
+        exitCode = cmd.execute(*args)
     }
 
     override fun getExitCode() = exitCode

--- a/application/src/main/kotlin/application/SpecmaticCommand.kt
+++ b/application/src/main/kotlin/application/SpecmaticCommand.kt
@@ -1,6 +1,7 @@
 package application
 
 import org.springframework.stereotype.Component
+import picocli.AutoComplete.GenerateCompletion
 import picocli.CommandLine.Command
 import java.util.concurrent.Callable
 
@@ -9,7 +10,7 @@ import java.util.concurrent.Callable
         name = "specmatic",
         mixinStandardHelpOptions = true,
         versionProvider = VersionProvider::class,
-        subcommands = [BundleCommand::class, CompareCommand::class, CompatibleCommand::class, DifferenceCommand::class, GraphCommand::class, MergeCommand::class, ToOpenAPICommand::class, ImportCommand::class, InstallCommand::class, ProxyCommand::class, PushCommand::class, ReDeclaredAPICommand::class, SamplesCommand::class, StubCommand::class, SubscribeCommand::class, TestCommand::class, ValidateViaLogs::class]
+        subcommands = [BundleCommand::class, CompareCommand::class, CompatibleCommand::class, DifferenceCommand::class, GenerateCompletion::class, GraphCommand::class, MergeCommand::class, ToOpenAPICommand::class, ImportCommand::class, InstallCommand::class, ProxyCommand::class, PushCommand::class, ReDeclaredAPICommand::class, SamplesCommand::class, StubCommand::class, SubscribeCommand::class, TestCommand::class, ValidateViaLogs::class]
 )
 class SpecmaticCommand : Callable<Int> {
     override fun call(): Int {

--- a/core/src/main/kotlin/in/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/in/specmatic/core/SpecmaticConfig.kt
@@ -152,7 +152,7 @@ val SpecmaticJsonFormat = Json {
 fun loadSpecmaticJsonConfig(configFileName: String? = null): SpecmaticConfigJson {
     val configFile = File(configFileName ?: globalConfigFileName)
     if (!configFile.exists()) {
-        throw ContractException("Could not find ${Configuration.DEFAULT_CONFIG_FILE_NAME} at path ${configFile.absolutePath}")
+        throw ContractException("Could not find ${Configuration.DEFAULT_CONFIG_FILE_NAME} at path ${configFile.canonicalPath}")
     }
     try {
         return SpecmaticJsonFormat.decodeFromString(configFile.readText())

--- a/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
@@ -46,26 +46,27 @@ open class SpecmaticJUnitSupport {
 
         val testsNames = mutableListOf<String>()
         val partialSuccesses: MutableList<Result.Success> = mutableListOf()
-        private val reportConfiguration = getReportConfiguration()
         private val openApiCoverageReportInput = OpenApiCoverageReportInput()
 
         @AfterAll
         @JvmStatic
         fun report() {
             val reportProcessors = listOf(OpenApiCoverageReportProcessor(openApiCoverageReportInput))
-            reportProcessors.forEach { it.process(reportConfiguration) }
+            reportProcessors.forEach { it.process(getReportConfiguration()) }
         }
 
         private fun getReportConfiguration(): ReportConfiguration {
             val reportConfiguration: ReportConfiguration? = try {
                 reportConfigurationFromConfig()
             } catch(e: Exception) {
-                logger.log("Could not load report configuration: " + exceptionCauseMessage(e))
+                logger.log("Could not load report configuration (got error \"" + exceptionCauseMessage(e) + "\"), running test with default report configuration")
                 null
             }
+
             val defaultFormatters = listOf(ReportFormatter(ReportFormatterType.TEXT, ReportFormatterLayout.TABLE))
             val defaultReportTypes =
                 ReportTypes(apiCoverage = APICoverage(openAPI = APICoverageConfiguration(successCriteria = SuccessCriteria(0, 0, false))))
+
             return when (reportConfiguration) {
                 null -> {
                     logger.log("API coverage report configuration not found in specmatic.json, proceeding with API coverage report without success criteria")

--- a/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
@@ -57,7 +57,12 @@ open class SpecmaticJUnitSupport {
         }
 
         private fun getReportConfiguration(): ReportConfiguration {
-            val reportConfiguration = reportConfigurationFromConfig()
+            val reportConfiguration: ReportConfiguration? = try {
+                reportConfigurationFromConfig()
+            } catch(e: Exception) {
+                logger.log("Could not load report configuration: " + exceptionCauseMessage(e))
+                null
+            }
             val defaultFormatters = listOf(ReportFormatter(ReportFormatterType.TEXT, ReportFormatterLayout.TABLE))
             val defaultReportTypes =
                 ReportTypes(apiCoverage = APICoverage(openAPI = APICoverageConfiguration(successCriteria = SuccessCriteria(0, 0, false))))


### PR DESCRIPTION
**What**:

2 minor fixes

1. Added a `generate-completion` command (which is hidden so it does not appear in help) so that bash completion scripts can be generated for the Specmatic command.
2. When report configuration is missing, use sane defaults instead of crashing. Sane defaults were already provided but were not being used.
3. Print the canonical path where `specmatic.json` is expected instead of absolute path which typically contains a period (e.g. `/Users/my-user-name/expected/path/./specmatic.json`)

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

Closes: #718 
