### PR TITLE
API coverage report json export

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -31,7 +31,7 @@ import java.io.File
 
 private const val BEARER_SECURITY_SCHEME = "bearer"
 
-class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI, val sourceProvider:String = "", val sourceRepository:String = "",  val sourceRepositoryBranch:String = "", val specificationPath:String = "") : IncludedSpecification,
+class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI, private val sourceProvider:String? = null, private val sourceRepository:String? = null, private val sourceRepositoryBranch:String? = null, private val specificationPath:String? = null) : IncludedSpecification,
     ApiSpecification {
     companion object {
         fun fromFile(openApiFilePath: String, relativeTo: String = ""): OpenApiSpecification {
@@ -51,7 +51,7 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
             return OpenApiSpecification(openApiFile, openApi)
         }
 
-        fun fromYAML(yamlContent: String, filePath: String, sourceProvider:String = "", sourceRepository:String = "",  sourceRepositoryBranch:String = "", specificationPath:String = "", loggerForErrors: LogStrategy = logger): OpenApiSpecification {
+        fun fromYAML(yamlContent: String, filePath: String,  loggerForErrors: LogStrategy = logger, sourceProvider:String? = null, sourceRepository:String? = null,  sourceRepositoryBranch:String? = null, specificationPath:String? = null,): OpenApiSpecification {
             val parseResult: SwaggerParseResult =
                 OpenAPIV3Parser().readContents(yamlContent, null, resolveExternalReferences(), filePath)
             val openApi: OpenAPI? = parseResult.openAPI

--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -31,7 +31,7 @@ import java.io.File
 
 private const val BEARER_SECURITY_SCHEME = "bearer"
 
-class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI) : IncludedSpecification,
+class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI, val sourceProvider:String = "", val sourceRepository:String = "",  val sourceRepositoryBranch:String = "", val specificationPath:String = "") : IncludedSpecification,
     ApiSpecification {
     companion object {
         fun fromFile(openApiFilePath: String, relativeTo: String = ""): OpenApiSpecification {
@@ -51,7 +51,7 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
             return OpenApiSpecification(openApiFile, openApi)
         }
 
-        fun fromYAML(yamlContent: String, filePath: String, loggerForErrors: LogStrategy = logger): OpenApiSpecification {
+        fun fromYAML(yamlContent: String, filePath: String, sourceProvider:String = "", sourceRepository:String = "",  sourceRepositoryBranch:String = "", specificationPath:String = "", loggerForErrors: LogStrategy = logger): OpenApiSpecification {
             val parseResult: SwaggerParseResult =
                 OpenAPIV3Parser().readContents(yamlContent, null, resolveExternalReferences(), filePath)
             val openApi: OpenAPI? = parseResult.openAPI
@@ -68,7 +68,7 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
                 printMessages(parseResult, filePath, loggerForErrors)
             }
 
-            return OpenApiSpecification(filePath, openApi)
+            return OpenApiSpecification(filePath, openApi, sourceProvider, sourceRepository, sourceRepositoryBranch, specificationPath)
         }
 
         private fun printMessages(parseResult: SwaggerParseResult, filePath: String, loggerForErrors: LogStrategy) {
@@ -237,6 +237,11 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
                             httpRequestPattern = httpRequestPattern,
                             httpResponsePattern = httpResponsePattern,
                             ignoreFailure = ignoreFailure,
+                            sourceProvider = sourceProvider,
+                            sourceRepository = sourceRepository,
+                            sourceRepositoryBranch = sourceRepositoryBranch,
+                            specification = specificationPath,
+                            serviceType = "HTTP"
                         )
                     }
                 }.flatten()
@@ -334,7 +339,12 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
                                     specmaticExampleRows.first().columnNames,
                                     specmaticExampleRows
                                 )
-                            ) else emptyList()
+                            ) else emptyList(),
+                            sourceProvider = sourceProvider,
+                            sourceRepository = sourceRepository,
+                            sourceRepositoryBranch = sourceRepositoryBranch,
+                            specification = specificationPath,
+                            serviceType = "HTTP"
                         )
                     }
                 }.flatten()

--- a/core/src/main/kotlin/in/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Feature.kt
@@ -41,7 +41,7 @@ class BadRequestOrDefault(private val badRequestResponses: Map<Int, HttpResponse
         httpResponse.status in badRequestResponses || defaultResponse != null
 }
 
-fun parseContractFileToFeature(contractPath: String, hook: Hook = PassThroughHook(), sourceProvider:String = "", sourceRepository:String = "",  sourceRepositoryBranch:String = "", specificationPath:String = "" ): Feature {
+fun parseContractFileToFeature(contractPath: String, hook: Hook = PassThroughHook(), sourceProvider:String? = null, sourceRepository:String? = null,  sourceRepositoryBranch:String? = null, specificationPath:String? = null): Feature {
     return parseContractFileToFeature(File(contractPath), hook, sourceProvider, sourceRepository, sourceRepositoryBranch, specificationPath)
 }
 
@@ -50,11 +50,11 @@ fun checkExists(file: File) = file.also {
         throw ContractException("File ${file.path} does not exist (absolute path ${file.canonicalPath})")
 }
 
-fun parseContractFileToFeature(file: File, hook: Hook = PassThroughHook(), sourceProvider:String = "", sourceRepository:String = "",  sourceRepositoryBranch:String = "", specificationPath:String = "" ): Feature {
+fun parseContractFileToFeature(file: File, hook: Hook = PassThroughHook(), sourceProvider:String? = null, sourceRepository:String? = null,  sourceRepositoryBranch:String? = null, specificationPath:String? = null): Feature {
     logger.debug("Parsing contract file ${file.path}, absolute path ${file.absolutePath}")
 
     return when (file.extension) {
-        "yaml" -> OpenApiSpecification.fromYAML(hook.readContract(file.path), file.path, sourceProvider, sourceRepository, sourceRepositoryBranch, specificationPath).toFeature()
+        "yaml" -> OpenApiSpecification.fromYAML(hook.readContract(file.path), file.path, sourceProvider =sourceProvider, sourceRepository = sourceRepository, sourceRepositoryBranch = sourceRepositoryBranch, specificationPath = specificationPath).toFeature()
         "wsdl" -> wsdlContentToFeature(checkExists(file).readText(), file.canonicalPath)
         in CONTRACT_EXTENSIONS -> parseGherkinStringToFeature(checkExists(file).readText().trim(), file.canonicalPath)
         else -> throw ContractException("File extension of ${file.path} not recognized")

--- a/core/src/main/kotlin/in/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Scenario.kt
@@ -52,11 +52,11 @@ data class Scenario(
     val exampleName: String? = null,
     val generativeTestingEnabled: Boolean = false,
     val generatedFromExamples: Boolean = examples.isNotEmpty(),
-    val sourceProvider:String = "",
-    val sourceRepository:String = "",
-    val sourceRepositoryBranch:String = "",
-    val specification:String = "",
-    val serviceType:String = ""
+    val sourceProvider:String? = null,
+    val sourceRepository:String? = null,
+    val sourceRepositoryBranch:String? = null,
+    val specification:String? = null,
+    val serviceType:String? = null
 ): ScenarioDetailsForResult {
     constructor(scenarioInfo: ScenarioInfo) : this(
         scenarioInfo.scenarioName,

--- a/core/src/main/kotlin/in/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Scenario.kt
@@ -51,7 +51,12 @@ data class Scenario(
     val badRequestOrDefault: BadRequestOrDefault? = null,
     val exampleName: String? = null,
     val generativeTestingEnabled: Boolean = false,
-    val generatedFromExamples: Boolean = examples.isNotEmpty()
+    val generatedFromExamples: Boolean = examples.isNotEmpty(),
+    val sourceProvider:String = "",
+    val sourceRepository:String = "",
+    val sourceRepositoryBranch:String = "",
+    val specification:String = "",
+    val serviceType:String = ""
 ): ScenarioDetailsForResult {
     constructor(scenarioInfo: ScenarioInfo) : this(
         scenarioInfo.scenarioName,
@@ -63,7 +68,12 @@ data class Scenario(
         scenarioInfo.fixtures,
         scenarioInfo.ignoreFailure,
         scenarioInfo.references,
-        scenarioInfo.bindings
+        scenarioInfo.bindings,
+        sourceProvider = scenarioInfo.sourceProvider,
+        sourceRepository = scenarioInfo.sourceRepository,
+        sourceRepositoryBranch = scenarioInfo.sourceRepositoryBranch,
+        specification = scenarioInfo.specification,
+        serviceType = scenarioInfo.serviceType
     )
 
     override val method: String
@@ -279,7 +289,12 @@ data class Scenario(
                         isNegative,
                         badRequestOrDefault,
                         row.name,
-                        generativeTestingEnabled
+                        generativeTestingEnabled,
+                        sourceProvider = sourceProvider,
+                        sourceRepository = sourceRepository,
+                        sourceRepositoryBranch = sourceRepositoryBranch,
+                        specification = specification,
+                        serviceType = serviceType
                     )
                 }
             }
@@ -302,7 +317,12 @@ data class Scenario(
                 fixtures,
                 ignoreFailure,
                 references,
-                bindings
+                bindings,
+                sourceProvider = sourceProvider,
+                sourceRepository = sourceRepository,
+                sourceRepositoryBranch = sourceRepositoryBranch,
+                specification = specification,
+                serviceType = serviceType
             )
         }
     }
@@ -459,7 +479,12 @@ data class Scenario(
             scenario.references,
             bindings,
             isGherkinScenario,
-            isNegative
+            isNegative,
+            sourceProvider = sourceProvider,
+            sourceRepository = sourceRepository,
+            sourceRepositoryBranch = sourceRepositoryBranch,
+            specification = specification,
+            serviceType = serviceType
         )
 
     fun newBasedOn(suggestions: List<Scenario>) =
@@ -481,7 +506,12 @@ data class Scenario(
         isNegative = true,
         badRequestOrDefault,
         exampleName,
-        generativeTestingEnabled
+        generativeTestingEnabled,
+        sourceProvider = sourceProvider,
+        sourceRepository = sourceRepository,
+        sourceRepositoryBranch = sourceRepositoryBranch,
+        specification = specification,
+        serviceType = serviceType
     )
 }
 

--- a/core/src/main/kotlin/in/specmatic/core/ScenarioInfo.kt
+++ b/core/src/main/kotlin/in/specmatic/core/ScenarioInfo.kt
@@ -15,7 +15,12 @@ data class ScenarioInfo(
     val ignoreFailure: Boolean = false,
     val references: Map<String, References> = emptyMap(),
     val bindings: Map<String, String> = emptyMap(),
-    val isGherkinScenario: Boolean = false
+    val isGherkinScenario: Boolean = false,
+    val sourceProvider:String = "",
+    val sourceRepository:String = "",
+    val sourceRepositoryBranch:String = "",
+    val specification:String = "",
+    val serviceType:String = ""
 ) {
     fun matchesSignature(other: ScenarioInfo) = httpRequestPattern.matchesSignature(other.httpRequestPattern) &&
             httpResponsePattern.status == other.httpResponsePattern.status

--- a/core/src/main/kotlin/in/specmatic/core/ScenarioInfo.kt
+++ b/core/src/main/kotlin/in/specmatic/core/ScenarioInfo.kt
@@ -16,11 +16,11 @@ data class ScenarioInfo(
     val references: Map<String, References> = emptyMap(),
     val bindings: Map<String, String> = emptyMap(),
     val isGherkinScenario: Boolean = false,
-    val sourceProvider:String = "",
-    val sourceRepository:String = "",
-    val sourceRepositoryBranch:String = "",
-    val specification:String = "",
-    val serviceType:String = ""
+    val sourceProvider:String? = null,
+    val sourceRepository:String? = null,
+    val sourceRepositoryBranch:String? = null,
+    val specification:String? = null,
+    val serviceType:String? = null
 ) {
     fun matchesSignature(other: ScenarioInfo) = httpRequestPattern.matchesSignature(other.httpRequestPattern) &&
             httpResponsePattern.status == other.httpResponsePattern.status

--- a/core/src/main/kotlin/in/specmatic/core/utilities/ContractSource.kt
+++ b/core/src/main/kotlin/in/specmatic/core/utilities/ContractSource.kt
@@ -80,7 +80,7 @@ data class GitRepo(
         }
 
         return selector.select(this).map {
-            ContractPathData(repoDir.path, repoDir.resolve(it).path)
+            ContractPathData(repoDir.path, repoDir.resolve(it).path, "git", gitRepositoryURL,branchName ?: "", it)
         }
     }
 
@@ -167,7 +167,7 @@ data class GitMonoRepo(override val testContracts: List<String>, override val st
         val configFileLocation = File(configFilePath).absoluteFile.parentFile
 
         return selector.select(this).map {
-            ContractPathData(monoRepoBaseDir.canonicalPath, configFileLocation.resolve(it).canonicalPath)
+            ContractPathData(monoRepoBaseDir.canonicalPath, configFileLocation.resolve(it).canonicalPath, specificationPath = it)
         }
     }
 }

--- a/core/src/main/kotlin/in/specmatic/core/utilities/ContractSource.kt
+++ b/core/src/main/kotlin/in/specmatic/core/utilities/ContractSource.kt
@@ -80,7 +80,7 @@ data class GitRepo(
         }
 
         return selector.select(this).map {
-            ContractPathData(repoDir.path, repoDir.resolve(it).path, "git", gitRepositoryURL,branchName ?: "", it)
+            ContractPathData(repoDir.path, repoDir.resolve(it).path, "git", gitRepositoryURL, branchName, it)
         }
     }
 
@@ -167,7 +167,7 @@ data class GitMonoRepo(override val testContracts: List<String>, override val st
         val configFileLocation = File(configFilePath).absoluteFile.parentFile
 
         return selector.select(this).map {
-            ContractPathData(monoRepoBaseDir.canonicalPath, configFileLocation.resolve(it).canonicalPath, specificationPath = it)
+            ContractPathData(monoRepoBaseDir.canonicalPath, configFileLocation.resolve(it).canonicalPath)
         }
     }
 }

--- a/core/src/main/kotlin/in/specmatic/core/utilities/ContractSource.kt
+++ b/core/src/main/kotlin/in/specmatic/core/utilities/ContractSource.kt
@@ -7,6 +7,7 @@ import `in`.specmatic.core.log.logger
 import java.io.File
 
 sealed class ContractSource {
+    abstract val type:String?
     abstract val testContracts: List<String>
     abstract val stubContracts: List<String>
     abstract fun pathDescriptor(path: String): String
@@ -21,7 +22,8 @@ data class GitRepo(
     val gitRepositoryURL: String,
     val branchName: String?,
     override val testContracts: List<String>,
-    override val stubContracts: List<String>
+    override val stubContracts: List<String>,
+    override val type: String?
 ) : ContractSource() {
     val repoName = gitRepositoryURL.split("/").last().removeSuffix(".git")
     override fun pathDescriptor(path: String): String {
@@ -80,7 +82,7 @@ data class GitRepo(
         }
 
         return selector.select(this).map {
-            ContractPathData(repoDir.path, repoDir.resolve(it).path, "git", gitRepositoryURL, branchName, it)
+            ContractPathData(repoDir.path, repoDir.resolve(it).path, type, gitRepositoryURL, branchName, it)
         }
     }
 
@@ -135,7 +137,8 @@ data class GitRepo(
         (sourceGit.workingDirectoryIsGitRepo() && sourceGit.getRemoteUrl() != this.gitRepositoryURL && sourceDir.listFiles()?.isEmpty() == true)
 }
 
-data class GitMonoRepo(override val testContracts: List<String>, override val stubContracts: List<String>) : ContractSource() {
+data class GitMonoRepo(override val testContracts: List<String>, override val stubContracts: List<String>,
+                       override val type: String?) : ContractSource() {
     override fun pathDescriptor(path: String): String = path
     override fun install(workingDirectory: File) {
         println("Checking list of mono repo paths...")
@@ -167,7 +170,7 @@ data class GitMonoRepo(override val testContracts: List<String>, override val st
         val configFileLocation = File(configFilePath).absoluteFile.parentFile
 
         return selector.select(this).map {
-            ContractPathData(monoRepoBaseDir.canonicalPath, configFileLocation.resolve(it).canonicalPath)
+            ContractPathData(monoRepoBaseDir.canonicalPath, configFileLocation.resolve(it).canonicalPath, provider = type, specificationPath = it)
         }
     }
 }

--- a/core/src/main/kotlin/in/specmatic/core/utilities/Utilities.kt
+++ b/core/src/main/kotlin/in/specmatic/core/utilities/Utilities.kt
@@ -255,10 +255,10 @@ fun gitRootDir(): String {
 data class ContractPathData(
     val baseDir: String,
     val path: String,
-    val provider: String = "",
-    val repository: String = "",
-    val branch: String = "",
-    val specificationPath: String = ""
+    val provider: String? = null,
+    val repository: String? = null,
+    val branch: String? = null,
+    val specificationPath: String? = null
 ) {
     val relativePath: String
       get() {

--- a/core/src/main/kotlin/in/specmatic/core/utilities/Utilities.kt
+++ b/core/src/main/kotlin/in/specmatic/core/utilities/Utilities.kt
@@ -174,8 +174,8 @@ fun loadSources(specmaticConfigJson: SpecmaticConfigJson): List<ContractSource> 
                 val testPaths = source.test ?: emptyList()
 
                 when (source.repository) {
-                    null -> GitMonoRepo(testPaths, stubPaths)
-                    else -> GitRepo(source.repository, source.branch, testPaths, stubPaths)
+                    null -> GitMonoRepo(testPaths, stubPaths, source.provider.toString())
+                    else -> GitRepo(source.repository, source.branch, testPaths, stubPaths, source.provider.toString())
                 }
             }
         }
@@ -199,10 +199,11 @@ fun loadSources(configJson: JSONObjectValue): List<ContractSource> {
 
                 val stubPaths = jsonArray(source, "stub")
                 val testPaths = jsonArray(source, "test")
+                val type = nativeString(source.jsonObject, "provider")
 
                 when (repositoryURL) {
-                    null -> GitMonoRepo(testPaths, stubPaths)
-                    else -> GitRepo(repositoryURL, branch, testPaths, stubPaths)
+                    null -> GitMonoRepo(testPaths, stubPaths, type)
+                    else -> GitRepo(repositoryURL, branch, testPaths, stubPaths, type)
                 }
             }
             else -> throw ContractException("Provider ${nativeString(source.jsonObject, "provider")} not recognised in $globalConfigFileName")

--- a/core/src/main/kotlin/in/specmatic/core/utilities/Utilities.kt
+++ b/core/src/main/kotlin/in/specmatic/core/utilities/Utilities.kt
@@ -252,7 +252,14 @@ fun gitRootDir(): String {
     return gitRoot.substring(gitRoot.lastIndexOf('/') + 1)
 }
 
-data class ContractPathData(val baseDir: String, val path: String) {
+data class ContractPathData(
+    val baseDir: String,
+    val path: String,
+    val provider: String = "",
+    val repository: String = "",
+    val branch: String = "",
+    val specificationPath: String = ""
+) {
     val relativePath: String
       get() {
           return File(this.path).relativeTo(File(this.baseDir)).path.let {

--- a/core/src/main/kotlin/in/specmatic/test/ContractTest.kt
+++ b/core/src/main/kotlin/in/specmatic/test/ContractTest.kt
@@ -3,7 +3,17 @@ package `in`.specmatic.test
 import `in`.specmatic.core.Result
 import `in`.specmatic.core.TestResult
 
-data class TestResultRecord(val path: String, val method: String, val responseStatus: Int, val result: TestResult) {
+data class TestResultRecord(
+    val path: String,
+    val method: String,
+    val responseStatus: Int,
+    val result: TestResult,
+    val sourceProvider: String = "",
+    val sourceRepository: String = "",
+    val sourceRepositoryBranch: String = "",
+    val specification: String = "",
+    val serviceType: String = ""
+) {
     val includeForCoverage = result !in listOf(TestResult.Skipped, TestResult.NotImplemented)
 }
 

--- a/core/src/main/kotlin/in/specmatic/test/ContractTest.kt
+++ b/core/src/main/kotlin/in/specmatic/test/ContractTest.kt
@@ -8,11 +8,11 @@ data class TestResultRecord(
     val method: String,
     val responseStatus: Int,
     val result: TestResult,
-    val sourceProvider: String = "",
-    val sourceRepository: String = "",
-    val sourceRepositoryBranch: String = "",
-    val specification: String = "",
-    val serviceType: String = ""
+    val sourceProvider: String? = null,
+    val sourceRepository: String? = null,
+    val sourceRepositoryBranch: String? = null,
+    val specification: String? = null,
+    val serviceType: String? = null
 ) {
     val includeForCoverage = result !in listOf(TestResult.Skipped, TestResult.NotImplemented)
 }

--- a/core/src/main/kotlin/in/specmatic/test/ScenarioTest.kt
+++ b/core/src/main/kotlin/in/specmatic/test/ScenarioTest.kt
@@ -6,10 +6,16 @@ import `in`.specmatic.core.Scenario
 import `in`.specmatic.core.TestResult
 import `in`.specmatic.core.executeTest
 
-class ScenarioTest(val scenario: Scenario, private val generativeTestingEnabled: Boolean = false) : ContractTest {
+class ScenarioTest(
+    val scenario: Scenario, private val generativeTestingEnabled: Boolean = false, val sourceProvider: String = "",
+    val sourceRepository: String = "",
+    val sourceRepositoryBranch: String = "",
+    val specification: String = "",
+    val serviceType: String = ""
+) : ContractTest {
     override fun testResultRecord(result: Result): TestResultRecord {
         val resultStatus = if (scenario.generatedFromExamples) result.testResult() else TestResult.Skipped
-        return TestResultRecord(convertPathParameterStyle(scenario.path), scenario.method, scenario.status, resultStatus)
+        return TestResultRecord(convertPathParameterStyle(scenario.path), scenario.method, scenario.status, resultStatus, sourceProvider, sourceRepository, sourceRepositoryBranch, specification, serviceType)
     }
 
     override fun generateTestScenarios(

--- a/core/src/main/kotlin/in/specmatic/test/ScenarioTest.kt
+++ b/core/src/main/kotlin/in/specmatic/test/ScenarioTest.kt
@@ -7,11 +7,13 @@ import `in`.specmatic.core.TestResult
 import `in`.specmatic.core.executeTest
 
 class ScenarioTest(
-    val scenario: Scenario, private val generativeTestingEnabled: Boolean = false, val sourceProvider: String = "",
-    val sourceRepository: String = "",
-    val sourceRepositoryBranch: String = "",
-    val specification: String = "",
-    val serviceType: String = ""
+    val scenario: Scenario,
+    private val generativeTestingEnabled: Boolean = false,
+    private val sourceProvider: String? = null,
+    private val sourceRepository: String? = null,
+    private val sourceRepositoryBranch: String? = null,
+    private val specification: String? = null,
+    private val serviceType: String? = null
 ) : ContractTest {
     override fun testResultRecord(result: Result): TestResultRecord {
         val resultStatus = if (scenario.generatedFromExamples) result.testResult() else TestResult.Skipped

--- a/core/src/test/kotlin/utilities/UtilitiesTest.kt
+++ b/core/src/test/kotlin/utilities/UtilitiesTest.kt
@@ -1,6 +1,7 @@
 package utilities
 
 import `in`.specmatic.core.CONTRACT_EXTENSION
+import `in`.specmatic.core.SourceProvider
 import `in`.specmatic.core.git.GitCommand
 import `in`.specmatic.core.git.SystemGit
 import `in`.specmatic.core.git.checkout
@@ -30,7 +31,7 @@ internal class UtilitiesTest {
 
     @Test
     fun `contractFilePathsFrom sources when contracts repo dir does not exist`() {
-        val sources = listOf(GitRepo("https://repo1", null, listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION")))
+        val sources = listOf(GitRepo("https://repo1", null, listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION"), SourceProvider.git.toString()))
         File(".spec").deleteRecursively()
 
         mockkStatic("in.specmatic.core.utilities.Utilities")
@@ -54,7 +55,7 @@ internal class UtilitiesTest {
     fun `contractFilePathsFrom sources with branch when contracts repo dir does not exist`() {
         val branchName = "featureBranch"
         val sources = listOf(GitRepo("https://repo1",
-            branchName, listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION")))
+            branchName, listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION"), SourceProvider.git.toString()))
         File(".spec").deleteRecursively()
 
         mockkStatic("in.specmatic.core.utilities.Utilities")
@@ -77,7 +78,7 @@ internal class UtilitiesTest {
 
     @Test
     fun `contractFilePathsFrom sources when contracts repo dir exists and is clean`() {
-        val sources = listOf(GitRepo("https://repo1", null, listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION")))
+        val sources = listOf(GitRepo("https://repo1", null, listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION"), SourceProvider.git.toString()))
         File(".spec").deleteRecursively()
         File(".spec/repos/repo1").mkdirs()
 
@@ -101,7 +102,7 @@ internal class UtilitiesTest {
 
     @Test
     fun `contractFilePathsFrom sources when contracts repo dir exists and is not clean`() {
-        val sources = listOf(GitRepo("https://repo1", null, listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION")))
+        val sources = listOf(GitRepo("https://repo1", null, listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION"), SourceProvider.git.toString()))
         File(".spec").deleteRecursively()
         File(".spec/repos/repo1").mkdirs()
 
@@ -128,7 +129,7 @@ internal class UtilitiesTest {
 
     @Test
     fun `contractFilePathsFrom sources when contracts repo dir exists and is behind remote`() {
-        val sources = listOf(GitRepo("https://repo1", null, listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION")))
+        val sources = listOf(GitRepo("https://repo1", null, listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION"), SourceProvider.git.toString()))
         File(".spec").deleteRecursively()
         File(".spec/repos/repo1").mkdirs()
 
@@ -171,11 +172,11 @@ internal class UtilitiesTest {
         val testPaths = contractFilePathsFrom(configFilePath, ".$CONTRACT_EXTENSION") { source -> source.testContracts }
         val stubPaths = contractFilePathsFrom(configFilePath, ".$CONTRACT_EXTENSION") { source -> source.stubContracts }
         val expectedStubPaths = listOf(
-            ContractPathData("/path/to/monorepo", "$currentPath/monorepo/a/1.$CONTRACT_EXTENSION"),
-            ContractPathData("/path/to/monorepo", "$currentPath/monorepo/b/1.$CONTRACT_EXTENSION")
+            ContractPathData("/path/to/monorepo", "$currentPath/monorepo/a/1.$CONTRACT_EXTENSION", provider = SourceProvider.git.toString(), specificationPath = "../a/1.spec"),
+            ContractPathData("/path/to/monorepo", "$currentPath/monorepo/b/1.$CONTRACT_EXTENSION", provider = SourceProvider.git.toString(), specificationPath = "../b/1.spec")
         )
         val expectedTestPaths = listOf(
-            ContractPathData("/path/to/monorepo", "$currentPath/monorepo/c/1.$CONTRACT_EXTENSION"),
+            ContractPathData("/path/to/monorepo", "$currentPath/monorepo/c/1.$CONTRACT_EXTENSION", provider=SourceProvider.git.toString(), specificationPath = "../c/1.spec"),
         )
 
         assertThat(stubPaths == expectedStubPaths).isTrue
@@ -189,7 +190,7 @@ internal class UtilitiesTest {
         val qontractJson = "{\"sources\": [{\"provider\": \"git\",\"repository\": \"https://repo1\",\"stub\": [\"a/1.$CONTRACT_EXTENSION\",\"b/1.$CONTRACT_EXTENSION\",\"c/1.$CONTRACT_EXTENSION\"]}]}"
         val configJson = parsedJSON(qontractJson) as JSONObjectValue
         val sources = loadSources(configJson)
-        val expectedSources = listOf(GitRepo("https://repo1", null, listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION")))
+        val expectedSources = listOf(GitRepo("https://repo1", null, listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION"), SourceProvider.git.toString()))
         assertThat(sources == expectedSources).isTrue
     }
 
@@ -200,8 +201,8 @@ internal class UtilitiesTest {
         val configJson = parsedJSON(qontractJson) as JSONObjectValue
         val sources = loadSources(configJson)
         val expectedSources = listOf(
-                GitRepo("https://repo1",null, listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION")),
-                GitRepo("https://repo2",null, listOf(), listOf("c/1.$CONTRACT_EXTENSION"))
+                GitRepo("https://repo1",null, listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION"), SourceProvider.git.toString()),
+                GitRepo("https://repo2",null, listOf(), listOf("c/1.$CONTRACT_EXTENSION"), SourceProvider.git.toString())
         )
         assertThat(sources == expectedSources).isTrue
     }
@@ -211,7 +212,7 @@ internal class UtilitiesTest {
         val qontractJson = "{\"sources\": [{\"provider\": \"git\",\"stub\": [\"a/1.$CONTRACT_EXTENSION\",\"b/1.$CONTRACT_EXTENSION\",\"c/1.$CONTRACT_EXTENSION\"]}]}"
         val configJson = parsedJSON(qontractJson) as JSONObjectValue
         val sources = loadSources(configJson)
-        val expectedSources = listOf(GitMonoRepo(listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION")))
+        val expectedSources = listOf(GitMonoRepo(listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION"), SourceProvider.git.toString()))
         assertThat(sources == expectedSources).isTrue
     }
 
@@ -220,7 +221,7 @@ internal class UtilitiesTest {
         val qontractJson = "{\"sources\": [{\"provider\": \"git\",\"test\": [\"a/1.$CONTRACT_EXTENSION\",\"b/1.$CONTRACT_EXTENSION\",\"c/1.$CONTRACT_EXTENSION\"]}]}"
         val configJson = parsedJSON(qontractJson) as JSONObjectValue
         val sources = loadSources(configJson)
-        val expectedSources = listOf(GitMonoRepo(listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION"), listOf()))
+        val expectedSources = listOf(GitMonoRepo(listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION"), listOf(), SourceProvider.git.toString()))
         assertThat(sources == expectedSources).isTrue
     }
 
@@ -229,7 +230,7 @@ internal class UtilitiesTest {
         val qontractJson = "{\"sources\": [{\"provider\": \"git\",\"test\": [\"a/1.$CONTRACT_EXTENSION\",\"b/1.$CONTRACT_EXTENSION\"],\"stub\": [\"c/1.$CONTRACT_EXTENSION\"]}]}"
         val configJson = parsedJSON(qontractJson) as JSONObjectValue
         val sources = loadSources(configJson)
-        val expectedSources = listOf(GitMonoRepo(listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION"), listOf("c/1.$CONTRACT_EXTENSION")))
+        val expectedSources = listOf(GitMonoRepo(listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION"), listOf("c/1.$CONTRACT_EXTENSION"), SourceProvider.git.toString()))
         assertThat(sources == expectedSources).isTrue
     }
 
@@ -240,8 +241,8 @@ internal class UtilitiesTest {
         val configJson = parsedJSON(qontractJson) as JSONObjectValue
         val sources = loadSources(configJson)
         val expectedSources = listOf(
-            GitMonoRepo(listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION")),
-                GitMonoRepo(listOf(), listOf("c/1.$CONTRACT_EXTENSION"))
+            GitMonoRepo(listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION"), SourceProvider.git.toString()),
+                GitMonoRepo(listOf(), listOf("c/1.$CONTRACT_EXTENSION"), SourceProvider.git.toString())
         )
         assertThat(sources == expectedSources).isTrue
     }
@@ -253,8 +254,8 @@ internal class UtilitiesTest {
         val configJson = parsedJSON(qontractJson) as JSONObjectValue
         val sources = loadSources(configJson)
         val expectedSources = listOf(
-                GitRepo("https://repo1", null, listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION")),
-                GitMonoRepo(listOf(), listOf("c/1.$CONTRACT_EXTENSION"))
+                GitRepo("https://repo1", null, listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION"), SourceProvider.git.toString()),
+                GitMonoRepo(listOf(), listOf("c/1.$CONTRACT_EXTENSION"), SourceProvider.git.toString())
         )
         assertThat(sources == expectedSources).isTrue
     }

--- a/core/src/test/kotlin/utilities/UtilitiesTest.kt
+++ b/core/src/test/kotlin/utilities/UtilitiesTest.kt
@@ -42,9 +42,9 @@ internal class UtilitiesTest {
 
         val contractPaths = contractFilePathsFrom("/configFilePath", ".$CONTRACT_EXTENSION") { source -> source.stubContracts }
         val expectedContractPaths = listOf(
-            ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/a/1.$CONTRACT_EXTENSION"),
-            ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/b/1.$CONTRACT_EXTENSION"),
-            ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/c/1.$CONTRACT_EXTENSION"),
+            ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/a/1.$CONTRACT_EXTENSION", "git", "https://repo1",  specificationPath = "a/1.spec"),
+            ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/b/1.$CONTRACT_EXTENSION", "git", "https://repo1",  specificationPath = "b/1.spec"),
+            ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/c/1.$CONTRACT_EXTENSION", "git", "https://repo1",   specificationPath = "c/1.spec"),
         )
         verify(exactly = 0) { checkout(any(), any()) }
         assertThat(contractPaths == expectedContractPaths).isTrue
@@ -67,9 +67,9 @@ internal class UtilitiesTest {
 
         val contractPaths = contractFilePathsFrom("/configFilePath", ".$CONTRACT_EXTENSION") { source -> source.stubContracts }
         val expectedContractPaths = listOf(
-            ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/a/1.$CONTRACT_EXTENSION"),
-            ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/b/1.$CONTRACT_EXTENSION"),
-            ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/c/1.$CONTRACT_EXTENSION"),
+            ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/a/1.$CONTRACT_EXTENSION", "git", "https://repo1", "featureBranch", "a/1.spec"),
+            ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/b/1.$CONTRACT_EXTENSION", "git", "https://repo1", "featureBranch", "b/1.spec"),
+            ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/c/1.$CONTRACT_EXTENSION", "git", "https://repo1", "featureBranch", "c/1.spec"),
         )
         verify(exactly = 1) { checkout(repositoryDirectory, branchName) }
         assertThat(contractPaths == expectedContractPaths).isTrue
@@ -92,9 +92,9 @@ internal class UtilitiesTest {
 
         val contractPaths = contractFilePathsFrom("/configFilePath", ".$CONTRACT_EXTENSION") { source -> source.stubContracts }
         val expectedContractPaths = listOf(
-                ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/a/1.$CONTRACT_EXTENSION"),
-                ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/b/1.$CONTRACT_EXTENSION"),
-                ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/c/1.$CONTRACT_EXTENSION"),
+                ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/a/1.$CONTRACT_EXTENSION", "git", "https://repo1",  specificationPath = "a/1.spec"),
+                ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/b/1.$CONTRACT_EXTENSION", "git", "https://repo1",  specificationPath = "b/1.spec"),
+                ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/c/1.$CONTRACT_EXTENSION", "git", "https://repo1",  specificationPath = "c/1.spec"),
         )
         assertThat(contractPaths == expectedContractPaths).isTrue
     }
@@ -119,9 +119,9 @@ internal class UtilitiesTest {
 
         val contractPaths = contractFilePathsFrom("/configFilePath", ".$CONTRACT_EXTENSION") { source -> source.stubContracts }
         val expectedContractPaths = listOf(
-            ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/a/1.$CONTRACT_EXTENSION"),
-            ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/b/1.$CONTRACT_EXTENSION"),
-            ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/c/1.$CONTRACT_EXTENSION"),
+            ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/a/1.$CONTRACT_EXTENSION", "git", "https://repo1",  specificationPath = "a/1.spec"),
+            ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/b/1.$CONTRACT_EXTENSION", "git", "https://repo1",  specificationPath = "b/1.spec"),
+            ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/c/1.$CONTRACT_EXTENSION", "git", "https://repo1",  specificationPath = "c/1.spec"),
         )
         assertThat(contractPaths == expectedContractPaths).isTrue
     }
@@ -145,9 +145,9 @@ internal class UtilitiesTest {
 
         val contractPaths = contractFilePathsFrom("/configFilePath", ".$CONTRACT_EXTENSION") { source -> source.stubContracts }
         val expectedContractPaths = listOf(
-            ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/a/1.$CONTRACT_EXTENSION"),
-            ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/b/1.$CONTRACT_EXTENSION"),
-            ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/c/1.$CONTRACT_EXTENSION"),
+            ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/a/1.$CONTRACT_EXTENSION", "git", "https://repo1",  specificationPath = "a/1.spec"),
+            ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/b/1.$CONTRACT_EXTENSION", "git", "https://repo1",  specificationPath = "b/1.spec"),
+            ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/c/1.$CONTRACT_EXTENSION", "git", "https://repo1",  specificationPath = "c/1.spec"),
         )
         assertThat(contractPaths == expectedContractPaths).isTrue
     }

--- a/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
@@ -126,7 +126,7 @@ open class SpecmaticJUnitSupport {
 
         fun getConfigFile() = System.getProperty(CONFIG_FILE_NAME) ?: globalConfigFileName
 
-        fun getConfigFileWithAbsolutePath() = File(getConfigFile()).absolutePath
+        fun getConfigFileWithAbsolutePath() = File(getConfigFile()).canonicalPath
     }
 
     private fun getEnvConfig(envName: String?): JSONObjectValue {
@@ -250,10 +250,10 @@ open class SpecmaticJUnitSupport {
         suggestionsPath: String,
         suggestionsData: String,
         config: TestConfig,
-        sourceProvider:String = "",
-        sourceRepository:String = "",
-        sourceRepositoryBranch:String = "",
-        specificationPath:String = ""
+        sourceProvider:String? = null,
+        sourceRepository:String? = null,
+        sourceRepositoryBranch:String? = null,
+        specificationPath:String? = null
     ): List<ContractTest> {
         if(isYAML(path) && !isOpenAPI(path))
             return emptyList()

--- a/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
@@ -184,8 +184,8 @@ open class SpecmaticJUnitSupport {
 
                     createIfDoesNotExist(workingDirectory.path)
 
-                    val contractFilePaths = contractTestPathsFrom(configFile, workingDirectory.path).map { it.path }
-                    contractFilePaths.flatMap { loadTestScenarios(it, "", "", testConfig) }
+                    val contractFilePaths = contractTestPathsFrom(configFile, workingDirectory.path)
+                    contractFilePaths.flatMap { loadTestScenarios(it.path, "", "", testConfig, it.provider, it.repository, it.branch, it.specificationPath) }
                 }
             }
 
@@ -246,14 +246,17 @@ open class SpecmaticJUnitSupport {
         path: String,
         suggestionsPath: String,
         suggestionsData: String,
-        config: TestConfig
+        config: TestConfig,
+        sourceProvider:String = "",
+        sourceRepository:String = "",
+        sourceRepositoryBranch:String = "",
+        specificationPath:String = ""
     ): List<ContractTest> {
         if(isYAML(path) && !isOpenAPI(path))
             return emptyList()
 
         val contractFile = File(path)
-        val feature = parseContractFileToFeature(contractFile.path, CommandHook(HookName.test_load_contract)).copy(testVariables = config.variables, testBaseURLs = config.baseURLs)
-
+        val feature = parseContractFileToFeature(contractFile.path, CommandHook(HookName.test_load_contract), sourceProvider, sourceRepository, sourceRepositoryBranch, specificationPath).copy(testVariables = config.variables, testBaseURLs = config.baseURLs)
         val suggestions = when {
             suggestionsPath.isNotEmpty() -> suggestionsFromFile(suggestionsPath)
             suggestionsData.isNotEmpty() -> suggestionsFromCommandLine(suggestionsData)

--- a/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
@@ -46,7 +46,7 @@ open class SpecmaticJUnitSupport {
 
         val testsNames = mutableListOf<String>()
         val partialSuccesses: MutableList<Result.Success> = mutableListOf()
-        private val openApiCoverageReportInput = OpenApiCoverageReportInput()
+        private val openApiCoverageReportInput = OpenApiCoverageReportInput(getConfigFileWithAbsolutePath())
 
         @AfterAll
         @JvmStatic
@@ -121,8 +121,12 @@ open class SpecmaticJUnitSupport {
         }
 
         fun reportConfigurationFromConfig(): ReportConfiguration? {
-            return reportConfigurationFrom(globalConfigFileName)
+            return reportConfigurationFrom(getConfigFile())
         }
+
+        fun getConfigFile() = System.getProperty(CONFIG_FILE_NAME) ?: globalConfigFileName
+
+        fun getConfigFileWithAbsolutePath() = File(getConfigFile()).absolutePath
     }
 
     private fun getEnvConfig(envName: String?): JSONObjectValue {
@@ -154,7 +158,6 @@ open class SpecmaticJUnitSupport {
     fun contractTest(): Collection<DynamicTest> {
         val contractPaths = System.getProperty(CONTRACT_PATHS)
         val givenWorkingDirectory = System.getProperty(WORKING_DIRECTORY)
-        val givenConfigFile = System.getProperty(CONFIG_FILE_NAME)
         val filterName: String? = System.getProperty(FILTER_NAME)
         val filterNotName: String? = System.getProperty(FILTER_NOT_NAME)
 
@@ -178,7 +181,7 @@ open class SpecmaticJUnitSupport {
                     contractPaths.split(",").flatMap { loadTestScenarios(it, suggestionsPath, suggestionsData, testConfig) }
                 }
                 else -> {
-                    val configFile = givenConfigFile ?: globalConfigFileName
+                    val configFile = getConfigFile()
 
                     exitIfDoesNotExist("config file", configFile)
 

--- a/junit5-support/src/main/kotlin/in/specmatic/test/reports/OpenApiCoverageReportProcessor.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/reports/OpenApiCoverageReportProcessor.kt
@@ -34,7 +34,7 @@ class OpenApiCoverageReportProcessor(private val openApiCoverageReportInput: Ope
     }
 
     private fun saveAsJson(openApiCoverageJsonReport: OpenApiCoverageJsonReport) {
-        println("Saving Open API Coverage Report json to $JSON_REPORT_PATH...")
+        println("Saving Open API Coverage Report json to $JSON_REPORT_PATH ...")
         val json = Json {
             encodeDefaults = false
         }

--- a/junit5-support/src/main/kotlin/in/specmatic/test/reports/OpenApiCoverageReportProcessor.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/reports/OpenApiCoverageReportProcessor.kt
@@ -3,14 +3,21 @@ package `in`.specmatic.test.reports
 import `in`.specmatic.core.ReportConfiguration
 import `in`.specmatic.core.ReportFormatterType
 import `in`.specmatic.core.log.logger
-import `in`.specmatic.test.reports.coverage.OpenAPICoverageReport
+import `in`.specmatic.test.reports.coverage.console.OpenAPICoverageConsoleReport
+import `in`.specmatic.test.reports.coverage.json.OpenApiCoverageJsonReport
 import `in`.specmatic.test.reports.coverage.OpenApiCoverageReportInput
 import `in`.specmatic.test.reports.renderers.CoverageReportTextRenderer
 import `in`.specmatic.test.reports.renderers.ReportRenderer
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import org.assertj.core.api.Assertions.assertThat
+import java.io.File
 
 class OpenApiCoverageReportProcessor(private val openApiCoverageReportInput: OpenApiCoverageReportInput ): ReportProcessor {
-
+    companion object {
+        const val JSON_REPORT_PATH = "./build/reports/specmatic"
+        const val JSON_REPORT_FILE_NAME = "coverage_report.json"
+    }
     override fun process(reportConfiguration: ReportConfiguration) {
         openApiCoverageReportInput.addExcludedAPIs(reportConfiguration.types.apiCoverage.openAPI.excludedEndpoints)
         val openAPICoverageReport = openApiCoverageReportInput.generate()
@@ -21,11 +28,24 @@ class OpenApiCoverageReportProcessor(private val openApiCoverageReportInput: Ope
             renderers.forEach { renderer ->
                 logger.log(renderer.render(openAPICoverageReport))
             }
+            saveAsJson(openApiCoverageReportInput.generateJsonReport())
         }
         assertSuccessCriteria(reportConfiguration,openAPICoverageReport)
     }
 
-    private fun configureOpenApiCoverageReportRenderers(reportConfiguration: ReportConfiguration): List<ReportRenderer<OpenAPICoverageReport>> {
+    private fun saveAsJson(openApiCoverageJsonReport: OpenApiCoverageJsonReport) {
+        println("Saving Open API Coverage Report json to $JSON_REPORT_PATH...")
+        val json = Json {
+            encodeDefaults = false
+        }
+        val reportJson = json.encodeToString(openApiCoverageJsonReport)
+        val directory = File(JSON_REPORT_PATH)
+        directory.mkdirs()
+        val file = File(directory, JSON_REPORT_FILE_NAME)
+        file.writeText(reportJson)
+    }
+
+    private fun configureOpenApiCoverageReportRenderers(reportConfiguration: ReportConfiguration): List<ReportRenderer<OpenAPICoverageConsoleReport>> {
         return reportConfiguration.formatters!!.map {
             when (it.type) {
                 ReportFormatterType.TEXT -> CoverageReportTextRenderer()
@@ -36,7 +56,7 @@ class OpenApiCoverageReportProcessor(private val openApiCoverageReportInput: Ope
 
     private fun assertSuccessCriteria(
         reportConfiguration: ReportConfiguration,
-        openAPICoverageReport: OpenAPICoverageReport
+        openAPICoverageReport: OpenAPICoverageConsoleReport
     ) {
         val successCriteria = reportConfiguration.types.apiCoverage.openAPI.successCriteria
         if (successCriteria.enforce) {

--- a/junit5-support/src/main/kotlin/in/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
@@ -191,9 +191,9 @@ class OpenApiCoverageReportInput(
 }
 
 data class CoverageGroupKey(
-    val sourceProvider: String,
-    val sourceRepository: String,
-    val sourceRepositoryBranch: String,
-    val specification: String,
-    val serviceType: String
+    val sourceProvider: String?,
+    val sourceRepository: String?,
+    val sourceRepositoryBranch: String?,
+    val specification: String?,
+    val serviceType: String?
 )

--- a/junit5-support/src/main/kotlin/in/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
@@ -94,7 +94,7 @@ class OpenApiCoverageReportInput(
                         method = operationGroup.second,
                         responseCode = operationGroup.third,
                         count = operationRows.count{it.includeForCoverage},
-                        coverageStatus = getRemarks(operationRows)
+                        coverageStatus = getRemarks(operationRows).toString()
                     )
                 }
             )

--- a/junit5-support/src/main/kotlin/in/specmatic/test/reports/coverage/console/OpenAPICoverageConsoleReport.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/reports/coverage/console/OpenAPICoverageConsoleReport.kt
@@ -1,14 +1,14 @@
-package `in`.specmatic.test.reports.coverage
+package `in`.specmatic.test.reports.coverage.console
 
 import kotlin.math.roundToInt
 
-data class OpenAPICoverageReport(
-    val rows: List<OpenApiCoverageRow>,
+data class OpenAPICoverageConsoleReport(
+    val rows: List<OpenApiCoverageConsoleRow>,
     val totalEndpointsCount: Int,
     val missedEndpointsCount: Int,
     val notImplementedAPICount: Int
 ) {
     val totalCoveragePercentage: Int = if (totalEndpointsCount > 0) (coveragePercentageSum(rows) / totalEndpointsCount).toDouble().roundToInt() else 0
 
-    private fun coveragePercentageSum(rows: List<OpenApiCoverageRow>) = rows.sumOf { it.coveragePercentage }
+    private fun coveragePercentageSum(rows: List<OpenApiCoverageConsoleRow>) = rows.sumOf { it.coveragePercentage }
 }

--- a/junit5-support/src/main/kotlin/in/specmatic/test/reports/coverage/console/OpenApiCoverageConsoleRow.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/reports/coverage/console/OpenApiCoverageConsoleRow.kt
@@ -1,6 +1,6 @@
-package `in`.specmatic.test.reports.coverage
+package `in`.specmatic.test.reports.coverage.console
 
-data class OpenApiCoverageRow(
+data class OpenApiCoverageConsoleRow(
     val method: String,
     val path: String,
     val responseStatus: String,

--- a/junit5-support/src/main/kotlin/in/specmatic/test/reports/coverage/json/OpenApiCoverageJsonReport.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/reports/coverage/json/OpenApiCoverageJsonReport.kt
@@ -1,0 +1,9 @@
+package `in`.specmatic.test.reports.coverage.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class OpenApiCoverageJsonReport(
+    val specmaticConfigPath:String,
+    val apiCoverage:List<OpenApiCoverageJsonRow>
+)

--- a/junit5-support/src/main/kotlin/in/specmatic/test/reports/coverage/json/OpenApiCoverageJsonRow.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/reports/coverage/json/OpenApiCoverageJsonRow.kt
@@ -1,0 +1,13 @@
+package `in`.specmatic.test.reports.coverage.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class OpenApiCoverageJsonRow(
+    val type: String?,
+    val repository: String?,
+    val branch: String?,
+    val specification: String?,
+    val serviceType: String?,
+    val operations: List<OpenApiCoverageOperation>
+)

--- a/junit5-support/src/main/kotlin/in/specmatic/test/reports/coverage/json/OpenApiCoverageJsonRow.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/reports/coverage/json/OpenApiCoverageJsonRow.kt
@@ -4,10 +4,10 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class OpenApiCoverageJsonRow(
-    val type: String?,
-    val repository: String?,
-    val branch: String?,
-    val specification: String?,
-    val serviceType: String?,
+    val type: String? = null,
+    val repository: String? = null,
+    val branch: String? = null,
+    val specification: String? = null,
+    val serviceType: String? = null,
     val operations: List<OpenApiCoverageOperation>
 )

--- a/junit5-support/src/main/kotlin/in/specmatic/test/reports/coverage/json/OpenApiCoverageOperation.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/reports/coverage/json/OpenApiCoverageOperation.kt
@@ -1,13 +1,12 @@
 package `in`.specmatic.test.reports.coverage.json
 
-import `in`.specmatic.test.reports.coverage.console.Remarks
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class OpenApiCoverageOperation(
     val path: String,
     val method: String,
-    val responseCode: Int,
-    val count: Int,
-    val coverageStatus: Remarks
+    val responseCode: Int = 0,
+    val count: Int = 0,
+    val coverageStatus: String
 )

--- a/junit5-support/src/main/kotlin/in/specmatic/test/reports/coverage/json/OpenApiCoverageOperation.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/reports/coverage/json/OpenApiCoverageOperation.kt
@@ -1,0 +1,13 @@
+package `in`.specmatic.test.reports.coverage.json
+
+import `in`.specmatic.test.reports.coverage.console.Remarks
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class OpenApiCoverageOperation(
+    val path: String,
+    val method: String,
+    val responseCode: Int,
+    val count: Int,
+    val coverageStatus: Remarks
+)

--- a/junit5-support/src/main/kotlin/in/specmatic/test/reports/renderers/CoverageReportTextRenderer.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/reports/renderers/CoverageReportTextRenderer.kt
@@ -1,9 +1,9 @@
 package `in`.specmatic.test.reports.renderers
 
-import `in`.specmatic.test.reports.coverage.OpenAPICoverageReport
+import `in`.specmatic.test.reports.coverage.console.OpenAPICoverageConsoleReport
 
-class CoverageReportTextRenderer: ReportRenderer<OpenAPICoverageReport> {
-    override fun render(report: OpenAPICoverageReport): String {
+class CoverageReportTextRenderer: ReportRenderer<OpenAPICoverageConsoleReport> {
+    override fun render(report: OpenAPICoverageConsoleReport): String {
         val maxPathSize: Int = report.rows.map { it.path.length }.max()
         val maxRemarksSize = report.rows.map{it.remarks.toString().length}.max()
 

--- a/junit5-support/src/test/kotlin/in/specmatic/test/ApiCoverageReportInputTest.kt
+++ b/junit5-support/src/test/kotlin/in/specmatic/test/ApiCoverageReportInputTest.kt
@@ -269,12 +269,8 @@ class ApiCoverageReportInputTest {
                         )
                     ),
                     OpenApiCoverageJsonRow(
-                        "",
-                        "",
-                        "",
-                        "",
-                        "HTTP",
-                        listOf(
+                        serviceType = "HTTP",
+                        operations = listOf(
                             OpenApiCoverageOperation( "/route3/{route_id}", "GET",0, 0, Remarks.Missed),
                             OpenApiCoverageOperation( "/route3/{route_id}", "POST",0, 0, Remarks.Missed)
                         )

--- a/junit5-support/src/test/kotlin/in/specmatic/test/ApiCoverageReportInputTest.kt
+++ b/junit5-support/src/test/kotlin/in/specmatic/test/ApiCoverageReportInputTest.kt
@@ -253,8 +253,8 @@ class ApiCoverageReportInputTest {
                         "in/specmatic/examples/store/route1.yaml",
                         "HTTP",
                         listOf(
-                            OpenApiCoverageOperation("/route1", "GET",200, 1, Remarks.Covered),
-                            OpenApiCoverageOperation( "/route1", "POST",200, 1, Remarks.Covered)
+                            OpenApiCoverageOperation("/route1", "GET",200, 1, Remarks.Covered.toString()),
+                            OpenApiCoverageOperation( "/route1", "POST",200, 1, Remarks.Covered.toString())
                         )
                     ),
                     OpenApiCoverageJsonRow(
@@ -264,15 +264,15 @@ class ApiCoverageReportInputTest {
                         "in/specmatic/examples/store/route2.yaml",
                         "HTTP",
                         listOf(
-                            OpenApiCoverageOperation( "/route2", "GET",200, 1, Remarks.Covered),
-                            OpenApiCoverageOperation( "/route2", "POST",200, 0, Remarks.NotImplemented)
+                            OpenApiCoverageOperation( "/route2", "GET",200, 1, Remarks.Covered.toString()),
+                            OpenApiCoverageOperation( "/route2", "POST",200, 0, Remarks.NotImplemented.toString())
                         )
                     ),
                     OpenApiCoverageJsonRow(
                         serviceType = "HTTP",
                         operations = listOf(
-                            OpenApiCoverageOperation( "/route3/{route_id}", "GET",0, 0, Remarks.Missed),
-                            OpenApiCoverageOperation( "/route3/{route_id}", "POST",0, 0, Remarks.Missed)
+                            OpenApiCoverageOperation( "/route3/{route_id}", "GET",0, 0, Remarks.Missed.toString()),
+                            OpenApiCoverageOperation( "/route3/{route_id}", "POST",0, 0, Remarks.Missed.toString()      )
                         )
                     )
                 )

--- a/junit5-support/src/test/kotlin/in/specmatic/test/ApiCoverageReportInputTest.kt
+++ b/junit5-support/src/test/kotlin/in/specmatic/test/ApiCoverageReportInputTest.kt
@@ -1,15 +1,21 @@
 package `in`.specmatic.test
 
 import `in`.specmatic.core.TestResult
-import `in`.specmatic.test.reports.coverage.OpenAPICoverageReport
-import `in`.specmatic.test.reports.coverage.OpenApiCoverageReportInput
-import `in`.specmatic.test.reports.coverage.OpenApiCoverageRow
-import `in`.specmatic.test.reports.coverage.Remarks
+import `in`.specmatic.test.reports.coverage.*
+import `in`.specmatic.test.reports.coverage.console.OpenAPICoverageConsoleReport
+import `in`.specmatic.test.reports.coverage.console.OpenApiCoverageConsoleRow
+import `in`.specmatic.test.reports.coverage.console.Remarks
+import `in`.specmatic.test.reports.coverage.json.OpenApiCoverageJsonReport
+import `in`.specmatic.test.reports.coverage.json.OpenApiCoverageJsonRow
+import `in`.specmatic.test.reports.coverage.json.OpenApiCoverageOperation
 import `in`.specmatic.test.reports.renderers.CoverageReportTextRenderer
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class ApiCoverageReportInputTest {
+    companion object {
+        const val CONFIG_FILE_PATH = "./specmatic.json"
+    }
     @Test
     fun `test generates api coverage report when all endpoints are covered`() {
         val testReportRecords = mutableListOf(
@@ -24,15 +30,15 @@ class ApiCoverageReportInputTest {
             API("GET", "/route2")
         )
 
-        val apiCoverageReport = OpenApiCoverageReportInput(testReportRecords, applicationAPIs).generate()
+        val apiCoverageReport = OpenApiCoverageReportInput(CONFIG_FILE_PATH, testReportRecords, applicationAPIs).generate()
         println(CoverageReportTextRenderer().render(apiCoverageReport))
         assertThat(apiCoverageReport).isEqualTo(
-            OpenAPICoverageReport(
+            OpenAPICoverageConsoleReport(
                 listOf(
-                    OpenApiCoverageRow("GET", "/route1", 200, 1, 100, Remarks.Covered),
-                    OpenApiCoverageRow("POST", "", "200", "1", 0, Remarks.Covered),
-                    OpenApiCoverageRow("", "", "401", "1", 0, Remarks.Covered),
-                    OpenApiCoverageRow("GET", "/route2", 200, 1, 100, Remarks.Covered)
+                    OpenApiCoverageConsoleRow("GET", "/route1", 200, 1, 100, Remarks.Covered),
+                    OpenApiCoverageConsoleRow("POST", "", "200", "1", 0, Remarks.Covered),
+                    OpenApiCoverageConsoleRow("", "", "401", "1", 0, Remarks.Covered),
+                    OpenApiCoverageConsoleRow("GET", "/route2", 200, 1, 100, Remarks.Covered)
                 ),
                 2, 0, 0
             )
@@ -57,18 +63,18 @@ class ApiCoverageReportInputTest {
             TestResultRecord("/route2", "GET", 200, TestResult.Success)
         )
 
-        val apiCoverageReport = OpenApiCoverageReportInput(testReportRecords, applicationAPIs).generate()
+        val apiCoverageReport = OpenApiCoverageReportInput(CONFIG_FILE_PATH, testReportRecords, applicationAPIs).generate()
         println(CoverageReportTextRenderer().render(apiCoverageReport))
         assertThat(apiCoverageReport).isEqualTo(
-            OpenAPICoverageReport(
+            OpenAPICoverageConsoleReport(
                 listOf(
-                    OpenApiCoverageRow("GET", "/route1", 200, 1, 100, Remarks.Covered),
-                    OpenApiCoverageRow("POST", "", 200, 1, 0, Remarks.Covered),
-                    OpenApiCoverageRow("", "", 401, 1, 0, Remarks.Covered),
-                    OpenApiCoverageRow("GET", "/route2", 200, 1, 50, Remarks.Covered),
-                    OpenApiCoverageRow("POST", "", 0, 0, 0, Remarks.Missed),
-                    OpenApiCoverageRow("GET", "/route3", 0, 0, 0, Remarks.Missed),
-                    OpenApiCoverageRow("POST", "", 0, 0, 0, Remarks.Missed)
+                    OpenApiCoverageConsoleRow("GET", "/route1", 200, 1, 100, Remarks.Covered),
+                    OpenApiCoverageConsoleRow("POST", "", 200, 1, 0, Remarks.Covered),
+                    OpenApiCoverageConsoleRow("", "", 401, 1, 0, Remarks.Covered),
+                    OpenApiCoverageConsoleRow("GET", "/route2", 200, 1, 50, Remarks.Covered),
+                    OpenApiCoverageConsoleRow("POST", "", 0, 0, 0, Remarks.Missed),
+                    OpenApiCoverageConsoleRow("GET", "/route3", 0, 0, 0, Remarks.Missed),
+                    OpenApiCoverageConsoleRow("POST", "", 0, 0, 0, Remarks.Missed)
                 ),
                 3, 2, 0
             )
@@ -99,16 +105,16 @@ class ApiCoverageReportInputTest {
         )
 
 
-        val apiCoverageReport = OpenApiCoverageReportInput(testReportRecords, applicationAPIs, excludedAPIs).generate()
+        val apiCoverageReport = OpenApiCoverageReportInput(CONFIG_FILE_PATH, testReportRecords, applicationAPIs, excludedAPIs).generate()
         println(CoverageReportTextRenderer().render(apiCoverageReport))
         assertThat(apiCoverageReport).isEqualTo(
-            OpenAPICoverageReport(
+            OpenAPICoverageConsoleReport(
                 listOf(
-                    OpenApiCoverageRow("GET", "/route1", 200, 1, 100, Remarks.Covered),
-                    OpenApiCoverageRow("POST", "", 200, 1, 0,  Remarks.Covered),
-                    OpenApiCoverageRow("", "", 401, 1, 0,  Remarks.Covered),
-                    OpenApiCoverageRow("GET", "/route2", 200, 1, 100,  Remarks.Covered),
-                    OpenApiCoverageRow("POST", "", 200, 1, 0,  Remarks.Covered)
+                    OpenApiCoverageConsoleRow("GET", "/route1", 200, 1, 100, Remarks.Covered),
+                    OpenApiCoverageConsoleRow("POST", "", 200, 1, 0,  Remarks.Covered),
+                    OpenApiCoverageConsoleRow("", "", 401, 1, 0,  Remarks.Covered),
+                    OpenApiCoverageConsoleRow("GET", "/route2", 200, 1, 100,  Remarks.Covered),
+                    OpenApiCoverageConsoleRow("POST", "", 200, 1, 0,  Remarks.Covered)
                 ),
                 2, 0, 0
             )
@@ -140,7 +146,7 @@ class ApiCoverageReportInputTest {
             "/heartbeat"
         )
 
-        val apiCoverageReport = OpenApiCoverageReportInput(testReportRecords, applicationAPIs, excludedAPIs).generate()
+        val apiCoverageReport = OpenApiCoverageReportInput(CONFIG_FILE_PATH, testReportRecords, applicationAPIs, excludedAPIs).generate()
         assertThat(apiCoverageReport.rows).isEmpty()
         assertThat(apiCoverageReport.totalCoveragePercentage).isEqualTo(0)
     }
@@ -151,7 +157,7 @@ class ApiCoverageReportInputTest {
         val applicationAPIs = mutableListOf<API>()
         val excludedAPIs = mutableListOf<String>()
 
-        val apiCoverageReport = OpenApiCoverageReportInput(testReportRecords, applicationAPIs, excludedAPIs).generate()
+        val apiCoverageReport = OpenApiCoverageReportInput(CONFIG_FILE_PATH, testReportRecords, applicationAPIs, excludedAPIs).generate()
         assertThat(apiCoverageReport.rows).isEmpty()
     }
 
@@ -170,15 +176,15 @@ class ApiCoverageReportInputTest {
             TestResultRecord("/route2", "POST", 200, TestResult.Failed)
         )
 
-        val apiCoverageReport = OpenApiCoverageReportInput(testReportRecords, applicationAPIs).generate()
+        val apiCoverageReport = OpenApiCoverageReportInput(CONFIG_FILE_PATH, testReportRecords, applicationAPIs).generate()
         println(CoverageReportTextRenderer().render(apiCoverageReport))
         assertThat(apiCoverageReport).isEqualTo(
-            OpenAPICoverageReport(
+            OpenAPICoverageConsoleReport(
                 listOf(
-                    OpenApiCoverageRow("GET", "/route1", 200, 1, 100,  Remarks.Covered),
-                    OpenApiCoverageRow("POST", "", 200, 1, 0,  Remarks.Covered),
-                    OpenApiCoverageRow("GET", "/route2", 200, 1, 50,  Remarks.Covered),
-                    OpenApiCoverageRow("POST", "", 200, 0, 0,  Remarks.NotImplemented)
+                    OpenApiCoverageConsoleRow("GET", "/route1", 200, 1, 100,  Remarks.Covered),
+                    OpenApiCoverageConsoleRow("POST", "", 200, 1, 0,  Remarks.Covered),
+                    OpenApiCoverageConsoleRow("GET", "/route2", 200, 1, 50,  Remarks.Covered),
+                    OpenApiCoverageConsoleRow("POST", "", 200, 0, 0,  Remarks.NotImplemented)
                 ),
                 2, 0, 1
             )
@@ -202,20 +208,80 @@ class ApiCoverageReportInputTest {
             TestResultRecord("/route2", "POST", 200, TestResult.Failed)
         )
 
-        val apiCoverageReport = OpenApiCoverageReportInput(testReportRecords, applicationAPIs).generate()
+        val apiCoverageReport = OpenApiCoverageReportInput(CONFIG_FILE_PATH, testReportRecords, applicationAPIs).generate()
         println(CoverageReportTextRenderer().render(apiCoverageReport))
         assertThat(apiCoverageReport).isEqualTo(
-            OpenAPICoverageReport(
+            OpenAPICoverageConsoleReport(
                 listOf(
-                    OpenApiCoverageRow("GET", "/route1", 200, 1, 100,  Remarks.Covered),
-                    OpenApiCoverageRow("POST", "", 200, 1, 0,  Remarks.Covered),
-                    OpenApiCoverageRow("GET", "/route2", 200, 1, 50,  Remarks.Covered),
-                    OpenApiCoverageRow("POST", "", 200, 0, 0,  Remarks.NotImplemented),
-                    OpenApiCoverageRow("GET", "/route3/{route_id}", 0, 0, 0,  Remarks.Missed),
-                    OpenApiCoverageRow("POST", "", 0, 0, 0,  Remarks.Missed)
+                    OpenApiCoverageConsoleRow("GET", "/route1", 200, 1, 100,  Remarks.Covered),
+                    OpenApiCoverageConsoleRow("POST", "", 200, 1, 0,  Remarks.Covered),
+                    OpenApiCoverageConsoleRow("GET", "/route2", 200, 1, 50,  Remarks.Covered),
+                    OpenApiCoverageConsoleRow("POST", "", 200, 0, 0,  Remarks.NotImplemented),
+                    OpenApiCoverageConsoleRow("GET", "/route3/{route_id}", 0, 0, 0,  Remarks.Missed),
+                    OpenApiCoverageConsoleRow("POST", "", 0, 0, 0,  Remarks.Missed)
                 ),
                 3, 1, 1
             )
         )
+    }
+
+    @Test
+    fun `test generates api coverage json report with partially covered and partially implemented endpoints for`() {
+        val applicationAPIs = mutableListOf(
+            API("GET", "/route1"),
+            API("POST", "/route1"),
+            API("GET", "/route2"),
+            API("GET", "/route3/{route_id}"),
+            API("POST", "/route3/{route_id}")
+        )
+
+        val testReportRecords = mutableListOf(
+            TestResultRecord("/route1", "GET", 200, TestResult.Success, "git", "https://github.com/znsio/specmatic-order-contracts.git", "main", "in/specmatic/examples/store/route1.yaml", "HTTP"),
+            TestResultRecord("/route1", "POST", 200, TestResult.Success, "git", "https://github.com/znsio/specmatic-order-contracts.git", "main", "in/specmatic/examples/store/route1.yaml", "HTTP"),
+            TestResultRecord("/route2", "GET", 200, TestResult.Success, "git", "https://github.com/znsio/specmatic-order-contracts.git", "main", "in/specmatic/examples/store/route2.yaml", "HTTP"),
+            TestResultRecord("/route2", "POST", 200, TestResult.Failed, "git", "https://github.com/znsio/specmatic-order-contracts.git", "main", "in/specmatic/examples/store/route2.yaml", "HTTP")
+        )
+
+        val openApiCoverageJsonReport = OpenApiCoverageReportInput(CONFIG_FILE_PATH, testReportRecords, applicationAPIs).generateJsonReport()
+        assertThat(openApiCoverageJsonReport).isEqualTo(
+            OpenApiCoverageJsonReport(
+                CONFIG_FILE_PATH, listOf(
+                    OpenApiCoverageJsonRow(
+                        "git",
+                        "https://github.com/znsio/specmatic-order-contracts.git",
+                        "main",
+                        "in/specmatic/examples/store/route1.yaml",
+                        "HTTP",
+                        listOf(
+                            OpenApiCoverageOperation("/route1", "GET",200, 1, Remarks.Covered),
+                            OpenApiCoverageOperation( "/route1", "POST",200, 1, Remarks.Covered)
+                        )
+                    ),
+                    OpenApiCoverageJsonRow(
+                        "git",
+                        "https://github.com/znsio/specmatic-order-contracts.git",
+                        "main",
+                        "in/specmatic/examples/store/route2.yaml",
+                        "HTTP",
+                        listOf(
+                            OpenApiCoverageOperation( "/route2", "GET",200, 1, Remarks.Covered),
+                            OpenApiCoverageOperation( "/route2", "POST",200, 0, Remarks.NotImplemented)
+                        )
+                    ),
+                    OpenApiCoverageJsonRow(
+                        "",
+                        "",
+                        "",
+                        "",
+                        "HTTP",
+                        listOf(
+                            OpenApiCoverageOperation( "/route3/{route_id}", "GET",0, 0, Remarks.Missed),
+                            OpenApiCoverageOperation( "/route3/{route_id}", "POST",0, 0, Remarks.Missed)
+                        )
+                    )
+                )
+            )
+        )
+
     }
 }

--- a/junit5-support/src/test/kotlin/in/specmatic/test/OpenApiCoverageConsoleRowTest.kt
+++ b/junit5-support/src/test/kotlin/in/specmatic/test/OpenApiCoverageConsoleRowTest.kt
@@ -1,16 +1,16 @@
 package `in`.specmatic.test
 
-import `in`.specmatic.test.reports.coverage.OpenApiCoverageRow
-import `in`.specmatic.test.reports.coverage.Remarks
+import `in`.specmatic.test.reports.coverage.console.OpenApiCoverageConsoleRow
+import `in`.specmatic.test.reports.coverage.console.Remarks
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
-class OpenApiCoverageRowTest {
+class OpenApiCoverageConsoleRowTest {
 
     @Test
     fun `test renders coverage percentage, path, method, response, count for top level row of covered endpoint`() {
         val path  = "/route1"
-        val coverageRowString = OpenApiCoverageRow("GET", path, 200, 1, 100, Remarks.Covered).toRowString(
+        val coverageRowString = OpenApiCoverageConsoleRow("GET", path, 200, 1, 100, Remarks.Covered).toRowString(
             path.length,
             Remarks.Covered.toString().length,
         )
@@ -21,7 +21,7 @@ class OpenApiCoverageRowTest {
     @Test
     fun `test renders path, method, response, count with coverage percentage blank for sub level row of covered endpoint`() {
         val path  = "/route1"
-        val coverageRowString = OpenApiCoverageRow("POST", "", 200, 1, 0, Remarks.Missed).toRowString(
+        val coverageRowString = OpenApiCoverageConsoleRow("POST", "", 200, 1, 0, Remarks.Missed).toRowString(
             path.length,
             Remarks.Missed.toString().length
         )
@@ -32,7 +32,7 @@ class OpenApiCoverageRowTest {
     @Test
     fun `test renders coverage percentage, path, method, with response, count for top level row of missed endpoint`() {
         val path  = "/route1"
-        val coverageRowString = OpenApiCoverageRow("GET", path, 0, 0, 0, Remarks.Missed).toRowString(
+        val coverageRowString = OpenApiCoverageConsoleRow("GET", path, 0, 0, 0, Remarks.Missed).toRowString(
             path.length,
             Remarks.Missed.toString().length
         )
@@ -44,7 +44,7 @@ class OpenApiCoverageRowTest {
     @Test
     fun `test renders coverage percentage, path, method, with response, count for sub level row of missed endpoint`() {
         val path  = "/route1"
-        val coverageRowString = OpenApiCoverageRow("POST", "", 0, 1, 0, Remarks.Missed).toRowString(
+        val coverageRowString = OpenApiCoverageConsoleRow("POST", "", 0, 1, 0, Remarks.Missed).toRowString(
             path.length,
             Remarks.Missed.toString().length
         )
@@ -55,7 +55,7 @@ class OpenApiCoverageRowTest {
     @Test
     fun `test renders coverage percentage, path, method, with response, count for top level row of not implemented endpoint`() {
         val path  = "/route1"
-        val coverageRowString = OpenApiCoverageRow("GET", path, 0, 0, 0, Remarks.NotImplemented).toRowString(
+        val coverageRowString = OpenApiCoverageConsoleRow("GET", path, 0, 0, 0, Remarks.NotImplemented).toRowString(
             path.length,
             Remarks.NotImplemented.toString().length
         )
@@ -66,7 +66,7 @@ class OpenApiCoverageRowTest {
     @Test
     fun `test renders coverage percentage, path, method, with response, count for sub level row of not implemented endpoint`() {
         val path  = "/route1"
-        val coverageRowString = OpenApiCoverageRow("GET", "", 200, 0, 0, Remarks.NotImplemented).toRowString(
+        val coverageRowString = OpenApiCoverageConsoleRow("GET", "", 200, 0, 0, Remarks.NotImplemented).toRowString(
             path.length,
             Remarks.NotImplemented.toString().length
         )


### PR DESCRIPTION
**What**:

Specmatic  will now also save the api coverage report as a json file at a specified location after executing contract tests.
(The api coverage report will also be printed on the console as before)




- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

