### PR TITLE
Added support for minProperties and maxProperties

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -1116,7 +1116,12 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
     ): JSONObjectPattern {
         val requiredFields = schema.required.orEmpty()
         val schemaProperties = toSchemaProperties(schema, requiredFields, patternName, typeStack)
-        val jsonObjectPattern = toJSONObjectPattern(schemaProperties, "(${patternName})")
+        val minProperties: Int? = schema.minProperties
+        val maxProperties: Int? = schema.maxProperties
+        val jsonObjectPattern = toJSONObjectPattern(schemaProperties, "(${patternName})").copy(
+            minProperties = minProperties,
+            maxProperties = maxProperties
+        )
         return cacheComponentPattern(patternName, jsonObjectPattern)
     }
 

--- a/core/src/test/kotlin/in/specmatic/core/pattern/JSONObjectPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/JSONObjectPatternTest.kt
@@ -547,8 +547,87 @@ internal class JSONObjectPatternTest {
                 assertThat(it.pattern.keys).hasSizeLessThanOrEqualTo(3)
             }
         }
+
+        @Nested
+        inner class BackwardCompatibility {
+            @ParameterizedTest
+            @CsvSource(
+                value = [
+                    """old | new | compatible""",
+                    """3   | 2   | false""",
+                    """3   | 4   | true""",
+                ],
+                delimiter = '|',
+                useHeadersInDisplayName = true,
+                ignoreLeadingAndTrailingWhitespace = true
+            )
+            fun `min cases`(old: Int, new: Int, compatible: Boolean) {
+                val older = JSONObjectPattern(
+                    mapOf(
+                        "id" to NumberPattern(),
+                        "name?" to StringPattern(),
+                        "address?" to StringPattern(),
+                        "department?" to StringPattern(),
+                    ),
+                    minProperties = old
+                )
+                val newer = JSONObjectPattern(
+                    mapOf(
+                        "id" to NumberPattern(),
+                        "name?" to StringPattern(),
+                        "address?" to StringPattern(),
+                        "department?" to StringPattern(),
+                    ),
+                    minProperties = new
+                )
+
+                val result = newer.encompasses(older, Resolver(), Resolver())
+
+                when(compatible) {
+                    true -> assertThat(result).isInstanceOf(Result.Success::class.java)
+                    false -> assertThat(result).isInstanceOf(Result.Failure::class.java)
+                }
+            }
+
+            @ParameterizedTest
+            @CsvSource(
+                value = [
+                    """old | new | compatible""",
+                    """3   | 2   | true""",
+                    """3   | 4   | false""",
+                ],
+                delimiter = '|',
+                useHeadersInDisplayName = true,
+                ignoreLeadingAndTrailingWhitespace = true
+            )
+            fun `max cases`(old: Int, new: Int, compatible: Boolean) {
+                val older = JSONObjectPattern(
+                    mapOf(
+                        "id" to NumberPattern(),
+                        "name?" to StringPattern(),
+                        "address?" to StringPattern(),
+                        "department?" to StringPattern(),
+                    ),
+                    maxProperties = old
+                )
+                val newer = JSONObjectPattern(
+                    mapOf(
+                        "id" to NumberPattern(),
+                        "name?" to StringPattern(),
+                        "address?" to StringPattern(),
+                        "department?" to StringPattern(),
+                    ),
+                    maxProperties = new
+                )
+
+                val result = newer.encompasses(older, Resolver(), Resolver())
+
+                when(compatible) {
+                    true -> assertThat(result).isInstanceOf(Result.Success::class.java)
+                    false -> assertThat(result).isInstanceOf(Result.Failure::class.java)
+                }            }
+        }
     }
 
-// backward compatibility (encompass)
 // integration test
 }

--- a/core/src/test/kotlin/in/specmatic/core/pattern/JSONObjectPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/JSONObjectPatternTest.kt
@@ -525,7 +525,30 @@ internal class JSONObjectPatternTest {
         }
     }
 
-// newBasedOn
+    @Nested
+    inner class TestGeneration {
+        @Test
+        fun `objects generated for tests should have a min of minProperties keys and a max of maxProperties keys`() {
+            val pattern = JSONObjectPattern(
+                mapOf(
+                    "id" to NumberPattern(),
+                    "name?" to StringPattern(),
+                    "address?" to StringPattern(),
+                    "department?" to StringPattern(),
+                ),
+                minProperties = 2,
+                maxProperties = 3
+            )
+
+            val newPatterns: List<JSONObjectPattern> = pattern.newBasedOn(Row(), Resolver())
+
+            assertThat(newPatterns).allSatisfy {
+                assertThat(it.pattern.keys).hasSizeGreaterThanOrEqualTo(2)
+                assertThat(it.pattern.keys).hasSizeLessThanOrEqualTo(3)
+            }
+        }
+    }
+
 // backward compatibility (encompass)
 // integration test
 }


### PR DESCRIPTION
**What**:

minProperties and maxProperties are features of the OpenAPI format. See "Number of properties" on the [Data Types](https://swagger.io/docs/specification/data-models/data-types/) page.

**Why**:

It was picked up as it is an interesting way to express constraints on certain kinds of JSON types.

**How**:

This PR adds `minProperties` and `maxProperties` to JSONObjectPattern. Matching, object generation, test generation and backward compatibility have all been addressed, and tests added.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
n/a, this is an OpenAPI feature, and has been implemented per the OpenAPI documentation

- [x] Tests

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #123

<!-- feel free to add additional comments -->
