### PR TITLE
Resolve refs to parameters and request / response body examples

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -326,16 +326,6 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
                             }
                         }
 
-                        specmaticExampleRows.forEach { row ->
-                            scenarioBreadCrumb(scenarioDetails) {
-                                httpRequestPattern.newBasedOn(
-                                    row,
-                                    Resolver(newPatterns = this.patterns).copy(mismatchMessages = Scenario.ContractAndRowValueMismatch),
-                                    httpResponsePattern.status
-                                )
-                            }
-                        }
-
                         val ignoreFailure = operation.tags.orEmpty().map { it.trim() }.contains("WIP")
 
                         ScenarioInfo(

--- a/core/src/main/kotlin/in/specmatic/core/Results.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Results.kt
@@ -59,7 +59,7 @@ data class Results(val results: List<Result> = emptyList()) {
 
         return when {
             filteredResults.isNotEmpty() -> listToDistinctReport(filteredResults)
-            else -> defaultMessage.trim()
+            else -> if(successCount > 0 && failureCount == 0) "" else defaultMessage.trim()
         }
     }
 

--- a/core/src/test/kotlin/in/specmatic/conversions/RefPartParsingTests.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/RefPartParsingTests.kt
@@ -1,0 +1,400 @@
+package `in`.specmatic.conversions
+
+import `in`.specmatic.core.HttpRequest
+import `in`.specmatic.core.HttpResponse
+import `in`.specmatic.core.pattern.parsedJSONObject
+import `in`.specmatic.core.value.Value
+import `in`.specmatic.test.TestExecutor
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class RefPartParsingTests {
+    @Test
+    fun `path refs`() {
+        val specification = """
+openapi: 3.0.0
+info:
+  title: Sample API
+  description: Optional multiline or single-line description in [CommonMark](http://commonmark.org/help/) or HTML.
+  version: 0.1.9
+servers:
+  - url: http://api.example.com/v1
+    description: Optional server description, e.g. Main (production) server
+  - url: http://staging-api.example.com
+    description: Optional server description, e.g. Internal staging server for testing
+paths:
+  /hello/{id}:
+    get:
+      summary: hello world
+      description: Optional extended description in CommonMark or HTML.
+      parameters:
+        - ${"$"}ref: '#/components/parameters/Id'
+      responses:
+        '200':
+          description: Says hello
+          content:
+            application/json:
+              schema:
+                type: string
+              examples:
+                200_OK:
+                  value: success
+components:
+  parameters:
+    Id:
+      in: path
+      name: id
+      schema:
+        type: integer
+      examples:
+        200_OK:
+          value: 10
+      required: true
+      description: Numeric ID
+        """.trimIndent()
+
+        val feature = OpenApiSpecification.fromYAML(specification, "").toFeature()
+
+        val results = feature.executeTests(object : TestExecutor {
+            override fun execute(request: HttpRequest): HttpResponse {
+                assertThat(request.path).isEqualTo("/hello/10")
+                return HttpResponse.OK("success")
+            }
+
+            override fun setServerState(serverState: Map<String, Value>) {
+            }
+        })
+
+        assertThat(results.success()).isTrue()
+        assertThat(results.successCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `header refs`() {
+        val specification = """
+openapi: 3.0.0
+info:
+  title: Sample API
+  description: Optional multiline or single-line description in [CommonMark](http://commonmark.org/help/) or HTML.
+  version: 0.1.9
+servers:
+  - url: http://api.example.com/v1
+    description: Optional server description, e.g. Main (production) server
+  - url: http://staging-api.example.com
+    description: Optional server description, e.g. Internal staging server for testing
+paths:
+  /hello:
+    get:
+      summary: hello world
+      description: Optional extended description in CommonMark or HTML.
+      parameters:
+        - ${"$"}ref: '#/components/parameters/Id'
+      responses:
+        '200':
+          description: Says hello
+          content:
+            application/json:
+              schema:
+                type: string
+              examples:
+                200_OK:
+                  value: success
+components:
+  parameters:
+    Id:
+      in: query
+      name: id
+      schema:
+        type: integer
+      examples:
+        200_OK:
+          value: 10
+      required: true
+      description: Numeric ID
+        """.trimIndent()
+
+        val feature = OpenApiSpecification.fromYAML(specification, "").toFeature()
+
+        val results = feature.executeTests(object : TestExecutor {
+            override fun execute(request: HttpRequest): HttpResponse {
+                assertThat(request.path).isEqualTo("/hello")
+                assertThat(request.queryParams).containsKey("id")
+
+                return HttpResponse.OK("success")
+            }
+
+            override fun setServerState(serverState: Map<String, Value>) {
+            }
+        })
+
+        assertThat(results.success()).isTrue()
+        assertThat(results.successCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `query param refs`() {
+        val specification = """
+openapi: 3.0.0
+info:
+  title: Sample API
+  description: Optional multiline or single-line description in [CommonMark](http://commonmark.org/help/) or HTML.
+  version: 0.1.9
+servers:
+  - url: http://api.example.com/v1
+    description: Optional server description, e.g. Main (production) server
+  - url: http://staging-api.example.com
+    description: Optional server description, e.g. Internal staging server for testing
+paths:
+  /hello:
+    get:
+      summary: hello world
+      description: Optional extended description in CommonMark or HTML.
+      parameters:
+        - ${"$"}ref: '#/components/parameters/Id'
+      responses:
+        '200':
+          description: Says hello
+          content:
+            application/json:
+              schema:
+                type: string
+              examples:
+                200_OK:
+                  value: success
+components:
+  parameters:
+    Id:
+      in: header
+      name: id
+      schema:
+        type: integer
+      examples:
+        200_OK:
+          value: 10
+      required: true
+      description: Numeric ID
+        """.trimIndent()
+
+        val feature = OpenApiSpecification.fromYAML(specification, "").toFeature()
+
+        val results = feature.executeTests(object : TestExecutor {
+            override fun execute(request: HttpRequest): HttpResponse {
+                assertThat(request.path).isEqualTo("/hello")
+                assertThat(request.headers).containsKey("id")
+
+                return HttpResponse.OK("success")
+            }
+
+            override fun setServerState(serverState: Map<String, Value>) {
+            }
+        })
+
+        assertThat(results.success()).isTrue()
+        assertThat(results.successCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `request body refs`() {
+        val specification = """
+---
+openapi: "3.0.1"
+info:
+  title: "Person API"
+  version: "1"
+paths:
+  /person:
+    post:
+      summary: "Get person by id"
+      parameters: []
+      requestBody:
+        ${"$"}ref: '#/components/requestBodies/PersonRequest'
+      responses:
+        200:
+          description: "Get person by id"
+          content:
+            text/plain:
+              schema:
+                type: "string"
+              examples:
+                200_OK:
+                  value: "success"
+components:
+  requestBodies:
+    PersonRequest:
+      content:
+        application/json:
+          schema:
+            required:
+            - "id"
+            properties:
+              id:
+                type: "string"
+          examples:
+            200_OK:
+              value:
+                id: "abc123"
+        """.trimIndent()
+
+        val feature = OpenApiSpecification.fromYAML(specification, "").toFeature()
+
+        val results = feature.executeTests(object : TestExecutor {
+            override fun execute(request: HttpRequest): HttpResponse {
+                val expectedRequest = parsedJSONObject("""{"id":"abc123"}""")
+                assertThat(request.body).isEqualTo(expectedRequest)
+                return HttpResponse.OK("success")
+            }
+
+            override fun setServerState(serverState: Map<String, Value>) {
+            }
+        })
+
+        println(results.distinctReport())
+
+        assertThat(results.failureCount).isEqualTo(0)
+        assertThat(results.successCount).isEqualTo(1)
+        assertThat(results.success()).isTrue()
+    }
+
+    @Test
+    fun `response body refs`() {
+        val specification = """
+---
+openapi: "3.0.1"
+info:
+  title: "Person API"
+  version: "1"
+paths:
+  /person:
+    post:
+      summary: "Get person by id"
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              required:
+              - "name"
+              properties:
+                name:
+                  type: "string"
+            examples:
+              200_OK:
+                value:
+                  name: "Jack"
+      responses:
+        200:
+          ${"$"}ref: '#/components/responses/IdResponse'
+components:
+  responses:
+    IdResponse:
+      description: "Get person by id"
+      content:
+        application/json:
+          schema:
+            required:
+            - "id"
+            properties:
+              id:
+                type: integer
+          examples:
+            200_OK:
+              value:
+                name: 123
+        """.trimIndent()
+
+        val feature = OpenApiSpecification.fromYAML(specification, "").toFeature()
+
+        val results = feature.executeTests(object : TestExecutor {
+            override fun execute(request: HttpRequest): HttpResponse {
+                val expectedRequest = parsedJSONObject("""{"name":"Jack"}""")
+                assertThat(request.body).isEqualTo(expectedRequest)
+                return HttpResponse.OK(parsedJSONObject("""{"id":123}"""))
+            }
+
+            override fun setServerState(serverState: Map<String, Value>) {
+            }
+        })
+
+        println(results.distinctReport())
+
+        assertThat(results.failureCount).isEqualTo(0)
+        assertThat(results.successCount).isEqualTo(1)
+        assertThat(results.success()).isTrue()
+    }
+
+    @Test
+    fun `ref within allOf`() {
+        val specification = """
+---
+openapi: "3.0.1"
+info:
+  title: "Person API"
+  version: "1"
+paths:
+  /person:
+    post:
+      summary: "Get person by id"
+      parameters: []
+      requestBody:
+        ${"$"}ref: '#/components/requestBodies/PersonRequest'
+      responses:
+        200:
+          description: "Get person by id"
+          content:
+            text/plain:
+              schema:
+                type: "string"
+              examples:
+                200_OK:
+                  value: "success"
+components:
+  schemas:
+    Id:
+      type: object
+      properties:
+        id:
+          type: string
+      required:
+        - id
+    Name:
+      type: object
+      properties:
+        name:
+          type: string
+      required:
+        - name
+  requestBodies:
+    PersonRequest:
+      content:
+        application/json:
+          schema:
+            allOf:
+              - ${"$"}ref: '#/components/schemas/Id'
+              - ${"$"}ref: '#/components/schemas/Name'
+          examples:
+            200_OK:
+              value:
+                id: "abc123"
+                name: "Jane"
+        """.trimIndent()
+
+        val feature = OpenApiSpecification.fromYAML(specification, "").toFeature()
+
+        val results = feature.executeTests(object : TestExecutor {
+            override fun execute(request: HttpRequest): HttpResponse {
+                val expectedRequest = parsedJSONObject("""{"id": "abc123", "name":"Jane"}""")
+                assertThat(request.body).isEqualTo(expectedRequest)
+                return HttpResponse.OK("success")
+            }
+
+            override fun setServerState(serverState: Map<String, Value>) {
+            }
+        })
+
+        println(results.distinctReport())
+
+        assertThat(results.failureCount).isEqualTo(0)
+        assertThat(results.successCount).isEqualTo(1)
+        assertThat(results.success()).isTrue()
+    }
+}

--- a/core/src/test/kotlin/in/specmatic/conversions/RefPartParsingTests.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/RefPartParsingTests.kt
@@ -152,12 +152,11 @@ paths:
     get:
       summary: hello world
       description: Optional extended description in CommonMark or HTML.
+      parameters:
+        - ${"$"}ref: '#/components/parameters/HelloRequestHeader'
       responses:
         '200':
           description: Says hello
-          headers:
-            X-HelloResponseHeader:
-              ${"$"}ref: '#/components/headers/HelloResponseHeader'
           content:
             application/json:
               schema:
@@ -166,8 +165,10 @@ paths:
                 200_OK:
                   value: success
 components:
-  headers:
-    HelloResponseHeader:
+  parameters:
+    HelloRequestHeader:
+      in: header
+      name: X-HelloResponseHeader
       schema:
         type: string
       examples:
@@ -181,6 +182,7 @@ components:
         val results = feature.executeTests(object : TestExecutor {
             override fun execute(request: HttpRequest): HttpResponse {
                 assertThat(request.path).isEqualTo("/hello")
+                assertThat(request.headers["X-HelloResponseHeader"]).isEqualTo("helloworld")
 
                 return HttpResponse.OK("success").copy(headers = mapOf("X-HelloResponseHeader" to "world"))
             }
@@ -213,12 +215,11 @@ paths:
     get:
       summary: hello world
       description: Optional extended description in CommonMark or HTML.
+      parameters:
+        - ${"$"}ref: '#/components/parameters/HelloRequestHeader'
       responses:
         '200':
           description: Says hello
-          headers:
-            X-HelloResponseHeader:
-              ${"$"}ref: '#/components/headers/HelloResponseHeader'
           content:
             application/json:
               schema:
@@ -227,8 +228,10 @@ paths:
                 200_OK:
                   value: success
 components:
-  headers:
-    HelloResponseHeader:
+  parameters:
+    HelloRequestHeader:
+      in: header
+      name: X-HelloResponseHeader
       schema:
         type: string
       examples:
@@ -245,6 +248,7 @@ components:
         val results = feature.executeTests(object : TestExecutor {
             override fun execute(request: HttpRequest): HttpResponse {
                 assertThat(request.path).isEqualTo("/hello")
+                assertThat(request.headers["X-HelloResponseHeader"]).isEqualTo("helloworld")
 
                 return HttpResponse.OK("success").copy(headers = mapOf("X-HelloResponseHeader" to "world"))
             }

--- a/core/src/test/kotlin/in/specmatic/core/ScenarioTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/ScenarioTest.kt
@@ -467,55 +467,6 @@ And response-body (number)
     }
 
     @Test
-    fun `test loading erroneous row value should return customized error`() {
-        assertThatThrownBy {
-            OpenApiSpecification.fromYAML(
-                """
-openapi: 3.0.0
-info:
-  title: Sample API
-  version: 0.1.9
-paths:
-  /data:
-    post:
-      summary: hello world
-      description: test
-      requestBody:
-        content:
-          application/json:
-            examples:
-              200_OK:
-                value:
-                  data: abc123
-            schema:
-              type: object
-              properties:
-                data:
-                  type: number
-              required:
-                - data
-      responses:
-        '200':
-          description: Says hello
-          content:
-            text/plain:
-              examples:
-                200_OK:
-                  value: 10
-              schema:
-                type: number
-        """.trimIndent(), ""
-            ).toFeature()
-        }.satisfies(Consumer {
-            val msg = exceptionCauseMessage(it)
-
-            println(msg)
-
-            assertThat(msg).contains("Contract expected")
-        })
-    }
-
-    @Test
     fun `test erroneous contract test response should return customized error`() {
         val contract = OpenApiSpecification.fromYAML(
             """


### PR DESCRIPTION
**What**:

1. OpenAPI allows the definitions of headers, query parameters, path parameters, request and response bodies to `$ref` to the components section instead of containing the definition inline.

For example, a request body definition could `$ref` to a component in the `requestBodies` section like this:

```yaml
paths:
  /person:
    post:
      summary: "Get person by id"
      parameters: []
      requestBody:
        ${"$"}ref: '#/components/requestBodies/PersonRequest'
components:
  requestBodies:
    PersonRequest:
      content:
        application/json:
          schema:
            required:
            - "id"
            properties:
              id:
                type: "string"
          examples:
            200_OK:
              value:
                id: "abc123"
```

Specmatic can now understand these kinds of `$ref`s for the definitions of parameters (header, query and path) and request and response bodies.

Support for form fields and multi-part requests will be implemented in a future PR.

2. Additionally, nested allOfs are now supported. Previously, if an allOf contains another allOf, the nested allOf would be completely ignored.

**Why**:

We have encountered several specifications recently such as those on the [TMForum ODA OpenAPI Table page](https://www.tmforum.org/oda/open-apis/table) that are defined this way.

**How**:

Specmatic now looks for `$ref`s in the previously mentioned types of components and resolves them where found.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [x] Sonar Quality Gate
