### PR TITLE
Parallelism

### DIFF
--- a/application/src/main/kotlin/application/TestCommand.kt
+++ b/application/src/main/kotlin/application/TestCommand.kt
@@ -202,7 +202,7 @@ class TestCommand : Callable<Unit> {
             System.setProperty("junit.jupiter.execution.parallel.enabled", "true");
 
             when (parallelism) {
-                "true" -> {
+                "auto" -> {
                     logger.log("Running contract tests in parallel (dynamically determined number of threads)")
                     System.setProperty("junit.jupiter.execution.parallel.config.strategy", "dynamic")
                 }

--- a/application/src/main/kotlin/application/TestCommand.kt
+++ b/application/src/main/kotlin/application/TestCommand.kt
@@ -196,7 +196,7 @@ class TestCommand : Callable<Unit> {
     }
 
     private fun setParallelism() {
-        Flags.parallelism()?.let { parallelism ->
+        Flags.testParallelism()?.let { parallelism ->
             validateParallelism(parallelism)
 
             System.setProperty("junit.jupiter.execution.parallel.enabled", "true");
@@ -223,7 +223,7 @@ class TestCommand : Callable<Unit> {
         try {
             parallelism.toInt()
         } catch(e: Throwable) {
-            exitWithMessage("The value of the ${Flags.PARALLEL_ENV_VAR} environment variable must be either 'true' or an integer value")
+            exitWithMessage("The value of the ${Flags.SPECMATIC_TEST_PARALLELISM} environment variable must be either 'true' or an integer value")
         }
     }
 }

--- a/application/src/main/kotlin/application/test/ContractExecutionListener.kt
+++ b/application/src/main/kotlin/application/test/ContractExecutionListener.kt
@@ -6,6 +6,7 @@ import org.junit.platform.engine.TestExecutionResult
 import org.junit.platform.launcher.TestExecutionListener
 import org.junit.platform.launcher.TestIdentifier
 import org.junit.platform.launcher.TestPlan
+import java.util.*
 import kotlin.system.exitProcess
 
 fun getContractExecutionPrinter(): ContractExecutionPrinter {

--- a/core/src/main/kotlin/in/specmatic/core/Flags.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Flags.kt
@@ -8,6 +8,7 @@ object Flags {
     private const val MAX_TEST_REQUEST_COMBINATIONS = "MAX_TEST_REQUEST_COMBINATIONS"
     const val SCHEMA_EXAMPLE_DEFAULT = "SCHEMA_EXAMPLE_DEFAULT"
     const val ONLY_POSITIVE = "ONLY_POSITIVE"
+    const val PARALLEL_ENV_VAR = "SPECMATIC_PARALLEL"
 
     private fun flagValue(flagName: String): String? {
         return System.getenv(flagName) ?: System.getProperty(flagName)
@@ -33,5 +34,9 @@ object Flags {
 
     fun onlyPositive(): Boolean {
         return booleanFlag(ONLY_POSITIVE)
+    }
+
+    fun parallelism(): String? {
+        return flagValue(PARALLEL_ENV_VAR)
     }
 }

--- a/core/src/main/kotlin/in/specmatic/core/Flags.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Flags.kt
@@ -8,7 +8,7 @@ object Flags {
     private const val MAX_TEST_REQUEST_COMBINATIONS = "MAX_TEST_REQUEST_COMBINATIONS"
     const val SCHEMA_EXAMPLE_DEFAULT = "SCHEMA_EXAMPLE_DEFAULT"
     const val ONLY_POSITIVE = "ONLY_POSITIVE"
-    const val PARALLEL_ENV_VAR = "SPECMATIC_PARALLEL"
+    const val SPECMATIC_TEST_PARALLELISM = "SPECMATIC_TEST_PARALLELISM"
 
     private fun flagValue(flagName: String): String? {
         return System.getenv(flagName) ?: System.getProperty(flagName)
@@ -36,7 +36,7 @@ object Flags {
         return booleanFlag(ONLY_POSITIVE)
     }
 
-    fun parallelism(): String? {
-        return flagValue(PARALLEL_ENV_VAR)
+    fun testParallelism(): String? {
+        return flagValue(SPECMATIC_TEST_PARALLELISM)
     }
 }

--- a/core/src/main/kotlin/in/specmatic/core/log/Logging.kt
+++ b/core/src/main/kotlin/in/specmatic/core/log/Logging.kt
@@ -1,7 +1,7 @@
 package `in`.specmatic.core.log
 
 var logger: LogStrategy = newLogger()
-fun newLogger(): LogStrategy = NonVerbose(CompositePrinter())
+fun newLogger(): LogStrategy = ThreadSafeLog(NonVerbose(CompositePrinter()))
 fun resetLogger() {
     logger = NonVerbose(CompositePrinter())
 }

--- a/core/src/main/kotlin/in/specmatic/core/log/ThreadSafeLog.kt
+++ b/core/src/main/kotlin/in/specmatic/core/log/ThreadSafeLog.kt
@@ -1,0 +1,34 @@
+package `in`.specmatic.core.log
+
+class ThreadSafeLog(val logger: LogStrategy) : LogStrategy by logger {
+    @Synchronized
+    override fun log(e: Throwable, msg: String?) {
+        logger.log(e, msg)
+    }
+
+    @Synchronized
+    override fun log(msg: String) {
+        logger.log(msg)
+    }
+
+    @Synchronized
+    override fun log(msg: LogMessage) {
+        logger.log(msg)
+    }
+
+    @Synchronized
+    override fun newLine() {
+        logger.newLine()
+    }
+
+    @Synchronized
+    override fun debug(msg: LogMessage) {
+        logger.debug(msg)
+    }
+
+    @Synchronized
+    override fun debug(e: Throwable, msg: String?) {
+        logger.debug(e, msg)
+    }
+
+}

--- a/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
@@ -64,10 +64,10 @@ open class SpecmaticJUnitSupport {
             reportProcessors.forEach { it.process(getReportConfiguration()) }
 
             threads.distinct().let {
-//                if(it.size > 1) {
+                if(it.size > 1) {
                     logger.newLine()
                     logger.log("Executed tests in ${it.size} threads")
-//                }
+                }
             }
         }
 

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=1.2.9
+version=1.2.10


### PR DESCRIPTION
**What**:

The contract tests can now be run in multiple threads.

In the TestCommand, set the environment variable SPECMATIC_TEST_PARALLELISM to auto (to let JUnit manage the parallelism of the tests) or a thread count.

In SpecmaticJUnitSupport, set the JUnit parallelism properties directly.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

