### PR TITLE
Query param expectations from examples

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -667,18 +667,21 @@ class OpenApiSpecification(private val openApiFilePath: String, private val pars
             securitySchemes = operationSecuritySchemes(operation, securitySchemes)
         )
 
-        val exampleQueryParams = operation.parameters.orEmpty().filterIsInstance<QueryParameter>().fold(emptyMap<String, Map<String, String>>()) {
-            acc, queryParameter ->
+        val exampleQueryParams =
+            operation.parameters.orEmpty()
+            .filterIsInstance<QueryParameter>()
+            .fold(emptyMap<String, Map<String, String>>()) {
+                acc, queryParameter ->
 
-            queryParameter
-                .examples.orEmpty()
-                .entries
-                .fold(acc) { acc, (exampleName, example) ->
-                    val exampleValue = example.value?.toString() ?: ""
-                    val exampleMap = acc[exampleName] ?: emptyMap()
-                    acc.plus(exampleName to exampleMap.plus(queryParameter.name to exampleValue))
-                }
-        }
+                queryParameter
+                    .examples.orEmpty()
+                    .entries
+                    .fold(acc) { acc, (exampleName, example) ->
+                        val exampleValue = example.value?.toString() ?: ""
+                        val exampleMap = acc[exampleName] ?: emptyMap()
+                        acc.plus(exampleName to exampleMap.plus(queryParameter.name to exampleValue))
+                    }
+            }
 
         return when (val requestBody = resolveRequestBody(operation)) {
             null -> {


### PR DESCRIPTION
**What**:

The feature for loading expectations from examples in the specification now loads query params.

**Why**:

A customer needed this feature.

**How**:

This PR adds code to read the examples when parsing a specification to an HttpRequestPattern.

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate
