### PR TITLE
Execute POST tests first

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -989,12 +989,13 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
         }
     }
 
-    private fun openApiOperations(pathItem: PathItem): Map<String, Operation> = mapOf<String, Operation?>(
-        "GET" to pathItem.get,
-        "POST" to pathItem.post,
-        "DELETE" to pathItem.delete,
-        "PUT" to pathItem.put,
-        "PATCH" to pathItem.patch
-    ).filter { (_, value) -> value != null }.map { (key, value) -> key to value!! }.toMap()
+    private fun openApiOperations(pathItem: PathItem): Map<String, Operation> {
+        return linkedMapOf<String, Operation?>(
+            "POST" to pathItem.post,
+            "GET" to pathItem.get,
+            "PATCH" to pathItem.patch,
+            "PUT" to pathItem.put,
+            "DELETE" to pathItem.delete
+        ).filter { (_, value) -> value != null }.map { (key, value) -> key to value!! }.toMap()
+    }
 }
-


### PR DESCRIPTION
**What**:

Execute POST methods first

**Why**:

POST is often used to create, so it may help to run the POST methods first, DELETE last, and others in between.

**How**:

The official OpenAPI parser does not maintain the order of the methods. So this PR modifies the code to explicitly run the POST tests first.

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [x] Sonar Quality Gate
