### PR TITLE
Forked processes inherit parent env vars

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/CommandHook.kt
+++ b/core/src/main/kotlin/in/specmatic/core/CommandHook.kt
@@ -17,7 +17,7 @@ class CommandHook(private val name: HookName): Hook {
 
         return command?.let {
             logger.log("  Invoking hook $name when loading contract $path")
-            ExternalCommand(it, ".", listOf("CONTRACT_FILE=$path")).executeAsSeparateProcess()
+            ExternalCommand(it, ".", mapOf("CONTRACT_FILE" to path)).executeAsSeparateProcess()
         } ?: File(path).readText()
     }
 }

--- a/core/src/main/kotlin/in/specmatic/core/git/SystemGit.kt
+++ b/core/src/main/kotlin/in/specmatic/core/git/SystemGit.kt
@@ -31,7 +31,7 @@ class SystemGit(override val workingDirectory: String = ".", private val prefix:
         return ExternalCommand(
             command,
             workingDirectory,
-            listOf("GIT_SSL_NO_VERIFY=true").toTypedArray()
+            mapOf("GIT_SSL_NO_VERIFY" to "true")
         ).executeAsSeparateProcess()
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/utilities/ExternalCommand.kt
+++ b/core/src/main/kotlin/in/specmatic/core/utilities/ExternalCommand.kt
@@ -7,20 +7,32 @@ import java.io.File
 class ExternalCommand(
     private val command: Array<String>,
     private val workingDirect: String,
-    private val environmentParameters: Array<String>
+    private val environmentParameters: Map<String, String>
 ) {
-    constructor (command: String, workingDirect: String, environmentParameters: List<String>) : this(command.split(" ").toTypedArray(), workingDirect, environmentParameters.toTypedArray())
+    constructor (
+        command: String,
+        workingDirect: String,
+        environmentParameters: Map<String, String>
+    ) : this(command.split(" ").toTypedArray(), workingDirect, environmentParameters)
+
+    constructor (
+        command: Array<String>,
+        workingDirect: String,
+    ) : this(command, workingDirect, emptyMap())
 
     fun executeAsSeparateProcess(): String {
         val commandWithParameters = command.joinToString(" ")
         return try {
-            val process =
-                Runtime.getRuntime().exec(command, environmentParameters, File(workingDirect))
-            val out = process.inputStream.bufferedReader().readText()
-            val err = process.errorStream.bufferedReader().readText()
-            process.waitFor()
+            val procBuilder = ProcessBuilder(command.asList()).directory(File(workingDirect))
+            val env = procBuilder.environment();
+            env.putAll(environmentParameters)
+            val proc = procBuilder.start()
+            val out = proc.inputStream.bufferedReader().readText()
+            val err = proc.errorStream.bufferedReader().readText()
+            val exitCode = proc.waitFor()
 
-            if (process.exitValue() != 0) throw NonZeroExitError("""Error executing $commandWithParameters: ${err.ifEmpty { out }}""", process.exitValue())
+            if (exitCode != 0)
+                throw NonZeroExitError("""Error executing $commandWithParameters: ${err.ifEmpty { out }}""", exitCode)
 
             out
         } catch (otherExceptions: Exception) {

--- a/core/src/main/kotlin/in/specmatic/stub/StubData.kt
+++ b/core/src/main/kotlin/in/specmatic/stub/StubData.kt
@@ -29,7 +29,7 @@ data class HttpStubData(
     private fun invokeExternalCommand(httpRequest: HttpRequest): HttpStubData {
         val result = executeExternalCommand(
             response.externalisedResponseCommand,
-            """SPECMATIC_REQUEST='${httpRequest.toJSON().toUnformattedStringLiteral()}'"""
+            mapOf("SPECMATIC_REQUEST" to """'${httpRequest.toJSON().toUnformattedStringLiteral()}'"""),
         )
         val responseMap = jsonStringToValueMap(result)
         val externalCommandResponse = HttpResponse.fromJSON(responseMap)
@@ -48,9 +48,9 @@ data class HttpStubData(
     }
 }
 
-fun executeExternalCommand(command: String, envParam: String): String {
-    logger.debug("Executing: $command with EnvParam: $envParam")
-    return ExternalCommand(command.split(" ").toTypedArray(), ".", arrayOf(envParam)).executeAsSeparateProcess()
+fun executeExternalCommand(command: String, envParams: Map<String, String>): String {
+    logger.debug("Executing: $command with EnvParams: $envParams")
+    return ExternalCommand(command, ".", envParams).executeAsSeparateProcess()
 }
 
 data class StubDataItems(val http: List<HttpStubData> = emptyList())

--- a/core/src/test/kotlin/in/specmatic/core/utilities/ExternalCommandTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/utilities/ExternalCommandTest.kt
@@ -37,4 +37,17 @@ internal class ExternalCommandTest {
             ExternalCommand(arrayOf("echo", "hello"), ".", emptyArray()).executeAsSeparateProcess()
         assertThat(commandOutput).isEqualTo("hello\n")
     }
+    
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    fun `should inherit parent process env`() {
+        val commandOutput =
+            ExternalCommand("env", ".", listOf("myVar1=myVal")).executeAsSeparateProcess()
+        assertThat(commandOutput).contains("myVar1=myVal")
+
+        val parentProcessEnv = System.getenv()
+        parentProcessEnv.forEach { (key, value) ->
+            assertThat(commandOutput).contains("$key=$value")
+        }
+    }
 }

--- a/core/src/test/kotlin/in/specmatic/core/utilities/ExternalCommandTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/utilities/ExternalCommandTest.kt
@@ -12,7 +12,7 @@ internal class ExternalCommandTest {
     @Test
     fun `should throw contract exception when external command does not exist`() {
         val exception = assertThrows(ContractException::class.java) {
-            ExternalCommand(arrayOf("missing_command"), ".", emptyArray()).executeAsSeparateProcess()
+            ExternalCommand(arrayOf("missing_command"), ".").executeAsSeparateProcess()
         }
         assertThat(exception.report()).isEqualTo(
             """Error running missing_command: Cannot run program "missing_command" (in directory "."): error=2, No such file or directory"""
@@ -23,7 +23,7 @@ internal class ExternalCommandTest {
     @DisabledOnOs(OS.WINDOWS)
     fun `should throw contract exception when external command returns non zero exit code`() {
         val exception = assertThrows(NonZeroExitError::class.java) {
-            ExternalCommand(arrayOf("cat", "missing_file"), ".", emptyArray()).executeAsSeparateProcess()
+            ExternalCommand(arrayOf("cat", "missing_file"), ".").executeAsSeparateProcess()
         }
         assertThat(exception.message?.trim()).isEqualTo(
             """Error executing cat missing_file: cat: missing_file: No such file or directory"""
@@ -34,7 +34,7 @@ internal class ExternalCommandTest {
     @DisabledOnOs(OS.WINDOWS)
     fun `should return command output`() {
         val commandOutput =
-            ExternalCommand(arrayOf("echo", "hello"), ".", emptyArray()).executeAsSeparateProcess()
+            ExternalCommand(arrayOf("echo", "hello"), ".").executeAsSeparateProcess()
         assertThat(commandOutput).isEqualTo("hello\n")
     }
     
@@ -42,7 +42,7 @@ internal class ExternalCommandTest {
     @DisabledOnOs(OS.WINDOWS)
     fun `should inherit parent process env`() {
         val commandOutput =
-            ExternalCommand("env", ".", listOf("myVar1=myVal")).executeAsSeparateProcess()
+            ExternalCommand("env", ".", mapOf("myVar1" to "myVal")).executeAsSeparateProcess()
         assertThat(commandOutput).contains("myVar1=myVal")
 
         val parentProcessEnv = System.getenv()


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Fixes #863 .

<!-- Why are these changes necessary? -->

**Why**: Forked process should inherit parent environment.

<!-- How were these changes implemented? -->

**How**: Replace archaic `Runtime.getRuntime().exec()` with `ProcessBuilder` which allows adding to the environment. As this requires map entries, the type of `ExternalRequest.environmentParameters` was changed from an Array<String> to Map<String, String>, and all callers updated.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [N/A] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [X] Tests
- [N/A] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #863 

<!-- feel free to add additional comments -->
