### PR TITLE
Log NOT SENT when Content-Type is missing in the request

### DIFF
--- a/core/src/main/kotlin/in/specmatic/test/HttpClient.kt
+++ b/core/src/main/kotlin/in/specmatic/test/HttpClient.kt
@@ -141,7 +141,7 @@ private fun ktorHttpRequestToHttpRequestForLogging(
         }
 
     val requestHeaders: Map<String, String> = request.headers.toMap().mapValues { it.value[0] }.plus(
-        CONTENT_TYPE to request.content.contentType.toString()
+        CONTENT_TYPE to (request.content.contentType?.toString() ?: "NOT SENT")
     )
 
     return HttpRequest(


### PR DESCRIPTION
**What**:

When the Content-Type header in the request is not sent, log it as:

Content-Type: NOT SENT

...rather than logging nothing or logging a stringizeded null value

**Why**:

We need to know explicitly that the header was not sent, for debugging purposes.

**How**:

Explained in the *What* section.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

