### PR TITLE
Fixes to examples as expectations

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/ExampleRequestBuilder.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/ExampleRequestBuilder.kt
@@ -1,0 +1,77 @@
+package `in`.specmatic.conversions
+
+import `in`.specmatic.core.HttpPathPattern
+import `in`.specmatic.core.HttpRequest
+import `in`.specmatic.core.pattern.parsedValue
+
+class ExampleRequestBuilder(
+    examplePathParams: Map<String, Map<String, String>>,
+    exampleHeaderParams: Map<String, Map<String, String>>,
+    exampleQueryParams: Map<String, Map<String, String>>,
+    val httpPathPattern: HttpPathPattern,
+    private val httpMethod: String,
+    val securitySchemes: Map<String, OpenAPISecurityScheme>
+) {
+    fun examplesWithRequestBodies(exampleBodies: Map<String, String?>): Map<String, List<HttpRequest>> {
+        val examplesWithBodies: Map<String, List<HttpRequest>> = exampleBodies.mapValues { (exampleName, bodyValue) ->
+            val bodies: List<HttpRequest> = if(exampleName in examplesBasedOnParameters) {
+                examplesBasedOnParameters.getValue(exampleName).map { exampleRequest ->
+                    exampleRequest.copy(body = parsedValue(bodyValue))
+                }
+            } else {
+                val httpRequest = HttpRequest(
+                    method = httpMethod,
+                    path = httpPathPattern.path,
+                    body = parsedValue(bodyValue)
+                )
+
+                val requestsWithSecurityParams = securitySchemes.map { (_, securityScheme) ->
+                    securityScheme.addTo(httpRequest)
+                }
+
+                requestsWithSecurityParams
+            }
+
+            bodies
+        }
+
+        val examplesWithoutBodies = (examplesBasedOnParameters.keys - exampleBodies.keys).associate { key ->
+            key to examplesBasedOnParameters.getValue(key)
+        }
+
+        val allExamples = examplesWithBodies + examplesWithoutBodies
+
+        return allExamples
+    }
+
+    private val unionOfParameterKeys =
+        (exampleQueryParams.keys + examplePathParams.keys + exampleHeaderParams.keys).distinct()
+
+    val examplesBasedOnParameters: Map<String, List<HttpRequest>> = unionOfParameterKeys.associateWith { exampleName ->
+        val queryParams = exampleQueryParams[exampleName] ?: emptyMap()
+        val pathParams = examplePathParams[exampleName] ?: emptyMap()
+        val headerParams = exampleHeaderParams[exampleName] ?: emptyMap()
+
+        val path = toConcretePath(pathParams, httpPathPattern)
+
+        val httpRequest =
+            HttpRequest(method = httpMethod, path = path, queryParametersMap = queryParams, headers = headerParams)
+
+        val requestsWithSecurityParams: List<HttpRequest> = securitySchemes.map { (_, securityScheme) ->
+            securityScheme.addTo(httpRequest)
+        }
+
+        requestsWithSecurityParams
+    }
+
+}
+
+private fun toConcretePath(
+    pathParams: Map<String, String>,
+    httpPathPattern: HttpPathPattern
+): String {
+    val path = pathParams.entries.fold(httpPathPattern.toOpenApiPath()) { acc, (key, value) ->
+        acc.replace("{$key}", value)
+    }
+    return path
+}

--- a/core/src/main/kotlin/in/specmatic/stub/ExamplesAsExpectationsMismatch.kt
+++ b/core/src/main/kotlin/in/specmatic/stub/ExamplesAsExpectationsMismatch.kt
@@ -1,0 +1,18 @@
+package `in`.specmatic.stub
+
+import `in`.specmatic.core.MismatchMessages
+
+class ExamplesAsExpectationsMismatch(val exampleName: String) : MismatchMessages {
+    override fun mismatchMessage(expected: String, actual: String): String {
+        return "$actual in the example \"$exampleName\" does not match $expected in the spec"
+    }
+
+    override fun unexpectedKey(keyLabel: String, keyName: String): String {
+        return "$keyLabel named $keyName in the example \"$exampleName\" was not found in the spec"
+    }
+
+    override fun expectedKeyWasMissing(keyLabel: String, keyName: String): String {
+        return "$keyLabel named $keyName in the spec was not found in the \"$exampleName\" example"
+    }
+
+}

--- a/core/src/main/kotlin/in/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/in/specmatic/stub/HttpStub.kt
@@ -19,7 +19,7 @@ import io.ktor.http.content.*
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
 import io.ktor.server.netty.*
-import io.ktor.server.plugins.cors.CORS
+import io.ktor.server.plugins.cors.*
 import io.ktor.server.plugins.doublereceive.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
@@ -533,21 +533,6 @@ class HttpStub(
             saveJsonFile(reportJson, JSON_REPORT_PATH, JSON_REPORT_FILE_NAME)
         }
     }
-}
-
-class ExamplesAsExpectationsMismatch(val exampleName: String) : MismatchMessages {
-    override fun mismatchMessage(expected: String, actual: String): String {
-        return "$actual in the example \"$exampleName\" does not match $expected in the spec"
-    }
-
-    override fun unexpectedKey(keyLabel: String, keyName: String): String {
-        return "$keyLabel named $keyName in the example \"$exampleName\" was not found in the spec"
-    }
-
-    override fun expectedKeyWasMissing(keyLabel: String, keyName: String): String {
-        return "$keyLabel named $keyName in the spec was not found in the \"$exampleName\" example"
-    }
-
 }
 
 class CouldNotParseRequest(innerException: Throwable) : Exception(exceptionCauseMessage(innerException))

--- a/core/src/main/kotlin/in/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/in/specmatic/stub/HttpStub.kt
@@ -83,25 +83,28 @@ class HttpStub(
     private fun staticHttpStubData(rawHttpStubs: List<HttpStubData>): MutableList<HttpStubData> {
         val staticStubs = rawHttpStubs.filter { it.stubToken == null }.toMutableList()
         val stubsFromSpecificationExamples: List<HttpStubData> = features.map { feature ->
-            feature.stubsFromExamples.entries.map {
-                it.value.mapNotNull { (request, response) ->
+            feature.stubsFromExamples.entries.map { (exampleName, examples) ->
+                examples.mapNotNull { (request, response) ->
                     try {
-                        val matchResult: HttpStubData =
-                            feature.matchingStub(request, response, ContractAndStubMismatchMessages)
-                        if (matchResult.matchFailure) {
-                            logger.log(matchResult.response.body.toStringLiteral())
+                        val stubData: HttpStubData =
+                            feature.matchingStub(request, response, ExamplesAsExpectationsMismatch(exampleName))
+
+                        if (stubData.matchFailure) {
+                            logger.log(stubData.response.body.toStringLiteral())
                             null
                         } else {
-                            matchResult
+                            stubData
                         }
                     } catch (e: Throwable) {
                         when (e) {
                             is ContractException, is NoMatchingScenario -> {
-                                logger.log(e)
+                                logger.log(e, "Error when loading example \"$exampleName\" as expectation")
                                 null
                             }
-
-                            else -> throw e
+                            else -> {
+                                logger.log(e, "Error when loading example \"$exampleName\" as expectation")
+                                throw e
+                            }
                         }
                     }
                 }
@@ -530,6 +533,21 @@ class HttpStub(
             saveJsonFile(reportJson, JSON_REPORT_PATH, JSON_REPORT_FILE_NAME)
         }
     }
+}
+
+class ExamplesAsExpectationsMismatch(val exampleName: String) : MismatchMessages {
+    override fun mismatchMessage(expected: String, actual: String): String {
+        return "$actual in the example \"$exampleName\" does not match $expected in the spec"
+    }
+
+    override fun unexpectedKey(keyLabel: String, keyName: String): String {
+        return "$keyLabel named $keyName in the example \"$exampleName\" was not found in the spec"
+    }
+
+    override fun expectedKeyWasMissing(keyLabel: String, keyName: String): String {
+        return "$keyLabel named $keyName in the spec was not found in the \"$exampleName\" example"
+    }
+
 }
 
 class CouldNotParseRequest(innerException: Throwable) : Exception(exceptionCauseMessage(innerException))

--- a/core/src/test/kotlin/in/specmatic/conversions/ExamplesAsStubTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/ExamplesAsStubTest.kt
@@ -487,7 +487,7 @@ components:
     }
 
     @Test
-    fun `expectations with path param and request body`() {
+    fun `expectations with path param + header + request body`() {
         val spec = """
 openapi: 3.0.0
 info:
@@ -498,6 +498,14 @@ paths:
     parameters:
       - name: id
         in: path
+        required: true
+        schema:
+          type: integer
+        examples:
+          SUCCESS:
+            value: 10
+      - name: trace-id
+        in: header
         required: true
         schema:
           type: integer
@@ -535,7 +543,13 @@ paths:
 
         val contract = OpenApiSpecification.fromYAML(spec, "").toFeature()
         HttpStub(contract).use { stub ->
-            val response = stub.client.execute(HttpRequest("POST", "/products/10", emptyMap(), parsedJSONObject("""{"name": "Macbook"}""")))
+            val request = HttpRequest(
+                "POST",
+                "/products/10",
+                mapOf("trace-id" to "10"),
+                parsedJSONObject("""{"name": "Macbook"}""")
+            )
+            val response = stub.client.execute(request)
             assertThat(response.status).isEqualTo(200)
             assertThat(response.body.toStringLiteral()).isEqualTo("success")
         }

--- a/core/src/test/kotlin/in/specmatic/conversions/ExamplesAsStubTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/ExamplesAsStubTest.kt
@@ -1,9 +1,12 @@
 package `in`.specmatic.conversions
 
 import `in`.specmatic.core.HttpRequest
+import `in`.specmatic.core.HttpResponse
 import `in`.specmatic.core.pattern.parsedJSONArray
 import `in`.specmatic.core.pattern.parsedJSONObject
+import `in`.specmatic.mock.ScenarioStub
 import `in`.specmatic.stub.HttpStub
+import `in`.specmatic.stub.HttpStubData
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -479,6 +482,61 @@ components:
                     """.trimIndent())
                     )
                 }
+        }
+    }
+
+    @Test
+    fun `expectations with path param and request body`() {
+        val spec = """
+openapi: 3.0.0
+info:
+  title: Product API
+  version: 0.1.9
+paths:
+  /products/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+        examples:
+          SUCCESS:
+            value: 10
+    post:
+      summary: create product
+      description: create product
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+            examples:
+              SUCCESS:
+                value:
+                  name: 'Macbook'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: string
+              examples:
+                SUCCESS:
+                  value: success
+""".trimIndent()
+
+        val contract = OpenApiSpecification.fromYAML(spec, "").toFeature()
+        HttpStub(contract).use { stub ->
+            val response = stub.client.execute(HttpRequest("POST", "/products/10", emptyMap(), parsedJSONObject("""{"name": "Macbook"}""")))
+            assertThat(response.status).isEqualTo(200)
+            assertThat(response.body.toStringLiteral()).isEqualTo("success")
         }
     }
 }


### PR DESCRIPTION
**What**:

* Bug fix: Path and headers are now loaded when a request body example exists. Previously they were omitted when the request body example was found.
* Show the name of the example if the example does not match the specification and hence cannot be loaded

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [x] Sonar Quality Gate