### PR TITLE
Signal failure when the URL is malformed

### DIFF
--- a/junit5-support/build.gradle
+++ b/junit5-support/build.gradle
@@ -24,6 +24,8 @@ dependencies {
 
     implementation "io.ktor:ktor-client-core-jvm:${ktor_version}"
     implementation "io.ktor:ktor-client-cio:${ktor_version}"
+
+    testImplementation "org.junit.jupiter:junit-jupiter-params:${junit_version}"
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {

--- a/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
@@ -240,7 +240,7 @@ open class SpecmaticJUnitSupport {
         } catch (e: Throwable) {
             logger.logError(e)
             logger.newLine()
-            return emptyList()
+            throw(e)
         }
 
         logger.log("Executing $totalTestCount tests")

--- a/junit5-support/src/test/kotlin/in/specmatic/test/SpecmaticJunitSupportTest.kt
+++ b/junit5-support/src/test/kotlin/in/specmatic/test/SpecmaticJunitSupportTest.kt
@@ -9,13 +9,19 @@ import `in`.specmatic.test.reports.coverage.Endpoint
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatCode
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import org.opentest4j.TestAbortedException
+import java.util.*
 
 class SpecmaticJunitSupportTest {
+    companion object {
+        val initialPropertyKeys = System.getProperties().mapKeys { it.key.toString() }.keys
+    }
+
     @Test
     fun `should retain open api path parameter convention for parameterized endpoints`() {
         val result: Pair<List<ContractTest>, List<Endpoint>> = SpecmaticJUnitSupport().loadTestScenarios(
@@ -137,6 +143,6 @@ class SpecmaticJunitSupportTest {
 
     @AfterEach
     fun tearDown() {
-        listOf(TEST_BASE_URL, HOST, PORT, PROTOCOL).forEach { System.clearProperty(it) }
+        System.getProperties().keys.minus(initialPropertyKeys).forEach { println("Clearing $it"); System.clearProperty(it.toString()) }
     }
 }

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=1.2.17
+version=1.2.18


### PR DESCRIPTION
**What**:

Fix a bug where if the testBaseURL is malformed (or an invalid value is provided for `port` property, parameter, etc), no tests are executed but the test suite passes.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

