### PR TITLE
Support for form-urlencoded schema ref to a schema

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -790,9 +790,12 @@ class OpenApiSpecification(private val openApiFilePath: String, private val pars
     }
 
     private fun toFormFields(mediaType: MediaType): Map<String, Pattern> {
-        val (_, resolvedSchema) = resolveReferenceToSchema(mediaType.schema.`$ref`)
+        val schema = mediaType.schema.`$ref`?.let {
+            val (_, resolvedSchema) = resolveReferenceToSchema(mediaType.schema.`$ref`)
+            resolvedSchema
+        } ?: mediaType.schema
 
-        return resolvedSchema.properties.map { (formFieldName, formFieldValue) ->
+        return schema.properties.map { (formFieldName, formFieldValue) ->
             formFieldName to toSpecmaticPattern(
                 formFieldValue, emptyList(), jsonInFormData = isJsonInString(mediaType, formFieldName)
             )

--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -789,12 +789,15 @@ class OpenApiSpecification(private val openApiFilePath: String, private val pars
         return BearerSecurityScheme(token)
     }
 
-    private fun toFormFields(mediaType: MediaType) =
-        mediaType.schema.properties.map { (formFieldName, formFieldValue) ->
+    private fun toFormFields(mediaType: MediaType): Map<String, Pattern> {
+        val (_, resolvedSchema) = resolveReferenceToSchema(mediaType.schema.`$ref`)
+
+        return resolvedSchema.properties.map { (formFieldName, formFieldValue) ->
             formFieldName to toSpecmaticPattern(
                 formFieldValue, emptyList(), jsonInFormData = isJsonInString(mediaType, formFieldName)
             )
         }.toMap()
+    }
 
     private fun isJsonInString(
         mediaType: MediaType, formFieldName: String?

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -5653,6 +5653,79 @@ paths:
     }
 
     @Test
+    fun `should generate tests for form fields with examples when the fields are in a ref`() {
+        val contractString = """
+                openapi: 3.0.3
+                info:
+                  title: test
+                  version: '1.0'
+                paths:
+                  '/users':
+                    post:
+                      responses:
+                        '200':
+                          description: OK
+                          content:
+                            text/plain:
+                              schema:
+                                type: string
+                              examples:
+                                200_OK:
+                                  value:
+                      requestBody:
+                        content:
+                          application/x-www-form-urlencoded:
+                             examples:
+                               200_OK:
+                                 value:
+                                     Data:
+                                       id: abc123
+                             encoding:
+                               Data:
+                                 contentType: application/json
+                             schema:
+                               ${"$"}ref: '#/components/schemas/Data'
+                components:
+                  schemas:
+                    Data:
+                      type: object
+                      properties:
+                        Data:
+                          type: object
+                          required:
+                            - id
+                          properties:
+                            id:
+                              type: string
+            """.trimIndent()
+
+        val feature = OpenApiSpecification.fromYAML(contractString, "").toFeature()
+
+        val results: List<Result> = feature.generateContractTestScenarios(emptyList()).map {
+            executeTest(it, object : TestExecutor {
+                override fun execute(request: HttpRequest): HttpResponse {
+                    assertThat(request.formFields).containsKey("Data")
+
+                    var parsedValue: Value = JSONObjectValue()
+                    assertThatCode { parsedValue = parsedJSON(request.formFields["Data"]!!) }.doesNotThrowAnyException()
+
+                    assertThat((parsedValue as JSONObjectValue).jsonObject).containsEntry("id", StringValue("abc123"))
+                    assertThat(request.formFields).hasSize(1)
+                    return HttpResponse.OK
+                }
+
+                override fun setServerState(serverState: Map<String, Value>) {
+                }
+            })
+        }
+
+        assertThat(results).hasSize(1)
+        println(results.single().reportString())
+
+        assertThat(results.single()).isInstanceOf(Result.Success::class.java)
+    }
+
+    @Test
     fun `should generate tests for multipart fields with examples`() {
         val contractString = """
                 openapi: 3.0.3

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -5678,11 +5678,7 @@ paths:
                              examples:
                                200_OK:
                                  value:
-                                     Data:
-                                       id: abc123
-                             encoding:
-                               Data:
-                                 contentType: application/json
+                                     Data: abc123
                              schema:
                                ${"$"}ref: '#/components/schemas/Data'
                 components:
@@ -5691,12 +5687,7 @@ paths:
                       type: object
                       properties:
                         Data:
-                          type: object
-                          required:
-                            - id
-                          properties:
-                            id:
-                              type: string
+                          type: string
             """.trimIndent()
 
         val feature = OpenApiSpecification.fromYAML(contractString, "").toFeature()
@@ -5705,12 +5696,9 @@ paths:
             executeTest(it, object : TestExecutor {
                 override fun execute(request: HttpRequest): HttpResponse {
                     assertThat(request.formFields).containsKey("Data")
-
-                    var parsedValue: Value = JSONObjectValue()
-                    assertThatCode { parsedValue = parsedJSON(request.formFields["Data"]!!) }.doesNotThrowAnyException()
-
-                    assertThat((parsedValue as JSONObjectValue).jsonObject).containsEntry("id", StringValue("abc123"))
+                    assertThat(request.formFields["Data"]).isEqualTo("abc123")
                     assertThat(request.formFields).hasSize(1)
+
                     return HttpResponse.OK
                 }
 


### PR DESCRIPTION
**What**:

Specmatic threw an error if a specification contained a `x-www-form-urlencoded` request but the schema had a `$ref` instead of an inline definition.

Here's an example.

```yaml
openapi: 3.0.3
info:
  title: test
  version: '1.0'
paths:
  '/users':
    post:
      responses:
        '200':
          description: OK
          content:
            text/plain:
              schema:
                type: string
              examples:
                200_OK:
                  value:
      requestBody:
        content:
          application/x-www-form-urlencoded:
              examples:
                200_OK:
                  value:
                      Data: abc123
              schema:
                ${"$"}ref: '#/components/schemas/Data'
components:
  schemas:
    Data:
      type: object
      properties:
        Data:
          type: string
```

This is valid OpenAPI syntax and support for it has been added in this PR.

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate
