### PR TITLE
Implemented negative tests for path params

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/URLPathSegmentPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/URLPathSegmentPattern.kt
@@ -29,7 +29,13 @@ data class URLPathSegmentPattern(override val pattern: Pattern, override val key
         }
 
     override fun negativeBasedOn(row: Row, resolver: Resolver): List<Pattern> {
-        return newBasedOn(row, resolver)
+        return when (pattern) {
+            is ExactValuePattern -> emptyList()
+            is StringPattern -> emptyList()
+            else -> resolver.withCyclePrevention(pattern) { cyclePreventedResolver ->
+                pattern.negativeBasedOn(row, cyclePreventedResolver).filterNot { it is NullPattern }.map { URLPathSegmentPattern(it, key) }
+            }
+        }
     }
 
     override fun parse(value: String, resolver: Resolver): Value = pattern.parse(value, resolver)

--- a/core/src/test/kotlin/in/specmatic/conversions/GenerativeTests.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/GenerativeTests.kt
@@ -1105,6 +1105,7 @@ class GenerativeTests {
 
         val results = feature.enableGenerativeTesting().executeTests(object : TestExecutor {
             override fun execute(request: HttpRequest): HttpResponse {
+                println(request.toLogString())
                 pathsSeen.add(request.path!!)
                 assertThat(request.body).isInstanceOf(JSONObjectValue::class.java)
 
@@ -1115,7 +1116,7 @@ class GenerativeTests {
             }
         })
 
-        assertThat(pathsSeen).withFailMessage("${pathsSeen.joinToString("\n")}\n${results.report()}").satisfiesExactlyInAnyOrder(
+        assertThat(pathsSeen.distinct()).withFailMessage("${pathsSeen.joinToString("\n")}\n${results.report()}").satisfiesExactlyInAnyOrder(
             { assertThat(it).isEqualTo("/person/100") },
             { assertThat(it).matches("^/person/(false|true)") },
             { assertThat(it).matches("/person/[A-Z]+$") }


### PR DESCRIPTION
**What**:

Generative tests is now implemented for path params.

For example, if a path in the specification is '/customer/{id}' and id is an integer, generative tests yields request with the following paths:

* /customer/100 (if the example has 100)
* /customer/false (or true, chosen at random)
* /customer/HXULY

**Why**:

We haven't needed this until now.

**How**:

Implemented fresh logic for this. All other negative tests were implemented using some for of dictionary-based generation. This is the first one where it's being done as a list. It might be possible to re-implement it using the dictionary logic as well.

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate
