### PR TITLE
Fixed issue in coverage report

### DIFF
--- a/core/src/main/kotlin/in/specmatic/test/ContractTest.kt
+++ b/core/src/main/kotlin/in/specmatic/test/ContractTest.kt
@@ -1,5 +1,6 @@
 package `in`.specmatic.test
 
+import `in`.specmatic.core.HttpResponse
 import `in`.specmatic.core.Result
 import `in`.specmatic.core.TestResult
 
@@ -19,8 +20,8 @@ data class TestResultRecord(
 }
 
 interface ContractTest {
-    fun testResultRecord(result: Result): TestResultRecord
+    fun testResultRecord(result: Result, response: HttpResponse?): TestResultRecord
     fun generateTestScenarios(testVariables: Map<String, String>, testBaseURLs: Map<String, String>): List<ContractTest>
     fun testDescription(): String
-    fun runTest(testBaseURL: String, timeOut: Int): Result
+    fun runTest(testBaseURL: String, timeOut: Int): Pair<Result, HttpResponse?>
 }

--- a/core/src/main/kotlin/in/specmatic/test/ScenarioTest.kt
+++ b/core/src/main/kotlin/in/specmatic/test/ScenarioTest.kt
@@ -12,9 +12,12 @@ class ScenarioTest(
     private val specification: String? = null,
     private val serviceType: String? = null,
 ) : ContractTest {
-    override fun testResultRecord(result: Result): TestResultRecord {
+    override fun testResultRecord(result: Result, response: HttpResponse?): TestResultRecord {
         val resultStatus = result.testResult()
-        return TestResultRecord(convertPathParameterStyle(scenario.path), scenario.method, scenario.status, resultStatus, sourceProvider, sourceRepository, sourceRepositoryBranch, specification, serviceType)
+
+        val responseStatus = scenario.getStatus(response)
+        return TestResultRecord(convertPathParameterStyle(scenario.path), scenario.method,
+            responseStatus, resultStatus, sourceProvider, sourceRepository, sourceRepositoryBranch, specification, serviceType)
     }
 
     override fun generateTestScenarios(
@@ -28,9 +31,10 @@ class ScenarioTest(
         return scenario.testDescription()
     }
 
-    override fun runTest(testBaseURL: String, timeOut: Int): Result {
+    override fun runTest(testBaseURL: String, timeOut: Int): Pair<Result, HttpResponse?> {
         val httpClient = HttpClient(testBaseURL, timeout = timeOut)
-        return executeTest(scenario, httpClient, resolverStrategies).updateScenario(scenario)
+        val (result, response) = executeTestAndReturnResultAndResponse(scenario, httpClient, resolverStrategies)
+        return Pair(result.updateScenario(scenario), response)
     }
 
 }

--- a/core/src/main/kotlin/in/specmatic/test/ScenarioTestGenerationFailure.kt
+++ b/core/src/main/kotlin/in/specmatic/test/ScenarioTestGenerationFailure.kt
@@ -1,12 +1,13 @@
 package `in`.specmatic.test
 
 import `in`.specmatic.conversions.convertPathParameterStyle
+import `in`.specmatic.core.HttpResponse
 import `in`.specmatic.core.utilities.exceptionCauseMessage
 import `in`.specmatic.core.Scenario
 import `in`.specmatic.core.Result
 
 class ScenarioTestGenerationFailure(val scenario: Scenario, val e: Throwable) : ContractTest {
-    override fun testResultRecord(result: Result): TestResultRecord {
+    override fun testResultRecord(result: Result, response: HttpResponse?): TestResultRecord {
         return TestResultRecord(convertPathParameterStyle(scenario.path), scenario.method, scenario.httpResponsePattern.status, result.testResult())
     }
 
@@ -18,7 +19,7 @@ class ScenarioTestGenerationFailure(val scenario: Scenario, val e: Throwable) : 
         return scenario.testDescription()
     }
 
-    override fun runTest(testBaseURL: String, timeOut: Int): Result {
-        return Result.Failure(exceptionCauseMessage(e)).updateScenario(scenario)
+    override fun runTest(testBaseURL: String, timeOut: Int): Pair<Result, HttpResponse?> {
+        return Pair(Result.Failure(exceptionCauseMessage(e)).updateScenario(scenario), null)
     }
 }

--- a/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
@@ -231,13 +231,14 @@ open class SpecmaticJUnitSupport {
 
                 testsNames.add(testScenario.testDescription())
 
-                lateinit var result:Result
+                lateinit var testResult: Pair<Result, HttpResponse?>
 
                 try {
                     val protocol = System.getProperty("protocol") ?: "http"
                     val testBaseURL = System.getProperty(TEST_BASE_URL)
                         ?: "$protocol://${System.getProperty(HOST)}:${System.getProperty(PORT)}"
-                    result = testScenario.runTest(testBaseURL, timeout)
+                    testResult = testScenario.runTest(testBaseURL, timeout)
+                    val (result, response) = testResult
 
                     if (result is Result.Success && result.isPartialSuccess()) {
                         partialSuccesses.add(result)
@@ -256,11 +257,11 @@ open class SpecmaticJUnitSupport {
                     }
 
                 } catch(e: Throwable) {
-                    result = Result.Failure(exceptionCauseMessage(e))
                     throw e
                 }
                 finally {
-                    openApiCoverageReportInput.addTestReportRecords(testScenario.testResultRecord(result))
+                    val (result, response) = testResult
+                    openApiCoverageReportInput.addTestReportRecords(testScenario.testResultRecord(result, response))
                 }
             }
         }.toList()


### PR DESCRIPTION
**What**:

Use the actual response status for negative scenarios.

**Why**:

This is needed so that the coverage report shows the actual 4xx status that came back from the application.

**How**:

We are now using the actual response and returning it's status for negative tests.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate
