### PR TITLE
Email and password format should be treated as strings

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -1008,6 +1008,10 @@ class OpenApiSpecification(
                 )
             }
 
+            is EmailSchema -> StringPattern(example = schema.example?.toString())
+
+            is PasswordSchema -> StringPattern(example = schema.example?.toString())
+
             is IntegerSchema -> when (schema.enum) {
                 null -> NumberPattern(example = schema.example?.toString())
                 else -> toEnum(schema, patternName) { enumValue ->

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
@@ -9,6 +9,8 @@ import `in`.specmatic.core.HttpRequest
 import `in`.specmatic.core.log.Verbose
 import `in`.specmatic.core.log.logger
 import `in`.specmatic.core.pattern.ContractException
+import `in`.specmatic.core.pattern.Pattern
+import `in`.specmatic.core.pattern.StringPattern
 import `in`.specmatic.core.pattern.parsedJSONObject
 import `in`.specmatic.core.utilities.exceptionCauseMessage
 import `in`.specmatic.core.value.JSONObjectValue
@@ -23,6 +25,7 @@ import io.ktor.server.engine.*
 import io.ktor.server.netty.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
+import io.ktor.util.reflect.*
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -2598,6 +2601,25 @@ components:
 
         assertThat(queryParamsSeen.sorted().distinct()).isEqualTo(listOf("id", "name"))
         assertThat(headersSeen.sorted().distinct()).isEqualTo(listOf("traceId"))
+    }
+
+    @Test
+    fun `should work with password and email formats while generating tests`() {
+        val feature = OpenApiSpecification.fromFile("openapi/spec_with_password_and_email_format_strings.yaml").toFeature()
+        var emailDataType: Pattern? = null
+        var passwordDataType: Pattern? = null
+        feature.executeTests(object : TestExecutor {
+            override fun execute(request: HttpRequest): HttpResponse {
+                emailDataType = request.jsonBody.findFirstChildByName("email")?.type()
+                passwordDataType = request.jsonBody.findFirstChildByName("password")?.type()
+                return HttpResponse.OK
+            }
+
+            override fun setServerState(serverState: Map<String, Value>) {
+            }
+        })
+        assertThat(emailDataType).isInstanceOf(StringPattern::class.java)
+        assertThat(passwordDataType).isInstanceOf(StringPattern::class.java)
     }
 }
 

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
@@ -2621,6 +2621,23 @@ components:
         assertThat(emailDataType).isInstanceOf(StringPattern::class.java)
         assertThat(passwordDataType).isInstanceOf(StringPattern::class.java)
     }
+
+    @Test
+    fun `should work with password and email formats while generating stub`() {
+        val feature = OpenApiSpecification.fromFile("openapi/spec_with_password_and_email_format_strings.yaml").toFeature()
+
+        val response = HttpStub(feature).use {
+            val restTemplate = RestTemplate()
+            restTemplate.postForObject(
+                URI.create("http://localhost:9000/users"),
+                NewUser("Euclid", "euclid@geometry.com", "password"),
+                CreatedUser::class.java
+            )
+        }
+
+        assertThat(response).isInstanceOf(CreatedUser::class.java)
+    }
+
 }
 
 data class CycleRoot(
@@ -2661,6 +2678,18 @@ data class MyBaseHolder(@JsonProperty("myBase") val myBase: MyBase)
 interface MyBase
 data class MySub1(@JsonProperty("aMyBase") val aMyBase: MyBase?) : MyBase
 data class MySub2(@JsonProperty("myVal") val myVal: String) : MyBase
+
+data class NewUser(
+    @JsonProperty val username: String,
+    @JsonProperty val email: String,
+    @JsonProperty val password: String
+)
+
+data class CreatedUser(
+    @JsonProperty("id") val id: Int,
+    @JsonProperty("username") val username: String,
+    @JsonProperty("email") val email: String
+)
 
 data class Pet(
     @JsonProperty("name") val name: String,

--- a/core/src/test/resources/openapi/spec_with_password_and_email_format_strings.yaml
+++ b/core/src/test/resources/openapi/spec_with_password_and_email_format_strings.yaml
@@ -36,6 +36,7 @@ paths:
                 type: object
                 required:
                   - id
+                  - email
                   - username
                 properties:
                   id:

--- a/core/src/test/resources/openapi/spec_with_password_and_email_format_strings.yaml
+++ b/core/src/test/resources/openapi/spec_with_password_and_email_format_strings.yaml
@@ -1,0 +1,47 @@
+openapi: 3.0.0
+info:
+  title: Sample API
+  version: 0.1.9
+paths:
+  /users:
+    post:
+      tags:
+        - User and Authentication
+      description: Register a new user
+      operationId: CreateUser
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - email
+                - password
+                - username
+              properties:
+                username:
+                  type: string
+                email:
+                  type: string
+                  format: email
+                password:
+                  type: string
+                  format: password
+      responses:
+        '201':
+          description: Details of the new user to register
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                  - username
+                properties:
+                  id:
+                    type: number
+                  email:
+                    type: string
+                    format: email
+                  username:
+                    type: string


### PR DESCRIPTION
Email and password format should be treated as strings instead of objects in OpenAPI specification

**What**:

Email and password format in OpenAPI spec should not generate / expect JSON objects, should be strings

**Why**:

Currently Specmatic expects and generates empty JSON objects for email and password format

**How**:

Temporarily treating email and password format as StringPattern, will need to implement EmailPattern and PasswordPattern separately

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [x] Sonar Quality Gate

**Issue ID**:
Closes: #747, #946