### PR TITLE
Fix the success() method in the Results class. issue #792 

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/Results.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Results.kt
@@ -6,7 +6,7 @@ data class Results(val results: List<Result> = emptyList()) {
     fun hasResults(): Boolean = results.isNotEmpty()
 
     fun hasFailures(): Boolean = results.any { it is Result.Failure }
-    fun success(): Boolean = !hasFailures()
+    fun success(): Boolean = successCount > 0 && failureCount == 0
 
     fun withoutFluff(fluffLevel: Int): Results = copy(results = results.filterNot { it.isFluffy(fluffLevel) })
 


### PR DESCRIPTION
**What**:Here i've Fix the `success()` method in the Results class.

**Why**:The `success()` method should return `true` if there are one or more successes and no failures. The current implementation does not check if there are no failures. This fix is necessary to correctly determine whether there are any failures.

**How**:I have updated the `success()` method in the `Results` class to check if there are successes (`Result.Success`) and no failures (`Result.Failure`). The method now returns `true` only when there are one or more successes and no failures.

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [ ] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #792 

Test cases were getting failed in my system so as per repo maintainers suggest to create PR im doing this.
