### PR TITLE
The Content-Type header should not be sent or expected when there is no requestBody in the OpenAPI specification

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -773,7 +773,7 @@ class OpenApiSpecification(
                 }
 
                 listOf(
-                    Pair(requestPattern, examples)
+                    Pair(requestPattern.copy(body = NoBodyPattern), examples)
                 )
             }
 

--- a/core/src/main/kotlin/in/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Feature.kt
@@ -1301,7 +1301,7 @@ private fun lexScenario(
     val filteredSteps =
         steps.map { step -> StepInfo(step.text, listOfDatatableRows(step), step) }.filterNot { it.isEmpty }
 
-    val parsedScenarioInfo = filteredSteps.fold(backgroundScenarioInfo ?: ScenarioInfo()) { scenarioInfo, step ->
+    val parsedScenarioInfo = filteredSteps.fold(backgroundScenarioInfo ?: ScenarioInfo(httpRequestPattern = HttpRequestPattern())) { scenarioInfo, step ->
         when (step.keyword) {
             in HTTP_METHODS -> {
                 step.words.getOrNull(1)?.let {

--- a/core/src/main/kotlin/in/specmatic/core/HttpRequest.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpRequest.kt
@@ -176,29 +176,35 @@ data class HttpRequest(
                 httpRequestBuilder.header("Host", it.authority)
         }
 
-        httpRequestBuilder.setBody(
-            when {
-                formFields.isNotEmpty() -> {
-                    val parameters = formFields.mapValues { listOf(it.value) }.toList()
-                    FormDataContent(parametersOf(*parameters.toTypedArray()))
-                }
+        if(body !is NoBodyValue) {
+            httpRequestBuilder.setBody(
+                when {
+                    formFields.isNotEmpty() -> {
+                        val parameters = formFields.mapValues { listOf(it.value) }.toList()
+                        FormDataContent(parametersOf(*parameters.toTypedArray()))
+                    }
 
-                multiPartFormData.isNotEmpty() -> {
-                    MultiPartFormDataContent(formData {
-                        multiPartFormData.forEach { value ->
-                            value.addTo(this)
+                    multiPartFormData.isNotEmpty() -> {
+                        MultiPartFormDataContent(formData {
+                            multiPartFormData.forEach { value ->
+                                value.addTo(this)
+                            }
+                        })
+                    }
+
+                    else -> {
+                        when {
+                            headers.containsKey(CONTENT_TYPE) -> TextContent(
+                                bodyString,
+                                ContentType.parse(headers[CONTENT_TYPE] as String)
+                            )
+
+                            else -> TextContent(bodyString, ContentType.parse(body.httpContentType))
                         }
-                    })
-                }
-
-                else -> {
-                    when {
-                        headers.containsKey(CONTENT_TYPE) -> TextContent(bodyString, ContentType.parse(headers[CONTENT_TYPE] as String))
-                        else -> TextContent(bodyString, ContentType.parse(body.httpContentType))
                     }
                 }
-            }
-        )
+            )
+        }
     }
 
     private fun withoutDuplicateHostHeader(headers: Map<String, String>, url: URL?): Map<String, String> {

--- a/core/src/main/kotlin/in/specmatic/core/NoBodyPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/NoBodyPattern.kt
@@ -3,7 +3,6 @@ package `in`.specmatic.core
 import `in`.specmatic.core.pattern.Pattern
 import `in`.specmatic.core.pattern.Row
 import `in`.specmatic.core.pattern.TypeStack
-import `in`.specmatic.core.value.EmptyString
 import `in`.specmatic.core.value.JSONArrayValue
 import `in`.specmatic.core.value.StringValue
 import `in`.specmatic.core.value.Value
@@ -31,7 +30,7 @@ object NoBodyPattern : Pattern {
     override fun negativeBasedOn(row: Row, resolver: Resolver): List<Pattern> = emptyList()
 
     override fun parse(value: String, resolver: Resolver): Value {
-        return NoBodyValue
+        return StringValue(value)
     }
 
     override fun encompasses(

--- a/core/src/main/kotlin/in/specmatic/core/NoBodyPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/NoBodyPattern.kt
@@ -6,14 +6,15 @@ import `in`.specmatic.core.pattern.TypeStack
 import `in`.specmatic.core.value.JSONArrayValue
 import `in`.specmatic.core.value.StringValue
 import `in`.specmatic.core.value.Value
+import `in`.specmatic.core.NoBodyValue
 
 object NoBodyPattern : Pattern {
     override fun matches(sampleData: Value?, resolver: Resolver): Result {
         if(sampleData == null)
             return Result.Success()
 
-        if(sampleData is StringValue && sampleData.string.isEmpty())
-            return Result.Success()
+//        if(sampleData is StringValue && sampleData.string.isEmpty())
+//            return Result.Success()
 
         if(sampleData is NoBodyValue)
             return Result.Success()
@@ -30,7 +31,10 @@ object NoBodyPattern : Pattern {
     override fun negativeBasedOn(row: Row, resolver: Resolver): List<Pattern> = emptyList()
 
     override fun parse(value: String, resolver: Resolver): Value {
-        return StringValue(value)
+        return if(value.isBlank())
+            NoBodyValue
+        else
+            StringValue(value)
     }
 
     override fun encompasses(

--- a/core/src/main/kotlin/in/specmatic/core/NoBodyPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/NoBodyPattern.kt
@@ -1,0 +1,58 @@
+package `in`.specmatic.core
+
+import `in`.specmatic.core.pattern.Pattern
+import `in`.specmatic.core.pattern.Row
+import `in`.specmatic.core.pattern.TypeStack
+import `in`.specmatic.core.value.EmptyString
+import `in`.specmatic.core.value.JSONArrayValue
+import `in`.specmatic.core.value.StringValue
+import `in`.specmatic.core.value.Value
+
+object NoBodyPattern : Pattern {
+    override fun matches(sampleData: Value?, resolver: Resolver): Result {
+        if(sampleData == null)
+            return Result.Success()
+
+        if(sampleData is StringValue && sampleData.string.isEmpty())
+            return Result.Success()
+
+        if(sampleData is NoBodyValue)
+            return Result.Success()
+
+        return Result.Failure("Expected no body, but found ${sampleData.displayableType()}")
+    }
+
+    override fun generate(resolver: Resolver): Value = NoBodyValue
+
+    override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> = listOf(this)
+
+    override fun newBasedOn(resolver: Resolver): List<Pattern> = listOf(this)
+
+    override fun negativeBasedOn(row: Row, resolver: Resolver): List<Pattern> = emptyList()
+
+    override fun parse(value: String, resolver: Resolver): Value {
+        return NoBodyValue
+    }
+
+    override fun encompasses(
+        otherPattern: Pattern,
+        thisResolver: Resolver,
+        otherResolver: Resolver,
+        typeStack: TypeStack
+    ): Result {
+        if(otherPattern is NoBodyPattern)
+            return Result.Success()
+
+        return Result.Failure("Expected no body, but found ${otherPattern.typeName}")
+    }
+
+    override fun listOf(valueList: List<Value>, resolver: Resolver): Value = JSONArrayValue(valueList)
+
+    override val typeAlias: String?
+        get() = null
+    override val typeName: String
+        get() = "no-body"
+    override val pattern: Any
+        get() = "no-body"
+
+}

--- a/core/src/main/kotlin/in/specmatic/core/NoBodyValue.kt
+++ b/core/src/main/kotlin/in/specmatic/core/NoBodyValue.kt
@@ -1,9 +1,7 @@
 package `in`.specmatic.core
 
 import `in`.specmatic.core.pattern.Pattern
-import `in`.specmatic.core.value.JSONArrayValue
-import `in`.specmatic.core.value.TypeDeclaration
-import `in`.specmatic.core.value.Value
+import `in`.specmatic.core.value.*
 
 object NoBodyValue : Value {
     override val httpContentType: String
@@ -47,5 +45,11 @@ object NoBodyValue : Value {
 
     override fun listOf(valueList: List<Value>): Value {
         return JSONArrayValue(valueList)
+    }
+
+    override fun toString(): String = toStringValue().string
+
+    override fun toStringValue(): StringValue {
+        return EmptyString
     }
 }

--- a/core/src/main/kotlin/in/specmatic/core/NoBodyValue.kt
+++ b/core/src/main/kotlin/in/specmatic/core/NoBodyValue.kt
@@ -1,0 +1,51 @@
+package `in`.specmatic.core
+
+import `in`.specmatic.core.pattern.Pattern
+import `in`.specmatic.core.value.JSONArrayValue
+import `in`.specmatic.core.value.TypeDeclaration
+import `in`.specmatic.core.value.Value
+
+object NoBodyValue : Value {
+    override val httpContentType: String
+        get() = "text/plain"
+
+    override fun displayableValue(): String {
+        return "No body"
+    }
+
+    override fun toStringLiteral(): String {
+        return ""
+    }
+
+    override fun displayableType(): String {
+        return "No body"
+    }
+
+    override fun exactMatchElseType(): Pattern {
+        return NoBodyPattern
+    }
+
+    override fun type(): Pattern {
+        return NoBodyPattern
+    }
+
+    override fun typeDeclarationWithoutKey(
+        exampleKey: String,
+        types: Map<String, Pattern>,
+        exampleDeclarations: ExampleDeclarations
+    ): Pair<TypeDeclaration, ExampleDeclarations> {
+        return TypeDeclaration("No body", types) to exampleDeclarations
+    }
+
+    override fun typeDeclarationWithKey(
+        key: String,
+        types: Map<String, Pattern>,
+        exampleDeclarations: ExampleDeclarations
+    ): Pair<TypeDeclaration, ExampleDeclarations> {
+        return TypeDeclaration("No body", types) to exampleDeclarations
+    }
+
+    override fun listOf(valueList: List<Value>): Value {
+        return JSONArrayValue(valueList)
+    }
+}

--- a/core/src/main/kotlin/in/specmatic/core/TestBackwardCompatibility.kt
+++ b/core/src/main/kotlin/in/specmatic/core/TestBackwardCompatibility.kt
@@ -5,16 +5,16 @@ import `in`.specmatic.core.utilities.capitalizeFirstChar
 import `in`.specmatic.core.value.NullValue
 import `in`.specmatic.core.value.Value
 
-fun testBackwardCompatibility(older: Feature, newerBehaviour: Feature): Results {
+fun testBackwardCompatibility(older: Feature, newer: Feature): Results {
     return older.generateBackwardCompatibilityTestScenarios().filter { !it.ignoreFailure }.fold(Results()) { results, olderScenario ->
-        val scenarioResults: List<Result> = testBackwardCompatibility(olderScenario, newerBehaviour)
+        val scenarioResults: List<Result> = testBackwardCompatibility(olderScenario, newer)
         results.copy(results = results.results.plus(scenarioResults))
     }.distinct()
 }
 
-fun findDifferences(older: Feature, newerBehaviour: Feature): Results {
+fun findDifferences(older: Feature, newer: Feature): Results {
     return older.generateBackwardCompatibilityTestScenarios().filter { !it.ignoreFailure }.fold(Results()) { results, olderScenario ->
-        val scenarioResults: List<Result> = findDifferences(olderScenario, newerBehaviour)
+        val scenarioResults: List<Result> = findDifferences(olderScenario, newer)
         results.copy(results = results.results.plus(scenarioResults))
     }.distinct()
 }

--- a/core/src/main/kotlin/in/specmatic/test/HttpClient.kt
+++ b/core/src/main/kotlin/in/specmatic/test/HttpClient.kt
@@ -134,7 +134,14 @@ private fun ktorHttpRequestToHttpRequestForLogging(
     val (body, formFields, multiPartFormData) =
         when (request.content) {
             is FormDataContent -> Triple(EmptyString, specmaticRequest.formFields, emptyList())
-            is TextContent -> Triple(specmaticRequest.body, emptyMap(), emptyList())
+            is TextContent -> {
+                val bodyValue = when (specmaticRequest.body) {
+                    is NoBodyValue -> NoBodyValue
+                    else -> specmaticRequest.body
+                }
+
+                Triple(bodyValue, emptyMap(), emptyList())
+            }
             is MultiPartFormDataContent -> Triple(EmptyString, emptyMap(), specmaticRequest.multiPartFormData)
             is EmptyContent -> Triple(EmptyString, emptyMap(), emptyList())
             else -> throw ContractException("Unknown type of body content sent in the request")

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
@@ -18,6 +18,11 @@ import `in`.specmatic.core.value.Value
 import `in`.specmatic.jsonBody
 import `in`.specmatic.stub.HttpStub
 import `in`.specmatic.test.TestExecutor
+import io.ktor.server.application.*
+import io.ktor.server.engine.*
+import io.ktor.server.netty.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request

--- a/core/src/test/kotlin/in/specmatic/core/TestBackwardCompatibilityKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/TestBackwardCompatibilityKtTest.kt
@@ -4,6 +4,7 @@ import `in`.specmatic.conversions.OpenApiSpecification
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Nested
 
 internal class TestBackwardCompatibilityKtTest {
@@ -2173,6 +2174,60 @@ paths:
     post:
       summary: hello world
       description: test
+      responses:
+        '200':
+          description: Says hello
+          content:
+            text/plain:
+              schema:
+                type: string
+""".trimIndent(), ""
+        ).toFeature()
+
+        val result = testBackwardCompatibility(oldContract, newContract)
+        assertThat(result.success()).withFailMessage(result.report()).isFalse()
+    }
+
+    @Test
+    @Disabled
+    fun `backward compatibility check going from nothing to string in request`() {
+        val oldContract = OpenApiSpecification.fromYAML(
+            """
+openapi: 3.0.0
+info:
+  title: Sample API
+  version: 0.1.9
+paths:
+  /data:
+    post:
+      summary: hello world
+      description: test
+      responses:
+        '200':
+          description: Says hello
+          content:
+            text/plain:
+              schema:
+                type: string
+""".trimIndent(), ""
+        ).toFeature()
+
+        val newContract = OpenApiSpecification.fromYAML(
+            """
+openapi: 3.0.0
+info:
+  title: Sample API
+  version: 0.1.9
+paths:
+  /data:
+    post:
+      summary: hello world
+      description: test
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
       responses:
         '200':
           description: Says hello

--- a/core/src/test/kotlin/in/specmatic/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/in/specmatic/stub/HttpStubTest.kt
@@ -1107,4 +1107,80 @@ paths:
             }
         }
     }
+
+    @Test
+    fun `stub out a spec with no request body and respond to a request which has no body`() {
+        val specification = OpenApiSpecification.fromYAML("""
+            openapi: 3.0.1
+            info:
+              title: Random
+              version: "1"
+            paths:
+              /data:
+                get:
+                  summary: Random
+                  responses:
+                    "200":
+                      description: Random
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                            properties:
+                              id:
+                                type: integer
+        """.trimIndent(), "").toFeature()
+
+        HttpStub(specification).use { stub ->
+            val request = HttpRequest("GET", "/data", body = NoBodyValue)
+
+            val response = stub.client.execute(request)
+
+            assertThat(response.status).isEqualTo(200)
+            response.body.let {
+                assertThat(it).isInstanceOf(JSONObjectValue::class.java)
+                it as JSONObjectValue
+
+                assertThat(it.jsonObject["id"]).isInstanceOf(NumberValue::class.java)
+            }
+        }
+    }
+
+    @Test
+    fun `stub should load an expectation for a spec with no request body and respond to a request in the expectation`() {
+        val specification = OpenApiSpecification.fromYAML("""
+            openapi: 3.0.1
+            info:
+              title: Random
+              version: "1"
+            paths:
+              /data:
+                get:
+                  summary: Random
+                  responses:
+                    "200":
+                      description: Random
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                            properties:
+                              id:
+                                type: integer
+        """.trimIndent(), "").toFeature()
+
+        HttpStub(specification).use { stub ->
+            val request = HttpRequest("GET", "/data", body = NoBodyValue)
+
+            val response = stub.client.execute(request)
+
+            assertThat(response.status).isEqualTo(200)
+            response.body.let {
+                assertThat(it).isInstanceOf(JSONObjectValue::class.java)
+                it as JSONObjectValue
+
+                assertThat(it.jsonObject["id"]).isInstanceOf(NumberValue::class.java)
+            }
+        }
+    }
 }

--- a/core/src/test/resources/openapi/spec_with_no_request_body.yaml
+++ b/core/src/test/resources/openapi/spec_with_no_request_body.yaml
@@ -1,0 +1,18 @@
+openapi: 3.0.1
+info:
+  title: Random
+  version: "1"
+paths:
+  /data:
+    get:
+      summary: Random
+      responses:
+        "200":
+          description: Random
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer

--- a/core/src/test/resources/openapi/spec_with_no_request_body_data/stub.json
+++ b/core/src/test/resources/openapi/spec_with_no_request_body_data/stub.json
@@ -1,0 +1,12 @@
+{
+  "http-request": {
+    "method": "GET",
+    "path": "/data"
+  },
+  "http-response": {
+    "status": 200,
+    "body": {
+      "id": 10
+    }
+  }
+}


### PR DESCRIPTION
**What**:

When there is no requestBody, Content-Type is not sent in test requests, and stubs do not require Content-Type.

**Why**:

By default, Specmatic assumed the existence of a string body. It now supports the idea of there being no body.

**How**:

This PR introduces two new types: NoBodyPattern (set when OpenAPISpecification parses a spec file) and NoBodyValue, which is recognised by HttpClient.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate
