### PR TITLE
Api Coverage Report improvements

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -30,7 +30,7 @@ import io.swagger.v3.parser.core.models.SwaggerParseResult
 import java.io.File
 
 private const val BEARER_SECURITY_SCHEME = "bearer"
-private const val SERVICE_TYPE_HTTP = "HTTP"
+const val SERVICE_TYPE_HTTP = "HTTP"
 
 private const val testDirectoryEnvironmentVariable = "SPECMATIC_TESTS_DIRECTORY"
 private const val testDirectoryProperty = "specmaticTestsDirectory"

--- a/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
@@ -81,6 +81,8 @@ open class SpecmaticJUnitSupport {
 
                 logger.debug(response.toLogString())
 
+                openApiCoverageReportInput.setEndpointsAPIFlag(true)
+
                 val endpointData = response.body as JSONObjectValue
                 val apis: List<API> = endpointData.getJSONObject("contexts").entries.flatMap {
                     val mappings: JSONArrayValue =

--- a/junit5-support/src/main/kotlin/in/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
@@ -1,5 +1,6 @@
 package `in`.specmatic.test.reports.coverage
 
+import `in`.specmatic.conversions.SERVICE_TYPE_HTTP
 import `in`.specmatic.conversions.convertPathParameterStyle
 import `in`.specmatic.core.TestResult
 import `in`.specmatic.core.pattern.ContractException
@@ -20,6 +21,7 @@ class OpenApiCoverageReportInput(
     private val applicationAPIs: MutableList<API> = mutableListOf(),
     private val excludedAPIs: MutableList<String> = mutableListOf(),
     private val allEndpoints: MutableList<Endpoint> = mutableListOf(),
+    private var endpointsAPISet: Boolean = false
 ) {
     fun addTestReportRecords(testResultRecord: TestResultRecord) {
         testResultRecords.add(testResultRecord)
@@ -35,6 +37,10 @@ class OpenApiCoverageReportInput(
 
     fun addEndpoints(endpoints: List<Endpoint>) {
         allEndpoints.addAll(endpoints)
+    }
+
+    fun setEndpointsAPIFlag(isSet: Boolean) {
+        endpointsAPISet = isSet
     }
 
     fun generate(): OpenAPICoverageConsoleReport {
@@ -91,9 +97,13 @@ class OpenApiCoverageReportInput(
     }
 
     private fun addTestResultsForTestsNotGeneratedBySpecmatic(allTests: List<TestResultRecord>, allEndpoints: List<Endpoint>): List<TestResultRecord> {
-        val missedEndpoints = allEndpoints.filter { endpoint -> allTests.none { it.path == endpoint.path && it.method == endpoint.method && it.responseStatus == endpoint.responseStatus  } }
+        val endpointsWithoutTests =
+            allEndpoints.filter { endpoint ->
+                allTests.none { it.path == endpoint.path && it.method == endpoint.method && it.responseStatus == endpoint.responseStatus }
+                        && excludedAPIs.none { it == endpoint.path }
+            }
         return allTests.plus(
-            missedEndpoints.map { endpoint ->  TestResultRecord(
+            endpointsWithoutTests.map { endpoint ->  TestResultRecord(
                 endpoint.path,
                 endpoint.method,
                 endpoint.responseStatus,
@@ -165,10 +175,19 @@ class OpenApiCoverageReportInput(
 
     private fun addTestResultsForMissingEndpoints(testResults: List<TestResultRecord>): List<TestResultRecord> {
         val testReportRecordsIncludingMissingAPIs = testResults.toMutableList()
-        applicationAPIs.forEach { api ->
-            if (testResults.none { it.path == api.path && it.method == api.method } && excludedAPIs.none { it == api.path }) {
-                val testResult = testResults.first()
-                testReportRecordsIncludingMissingAPIs.add(TestResultRecord(api.path, api.method, 0, TestResult.Skipped, serviceType = testResult.serviceType))
+        if(endpointsAPISet) {
+            applicationAPIs.forEach { api ->
+                if (allEndpoints.none { it.path == api.path && it.method == api.method } && excludedAPIs.none { it == api.path }) {
+                    testReportRecordsIncludingMissingAPIs.add(
+                        TestResultRecord(
+                            api.path,
+                            api.method,
+                            0,
+                            TestResult.Skipped,
+                            serviceType = SERVICE_TYPE_HTTP
+                        )
+                    )
+                }
             }
         }
         return testReportRecordsIncludingMissingAPIs
@@ -227,7 +246,7 @@ class OpenApiCoverageReportInput(
 
     private fun identifyTestsThatFailedBecauseOfEndpointsThatWereNotImplemented(testResults: List<TestResultRecord>): List<TestResultRecord> {
         val notImplementedTests =
-            testResults.filter { it.result == TestResult.Failed && applicationAPIs.none { api -> api.path == it.path && api.method == it.method } }
+            testResults.filter { it.result == TestResult.Failed && (endpointsAPISet && applicationAPIs.none { api -> api.path == it.path && api.method == it.method }) }
         return testResults.minus(notImplementedTests.toSet())
             .plus(notImplementedTests.map { it.copy(result = TestResult.NotImplemented) })
     }

--- a/junit5-support/src/main/kotlin/in/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
@@ -229,7 +229,6 @@ class OpenApiCoverageReportInput(
             true -> {
                 when (val result = testResultRecords.first().result) {
                     TestResult.Skipped -> Remarks.Missed
-                    TestResult.NotImplemented -> Remarks.NotImplemented
                     TestResult.DidNotRun -> Remarks.DidNotRun
                     else -> throw ContractException("Cannot determine remarks for unknown test result: $result")
                 }

--- a/junit5-support/src/test/kotlin/in/specmatic/test/ApiCoverageReportInputTest.kt
+++ b/junit5-support/src/test/kotlin/in/specmatic/test/ApiCoverageReportInputTest.kt
@@ -30,7 +30,14 @@ class ApiCoverageReportInputTest {
             API("GET", "/route2")
         )
 
-        val apiCoverageReport = OpenApiCoverageReportInput(CONFIG_FILE_PATH, testReportRecords, applicationAPIs).generate()
+        val endpointsInSpec = mutableListOf(
+            Endpoint("/route1", "GET", 200),
+            Endpoint("/route1", "POST", 200),
+            Endpoint("/route1", "POST", 401),
+            Endpoint("/route2", "GET", 200),
+        )
+
+        val apiCoverageReport = OpenApiCoverageReportInput(CONFIG_FILE_PATH, testReportRecords, applicationAPIs, allEndpoints = endpointsInSpec, endpointsAPISet = true).generate()
         println(CoverageReportTextRenderer().render(apiCoverageReport))
         assertThat(apiCoverageReport).isEqualTo(
             OpenAPICoverageConsoleReport(
@@ -63,7 +70,14 @@ class ApiCoverageReportInputTest {
             TestResultRecord("/route2", "GET", 200, TestResult.Success)
         )
 
-        val apiCoverageReport = OpenApiCoverageReportInput(CONFIG_FILE_PATH, testReportRecords, applicationAPIs).generate()
+        val endpointsInSpec = mutableListOf(
+            Endpoint("/route1", "GET", 200),
+            Endpoint("/route1", "POST", 200),
+            Endpoint("/route1", "POST", 401),
+            Endpoint("/route2", "GET", 200),
+        )
+
+        val apiCoverageReport = OpenApiCoverageReportInput(CONFIG_FILE_PATH, testReportRecords, applicationAPIs, allEndpoints = endpointsInSpec, endpointsAPISet = true).generate()
         println(CoverageReportTextRenderer().render(apiCoverageReport))
         assertThat(apiCoverageReport).isEqualTo(
             OpenAPICoverageConsoleReport(
@@ -99,13 +113,21 @@ class ApiCoverageReportInputTest {
             API("GET", "/heartbeat")
         )
 
+        val endpointsInSpec = mutableListOf(
+            Endpoint("/route1", "GET", 200),
+            Endpoint("/route1", "POST", 200),
+            Endpoint("/route1", "POST", 401),
+            Endpoint("/route2", "GET", 200),
+            Endpoint("/route2", "POST", 200),
+        )
+
         val excludedAPIs = mutableListOf(
             "/healthCheck",
             "/heartbeat"
         )
 
 
-        val apiCoverageReport = OpenApiCoverageReportInput(CONFIG_FILE_PATH, testReportRecords, applicationAPIs, excludedAPIs).generate()
+        val apiCoverageReport = OpenApiCoverageReportInput(CONFIG_FILE_PATH, testReportRecords, applicationAPIs, excludedAPIs, endpointsInSpec,true).generate()
         println(CoverageReportTextRenderer().render(apiCoverageReport))
         assertThat(apiCoverageReport).isEqualTo(
             OpenAPICoverageConsoleReport(
@@ -122,7 +144,7 @@ class ApiCoverageReportInputTest {
     }
 
     @Test
-    fun `test generates empty api coverage report with all endpoints marked as excluded`() {
+    fun `test generates empty api coverage report when all endpoints are marked as excluded`() {
         val testReportRecords = mutableListOf(
             TestResultRecord("/route1", "GET", 200, TestResult.Success),
             TestResultRecord("/route1", "POST", 200, TestResult.Success),
@@ -139,6 +161,14 @@ class ApiCoverageReportInputTest {
             API("GET", "/heartbeat")
         )
 
+        val endpointsInSpec = mutableListOf(
+            Endpoint("/route1", "GET", 200),
+            Endpoint("/route1", "POST", 200),
+            Endpoint("/route1", "POST", 401),
+            Endpoint("/route2", "GET", 200),
+            Endpoint("/route2", "POST", 200),
+        )
+
         val excludedAPIs = mutableListOf(
             "/route1",
             "/route2",
@@ -146,18 +176,19 @@ class ApiCoverageReportInputTest {
             "/heartbeat"
         )
 
-        val apiCoverageReport = OpenApiCoverageReportInput(CONFIG_FILE_PATH, testReportRecords, applicationAPIs, excludedAPIs).generate()
+        val apiCoverageReport = OpenApiCoverageReportInput(CONFIG_FILE_PATH, testReportRecords, applicationAPIs, excludedAPIs, endpointsInSpec,true).generate()
         assertThat(apiCoverageReport.rows).isEmpty()
         assertThat(apiCoverageReport.totalCoveragePercentage).isEqualTo(0)
     }
 
     @Test
-    fun `test generates empty api coverage report with all no paths are documented in the open api spec and endpoints api is not defined`() {
+    fun `test generates empty api coverage report when no paths are documented in the open api spec and endpoints api is not defined`() {
         val testReportRecords = mutableListOf<TestResultRecord>()
         val applicationAPIs = mutableListOf<API>()
         val excludedAPIs = mutableListOf<String>()
+        val specEndpoints = mutableListOf<Endpoint>()
 
-        val apiCoverageReport = OpenApiCoverageReportInput(CONFIG_FILE_PATH, testReportRecords, applicationAPIs, excludedAPIs).generate()
+        val apiCoverageReport = OpenApiCoverageReportInput(CONFIG_FILE_PATH, testReportRecords, applicationAPIs, excludedAPIs, specEndpoints, false).generate()
         assertThat(apiCoverageReport.rows).isEmpty()
     }
 
@@ -175,7 +206,14 @@ class ApiCoverageReportInputTest {
             TestResultRecord("/route2", "POST", 200, TestResult.Failed)
         )
 
-        val apiCoverageReport = OpenApiCoverageReportInput(CONFIG_FILE_PATH, testReportRecords, applicationAPIs).generate()
+        val endpointsInSpec = mutableListOf(
+            Endpoint("/route1", "GET", 200),
+            Endpoint("/route1", "POST", 200),
+            Endpoint("/route2", "GET", 200),
+            Endpoint("/route2", "POST", 200),
+        )
+
+        val apiCoverageReport = OpenApiCoverageReportInput(CONFIG_FILE_PATH, testReportRecords, applicationAPIs, allEndpoints = endpointsInSpec, endpointsAPISet = true).generate()
         println(CoverageReportTextRenderer().render(apiCoverageReport))
         assertThat(apiCoverageReport).isEqualTo(
             OpenAPICoverageConsoleReport(
@@ -207,7 +245,14 @@ class ApiCoverageReportInputTest {
             TestResultRecord("/route2", "POST", 200, TestResult.Failed)
         )
 
-        val apiCoverageReport = OpenApiCoverageReportInput(CONFIG_FILE_PATH, testReportRecords, applicationAPIs).generate()
+        val endpointsInSpec = mutableListOf(
+            Endpoint("/route1", "GET", 200),
+            Endpoint("/route1", "POST", 200),
+            Endpoint("/route2", "GET", 200),
+            Endpoint("/route2", "POST", 200),
+        )
+
+        val apiCoverageReport = OpenApiCoverageReportInput(CONFIG_FILE_PATH, testReportRecords, applicationAPIs, allEndpoints = endpointsInSpec, endpointsAPISet = true).generate()
         println(CoverageReportTextRenderer().render(apiCoverageReport))
         assertThat(apiCoverageReport).isEqualTo(
             OpenAPICoverageConsoleReport(
@@ -241,7 +286,14 @@ class ApiCoverageReportInputTest {
             TestResultRecord("/route2", "POST", 200, TestResult.Failed, "git", "https://github.com/znsio/specmatic-order-contracts.git", "main", "in/specmatic/examples/store/route2.yaml", "HTTP")
         )
 
-        val openApiCoverageJsonReport = OpenApiCoverageReportInput(CONFIG_FILE_PATH, testReportRecords, applicationAPIs).generateJsonReport()
+        val endpointsInSpec = mutableListOf(
+            Endpoint("/route1", "GET", 200),
+            Endpoint("/route1", "POST", 200),
+            Endpoint("/route2", "GET", 200),
+            Endpoint("/route2", "POST", 200),
+        )
+
+        val openApiCoverageJsonReport = OpenApiCoverageReportInput(CONFIG_FILE_PATH, testReportRecords, applicationAPIs, allEndpoints = endpointsInSpec, endpointsAPISet = true).generateJsonReport()
         assertThat(openApiCoverageJsonReport).isEqualTo(
             OpenApiCoverageJsonReport(
                 CONFIG_FILE_PATH, listOf(
@@ -304,7 +356,7 @@ class ApiCoverageReportInputTest {
             Endpoint("/route2", "GET", 400)
         )
 
-        val apiCoverageReport = OpenApiCoverageReportInput(CONFIG_FILE_PATH, testReportRecords, applicationAPIs, allEndpoints = allEndpoints).generate()
+        val apiCoverageReport = OpenApiCoverageReportInput(CONFIG_FILE_PATH, testReportRecords, applicationAPIs, allEndpoints = allEndpoints, endpointsAPISet = true).generate()
         println(CoverageReportTextRenderer().render(apiCoverageReport))
         assertThat(apiCoverageReport).isEqualTo(
             OpenAPICoverageConsoleReport(

--- a/junit5-support/src/test/kotlin/in/specmatic/test/ApiCoverageReportStatusTest.kt
+++ b/junit5-support/src/test/kotlin/in/specmatic/test/ApiCoverageReportStatusTest.kt
@@ -8,7 +8,7 @@ import `in`.specmatic.test.reports.coverage.console.Remarks
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
-class CoverageStatusTest {
+class ApiCoverageReportStatusTest {
 
     companion object {
         const val CONFIG_FILE_PATH = "./specmatic.json"

--- a/junit5-support/src/test/kotlin/in/specmatic/test/CoverageStatusTest.kt
+++ b/junit5-support/src/test/kotlin/in/specmatic/test/CoverageStatusTest.kt
@@ -1,0 +1,185 @@
+package `in`.specmatic.test
+
+import `in`.specmatic.core.TestResult
+import `in`.specmatic.test.reports.coverage.Endpoint
+import `in`.specmatic.test.reports.coverage.OpenApiCoverageReportInput
+import `in`.specmatic.test.reports.coverage.console.OpenApiCoverageConsoleRow
+import `in`.specmatic.test.reports.coverage.console.Remarks
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class CoverageStatusTest {
+
+    companion object {
+        const val CONFIG_FILE_PATH = "./specmatic.json"
+    }
+
+    @Test
+    fun `identifies endpoint as 'covered' when contract test passes and route+method is present in actuator`() {
+        val endpointsInSpec = mutableListOf(
+            Endpoint("/route1", "GET", 200)
+        )
+
+        val applicationAPIs = mutableListOf(
+            API("GET", "/route1")
+        )
+
+        val contractTestResults = mutableListOf(
+            TestResultRecord("/route1", "GET", 200, TestResult.Success),
+        )
+
+        val apiCoverageReport = OpenApiCoverageReportInput(
+            CONFIG_FILE_PATH,
+            contractTestResults,
+            applicationAPIs,
+            allEndpoints = endpointsInSpec,
+            endpointsAPISet = true
+        ).generate()
+        assertThat(apiCoverageReport.rows).isEqualTo(
+            listOf(
+                OpenApiCoverageConsoleRow("GET", "/route1", 200, 1, 100, Remarks.Covered)
+            )
+        )
+    }
+
+    @Test
+    fun `identifies endpoint as 'covered' when contract test fails and route+method is present in actuator`() {
+        val endpointsInSpec = mutableListOf(
+            Endpoint("/route1", "GET", 200),
+        )
+
+        val applicationAPIs = mutableListOf(
+            API("GET", "/route1")
+        )
+
+        val contractTestResults = mutableListOf(
+            TestResultRecord("/route1", "GET", 200, TestResult.Failed)
+        )
+
+        val apiCoverageReport = OpenApiCoverageReportInput(
+            CONFIG_FILE_PATH,
+            contractTestResults,
+            applicationAPIs,
+            allEndpoints = endpointsInSpec,
+            endpointsAPISet = true
+        ).generate()
+        assertThat(apiCoverageReport.rows).isEqualTo(
+            listOf(
+                OpenApiCoverageConsoleRow("GET", "/route1", 200, 1, 100, Remarks.Covered)
+            )
+        )
+    }
+
+    @Test
+    fun `identifies endpoint as 'not implemented' when the endpoint is present in spec, the contract test fails, and route+method is not present in actuator`() {
+        val endpointsInSpec = mutableListOf(
+            Endpoint("/route1", "GET", 200),
+            Endpoint("/route2", "GET", 200)
+        )
+
+        val applicationAPIs = mutableListOf(
+            API("GET", "/route1")
+        )
+
+        val contractTestResults = mutableListOf(
+            TestResultRecord("/route1", "GET", 200, TestResult.Success),
+            TestResultRecord("/route2", "GET", 200, TestResult.Failed),
+        )
+
+        val apiCoverageReport = OpenApiCoverageReportInput(
+            CONFIG_FILE_PATH,
+            contractTestResults,
+            applicationAPIs,
+            allEndpoints = endpointsInSpec,
+            endpointsAPISet = true
+        ).generate()
+        assertThat(apiCoverageReport.rows).isEqualTo(
+            listOf(
+                OpenApiCoverageConsoleRow("GET", "/route1", 200, 1, 100, Remarks.Covered),
+                OpenApiCoverageConsoleRow("GET", "/route2", 200, 1, 0, Remarks.NotImplemented)
+            )
+        )
+    }
+
+    @Test
+    fun `identifies endpoint as 'covered' -when the endpoint is present in spec, the contract test fails, and actuator is not available`() {
+        val endpointsInSpec = mutableListOf(
+            Endpoint("/route1", "GET", 200)
+        )
+
+        val applicationAPIs = mutableListOf<API>()
+
+        val contractTestResults = mutableListOf(
+            TestResultRecord("/route1", "GET", 200, TestResult.Failed),
+        )
+
+        val apiCoverageReport = OpenApiCoverageReportInput(
+            CONFIG_FILE_PATH,
+            contractTestResults,
+            applicationAPIs,
+            allEndpoints = endpointsInSpec,
+            endpointsAPISet = false
+        ).generate()
+        assertThat(apiCoverageReport.rows).isEqualTo(
+            listOf(
+                OpenApiCoverageConsoleRow("GET", "/route1", 200, 1, 100, Remarks.Covered)
+            )
+        )
+    }
+
+    @Test
+    fun `identifies endpoint as 'missing in spec' for endpoints present in actuator but not in the spec`() {
+        val endpointsInSpec = mutableListOf(
+            Endpoint("/route1", "GET", 200)
+        )
+
+        val applicationAPIs = mutableListOf(
+            API("GET", "/route1"),
+            API("GET", "/route2")
+        )
+
+        val contractTestResults = mutableListOf(
+            TestResultRecord("/route1", "GET", 200, TestResult.Success)
+        )
+
+        val apiCoverageReport = OpenApiCoverageReportInput(
+            CONFIG_FILE_PATH,
+            contractTestResults,
+            applicationAPIs,
+            allEndpoints = endpointsInSpec,
+            endpointsAPISet = true
+        ).generate()
+        assertThat(apiCoverageReport.rows).isEqualTo(
+            listOf(
+                OpenApiCoverageConsoleRow("GET", "/route1", 200, 1, 100, Remarks.Covered),
+                OpenApiCoverageConsoleRow("GET", "/route2", 0, 0, 0, Remarks.Missed)
+            )
+        )
+    }
+
+    @Test
+    fun `identifies endpoint as 'did not run' when contract test is not generated for an endpoint present in the spec`() {
+        val endpointsInSpec = mutableListOf(
+            Endpoint("/route1", "GET", 200),
+        )
+
+        val applicationAPIs = mutableListOf(
+            API("GET", "/route1")
+        )
+
+        val contractTestResults = mutableListOf<TestResultRecord>()
+
+        val apiCoverageReport = OpenApiCoverageReportInput(
+            CONFIG_FILE_PATH,
+            contractTestResults,
+            applicationAPIs,
+            allEndpoints = endpointsInSpec,
+            endpointsAPISet = true
+        ).generate()
+        assertThat(apiCoverageReport.rows).isEqualTo(
+            listOf(
+                OpenApiCoverageConsoleRow("GET", "/route1", 200, 0, 0, Remarks.DidNotRun)
+            )
+        )
+    }
+}


### PR DESCRIPTION
**What**:
Api Coverage Report improvements:
- An endpoint will be reported as covered if the corresponding contract test fails and the actuator is not available (endpoints api is not set)
- Used the spec endpoints to determine 'missing in spec' endpoints rather than using contract test results.

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate