### PR TITLE
Fixed proxy error when converging array types

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Feature.kt
@@ -703,7 +703,7 @@ data class Feature(
                 "DELETE" -> pathItem.delete
                 else -> TODO("Method \"${scenario.httpRequestPattern.method}\" in scenario ${scenario.name}")
             } ?: Operation().apply {
-                this.summary = scenario.name
+                this.summary = withoutQueryParams(scenario.name)
             }
 
             val pathParameters = scenario.httpRequestPattern.urlMatcher.pathParameters()
@@ -747,7 +747,7 @@ data class Feature(
 
             val apiResponse = ApiResponse()
 
-            apiResponse.description = scenario.name
+            apiResponse.description = withoutQueryParams(scenario.name)
 
             val openApiResponseHeaders = scenario.httpResponsePattern.headersPattern.pattern.map { (key, pattern) ->
                 val header = Header()
@@ -832,6 +832,10 @@ data class Feature(
         }
 
         return openAPI
+    }
+
+    private fun withoutQueryParams(name: String): String {
+        return name.replace(Regex("""\?.*$"""), "")
     }
 
     private fun numberTemplatized(urlMatcher: URLMatcher?): URLMatcher {

--- a/core/src/main/kotlin/in/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Feature.kt
@@ -486,16 +486,34 @@ data class Feature(
         newPayload: Pattern,
         scenarioName: String,
         updateConverged: (Pattern) -> Scenario
-    ): Scenario = if (basePayload is TabularPattern && newPayload is TabularPattern) {
-        val converged = TabularPattern(convergePatternMap(basePayload.pattern, newPayload.pattern))
+    ): Scenario {
+        return updateConverged(converge(basePayload, newPayload, scenarioName))
+    }
 
-        updateConverged(converged)
-    } else if (bothAreIdenticalDeferreds(basePayload, newPayload)) {
-        updateConverged(basePayload)
-    } else if (bothAreTheSamePrimitive(basePayload, newPayload)) {
-        updateConverged(basePayload)
-    } else {
-        throw ContractException("Payload definitions with different names found (seen in Scenario named ${scenarioName}: ${basePayload.typeAlias ?: basePayload.typeName}, ${newPayload.typeAlias ?: newPayload.typeName})")
+    fun converge(
+        basePayload: Pattern,
+        newPayload: Pattern,
+        scenarioName: String,
+    ): Pattern {
+        return if (basePayload is TabularPattern && newPayload is TabularPattern) {
+            TabularPattern(convergePatternMap(basePayload.pattern, newPayload.pattern))
+        } else if (basePayload is ListPattern && newPayload is JSONArrayPattern) {
+            val convergedNewPattern: Pattern = newPayload.pattern.fold(basePayload.pattern) { acc, newPattern ->
+                converge(acc, newPattern, scenarioName)
+            }
+
+            ListPattern(convergedNewPattern)
+        } else if (basePayload is ListPattern && newPayload is ListPattern) {
+            val convergedNewPattern: Pattern = converge(basePayload.pattern, newPayload.pattern, scenarioName)
+
+            ListPattern(convergedNewPattern)
+        } else if (bothAreIdenticalDeferreds(basePayload, newPayload)) {
+            basePayload
+        } else if (bothAreTheSamePrimitive(basePayload, newPayload)) {
+            basePayload
+        } else {
+            throw ContractException("Payload definitions could not be converged (seen in Scenario named ${scenarioName}: ${basePayload.typeAlias ?: basePayload.typeName}, ${newPayload.typeAlias ?: newPayload.typeName})")
+        }
     }
 
     private fun bothAreTheSamePrimitive(

--- a/core/src/test/kotlin/in/specmatic/core/FeatureKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/FeatureKtTest.kt
@@ -364,7 +364,7 @@ class FeatureKtTest {
         val gherkin = toGherkinFeature("New Feature", stubs)
         val openApi = parseGherkinStringToFeature(gherkin).toOpenApi()
         assertThat(Yaml.pretty(openApi).trim()).isEqualTo("""
-            openapi: 3.0.1
+              openapi: 3.0.1
               info:
                 title: New Feature
                 version: "1"

--- a/core/src/test/kotlin/in/specmatic/core/FeatureKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/FeatureKtTest.kt
@@ -313,42 +313,97 @@ class FeatureKtTest {
         val gherkin = toGherkinFeature("New Feature", stubs)
         val openApi = parseGherkinStringToFeature(gherkin).toOpenApi()
         assertThat(Yaml.pretty(openApi).trim()).isEqualTo("""
+          openapi: 3.0.1
+          info:
+            title: New Feature
+            version: "1"
+          paths:
+            /body:
+              post:
+                summary: stub0
+                parameters: []
+                requestBody:
+                  content:
+                    application/json:
+                      schema:
+                        ${"$"}ref: '#/components/schemas/Body_RequestBody'
+                responses:
+                  "200":
+                    description: stub0
+          components:
+            schemas:
+              Addresses:
+                required:
+                - street
+                properties:
+                  street:
+                    type: string
+              Body_RequestBody:
+                required:
+                - addresses
+                - id
+                properties:
+                  id:
+                    type: number
+                  addresses:
+                    type: array
+                    items:
+                      ${"$"}ref: '#/components/schemas/Addresses'
+        """.trimIndent())
+    }
+
+    @Test
+    fun `Scenario and description of a GET should not contain the query param section`() {
+        val requestBody =
+            parsedJSONObject("""{id: 10, addresses: [{"street": "Shaeffer Street"}, {"street": "Ransom Street"}]}""")
+
+        val stubs = listOf(
+            NamedStub("http://localhost?a=b", ScenarioStub(HttpRequest("GET", "/data", queryParams = mapOf("id" to "10"), body = requestBody), HttpResponse.OK))
+        )
+
+        val gherkin = toGherkinFeature("New Feature", stubs)
+        val openApi = parseGherkinStringToFeature(gherkin).toOpenApi()
+        assertThat(Yaml.pretty(openApi).trim()).isEqualTo("""
             openapi: 3.0.1
-            info:
-              title: New Feature
-              version: "1"
-            paths:
-              /body:
-                post:
-                  summary: stub0
-                  parameters: []
-                  requestBody:
-                    content:
-                      application/json:
-                        schema:
-                          ${"$"}ref: '#/components/schemas/Body_RequestBody'
-                  responses:
-                    "200":
-                      description: stub0
-            components:
-              schemas:
-                Addresses:
-                  required:
-                  - street
-                  properties:
-                    street:
-                      type: string
-                Body_RequestBody:
-                  required:
-                  - addresses
-                  - id
-                  properties:
-                    id:
-                      type: number
-                    addresses:
-                      type: array
-                      items:
-                        ${"$"}ref: '#/components/schemas/Addresses'
+              info:
+                title: New Feature
+                version: "1"
+              paths:
+                /data:
+                  get:
+                    summary: http://localhost
+                    parameters:
+                    - name: id
+                      in: query
+                      schema:
+                        type: number
+                    requestBody:
+                      content:
+                        application/json:
+                          schema:
+                            ${"$"}ref: '#/components/schemas/Data_RequestBody'
+                    responses:
+                      "200":
+                        description: http://localhost
+              components:
+                schemas:
+                  Addresses:
+                    required:
+                    - street
+                    properties:
+                      street:
+                        type: string
+                  Data_RequestBody:
+                    required:
+                    - addresses
+                    - id
+                    properties:
+                      id:
+                        type: number
+                      addresses:
+                        type: array
+                        items:
+                          ${"$"}ref: '#/components/schemas/Addresses'
         """.trimIndent())
     }
 


### PR DESCRIPTION
**What**:

The proxy could not handle arrays. For example, if two tests ran with the following in their request payloads:

test1:
{
  "id": 10,
  "addresses": [ { "name": "Jack" }, { "name": "Jill" }]
}

test2:
{
  "id": 20,
  "addresses": [ { "name": "Jane" }, { "name": "Janice" }]
}

The proxy command was unable to infer the specification from the above as it could not handle arrays under the addresses key. This PR contains the fix for this.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #123

<!-- feel free to add additional comments -->
