### PR TITLE
Updating JUnit build to include Core as an API dependency instead of implementation

### DIFF
--- a/junit5-support/build.gradle
+++ b/junit5-support/build.gradle
@@ -15,7 +15,7 @@ def ktor_version = "2.3.7"
 def junit_version = "5.10.1"
 
 dependencies {
-    implementation project(':core')
+    api project(':core')
     implementation "org.junit.jupiter:junit-jupiter-engine:${junit_version}"
     implementation 'org.jetbrains.kotlin:kotlin-maven-serialization'
     implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2'


### PR DESCRIPTION
This will also expose the core APIs to people who include specmatic-junit-support and thereby can access Stub interface etc. without having to additionally add specmatic-core jar dependency

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [ ] Tests
- [ ] Sonar Quality Gate

