### PR TITLE
Fixed the stringly check for query scalar patterns

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/pattern/EnumPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/EnumPattern.kt
@@ -29,7 +29,7 @@ private infix fun Boolean.yet(otherBooleanValue: Boolean): Boolean {
 data class EnumPattern(
     override val pattern: AnyPattern,
     val nullable: Boolean
-) : Pattern by pattern {
+) : Pattern by pattern, ScalarType {
     constructor(values: List<Value>,
                 key: String? = null,
                 typeAlias: String? = null,

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=1.2.15
+version=1.2.16


### PR DESCRIPTION
**What**:

Due to an issue in the stringlyCheck functionality, invalid -ve tests were being generated for query params. This PR fixes the bug.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #123

<!-- feel free to add additional comments -->
