### PR TITLE
Refactor the construction of a nullable schema

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -965,13 +965,13 @@ class OpenApiSpecification(private val openApiFile: String, val openApi: OpenAPI
             }
         }
 
-        return when (schema.nullable != true) {
-            true -> pattern
-            else -> when (pattern) {
+        return when (schema.nullable) {
+            true -> when (pattern) {
                 NullPattern -> pattern
                 is AnyPattern -> pattern.copy(example = schema.example?.toString())
                 else -> AnyPattern(listOf(NullPattern, pattern), example = schema.example?.toString())
             }
+            else -> pattern
         }
     }
 


### PR DESCRIPTION

**What**:

This PR inverts the condition that constructs a nullable schema in toSpecmaticPattern, which makes it a more readable.

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate
