### PR TITLE
Space in path issue

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Feature.kt
@@ -1305,8 +1305,9 @@ private fun lexScenario(
         when (step.keyword) {
             in HTTP_METHODS -> {
                 step.words.getOrNull(1)?.let {
+                    val urlInSpec = step.rest.uriEscape()
                     val pathParamPattern = try {
-                        buildHttpPathPattern(URI.create(step.rest))
+                        buildHttpPathPattern(URI.create(urlInSpec))
                     } catch (e: Throwable) {
                         throw Exception(
                             "Could not parse the contract URL \"${step.rest}\" in scenario \"${scenarioInfo.scenarioName}\"",
@@ -1314,7 +1315,7 @@ private fun lexScenario(
                         )
                     }
 
-                    val queryParamPattern = buildQueryPattern(URI.create(step.rest))
+                    val queryParamPattern = buildQueryPattern(URI.create(urlInSpec))
 
                     scenarioInfo.copy(
                         httpRequestPattern = scenarioInfo.httpRequestPattern.copy(

--- a/core/src/main/kotlin/in/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Feature.kt
@@ -1305,7 +1305,7 @@ private fun lexScenario(
         when (step.keyword) {
             in HTTP_METHODS -> {
                 step.words.getOrNull(1)?.let {
-                    val urlInSpec = step.rest.uriEscape()
+                    val urlInSpec = step.rest
                     val pathParamPattern = try {
                         buildHttpPathPattern(URI.create(urlInSpec))
                     } catch (e: Throwable) {

--- a/core/src/main/kotlin/in/specmatic/core/HttpRequest.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpRequest.kt
@@ -13,12 +13,8 @@ import org.apache.http.client.utils.URLEncodedUtils
 import org.apache.http.message.BasicNameValuePair
 import java.io.File
 import java.io.UnsupportedEncodingException
-import java.net.URI
-import java.net.URISyntaxException
-import java.net.URL
-import java.net.URLEncoder
+import java.net.*
 import java.nio.charset.StandardCharsets
-import java.net.URLDecoder
 
 const val FORM_FIELDS_JSON_KEY = "form-fields"
 const val MULTIPART_FORMDATA_JSON_KEY = "multipart-formdata"
@@ -551,39 +547,6 @@ fun escapeSpaceInPath(path: String): String {
     return path.split("/").joinToString("/") { segment ->
         URLEncoder.encode(segment, StandardCharsets.UTF_8.toString()).replace("+", "%20")
     }
-}
-
-class URLParts(url: String) {
-    private val queryStartIndex = url.indexOf('?')
-    private val baseUrl = if (queryStartIndex != -1) url.substring(0, queryStartIndex) else url
-
-    val parts = baseUrl.split("/", limit = 4)
-
-    private val queryOnwards = if (queryStartIndex != -1) url.substring(queryStartIndex) else ""
-
-    fun withEncodedPathSegments(): String {
-        if(noPathInURL())
-            return baseUrl
-
-        val (scheme, _, authority, path) = parts
-
-        val escapedPath = escapeSpaceInPath(path)
-
-        return "$scheme//$authority/$escapedPath$queryOnwards"
-    }
-
-    fun withDecodedPathSegments(): String {
-        if(noPathInURL())
-            return baseUrl
-
-        val (scheme, _, authority, path) = parts
-
-        val escapedPath = decodePath(path)
-
-        return "$scheme//$authority/$escapedPath$queryOnwards"
-    }
-
-    private fun noPathInURL() = parts.size < 4
 }
 
 fun urlDecodePathSegments(url: String): String {

--- a/core/src/main/kotlin/in/specmatic/core/HttpRequest.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpRequest.kt
@@ -547,10 +547,6 @@ fun listOfExcludedHeaders(): List<String> = HttpHeaders.UnsafeHeadersList.plus(
     )
 ).distinct().map { it.lowercase() }
 
-fun String.uriEscape(): String = this.replace(" ", "%20")
-
-fun String.uriDecode(): String = this.replace("%20", " ")
-
 fun escapeSpaceInPath(path: String): String {
     return path.split("/").joinToString("/") { segment ->
         URLEncoder.encode(segment, StandardCharsets.UTF_8.toString()).replace("+", "%20")

--- a/core/src/main/kotlin/in/specmatic/core/URLParts.kt
+++ b/core/src/main/kotlin/in/specmatic/core/URLParts.kt
@@ -1,0 +1,37 @@
+package `in`.specmatic.core
+
+private const val MIN_URL_PARTS_WHEN_PATH_EXISTS = 4
+private const val QUERY_PARAM_START_CHAR = '?'
+
+class URLParts(url: String) {
+    private val queryStartIndex = url.indexOf(QUERY_PARAM_START_CHAR)
+    private val baseUrl = if (queryStartIndex != -1) url.substring(0, queryStartIndex) else url
+
+    val parts = baseUrl.split("/", limit = MIN_URL_PARTS_WHEN_PATH_EXISTS)
+
+    private val queryOnwards = if (queryStartIndex != -1) url.substring(queryStartIndex) else ""
+
+    fun withEncodedPathSegments(): String {
+        if(noPathInURL())
+            return baseUrl
+
+        val (scheme, _, authority, path) = parts
+
+        val escapedPath = escapeSpaceInPath(path)
+
+        return "$scheme//$authority/$escapedPath$queryOnwards"
+    }
+
+    fun withDecodedPathSegments(): String {
+        if(noPathInURL())
+            return baseUrl
+
+        val (scheme, _, authority, path) = parts
+
+        val escapedPath = decodePath(path)
+
+        return "$scheme//$authority/$escapedPath$queryOnwards"
+    }
+
+    private fun noPathInURL() = parts.size < MIN_URL_PARTS_WHEN_PATH_EXISTS
+}

--- a/core/src/main/kotlin/in/specmatic/proxy/Proxy.kt
+++ b/core/src/main/kotlin/in/specmatic/proxy/Proxy.kt
@@ -119,7 +119,8 @@ class Proxy(host: String, port: Int, baseURL: String, private val outputDirector
     }
 
     private fun isFullURL(path: String?): Boolean {
-        return path != null && try { URL(escapeSpaceInUrl(path)); true } catch(e: Throwable) { false }
+        return path != null && try {
+            URL(URLParts(path).withEncodedPathSegments()); true } catch(e: Throwable) { false }
     }
 
     init {

--- a/core/src/main/kotlin/in/specmatic/proxy/Proxy.kt
+++ b/core/src/main/kotlin/in/specmatic/proxy/Proxy.kt
@@ -119,7 +119,7 @@ class Proxy(host: String, port: Int, baseURL: String, private val outputDirector
     }
 
     private fun isFullURL(path: String?): Boolean {
-        return path != null && try { URL(path); true } catch(e: Throwable) { false }
+        return path != null && try { URL(path.uriEscape()); true } catch(e: Throwable) { false }
     }
 
     init {

--- a/core/src/main/kotlin/in/specmatic/proxy/Proxy.kt
+++ b/core/src/main/kotlin/in/specmatic/proxy/Proxy.kt
@@ -119,7 +119,7 @@ class Proxy(host: String, port: Int, baseURL: String, private val outputDirector
     }
 
     private fun isFullURL(path: String?): Boolean {
-        return path != null && try { URL(path.uriEscape()); true } catch(e: Throwable) { false }
+        return path != null && try { URL(escapeSpaceInUrl(path)); true } catch(e: Throwable) { false }
     }
 
     init {

--- a/core/src/main/kotlin/in/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/in/specmatic/stub/HttpStub.kt
@@ -542,7 +542,7 @@ internal suspend fun ktorHttpRequestToHttpRequest(call: ApplicationCall): HttpRe
 
         return HttpRequest(
             method = call.request.httpMethod.value,
-            path = call.request.path().uriDecode(),
+            path = urlDecodePathSegments(call.request.path()),
             headers = requestHeaders,
             body = body,
             queryParams = toParams(call.request.queryParameters),

--- a/core/src/main/kotlin/in/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/in/specmatic/stub/HttpStub.kt
@@ -542,7 +542,7 @@ internal suspend fun ktorHttpRequestToHttpRequest(call: ApplicationCall): HttpRe
 
         return HttpRequest(
             method = call.request.httpMethod.value,
-            path = call.request.path(),
+            path = call.request.path().uriDecode(),
             headers = requestHeaders,
             body = body,
             queryParams = toParams(call.request.queryParameters),

--- a/core/src/main/kotlin/in/specmatic/test/HttpClient.kt
+++ b/core/src/main/kotlin/in/specmatic/test/HttpClient.kt
@@ -53,7 +53,7 @@ class HttpClient(
         return runBlocking {
             httpClientFactory.create(timeout).use { ktorClient ->
                 val ktorResponse: io.ktor.client.statement.HttpResponse = ktorClient.request(url) {
-                    requestWithFileContent.buildRequest(this, url)
+                    requestWithFileContent.buildKTORRequest(this, url)
                 }
 
                 val outboundRequest: HttpRequest =

--- a/core/src/test/kotlin/in/specmatic/core/HttpRequestTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/HttpRequestTest.kt
@@ -224,7 +224,7 @@ internal class HttpRequestTest {
             this.url.host = "test.com"
             this.url.port = 80
         }
-        HttpRequest("GET", "/").buildRequest(builderWithPort80, null)
+        HttpRequest("GET", "/").buildKTORRequest(builderWithPort80, null)
         assertThat(builderWithPort80.headers["Host"]).isEqualTo("test.com")
 
         val httpRequestBuilderWithHTTPS = HttpRequestBuilder().apply {
@@ -232,7 +232,7 @@ internal class HttpRequestTest {
             this.url.host = "test.com"
             this.url.port = 443
         }
-        HttpRequest("GET", "/").buildRequest(httpRequestBuilderWithHTTPS, null)
+        HttpRequest("GET", "/").buildKTORRequest(httpRequestBuilderWithHTTPS, null)
         assertThat(httpRequestBuilderWithHTTPS.headers["Host"]).isEqualTo("test.com")
     }
 
@@ -242,7 +242,7 @@ internal class HttpRequestTest {
             this.url.host = "test.com"
             this.url.port = 8080
         }
-        HttpRequest("GET", "/").buildRequest(httpRequestBuilder2, null)
+        HttpRequest("GET", "/").buildKTORRequest(httpRequestBuilder2, null)
         assertThat(httpRequestBuilder2.headers["Host"]).isNull()
     }
 
@@ -336,5 +336,11 @@ internal class HttpRequestTest {
                 "/test"
             )
         ).isEqualTo("No matching REST stub (strict mode) found for method POST and path /test (assuming you're looking for a REST API since no SOAPAction header was detected)")
+    }
+
+    @Test
+    fun `should percent-encode spaces within path segments`() {
+        val request = HttpRequest("GET", "/test path")
+        assertThat(request.getURL("http://localhost")).isEqualTo("http://localhost/test%20path")
     }
 }

--- a/core/src/test/kotlin/in/specmatic/core/URLPartsTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/URLPartsTest.kt
@@ -1,0 +1,39 @@
+package `in`.specmatic.core
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
+
+class URLPartsTest {
+    @ParameterizedTest
+    @MethodSource("urlWithSpacesProvider")
+    fun `URL with spaces in path segment should be percent encoded`(urlWithSpaces: String, encodedUrl: String) {
+        val urlParts = URLParts(urlWithSpaces)
+        assertThat(urlParts.withEncodedPathSegments()).isEqualTo(encodedUrl)
+    }
+
+    @ParameterizedTest
+    @MethodSource("encodedUrlProvider")
+    fun `URL with percent encoded spaces in path segments should be decoded`(encodedUrl: String, decodedUrl: String) {
+        val urlParts = URLParts(encodedUrl)
+        assertThat(urlParts.withDecodedPathSegments()).isEqualTo(decodedUrl)
+    }
+
+    companion object {
+        @JvmStatic
+        fun urlWithSpacesProvider(): Stream<Arguments> =
+            Stream.of(
+                Arguments.arguments("http://example.com/path with spaces?query=param", "http://example.com/path%20with%20spaces?query=param"),
+                Arguments.arguments("http://example.com/path with spaces", "http://example.com/path%20with%20spaces")
+            )
+
+        @JvmStatic
+        fun encodedUrlProvider(): Stream<Arguments> =
+            Stream.of(
+                Arguments.arguments("http://example.com/path%20with%20spaces?query=param", "http://example.com/path with spaces?query=param"),
+                Arguments.arguments("http://example.com/path%20with%20spaces", "http://example.com/path with spaces")
+            )
+    }
+}

--- a/core/src/test/kotlin/in/specmatic/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/in/specmatic/stub/HttpStubTest.kt
@@ -1039,4 +1039,21 @@ paths:
             }
         }
     }
+
+    @Test
+    fun `should load a stub with query params and a space in the path and return the stubbed response`() {
+        createStubFromContracts(listOf("src/test/resources/openapi/spec_with_query_and_space_in_path.yaml")).use { stub ->
+            val request = HttpRequest("GET", "/da ta", queryParams = mapOf("id" to "5"))
+
+            val response = stub.client.execute(request)
+
+            assertThat(response.status).isEqualTo(200)
+            response.body.let {
+                assertThat(it).isInstanceOf(JSONObjectValue::class.java)
+                it as JSONObjectValue
+
+                assertThat(it.jsonObject).containsEntry("id", NumberValue(10))
+            }
+        }
+    }
 }

--- a/core/src/test/kotlin/in/specmatic/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/in/specmatic/stub/HttpStubTest.kt
@@ -1005,10 +1005,12 @@ paths:
 
     @Test
     fun `should stub out a path having a space and return a randomised response`() {
+        val pathWithSpace = "/da ta"
+
         val specification = OpenApiSpecification.fromFile("src/test/resources/openapi/spec_with_space_in_path.yaml").toFeature()
 
         HttpStub(specification).use { stub ->
-            val request = HttpRequest("GET", "/da ta")
+            val request = HttpRequest("GET", pathWithSpace)
 
             val response = stub.client.execute(request)
 
@@ -1025,8 +1027,10 @@ paths:
 
     @Test
     fun `should load a stub with a space in the path and return the stubbed response`() {
+        val pathWithSpace = "/da ta"
+
         createStubFromContracts(listOf("src/test/resources/openapi/spec_with_space_in_path.yaml")).use { stub ->
-            val request = HttpRequest("GET", "/da ta")
+            val request = HttpRequest("GET", pathWithSpace)
 
             val response = stub.client.execute(request)
 
@@ -1042,8 +1046,10 @@ paths:
 
     @Test
     fun `should load a stub with query params and a space in the path and return the stubbed response`() {
+        val pathWithSpace = "/da ta"
+
         createStubFromContracts(listOf("src/test/resources/openapi/spec_with_query_and_space_in_path.yaml")).use { stub ->
-            val request = HttpRequest("GET", "/da ta", queryParams = mapOf("id" to "5"))
+            val request = HttpRequest("GET", pathWithSpace, queryParams = mapOf("id" to "5"))
 
             val response = stub.client.execute(request)
 
@@ -1053,6 +1059,51 @@ paths:
                 it as JSONObjectValue
 
                 assertThat(it.jsonObject).containsEntry("id", NumberValue(10))
+            }
+        }
+    }
+
+    @Test
+    fun `should load a stub with a space in query params and return the stubbed response`() {
+        val queryParamWithSpace = "id entifier"
+
+        val specification = OpenApiSpecification.fromYAML("""
+            openapi: 3.0.1
+            info:
+              title: Random
+              version: "1"
+            paths:
+              /data:
+                get:
+                  summary: Random
+                  parameters:
+                    - name: $queryParamWithSpace
+                      in: query
+                      schema:
+                        type: integer
+                  responses:
+                    "200":
+                      description: Random
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                            properties:
+                              id:
+                                type: integer
+        """.trimIndent(), "").toFeature()
+
+        HttpStub(specification).use { stub ->
+            val request = HttpRequest("GET", "/data", queryParams = mapOf(queryParamWithSpace to "5"))
+
+            val response = stub.client.execute(request)
+
+            assertThat(response.status).isEqualTo(200)
+            response.body.let {
+                assertThat(it).isInstanceOf(JSONObjectValue::class.java)
+                it as JSONObjectValue
+
+                assertThat(it.jsonObject["id"]).isInstanceOf(NumberValue::class.java)
             }
         }
     }

--- a/core/src/test/resources/openapi/spec_with_query_and_space_in_path.yaml
+++ b/core/src/test/resources/openapi/spec_with_query_and_space_in_path.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.1
+info:
+  title: Random
+  version: "1"
+paths:
+  /da ta:
+    get:
+      summary: Random
+      parameters:
+        - name: id
+          in: query
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Random
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer

--- a/core/src/test/resources/openapi/spec_with_query_and_space_in_path_data/stub.json
+++ b/core/src/test/resources/openapi/spec_with_query_and_space_in_path_data/stub.json
@@ -1,0 +1,15 @@
+{
+  "http-request": {
+    "method": "GET",
+    "path": "/da ta",
+    "query": {
+      "id": 5
+    }
+  },
+  "http-response": {
+    "status": 200,
+    "body": {
+      "id": 10
+    }
+  }
+}

--- a/core/src/test/resources/openapi/spec_with_space_in_path.yaml
+++ b/core/src/test/resources/openapi/spec_with_space_in_path.yaml
@@ -1,0 +1,18 @@
+openapi: 3.0.1
+info:
+  title: Random
+  version: "1"
+paths:
+  /da ta:
+    get:
+      summary: Random
+      responses:
+        "200":
+          description: Random
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer

--- a/core/src/test/resources/openapi/spec_with_space_in_path_data/stub.json
+++ b/core/src/test/resources/openapi/spec_with_space_in_path_data/stub.json
@@ -1,0 +1,12 @@
+{
+  "http-request": {
+    "method": "GET",
+    "path": "/da ta"
+  },
+  "http-response": {
+    "status": 200,
+    "body": {
+      "id": 10
+    }
+  }
+}


### PR DESCRIPTION
**What**:

A bug report from more than one highlighted that when a space exists in the path in a specification, Specmatic is unable to parse it.

**Why**:

Spaces in the path are valid, both in HTTP and in OpenAPI and should be supported.

**How**:

We've introduced code to parse out the path and escape segments when receiving a path (stub / proxy) or sending it (test / proxy)

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [x] Sonar Quality Gate

**Issue ID**:
Closes: #905
