### PR TITLE
Examples as stub expectations

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/IncludedSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/IncludedSpecification.kt
@@ -1,10 +1,12 @@
 package `in`.specmatic.conversions
 
+import `in`.specmatic.core.HttpRequest
+import `in`.specmatic.core.HttpResponse
 import `in`.specmatic.core.ScenarioInfo
 import io.cucumber.messages.types.Step
 
 interface IncludedSpecification {
-    fun toScenarioInfos(): List<ScenarioInfo>
+    fun toScenarioInfos(): Pair<List<ScenarioInfo>, Map<String, Pair<HttpRequest, HttpResponse>>>
     fun matches(
         specmaticScenarioInfo: ScenarioInfo,
         steps: List<Step>

--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -229,7 +229,7 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
     private fun openApitoScenarioInfos(): List<ScenarioInfo> {
         return openApiPaths().map { (openApiPath, pathItem) ->
             openApiOperations(pathItem).map { (httpMethod, operation) ->
-                val specmaticPath = toSpecmaticPath2(openApiPath, operation)
+                val specmaticPath = toSpecmaticPath(openApiPath, operation)
 
                 toHttpResponsePatterns(operation.responses).map { (response, responseMediaType, httpResponsePattern) ->
                     toHttpRequestPatterns(
@@ -271,7 +271,7 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
     private fun toScenarioInfosWithExamples(): List<ScenarioInfo> {
         return openApiPaths().map { (openApiPath, pathItem) ->
             openApiOperations(pathItem).map { (httpMethod, operation) ->
-                val specmaticPath = toSpecmaticPath2(openApiPath, operation)
+                val specmaticPath = toSpecmaticPath(openApiPath, operation)
 
                 toHttpResponsePatterns(operation.responses).map { (response, responseMediaType, httpResponsePattern) ->
                     val responseExamples: Map<String, Example> = responseMediaType.examples.orEmpty()
@@ -937,7 +937,7 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
 
     private fun componentNameFromReference(component: String) = component.substringAfterLast("/")
 
-    private fun toSpecmaticPath2(openApiPath: String, operation: Operation): URLMatcher {
+    private fun toSpecmaticPath(openApiPath: String, operation: Operation): URLMatcher {
         val parameters = operation.parameters ?: return toURLMatcherWithOptionalQueryParams(openApiPath)
 
         val pathStringParts: List<String> = openApiPath.removePrefix("/").removeSuffix("/").let {

--- a/core/src/main/kotlin/in/specmatic/conversions/WsdlSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/WsdlSpecification.kt
@@ -36,7 +36,7 @@ class WSDLFile(private val location: String) : WSDLContent {
 }
 
 class WsdlSpecification(private val wsdlFile: WSDLContent) : IncludedSpecification {
-    private val openApiScenarioInfos = toScenarioInfos()
+    private val openApiScenarioInfos: List<ScenarioInfo> = toScenarioInfos().first
 
     override fun matches(
         specmaticScenarioInfo: ScenarioInfo,
@@ -96,8 +96,8 @@ class WsdlSpecification(private val wsdlFile: WSDLContent) : IncludedSpecificati
         }
     }
 
-    override fun toScenarioInfos(): List<ScenarioInfo> {
-        return scenarioInfos(wsdlToFeatureChildren(wsdlFile), "")
+    override fun toScenarioInfos(): Pair<List<ScenarioInfo>, Map<String, Pair<HttpRequest, HttpResponse>>> {
+        return scenarioInfos(wsdlToFeatureChildren(wsdlFile), "") to emptyMap()
     }
 
     private fun wsdlToFeatureChildren(wsdlFile: WSDLContent): List<FeatureChild> {

--- a/core/src/main/kotlin/in/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Feature.kt
@@ -85,7 +85,8 @@ data class Feature(
     val sourceRepository:String? = null,
     val sourceRepositoryBranch:String? = null,
     val specification:String? = null,
-    val serviceType:String? = null
+    val serviceType:String? = null,
+    val stubsFromExamples: Map<String, Pair<HttpRequest, HttpResponse>> = emptyMap()
 ) {
     fun lookupResponse(httpRequest: HttpRequest): HttpResponse {
         try {
@@ -1630,7 +1631,7 @@ fun scenarioInfos(
     val includedSpecifications = listOfNotNull(openApiSpecification, wsdlSpecification)
 
     val scenarioInfosBelongingToIncludedSpecifications =
-        includedSpecifications.map { it.toScenarioInfos() }.flatten()
+        includedSpecifications.map { it.toScenarioInfos().first }.flatten()
 
     val backgroundInfo = backgroundScenario(featureChildren)?.let { feature ->
         lexScenario(

--- a/core/src/main/kotlin/in/specmatic/core/URLMatcher.kt
+++ b/core/src/main/kotlin/in/specmatic/core/URLMatcher.kt
@@ -227,14 +227,6 @@ data class URLMatcher(val queryPattern: Map<String, Pattern>, val pathPattern: L
     fun pathParameters(): List<URLPathPattern> {
         return pathPattern.filter { !it.pattern.instanceOf(ExactValuePattern::class) }
     }
-
-    fun withOptionalQueryParams(apiKeyQueryParams: Set<String> = emptySet()): URLMatcher {
-        val allQueryParams = apiKeyQueryParams.associate { apiKeyQueryParam ->
-            "${apiKeyQueryParam}?" to StringPattern()
-        }.plus(this.queryPattern)
-
-        return this.copy(queryPattern = allQueryParams)
-    }
 }
 
 internal fun toURLMatcherWithOptionalQueryParams(url: String, apiKeyQueryParams: Set<String> = emptySet()): URLMatcher =

--- a/core/src/main/kotlin/in/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/in/specmatic/stub/HttpStub.kt
@@ -75,8 +75,8 @@ class HttpStub(
     private val threadSafeHttpStubs = ThreadSafeListOfStubs(staticHttpStubData(_httpStubs))
 
     private fun staticHttpStubData(_httpStubs: List<HttpStubData>): MutableList<HttpStubData> {
-        val explicitStubs = _httpStubs.filter { it.stubToken == null }.toMutableList()
-        val stubsFromSpecification = features.map { feature ->
+        val staticStubs = _httpStubs.filter { it.stubToken == null }.toMutableList()
+        val stubsFromSpecificationExamples: List<HttpStubData> = features.map { feature ->
             feature.stubsFromExamples.entries.mapNotNull {
                 val (request, response) = it.value
                 try {
@@ -100,7 +100,7 @@ class HttpStub(
             }
         }.flatten()
 
-        return stubsFromSpecification.plus(explicitStubs).toMutableList()
+        return staticStubs.plus(stubsFromSpecificationExamples).toMutableList()
     }
 
     private val threadSafeHttpStubQueue = ThreadSafeListOfStubs(_httpStubs.filter { it.stubToken != null }.reversed().toMutableList())

--- a/core/src/main/kotlin/in/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/in/specmatic/stub/HttpStub.kt
@@ -72,7 +72,37 @@ class HttpStub(
         const val JSON_REPORT_FILE_NAME = "stub_usage_report.json"
     }
 
-    private val threadSafeHttpStubs = ThreadSafeListOfStubs(_httpStubs.filter { it.stubToken == null }.toMutableList())
+    private val threadSafeHttpStubs = ThreadSafeListOfStubs(staticHttpStubData(_httpStubs))
+
+    private fun staticHttpStubData(_httpStubs: List<HttpStubData>): MutableList<HttpStubData> {
+        val explicitStubs = _httpStubs.filter { it.stubToken == null }.toMutableList()
+        val stubsFromSpecification = features.map { feature ->
+            feature.stubsFromExamples.entries.mapNotNull {
+                val (request, response) = it.value
+                try {
+                    val matchResult: HttpStubData =
+                        feature.matchingStub(request, response, ContractAndStubMismatchMessages)
+                    if (matchResult.matchFailure) {
+                        logger.log(matchResult.response.body.toStringLiteral())
+                        null
+                    } else {
+                        matchResult
+                    }
+                } catch(e: Throwable) {
+                    when(e) {
+                        is ContractException, is NoMatchingScenario -> {
+                            logger.log(e)
+                            null
+                        }
+                        else -> throw e
+                    }
+                }
+            }
+        }.flatten()
+
+        return stubsFromSpecification.plus(explicitStubs).toMutableList()
+    }
+
     private val threadSafeHttpStubQueue = ThreadSafeListOfStubs(_httpStubs.filter { it.stubToken != null }.reversed().toMutableList())
 
     private val _logs: MutableList<StubEndpoint> = Collections.synchronizedList(ArrayList())

--- a/core/src/main/kotlin/in/specmatic/stub/StubData.kt
+++ b/core/src/main/kotlin/in/specmatic/stub/StubData.kt
@@ -6,8 +6,6 @@ import `in`.specmatic.core.pattern.ContractException
 import `in`.specmatic.core.utilities.ExternalCommand
 import `in`.specmatic.core.utilities.jsonStringToValueMap
 
-interface StubData
-
 data class HttpStubData(
     val requestType: HttpRequestPattern,
     val response: HttpResponse,
@@ -19,7 +17,10 @@ data class HttpStubData(
     val requestBodyRegex: Regex? = null,
     val feature:Feature? = null,
     val scenario: Scenario? = null
-) : StubData {
+) {
+    val matchFailure: Boolean
+        get() = response.headers[SPECMATIC_RESULT_HEADER] == "failure"
+
     fun softCastResponseToXML(httpRequest: HttpRequest): HttpStubData = when {
         response.externalisedResponseCommand.isNotEmpty() -> invokeExternalCommand(httpRequest).copy(contractPath = contractPath)
         else -> this.copy(response = response.copy(body = softCastValueToXML(response.body)))

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
@@ -1200,7 +1200,8 @@ Background:
         )
         val openapiSpec = OpenApiSpecification.fromFile("openapi/petstore-expanded.yaml")
 
-        assertThat(feature.scenarios).hasSameSizeAs(openapiSpec.toScenarioInfos())
+        val (expectedScenarios, _) = openapiSpec.toScenarioInfos()
+        assertThat(feature.scenarios).hasSameSizeAs(expectedScenarios)
 
         val apiIdentifiersFromGherkinSpec = feature.scenarios.map {
             it.apiIdentifier

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -213,7 +213,7 @@ Pet:
     @Test
     fun `should generate 200 OK scenarioInfos from openAPI`() {
         val openApiSpecification = OpenApiSpecification.fromFile(OPENAPI_FILE)
-        val scenarioInfos = openApiSpecification.toScenarioInfos()
+        val (scenarioInfos, _) = openApiSpecification.toScenarioInfos()
         assertThat(scenarioInfos.size).isEqualTo(3)
     }
 
@@ -261,15 +261,15 @@ Pet:
     @Test
     fun `should not resolve non ref nested types to Deferred Pattern`() {
         val openApiSpecification = OpenApiSpecification.fromFile(OPENAPI_FILE)
-        val scenarioInfos = openApiSpecification.toScenarioInfos()
-        val nestedTypeWithoutRef = scenarioInfos.first().patterns.getOrDefault("(NestedTypeWithoutRef)", NullPattern)
+        val (scenarioInfoData, _) = openApiSpecification.toScenarioInfos()
+        val nestedTypeWithoutRef = scenarioInfoData.first().patterns.getOrDefault("(NestedTypeWithoutRef)", NullPattern)
         assertThat(containsDeferredPattern(nestedTypeWithoutRef)).isFalse
     }
 
     @Test
     fun `should resolve ref nested types to Deferred Pattern`() {
         val openApiSpecification = OpenApiSpecification.fromFile(OPENAPI_FILE)
-        val scenarioInfos = openApiSpecification.toScenarioInfos()
+        val (scenarioInfos, _) = openApiSpecification.toScenarioInfos()
         val nestedTypeWithRef = scenarioInfos[4].patterns["(NestedTypeWithRef)"]
         assertThat(containsDeferredPattern(nestedTypeWithRef!!)).isTrue
     }
@@ -284,7 +284,7 @@ Pet:
     @Test
     fun `none of the scenarios should expect the Content-Type header`() {
         val openApiSpecification = OpenApiSpecification.fromFile(OPENAPI_FILE)
-        val scenarioInfos = openApiSpecification.toScenarioInfos()
+        val (scenarioInfos, _) = openApiSpecification.toScenarioInfos()
 
         for (scenarioInfo in scenarioInfos) {
             assertNotFoundInHeaders("Content-Type", scenarioInfo.httpRequestPattern.headersPattern)
@@ -3699,7 +3699,8 @@ paths:
     @Test
     fun `should resolve ref to another file`() {
         val openApiSpecification = OpenApiSpecification.fromFile(OPENAPI_FILE_WITH_REFERENCE)
-        assertThat(openApiSpecification.toScenarioInfos().size).isEqualTo(1)
+        val (scenarioInfos, _) = openApiSpecification.toScenarioInfos()
+        assertThat((scenarioInfos).size).isEqualTo(1)
         assertThat(openApiSpecification.patterns["(Pet)"]).isNotNull
     }
 


### PR DESCRIPTION
**What**:

Added the ability to use examples as stub expectations.

**Why**:

This feature has been requested many times through different channels.

**How**:

The examples are read when the examples and stored in the Feature object.

They are given least priority, just by virtue of being the earliest expectations in the expectation stack.

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests

