### PR TITLE
removing explicit kotlin compile jvm target to 1.8

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -100,12 +100,6 @@ jacocoTestReport {
 
 group = 'in.specmatic'
 
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
-}
-
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -59,12 +59,6 @@ sonarqube {
     }
 }
 
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
-}
-
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }
@@ -75,12 +69,6 @@ repositories {
 
 compileKotlin {
     kotlinOptions {
-        jvmTarget = "1.8"
         freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
-    }
-}
-compileTestKotlin {
-    kotlinOptions {
-        jvmTarget = "1.8"
     }
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -52,12 +52,6 @@ dependencies {
     testImplementation "io.ktor:ktor-client-mock-jvm:$ktor_version"
 }
 
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
-}
-
 test {
     useJUnitPlatform()
 }

--- a/junit5-support/build.gradle
+++ b/junit5-support/build.gradle
@@ -26,12 +26,6 @@ dependencies {
     implementation "io.ktor:ktor-client-cio:${ktor_version}"
 }
 
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
-}
-
 test {
     useJUnitPlatform()
 }


### PR DESCRIPTION
**What**:

Removing explicit kotlin compile jvm target to 1.8

**Why**:

CodeQL and Sonar builds are failing with ```Caused by: org.gradle.api.GradleException: 'compileJava' task (current target is 11) and 'compileKotlin' task (current target is 1.8) jvm target compatibility should be set to the same Java version```

**How**:

The JDK on the build machines are set to 1.8 and release also ensure 1.8 JDK, so there is not need to explicitly set target JVM to 1.8

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [ ] Tests
- [ ] Sonar Quality Gate
