### PR TITLE
Adding EmailPattern to generate and match email

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -1008,7 +1008,7 @@ class OpenApiSpecification(
                 )
             }
 
-            is EmailSchema -> EmailPattern.create(example = schema.example?.toString())
+            is EmailSchema -> EmailPattern(example = schema.example?.toString())
 
             is PasswordSchema -> StringPattern(example = schema.example?.toString())
 

--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -1008,7 +1008,7 @@ class OpenApiSpecification(
                 )
             }
 
-            is EmailSchema -> StringPattern(example = schema.example?.toString())
+            is EmailSchema -> EmailPattern.create(example = schema.example?.toString())
 
             is PasswordSchema -> StringPattern(example = schema.example?.toString())
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/EmailPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/EmailPattern.kt
@@ -1,0 +1,44 @@
+package `in`.specmatic.core.pattern
+
+import `in`.specmatic.core.*
+import `in`.specmatic.core.value.StringValue
+import `in`.specmatic.core.value.Value
+import java.util.*
+
+private const val EMAIL_REGEX = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}\$"
+
+class EmailPattern private constructor(private val stringPatternDelegate: StringPattern) :
+    Pattern by stringPatternDelegate {
+
+    companion object {
+        val emailRegex = Regex(EMAIL_REGEX)
+
+        fun create(
+            typeAlias: String? = null,
+            minLength: Int? = null,
+            maxLength: Int? = null,
+            example: String? = null
+        ): EmailPattern {
+            val stringPattern = StringPattern(typeAlias, minLength, maxLength, example)
+            return EmailPattern(stringPattern)
+        }
+    }
+
+    override fun matches(sampleData: Value?, resolver: Resolver): Result {
+        if (sampleData !is StringValue) return mismatchResult("email string", sampleData, resolver.mismatchMessages)
+        val email = sampleData.toStringLiteral()
+        return if (emailRegex.matches(email)) {
+            Result.Success()
+        } else {
+            mismatchResult("email string", sampleData, resolver.mismatchMessages)
+        }
+    }
+
+    override fun generate(resolver: Resolver): Value {
+        val localPart = randomString(5).lowercase(Locale.getDefault())
+        val domain = randomString(5).lowercase(Locale.getDefault())
+        return StringValue("$localPart@$domain.com")
+    }
+
+    override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> = listOf(this)
+}

--- a/core/src/main/kotlin/in/specmatic/core/pattern/EmailPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/EmailPattern.kt
@@ -8,7 +8,7 @@ import java.util.*
 private const val EMAIL_REGEX = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}\$"
 
 class EmailPattern (private val stringPatternDelegate: StringPattern) :
-    Pattern by stringPatternDelegate {
+    Pattern by stringPatternDelegate, ScalarType {
 
     constructor(
         typeAlias: String? = null,

--- a/core/src/main/kotlin/in/specmatic/core/pattern/NumberPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/NumberPattern.kt
@@ -111,6 +111,6 @@ fun encompasses(
         otherPattern is EnumPattern -> {
             encompasses(thisPattern, otherPattern.pattern, thisResolver, otherResolver, typeStack)
         }
-        thisPattern.matches(otherPattern.generate(otherResolver), thisResolver) is Result.Success -> Result.Success()
+        thisPattern is ScalarType && otherPattern is ScalarType && thisPattern.matches(otherPattern.generate(otherResolver), thisResolver) is Result.Success -> Result.Success()
         else -> mismatchResult(thisPattern, otherPattern, thisResolver.mismatchMessages)
     }

--- a/core/src/main/kotlin/in/specmatic/core/pattern/NumberPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/NumberPattern.kt
@@ -111,5 +111,6 @@ fun encompasses(
         otherPattern is EnumPattern -> {
             encompasses(thisPattern, otherPattern.pattern, thisResolver, otherResolver, typeStack)
         }
+        thisPattern is StringPattern && otherPattern is EmailPattern -> otherPattern.fitsWithin(thisPattern.patternSet(thisResolver), thisResolver, otherResolver, typeStack)
         else -> mismatchResult(thisPattern, otherPattern, thisResolver.mismatchMessages)
     }

--- a/core/src/main/kotlin/in/specmatic/core/pattern/NumberPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/NumberPattern.kt
@@ -111,6 +111,6 @@ fun encompasses(
         otherPattern is EnumPattern -> {
             encompasses(thisPattern, otherPattern.pattern, thisResolver, otherResolver, typeStack)
         }
-        thisPattern is StringPattern && otherPattern is EmailPattern -> otherPattern.fitsWithin(thisPattern.patternSet(thisResolver), thisResolver, otherResolver, typeStack)
+        thisPattern.matches(otherPattern.generate(otherResolver), thisResolver) is Result.Success -> Result.Success()
         else -> mismatchResult(thisPattern, otherPattern, thisResolver.mismatchMessages)
     }

--- a/core/src/test/kotlin/in/specmatic/core/pattern/EmailPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/EmailPatternTest.kt
@@ -1,0 +1,31 @@
+package `in`.specmatic.core.pattern
+
+import `in`.specmatic.GENERATION
+import `in`.specmatic.core.Resolver
+import `in`.specmatic.core.Result
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+
+class EmailPatternTest {
+    @Test
+    @Tag(GENERATION)
+    fun `negative values should be generated`() {
+        val result = EmailPattern().negativeBasedOn(Row(), Resolver())
+        assertThat(result.map { it.typeName }).containsExactlyInAnyOrder(
+            "null",
+            "number",
+            "boolean",
+            "string"
+        )
+    }
+
+    @Test
+    fun `email should not encompass string`() {
+        assertThat(
+            EmailPattern().encompasses(StringPattern(), Resolver(), Resolver(), emptySet())
+        ).isInstanceOf(Result.Failure::class.java)
+    }
+
+}

--- a/core/src/test/kotlin/in/specmatic/core/pattern/StringPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/StringPatternTest.kt
@@ -137,7 +137,12 @@ internal class StringPatternTest {
         assertThat(result.map { it.typeName }).containsExactlyInAnyOrder(
             "null",
             "number",
-            "boolean"
+            "boolean",
         )
+    }
+
+    @Test
+    fun `string pattern encompasses email`() {
+        assertThat(StringPattern().encompasses(EmailPattern(), Resolver(), Resolver())).isInstanceOf(Result.Success::class.java)
     }
 }


### PR DESCRIPTION
**What**:

Adding support for OpenAPI email format

**Why**:

To generate emails for tests and match emails in stubs

**How**:

Added EmailPattern which composes StringPattern and delegates all functionality except generation and matching.

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [x] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #946 
