### PR TITLE
allow setting OAuth2 token through environment variable

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -32,10 +32,12 @@ import io.swagger.v3.parser.core.models.SwaggerParseResult
 import java.io.File
 
 private const val BEARER_SECURITY_SCHEME = "bearer"
+private const val SPECMATIC_OAUTH2_TOKEN = "SPECMATIC_OAUTH2_TOKEN"
 private const val SERVICE_TYPE_HTTP = "HTTP"
 
 private const val testDirectoryEnvironmentVariable = "SPECMATIC_TESTS_DIRECTORY"
 private const val testDirectoryProperty = "specmaticTestsDirectory"
+
 
 class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI, private val sourceProvider:String? = null, private val sourceRepository:String? = null, private val sourceRepositoryBranch:String? = null, private val specificationPath:String? = null, private val securityConfiguration:SecurityConfiguration? = null) : IncludedSpecification,
     ApiSpecification {
@@ -769,11 +771,15 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
             BEARER_SECURITY_SCHEME, SecurityScheme.Type.OAUTH2.toString() ->
                 securitySchemeConfiguration?.let {
                     (it as SecuritySchemeWithOAuthToken).token
-                }
+                } ?: getBearerTokenFromEnvironment()
 
             else -> throw ContractException("Cannot use the Bearer Security Scheme implementation for scheme type: $type")
         }
         return BearerSecurityScheme(token)
+    }
+
+    private fun getBearerTokenFromEnvironment(): String? {
+        return System.getenv(SPECMATIC_OAUTH2_TOKEN)
     }
 
     private fun toFormFields(mediaType: MediaType) =


### PR DESCRIPTION
**What**:

Externalise OAuth2 token to environment variable

**Why**:

We will not alway be able to pass the OAuth2 token through specmatic.json in usecases such as when specmatic is being used from command line 

**How**:

If OAuth2 token is not available in configuration pick it up from environment. This is assuming people who are setting this env variable will not have specatmatic.json and even if they do, have not configured security token.

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [ ] Tests
- [ ] Sonar Quality Gate
