### PR TITLE
Log startup error

### DIFF
--- a/application/src/main/kotlin/application/test/ColorPrinter.kt
+++ b/application/src/main/kotlin/application/test/ColorPrinter.kt
@@ -16,7 +16,7 @@ class ColorPrinter: ContractExecutionPrinter {
 
         println(color.a(testSummary.message).reset())
         println()
-        println("Tests ran at ${currentDateAndTime()}")
+        println("Executed at ${currentDateAndTime()}")
     }
 
     override fun printTestSummary(testIdentifier: TestIdentifier?, testExecutionResult: TestExecutionResult?) {

--- a/application/src/main/kotlin/application/test/MonochromePrinter.kt
+++ b/application/src/main/kotlin/application/test/MonochromePrinter.kt
@@ -7,7 +7,7 @@ class MonochromePrinter: ContractExecutionPrinter {
     override fun printFinalSummary(testSummary: TestSummary) {
         println(testSummary.message)
         println()
-        println("Tests ran at ${currentDateAndTime()}")
+        println("Executed at ${currentDateAndTime()}")
     }
 
     override fun printTestSummary(testIdentifier: TestIdentifier?, testExecutionResult: TestExecutionResult?) {

--- a/core/src/main/kotlin/in/specmatic/core/log/LogStrategy.kt
+++ b/core/src/main/kotlin/in/specmatic/core/log/LogStrategy.kt
@@ -10,7 +10,7 @@ interface LogStrategy {
     fun log(e: Throwable, msg: String? = null)
     fun log(msg: String)
     fun log(msg: LogMessage)
-
+    fun logError(e:Throwable)
     fun newLine()
     fun debug(msg: String): String
     fun debug(msg: LogMessage)

--- a/core/src/main/kotlin/in/specmatic/core/log/NonVerbose.kt
+++ b/core/src/main/kotlin/in/specmatic/core/log/NonVerbose.kt
@@ -37,6 +37,10 @@ class NonVerbose(override val printer: CompositePrinter) : LogStrategy {
         print(msg)
     }
 
+    override fun logError(e: Throwable) {
+        log(e,"ERROR")
+    }
+
     override fun newLine() {
         print(NewLineLogMessage)
     }

--- a/core/src/main/kotlin/in/specmatic/core/log/ThreadSafeLog.kt
+++ b/core/src/main/kotlin/in/specmatic/core/log/ThreadSafeLog.kt
@@ -31,4 +31,8 @@ class ThreadSafeLog(val logger: LogStrategy) : LogStrategy by logger {
         logger.debug(e, msg)
     }
 
+    @Synchronized
+    override fun logError(e: Throwable) {
+        logger.logError(e)
+    }
 }

--- a/core/src/main/kotlin/in/specmatic/core/log/Verbose.kt
+++ b/core/src/main/kotlin/in/specmatic/core/log/Verbose.kt
@@ -39,6 +39,10 @@ class Verbose(override val printer: CompositePrinter = CompositePrinter()) : Log
         print(msg)
     }
 
+    override fun logError(e: Throwable) {
+        log(e,"ERROR")
+    }
+
     override fun newLine() {
         print(NewLineLogMessage)
     }

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -6275,6 +6275,10 @@ paths:
                 TODO("Not yet implemented")
             }
 
+            override fun logError(e: Throwable) {
+                TODO("Not yet implemented")
+            }
+
             override fun newLine() {
                 TODO("Not yet implemented")
             }
@@ -6356,6 +6360,10 @@ paths:
             }
 
             override fun log(msg: LogMessage) {
+                TODO("Not yet implemented")
+            }
+
+            override fun logError(e: Throwable) {
                 TODO("Not yet implemented")
             }
 

--- a/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
@@ -332,8 +332,8 @@ open class SpecmaticJUnitSupport {
 
     enum class URIValidationResult(val message: String) {
         URIParsingError("Please specify a valid URL"),
-        InvalidURLScheme("Please specify a valid scheme / protocol (http or https)"),
-        InvalidPort("Please specify a valid port number"),
+        InvalidURLSchemeError("Please specify a valid scheme / protocol (http or https)"),
+        InvalidPortError("Please specify a valid port number"),
         Success("This URL is valid");
     }
 
@@ -350,9 +350,8 @@ open class SpecmaticJUnitSupport {
         val validPorts = 1..65535
 
         return when {
-            !validProtocols.contains(parsedURI.scheme) -> InvalidURLScheme
-//            parsedURI.port != -1 && !validPorts.contains(parsedURI.port) -> InvalidPort
-            parsedURI.port == -1 && !validPorts.contains(parsedURI.port) -> InvalidPort
+            !validProtocols.contains(parsedURI.scheme) -> InvalidURLSchemeError
+            parsedURI.port == -1 && !validPorts.contains(parsedURI.port) -> InvalidPortError
 
             else -> Success
         }

--- a/junit5-support/src/main/kotlin/in/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
@@ -24,6 +24,10 @@ class OpenApiCoverageReportInput(
         testResultRecords.add(testResultRecord)
     }
 
+    fun areTestResultsEmpty(): Boolean {
+        return testResultRecords.isEmpty()
+    }
+
     fun addAPIs(apis: List<API>) {
         applicationAPIs.addAll(apis)
     }


### PR DESCRIPTION
**What**:

When an invalid `testBaseURL` value has been provided, preventing any contract tests from running, the error message was unclear, and the screen was too cluttered. As a result, it was hard for a user to figure out that the URL was at fault.

**How**:

This PR makes the error message clearer, and removes the API Coverage Summary, which is of no value in any case when an invalid URL has prevented all of the contract tests from running.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

