### PR TITLE
Fixes to oneOf generation and error messages

### DIFF
--- a/application/src/main/kotlin/application/TestCommand.kt
+++ b/application/src/main/kotlin/application/TestCommand.kt
@@ -66,10 +66,10 @@ class TestCommand : Callable<Unit> {
     @Option(names = ["--suggestions"], description = ["A json value with scenario name and multiple suggestions"], defaultValue = "")
     var suggestions: String = ""
 
-    @Option(names = ["--filter-name"], description = ["Run only tests with this value in their name"], defaultValue = "")
+    @Option(names = ["--filter-name"], description = ["Run only tests with this value in their name"], defaultValue = "\${env:SPECMATIC_FILTER_NAME}")
     var filterName: String = ""
 
-    @Option(names = ["--filter-not-name"], description = ["Run only tests which do not have this value in their name"], defaultValue = "")
+    @Option(names = ["--filter-not-name"], description = ["Run only tests which do not have this value in their name"], defaultValue = "\${env:SPECMATIC_FILTER_NOT_NAME}")
     var filterNotName: String = ""
 
     @Option(names = ["--env"], description = ["Environment name"])
@@ -129,7 +129,7 @@ class TestCommand : Callable<Unit> {
         }
 
         if(filterNotName.isNotBlank()) {
-            System.setProperty(FILTER_NOT_NAME, filterName)
+            System.setProperty(FILTER_NOT_NAME, filterNotName)
         }
 
         variablesFileName?.let {

--- a/core/src/main/kotlin/in/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Scenario.kt
@@ -551,13 +551,13 @@ object ContractAndResponseMismatch : MismatchMessages {
     }
 
     override fun unexpectedKey(keyLabel: String, keyName: String): String {
-        return "${keyLabel.lowercase().capitalizeFirstChar()} named $keyName in the response was not in the contract"
+        return "${keyLabel.lowercase().capitalizeFirstChar()} named $keyName in the response was not in the specification"
     }
 
     override fun expectedKeyWasMissing(keyLabel: String, keyName: String): String {
         return "${
             keyLabel.lowercase().capitalizeFirstChar()
-        } named $keyName in the contract was not found in the response"
+        } named $keyName in the specification was not found in the response"
     }
 }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/AnyPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/AnyPattern.kt
@@ -1,9 +1,6 @@
 package `in`.specmatic.core.pattern
 
-import `in`.specmatic.core.MismatchMessages
-import `in`.specmatic.core.Resolver
-import `in`.specmatic.core.Result
-import `in`.specmatic.core.mismatchResult
+import `in`.specmatic.core.*
 import `in`.specmatic.core.value.EmptyString
 import `in`.specmatic.core.value.NullValue
 import `in`.specmatic.core.value.ScalarValue
@@ -76,12 +73,41 @@ data class AnyPattern(
     }
 
     override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> {
-        val isNullable = pattern.any {it is NullPattern}
-        return pattern.sortedBy{ it is NullPattern }.flatMap { innerPattern ->
-            resolver.withCyclePrevention(innerPattern, isNullable) { cyclePreventedResolver ->
-                innerPattern.newBasedOn(row, cyclePreventedResolver)
-            }?: listOf()  // Terminates cycle gracefully. Only happens if isNullable=true so that it is contract-valid.
+        val isNullable = pattern.any { it is NullPattern }
+        val patternResults: List<Pair<List<Pattern>?, Throwable?>> =
+            pattern.sortedBy { it is NullPattern }.map { innerPattern ->
+                try {
+                    val patterns =
+                        resolver.withCyclePrevention(innerPattern, isNullable) { cyclePreventedResolver ->
+                            innerPattern.newBasedOn(row, cyclePreventedResolver)
+                        } ?: listOf()
+                    Pair(patterns, null)
+                } catch (e: Throwable) {
+                    Pair(null, e)
+                }
+            }
+
+        return newTypesOrExceptionIfNone(patternResults, "Could not generate new tests")
+    }
+
+    private fun newTypesOrExceptionIfNone(patternResults: List<Pair<List<Pattern>?, Throwable?>>, message: String): List<Pattern> {
+        val newPatterns: List<Pattern> = patternResults.mapNotNull { it.first }.flatten()
+
+        if (newPatterns.isEmpty() && pattern.isNotEmpty()) {
+            val exceptions = patternResults.mapNotNull { it.second }.map {
+                when (it) {
+                    is ContractException -> it
+                    else -> ContractException(exceptionCause = it)
+                }
+            }
+
+            val failures = exceptions.map { it.failure() }
+
+            val failure = Result.Failure.fromFailures(failures)
+
+            throw ContractException(failure.toFailureReport(message))
         }
+        return newPatterns
     }
 
     override fun newBasedOn(resolver: Resolver): List<Pattern> {
@@ -96,9 +122,20 @@ data class AnyPattern(
     override fun negativeBasedOn(row: Row, resolver: Resolver): List<Pattern> {
         val nullable = pattern.any { it is NullPattern }
 
-        val negativeTypes = pattern.flatMap {
-            it.negativeBasedOn(row, resolver)
-        }.let {
+        val negativeTypeResults = pattern.map {
+            try {
+                val patterns =
+                    it.negativeBasedOn(row, resolver)
+                Pair(patterns, null)
+            } catch(e: Throwable) {
+                Pair(null, e)
+            }
+        }
+
+        val negativeTypes = newTypesOrExceptionIfNone(
+            negativeTypeResults,
+            "Could not get negative tests"
+        ).let {
             if (nullable)
                 it.filterNot { it is NullPattern }
             else

--- a/core/src/main/kotlin/in/specmatic/core/pattern/ContractException.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/ContractException.kt
@@ -15,7 +15,7 @@ data class ContractException(
     val exceptionCause: Throwable? = null,
     val scenario: ScenarioDetailsForResult? = null,
     val isCycle: Boolean = isCycle(exceptionCause)
-) : Exception(errorMessage) {
+) : Exception(errorMessage, exceptionCause) {
     constructor(failureReport: FailureReport): this(failureReport.toText())
 
     fun failure(): Result.Failure =

--- a/core/src/main/kotlin/in/specmatic/stub/ContractExternalResponseMismatch.kt
+++ b/core/src/main/kotlin/in/specmatic/stub/ContractExternalResponseMismatch.kt
@@ -13,6 +13,6 @@ object ContractExternalResponseMismatch: MismatchMessages {
     }
 
     override fun expectedKeyWasMissing(keyLabel: String, keyName: String): String {
-        return "${keyLabel.lowercase().capitalizeFirstChar()} named $keyName in the contract was not found in the response from the external command"
+        return "${keyLabel.lowercase().capitalizeFirstChar()} named $keyName in the specification was not found in the response from the external command"
     }
 }

--- a/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
@@ -287,8 +287,8 @@ open class SpecmaticJUnitSupport {
                 if (it.scenarios.isEmpty())
                     logger.log("All scenarios were filtered out.")
                 else if (it.scenarios.size < feature.scenarios.size) {
-                    logger.log("Selected scenarios:")
-                    it.scenarios.forEach { scenario -> logger.log(scenario.testDescription().prependIndent("  ")) }
+                    logger.debug("Selected scenarios:")
+                    it.scenarios.forEach { scenario -> logger.debug(scenario.testDescription().prependIndent("  ")) }
                 }
             }
             .generateContractTests(suggestions)


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

* There a bug fix to generation of oneOf. It was breaking when generative tests were on and out of 3 options only 1 matched the row. For now we simply don't generate if the row breaks. Need to discuss what to do if the example exists but the can't be used by some option in the oneOf.
* Updated some language to say `specification` instead of `contract`.

**Why**:

* The bug fix was required as without that generative tests were not working. It's more of a temp fix really to make sure generative tests can at least run, until we decide what's the real fix.
* The language fix was needed as the older language was looking awkward in a recent video we recorded.

**How**:

Updated newBasedOn and negativeBasedOn in Anypattern, and some language strings where needed.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #123

<!-- feel free to add additional comments -->
