### PR TITLE
Bearer security scheme improvements

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/BearerSecurityScheme.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/BearerSecurityScheme.kt
@@ -3,13 +3,12 @@ package `in`.specmatic.conversions
 import `in`.specmatic.core.*
 import `in`.specmatic.core.pattern.Row
 import `in`.specmatic.core.pattern.StringPattern
-import io.ktor.http.*
 import org.apache.http.HttpHeaders.AUTHORIZATION
 
 class BearerSecurityScheme(private val token: String? = null) : OpenAPISecurityScheme {
     override fun matches(httpRequest: HttpRequest): Result {
-        val authHeaderValue: String? = httpRequest.headers["Authorization"] ?: httpRequest.headers.entries.find {
-            it.key.equals("authorization", ignoreCase = true)
+        val authHeaderValue: String? = httpRequest.headers.entries.find {
+            it.key.equals(AUTHORIZATION.lowercase(), ignoreCase = true)
         }?.value
 
         if (authHeaderValue == null) {
@@ -29,13 +28,12 @@ class BearerSecurityScheme(private val token: String? = null) : OpenAPISecurityS
     }
 
     override fun addTo(httpRequest: HttpRequest): HttpRequest {
-        val updatedHeaders = httpRequest.headers.toMutableMap().apply {
-            // Remove any existing Authorization header (case-insensitive)
-            remove(keys.firstOrNull { it.equals(AUTHORIZATION, ignoreCase = true) })
-
-            // Add the new Authorization header
-            put(AUTHORIZATION, getAuthorizationHeaderValue())
-        }
+        val updatedHeaders = httpRequest.headers.filterKeys {
+            !it.equals(
+                AUTHORIZATION,
+                ignoreCase = true
+            )
+        } + (AUTHORIZATION to getAuthorizationHeaderValue())
         return httpRequest.copy(headers = updatedHeaders)
     }
 

--- a/core/src/test/kotlin/in/specmatic/conversions/BearerSecuritySchemeTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/BearerSecuritySchemeTest.kt
@@ -59,5 +59,11 @@ class BearerSecuritySchemeTest {
             headers = mapOf(authorizationHeaderName to "Bearer efgh5678")
         ))
         assertThat(updatedHttpRequest.headers[AUTHORIZATION]).isEqualTo("Bearer abcd1234")
+        assertThat(updatedHttpRequest.headers.filterKeys {
+            it.equals(
+                AUTHORIZATION,
+                ignoreCase = true
+            )
+        }.count()).isEqualTo(1)
     }
 }


### PR DESCRIPTION
**What**:

Bearer security scheme improvements

**Why**:

Improving test coverage and cleanup

**How**:

1. removing extra Authorization header lookup
2. avoiding mutable map in addTo
3. parameterising tests with different casing for Authorization header
4. adding tests for addTo

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [x] Sonar Quality Gate

