### PR TITLE
updated the code to handle the lower case authorization header for issue 658, added test case for the same as well

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/BearerSecurityScheme.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/BearerSecurityScheme.kt
@@ -3,37 +3,49 @@ package `in`.specmatic.conversions
 import `in`.specmatic.core.*
 import `in`.specmatic.core.pattern.Row
 import `in`.specmatic.core.pattern.StringPattern
+import io.ktor.http.*
 import org.apache.http.HttpHeaders.AUTHORIZATION
 
 class BearerSecurityScheme(private val token: String? = null) : OpenAPISecurityScheme {
     override fun matches(httpRequest: HttpRequest): Result {
-        httpRequest.headers.let {
-            val authHeaderValue: String = it["Authorization"] ?: it["authorization"]
-            ?: return Result.Failure("$AUTHORIZATION header is missing in request")
+        val authHeaderValue: String? = httpRequest.headers["Authorization"] ?: httpRequest.headers.entries.find {
+            it.key.equals("authorization", ignoreCase = true)
+        }?.value
 
-            if (!authHeaderValue.lowercase().startsWith("bearer"))
-                return Result.Failure("$AUTHORIZATION header must be prefixed with \"Bearer\"")
+        if (authHeaderValue == null) {
+            return Result.Failure("$AUTHORIZATION header is missing in request")
         }
+
+        if (!authHeaderValue.lowercase().startsWith("bearer")) {
+            return Result.Failure("$AUTHORIZATION header must be prefixed with \"Bearer\"")
+        }
+
         return Result.Success()
     }
 
     override fun removeParam(httpRequest: HttpRequest): HttpRequest {
-        return httpRequest.copy(headers = httpRequest.headers.minus(AUTHORIZATION))
+        val headersWithoutAuthorization = httpRequest.headers.filterKeys { !it.equals(AUTHORIZATION, ignoreCase = true) }
+        return httpRequest.copy(headers = headersWithoutAuthorization)
     }
 
     override fun addTo(httpRequest: HttpRequest): HttpRequest {
-        return httpRequest.copy(
-            headers = httpRequest.headers.plus(
-                AUTHORIZATION to getAuthorizationHeaderValue()
-            )
-        )
+        val updatedHeaders = httpRequest.headers.toMutableMap().apply {
+            // Remove any existing Authorization header (case-insensitive)
+            remove(keys.firstOrNull { it.equals(AUTHORIZATION, ignoreCase = true) })
+
+            // Add the new Authorization header
+            put(AUTHORIZATION, getAuthorizationHeaderValue())
+        }
+        return httpRequest.copy(headers = updatedHeaders)
     }
 
     override fun addTo(requestPattern: HttpRequestPattern, row: Row): HttpRequestPattern {
         return addToHeaderType(AUTHORIZATION, row, requestPattern)
     }
 
-    override fun isInRow(row: Row): Boolean = row.containsField(AUTHORIZATION)
+    override fun isInRow(row: Row): Boolean {
+        return row.columnNames.any { it.equals(AUTHORIZATION, ignoreCase = true) }
+    }
 
     private fun getAuthorizationHeaderValue(): String {
         return "Bearer " + (token ?: StringPattern().generate(Resolver()).toStringLiteral())

--- a/core/src/main/kotlin/in/specmatic/conversions/BearerSecurityScheme.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/BearerSecurityScheme.kt
@@ -8,8 +8,8 @@ import org.apache.http.HttpHeaders.AUTHORIZATION
 class BearerSecurityScheme(private val token: String? = null) : OpenAPISecurityScheme {
     override fun matches(httpRequest: HttpRequest): Result {
         httpRequest.headers.let {
-            val authHeaderValue: String = it[AUTHORIZATION]
-                ?: return Result.Failure("$AUTHORIZATION header is missing in request")
+            val authHeaderValue: String = it["Authorization"] ?: it["authorization"]
+            ?: return Result.Failure("$AUTHORIZATION header is missing in request")
 
             if (!authHeaderValue.lowercase().startsWith("bearer"))
                 return Result.Failure("$AUTHORIZATION header must be prefixed with \"Bearer\"")

--- a/core/src/test/kotlin/in/specmatic/conversions/BearerSecuritySchemeTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/BearerSecuritySchemeTest.kt
@@ -19,8 +19,14 @@ class BearerSecuritySchemeTest {
     }
 
     @Test
-    fun `Bearer security scheme matches requests with authorization header set`() {
+    fun `Bearer security scheme matches requests with upper case authorization header set`() {
         val requestWithBearer = HttpRequest(method = "POST", path = "/customer", headers = mapOf(AUTHORIZATION to "Bearer foo"))
+        assertThat(scheme.matches(requestWithBearer).isSuccess()).isTrue
+    }
+
+    @Test
+    fun `Bearer security scheme matches requests with lower case authorization header set`() {
+        val requestWithBearer = HttpRequest(method = "POST", path = "/customer", headers = mapOf("authorization" to "bearer foo"))
         assertThat(scheme.matches(requestWithBearer).isSuccess()).isTrue
     }
 


### PR DESCRIPTION


<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

I have updated[ BearerSecurityScheme.kt ](https://github.com/znsio/specmatic/blob/main/core/src/main/kotlin/in/specmatic/conversions/BearerSecurityScheme.kt), the method **matches** to handle lower case authorization header for **fetch apis** as per the [issue](https://github.com/znsio/specmatic/issues/658).
Earlier the code was designed such a way where it was only handling the scenarios where "**Authorization**" header is in capitalize where as Fetch APIs make the headers in lower case by default.

<!-- Why are these changes necessary? -->

"I need to implement changes to prevent the 'cannot find the authorization header' error in Specmatic when testing Fetch APIs. The objective is to enable Specmatic to gracefully test Fetch APIs without encountering this specific issue."

<!-- How were these changes implemented? -->

I have added one more condition in elvis operator to check for "**authorization**" as well with "**Authorization**"

The change was in the [file](https://github.com/znsio/specmatic/blob/main/core/src/main/kotlin/in/specmatic/conversions/BearerSecurityScheme.kt)

**earlier the code was**
```
   val authHeaderValue: String = it[AUTHORIZATION]
                ?: return Result.Failure("$AUTHORIZATION header is missing in request")
```
   **After the changes** 
   
 ```
 val authHeaderValue: String = it["Authorization"] ?: it["authorization"]
            ?: return Result.Failure("$AUTHORIZATION header is missing in request")
```

            
  New test case is added in this [file](https://github.com/znsio/specmatic/blob/main/core/src/test/kotlin/in/specmatic/conversions/BearerSecuritySchemeTest.kt) 

  ```
  @Test
    fun `Bearer security scheme matches requests with lower case authorization header set`() {
        val requestWithBearer = HttpRequest(method = "POST", path = "/customer", headers = mapOf("authorization" to "bearer foo"))
        assertThat(scheme.matches(requestWithBearer).isSuccess()).isTrue
    }
```


<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation- N/A
- [x] Tests
- [ ] Sonar Quality Gate- N/A

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
[Closes: #658](https://github.com/znsio/specmatic/issues/658)

<!-- feel free to add additional comments -->
