### PR TITLE
Support for all syntactical equivalents of free form objects

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -838,7 +838,11 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
             is ObjectSchema -> {
                 if (schema.additionalProperties is Schema<*>) {
                     toDictionaryPattern(schema, typeStack, patternName)
-                } else if (schema.xml?.name != null) {
+                }
+                if(noPropertiesDefinedInSchema(schema)) {
+                    toFreeFormDictionaryWithStringKeysPattern()
+                }
+                else if (schema.xml?.name != null) {
                     toXMLPattern(schema, typeStack = typeStack)
                 } else {
                     toJsonObjectPattern(schema, patternName, typeStack)
@@ -1155,6 +1159,8 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
             StringPattern(), toSpecmaticPattern(valueSchema, typeStack, valueSchemaTypeName, false)
         )
     }
+
+    private fun noPropertiesDefinedInSchema(valueSchema: Schema<Any>) = valueSchema.properties == null
 
     private fun toFreeFormDictionaryWithStringKeysPattern(): DictionaryPattern {
         return DictionaryPattern(

--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -839,7 +839,7 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
                 if (schema.additionalProperties is Schema<*>) {
                     toDictionaryPattern(schema, typeStack, patternName)
                 }
-                if(noPropertiesDefinedInSchema(schema)) {
+                else if (noPropertiesDefinedInSchema(schema)) {
                     toFreeFormDictionaryWithStringKeysPattern()
                 }
                 else if (schema.xml?.name != null) {

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -22,6 +22,8 @@ import io.swagger.v3.oas.models.OpenAPI
 import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 import java.io.File
 import java.util.function.Consumer
 
@@ -3717,9 +3719,9 @@ paths:
     }
 
     @Nested
-    inner class WhenAdditionalPropertiesIsOfTypeObjectWithNoPropertiesDefined {
+    class AllSyntacticalEquivalentsOfFreeFormObjects {
         @Test
-        fun `payload with string keys and json object values should meet the specification`() {
+        fun `when schema is an object with additional properties of type object with no properties defined`() {
             val spec =
                 """
 ---
@@ -3758,7 +3760,7 @@ paths:
         }
 
         @Test
-        fun `payload with string keys and json object values should meet the specification also when additional properties is set as true`() {
+        fun `when schema is an object with additional properties of type object with with no properties defined and additional properties set as true`() {
             val spec =
                 """
 ---
@@ -3795,6 +3797,54 @@ paths:
 
             val stub: HttpStubData = feature.matchingStub(request, response)
             assertThat(stub.requestType.matches(request, Resolver())).isInstanceOf(Result.Success::class.java)
+        }
+
+        @ParameterizedTest
+        @MethodSource("freeFormObjectData")
+        fun `when schema is defined just as an object with no properties defined`(data: String) {
+            val spec =
+                """
+---
+openapi: 3.0.1
+info:
+  title: API
+  version: 1
+paths:
+  /data:
+    post:
+      summary: API
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                payload:
+                  type: object
+      responses:
+        200:
+          description: API
+""".trimIndent()
+
+            val feature = OpenApiSpecification.fromYAML(spec, "").toFeature()
+
+            val request =
+                HttpRequest("POST", "/data", body = parsedValue("""{ "payload" : { "id": 10, "data": $data } }"""))
+            val response = HttpResponse.OK
+
+            val stub: HttpStubData = feature.matchingStub(request, response)
+            assertThat(stub.requestType.matches(request, Resolver())).isInstanceOf(Result.Success::class.java)
+        }
+
+        companion object {
+            @JvmStatic
+            fun freeFormObjectData() = listOf(
+                """ "" """,
+                """ "some data" """,
+                """{ "id": 10, "name": "John"}""",
+                """{ "id": 10, "name": "John" , "address": {"street": "abc"} }"""
+            )
         }
     }
 

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -3716,6 +3716,88 @@ paths:
         }
     }
 
+    @Nested
+    inner class WhenAdditionalPropertiesIsOfTypeObjectWithNoPropertiesDefined {
+        @Test
+        fun `payload with string keys and json object values should meet the specification`() {
+            val spec =
+                """
+---
+openapi: 3.0.1
+info:
+  title: API
+  version: 1
+paths:
+  /data:
+    post:
+      summary: API
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                payload:
+                  type: object
+                  additionalProperties:
+                    type: object
+      responses:
+        200:
+          description: API
+""".trimIndent()
+
+            val feature = OpenApiSpecification.fromYAML(spec, "").toFeature()
+
+            val request =
+                HttpRequest("POST", "/data", body = parsedValue(""" { "payload" : {"data" : { "id": 10, "name": "John" } } } """))
+            val response = HttpResponse.OK
+
+            val stub: HttpStubData = feature.matchingStub(request, response)
+            assertThat(stub.requestType.matches(request, Resolver())).isInstanceOf(Result.Success::class.java)
+        }
+
+        @Test
+        fun `payload with string keys and json object values should meet the specification also when additional properties is set as true`() {
+            val spec =
+                """
+---
+openapi: 3.0.1
+info:
+  title: API
+  version: 1
+paths:
+  /data:
+    post:
+      summary: API
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                payload:
+                  type: object
+                  additionalProperties:
+                    type: object
+                    additionalProperties: true
+      responses:
+        200:
+          description: API
+""".trimIndent()
+
+            val feature = OpenApiSpecification.fromYAML(spec, "").toFeature()
+
+            val request =
+                HttpRequest("POST", "/data", body = parsedValue(""" { "payload" : {"data1" : { "id": 10, "name": "John" }, "data2" : { "id": 10, "Age": 20 } } } """))
+            val response = HttpResponse.OK
+
+            val stub: HttpStubData = feature.matchingStub(request, response)
+            assertThat(stub.requestType.matches(request, Resolver())).isInstanceOf(Result.Success::class.java)
+        }
+    }
+
     @Test
     fun `conversion supports dictionary type`() {
         val gherkin = """


### PR DESCRIPTION
**What**:
Implemented support for all syntactical equivalents of free-form objects in OpenAPI 3.x

**Checklist**:

- [x] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [x] Sonar Quality Gate

**Issue ID**:
Closes: #844
