### PR TITLE
Use schema example as the default example

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -820,19 +820,19 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
         }
         else when (schema) {
             is StringSchema -> when (schema.enum) {
-                null -> StringPattern(minLength = schema.minLength, maxLength = schema.maxLength)
-                else -> toEnum(schema, patternName) { enumValue -> StringValue(enumValue.toString()) }
+                null -> StringPattern(minLength = schema.minLength, maxLength = schema.maxLength, example = schema.example?.toString())
+                else -> toEnum(schema, patternName) { enumValue -> StringValue(enumValue.toString()) }.copy(example = schema.example?.toString())
             }
             is IntegerSchema -> when (schema.enum) {
-                null -> NumberPattern()
-                else -> toEnum(schema, patternName) { enumValue -> NumberValue(enumValue.toString().toInt()) }
+                null -> NumberPattern(example = schema.example?.toString())
+                else -> toEnum(schema, patternName) { enumValue -> NumberValue(enumValue.toString().toInt()) }.copy(example = schema.example?.toString())
             }
             is BinarySchema -> BinaryPattern()
-            is NumberSchema -> NumberPattern()
+            is NumberSchema -> NumberPattern(example = schema.example?.toString())
             is UUIDSchema -> UUIDPattern
             is DateTimeSchema -> DateTimePattern
             is DateSchema -> DatePattern
-            is BooleanSchema -> BooleanPattern
+            is BooleanSchema -> BooleanPattern(example = schema.example?.toString())
             is ObjectSchema -> {
                 if (schema.additionalProperties is Schema<*>) {
                     toDictionaryPattern(schema, typeStack, patternName)
@@ -931,8 +931,9 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
         return when (schema.nullable != true) {
             true -> pattern
             else -> when (pattern) {
-                is AnyPattern, NullPattern -> pattern
-                else -> AnyPattern(listOf(NullPattern, pattern))
+                NullPattern -> pattern
+                is AnyPattern -> pattern.copy(example = schema.example?.toString())
+                else -> AnyPattern(listOf(NullPattern, pattern), example = schema.example?.toString())
             }
         }
     }

--- a/core/src/main/kotlin/in/specmatic/core/Flags.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Flags.kt
@@ -6,6 +6,7 @@ object Flags {
     private const val customResponseName = "CUSTOM_RESPONSE"
     const val negativeTestingFlag = "SPECMATIC_GENERATIVE_TESTS"
     const val maxTestRequestCombinationsFlag = "MAX_TEST_REQUEST_COMBINATIONS"
+    const val schemaExampleDefault = "SCHEMA_EXAMPLE_DEFAULT"
 
     private fun flagValue(flagName: String): String? {
         return System.getenv(flagName) ?: System.getProperty(flagName)
@@ -13,6 +14,10 @@ object Flags {
 
     fun customResponse(): Boolean {
         return flagValue(customResponseName) == "true"
+    }
+
+    fun schemaExampleDefaultEnabled(): Boolean {
+        return BooleanUtils.toBoolean(flagValue(schemaExampleDefault) ?: "true")
     }
 
     fun generativeTestingEnabled(): Boolean {

--- a/core/src/main/kotlin/in/specmatic/core/pattern/BinaryPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/BinaryPattern.kt
@@ -38,7 +38,7 @@ data class BinaryPattern(
     override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> = listOf(this)
     override fun newBasedOn(resolver: Resolver): List<Pattern> = listOf(this)
     override fun negativeBasedOn(row: Row, resolver: Resolver): List<Pattern> {
-        return listOf(NullPattern, NumberPattern(), BooleanPattern)
+        return listOf(NullPattern, NumberPattern(), BooleanPattern())
     }
 
     override fun parse(value: String, resolver: Resolver): Value = StringValue(value)

--- a/core/src/main/kotlin/in/specmatic/core/pattern/BooleanPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/BooleanPattern.kt
@@ -17,20 +17,7 @@ data class BooleanPattern(val example: String? = null) : Pattern, ScalarType {
         }
 
     override fun generate(resolver: Resolver): Value =
-        matchingExample() ?: randomBoolean()
-
-    private fun matchingExample(): Value? {
-        if(example == null)
-            return example
-
-        val value = this.parse(example, Resolver())
-        val exampleMatchResult = this.matches(value, Resolver())
-
-        if(exampleMatchResult.isSuccess())
-            return value
-
-        throw ContractException("Example \"$example\" does not match $typeName type")
-    }
+        matchingExample(example, this) ?: randomBoolean()
 
     override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> = listOf(this)
     override fun newBasedOn(resolver: Resolver): List<Pattern> = listOf(this)
@@ -61,4 +48,17 @@ data class BooleanPattern(val example: String? = null) : Pattern, ScalarType {
 fun randomBoolean() = when (Random().nextInt(2)) {
     0 -> BooleanValue(false)
     else -> BooleanValue(true)
+}
+
+fun matchingExample(example: String?, pattern: Pattern): Value? {
+    if(example == null)
+        return example
+
+    val value = pattern.parse(example, Resolver())
+    val exampleMatchResult = pattern.matches(value, Resolver())
+
+    if(exampleMatchResult.isSuccess())
+        return value
+
+    throw ContractException("Example \"$example\" does not match ${pattern.typeName} type")
 }

--- a/core/src/main/kotlin/in/specmatic/core/pattern/BooleanPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/BooleanPattern.kt
@@ -49,16 +49,3 @@ fun randomBoolean() = when (Random().nextInt(2)) {
     0 -> BooleanValue(false)
     else -> BooleanValue(true)
 }
-
-fun matchingExample(example: String?, pattern: Pattern): Value? {
-    if(example == null)
-        return example
-
-    val value = pattern.parse(example, Resolver())
-    val exampleMatchResult = pattern.matches(value, Resolver())
-
-    if(exampleMatchResult.isSuccess())
-        return value
-
-    throw ContractException("Example \"$example\" does not match ${pattern.typeName} type")
-}

--- a/core/src/main/kotlin/in/specmatic/core/pattern/BooleanPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/BooleanPattern.kt
@@ -5,10 +5,11 @@ import `in`.specmatic.core.Result
 import `in`.specmatic.core.mismatchResult
 import `in`.specmatic.core.value.BooleanValue
 import `in`.specmatic.core.value.JSONArrayValue
+import `in`.specmatic.core.value.StringValue
 import `in`.specmatic.core.value.Value
 import java.util.*
 
-object BooleanPattern : Pattern, ScalarType {
+data class BooleanPattern(val example: String? = null) : Pattern, ScalarType {
     override fun matches(sampleData: Value?, resolver: Resolver): Result =
         when(sampleData) {
             is BooleanValue -> Result.Success()
@@ -16,7 +17,20 @@ object BooleanPattern : Pattern, ScalarType {
         }
 
     override fun generate(resolver: Resolver): Value =
-        randomBoolean()
+        matchingExample() ?: randomBoolean()
+
+    private fun matchingExample(): Value? {
+        if(example == null)
+            return example
+
+        val value = this.parse(example, Resolver())
+        val exampleMatchResult = this.matches(value, Resolver())
+
+        if(exampleMatchResult.isSuccess())
+            return value
+
+        throw ContractException("Example \"$example\" does not match $typeName type")
+    }
 
     override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> = listOf(this)
     override fun newBasedOn(resolver: Resolver): List<Pattern> = listOf(this)
@@ -25,7 +39,7 @@ object BooleanPattern : Pattern, ScalarType {
     }
 
     override fun parse(value: String, resolver: Resolver): Value = when (value) {
-        !in listOf("true", "false") -> throw ContractException(mismatchResult(BooleanPattern, value, resolver.mismatchMessages).toFailureReport())
+        !in listOf("true", "false") -> throw ContractException(mismatchResult(BooleanPattern(), value, resolver.mismatchMessages).toFailureReport())
         else -> BooleanValue(value.toBoolean())
     }
     override fun encompasses(otherPattern: Pattern, thisResolver: Resolver, otherResolver: Resolver, typeStack: TypeStack): Result {

--- a/core/src/main/kotlin/in/specmatic/core/pattern/Grammar.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/Grammar.kt
@@ -29,7 +29,7 @@ internal fun containsKey(jsonObject: Map<String, Any?>, key: String) =
 internal val builtInPatterns = mapOf(
     "(number)" to NumberPattern(),
     "(string)" to StringPattern(),
-    "(boolean)" to BooleanPattern,
+    "(boolean)" to BooleanPattern(),
     "(null)" to NullPattern,
     "(empty)" to EmptyStringPattern,
     "(date)" to DatePattern,

--- a/core/src/main/kotlin/in/specmatic/core/pattern/NumberPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/NumberPattern.kt
@@ -39,21 +39,8 @@ data class NumberPattern(
     }
 
     override fun generate(resolver: Resolver): Value =
-        matchingExample() ?:
+        matchingExample(example, this) ?:
             NumberValue(randomNumber(minLength ?: 3))
-
-    private fun matchingExample(): Value? {
-        if(example == null)
-            return example
-
-        val value = this.parse(example, Resolver())
-        val exampleMatchResult = this.matches(value, Resolver())
-
-        if(exampleMatchResult.isSuccess())
-            return value
-
-        throw ContractException("Example \"$example\" does not match $typeName type")
-    }
 
     private fun randomNumber(minLength: Int): Int {
         val first = randomPositiveDigit().toString()

--- a/core/src/main/kotlin/in/specmatic/core/pattern/NumberPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/NumberPattern.kt
@@ -5,13 +5,15 @@ import `in`.specmatic.core.Result
 import `in`.specmatic.core.mismatchResult
 import `in`.specmatic.core.value.JSONArrayValue
 import `in`.specmatic.core.value.NumberValue
+import `in`.specmatic.core.value.StringValue
 import `in`.specmatic.core.value.Value
 import java.util.*
 
 data class NumberPattern(
     override val typeAlias: String? = null,
     val minLength: Int? = null,
-    val maxLength: Int? = null
+    val maxLength: Int? = null,
+    val example: String? = null
 ) : Pattern, ScalarType {
     init {
         require(minLength?.let { minLength > 0 } ?: true) {"minLength cannot be less than 1"}
@@ -36,7 +38,22 @@ data class NumberPattern(
         }
     }
 
-    override fun generate(resolver: Resolver): Value = NumberValue(randomNumber(minLength ?: 3))
+    override fun generate(resolver: Resolver): Value =
+        matchingExample() ?:
+            NumberValue(randomNumber(minLength ?: 3))
+
+    private fun matchingExample(): Value? {
+        if(example == null)
+            return example
+
+        val value = this.parse(example, Resolver())
+        val exampleMatchResult = this.matches(value, Resolver())
+
+        if(exampleMatchResult.isSuccess())
+            return value
+
+        throw ContractException("Example \"$example\" does not match $typeName type")
+    }
 
     private fun randomNumber(minLength: Int): Int {
         val first = randomPositiveDigit().toString()

--- a/core/src/main/kotlin/in/specmatic/core/pattern/Pattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/Pattern.kt
@@ -1,5 +1,6 @@
 package `in`.specmatic.core.pattern
 
+import `in`.specmatic.core.Flags
 import `in`.specmatic.core.Resolver
 import `in`.specmatic.core.Result
 import `in`.specmatic.core.value.StringValue
@@ -60,4 +61,20 @@ interface Pattern {
     val typeAlias: String?
     val typeName: String
     val pattern: Any
+}
+
+fun matchingExample(example: String?, pattern: Pattern): Value? {
+    if(!Flags.schemaExampleDefaultEnabled())
+        return null
+
+    if(example == null)
+        return example
+
+    val value = pattern.parse(example, Resolver())
+    val exampleMatchResult = pattern.matches(value, Resolver())
+
+    if(exampleMatchResult.isSuccess())
+        return value
+
+    throw ContractException("Example \"$example\" does not match ${pattern.typeName} type")
 }

--- a/core/src/main/kotlin/in/specmatic/core/pattern/StringPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/StringPattern.kt
@@ -57,19 +57,7 @@ data class StringPattern(
             else -> 5
         }
     
-    override fun generate(resolver: Resolver): Value = matchingExample() ?: StringValue(randomString(randomStringLength))
-
-    private fun matchingExample(): Value? {
-        if(example == null)
-            return example
-
-        val exampleMatchResult = this.matches(StringValue(example), Resolver())
-
-        if(exampleMatchResult.isSuccess())
-            return StringValue(example)
-
-        throw ContractException("Example \"$example\" does not match $typeName type")
-    }
+    override fun generate(resolver: Resolver): Value = matchingExample(example, this) ?: StringValue(randomString(randomStringLength))
 
     override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> = listOf(this)
     override fun newBasedOn(resolver: Resolver): List<Pattern> = listOf(this)

--- a/core/src/main/kotlin/in/specmatic/core/pattern/StringPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/StringPattern.kt
@@ -12,7 +12,8 @@ import java.util.*
 data class StringPattern(
     override val typeAlias: String? = null,
     val minLength: Int? = null,
-    val maxLength: Int? = null
+    val maxLength: Int? = null,
+    val example: String? = null
 ) : Pattern, ScalarType {
     init {
         require(minLength?.let { maxLength?.let { minLength <= maxLength } }
@@ -56,12 +57,24 @@ data class StringPattern(
             else -> 5
         }
     
-    override fun generate(resolver: Resolver): Value = StringValue(randomString(randomStringLength))
+    override fun generate(resolver: Resolver): Value = matchingExample() ?: StringValue(randomString(randomStringLength))
+
+    private fun matchingExample(): Value? {
+        if(example == null)
+            return example
+
+        val exampleMatchResult = this.matches(StringValue(example), Resolver())
+
+        if(exampleMatchResult.isSuccess())
+            return StringValue(example)
+
+        throw ContractException("Example \"$example\" does not match $typeName type")
+    }
 
     override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> = listOf(this)
     override fun newBasedOn(resolver: Resolver): List<Pattern> = listOf(this)
     override fun negativeBasedOn(row: Row, resolver: Resolver): List<Pattern> {
-        return listOf(NullPattern, NumberPattern(), BooleanPattern)
+        return listOf(NullPattern, NumberPattern(), BooleanPattern())
     }
 
     override fun parse(value: String, resolver: Resolver): Value = StringValue(value)

--- a/core/src/main/kotlin/in/specmatic/core/value/BooleanValue.kt
+++ b/core/src/main/kotlin/in/specmatic/core/value/BooleanValue.kt
@@ -12,7 +12,7 @@ data class BooleanValue(val booleanValue: Boolean) : Value, ScalarValue {
     override fun toStringLiteral() = booleanValue.toString()
     override fun displayableType(): String = "boolean"
     override fun exactMatchElseType(): Pattern = ExactValuePattern(this)
-    override fun type(): Pattern = BooleanPattern
+    override fun type(): Pattern = BooleanPattern()
 
     override fun typeDeclarationWithKey(key: String, types: Map<String, Pattern>, exampleDeclarations: ExampleDeclarations): Pair<TypeDeclaration, ExampleDeclarations> =
             primitiveTypeDeclarationWithKey(key, types, exampleDeclarations, displayableType(), booleanValue.toString())

--- a/core/src/test/kotlin/in/specmatic/conversions/DefaultValuesInOpenapiSpecification.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/DefaultValuesInOpenapiSpecification.kt
@@ -1,0 +1,159 @@
+package `in`.specmatic.conversions
+
+import `in`.specmatic.core.jsonObject
+import `in`.specmatic.core.pattern.JSONObjectPattern
+import `in`.specmatic.core.value.JSONArrayValue
+import `in`.specmatic.core.value.JSONObjectValue
+import `in`.specmatic.core.value.NumberValue
+import `in`.specmatic.core.value.StringValue
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class DefaultValuesInOpenapiSpecification {
+    @Test
+    fun `schema examples should be used as default values`() {
+        val specification = OpenApiSpecification.fromYAML("""
+            openapi: 3.0.1
+            info:
+              title: Employee API
+              version: 1.0.0
+            paths:
+              /employees:
+                post:
+                  requestBody:
+                    content:
+                      application/json:
+                        schema:
+                          ${'$'}ref: '#/components/schemas/Employee'
+                  responses:
+                    '200':
+                      description: OK
+                      content:
+                        text/plain:
+                          schema:
+                            type: string
+            components:
+              schemas:
+                Employee:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                      example: 'Jane Doe'
+                    age:
+                      type: integer
+                      format: int32
+                      example: 35
+                    salary:
+                      type: number
+                      format: double
+                      nullable: true
+                      example: 50000
+                    salary_history:
+                      type: array
+                      items:
+                        type: number
+                        example: 1000
+                  required:
+                    - name
+                    - age
+                    - salary
+            """.trimIndent(), "").toFeature()
+
+        val withGenerativeTestsEnabled = specification.copy(generativeTestingEnabled = true)
+
+        val testRequestBodies = withGenerativeTestsEnabled.generateContractTestScenarios(emptyList()).filter {
+            !it.isNegative
+        }.map {
+            it.httpRequestPattern.body.generate(it.resolver)
+        }.filterIsInstance<JSONObjectPattern>()
+
+        assertThat(testRequestBodies).allSatisfy {
+            assertThat(it.pattern["name"]).isEqualTo(StringValue("Jane Doe"))
+            assertThat(it.pattern["age"]).isEqualTo(NumberValue(35))
+            assertThat(it.pattern["salary"]).isEqualTo(NumberValue(50000))
+            val salaryHistory = it.pattern["salary_history"] as JSONArrayValue
+            assertThat(salaryHistory.list).allSatisfy {
+                assertThat(it).isEqualTo(NumberValue(1000))
+            }
+        }
+    }
+
+    @Test
+    fun `named examples should be given preference over schema examples`() {
+        val specification = OpenApiSpecification.fromYAML("""
+            openapi: 3.0.1
+            info:
+              title: Employee API
+              version: 1.0.0
+            paths:
+              /employees:
+                post:
+                  requestBody:
+                    content:
+                      application/json:
+                        schema:
+                          ${'$'}ref: '#/components/schemas/Employee'
+                        examples:
+                          SUCCESS:
+                            value:
+                              name: 'John Doe'
+                              age: 30
+                  responses:
+                    '200':
+                      description: OK
+                      content:
+                        text/plain:
+                          schema:
+                            type: string
+                          examples:
+                            SUCCESS:
+                              value: 'success'
+            components:
+              schemas:
+                Employee:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                      example: 'Jane Doe'
+                    age:
+                      type: integer
+                      format: int32
+                      example: 35
+                    salary:
+                      type: number
+                      format: double
+                      nullable: true
+                      example: 50000
+                  required:
+                    - name
+                    - age
+            """.trimIndent(), "").toFeature()
+
+        val withGenerativeTestsEnabled = specification.copy(generativeTestingEnabled = true)
+
+        val generateContractTestScenarios = withGenerativeTestsEnabled.generateContractTestScenarios(emptyList())
+
+        val positiveTests = generateContractTestScenarios.filter {
+            !it.isNegative
+        }
+
+        val testRequestBodies = positiveTests.map {
+            it.httpRequestPattern.body.generate(it.resolver)
+        }
+
+        assertThat(testRequestBodies).allSatisfy {
+            assertThat(it).isInstanceOf(JSONObjectValue::class.java)
+
+            it as JSONObjectValue
+
+            assertThat(it.jsonObject["name"]).isEqualTo(StringValue("John Doe"))
+            assertThat(it.jsonObject["age"]).isEqualTo(NumberValue(30))
+
+            if("salary" in it.jsonObject) {
+                assertThat(it.jsonObject["salary"]).isEqualTo(NumberValue(50000))
+            }
+        }
+    }
+}

--- a/core/src/test/kotlin/in/specmatic/conversions/DefaultValuesInOpenapiSpecification.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/DefaultValuesInOpenapiSpecification.kt
@@ -1,6 +1,5 @@
 package `in`.specmatic.conversions
 
-import `in`.specmatic.core.jsonObject
 import `in`.specmatic.core.pattern.JSONObjectPattern
 import `in`.specmatic.core.value.JSONArrayValue
 import `in`.specmatic.core.value.JSONObjectValue

--- a/core/src/test/kotlin/in/specmatic/conversions/DefaultValuesInOpenapiSpecification.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/DefaultValuesInOpenapiSpecification.kt
@@ -6,9 +6,26 @@ import `in`.specmatic.core.value.JSONObjectValue
 import `in`.specmatic.core.value.NumberValue
 import `in`.specmatic.core.value.StringValue
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 class DefaultValuesInOpenapiSpecification {
+    companion object {
+        @BeforeAll
+        @JvmStatic
+        fun setup() {
+            System.setProperty("SCHEMA_EXAMPLE_DEFAULT", "true")
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun tearDown() {
+            System.setProperty("SCHEMA_EXAMPLE_DEFAULT", "false")
+        }
+    }
+
     @Test
     fun `schema examples should be used as default values`() {
         val specification = OpenApiSpecification.fromYAML("""

--- a/core/src/test/kotlin/in/specmatic/conversions/DefaultValuesInOpenapiSpecification.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/DefaultValuesInOpenapiSpecification.kt
@@ -70,10 +70,19 @@ class DefaultValuesInOpenapiSpecification {
                       items:
                         type: number
                         example: 1000
+                    years_employed:
+                      type: array
+                      items:
+                        type: number
+                      example:
+                        - 2021
+                        - 2022
+                        - 2023
                   required:
                     - name
                     - age
                     - salary
+                    - years_employed
             """.trimIndent(), "").toFeature()
 
         val withGenerativeTestsEnabled = specification.copy(generativeTestingEnabled = true)
@@ -88,10 +97,14 @@ class DefaultValuesInOpenapiSpecification {
             assertThat(it.pattern["name"]).isEqualTo(StringValue("Jane Doe"))
             assertThat(it.pattern["age"]).isEqualTo(NumberValue(35))
             assertThat(it.pattern["salary"]).isEqualTo(NumberValue(50000))
+
             val salaryHistory = it.pattern["salary_history"] as JSONArrayValue
             assertThat(salaryHistory.list).allSatisfy {
                 assertThat(it).isEqualTo(NumberValue(1000))
             }
+
+            val yearsEmployed = it.pattern["years_employed"] as JSONArrayValue
+            assertThat(yearsEmployed.list).isEqualTo(JSONArrayValue(listOf(NumberValue(2021), NumberValue(2022), NumberValue(2023))))
         }
     }
 

--- a/core/src/test/kotlin/in/specmatic/core/HttpRequestPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/HttpRequestPatternTest.kt
@@ -127,7 +127,7 @@ internal class HttpRequestPatternTest {
 
     @Test
     fun `boolean bodies should match boolean strings`() {
-        val requestPattern = HttpRequestPattern(method = "GET", urlMatcher = toURLMatcherWithOptionalQueryParams("/"), body = BooleanPattern)
+        val requestPattern = HttpRequestPattern(method = "GET", urlMatcher = toURLMatcherWithOptionalQueryParams("/"), body = BooleanPattern())
         val request = HttpRequest("GET", path = "/", body = StringValue("true"))
 
         assertThat(requestPattern.matches(request, Resolver())).isInstanceOf(Success::class.java)
@@ -135,7 +135,7 @@ internal class HttpRequestPatternTest {
 
     @Test
     fun `boolean bodies should not match non-boolean strings`() {
-        val requestPattern = HttpRequestPattern(method = "GET", urlMatcher = toURLMatcherWithOptionalQueryParams("/"), body = BooleanPattern)
+        val requestPattern = HttpRequestPattern(method = "GET", urlMatcher = toURLMatcherWithOptionalQueryParams("/"), body = BooleanPattern())
         val request = HttpRequest("GET", path = "/", body = StringValue("10"))
 
         assertThat(requestPattern.matches(request, Resolver())).isInstanceOf(Failure::class.java)

--- a/core/src/test/kotlin/in/specmatic/core/PatternDefinitionTests.kt
+++ b/core/src/test/kotlin/in/specmatic/core/PatternDefinitionTests.kt
@@ -214,7 +214,7 @@ class PatternDefinitionTests {
     @Test
     fun `(boolean) should match a boolean value`() {
         val boolValue = true
-        val boolPattern = BooleanPattern
+        val boolPattern = BooleanPattern()
 
         BooleanValue(boolValue) shouldMatch  boolPattern
     }

--- a/core/src/test/kotlin/in/specmatic/core/ScenarioTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/ScenarioTest.kt
@@ -2,14 +2,12 @@ package `in`.specmatic.core
 
 import `in`.specmatic.conversions.OpenApiSpecification
 import `in`.specmatic.core.pattern.*
-import `in`.specmatic.core.utilities.exceptionCauseMessage
 import `in`.specmatic.core.value.*
 import `in`.specmatic.mock.ScenarioStub
 import `in`.specmatic.test.TestExecutor
 import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
 import org.junit.jupiter.api.Test
 import java.util.*

--- a/core/src/test/kotlin/in/specmatic/core/URLMatcherTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/URLMatcherTest.kt
@@ -209,7 +209,7 @@ internal class URLMatcherTest {
         val matcher = toURLMatcherWithOptionalQueryParams(URI("/pets/(status:boolean)"))
         val matchers = matcher.newBasedOn(Row(), Resolver())
         assertThat(matchers).hasSize(1)
-        assertThat(matchers.single()).isEqualTo(URLMatcher(emptyMap(), listOf(URLPathPattern(ExactValuePattern(StringValue("pets"))), URLPathPattern(BooleanPattern, "status")), "/pets/(status:boolean)"))
+        assertThat(matchers.single()).isEqualTo(URLMatcher(emptyMap(), listOf(URLPathPattern(ExactValuePattern(StringValue("pets"))), URLPathPattern(BooleanPattern(), "status")), "/pets/(status:boolean)"))
     }
 
     @Test
@@ -221,7 +221,7 @@ internal class URLMatcherTest {
         val matcherWithoutQueryParams = URLMatcher(emptyMap(), listOf(URLPathPattern(ExactValuePattern(StringValue("pets")))), "/pets")
         assertThat(matchers).contains(matcherWithoutQueryParams)
 
-        val matcherWithQueryParams = URLMatcher(mapOf("available" to BooleanPattern), listOf(URLPathPattern(ExactValuePattern(StringValue("pets")))), "/pets")
+        val matcherWithQueryParams = URLMatcher(mapOf("available" to BooleanPattern()), listOf(URLPathPattern(ExactValuePattern(StringValue("pets")))), "/pets")
         assertThat(matchers).contains(matcherWithQueryParams)
     }
 

--- a/core/src/test/kotlin/in/specmatic/core/pattern/AnyPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/AnyPatternTest.kt
@@ -190,7 +190,7 @@ internal class AnyPatternTest {
     fun `values for negative tests`() {
         val negativeTypes = AnyPattern(listOf(NullPattern, StringPattern())).negativeBasedOn(Row(), Resolver())
 
-        val expectedTypes = listOf(NumberPattern(), BooleanPattern)
+        val expectedTypes = listOf(NumberPattern(), BooleanPattern())
 
         assertThat(negativeTypes).containsAll(expectedTypes)
         assertThat(negativeTypes).hasSize(expectedTypes.size)

--- a/core/src/test/kotlin/in/specmatic/core/pattern/BooleanPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/BooleanPatternTest.kt
@@ -7,6 +7,6 @@ import `in`.specmatic.shouldNotMatch
 internal class BooleanPatternTest {
     @Test
     fun `should fail to match nulls graceully`() {
-        NullValue shouldNotMatch BooleanPattern
+        NullValue shouldNotMatch BooleanPattern()
     }
 }

--- a/core/src/test/kotlin/in/specmatic/core/pattern/JSONArrayPatternKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/JSONArrayPatternKtTest.kt
@@ -45,7 +45,7 @@ internal class JSONArrayPatternKtTest {
     @Nested
     @DisplayName("Given [optional, required, optional, required]")
     inner class OneCompulsoryAndOneRequired {
-        private val combinations = allOrNothingListCombinations(listOf(listOf(StringPattern(), null), listOf(NumberPattern()), listOf(BooleanPattern, null), listOf(DateTimePattern)))
+        private val combinations = allOrNothingListCombinations(listOf(listOf(StringPattern(), null), listOf(NumberPattern()), listOf(BooleanPattern(), null), listOf(DateTimePattern)))
 
         @Test
         fun `two results should be generated`() {
@@ -59,7 +59,7 @@ internal class JSONArrayPatternKtTest {
 
         @Test
         fun `the other result should have all the types with order preserved`() {
-            assertThat(combinations).contains(listOf(StringPattern(), NumberPattern(), BooleanPattern, DateTimePattern))
+            assertThat(combinations).contains(listOf(StringPattern(), NumberPattern(), BooleanPattern(), DateTimePattern))
         }
     }
 

--- a/core/src/test/kotlin/in/specmatic/core/pattern/PatternInStringPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/PatternInStringPatternTest.kt
@@ -16,7 +16,7 @@ internal class PatternInStringPatternTest {
 
     @Test
     fun `should match a boolean in string`() {
-        StringValue("true") shouldMatch PatternInStringPattern(BooleanPattern)
+        StringValue("true") shouldMatch PatternInStringPattern(BooleanPattern())
     }
 
     @Test
@@ -64,7 +64,7 @@ internal class PatternInStringPatternTest {
 
         assertThat(pattern1.encompasses(pattern2, Resolver(), Resolver())).isInstanceOf(Result.Success::class.java)
 
-        val pattern3 = PatternInStringPattern(BooleanPattern)
+        val pattern3 = PatternInStringPattern(BooleanPattern())
         assertThat(pattern1.encompasses(pattern3, Resolver(), Resolver())).isInstanceOf(Result.Failure::class.java)
     }
 

--- a/core/src/test/kotlin/in/specmatic/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/in/specmatic/stub/HttpStubTest.kt
@@ -10,7 +10,6 @@ import `in`.specmatic.mock.DELAY_IN_SECONDS
 import `in`.specmatic.mock.ScenarioStub
 import `in`.specmatic.shouldMatch
 import `in`.specmatic.test.HttpClient
-import io.ktor.client.request.*
 import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=1.0.0
+version=1.0.1


### PR DESCRIPTION
**What**:

Use the example in the schema as the default when the SCHEMA_EXAMPLE_DEFAULT environment variable or property is set.

**Why**:

When generating values, random values will often not be understood by the application. The default value can be setup ahead of the tests so that the application understands it.

**How**:

We've added an example to just the primitive data types for now (String, Number, Boolean), and we use it if
- the flag is on
- no named example is available
- a schema example is available

If any of the above are not true, a random value is generated.

The generated value is validated before being accepted.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #123

<!-- feel free to add additional comments -->
