### PR TITLE
Api coverage report improvements

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/Result.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Result.kt
@@ -186,7 +186,8 @@ enum class TestResult {
     Error,
     Failed,
     Skipped,
-    NotImplemented
+    NotImplemented,
+    DidNotRun
 }
 
 enum class FailureReason(val fluffLevel: Int) {

--- a/core/src/main/kotlin/in/specmatic/test/ContractTest.kt
+++ b/core/src/main/kotlin/in/specmatic/test/ContractTest.kt
@@ -14,7 +14,7 @@ data class TestResultRecord(
     val specification: String? = null,
     val serviceType: String? = null
 ) {
-    val includeForCoverage = result !in listOf(TestResult.Skipped, TestResult.NotImplemented)
+    val includeForCoverage = result !in listOf(TestResult.Skipped, TestResult.NotImplemented, TestResult.DidNotRun)
 }
 
 interface ContractTest {

--- a/core/src/main/kotlin/in/specmatic/test/ScenarioTest.kt
+++ b/core/src/main/kotlin/in/specmatic/test/ScenarioTest.kt
@@ -16,7 +16,7 @@ class ScenarioTest(
     private val serviceType: String? = null
 ) : ContractTest {
     override fun testResultRecord(result: Result): TestResultRecord {
-        val resultStatus = if (scenario.generatedFromExamples) result.testResult() else TestResult.Skipped
+        val resultStatus = result.testResult()
         return TestResultRecord(convertPathParameterStyle(scenario.path), scenario.method, scenario.status, resultStatus, sourceProvider, sourceRepository, sourceRepositoryBranch, specification, serviceType)
     }
 

--- a/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
@@ -12,6 +12,7 @@ import `in`.specmatic.core.value.Value
 import `in`.specmatic.stub.isOpenAPI
 import `in`.specmatic.stub.isYAML
 import `in`.specmatic.test.reports.OpenApiCoverageReportProcessor
+import `in`.specmatic.test.reports.coverage.Endpoint
 import `in`.specmatic.test.reports.coverage.OpenApiCoverageReportInput
 import kotlinx.serialization.Serializable
 import org.junit.jupiter.api.AfterAll
@@ -160,9 +161,9 @@ open class SpecmaticJUnitSupport {
             return loadExceptionAsTestError(e)
         }
         val testScenarios = try {
-            val testScenarios = when {
+            val (testScenarios, allEndpoints) = when {
                 contractPaths != null -> {
-                    contractPaths.split(",").flatMap {
+                    val testScenariosAndEndpointsPairList = contractPaths.split(",").map {
                         loadTestScenarios(
                             it,
                             suggestionsPath,
@@ -173,6 +174,9 @@ open class SpecmaticJUnitSupport {
                             filterNotName = filterNotName
                         )
                     }
+                    val tests: List<ContractTest> = testScenariosAndEndpointsPairList.flatMap { it.first }
+                    val endpoints: List<Endpoint> = testScenariosAndEndpointsPairList.flatMap { it.second }
+                    Pair(tests, endpoints)
                 }
                 else -> {
                     val configFile = configFile
@@ -185,10 +189,16 @@ open class SpecmaticJUnitSupport {
 
                     val contractFilePaths = contractTestPathsFrom(configFile, workingDirectory.path)
 
-                    contractFilePaths.flatMap { loadTestScenarios(it.path, "", "", testConfig, it.provider, it.repository, it.branch, it.specificationPath, specmaticConfigJson?.security, filterName, filterNotName) }
+                    val testScenariosAndEndpointsPairList = contractFilePaths.map { loadTestScenarios(it.path, "", "", testConfig, it.provider, it.repository, it.branch, it.specificationPath, specmaticConfigJson?.security, filterName, filterNotName) }
+
+                    val tests: List<ContractTest> = testScenariosAndEndpointsPairList.flatMap { it.first }
+
+                    val endpoints: List<Endpoint> = testScenariosAndEndpointsPairList.flatMap { it.second }
+
+                    Pair(tests, endpoints)
                 }
             }
-
+            openApiCoverageReportInput.addEndpoints(allEndpoints)
             selectTestsToRun(testScenarios, filterName, filterNotName) { it.testDescription() }
         } catch(e: ContractException) {
             return loadExceptionAsTestError(e)
@@ -265,9 +275,9 @@ open class SpecmaticJUnitSupport {
         securityConfiguration: SecurityConfiguration? = null,
         filterName: String?,
         filterNotName: String?
-    ): List<ContractTest> {
+    ): Pair<List<ContractTest>, List<Endpoint>> {
         if(isYAML(path) && !isOpenAPI(path))
-            return emptyList()
+            return Pair(emptyList(), emptyList())
 
         val contractFile = File(path)
         val feature = parseContractFileToFeature(contractFile.path, CommandHook(HookName.test_load_contract), sourceProvider, sourceRepository, sourceRepositoryBranch, specificationPath, securityConfiguration).copy(testVariables = config.variables, testBaseURLs = config.baseURLs)
@@ -277,7 +287,20 @@ open class SpecmaticJUnitSupport {
             else -> emptyList()
         }
 
-        return feature
+        val allEndpoints: List<Endpoint> = feature.scenarios.map { scenario ->
+            Endpoint(
+                scenario.path,
+                scenario.method,
+                scenario.httpResponsePattern.status,
+                scenario.sourceProvider,
+                scenario.sourceRepository,
+                scenario.sourceRepositoryBranch,
+                scenario.specification,
+                scenario.serviceType
+            )
+        }
+
+        val tests: List<ContractTest> = feature
             .copy(scenarios = selectTestsToRun(feature.scenarios, filterName, filterNotName) { it.testDescription() })
             .also {
                 if (it.scenarios.isEmpty())
@@ -288,6 +311,8 @@ open class SpecmaticJUnitSupport {
                 }
             }
             .generateContractTests(suggestions)
+
+        return Pair(tests, allEndpoints)
     }
 
     private fun suggestionsFromFile(suggestionsPath: String): List<Scenario> {

--- a/junit5-support/src/main/kotlin/in/specmatic/test/reports/coverage/console/OpenApiCoverageConsoleRow.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/reports/coverage/console/OpenApiCoverageConsoleRow.kt
@@ -43,7 +43,8 @@ data class OpenApiCoverageConsoleRow(
 enum class Remarks(val value: String) {
     Covered("covered"),
     Missed("missing in spec"),
-    NotImplemented("not implemented");
+    NotImplemented("not implemented"),
+    DidNotRun("did not run");
 
     override fun toString(): String {
         return value


### PR DESCRIPTION
**What**:
- Removed restriction on having examples to show the test in coverage report.
- API Coverage report will include all the paths, methods and endpoints as the master list.




- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

