### PR TITLE
API Coverage Report json file via command line bug fix

### DIFF
--- a/application/src/main/kotlin/application/TestCommand.kt
+++ b/application/src/main/kotlin/application/TestCommand.kt
@@ -108,8 +108,6 @@ class TestCommand : Callable<Unit> {
             System.setProperty(CONFIG_FILE_NAME, it)
         }
 
-        contractPaths = loadContractPaths()
-
         if(port == 0) {
             port = when {
                 useHttps -> 443
@@ -146,7 +144,7 @@ class TestCommand : Callable<Unit> {
         if(testBaseURL.isNotEmpty())
             System.setProperty(TEST_BASE_URL, testBaseURL)
 
-        System.setProperty(CONTRACT_PATHS, contractPaths.joinToString(","))
+        if(contractPaths.isNotEmpty()) System.setProperty(CONTRACT_PATHS, contractPaths.joinToString(","))
 
         val request: LauncherDiscoveryRequest = LauncherDiscoveryRequestBuilder.request()
                 .selectors(selectClass(SpecmaticJUnitSupport::class.java))
@@ -238,16 +236,6 @@ class TestCommand : Callable<Unit> {
     }
     catch (e: Throwable) {
         logger.log(e)
-    }
-
-    private fun loadContractPaths(): List<String> {
-        return when {
-            contractPaths.isEmpty() -> {
-                logger.debug("No contractPaths specified. Using configuration file named ${Configuration.globalConfigFileName}")
-                specmaticConfig.contractTestPaths()
-            }
-            else -> contractPaths
-        }
     }
 }
 

--- a/application/src/main/kotlin/application/TestCommand.kt
+++ b/application/src/main/kotlin/application/TestCommand.kt
@@ -23,6 +23,7 @@ import `in`.specmatic.test.SpecmaticJUnitSupport.Companion.TIMEOUT
 import `in`.specmatic.test.SpecmaticJUnitSupport.Companion.VARIABLES_FILE_NAME
 import org.junit.platform.engine.discovery.DiscoverySelectors.selectClass
 import org.junit.platform.launcher.Launcher
+import org.junit.platform.launcher.LauncherDiscoveryListener
 import org.junit.platform.launcher.LauncherDiscoveryRequest
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder
 import org.springframework.beans.factory.annotation.Autowired

--- a/application/src/test/kotlin/application/TestCommandTest.kt
+++ b/application/src/test/kotlin/application/TestCommandTest.kt
@@ -44,16 +44,17 @@ internal class TestCommandTest {
     fun `clean up test command`() {
         testCommand.contractPaths = arrayListOf()
         testCommand.junitReportDirName = null
+        System.clearProperty(CONTRACT_PATHS)
     }
 
     @Test
-    fun `when contract files are not given it should load from qontract config`() {
+    fun `when contract files are not given it should not load from specmatic config`() {
         every { specmaticConfig.contractTestPaths() }.returns(contractsToBeRunAsTests)
 
         CommandLine(testCommand, factory).execute()
 
-        verify(exactly = 1) { specmaticConfig.contractTestPaths() }
-        assertThat(System.getProperty(CONTRACT_PATHS)).isEqualTo(contractsToBeRunAsTests.joinToString(","))
+        verify(exactly = 0) { specmaticConfig.contractTestPaths() }
+        assertThat(System.getProperty(CONTRACT_PATHS)).isNull()
     }
 
     @Test

--- a/core/src/main/kotlin/in/specmatic/core/Configuration.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Configuration.kt
@@ -2,15 +2,22 @@ package `in`.specmatic.core
 
 import java.io.File
 
+// moved here because when it's inside, for some reason when SpecmaticJUnitSupport.configFile
+// calls globalConfigFileName, it results in a call to the config var and we don't know why,
+// and if the configuration file is invalid, an exception is thrown and eaten silently by JUnit's
+// test discovery functionality.
+// Moving it here so we can use a function to read it which is not inside Configuration
+private var _globalConfigFileName: String = "./${Configuration.DEFAULT_CONFIG_FILE_NAME}"
+public fun getGlobalConfigFileName(): String = _globalConfigFileName
+
 class Configuration {
     companion object {
         var gitCommand: String = System.getProperty("gitCommandPath") ?: System.getenv("SPECMATIC_GIT_COMMAND_PATH") ?: "git"
         const val TEST_BUNDLE_RELATIVE_PATH = ".${APPLICATION_NAME_LOWER_CASE}_test_bundle"
         const val DEFAULT_CONFIG_FILE_NAME = "$APPLICATION_NAME_LOWER_CASE.json"
 
-        private var _globalConfigFileName: String = "./$DEFAULT_CONFIG_FILE_NAME"
         var globalConfigFileName: String
-            get() = _globalConfigFileName
+            get() = getGlobalConfigFileName()
 
             set(value) {
                 _globalConfigFileName = value

--- a/core/src/main/kotlin/in/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/in/specmatic/core/SpecmaticConfig.kt
@@ -3,10 +3,10 @@ package `in`.specmatic.core
 import `in`.specmatic.core.Configuration.Companion.globalConfigFileName
 import `in`.specmatic.core.pattern.ContractException
 import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import java.io.File
-import kotlinx.serialization.Serializable
 
 const val APPLICATION_NAME = "Specmatic"
 const val APPLICATION_NAME_LOWER_CASE = "specmatic"
@@ -157,6 +157,6 @@ fun loadSpecmaticJsonConfig(configFileName: String? = null): SpecmaticConfigJson
     try {
         return SpecmaticJsonFormat.decodeFromString(configFile.readText())
     } catch (e: Throwable) {
-        throw ContractException("Your specmatic.json file may have some missing configuration sections. Please ensure that the specmatic.json fie adheres to the schema described at: https://specmatic.in/documentation/specmatic_json.html#complete-sample-specmaticjson-with-all-attributes")
+        throw Exception("Your specmatic.json file may have some missing configuration sections. Please ensure that the specmatic.json fie adheres to the schema described at: https://specmatic.in/documentation/specmatic_json.html#complete-sample-specmaticjson-with-all-attributes")
     }
 }

--- a/core/src/main/kotlin/in/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/in/specmatic/core/SpecmaticConfig.kt
@@ -157,6 +157,6 @@ fun loadSpecmaticJsonConfig(configFileName: String? = null): SpecmaticConfigJson
     try {
         return SpecmaticJsonFormat.decodeFromString(configFile.readText())
     } catch (e: Throwable) {
-        throw Exception("Your specmatic.json file may have some missing configuration sections. Please ensure that the specmatic.json fie adheres to the schema described at: https://specmatic.in/documentation/specmatic_json.html#complete-sample-specmaticjson-with-all-attributes")
+        throw Exception("Your specmatic.json file may have some missing configuration sections. Please ensure that the specmatic.json file adheres to the schema described at: https://specmatic.in/documentation/specmatic_json.html#complete-sample-specmaticjson-with-all-attributes")
     }
 }

--- a/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
@@ -63,8 +63,7 @@ open class SpecmaticJUnitSupport {
             val defaultReportTypes = ReportTypes(apiCoverage = APICoverage(openAPI = APICoverageConfiguration(successCriteria = SuccessCriteria(0, 0, false))))
             return when (val reportConfiguration = specmaticConfigJson?.report) {
                 null -> {
-                    logger.log("Could not load report configuration, running test with default report configuration")
-                    logger.log("API coverage report configuration not found in specmatic.json, proceeding with API coverage report without success criteria")
+                    logger.log("Could not load report configuration, coverage will be calculated but no coverage threshold will be enforced")
                     ReportConfiguration(formatters = defaultFormatters, types = defaultReportTypes)
                 }
                 else -> {
@@ -115,7 +114,7 @@ open class SpecmaticJUnitSupport {
             }
         }
 
-        val configFile get() = System.getProperty(CONFIG_FILE_NAME) ?: "./${Configuration.DEFAULT_CONFIG_FILE_NAME}"
+        val configFile get() = System.getProperty(CONFIG_FILE_NAME) ?: getGlobalConfigFileName()
 
         private fun getConfigFileWithAbsolutePath() = File(configFile).canonicalPath
     }

--- a/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
@@ -115,7 +115,7 @@ open class SpecmaticJUnitSupport {
             }
         }
 
-        val configFile get() = System.getProperty(CONFIG_FILE_NAME) ?: globalConfigFileName
+        val configFile get() = System.getProperty(CONFIG_FILE_NAME) ?: "./${Configuration.DEFAULT_CONFIG_FILE_NAME}"
 
         private fun getConfigFileWithAbsolutePath() = File(configFile).canonicalPath
     }
@@ -250,9 +250,12 @@ open class SpecmaticJUnitSupport {
         return try {
             loadSpecmaticJsonConfig(configFile)
         }
-        catch (e: Throwable) {
+        catch (e: ContractException) {
             logger.log(exceptionCauseMessage(e))
             null
+        }
+        catch (e: Throwable) {
+            exitWithMessage(exceptionCauseMessage(e))
         }
     }
 

--- a/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
@@ -179,13 +179,13 @@ open class SpecmaticJUnitSupport {
             val testScenarios = when {
                 contractPaths != null -> {
                     contractPaths.split(",").flatMap { specification ->
-                        val sources = specmaticJson?.let { loadSources(specmaticJson) }
-                        val sourceAndSpecification = sources?.flatMap { source ->
+                        val sources: List<ContractSource>? = specmaticJson?.let { loadSources(specmaticJson) }
+                        val sourceAndSpecification: Pair<ContractSource, String>? = sources?.flatMap { source ->
                             source.testContracts.mapNotNull { testContract ->
                                 if (specification.endsWith(testContract)) Pair(source, testContract) else null
                             }
                         }?.firstOrNull()
-                        val specSource = sourceAndSpecification?.let {
+                        val specSource: SpecificationSource = sourceAndSpecification?.let {
                             val source = sourceAndSpecification.first
                             val specificationPath = sourceAndSpecification.second
                             when (source) {

--- a/junit5-support/src/main/kotlin/in/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
@@ -15,7 +15,7 @@ import kotlin.math.min
 import kotlin.math.roundToInt
 
 class OpenApiCoverageReportInput(
-    private val configFilePath:String,
+    private val configFilePath:String? = null,
     private val testResultRecords: MutableList<TestResultRecord> = mutableListOf(),
     private val applicationAPIs: MutableList<API> = mutableListOf(),
     private val excludedAPIs: MutableList<String> = mutableListOf()

--- a/junit5-support/src/main/kotlin/in/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
@@ -15,7 +15,7 @@ import kotlin.math.min
 import kotlin.math.roundToInt
 
 class OpenApiCoverageReportInput(
-    private val configFilePath:String? = null,
+    private var configFilePath:String,
     private val testResultRecords: MutableList<TestResultRecord> = mutableListOf(),
     private val applicationAPIs: MutableList<API> = mutableListOf(),
     private val excludedAPIs: MutableList<String> = mutableListOf()

--- a/junit5-support/src/main/kotlin/in/specmatic/test/reports/coverage/json/OpenApiCoverageJsonReport.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/reports/coverage/json/OpenApiCoverageJsonReport.kt
@@ -4,6 +4,6 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class OpenApiCoverageJsonReport(
-    val specmaticConfigPath:String,
+    val specmaticConfigPath:String? = null,
     val apiCoverage:List<OpenApiCoverageJsonRow>
 )

--- a/junit5-support/src/main/kotlin/in/specmatic/test/reports/coverage/json/OpenApiCoverageJsonReport.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/reports/coverage/json/OpenApiCoverageJsonReport.kt
@@ -4,6 +4,6 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class OpenApiCoverageJsonReport(
-    val specmaticConfigPath:String? = null,
+    val specmaticConfigPath:String,
     val apiCoverage:List<OpenApiCoverageJsonRow>
 )


### PR DESCRIPTION

**What**:

Fixed bug in rendering source repository information in the API Coverage Report json file, when Specmatic tests are executed via command line.


- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate
