### PR TITLE
Fix AnyPattern nullable bug

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/pattern/AnyPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/AnyPattern.kt
@@ -153,11 +153,7 @@ data class AnyPattern(
         if (pattern.isEmpty())
             throw ContractException("AnyPattern doesn't have any types, so can't infer which type of list to wrap the given value in")
 
-        if (pattern.size >= 2) {
-            return pattern.single { it !is NullPattern }.listOf(valueList, resolver)
-        }
-
-        return pattern.single().listOf(valueList, resolver)
+        return pattern.first().listOf(valueList, resolver)
     }
 
     override val typeName: String

--- a/core/src/test/kotlin/in/specmatic/core/pattern/AnyPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/AnyPatternTest.kt
@@ -1,17 +1,16 @@
 package `in`.specmatic.core.pattern
 
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions.*
-import org.junit.jupiter.api.Test
 import `in`.specmatic.core.Resolver
 import `in`.specmatic.core.Result
 import `in`.specmatic.core.utilities.withNullPattern
 import `in`.specmatic.core.value.*
 import `in`.specmatic.emptyPattern
 import `in`.specmatic.shouldMatch
-import org.checkerframework.common.value.qual.StringVal
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
 internal class AnyPatternTest {
     @Test

--- a/core/src/test/kotlin/in/specmatic/core/pattern/AnyPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/AnyPatternTest.kt
@@ -224,20 +224,22 @@ internal class AnyPatternTest {
     }
 
     @Test
-    fun `should generate a Nullable list swiftly`() {
+    fun `should wrap values in the relevant list type`() {
         val type = AnyPattern(listOf(NullPattern, StringPattern()))
-        val listOf = type.listOf(listOf(StringValue("It's me"), StringValue("Hi"), StringValue("I'm the problem it's me")), Resolver())
-        assertEquals(3, (listOf as JSONArrayValue).list.size)
-        assertEquals("It's me", (listOf as JSONArrayValue).list.get(0).toStringLiteral())
-        assertEquals("Hi", (listOf as JSONArrayValue).list.get(1).toStringLiteral())
-        assertEquals("I'm the problem it's me", (listOf as JSONArrayValue).list.get(2).toStringLiteral())
+        val wrappedList = type.listOf(listOf(StringValue("It's me"), StringValue("Hi"), StringValue("I'm the problem it's me")), Resolver()) as JSONArrayValue
+
+        val wrappedValues = wrappedList.list.map { it.toStringLiteral() }
+        val expectedValues = listOf("It's me", "Hi", "I'm the problem it's me")
+
+        assertThat(wrappedValues).isEqualTo(expectedValues)
     }
 
     @Test
-    fun `should generate a Nullable from a row`() {
-        val type = AnyPattern(listOf(NullPattern, JSONObjectPattern(pattern = mapOf(Pair("foo", StringPattern())))))
-        val row = Row(columnNames = listOf("foo"), values=listOf("bar"))
-        val newBasedOnPattern = type.newBasedOn(row, Resolver())
-        assertEquals("bar", ((newBasedOnPattern.single(){it !is NullPattern} as JSONObjectPattern).pattern.get("foo") as ExactValuePattern).toString())
+    fun `should wrap values in the relevant list type when the AnyPattern object represents an enum with 3 options`() {
+        val type = AnyPattern(listOf(
+            ExactValuePattern(StringValue("one")), ExactValuePattern(StringValue("two")), ExactValuePattern(StringValue("three"))))
+        val listOf = type.listOf(listOf(StringValue("one"), StringValue("two"), StringValue("three")), Resolver())
+
+        assertEquals(3, (listOf as JSONArrayValue).list.size)
     }
 }

--- a/core/src/test/kotlin/in/specmatic/core/pattern/AnyPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/AnyPatternTest.kt
@@ -6,12 +6,10 @@ import org.junit.jupiter.api.Test
 import `in`.specmatic.core.Resolver
 import `in`.specmatic.core.Result
 import `in`.specmatic.core.utilities.withNullPattern
-import `in`.specmatic.core.value.JSONObjectValue
-import `in`.specmatic.core.value.NumberValue
-import `in`.specmatic.core.value.StringValue
-import `in`.specmatic.core.value.Value
+import `in`.specmatic.core.value.*
 import `in`.specmatic.emptyPattern
 import `in`.specmatic.shouldMatch
+import org.checkerframework.common.value.qual.StringVal
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Nested
 
@@ -224,5 +222,23 @@ internal class AnyPatternTest {
             
                Key named "salutation" was unexpected
        """.trimIndent())
+    }
+
+    @Test
+    fun `should generate a Nullable list swiftly`() {
+        val type = AnyPattern(listOf(NullPattern, StringPattern()))
+        val listOf = type.listOf(listOf(StringValue("It's me"), StringValue("Hi"), StringValue("I'm the problem it's me")), Resolver())
+        assertEquals(3, (listOf as JSONArrayValue).list.size)
+        assertEquals("It's me", (listOf as JSONArrayValue).list.get(0).toStringLiteral())
+        assertEquals("Hi", (listOf as JSONArrayValue).list.get(1).toStringLiteral())
+        assertEquals("I'm the problem it's me", (listOf as JSONArrayValue).list.get(2).toStringLiteral())
+    }
+
+    @Test
+    fun `should generate a Nullable from a row`() {
+        val type = AnyPattern(listOf(NullPattern, JSONObjectPattern(pattern = mapOf(Pair("foo", StringPattern())))))
+        val row = Row(columnNames = listOf("foo"), values=listOf("bar"))
+        val newBasedOnPattern = type.newBasedOn(row, Resolver())
+        assertEquals("bar", ((newBasedOnPattern.single(){it !is NullPattern} as JSONObjectPattern).pattern.get("foo") as ExactValuePattern).toString())
     }
 }


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Changing how newBaseOn & listOf of the AnyPattern handle the presence of NullPattern in their PatternList

**Why**: The use of the method single() on the PatternList throwed an Exception when trying to generate a nullable array

**How**: Adding checks and excluding the NullablePattern from the selection in specific cases

**Checklist**:

- [NA] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [X] Tests
- [NA] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #742

<!-- feel free to add additional comments -->
