### PR TITLE
Added more validations to the OpenAPI spec parser

### DIFF
--- a/application/src/test/kotlin/application/StubCommandTest.kt
+++ b/application/src/test/kotlin/application/StubCommandTest.kt
@@ -118,7 +118,7 @@ internal class StubCommandTest {
         verify(exactly = 1) { httpStubEngine.runHTTPStub(
             stubInfo,
             host,
-            port,
+            any(),
             certInfo,
             strictMode,
             any(),
@@ -209,7 +209,7 @@ internal class StubCommandTest {
         verify(exactly = 1) { httpStubEngine.runHTTPStub(
             stubInfo,
             host,
-            port,
+            any(),
             certInfo,
             strictMode,
             any(),

--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiOperation.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiOperation.kt
@@ -1,0 +1,21 @@
+package `in`.specmatic.conversions
+
+import `in`.specmatic.core.pattern.ContractException
+import io.swagger.v3.oas.models.Operation
+
+class OpenApiOperation(val operation: Operation) {
+    fun validateParameters() {
+        operation.parameters.orEmpty().forEach { parameter ->
+            if(parameter.name == null)
+                throw ContractException("A parameter does not have a name.")
+
+            if(parameter.schema == null)
+                throw ContractException("A parameter does not have a schema.")
+
+            if(parameter.schema.type == "array" && parameter.schema.items == null)
+                throw ContractException("A parameter of type \"array\" has not defined \"items\".")
+
+        }
+    }
+
+}

--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -6,6 +6,7 @@ import `in`.specmatic.core.Result.Failure
 import `in`.specmatic.core.log.LogStrategy
 import `in`.specmatic.core.log.logger
 import `in`.specmatic.core.pattern.*
+import `in`.specmatic.core.utilities.capitalizeFirstChar
 import `in`.specmatic.core.utilities.readEnvVarOrProperty
 import `in`.specmatic.core.value.*
 import `in`.specmatic.core.wsdl.parser.message.MULTIPLE_ATTRIBUTE_VALUE
@@ -557,7 +558,7 @@ class OpenApiSpecification(
                 status = if (status == "default") 1000 else status.toInt(),
                 body = when (contentType) {
                     "application/xml" -> toXMLPattern(mediaType)
-                    else -> toSpecmaticPattern(mediaType)
+                    else -> toSpecmaticPattern(mediaType, "response")
                 }
             )
 
@@ -685,7 +686,7 @@ class OpenApiSpecification(
 
                     Pair(
                         requestPattern.copy(
-                            body = toSpecmaticPattern(mediaType),
+                            body = toSpecmaticPattern(mediaType, "request"),
                             headersPattern = headersPatternWithContentType(requestPattern, contentType)
                         ), allExamples
                     )
@@ -792,8 +793,8 @@ class OpenApiSpecification(
     ) = if (mediaType.encoding.isNullOrEmpty()) false
     else mediaType.encoding[formFieldName]?.contentType == "application/json"
 
-    private fun toSpecmaticPattern(mediaType: MediaType, jsonInFormData: Boolean = false): Pattern =
-        toSpecmaticPattern(mediaType.schema ?: throw ContractException("Response body definition is missing"), emptyList(), jsonInFormData = jsonInFormData)
+    private fun toSpecmaticPattern(mediaType: MediaType, section: String, jsonInFormData: Boolean = false): Pattern =
+        toSpecmaticPattern(mediaType.schema ?: throw ContractException("${section.capitalizeFirstChar()} body definition is missing"), emptyList(), jsonInFormData = jsonInFormData)
 
     private fun resolveDeepAllOfs(schema: Schema<Any>): List<Schema<Any>> {
         if (schema.allOf == null)

--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -963,10 +963,12 @@ class OpenApiSpecification(
                     DeferredPattern("(${componentName})")
                 }
                 else {
-                    if(patternName.isNotBlank())
-                        throw ContractException("\"type\" attribute was not provided in schema $patternName, please check the syntax of the specification")
+                    val schemaFragment = if(patternName.isNotBlank()) "schema $patternName" else "in one of the schemas"
+
+                    throw if(schema.javaClass.simpleName != "Schema")
+                        ContractException("\"type\" attribute was not provided in $schemaFragment, please check the syntax of the specification")
                     else
-                        throw ContractException("\"type\" attribute was not provided in one of the schemas, please check the syntax of the specification")
+                        ContractException("\"type\" attribute was not provided in $schemaFragment, please check the syntax of the specification")
                 }
             }
         }.also {

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiIntegrationTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiIntegrationTest.kt
@@ -4,6 +4,7 @@ import com.google.common.net.HttpHeaders
 import `in`.specmatic.core.*
 import `in`.specmatic.core.pattern.ContractException
 import `in`.specmatic.core.pattern.parsedJSONObject
+import `in`.specmatic.core.utilities.exceptionCauseMessage
 import `in`.specmatic.core.value.Value
 import `in`.specmatic.stub.createStubFromContracts
 import `in`.specmatic.test.TestExecutor
@@ -622,7 +623,7 @@ Background:
   Given openapi openapi/unsupported-authentication.yaml
         """.trimIndent(), sourceSpecPath
                 )
-            }.also { assertThat(it.message).isEqualTo("Specmatic only supports oauth2, bearer, and api key authentication (header, query) security schemes at the moment") }
+            }.also { assertThat(exceptionCauseMessage(it)).contains("Specmatic only supports oauth2, bearer, and api key authentication (header, query) security schemes at the moment") }
         }
 
         @Test
@@ -636,7 +637,7 @@ Background:
   Given openapi openapi/apiKeyAuthCookie.yaml
         """.trimIndent(), sourceSpecPath
                 )
-            }.also { assertThat(it.message).isEqualTo("Specmatic only supports oauth2, bearer, and api key authentication (header, query) security schemes at the moment") }
+            }.also { assertThat(exceptionCauseMessage(it)).contains("Specmatic only supports oauth2, bearer, and api key authentication (header, query) security schemes at the moment") }
         }
 
         @Test

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiOperationTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiOperationTest.kt
@@ -1,0 +1,80 @@
+package `in`.specmatic.conversions
+
+import io.swagger.v3.oas.models.Operation
+import io.swagger.v3.oas.models.media.StringSchema
+import io.swagger.v3.oas.models.parameters.Parameter
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import `in`.specmatic.core.pattern.ContractException
+import io.swagger.v3.oas.models.media.ArraySchema
+import org.junit.jupiter.api.assertDoesNotThrow
+
+class OpenApiOperationTest {
+    @Test
+    fun `validates a valid parameter without throwing an exception`() {
+        val operation = Operation()
+        operation.parameters = listOf(
+            Parameter().apply {
+                name = "data"
+                schema = StringSchema()
+            }
+        )
+        val openApiOperation = OpenApiOperation(operation)
+        assertDoesNotThrow { openApiOperation.validateParameters() }
+    }
+
+    @Test
+    fun `validates a valid array parameter without throwing an exception`() {
+        val operation = Operation()
+        operation.parameters = listOf(
+            Parameter().apply {
+                name = "data"
+                schema = ArraySchema().apply {
+                    this.items = StringSchema()
+                }
+            }
+        )
+
+        val openApiOperation = OpenApiOperation(operation)
+        assertDoesNotThrow { openApiOperation.validateParameters() }
+    }
+
+    @Test
+    fun `throws exception when parameter name is missing`() {
+        val operation = Operation()
+        operation.parameters = listOf(
+            Parameter().apply {
+                schema = StringSchema()
+            }
+        )
+        val openApiOperation = OpenApiOperation(operation)
+        assertThrows(ContractException::class.java) { openApiOperation.validateParameters() }
+    }
+
+    @Test
+    fun `throws exception when parameter schema is missing`() {
+        val operation = Operation()
+        operation.parameters = listOf(
+            Parameter().apply {
+                name = "name"
+            }
+        )
+        val openApiOperation = OpenApiOperation(operation)
+        assertThrows(ContractException::class.java) { openApiOperation.validateParameters() }
+    }
+
+    @Test
+    fun `throws exception when parameter type is array but items are not defined`() {
+        val operation = Operation()
+        operation.parameters = listOf(
+            Parameter().apply {
+                name = "name"
+                schema = StringSchema().apply {
+                    type = "array"
+                }
+            }
+        )
+        val openApiOperation = OpenApiOperation(operation)
+        assertThrows(ContractException::class.java) { openApiOperation.validateParameters() }
+    }
+}

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -7166,6 +7166,138 @@ components:
         )
     }
 
+    @Test
+    fun `show an error when a type is not provided`() {
+        assertThatThrownBy {
+            OpenApiSpecification.fromYAML(
+                """
+openapi: 3.0.3
+info:
+  title: My service
+  description: My service
+  version: 1.0.0
+servers:
+  - url: 'https://localhost:8080'
+paths:
+  /api/nocontent:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: The name of the entity
+      responses:
+        204:
+          description: No content
+            """.trimIndent(), ""
+            ).toFeature()
+        }.satisfies(
+            {
+                println(exceptionCauseMessage(it))
+                assertThat(exceptionCauseMessage(it)).contains(""""type" attribute was not provided""")
+            }
+        )
+    }
+
+    @Test
+    fun `show an error when parameter name is not provided`() {
+        assertThatThrownBy {
+            OpenApiSpecification.fromYAML(
+                """
+openapi: 3.0.3
+info:
+  title: My service
+  description: My service
+  version: 1.0.0
+servers:
+  - url: 'https://localhost:8080'
+paths:
+  /api/nocontent:
+    get:
+      parameters:
+      - in: query
+        schema:
+          type: string
+      responses:
+        204:
+          description: No content
+            """.trimIndent(), ""
+            ).toFeature()
+        }.satisfies(
+            {
+                println(exceptionCauseMessage(it))
+                assertThat(exceptionCauseMessage(it)).contains("""A parameter of /api/nocontent does not have a nam""")
+            }
+        )
+    }
+
+    @Test
+    fun `show an error when parameter schema is not provided`() {
+        assertThatThrownBy {
+            OpenApiSpecification.fromYAML(
+                """
+openapi: 3.0.3
+info:
+  title: My service
+  description: My service
+  version: 1.0.0
+servers:
+  - url: 'https://localhost:8080'
+paths:
+  /api/nocontent:
+    get:
+      parameters:
+      - in: query
+        name: id
+      responses:
+        204:
+          description: No content
+            """.trimIndent(), ""
+            ).toFeature()
+        }.satisfies(
+            {
+                println(exceptionCauseMessage(it))
+                assertThat(exceptionCauseMessage(it)).contains("""A parameter of /api/nocontent does not have a schema""")
+            }
+        )
+    }
+
+    @Test
+    fun `show an error when parameter schema is array and items is not provided`() {
+        assertThatThrownBy {
+            OpenApiSpecification.fromYAML(
+                """
+openapi: 3.0.3
+info:
+  title: My service
+  description: My service
+  version: 1.0.0
+servers:
+  - url: 'https://localhost:8080'
+paths:
+  /api/nocontent:
+    get:
+      parameters:
+      - in: query
+        name: id
+        schema:
+          type: array
+      responses:
+        204:
+          description: No content
+            """.trimIndent(), ""
+            ).toFeature()
+        }.satisfies(
+            {
+                println(exceptionCauseMessage(it))
+                assertThat(exceptionCauseMessage(it)).contains("""A parameter of /api/nocontent of type "array" has not defined "items"""")
+            }
+        )
+    }
+
     private fun ignoreButLogException(function: () -> OpenApiSpecification) {
         try {
             function()

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -7331,7 +7331,7 @@ paths:
         }.satisfies(
             {
                 println(exceptionCauseMessage(it))
-                assertThat(exceptionCauseMessage(it)).contains("""A parameter of /api/nocontent does not have a nam""")
+                assertThat(exceptionCauseMessage(it)).contains("""A parameter does not have a nam""")
             }
         )
     }
@@ -7362,7 +7362,7 @@ paths:
         }.satisfies(
             {
                 println(exceptionCauseMessage(it))
-                assertThat(exceptionCauseMessage(it)).contains("""A parameter of /api/nocontent does not have a schema""")
+                assertThat(exceptionCauseMessage(it)).contains("""A parameter does not have a schema""")
             }
         )
     }
@@ -7395,7 +7395,7 @@ paths:
         }.satisfies(
             {
                 println(exceptionCauseMessage(it))
-                assertThat(exceptionCauseMessage(it)).contains("""A parameter of /api/nocontent of type "array" has not defined "items"""")
+                assertThat(exceptionCauseMessage(it)).contains("""A parameter of type "array" has not defined "items"""")
             }
         )
     }

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -7167,6 +7167,45 @@ components:
     }
 
     @Test
+    fun `show an error when examples with no mediaType is found in the response`() {
+        assertThatThrownBy {
+            OpenApiSpecification.fromYAML(
+                """
+openapi: 3.0.3
+info:
+  title: My service
+  description: My service
+  version: 1.0.0
+servers:
+  - url: 'https://localhost:8080'
+paths:
+  /api/nocontent:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: The name of the entity
+      responses:
+        "200":
+          description: Random
+          content:
+            text/plain:
+              example: sample response
+            """.trimIndent(), ""
+            ).toFeature()
+        }.satisfies(
+            {
+                println(exceptionCauseMessage(it))
+                assertThat(exceptionCauseMessage(it)).contains("""Response body definition is missing""")
+            }
+        )
+    }
+
+    @Test
     fun `show an error when a type is not provided`() {
         assertThatThrownBy {
             OpenApiSpecification.fromYAML(

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -7167,6 +7167,38 @@ components:
     }
 
     @Test
+    fun `show an error when examples with no mediaType is found in the request`() {
+        assertThatThrownBy {
+            OpenApiSpecification.fromYAML(
+                """
+openapi: 3.0.3
+info:
+  title: My service
+  description: My service
+  version: 1.0.0
+servers:
+  - url: 'https://localhost:8080'
+paths:
+  /api/nocontent:
+    post:
+      requestBody:
+        content:
+          application/json:
+            example: test data
+      responses:
+        "204":
+          description: No response
+""".trimIndent(), ""
+            ).toFeature()
+        }.satisfies(
+            {
+                println(exceptionCauseMessage(it))
+                assertThat(exceptionCauseMessage(it)).contains("""Request body definition is missing""")
+            }
+        )
+    }
+
+    @Test
     fun `show an error when examples with no mediaType is found in the response`() {
         assertThatThrownBy {
             OpenApiSpecification.fromYAML(

--- a/core/src/test/kotlin/in/specmatic/core/CyclePrevention.kt
+++ b/core/src/test/kotlin/in/specmatic/core/CyclePrevention.kt
@@ -421,8 +421,7 @@ class CyclePrevention {
                   type: object
                   properties:
                     key2:
-                      type:
-                        ${'$'}ref: '#/components/schemas/TopLevel'
+                      ${'$'}ref: '#/components/schemas/TopLevel'
         """.trimIndent(), "").toFeature()
 
         val response = HttpStub(feature).use {
@@ -512,12 +511,11 @@ class CyclePrevention {
                   type: object
                   properties:
                     key2:
-                      type:
-                        oneOf:
-                          - type: object
-                            properties: {}
-                            nullable: true
-                          - ${'$'}ref: '#/components/schemas/TopLevel'
+                      oneOf:
+                        - type: object
+                          properties: {}
+                          nullable: true
+                        - ${'$'}ref: '#/components/schemas/TopLevel'
         """.trimIndent(), "").toFeature()
 
         val response = HttpStub(feature).use {


### PR DESCRIPTION
**What**:

Added some validations for errors in an OpenAPI spec, including a missing schema in a request or response mediaType

**Why**:

This was done to make it easier for users to pinpoint the source of the problem in case they have not validated the specification using Swagger Editor.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #553 

<!-- feel free to add additional comments -->
