### PR TITLE
Handle bool with capitalised T or F in query

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/pattern/BooleanPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/BooleanPattern.kt
@@ -24,7 +24,7 @@ data class BooleanPattern(val example: String? = null) : Pattern, ScalarType {
         return listOf(NullPattern)
     }
 
-    override fun parse(value: String, resolver: Resolver): Value = when (value) {
+    override fun parse(value: String, resolver: Resolver): Value = when (value.lowercase()) {
         !in listOf("true", "false") -> throw ContractException(mismatchResult(BooleanPattern(), value, resolver.mismatchMessages).toFailureReport())
         else -> BooleanValue(value.toBoolean())
     }


### PR DESCRIPTION
**What**:

When a query param is sent as a True or False (capital T or F), Specmatic should recognize it as a boolean value.

**Why**:

Python sends its native type serialised as True and False. Others may send similar values. Query params are not JSON, so we should recognised true or false case insensitively.

**How**:

The BooleanPattern class has a parse method, and this has been updated to recognise boolean values case-insensitively.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate
