### PR TITLE
check-ignore gracefully handle non-zero exit

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/git/SystemGit.kt
+++ b/core/src/main/kotlin/in/specmatic/core/git/SystemGit.kt
@@ -78,10 +78,7 @@ class SystemGit(override val workingDirectory: String = ".", private val prefix:
             return execute(Configuration.gitCommand, "check-ignore", path)
         }
         catch (nonZeroExitError:NonZeroExitError) {
-            if(nonZeroExitError.exitCode == 1) {
-                return ""
-            }
-            throw nonZeroExitError
+            return ""
         }
     }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Fixes #861 . 

<!-- Why are these changes necessary? -->

**Why**: Git check-ignore should gracefully handle non-zero exit codes, as already happens for exitCode=1.

<!-- How were these changes implemented? -->

**How**: Treat any non-zero exit code as .gitignore needing to be updated (not just exitCode=1).

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [N/A] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [X] Tests
- [N/A] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #861 

<!-- feel free to add additional comments -->
