### PR TITLE
Docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,51 @@
+name: Manual Release Build and Docker Image
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-and-dockerize:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew build
+
+      - name: Read version from properties
+        id: read_version
+        run: |
+          echo "Reading version from version.properties..."
+          version=$(grep 'version=' version.properties | cut -d'=' -f2)
+          echo "Version: $version"
+          echo "::set-output name=VERSION::$version"
+
+      - name: Set up Docker
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y docker.io
+          sudo systemctl start docker
+          sudo docker --version
+
+      - name: Docker Login
+        run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+          
+      - name: Build Docker Image
+        run: docker build --no-cache -t znsio/specmatic:${{ steps.read_version.outputs.VERSION }} .
+
+      - name: Push Docker Image
+        run: docker push znsio/specmatic:${{ steps.read_version.outputs.VERSION }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,22 @@ Generate Fat Jar. The `specmatic.jar` should be available in `<projectRoot>/appl
 
 Run the `specmatic.jar` to verify any commands as part of your changes.
 
+## Docker Image
+
+To build the docker image, run the following command to create fat jar.
+
+```./gradlew clean build```
+
+Create docker image with appropriate tag. Please keep version consistent with the version.properties file.
+
+```docker build --no-cache -t znsio/specmatic:<version> .```
+
+Login to docker hub and push the image
+
+```docker login -u <username>```
+
+```docker push znsio/specmatic:<version>```
+
 ## Help needed
 
 Please checkout the [the open issues](https://github.com/znsio/specmatic/issues?q=is%3Aopen+is%3Aissue)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,13 @@
-FROM eclipse-temurin:11
-COPY ./application/build/libs/specmatic.jar .
-ENTRYPOINT ["java", "-jar", "specmatic.jar"]
+FROM openjdk:17-jdk-buster
+
+WORKDIR /usr/src/app
+
+RUN apt-get update && \
+    apt-get install -y git && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY ./application/build/libs/specmatic.jar /usr/src/app/specmatic.jar
+
+ENTRYPOINT ["java", "-jar", "/usr/src/app/specmatic.jar"]
+
+CMD []

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
-FROM openjdk:17-jdk-buster
+FROM ubuntu:22.04
 
 WORKDIR /usr/src/app
+
+RUN apt-get update && \
+    apt-get install -y openjdk-17-jre && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN apt-get update && \
     apt-get install -y git && \


### PR DESCRIPTION
**What**:

Build a docker image with the Specmatic shadow jar for every release.

**Why**:

Helps users who want to run Specmatic out of a docker container such as in CI or on local machines. It also removes need to have a local JVM setup.

**How**:

Standard Dockerfile based build that is then published to Dockerhub

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [ ] Tests
- [ ] Sonar Quality Gate
