### PR TITLE
Issue 792

### DIFF
--- a/application/src/main/kotlin/application/CompatibleCommand.kt
+++ b/application/src/main/kotlin/application/CompatibleCommand.kt
@@ -360,8 +360,8 @@ internal data class CompatibilityOutput(val exitCode: Int, val message: String)
 internal fun compatibilityMessage(results: Outcome<Results>): CompatibilityOutput {
     return when {
         results.result == null -> CompatibilityOutput(1, results.errorMessage)
-        results.result.success() -> CompatibilityOutput(0, results.errorMessage.ifEmpty { "The newer contract is backward compatible" })
-        else -> CompatibilityOutput(1, compatibilityReport(results.result, "The newer contract is NOT backward compatible"))
+        results.result.hasFailures() -> CompatibilityOutput(1, compatibilityReport(results.result, "The newer contract is NOT backward compatible"))
+        else -> CompatibilityOutput(0, results.errorMessage.ifEmpty { "The newer contract is backward compatible" })
     }
 }
 

--- a/core/src/main/kotlin/in/specmatic/core/Results.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Results.kt
@@ -6,7 +6,7 @@ data class Results(val results: List<Result> = emptyList()) {
     fun hasResults(): Boolean = results.isNotEmpty()
 
     fun hasFailures(): Boolean = results.any { it is Result.Failure }
-    fun success(): Boolean = !hasFailures()
+    fun success(): Boolean = successCount > 0 && failureCount == 0
 
     fun withoutFluff(fluffLevel: Int): Results = copy(results = results.filterNot { it.isFluffy(fluffLevel) })
 

--- a/core/src/main/kotlin/in/specmatic/core/Results.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Results.kt
@@ -6,7 +6,7 @@ data class Results(val results: List<Result> = emptyList()) {
     fun hasResults(): Boolean = results.isNotEmpty()
 
     fun hasFailures(): Boolean = results.any { it is Result.Failure }
-    fun success(): Boolean = successCount > 0 && failureCount == 0
+    fun success(): Boolean = if(hasResults()) successCount > 0 && failureCount == 0 else true
 
     fun withoutFluff(fluffLevel: Int): Results = copy(results = results.filterNot { it.isFluffy(fluffLevel) })
 

--- a/core/src/test/kotlin/in/specmatic/core/TestBackwardCompatibilityKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/TestBackwardCompatibilityKtTest.kt
@@ -884,7 +884,7 @@ Then status 200
 
         assertThat(results.successCount).isZero()
         assertThat(results.failureCount).isZero()
-        assertThat(results.success()).isTrue()
+        assertThat(results.hasFailures()).isFalse()
     }
 
     @Test


### PR DESCRIPTION
What: Here i've Fix the success() method in the Results class. I have piggy-backed on the PR created by Tejas: https://github.com/znsio/specmatic/pull/800

Why: The success() method should return true if there are one or more successes and no failures. The current implementation does not check if there are no failures. This fix is necessary to correctly determine whether there are any failures.

How: I have updated the success() method in the Results class to check if there are successes (Result.Success) and no failures (Result.Failure). The method now returns true only when there are one or more successes and no failures. However, the result is success if there are 0 results.

Checklist:

 Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
 Tests
 Sonar Quality Gate
Issue ID:
Closes: https://github.com/znsio/specmatic/issues/792
