### PR TITLE
#721 Implemented support for the RFC3339 datetime format.

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/pattern/DatePattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/DatePattern.kt
@@ -5,7 +5,6 @@ import `in`.specmatic.core.Result
 import `in`.specmatic.core.value.JSONArrayValue
 import `in`.specmatic.core.value.StringValue
 import `in`.specmatic.core.value.Value
-import java.time.LocalDateTime
 
 object DatePattern : Pattern, ScalarType {
     override fun matches(sampleData: Value?, resolver: Resolver): Result = when (sampleData) {
@@ -16,7 +15,7 @@ object DatePattern : Pattern, ScalarType {
         else -> Result.Failure("Date types can only be represented using strings")
     }
 
-    override fun generate(resolver: Resolver): StringValue = currentDateInRFC3339Format()
+    override fun generate(resolver: Resolver): StringValue = StringValue(RFC3339.currentDate())
 
     override fun newBasedOn(row: Row, resolver: Resolver): List<DatePattern> = listOf(this)
 
@@ -48,9 +47,3 @@ object DatePattern : Pattern, ScalarType {
 
     override fun toString() = pattern
 }
-
-private fun currentDateInRFC3339Format() = StringValue(
-    LocalDateTime.now().format(
-        RFC3339.dateFormatter
-    )
-)

--- a/core/src/main/kotlin/in/specmatic/core/pattern/DatePattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/DatePattern.kt
@@ -6,9 +6,6 @@ import `in`.specmatic.core.value.JSONArrayValue
 import `in`.specmatic.core.value.StringValue
 import `in`.specmatic.core.value.Value
 import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
-
-private const val RFC3339_DATETIME_FORMAT = "yyyy-MM-dd"
 
 object DatePattern : Pattern, ScalarType {
     override fun matches(sampleData: Value?, resolver: Resolver): Result = when (sampleData) {
@@ -30,7 +27,7 @@ object DatePattern : Pattern, ScalarType {
 
     override fun parse(value: String, resolver: Resolver): StringValue =
         attempt {
-            DateTimeFormatter.ISO_DATE.parse(value)
+            RFC3339.dateFormatter.parse(value)
             StringValue(value)
         }
 
@@ -54,8 +51,6 @@ object DatePattern : Pattern, ScalarType {
 
 private fun currentDateInRFC3339Format() = StringValue(
     LocalDateTime.now().format(
-        DateTimeFormatter.ofPattern(
-            RFC3339_DATETIME_FORMAT
-        )
+        RFC3339.dateFormatter
     )
 )

--- a/core/src/main/kotlin/in/specmatic/core/pattern/DatePattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/DatePattern.kt
@@ -8,6 +8,8 @@ import `in`.specmatic.core.value.Value
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
+private const val RFC3339_DATETIME_FORMAT = "yyyy-MM-dd"
+
 object DatePattern : Pattern, ScalarType {
     override fun matches(sampleData: Value?, resolver: Resolver): Result = when (sampleData) {
         is StringValue -> resultOf {
@@ -17,7 +19,7 @@ object DatePattern : Pattern, ScalarType {
         else -> Result.Failure("Date types can only be represented using strings")
     }
 
-    override fun generate(resolver: Resolver): StringValue = currentDateTime()
+    override fun generate(resolver: Resolver): StringValue = currentDateInRFC3339Format()
 
     override fun newBasedOn(row: Row, resolver: Resolver): List<DatePattern> = listOf(this)
 
@@ -50,4 +52,10 @@ object DatePattern : Pattern, ScalarType {
     override fun toString() = pattern
 }
 
-private fun currentDateTime() = StringValue(LocalDateTime.now().format(DateTimeFormatter.ISO_DATE))
+private fun currentDateInRFC3339Format() = StringValue(
+    LocalDateTime.now().format(
+        DateTimeFormatter.ofPattern(
+            RFC3339_DATETIME_FORMAT
+        )
+    )
+)

--- a/core/src/main/kotlin/in/specmatic/core/pattern/DateTimePattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/DateTimePattern.kt
@@ -5,9 +5,6 @@ import `in`.specmatic.core.Result
 import `in`.specmatic.core.value.JSONArrayValue
 import `in`.specmatic.core.value.StringValue
 import `in`.specmatic.core.value.Value
-import java.time.LocalDateTime
-import java.time.ZoneId
-import java.time.ZonedDateTime
 
 
 object DateTimePattern : Pattern, ScalarType {
@@ -19,7 +16,7 @@ object DateTimePattern : Pattern, ScalarType {
         else -> Result.Failure("DateTime types can only be represented using strings")
     }
 
-    override fun generate(resolver: Resolver): StringValue = currentDateTimeInRFC339Format()
+    override fun generate(resolver: Resolver): StringValue = StringValue(RFC3339.currentDateTime())
 
     override fun newBasedOn(row: Row, resolver: Resolver): List<DateTimePattern> = listOf(this)
 
@@ -50,9 +47,4 @@ object DateTimePattern : Pattern, ScalarType {
     override val pattern = "(datetime)"
 
     override fun toString() = pattern
-}
-
-fun currentDateTimeInRFC339Format(): StringValue {
-    val dateTimeWithSystemOffset = ZonedDateTime.of(LocalDateTime.now(),  ZoneId.systemDefault())
-    return StringValue(dateTimeWithSystemOffset.format(RFC3339.dateTimeFormatter))
 }

--- a/core/src/main/kotlin/in/specmatic/core/pattern/DateTimePattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/DateTimePattern.kt
@@ -8,9 +8,7 @@ import `in`.specmatic.core.value.Value
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.ZonedDateTime
-import java.time.format.DateTimeFormatter
 
-private const val RFC3339_DATETIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ssXXX"
 
 object DateTimePattern : Pattern, ScalarType {
     override fun matches(sampleData: Value?, resolver: Resolver): Result = when (sampleData) {
@@ -32,7 +30,7 @@ object DateTimePattern : Pattern, ScalarType {
 
     override fun parse(value: String, resolver: Resolver): StringValue =
             attempt {
-                DateTimeFormatter.ofPattern(RFC3339_DATETIME_FORMAT).parse(value)
+                RFC3339.dateTimeFormatter.parse(value)
                 StringValue(value)
             }
 
@@ -56,6 +54,5 @@ object DateTimePattern : Pattern, ScalarType {
 
 fun currentDateTimeInRFC339Format(): StringValue {
     val dateTimeWithSystemOffset = ZonedDateTime.of(LocalDateTime.now(),  ZoneId.systemDefault())
-    val formatter = DateTimeFormatter.ofPattern(RFC3339_DATETIME_FORMAT)
-    return StringValue(dateTimeWithSystemOffset.format(formatter))
+    return StringValue(dateTimeWithSystemOffset.format(RFC3339.dateTimeFormatter))
 }

--- a/core/src/main/kotlin/in/specmatic/core/pattern/DateTimePattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/DateTimePattern.kt
@@ -6,7 +6,11 @@ import `in`.specmatic.core.value.JSONArrayValue
 import `in`.specmatic.core.value.StringValue
 import `in`.specmatic.core.value.Value
 import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
+
+private const val RFC3339_DATETIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ssXXX"
 
 object DateTimePattern : Pattern, ScalarType {
     override fun matches(sampleData: Value?, resolver: Resolver): Result = when (sampleData) {
@@ -17,7 +21,7 @@ object DateTimePattern : Pattern, ScalarType {
         else -> Result.Failure("DateTime types can only be represented using strings")
     }
 
-    override fun generate(resolver: Resolver): StringValue = currentDateTime()
+    override fun generate(resolver: Resolver): StringValue = currentDateTimeInRFC339Format()
 
     override fun newBasedOn(row: Row, resolver: Resolver): List<DateTimePattern> = listOf(this)
 
@@ -28,7 +32,7 @@ object DateTimePattern : Pattern, ScalarType {
 
     override fun parse(value: String, resolver: Resolver): StringValue =
             attempt {
-                DateTimeFormatter.ISO_DATE_TIME.parse(value)
+                DateTimeFormatter.ofPattern(RFC3339_DATETIME_FORMAT).parse(value)
                 StringValue(value)
             }
 
@@ -50,4 +54,8 @@ object DateTimePattern : Pattern, ScalarType {
     override fun toString() = pattern
 }
 
-private fun currentDateTime() = StringValue(LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME))
+fun currentDateTimeInRFC339Format(): StringValue {
+    val dateTimeWithSystemOffset = ZonedDateTime.of(LocalDateTime.now(),  ZoneId.systemDefault())
+    val formatter = DateTimeFormatter.ofPattern(RFC3339_DATETIME_FORMAT)
+    return StringValue(dateTimeWithSystemOffset.format(formatter))
+}

--- a/core/src/main/kotlin/in/specmatic/core/pattern/RFC3339.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/RFC3339.kt
@@ -1,5 +1,8 @@
 package `in`.specmatic.core.pattern
 
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 
 private const val DATETIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ssXXX"
@@ -9,5 +12,14 @@ class RFC3339 {
     companion object{
         val dateTimeFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern(DATETIME_FORMAT)
         val dateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern(DATE_FORMAT)
+
+        fun currentDateTime(): String {
+            val dateTimeWithSystemOffset = ZonedDateTime.of(LocalDateTime.now(), ZoneId.systemDefault())
+            return dateTimeWithSystemOffset.format(dateTimeFormatter)
+        }
+
+        fun currentDate(): String = LocalDateTime.now().format(
+            dateFormatter
+        )
     }
 }

--- a/core/src/main/kotlin/in/specmatic/core/pattern/RFC3339.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/RFC3339.kt
@@ -1,0 +1,13 @@
+package `in`.specmatic.core.pattern
+
+import java.time.format.DateTimeFormatter
+
+private const val DATETIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ssXXX"
+private const val DATE_FORMAT = "yyyy-MM-dd"
+
+class RFC3339 {
+    companion object{
+        val dateTimeFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern(DATETIME_FORMAT)
+        val dateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern(DATE_FORMAT)
+    }
+}

--- a/core/src/test/kotlin/in/specmatic/core/pattern/DatePatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/DatePatternTest.kt
@@ -6,18 +6,16 @@ import `in`.specmatic.core.value.StringValue
 import `in`.specmatic.shouldMatch
 import `in`.specmatic.shouldNotMatch
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
-import java.time.format.DateTimeFormatter
 
 internal class DatePatternTest {
     @Test
     fun `should parse a valid date value`() {
-        val dateString = LocalDate.now().format(DateTimeFormatter.ISO_DATE)
+        val dateString = LocalDate.now().format(RFC3339.dateFormatter)
         val dateValue = DatePattern.parse(dateString, Resolver())
 
-        assertEquals(dateString, dateValue.string)
+        assertThat(dateString).isEqualTo(dateValue.string)
     }
 
     @Test
@@ -25,7 +23,7 @@ internal class DatePatternTest {
         val valueGenerated = DatePattern.generate(Resolver())
         val valueParsed = DatePattern.parse(valueGenerated.string, Resolver())
 
-        assertEquals(valueGenerated, valueParsed)
+        assertThat(valueGenerated).isEqualTo(valueParsed)
     }
 
     @Test
@@ -43,8 +41,8 @@ internal class DatePatternTest {
     @Test
     fun `should return itself when generating a new pattern based on a row`() {
         val datePatterns = DatePattern.newBasedOn(Row(), Resolver())
-        assertEquals(1, datePatterns.size)
-        assertEquals(DatePattern, datePatterns.first())
+        assertThat(1).isEqualTo(datePatterns.size)
+        assertThat(DatePattern).isEqualTo(datePatterns.first())
     }
 
     @Test

--- a/core/src/test/kotlin/in/specmatic/core/pattern/DatePatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/DatePatternTest.kt
@@ -48,7 +48,7 @@ internal class DatePatternTest {
     }
 
     @Test
-    fun `should match this date format`() {
+    fun `should match RFC3339 date format`() {
         val date1 = StringValue("2020-04-12")
         val date2 = StringValue("2020-04-22")
 

--- a/core/src/test/kotlin/in/specmatic/core/pattern/DatePatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/DatePatternTest.kt
@@ -15,7 +15,7 @@ internal class DatePatternTest {
         val dateString = LocalDate.now().format(RFC3339.dateFormatter)
         val dateValue = DatePattern.parse(dateString, Resolver())
 
-        assertThat(dateString).isEqualTo(dateValue.string)
+        assertThat(dateValue.string).isEqualTo(dateString)
     }
 
     @Test
@@ -23,7 +23,7 @@ internal class DatePatternTest {
         val valueGenerated = DatePattern.generate(Resolver())
         val valueParsed = DatePattern.parse(valueGenerated.string, Resolver())
 
-        assertThat(valueGenerated).isEqualTo(valueParsed)
+        assertThat(valueParsed).isEqualTo(valueGenerated)
     }
 
     @Test
@@ -41,8 +41,8 @@ internal class DatePatternTest {
     @Test
     fun `should return itself when generating a new pattern based on a row`() {
         val datePatterns = DatePattern.newBasedOn(Row(), Resolver())
-        assertThat(1).isEqualTo(datePatterns.size)
-        assertThat(DatePattern).isEqualTo(datePatterns.first())
+        assertThat(datePatterns.size).isEqualTo(1)
+        assertThat(datePatterns.first() ).isEqualTo(DatePattern)
     }
 
     @Test

--- a/core/src/test/kotlin/in/specmatic/core/pattern/DateTimePatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/DateTimePatternTest.kt
@@ -11,10 +11,10 @@ import org.junit.jupiter.api.Test
 internal class DateTimePatternTest {
     @Test
     fun `should parse a valid datetime value`() {
-        val dateString = currentDateTimeInRFC339Format().string
+        val dateString = RFC3339.currentDateTime()
         val dateValue = DateTimePattern.parse(dateString, Resolver())
 
-        assertThat(dateString).isEqualTo(dateValue.string)
+        assertThat(dateValue.string).isEqualTo(dateString)
     }
 
     @Test
@@ -22,7 +22,7 @@ internal class DateTimePatternTest {
         val valueGenerated = DateTimePattern.generate(Resolver())
         val valueParsed = DateTimePattern.parse(valueGenerated.string, Resolver())
 
-        assertThat(valueGenerated).isEqualTo(valueParsed)
+        assertThat(valueParsed).isEqualTo(valueGenerated)
     }
 
     @Test
@@ -40,8 +40,8 @@ internal class DateTimePatternTest {
     @Test
     fun `should return itself when generating a new pattern based on a row`() {
         val datePatterns = DateTimePattern.newBasedOn(Row(), Resolver())
-        assertThat(1).isEqualTo(datePatterns.size)
-        assertThat(DateTimePattern).isEqualTo(datePatterns.first())
+        assertThat(datePatterns.size).isEqualTo(1)
+        assertThat(datePatterns.first()).isEqualTo(DateTimePattern)
     }
 
     @Test

--- a/core/src/test/kotlin/in/specmatic/core/pattern/DateTimePatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/DateTimePatternTest.kt
@@ -1,13 +1,12 @@
 package `in`.specmatic.core.pattern
 
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Test
 import `in`.specmatic.core.Resolver
 import `in`.specmatic.core.Result
 import `in`.specmatic.core.value.StringValue
 import `in`.specmatic.shouldMatch
 import `in`.specmatic.shouldNotMatch
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
 
 internal class DateTimePatternTest {
     @Test
@@ -15,7 +14,7 @@ internal class DateTimePatternTest {
         val dateString = currentDateTimeInRFC339Format().string
         val dateValue = DateTimePattern.parse(dateString, Resolver())
 
-        assertEquals(dateString, dateValue.string)
+        assertThat(dateString).isEqualTo(dateValue.string)
     }
 
     @Test
@@ -23,7 +22,7 @@ internal class DateTimePatternTest {
         val valueGenerated = DateTimePattern.generate(Resolver())
         val valueParsed = DateTimePattern.parse(valueGenerated.string, Resolver())
 
-        assertEquals(valueGenerated, valueParsed)
+        assertThat(valueGenerated).isEqualTo(valueParsed)
     }
 
     @Test
@@ -41,8 +40,8 @@ internal class DateTimePatternTest {
     @Test
     fun `should return itself when generating a new pattern based on a row`() {
         val datePatterns = DateTimePattern.newBasedOn(Row(), Resolver())
-        assertEquals(1, datePatterns.size)
-        assertEquals(DateTimePattern, datePatterns.first())
+        assertThat(1).isEqualTo(datePatterns.size)
+        assertThat(DateTimePattern).isEqualTo(datePatterns.first())
     }
 
     @Test

--- a/core/src/test/kotlin/in/specmatic/core/pattern/DateTimePatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/DateTimePatternTest.kt
@@ -8,13 +8,11 @@ import `in`.specmatic.core.Result
 import `in`.specmatic.core.value.StringValue
 import `in`.specmatic.shouldMatch
 import `in`.specmatic.shouldNotMatch
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 
 internal class DateTimePatternTest {
     @Test
     fun `should parse a valid datetime value`() {
-        val dateString = LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME)
+        val dateString = currentDateTimeInRFC339Format().string
         val dateValue = DateTimePattern.parse(dateString, Resolver())
 
         assertEquals(dateString, dateValue.string)
@@ -48,9 +46,9 @@ internal class DateTimePatternTest {
     }
 
     @Test
-    fun `should match this date time format`() {
-        val date1 = StringValue("2020-04-12T00:00:00")
-        val date2 = StringValue("2020-04-22T23:59:59")
+    fun `should match RFC3339 date time format`() {
+        val date1 = StringValue("2020-04-12T00:00:00+05:30")
+        val date2 = StringValue("2014-12-03T10:05:59+08:00")
 
         assertThat(DateTimePattern.matches(date1, Resolver())).isInstanceOf(Result.Success::class.java)
         assertThat(DateTimePattern.matches(date2, Resolver())).isInstanceOf(Result.Success::class.java)

--- a/core/src/test/kotlin/in/specmatic/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/in/specmatic/stub/HttpStubTest.kt
@@ -181,7 +181,7 @@ And response-body (string)
         val mock = ScenarioStub(request, HttpResponse(200, "done"))
 
         HttpStub(gherkin, listOf(mock)).use { fake ->
-            val postResponse = RestTemplate().postForEntity<String>(fake.endPoint + "/date", "2020-04-12T00:00:00")
+            val postResponse = RestTemplate().postForEntity<String>(fake.endPoint + "/date", "2020-04-12T00:00:00+05:00")
             assertThat(postResponse.statusCode.value()).isEqualTo(200)
             assertThat(postResponse.body).isEqualTo("done")
         }
@@ -203,7 +203,7 @@ And response-body (string)
 
         HttpStub(gherkin, listOf(mock)).use { fake ->
             val postResponse =
-                RestTemplate().postForEntity<String>(fake.endPoint + "/date", """{"date": "2020-04-12T00:00:00"}""")
+                RestTemplate().postForEntity<String>(fake.endPoint + "/date", """{"date": "2020-04-12T00:00:00+05:00"}""")
             assertThat(postResponse.statusCode.value()).isEqualTo(200)
             assertThat(postResponse.body).isEqualTo("done")
         }


### PR DESCRIPTION
**What**:
Implemented support for the RFC3339 datetime format as defined in the [open api specification](https://swagger.io/docs/specification/data-models/data-types/#string)
This means that:
- The datetime strings generated by specmatic will include the  timezone offset as specified in [RFC3339](https://datatracker.ietf.org/doc/html/rfc3339) 
- All datetime strings sent to specmatic ( as part of examples, stub requests) would need to confirm to the [RFC3339](https://datatracker.ietf.org/doc/html/rfc3339) format.


**Checklist**:
- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

**Issue ID**:
Closes: #721
