### PR TITLE
Fixed proxy generation when the request has no body

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/GherkinClause.kt
+++ b/core/src/main/kotlin/in/specmatic/core/GherkinClause.kt
@@ -23,7 +23,7 @@ fun responseBodyToGherkinClauses(typeName: String, body: Value?, types: Map<Stri
 }
 
 fun requestBodyToGherkinClauses(body: Value?, types: Map<String, Pattern>, exampleDeclarationsStore: ExampleDeclarations): Triple<List<GherkinClause>, Map<String, Pattern>, ExampleDeclarations> {
-    if(body == EmptyString)
+    if(body == EmptyString || body == NoBodyValue)
         return Triple(emptyList(), types, exampleDeclarationsStore)
 
     val declarations = body?.typeDeclarationWithoutKey("RequestBody", types, exampleDeclarationsStore)?.let { (typeDeclaration, exampleDeclaration) ->

--- a/core/src/main/kotlin/in/specmatic/core/utilities/JSONSerialisation.kt
+++ b/core/src/main/kotlin/in/specmatic/core/utilities/JSONSerialisation.kt
@@ -1,5 +1,6 @@
 package `in`.specmatic.core.utilities
 
+import `in`.specmatic.core.NoBodyValue
 import kotlinx.serialization.*
 import kotlinx.serialization.json.*
 
@@ -111,7 +112,7 @@ fun valueMapToPlainJsonString(value: Map<String, Value>): String {
 }
 
 fun mapToStringElement(data: Map<String, Value>): Map<String, JsonElement> {
-    return data.mapValues { valueToJsonElement(it.value) }
+    return data.filterNot { it.value is NoBodyValue }.mapValues { valueToJsonElement(it.value) }
 }
 
 private fun valueToJsonElement(value: Value): JsonElement {


### PR DESCRIPTION
**What**:

When the request has no body, the proxy-generated spec and stub json files were both incorrect, due to which the recorded spec could not load the recorded stub json.

This PR fixes the problem.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate
