### PR TITLE
Support all openapi file extensions

### DIFF
--- a/application/src/main/kotlin/application/BundleCommand.kt
+++ b/application/src/main/kotlin/application/BundleCommand.kt
@@ -3,6 +3,7 @@
 package application
 
 import `in`.specmatic.core.APPLICATION_NAME_LOWER_CASE
+import `in`.specmatic.core.YAML
 import `in`.specmatic.core.log.logger
 import `in`.specmatic.core.utilities.ContractPathData
 import `in`.specmatic.stub.customImplicitStubBase
@@ -160,7 +161,7 @@ private fun createBundle(
     zipper.compress(bundleOutputPath ?: bundle.bundlePath, zipperEntries)
 }
 
-private fun yamlFileName(path: String): String = path.removeSuffix(".spec") + ".yaml"
+private fun yamlFileName(path: String): String = path.removeSuffix(".spec") + ".${YAML}"
 
 private fun yamlExists(pathData: String): Boolean =
         File(yamlFileName(pathData)).exists()

--- a/application/src/main/kotlin/application/CompatibleCommand.kt
+++ b/application/src/main/kotlin/application/CompatibleCommand.kt
@@ -11,6 +11,7 @@ import `in`.specmatic.core.log.Verbose
 import `in`.specmatic.core.log.logger
 import `in`.specmatic.core.pattern.ContractException
 import `in`.specmatic.core.utilities.exceptionCauseMessage
+import `in`.specmatic.stub.hasOpenApiFileExtension
 import `in`.specmatic.test.ResultAssert
 import org.junit.jupiter.api.DynamicTest
 import org.junit.jupiter.api.TestFactory
@@ -90,7 +91,7 @@ class GitCompatibleCommand : Callable<Int> {
         if(verbose)
             logger = Verbose(CompositePrinter())
 
-        if(!inputContractPath.isContractFile() && !inputContractPath.endsWith(".yaml") && !File(inputContractPath).isDirectory) {
+        if(!inputContractPath.isContractFile() && !hasOpenApiFileExtension(inputContractPath) && !File(inputContractPath).isDirectory) {
             logger.log(invalidContractExtensionMessage(inputContractPath))
             return 1
         }

--- a/application/src/main/kotlin/application/ToOpenAPICommand.kt
+++ b/application/src/main/kotlin/application/ToOpenAPICommand.kt
@@ -2,6 +2,7 @@
 
 package application
 
+import `in`.specmatic.core.YAML
 import `in`.specmatic.core.log.HeadingLog
 import `in`.specmatic.core.log.Verbose
 import `in`.specmatic.core.log.logger
@@ -44,7 +45,7 @@ class ToOpenAPICommand : Callable<Unit> {
             val openAPIYaml = Yaml.pretty(openAPI)
             val contractFile = File(contractPath)
             val openAPIFile: File =
-                contractFile.canonicalFile.parentFile.resolve(contractFile.nameWithoutExtension + ".yaml")
+                contractFile.canonicalFile.parentFile.resolve("${contractFile.nameWithoutExtension}.$YAML")
             openAPIFile.writeText(openAPIYaml)
         } catch(e: Throwable) {
             logger.log(e)

--- a/core/src/main/kotlin/in/specmatic/reports/CentralContractRepoReport.kt
+++ b/core/src/main/kotlin/in/specmatic/reports/CentralContractRepoReport.kt
@@ -5,7 +5,7 @@ import `in`.specmatic.conversions.convertPathParameterStyle
 import `in`.specmatic.core.log.logger
 import `in`.specmatic.core.utilities.exceptionCauseMessage
 import `in`.specmatic.stub.isOpenAPI
-import `in`.specmatic.stub.isYAML
+import `in`.specmatic.stub.hasOpenApiFileExtension
 import java.io.File
 
 class CentralContractRepoReport {
@@ -58,7 +58,7 @@ class CentralContractRepoReport {
         for (file in allFiles) {
             if (file.isDirectory) {
                 specifications.addAll(findSpecifications(file.canonicalPath))
-            } else if (isYAML(file.canonicalPath) && isOpenAPI(file.canonicalPath)) {
+            } else if (hasOpenApiFileExtension(file.canonicalPath) && isOpenAPI(file.canonicalPath)) {
                 specifications.add(file)
             }
         }

--- a/core/src/main/kotlin/in/specmatic/stub/api.kt
+++ b/core/src/main/kotlin/in/specmatic/stub/api.kt
@@ -67,7 +67,7 @@ fun loadContractStubsFromImplicitPaths(contractPathDataList: List<ContractPathDa
             contractPath.isFile && contractPath.extension in CONTRACT_EXTENSIONS -> {
                 consoleLog(StringLog("Loading $contractPath"))
 
-                if(isYAML(contractPath.path) && !isOpenAPI(contractPath.path.trim())) {
+                if(hasOpenApiFileExtension(contractPath.path) && !isOpenAPI(contractPath.path.trim())) {
                     logger.log("Ignoring ${contractPath.path} as it is not an OpenAPI specification")
                     emptyList()
                 }
@@ -112,7 +112,8 @@ fun loadContractStubsFromImplicitPaths(contractPathDataList: List<ContractPathDa
     }
 }
 
-fun isYAML(contractPath: String): Boolean = contractPath.trim().endsWith(".yaml")
+fun hasOpenApiFileExtension(contractPath: String): Boolean =
+    OPENAPI_FILE_EXTENSIONS.any { contractPath.trim().endsWith(".$it") }
 
 private fun logIgnoredFiles(implicitDataDir: File) {
     val ignoredFiles = implicitDataDir.listFiles()?.toList()?.filter { it.extension != "json" }?.filter { it.isFile } ?: emptyList()
@@ -316,7 +317,7 @@ fun implicitContractDataDir(contractPath: String, customBase: String? = null): F
 }
 
 fun loadIfOpenAPISpecification(contractPathData: ContractPathData): Pair<String, Feature>? {
-    if (!isYAML(contractPathData.path))
+    if (!hasOpenApiFileExtension(contractPathData.path))
         return Pair(contractPathData.path, parseContractFileToFeature(contractPathData.path, CommandHook(HookName.stub_load_contract), contractPathData.provider, contractPathData.repository, contractPathData.branch, contractPathData.specificationPath))
 
     if (isOpenAPI(contractPathData.path))

--- a/core/src/test/kotlin/in/specmatic/proxy/ProxyTest.kt
+++ b/core/src/test/kotlin/in/specmatic/proxy/ProxyTest.kt
@@ -1,17 +1,16 @@
 package `in`.specmatic.proxy
 
 import `in`.specmatic.conversions.OpenApiSpecification
+import `in`.specmatic.core.YAML
 import `in`.specmatic.core.parseGherkinStringToFeature
 import `in`.specmatic.core.pattern.parsedJSON
 import `in`.specmatic.stub.HttpStub
-import `in`.specmatic.stub.createStubFromContracts
 import io.ktor.http.*
 import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.http.client.SimpleClientHttpRequestFactory
 import org.springframework.web.client.RestTemplate
-import org.springframework.web.client.getForEntity
 import java.io.File
 import java.net.InetSocketAddress
 
@@ -167,7 +166,7 @@ class FakeFileWriter : FileWriter {
     override fun writeText(path: String, content: String) {
         this.receivedPaths.add(path)
 
-        if (path.endsWith(".yaml"))
+        if (path.endsWith(".${YAML}"))
             this.receivedContract = content
         else
             this.receivedStub = content

--- a/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
@@ -11,7 +11,7 @@ import `in`.specmatic.core.value.JSONArrayValue
 import `in`.specmatic.core.value.JSONObjectValue
 import `in`.specmatic.core.value.Value
 import `in`.specmatic.stub.isOpenAPI
-import `in`.specmatic.stub.isYAML
+import `in`.specmatic.stub.hasOpenApiFileExtension
 import `in`.specmatic.test.reports.OpenApiCoverageReportProcessor
 import `in`.specmatic.test.reports.coverage.Endpoint
 import `in`.specmatic.test.reports.coverage.OpenApiCoverageReportInput
@@ -291,7 +291,7 @@ open class SpecmaticJUnitSupport {
         filterName: String?,
         filterNotName: String?
     ): Pair<List<ContractTest>, List<Endpoint>> {
-        if(isYAML(path) && !isOpenAPI(path))
+        if(hasOpenApiFileExtension(path) && !isOpenAPI(path))
             return Pair(emptyList(), emptyList())
 
         val contractFile = File(path)


### PR DESCRIPTION
**What**:

Support `.yaml`,`.yml`,`.json` extensions for OpenAPI specifications

**Why**:

Currently some parts of Specmatic only works with `.yaml`, many users have shared feedback that they have `.yml` files

**How**:

Allow all three extensions.

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

**Issue ID**:
Closes: #697
