### PR TITLE
Specification stats

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -40,7 +40,7 @@ const val NO_SECURITY_SCHEMA_IN_SPECIFICATION = "NO-SECURITY-SCHEME-IN-SPECIFICA
 
 class OpenApiSpecification(private val openApiFilePath: String, private val parsedOpenApi: OpenAPI, private val sourceProvider:String? = null, private val sourceRepository:String? = null, private val sourceRepositoryBranch:String? = null, private val specificationPath:String? = null, private val securityConfiguration:SecurityConfiguration? = null) : IncludedSpecification, ApiSpecification {
     init {
-        logger.log(OpenApiSpecificationInfo(openApiFilePath, parsedOpenApi).toString())
+        logger.log(openApiSpecificationInfo(openApiFilePath, parsedOpenApi))
     }
 
     companion object {

--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -38,9 +38,11 @@ private const val testDirectoryProperty = "specmaticTestsDirectory"
 
 const val NO_SECURITY_SCHEMA_IN_SPECIFICATION = "NO-SECURITY-SCHEME-IN-SPECIFICATION"
 
-class OpenApiSpecification(private val openApiFilePath: String, private val parsedOpenApi: OpenAPI, private val sourceProvider:String? = null, private val sourceRepository:String? = null, private val sourceRepositoryBranch:String? = null, private val specificationPath:String? = null, private val securityConfiguration:SecurityConfiguration? = null) : IncludedSpecification,
+class OpenApiSpecification(private val openApiFilePath: String, private val parsedOpenApi: OpenAPI, private val sourceProvider:String? = null, private val sourceRepository:String? = null, private val sourceRepositoryBranch:String? = null, private val specificationPath:String? = null, private val securityConfiguration:SecurityConfiguration? = null) : IncludedSpecification, ApiSpecification {
+    init {
+        logger.log(OpenApiSpecificationInfo(openApiFilePath, parsedOpenApi).toString())
+    }
 
-    ApiSpecification {
     companion object {
         fun fromFile(openApiFilePath: String, relativeTo: String = ""): OpenApiSpecification {
             val openApiFile = File(openApiFilePath).let { openApiFile ->

--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecificationInfo.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecificationInfo.kt
@@ -6,40 +6,19 @@ class OpenApiSpecificationInfo(private val openApiFilePath: String, private val 
     override fun toString(): String {
         val info = StringBuilder()
 
-        info.append("========================================\n")
-        info.append("Loaded OpenAPI File: $openApiFilePath\n")
-        info.append("OpenAPI Version: ${parsedOpenApi.openapi}\n")
-
-        parsedOpenApi.info?.let {
-            info.append("API Info:\n")
-            info.append("  Title: ${it.title}\n")
-            info.append("  Version: ${it.version}\n")
-            info.append("  Description: ${it.description}\n")
-        }
+        info.append("API Specification Summary: $openApiFilePath\n")
+        info.append("  OpenAPI Version: ${parsedOpenApi.openapi}\n")
 
         parsedOpenApi.paths?.let {
-            info.append("No of API Paths: ${it.size}\n")
-            it.map { (_, pathItem) ->
-                pathItem.readOperationsMap().map { (_, operation) ->
-                    operation.operationId
-                }
-            }.flatten().toList().let { info.append("No of API Operations: ${it.size}\n") }
+            val operationsCount = it.map { (_, pathItem) ->
+                pathItem.readOperationsMap().map { (_, operation) -> operation.operationId }
+            }.flatten().toList().size
+            info.append("  API Paths: ${it.size}, API Operations: $operationsCount\n")
         }
 
         parsedOpenApi.components?.let {
-            info.append("API Components:\n")
-            info.append("  Schemas: ${it.schemas?.keys}\n")
-            info.append("  Responses: ${it.responses?.keys}\n")
-            info.append("  Parameters: ${it.parameters?.keys}\n")
-            info.append("  Examples: ${it.examples?.keys}\n")
-            info.append("  Request Bodies: ${it.requestBodies?.keys}\n")
-            info.append("  Headers: ${it.headers?.keys}\n")
-            info.append("  Security Schemes: ${it.securitySchemes?.keys}\n")
-            info.append("  Links: ${it.links?.keys}\n")
-            info.append("  Callbacks: ${it.callbacks?.keys}\n")
+            info.append("  Schema components: ${it.schemas?.size}, Security Schemes: ${it.securitySchemes?.keys}\n")
         }
-
-        info.append("========================================\n")
 
         return info.toString()
     }

--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecificationInfo.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecificationInfo.kt
@@ -24,17 +24,19 @@ class OpenApiSpecificationInfo(private val openApiFilePath: String, private val 
             }
         }.flatten().toList().let { info.append("No of API Operations: ${it.size}\n") }
 
-        val components = parsedOpenApi.components
-        info.append("API Components:\n")
-        info.append("  Schemas: ${components.schemas?.keys}\n")
-        info.append("  Responses: ${components.responses?.keys}\n")
-        info.append("  Parameters: ${components.parameters?.keys}\n")
-        info.append("  Examples: ${components.examples?.keys}\n")
-        info.append("  Request Bodies: ${components.requestBodies?.keys}\n")
-        info.append("  Headers: ${components.headers?.keys}\n")
-        info.append("  Security Schemes: ${components.securitySchemes?.keys}\n")
-        info.append("  Links: ${components.links?.keys}\n")
-        info.append("  Callbacks: ${components.callbacks?.keys}\n")
+        val components = parsedOpenApi.components?.let {
+            info.append("API Components:\n")
+            info.append("  Schemas: ${it.schemas?.keys}\n")
+            info.append("  Responses: ${it.responses?.keys}\n")
+            info.append("  Parameters: ${it.parameters?.keys}\n")
+            info.append("  Examples: ${it.examples?.keys}\n")
+            info.append("  Request Bodies: ${it.requestBodies?.keys}\n")
+            info.append("  Headers: ${it.headers?.keys}\n")
+            info.append("  Security Schemes: ${it.securitySchemes?.keys}\n")
+            info.append("  Links: ${it.links?.keys}\n")
+            info.append("  Callbacks: ${it.callbacks?.keys}\n")
+        }
+
         info.append("========================================\n")
 
         return info.toString()

--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecificationInfo.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecificationInfo.kt
@@ -2,24 +2,22 @@ package `in`.specmatic.conversions
 
 import io.swagger.v3.oas.models.OpenAPI
 
-class OpenApiSpecificationInfo(private val openApiFilePath: String, private val parsedOpenApi: OpenAPI) {
-    override fun toString(): String {
-        val info = StringBuilder()
+fun openApiSpecificationInfo(openApiFilePath: String, parsedOpenApi: OpenAPI): String {
+    val info = StringBuilder()
 
-        info.append("API Specification Summary: $openApiFilePath\n")
-        info.append("  OpenAPI Version: ${parsedOpenApi.openapi}\n")
+    info.append("API Specification Summary: $openApiFilePath\n")
+    info.append("  OpenAPI Version: ${parsedOpenApi.openapi}\n")
 
-        parsedOpenApi.paths?.let {
-            val operationsCount = it.map { (_, pathItem) ->
-                pathItem.readOperationsMap().map { (_, operation) -> operation.operationId }
-            }.flatten().toList().size
-            info.append("  API Paths: ${it.size}, API Operations: $operationsCount\n")
-        }
-
-        parsedOpenApi.components?.let {
-            info.append("  Schema components: ${it.schemas?.size}, Security Schemes: ${it.securitySchemes?.keys}\n")
-        }
-
-        return info.toString()
+    parsedOpenApi.paths?.let {
+        val operationsCount = it.map { (_, pathItem) ->
+            pathItem.readOperationsMap().map { (_, operation) -> operation.operationId }
+        }.flatten().toList().size
+        info.append("  API Paths: ${it.size}, API Operations: $operationsCount\n")
     }
+
+    parsedOpenApi.components?.let {
+        info.append("  Schema components: ${it.schemas?.size}, Security Schemes: ${it.securitySchemes?.values?.map { securityScheme -> securityScheme.type }}\n")
+    }
+
+    return info.toString()
 }

--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecificationInfo.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecificationInfo.kt
@@ -1,0 +1,42 @@
+package `in`.specmatic.conversions
+
+import io.swagger.v3.oas.models.OpenAPI
+
+class OpenApiSpecificationInfo(private val openApiFilePath: String, private val parsedOpenApi: OpenAPI) {
+    override fun toString(): String {
+        val info = StringBuilder()
+
+        info.append("========================================\n")
+        info.append("Loaded OpenAPI File: $openApiFilePath\n")
+        info.append("OpenAPI Version: ${parsedOpenApi.openapi}\n")
+
+        val apiInfo = parsedOpenApi.info
+        info.append("API Info:\n")
+        info.append("  Title: ${apiInfo.title}\n")
+        info.append("  Version: ${apiInfo.version}\n")
+        info.append("  Description: ${apiInfo.description}\n")
+
+        val paths = parsedOpenApi.paths
+        info.append("No of API Paths: ${paths.size}\n")
+        paths.map { (_, pathItem) ->
+            pathItem.readOperationsMap().map { (_, operation) ->
+                operation.operationId
+            }
+        }.flatten().toList().let { info.append("No of API Operations: ${it.size}\n") }
+
+        val components = parsedOpenApi.components
+        info.append("API Components:\n")
+        info.append("  Schemas: ${components.schemas?.keys}\n")
+        info.append("  Responses: ${components.responses?.keys}\n")
+        info.append("  Parameters: ${components.parameters?.keys}\n")
+        info.append("  Examples: ${components.examples?.keys}\n")
+        info.append("  Request Bodies: ${components.requestBodies?.keys}\n")
+        info.append("  Headers: ${components.headers?.keys}\n")
+        info.append("  Security Schemes: ${components.securitySchemes?.keys}\n")
+        info.append("  Links: ${components.links?.keys}\n")
+        info.append("  Callbacks: ${components.callbacks?.keys}\n")
+        info.append("========================================\n")
+
+        return info.toString()
+    }
+}

--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecificationInfo.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecificationInfo.kt
@@ -10,21 +10,23 @@ class OpenApiSpecificationInfo(private val openApiFilePath: String, private val 
         info.append("Loaded OpenAPI File: $openApiFilePath\n")
         info.append("OpenAPI Version: ${parsedOpenApi.openapi}\n")
 
-        val apiInfo = parsedOpenApi.info
-        info.append("API Info:\n")
-        info.append("  Title: ${apiInfo.title}\n")
-        info.append("  Version: ${apiInfo.version}\n")
-        info.append("  Description: ${apiInfo.description}\n")
+        parsedOpenApi.info?.let {
+            info.append("API Info:\n")
+            info.append("  Title: ${it.title}\n")
+            info.append("  Version: ${it.version}\n")
+            info.append("  Description: ${it.description}\n")
+        }
 
-        val paths = parsedOpenApi.paths
-        info.append("No of API Paths: ${paths.size}\n")
-        paths.map { (_, pathItem) ->
-            pathItem.readOperationsMap().map { (_, operation) ->
-                operation.operationId
-            }
-        }.flatten().toList().let { info.append("No of API Operations: ${it.size}\n") }
+        parsedOpenApi.paths?.let {
+            info.append("No of API Paths: ${it.size}\n")
+            it.map { (_, pathItem) ->
+                pathItem.readOperationsMap().map { (_, operation) ->
+                    operation.operationId
+                }
+            }.flatten().toList().let { info.append("No of API Operations: ${it.size}\n") }
+        }
 
-        val components = parsedOpenApi.components?.let {
+        parsedOpenApi.components?.let {
             info.append("API Components:\n")
             info.append("  Schemas: ${it.schemas?.keys}\n")
             info.append("  Responses: ${it.responses?.keys}\n")

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationInfoTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationInfoTest.kt
@@ -33,26 +33,10 @@ class OpenApiSpecificationInfoTest {
 
         // Assert
         val expected = """
-           ========================================
-           Loaded OpenAPI File: testFilePath
-           OpenAPI Version: 3.0.0
-           API Info:
-             Title: Test API
-             Version: 1.0.0
-             Description: This is a test API
-           No of API Paths: 1
-           No of API Operations: 1
-           API Components:
-             Schemas: [testSchema]
-             Responses: null
-             Parameters: null
-             Examples: null
-             Request Bodies: null
-             Headers: null
-             Security Schemes: null
-             Links: null
-             Callbacks: null
-           ========================================
+          API Specification Summary: testFilePath
+            OpenAPI Version: 3.0.0
+            API Paths: 1, API Operations: 1
+            Schema components: 1, Security Schemes: null
 
         """.trimIndent()
 

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationInfoTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationInfoTest.kt
@@ -1,0 +1,61 @@
+package `in`.specmatic.conversions
+
+import io.swagger.v3.oas.models.*
+import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.media.Schema
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class OpenApiSpecificationInfoTest {
+    @Test
+    fun `should return correct string representation for a specification with a single path and operation`() {
+        // Arrange
+        val openApi = OpenAPI().apply {
+            openapi = "3.0.0"
+            info = Info().apply {
+                title = "Test API"
+                version = "1.0.0"
+                description = "This is a test API"
+            }
+            paths = Paths().also { paths ->
+                paths.addPathItem("/test", PathItem().also { pathItem ->
+                    pathItem.get = Operation().also { operation -> operation.operationId = "testOperation" }
+                })
+            }
+            components = Components().also {
+                it.schemas = mutableMapOf("testSchema" to Schema<Any>())
+            }
+        }
+        val openApiSpecificationInfo = OpenApiSpecificationInfo("testFilePath", openApi)
+
+        // Act
+        val actual = openApiSpecificationInfo.toString()
+
+        // Assert
+        val expected = """
+           ========================================
+           Loaded OpenAPI File: testFilePath
+           OpenAPI Version: 3.0.0
+           API Info:
+             Title: Test API
+             Version: 1.0.0
+             Description: This is a test API
+           No of API Paths: 1
+           No of API Operations: 1
+           API Components:
+             Schemas: [testSchema]
+             Responses: null
+             Parameters: null
+             Examples: null
+             Request Bodies: null
+             Headers: null
+             Security Schemes: null
+             Links: null
+             Callbacks: null
+           ========================================
+
+        """.trimIndent()
+
+        assertThat(actual).isEqualTo(expected)
+    }
+}

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationInfoTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationInfoTest.kt
@@ -3,13 +3,13 @@ package `in`.specmatic.conversions
 import io.swagger.v3.oas.models.*
 import io.swagger.v3.oas.models.info.Info
 import io.swagger.v3.oas.models.media.Schema
+import io.swagger.v3.oas.models.security.SecurityScheme
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class OpenApiSpecificationInfoTest {
     @Test
-    fun `should return correct string representation for a specification with a single path and operation`() {
-        // Arrange
+    fun `should generate summary with a single path and operation`() {
         val openApi = OpenAPI().apply {
             openapi = "3.0.0"
             info = Info().apply {
@@ -26,12 +26,7 @@ class OpenApiSpecificationInfoTest {
                 it.schemas = mutableMapOf("testSchema" to Schema<Any>())
             }
         }
-        val openApiSpecificationInfo = OpenApiSpecificationInfo("testFilePath", openApi)
 
-        // Act
-        val actual = openApiSpecificationInfo.toString()
-
-        // Assert
         val expected = """
           API Specification Summary: testFilePath
             OpenAPI Version: 3.0.0
@@ -40,6 +35,65 @@ class OpenApiSpecificationInfoTest {
 
         """.trimIndent()
 
-        assertThat(actual).isEqualTo(expected)
+        assertThat(openApiSpecificationInfo("testFilePath", openApi)).isEqualTo(expected)
+    }
+
+    @Test
+    fun `should generate summary with multiple paths and operations`() {
+        val openApi = OpenAPI().apply {
+            openapi = "3.0.0"
+            info = Info().apply {
+                title = "Test API"
+                version = "1.0.0"
+                description = "This is a test API"
+            }
+            paths = Paths().also { paths ->
+                paths.addPathItem("/test1", PathItem().also { pathItem ->
+                    pathItem.get = Operation().also { operation -> operation.operationId = "testOperation1" }
+                })
+                paths.addPathItem("/test2", PathItem().also { pathItem ->
+                    pathItem.post = Operation().also { operation -> operation.operationId = "testOperation2" }
+                })
+            }
+            components = Components().also {
+                it.schemas = mutableMapOf("testSchema1" to Schema<Any>(), "testSchema2" to Schema<Any>())
+                it.securitySchemes =
+                    mutableMapOf("testSecurityScheme" to SecurityScheme().also { it.type = SecurityScheme.Type.APIKEY })
+            }
+        }
+
+        val expected = """
+          API Specification Summary: testFilePath
+            OpenAPI Version: 3.0.0
+            API Paths: 2, API Operations: 2
+            Schema components: 2, Security Schemes: [apiKey]
+
+        """.trimIndent()
+
+        assertThat(openApiSpecificationInfo("testFilePath", openApi)).isEqualTo(expected)
+    }
+
+    @Test
+    fun `should generate summary with no paths and operations`() {
+        val openApi = OpenAPI().apply {
+            openapi = "3.0.0"
+            info = Info().apply {
+                title = "Test API"
+                version = "1.0.0"
+                description = "This is a test API"
+            }
+            paths = Paths()
+            components = Components()
+        }
+
+        val expected = """
+          API Specification Summary: testFilePath
+            OpenAPI Version: 3.0.0
+            API Paths: 0, API Operations: 0
+            Schema components: null, Security Schemes: null
+
+        """.trimIndent()
+
+        assertThat(openApiSpecificationInfo("testFilePath", openApi)).isEqualTo(expected)
     }
 }


### PR DESCRIPTION
**What**:

Print a summary of API specifications that have been parsed.

**Why**:

To provide visibility into the fact that Specmatic has read the Specification successfully and also to log critical stats that are helpful while logging bugs and issues.

**How**:

OpenAPISpecification on init prints the summary for all scenarios where an OpenAPI spec is parsed including
- [x] Stub
- [x] Test
- [x] Backward compatibility
Example:

```
API Specification Summary: testFilePath
  OpenAPI Version: 3.0.0
  API Paths: 2, API Operations: 2
  Schema components: 2, Security Schemes: [apiKey]
```

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [x] Sonar Quality Gate

