### PR TITLE
Removing check for specmatic.json file to print API coverage

### DIFF
--- a/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
@@ -49,10 +49,8 @@ open class SpecmaticJUnitSupport {
         @AfterAll
         @JvmStatic
         fun report() {
-            specmaticConfigJson?.let {
-                val reportProcessors = listOf(OpenApiCoverageReportProcessor(openApiCoverageReportInput))
-                reportProcessors.forEach { it.process(getReportConfiguration()) }
-            }
+            val reportProcessors = listOf(OpenApiCoverageReportProcessor(openApiCoverageReportInput))
+            reportProcessors.forEach { it.process(getReportConfiguration()) }
         }
 
         private fun getReportConfiguration(): ReportConfiguration {


### PR DESCRIPTION
**What**:

Printing API coverage report with default settings even when specmatic.json is not available. 

**Why**:

We cannot expect specmatic.json to be available where we are running the specmatic from command line.

**How**:

Removing check for specmatic.json in `SpecmaticJUnitSupport` which is preventing API coverage report from being printed when specmatic.json is not available.

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation - N/A
- [ ] Tests
- [x] Sonar Quality Gate

