### PR TITLE
moving to checkout@v3 instead of checkout@v4

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
     - name: Set up JDK 1.8
       uses: actions/setup-java@v3
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
     - name: Set up JDK 1.8
       uses: actions/setup-java@v3
       with:

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
       with: { fetch-depth: 0 }
     - name: Set up JDK 11
       uses: actions/setup-java@v3


### PR DESCRIPTION
**What**:

Moving back to checkout@v3 from checkout@v4 in github actions

**Why**:

After the checkout@v4 update CodeQL and Sonar seem to be failing

**How**:

Temporarily moving to checkout@v3

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [ ] Tests
- [ ] Sonar Quality Gate
