### PR TITLE
Improved error message shown when an http status is not a number

### DIFF
--- a/application/src/main/kotlin/application/HTTPStubEngine.kt
+++ b/application/src/main/kotlin/application/HTTPStubEngine.kt
@@ -2,6 +2,7 @@ package application
 
 import `in`.specmatic.core.Feature
 import `in`.specmatic.core.WorkingDirectory
+import `in`.specmatic.core.log.NewLineLogMessage
 import `in`.specmatic.core.log.StringLog
 import `in`.specmatic.core.log.consoleLog
 import `in`.specmatic.mock.ScenarioStub
@@ -42,6 +43,7 @@ class HTTPStubEngine {
             workingDirectory = workingDirectory,
             specmaticConfigPath = specmaticConfigPath
         ).also {
+            consoleLog(NewLineLogMessage)
             val protocol = if (keyStoreData != null) "https" else "http"
             consoleLog(StringLog("Stub server is running on ${protocol}://$host:$port. Ctrl + C to stop."))
         }

--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -471,7 +471,7 @@ class OpenApiSpecification(
     private fun toHttpResponsePatterns(responses: ApiResponses?): List<ResponseData> {
         return responses.orEmpty().map { (status, response) ->
             val headersMap = openAPIHeadersToSpecmatic(response)
-            if(!isNumber(status))
+            if(!isNumber(status) && status != "default")
                 throw ContractException("Response status codes are expected to be numbers, but \"$status\" was found")
 
             openAPIResponseToSpecmatic(response, status, headersMap)

--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -286,7 +286,9 @@ class OpenApiSpecification(
 
                     val requestBody: RequestBody? = resolveRequestBody(operation)
 
-                    val httpResponsePatterns: List<ResponseData> = toHttpResponsePatterns(operation.responses)
+                    val httpResponsePatterns: List<ResponseData> = attempt("Error parsing responses for operation $httpMethod $openApiPath") {
+                        toHttpResponsePatterns(operation.responses)
+                    }
                     val httpRequestPatterns: List<Pair<HttpRequestPattern, Map<String, List<HttpRequest>>>> =
                         toHttpRequestPatterns(
                             specmaticPathParam, specmaticQueryParam, httpMethod, operation
@@ -462,9 +464,16 @@ class OpenApiSpecification(
 
     private fun openApiPaths() = parsedOpenApi.paths.orEmpty()
 
+    private fun isNumber(value: String): Boolean {
+        return value.toIntOrNull() != null
+    }
+
     private fun toHttpResponsePatterns(responses: ApiResponses?): List<ResponseData> {
         return responses.orEmpty().map { (status, response) ->
             val headersMap = openAPIHeadersToSpecmatic(response)
+            if(!isNumber(status))
+                throw ContractException("Response status codes are expected to be numbers, but \"$status\" was found")
+
             openAPIResponseToSpecmatic(response, status, headersMap)
         }.flatten()
     }

--- a/core/src/main/kotlin/in/specmatic/stub/api.kt
+++ b/core/src/main/kotlin/in/specmatic/stub/api.kt
@@ -89,7 +89,7 @@ fun loadContractStubsFromImplicitPaths(contractPathDataList: List<ContractPathDa
                                     try {
                                         Pair(it.path, stringToMockScenario(StringValue(it.readText())))
                                     } catch (e: Throwable) {
-                                        logger.log(e, "    Could not load stub file ${it.canonicalPath}")
+                                        logger.log(e, "  Could not load stub file ${it.canonicalPath}")
                                         null
                                     }
                                 }
@@ -100,7 +100,7 @@ fun loadContractStubsFromImplicitPaths(contractPathDataList: List<ContractPathDa
 
                     loadContractStubs(listOf(Pair(contractPath.path, feature)), stubData)
                 } catch(e: Throwable) {
-                    logger.log(e, "    Could not load ${contractPath.canonicalPath}")
+                    logger.log(e, "  Could not load ${contractPath.canonicalPath}")
                     emptyList()
                 }
             }

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -7015,6 +7015,43 @@ paths:
         }
     }
 
+    @Test
+    fun `show clear error for non-numerical response codes`() {
+        try {
+            OpenApiSpecification.fromYAML(
+                """
+            openapi: 3.0.1
+            info:
+              title: Random
+              version: "1"
+            paths:
+              /random1:
+                post:
+                  summary: With examples
+                  parameters: []
+                  requestBody:
+                    content:
+                      application/json:
+                        schema:
+                          required:
+                          - id
+                          properties:
+                            id:
+                              type: number
+                  responses:
+                    "2xx":
+                      description: Random
+                      content:
+                        text/plain:
+                          schema:
+                            type: string
+        """.trimIndent(), ""
+            ).toFeature()
+        } catch (e: Throwable) {
+            assertThat(exceptionCauseMessage(e)).contains("2xx")
+        }
+    }
+
     private fun ignoreButLogException(function: () -> OpenApiSpecification) {
         try {
             function()

--- a/core/src/test/kotlin/in/specmatic/conversions/RefPartParsingTests.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/RefPartParsingTests.kt
@@ -4,6 +4,7 @@ import `in`.specmatic.core.HttpRequest
 import `in`.specmatic.core.HttpResponse
 import `in`.specmatic.core.pattern.ContractException
 import `in`.specmatic.core.pattern.parsedJSONObject
+import `in`.specmatic.core.utilities.exceptionCauseMessage
 import `in`.specmatic.core.value.Value
 import `in`.specmatic.test.TestExecutor
 import org.assertj.core.api.Assertions.assertThat
@@ -320,7 +321,9 @@ paths:
             OpenApiSpecification.fromYAML(specification, "").toFeature()
         }
             .isInstanceOf(ContractException::class.java)
-            .hasMessageContaining("X-HelloResponseHeader")
+            .satisfies( {
+                assertThat(exceptionCauseMessage(it)).contains("X-HelloResponseHeader")
+            })
     }
 
     @Test


### PR DESCRIPTION
**What**:

Show a message saying that the status has to be a number but what was found (e.g. '4xx') was not a number.

**Why**:

Specifications may have non-numerical values for a response code, and the error from Specmatic needs to be made clearer.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #696 

<!-- feel free to add additional comments -->
