### PR TITLE
Fix fragile test checking for env var inheritance by excluding CODEQL env variables

### DIFF
--- a/core/src/test/kotlin/in/specmatic/core/utilities/ExternalCommandTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/utilities/ExternalCommandTest.kt
@@ -53,7 +53,15 @@ internal class ExternalCommandTest {
 
         val parentProcessEnv = System.getenv()
         parentProcessEnv.forEach { (key, value) ->
-            assertThat(commandOutput).contains("$key=$value")
+            if(valueMayChangeInChildProcess(key)) {
+                assertThat(commandOutput).contains("$key=")
+            } else {
+                assertThat(commandOutput).contains("$key=$value")
+            }
         }
+    }
+
+    private fun valueMayChangeInChildProcess(key: String): Boolean {
+        return key.startsWith("CODEQL_")
     }
 }


### PR DESCRIPTION
**What**:

At least one CODEQL environment variable sometimes changes it's value in the child process. So for CODEQL environment variables we will check for the existence of the variable name only.

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

