### PR TITLE
Publish shadow jar

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -126,7 +126,7 @@ javadoc {
 publishing {
     publications {
         mavenJava(MavenPublication) {
-            artifactId = 'specmatic'
+            artifactId = 'specmatic-executable'
             from components.java
             pom {
                 name = 'Specmatic Command'

--- a/application/build.gradle
+++ b/application/build.gradle
@@ -129,8 +129,8 @@ publishing {
             artifactId = 'specmatic-executable'
             from components.java
             pom {
-                name = 'Specmatic Command'
-                description = 'Executable command for Specmatic'
+                name = 'Specmatic Executable'
+                description = 'Command-line standalone executable jar for Specmatic'
                 url = 'https://specmatic.in'
                 licenses {
                     license {

--- a/application/build.gradle
+++ b/application/build.gradle
@@ -122,3 +122,53 @@ javadoc {
         options.addBooleanOption('html5', true)
     }
 }
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            artifactId = 'specmatic'
+            from components.java
+            pom {
+                name = 'Specmatic Command'
+                description = 'Executable command for Specmatic'
+                url = 'https://specmatic.in'
+                licenses {
+                    license {
+                        name = 'MIT'
+                        url = 'https://github.com/znsio/specmatic/blob/main/License.md'
+                    }
+                }
+                developers {
+                    developer {
+                        id = 'specmaticBuilders'
+                        name = 'Specmatic Builders'
+                        email = 'info@specmatic.in'
+                    }
+                }
+                scm {
+                    connection = 'scm:git:git@github.com:znsio/specmatic.git'
+                    url = 'https://specmatic.in/'
+                }
+            }
+        }
+    }
+    repositories {
+        maven {
+            def releasesRepoUrl = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2"
+            def snapshotsRepoUrl = "https://s01.oss.sonatype.org/content/repositories/snapshots"
+            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+            credentials {
+                username = project.hasProperty("ossrhUsername") ? project.getProperty("ossrhUsername") : ""
+                password = project.hasProperty("ossrhPassword") ? project.getProperty("ossrhPassword") : ""
+            }
+        }
+    }
+}
+
+signing {
+    sign publishing.publications.mavenJava
+}
+
+tasks.withType(Sign).configureEach {
+    onlyIf { project.hasProperty("signing.keyId") }
+}


### PR DESCRIPTION
**What**:

The application jar now gets published to maven central as specmatic-executable.

**How**:

The `build.gradle` file in the `application` project has been updated with publishing details much like the `core` `junit5-support` projects.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #731 

<!-- feel free to add additional comments -->
