### PR TITLE
Added support for oneOf nested within allOf

### DIFF
--- a/core/src/test/kotlin/in/specmatic/conversions/OneOfWithinAnyOfTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OneOfWithinAnyOfTest.kt
@@ -1,0 +1,112 @@
+package `in`.specmatic.conversions
+
+import `in`.specmatic.core.Feature
+import `in`.specmatic.core.HttpRequest
+import `in`.specmatic.core.HttpResponse
+import `in`.specmatic.core.Result.Failure
+import `in`.specmatic.core.Result.Success
+import `in`.specmatic.core.pattern.parsedJSONObject
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class OneOfWithinAnyOfTest {
+    val feature: Feature = OpenApiSpecification.fromYAML("""
+---
+openapi: "3.0.1"
+info:
+  title: "Person API"
+  version: "1.0"
+paths:
+  /person/{id}:
+    get:
+      summary: "Get a person's record"
+      parameters:
+        - name: id
+          in: path
+          schema:
+            type: string
+          examples:
+            200_OK:
+              value: 10
+      responses:
+        200:
+          description: "A person's details"
+          content:
+            application/json:
+              schema:
+                ${"$"}ref: "#/components/schemas/PersonRecord"
+              examples:
+                200_OK:
+                  value:
+components:
+  schemas:
+    Id:
+      type: object
+      properties:
+        id:
+          type: integer
+      required:
+        - id
+    PersonDetails:
+      oneOf:
+        - ${"$"}ref: '#/components/schemas/SimpleName'
+        - ${"$"}ref: '#/components/schemas/DestructuredName'
+    SimpleName:
+      type: object
+      properties:
+        name:
+          type: string
+      required:
+        - name
+    DestructuredName:
+      type: object
+      properties:
+        first_name:
+          type: string
+        last_name:
+          type: string
+      required:
+        - first_name
+        - last_name
+    PersonRecord:
+      allOf:
+        - ${"$"}ref: '#/components/schemas/Id'
+        - ${"$"}ref: '#/components/schemas/PersonDetails'
+        """.trimIndent(), "").toFeature()
+
+    @Test
+    fun `matching stub`() {
+        val result = feature.scenarios.first().matchesMock(
+            HttpRequest(path = "/person/10", method = "GET"),
+            HttpResponse.OK(parsedJSONObject("""{"id": 10, "name": "Sherlock Holmes"}""")),
+        )
+
+        println(result.reportString())
+
+        assertThat(result).isInstanceOf(Success::class.java)
+    }
+
+    @Test
+    fun `also matching stub`() {
+        val result = feature.scenarios.first().matchesMock(
+            HttpRequest(path = "/person/10", method = "GET"),
+            HttpResponse.OK(parsedJSONObject("""{"id": 10, "first_name": "Sherlock", "last_name": "Holmes"}"""))
+        )
+
+        println(result.reportString())
+
+        assertThat(result).isInstanceOf(Success::class.java)
+    }
+
+    @Test
+    fun `non matching stub`() {
+        val result = feature.scenarios.first().matchesMock(
+            HttpRequest(path = "/person/10", method = "GET"),
+            HttpResponse.OK(parsedJSONObject("""{"id": 10, "full_name": "Sherlock Holmes"}"""))
+        )
+
+        println(result.reportString())
+
+        assertThat(result).isInstanceOf(Failure::class.java)
+    }
+}


### PR DESCRIPTION
**What**:

Adds support for nested oneOf

**Why**:

The approach to computing allOf ignored oneOf when they were nested in within the allOf.

e.g.

allOf
- oneOf
  - $ref: '#/components/schemas/Cat'
  - $ref: '#/components/schemas/Dog'
- object
   properties:
     id:
       type: string
     name:
       type: string

**How**:

We added code within the allOf section of the parser to handle this.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #123

<!-- feel free to add additional comments -->
