### PR TITLE
Fixed the logic for matching the path of a wrapper scenario

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/ScenarioInfo.kt
+++ b/core/src/main/kotlin/in/specmatic/core/ScenarioInfo.kt
@@ -44,12 +44,14 @@ data class ScenarioInfo(
                     Pair("exact", "exact") -> apiSpecification.exactValuePatternsAreEqual(openapiURLPart, wrapperURLPart)
                     Pair("exact", "pattern") -> false
                     Pair("pattern", "exact") -> {
-                        attempt("Error matching url ${this.httpRequestPattern.httpPathPattern.path} to the specification") {
+                        try {
                             apiSpecification.patternMatchesExact(
                                 wrapperURLPart,
                                 openapiURLPart,
                                 resolver
                             )
+                        } catch(e: Throwable) {
+                            false
                         }
                     }
                     Pair("pattern", "pattern") -> {

--- a/core/src/test/resources/openapi/similar_paths.yaml
+++ b/core/src/test/resources/openapi/similar_paths.yaml
@@ -1,0 +1,54 @@
+openapi: 3.0.1
+info:
+  title: test case
+  version: "1"
+servers:
+  - url: https://test.com
+
+paths:
+  /v1/users/me:
+    get:
+      operationId: getCurrentUser
+      responses:
+        "200":
+          description: "Ok"
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - fullname
+                properties:
+                  fullname:
+                    type: string
+  /v1/users/{userId}:
+    get:
+      operationId: getUserById
+      parameters:
+        - name: userId
+          schema:
+            type: number
+          in: path
+          required: true
+      responses:
+        "200":
+          description: "Ok"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+
+components:
+  schemas:
+    User:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: number
+        firstname:
+          type: string
+        lastname:
+          type: string


### PR DESCRIPTION
**What**:

Given two paths in an OpenAPI spec such as `/user/{id}` and `/user/me`, and a Scenario in a Gherkin wrapper having the path `/user/me`, contract tests would fail, and the error was that `me` was not a number.

See #717 for more details.

This PR fixes the issue by updating the matching logic, so that
1. a Gherkin wrapper Scenario with the path `/user/me` would successfully match it's OpenAPI counterpart, 
2. while preserving the functionality whereby `/user/abc` would fail since `abc` is neither `me` nor a number.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #717

<!-- feel free to add additional comments -->
