### PR TITLE
When loading example as stub, use a fake auth parameter

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/IncludedSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/IncludedSpecification.kt
@@ -6,7 +6,7 @@ import `in`.specmatic.core.ScenarioInfo
 import io.cucumber.messages.types.Step
 
 interface IncludedSpecification {
-    fun toScenarioInfos(): Pair<List<ScenarioInfo>, Map<String, Pair<HttpRequest, HttpResponse>>>
+    fun toScenarioInfos(): Pair<List<ScenarioInfo>, Map<String, List<Pair<HttpRequest, HttpResponse>>>>
     fun matches(
         specmaticScenarioInfo: ScenarioInfo,
         steps: List<Step>

--- a/core/src/main/kotlin/in/specmatic/conversions/NoSecurityScheme.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/NoSecurityScheme.kt
@@ -1,0 +1,36 @@
+package `in`.specmatic.conversions
+
+import `in`.specmatic.core.HttpRequest
+import `in`.specmatic.core.HttpRequestPattern
+import `in`.specmatic.core.Result
+import `in`.specmatic.core.pattern.Row
+
+class NoSecurityScheme : OpenAPISecurityScheme {
+    override fun matches(httpRequest: HttpRequest): Result {
+        return Result.Success()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        return other is NoSecurityScheme
+    }
+
+    override fun hashCode(): Int {
+        return javaClass.hashCode()
+    }
+
+    override fun removeParam(httpRequest: HttpRequest): HttpRequest {
+        return httpRequest
+    }
+
+    override fun addTo(httpRequest: HttpRequest): HttpRequest {
+        return httpRequest
+    }
+
+    override fun addTo(requestPattern: HttpRequestPattern, row: Row): HttpRequestPattern {
+        return requestPattern
+    }
+
+    override fun isInRow(row: Row): Boolean {
+        return false
+    }
+}

--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -40,6 +40,8 @@ private const val testDirectoryEnvironmentVariable = "SPECMATIC_TESTS_DIRECTORY"
 private const val testDirectoryProperty = "specmaticTestsDirectory"
 
 
+const val NO_SECURITY_SCHEM_IN_SPECIFICATION = "NO-SECURITY-SCHEME-IN-SPECIFICATION"
+
 class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI, private val sourceProvider:String? = null, private val sourceRepository:String? = null, private val sourceRepositoryBranch:String? = null, private val specificationPath:String? = null, private val securityConfiguration:SecurityConfiguration? = null) : IncludedSpecification,
     ApiSpecification {
     companion object {
@@ -655,7 +657,7 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
         val contractSecuritySchemes: Map<String, OpenAPISecurityScheme> =
             openApi.components?.securitySchemes?.mapValues { (schemeName, scheme) ->
                 toSecurityScheme(schemeName, scheme)
-            } ?: emptyMap()
+            } ?: mapOf(NO_SECURITY_SCHEM_IN_SPECIFICATION to NoSecurityScheme())
 
         val parameters = operation.parameters
 
@@ -754,7 +756,7 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
             globalSecurityRequirements.plus(operationSecurityRequirements).distinct()
         val operationSecuritySchemes: List<OpenAPISecurityScheme> =
             contractSecuritySchemes.filter { (name, scheme) -> name in operationSecurityRequirementsSuperSet }.values.toList()
-        return operationSecuritySchemes
+        return operationSecuritySchemes.ifEmpty { listOf(NoSecurityScheme()) }
     }
 
     private fun toSecurityScheme(schemeName: String, securityScheme: SecurityScheme): OpenAPISecurityScheme {

--- a/core/src/main/kotlin/in/specmatic/conversions/WsdlSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/WsdlSpecification.kt
@@ -96,7 +96,7 @@ class WsdlSpecification(private val wsdlFile: WSDLContent) : IncludedSpecificati
         }
     }
 
-    override fun toScenarioInfos(): Pair<List<ScenarioInfo>, Map<String, Pair<HttpRequest, HttpResponse>>> {
+    override fun toScenarioInfos(): Pair<List<ScenarioInfo>, Map<String, List<Pair<HttpRequest, HttpResponse>>>> {
         return scenarioInfos(wsdlToFeatureChildren(wsdlFile), "") to emptyMap()
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Feature.kt
@@ -98,7 +98,7 @@ data class Feature(
     val sourceRepositoryBranch:String? = null,
     val specification:String? = null,
     val serviceType:String? = null,
-    val stubsFromExamples: Map<String, Pair<HttpRequest, HttpResponse>> = emptyMap()
+    val stubsFromExamples: Map<String, List<Pair<HttpRequest, HttpResponse>>> = emptyMap()
 ) {
     fun lookupResponse(httpRequest: HttpRequest): HttpResponse {
         try {

--- a/core/src/main/kotlin/in/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpRequestPattern.kt
@@ -1,5 +1,6 @@
 package `in`.specmatic.core
 
+import `in`.specmatic.conversions.NoSecurityScheme
 import `in`.specmatic.conversions.OpenAPISecurityScheme
 import `in`.specmatic.core.Result.Failure
 import `in`.specmatic.core.Result.Success
@@ -23,7 +24,7 @@ data class HttpRequestPattern(
     val body: Pattern = EmptyStringPattern,
     val formFieldsPattern: Map<String, Pattern> = emptyMap(),
     val multiPartFormDataPattern: List<MultiPartFormDataPattern> = emptyList(),
-    val securitySchemes: List<OpenAPISecurityScheme> = emptyList()
+    val securitySchemes: List<OpenAPISecurityScheme> = listOf(NoSecurityScheme())
 ) {
     fun matches(incomingHttpRequest: HttpRequest, resolver: Resolver, headersResolver: Resolver? = null, requestBodyReqex: Regex? = null): Result {
         val result = incomingHttpRequest to resolver to
@@ -56,9 +57,6 @@ data class HttpRequestPattern(
 
     private fun matchSecurityScheme(parameters: Triple<HttpRequest, Resolver, List<Failure>>): MatchingResult<Triple<HttpRequest, Resolver, List<Failure>>> {
         val (httpRequest, resolver, failures) = parameters
-
-        if(securitySchemes.isEmpty())
-            return MatchSuccess(Triple(httpRequest, resolver, failures))
 
         val matchFailures = mutableListOf<Failure>()
         val matchingSecurityScheme: OpenAPISecurityScheme = securitySchemes.firstOrNull {
@@ -475,17 +473,13 @@ data class HttpRequestPattern(
                                     multiPartFormDataPattern = newFormDataPartList
                                 )
 
-                                if(securitySchemes.isEmpty()) {
-                                    listOf(newRequestPattern)
-                                } else {
-                                    val schemeInRow = securitySchemes.find { it.isInRow(row) }
+                                val schemeInRow = securitySchemes.find { it.isInRow(row) }
 
-                                    if(schemeInRow != null) {
-                                        listOf(schemeInRow.addTo(newRequestPattern, row))
-                                    } else {
-                                        securitySchemes.map {
-                                            newRequestPattern.copy(securitySchemes = listOf(it))
-                                        }
+                                if(schemeInRow != null) {
+                                    listOf(schemeInRow.addTo(newRequestPattern, row))
+                                } else {
+                                    securitySchemes.map {
+                                        newRequestPattern.copy(securitySchemes = listOf(it))
                                     }
                                 }
                             }
@@ -527,11 +521,8 @@ data class HttpRequestPattern(
                                     multiPartFormDataPattern = newFormDataPartList
                                 )
 
-                                when(securitySchemes) {
-                                    emptyList<OpenAPISecurityScheme>() -> listOf(newRequestPattern)
-                                    else -> securitySchemes.map {
-                                        newRequestPattern.copy(securitySchemes = listOf(it))
-                                    }
+                                securitySchemes.map {
+                                    newRequestPattern.copy(securitySchemes = listOf(it))
                                 }
                             }
                         }
@@ -629,11 +620,8 @@ data class HttpRequestPattern(
             }
             // If security schemes are present, for now we'll just take the first scheme and assign it to each negative request pattern.
             // Ideally we should generate negative patterns from the security schemes and use them.
-            when (securitySchemes.isEmpty()) {
-                true -> negativeRequestPatterns
-                false -> negativeRequestPatterns.map {
-                    it.copy(securitySchemes = listOf(securitySchemes.first()))
-                }
+            negativeRequestPatterns.map {
+                it.copy(securitySchemes = listOf(securitySchemes.first()))
             }
         }
     }

--- a/core/src/main/kotlin/in/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/in/specmatic/stub/HttpStub.kt
@@ -77,28 +77,30 @@ class HttpStub(
     private fun staticHttpStubData(_httpStubs: List<HttpStubData>): MutableList<HttpStubData> {
         val staticStubs = _httpStubs.filter { it.stubToken == null }.toMutableList()
         val stubsFromSpecificationExamples: List<HttpStubData> = features.map { feature ->
-            feature.stubsFromExamples.entries.mapNotNull {
-                val (request, response) = it.value
-                try {
-                    val matchResult: HttpStubData =
-                        feature.matchingStub(request, response, ContractAndStubMismatchMessages)
-                    if (matchResult.matchFailure) {
-                        logger.log(matchResult.response.body.toStringLiteral())
-                        null
-                    } else {
-                        matchResult
-                    }
-                } catch(e: Throwable) {
-                    when(e) {
-                        is ContractException, is NoMatchingScenario -> {
-                            logger.log(e)
+            feature.stubsFromExamples.entries.map {
+                it.value.mapNotNull { (request, response) ->
+                    try {
+                        val matchResult: HttpStubData =
+                            feature.matchingStub(request, response, ContractAndStubMismatchMessages)
+                        if (matchResult.matchFailure) {
+                            logger.log(matchResult.response.body.toStringLiteral())
                             null
+                        } else {
+                            matchResult
                         }
-                        else -> throw e
+                    } catch (e: Throwable) {
+                        when (e) {
+                            is ContractException, is NoMatchingScenario -> {
+                                logger.log(e)
+                                null
+                            }
+
+                            else -> throw e
+                        }
                     }
                 }
             }
-        }.flatten()
+        }.flatten().flatten()
 
         return staticStubs.plus(stubsFromSpecificationExamples).toMutableList()
     }

--- a/core/src/test/kotlin/in/specmatic/conversions/ExamplesAsStub.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/ExamplesAsStub.kt
@@ -1,0 +1,74 @@
+package `in`.specmatic.conversions
+
+import `in`.specmatic.core.HttpRequest
+import `in`.specmatic.core.pattern.parsedJSONObject
+import `in`.specmatic.stub.HttpStub
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ExamplesAsStub {
+    @Test
+    fun `any value should match the given security scheme`() {
+        val feature = OpenApiSpecification.fromYAML("""
+openapi: 3.0.0
+info:
+  title: Sample API
+  description: Optional multiline or single-line description in [CommonMark](http://commonmark.org/help/) or HTML.
+  version: 0.1.9
+servers:
+  - url: http://api.example.com/v1
+    description: Optional server description, e.g. Main (production) server
+  - url: http://staging-api.example.com
+    description: Optional server description, e.g. Internal staging server for testing
+paths:
+  /hello:
+    post:
+      summary: hello world
+      description: Optional extended description in CommonMark or HTML.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - message
+              properties:
+                message:
+                  type: string
+            examples:
+              SUCCESS:
+                value:
+                  message: Hello World!
+      responses:
+        '200':
+          description: Says hello
+          content:
+            application/json:
+              schema:
+                type: string
+              examples:
+                SUCCESS:
+                  value:
+                    Hello to you!
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+
+security:
+  - BearerAuth: []
+         """.trimIndent(), "").toFeature()
+
+        HttpStub(feature).use {
+            val response = it.client.execute(HttpRequest(
+                "POST",
+                "/hello",
+                mapOf("Authorization" to "Bearer 1234"),
+                parsedJSONObject("""{"message": "Hello World!"}""")
+            ))
+
+            assertThat(response.body.toStringLiteral()).isEqualTo("Hello to you!")
+        }
+    }
+}


### PR DESCRIPTION
**What**:

When loading an expectation from an example in the specification, if a security scheme was provided, the expectation would be rejected with an error saying the respective header or query parameter was missing.

**Why**:

Security scheme examples can't be provided in the specification, so examples of APIs with security schemes can't become valid expectations without a little help from Specmatic.

**How**:

Specmatic adds a dummy security header / query parameter in the expectation when it comes from an example, which lets the expectation match requests that have the security parameter. The value is not validated in any case (except for bearer auth and only to ensure that it starts with bearer).


**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #123

<!-- feel free to add additional comments -->
