### PR TITLE
Improve test name filter

### DIFF
--- a/application/src/test/kotlin/in/specmatic/test/SpecmaticJUnitSupportKtTest.kt
+++ b/application/src/test/kotlin/in/specmatic/test/SpecmaticJUnitSupportKtTest.kt
@@ -55,14 +55,14 @@ paths:
 
     @Test
     fun `should select tests containing the value of filterName in testDescription`() {
-        val selected = selectTestsToRun(contractTests, "TEST1")
+        val selected = selectTestsToRun(contractTests, "TEST1") { it.testDescription() }
         assertThat(selected).hasSize(1)
         assertThat(selected.first().testDescription()).contains("TEST1")
     }
 
     @Test
     fun `should select tests whose testDescriptions contain any of the multiple comma separate values in filterName`() {
-        val selected = selectTestsToRun(contractTests, "TEST1, TEST2")
+        val selected = selectTestsToRun(contractTests, "TEST1, TEST2") { it.testDescription() }
         assertThat(selected).hasSize(2)
         assertThat(selected.map { it.testDescription() }).allMatch {
             it.contains("TEST1") || it.contains("TEST2")
@@ -71,7 +71,7 @@ paths:
 
     @Test
     fun `should omit tests containing the value of filterNotName in testDescription`() {
-        val selected = selectTestsToRun(contractTests, filterNotName = "TEST1")
+        val selected = selectTestsToRun(contractTests, filterNotName = "TEST1") { it.testDescription() }
         assertThat(selected).hasSize(2)
         assertThat(selected.map { it.testDescription() }).allMatch {
             it.contains("TEST2") || it.contains("TEST3")
@@ -80,8 +80,99 @@ paths:
 
     @Test
     fun `should omit tests whose testDescriptions contain any of the multiple comma separate values in filterNotName`() {
-        val selected = selectTestsToRun(contractTests, filterNotName = "TEST1, TEST2")
+        val selected = selectTestsToRun(contractTests, filterNotName = "TEST1, TEST2") { it.testDescription() }
         assertThat(selected).hasSize(1)
         assertThat(selected.first().testDescription()).contains("TEST3")
+    }
+
+    @Test
+    fun `should not filter the tests if filterName is empty`() {
+        val selected = selectTestsToRun(contractTests, filterName = "") { it.testDescription() }
+
+        assertThat(selected).hasSize(3)
+
+        val descriptions = selected.map { it.testDescription() }.sorted()
+
+        assertThat(descriptions[0]).contains("TEST1")
+        assertThat(descriptions[1]).contains("TEST2")
+        assertThat(descriptions[2]).contains("TEST3")
+    }
+
+    @Test
+    fun `should not filter the tests if filterName is blank`() {
+        val selected = selectTestsToRun(contractTests, filterName = " ") { it.testDescription() }
+
+        assertThat(selected).hasSize(3)
+
+        val descriptions = selected.map { it.testDescription() }.sorted()
+
+        assertThat(descriptions[0]).contains("TEST1")
+        assertThat(descriptions[1]).contains("TEST2")
+        assertThat(descriptions[2]).contains("TEST3")
+    }
+
+    @Test
+    fun `should not filter the tests if filterName is null`() {
+        val selected = selectTestsToRun(contractTests, filterName = null) { it.testDescription() }
+
+        assertThat(selected).hasSize(3)
+
+        val descriptions = selected.map { it.testDescription() }.sorted()
+
+        assertThat(descriptions[0]).contains("TEST1")
+        assertThat(descriptions[1]).contains("TEST2")
+        assertThat(descriptions[2]).contains("TEST3")
+    }
+
+    @Test
+    fun `should not filter the tests if filterNotName is not found in any of the test names`() {
+        val selected = selectTestsToRun(contractTests, filterNotName = "UNKNOWN_TEST_NAME_1, UNKNOWN_TEST_NAME_2") { it.testDescription() }
+
+        assertThat(selected).hasSize(3)
+
+        val descriptions = selected.map { it.testDescription() }.sorted()
+
+        assertThat(descriptions[0]).contains("TEST1")
+        assertThat(descriptions[1]).contains("TEST2")
+        assertThat(descriptions[2]).contains("TEST3")
+    }
+
+    @Test
+    fun `should not filter the tests if filterNotName is null`() {
+        val selected = selectTestsToRun(contractTests, filterNotName = null) { it.testDescription() }
+
+        assertThat(selected).hasSize(3)
+
+        val descriptions = selected.map { it.testDescription() }.sorted()
+
+        assertThat(descriptions[0]).contains("TEST1")
+        assertThat(descriptions[1]).contains("TEST2")
+        assertThat(descriptions[2]).contains("TEST3")
+    }
+
+    @Test
+    fun `should not filter the tests if filterNotName is empty`() {
+        val selected = selectTestsToRun(contractTests, filterNotName = "") { it.testDescription() }
+
+        assertThat(selected).hasSize(3)
+
+        val descriptions = selected.map { it.testDescription() }.sorted()
+
+        assertThat(descriptions[0]).contains("TEST1")
+        assertThat(descriptions[1]).contains("TEST2")
+        assertThat(descriptions[2]).contains("TEST3")
+    }
+
+    @Test
+    fun `should not filter the tests if filterNotName is blank`() {
+        val selected = selectTestsToRun(contractTests, filterNotName = " ") { it.testDescription() }
+
+        assertThat(selected).hasSize(3)
+
+        val descriptions = selected.map { it.testDescription() }.sorted()
+
+        assertThat(descriptions[0]).contains("TEST1")
+        assertThat(descriptions[1]).contains("TEST2")
+        assertThat(descriptions[2]).contains("TEST3")
     }
 }

--- a/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
@@ -282,7 +282,7 @@ open class SpecmaticJUnitSupport {
         }
 
         return feature
-            .copy(scenarios = selectTestsToRun(feature.scenarios, filterName, filterNotName) { it.name })
+            .copy(scenarios = selectTestsToRun(feature.scenarios, filterName, filterNotName) { it.testDescription() })
             .also {
                 if (it.scenarios.isEmpty())
                     logger.log("All scenarios were filtered out.")

--- a/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
@@ -170,7 +170,9 @@ open class SpecmaticJUnitSupport {
                             suggestionsPath,
                             suggestionsData,
                             testConfig,
-                            specificationPath = it
+                            specificationPath = it,
+                            filterName = filterName,
+                            filterNotName = filterNotName
                         )
                     }
                 }
@@ -185,11 +187,11 @@ open class SpecmaticJUnitSupport {
 
                     val contractFilePaths = contractTestPathsFrom(configFile, workingDirectory.path)
 
-                    contractFilePaths.flatMap { loadTestScenarios(it.path, "", "", testConfig, it.provider, it.repository, it.branch, it.specificationPath, specmaticConfigJson?.security) }
+                    contractFilePaths.flatMap { loadTestScenarios(it.path, "", "", testConfig, it.provider, it.repository, it.branch, it.specificationPath, specmaticConfigJson?.security, filterName, filterNotName) }
                 }
             }
 
-            selectTestsToRun(testScenarios, filterName, filterNotName)
+            selectTestsToRun(testScenarios, filterName, filterNotName) { it.testDescription() }
         } catch(e: ContractException) {
             return loadExceptionAsTestError(e)
         } catch(e: Throwable) {
@@ -260,11 +262,13 @@ open class SpecmaticJUnitSupport {
         suggestionsPath: String,
         suggestionsData: String,
         config: TestConfig,
-        sourceProvider:String? = null,
-        sourceRepository:String? = null,
-        sourceRepositoryBranch:String? = null,
-        specificationPath:String? = null,
-        securityConfiguration: SecurityConfiguration? = null
+        sourceProvider: String? = null,
+        sourceRepository: String? = null,
+        sourceRepositoryBranch: String? = null,
+        specificationPath: String? = null,
+        securityConfiguration: SecurityConfiguration? = null,
+        filterName: String?,
+        filterNotName: String?
     ): List<ContractTest> {
         if(isYAML(path) && !isOpenAPI(path))
             return emptyList()
@@ -277,7 +281,9 @@ open class SpecmaticJUnitSupport {
             else -> emptyList()
         }
 
-        return feature.generateContractTests(suggestions)
+        return feature
+            .copy(scenarios = selectTestsToRun(feature.scenarios, filterName, filterNotName) { it.name })
+            .generateContractTests(suggestions)
     }
 
     private fun suggestionsFromFile(suggestionsPath: String): List<Scenario> {
@@ -334,25 +340,26 @@ private fun asJSONObjectValue(value: Value, errorMessage: String): Map<String, V
     return value.jsonObject
 }
 
-fun selectTestsToRun(
-    testScenarios: List<ContractTest>,
+fun <T> selectTestsToRun(
+    testScenarios: List<T>,
     filterName: String? = null,
-    filterNotName: String? = null
-): List<ContractTest> {
+    filterNotName: String? = null,
+    getTestDescription: (T) -> String
+): List<T> {
     val filteredByName = if (!filterName.isNullOrBlank()) {
         val filterNames = filterName.split(",").map { it.trim() }
 
         testScenarios.filter { test ->
-            filterNames.any { test.testDescription().contains(it) }
+            filterNames.any { getTestDescription(test).contains(it) }
         }
     } else
         testScenarios
 
-    val filteredByNotName: List<ContractTest> = if(!filterNotName.isNullOrBlank()) {
+    val filteredByNotName: List<T> = if(!filterNotName.isNullOrBlank()) {
         val filterNotNames = filterNotName.split(",").map { it.trim() }
 
         testScenarios.filterNot { test ->
-            filterNotNames.any { test.testDescription().contains(it) }
+            filterNotNames.any { getTestDescription(test).contains(it) }
         }
     } else
         filteredByName

--- a/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
@@ -283,6 +283,14 @@ open class SpecmaticJUnitSupport {
 
         return feature
             .copy(scenarios = selectTestsToRun(feature.scenarios, filterName, filterNotName) { it.name })
+            .also {
+                if (it.scenarios.isEmpty())
+                    logger.log("All scenarios were filtered out.")
+                else if (it.scenarios.size < feature.scenarios.size) {
+                    logger.log("Selected scenarios:")
+                    it.scenarios.forEach { scenario -> logger.log(scenario.name.prependIndent("  ")) }
+                }
+            }
             .generateContractTests(suggestions)
     }
 
@@ -358,7 +366,7 @@ fun <T> selectTestsToRun(
     val filteredByNotName: List<T> = if(!filterNotName.isNullOrBlank()) {
         val filterNotNames = filterNotName.split(",").map { it.trim() }
 
-        testScenarios.filterNot { test ->
+        filteredByName.filterNot { test ->
             filterNotNames.any { getTestDescription(test).contains(it) }
         }
     } else


### PR DESCRIPTION
**What**:

This PR does the following
1. filters the tests before the test generation (see more on this in the how section)
2. logs descriptions of tests that were selected, if any tests were filtered out
3. fixes bug in the filteration logic

**Why**:

We saw some cases where we needed to leave the spec as pristine as possible and run tests for only 1 or 2 specific APIs.

**How**:

Tests are generated in two steps.
1. Load the operations from the specification file
2. Generate tests from the examples in each of the operations

The filtration was done after step 2, which means that it was done after all the permutations were derived.

With this PRs, the filtration logic runs after step 1 as well, before any of the permutations.

It still runs after step 2, in case any of the filter terms include test names. Test names are not available yet after step 1 given that the examples have not been taken into account.

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
