### PR TITLE
Made the test format the same as stub format

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/ExampleFromFile.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/ExampleFromFile.kt
@@ -25,8 +25,8 @@ class ExampleFromFile(val json: JSONObjectValue, val file: File) {
     } ?: throw ContractException("Request path was not found.")
 
     val testName: String = attempt("Error reading expectation name in file ${file.parentFile.canonicalPath}") {
-        json.findFirstChildByPath("name")?.toStringLiteral()
-    } ?: throw ContractException("Name was not found.")
+        json.findFirstChildByPath("name")?.toStringLiteral() ?: file.nameWithoutExtension
+    }
 
     val queryParams: Map<String, String> =
         attempt("Error reading query params in file ${file.parentFile.canonicalPath}") {
@@ -40,13 +40,6 @@ class ExampleFromFile(val json: JSONObjectValue, val file: File) {
             value.toStringLiteral()
         } ?: emptyMap()
     }
-
-    val pathParams: Map<String, String> =
-        attempt("Error reading path params in file ${file.parentFile.canonicalPath}") {
-            (json.findFirstChildByPath("http-request.path-params") as JSONObjectValue?)?.jsonObject?.mapValues { (_, value) ->
-                value.toStringLiteral()
-            } ?: emptyMap()
-        }
 
     val requestBody: Value? = attempt("Error reading request body in file ${file.parentFile.canonicalPath}") {
         json.findFirstChildByPath("http-request.body")

--- a/core/src/main/kotlin/in/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Feature.kt
@@ -1281,7 +1281,6 @@ data class Feature(
                     val examples: Map<String, String> =
                         headers
                             .plus(queryParams)
-                            .plus(pathParams)
                             .plus(requestBody?.let { mapOf("(REQUEST-BODY)" to it.toStringLiteral()) } ?: emptyMap())
 
                     val (

--- a/core/src/main/kotlin/in/specmatic/core/HttpPathPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpPathPattern.kt
@@ -247,6 +247,17 @@ data class HttpPathPattern(
 
         else -> (urlPathPattern.newBasedOn(row, resolver) + urlPathPattern.negativeBasedOn(row, resolver)).distinct()
     }
+
+    fun extractPathParams(requestPath: String, resolver: Resolver): Map<String, String> {
+        val pathSegments = requestPath.split("/").filter { it.isNotEmpty() }
+
+        return pathSegmentPatterns.zip(pathSegments).mapNotNull { (pattern, value) ->
+            when {
+                pattern.pattern is ExactValuePattern -> null
+                else -> pattern.key!! to value
+            }
+        }.toMap()
+    }
 }
 
 internal fun buildHttpPathPattern(

--- a/core/src/main/kotlin/in/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpRequestPattern.kt
@@ -194,13 +194,18 @@ data class HttpRequestPattern(
     private fun matchPath(parameters: Pair<HttpRequest, Resolver>): MatchingResult<Pair<HttpRequest, Resolver>> {
         val (httpRequest, resolver) = parameters
 
-        val result = httpPathPattern!!.matches(httpRequest.path!!, resolver)
+        val result = matchesPath(httpRequest.path!!, resolver)
 
         return if (result is Failure)
             MatchFailure(result)
         else
             MatchSuccess(parameters)
     }
+
+    fun matchesPath(
+        path: String,
+        resolver: Resolver
+    ) = httpPathPattern!!.matches(path, resolver)
 
     private fun matchQuery(parameters: Triple<HttpRequest, Resolver, List<Failure>>): MatchingResult<Triple<HttpRequest, Resolver, List<Failure>>> {
         val (httpRequest, resolver, failures) = parameters
@@ -636,6 +641,14 @@ data class HttpRequestPattern(
             }
         }
     }
+
+    fun addPathParamsToRows(requestPath: String, row: Row, resolver: Resolver): Row {
+        return httpPathPattern?.let { httpPathPattern ->
+            val pathParams = httpPathPattern.extractPathParams(requestPath, resolver)
+            return row.addFields(pathParams)
+        } ?: row
+    }
+
 }
 
 fun missingParam(missingValue: String): ContractException {

--- a/core/src/main/kotlin/in/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Scenario.kt
@@ -474,19 +474,28 @@ data class Scenario(
     }
 
     fun useExamples(externalisedJSONExamples: Map<OpenApiSpecification.OperationIdentifier, List<Row>>): Scenario {
-        val operationIdentifier = OpenApiSpecification.OperationIdentifier(method, path, status)
+        val matchingTestData: Map<OpenApiSpecification.OperationIdentifier, List<Row>> = matchingRows(externalisedJSONExamples)
 
-        val newExamples: List<Examples> = externalisedJSONExamples[operationIdentifier]?.let { rows ->
+        val newExamples: List<Examples> = matchingTestData.map { (operationId, rows) ->
             if(rows.isEmpty())
-                return@let emptyList()
+                return@map emptyList()
 
-            val columns = rows.first().columnNames
+            val rowsWithPathData: List<Row> = rows.map { row -> httpRequestPattern.addPathParamsToRows(operationId.requestPath, row, resolver) }
 
-            listOf(Examples(columns, rows))
-        } ?: emptyList()
+            val columns = rowsWithPathData.first().columnNames
+
+            listOf(Examples(columns, rowsWithPathData))
+        }.flatten()
 
         return this.copy(examples = newExamples)
     }
+
+    private fun matchingRows(externalisedJSONExamples: Map<OpenApiSpecification.OperationIdentifier, List<Row>>) =
+        externalisedJSONExamples.filter { (operationId, rows) ->
+            operationId.requestMethod.equals(method, ignoreCase = true)
+                    && operationId.responseStatus == status
+                    && httpRequestPattern.matchesPath(operationId.requestPath, resolver).isSuccess()
+        }
 }
 
 fun newExpectedServerStateBasedOn(

--- a/core/src/main/kotlin/in/specmatic/core/pattern/Row.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/Row.kt
@@ -109,4 +109,13 @@ data class Row(
 
     private fun thisFieldHasAnExample(key: String) =
         this.containsField(withoutOptionality(key))
+
+    fun addFields(params: Map<String, String>): Row {
+        return params.entries.fold(this) { row, (key, value) ->
+            val newColumns = row.columnNames + key
+            val newValues = row.values + value
+
+            row.copy(columnNames = newColumns, values = newValues)
+        }
+    }
 }

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -14,6 +14,7 @@ import `in`.specmatic.mock.NoMatchingScenario
 import `in`.specmatic.mock.ScenarioStub
 import `in`.specmatic.stub.HttpStub
 import `in`.specmatic.stub.HttpStubData
+import `in`.specmatic.stub.captureStandardOutput
 import `in`.specmatic.stub.createStubFromContracts
 import `in`.specmatic.test.TestExecutor
 import io.ktor.util.reflect.*
@@ -7164,6 +7165,36 @@ components:
                 assertThat(exceptionCauseMessage(it)).withFailMessage(exceptionCauseMessage(it)).contains("Id")
             }
         )
+    }
+
+    @Test
+    fun `should load externalized test data with name in file`() {
+        val specFilePath = "core/src/test/resources/openapi/spec_with_externalized_test_data.yaml"
+        val spec = OpenApiSpecification.fromFile(specFilePath, "").toFeature().loadExternalisedExamples()
+
+        val results = spec.executeTests(object : TestExecutor {
+            override fun execute(request: HttpRequest): HttpResponse {
+                assertThat(request.path).isEqualTo("/resource/10")
+                return HttpResponse.ok("success")
+            }
+
+            override fun setServerState(serverState: Map<String, Value>) {
+            }
+        })
+
+        assertThat(results.success()).withFailMessage(results.report()).isTrue()
+        assertThat(results.successCount).isOne()
+    }
+
+    @Test
+    fun `should load externalized test data using filename when name is not in file`() {
+        val specFilePath = "core/src/test/resources/openapi/spec_with_unnamed_externalized_test_data.yaml"
+        val spec = OpenApiSpecification.fromFile(specFilePath, "")
+            .toFeature()
+            .loadExternalisedExamples()
+
+        val tests = spec.generateContractTestScenarios(emptyList())
+        assertThat(tests.single().testDescription()).contains("test_in_file_name")
     }
 
     private fun ignoreButLogException(function: () -> OpenApiSpecification) {

--- a/core/src/test/resources/openapi/spec_with_externalized_test_data.yaml
+++ b/core/src/test/resources/openapi/spec_with_externalized_test_data.yaml
@@ -1,0 +1,20 @@
+openapi: "3.0.0"
+info:
+  version: "1.0.0"
+  title: Simple API
+paths:
+  /resource/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      responses:
+        '200':
+          description: A text value
+          content:
+            text/plain:
+              schema:
+                type: string

--- a/core/src/test/resources/openapi/spec_with_externalized_test_data_tests/test.json
+++ b/core/src/test/resources/openapi/spec_with_externalized_test_data_tests/test.json
@@ -1,0 +1,10 @@
+{
+  "http-request": {
+    "method": "GET",
+    "path": "/resource/10"
+  },
+  "http-response": {
+    "status": 200
+  },
+  "name": "Get Resource"
+}

--- a/core/src/test/resources/openapi/spec_with_unnamed_externalized_test_data.yaml
+++ b/core/src/test/resources/openapi/spec_with_unnamed_externalized_test_data.yaml
@@ -1,0 +1,20 @@
+openapi: "3.0.0"
+info:
+  version: "1.0.0"
+  title: Simple API
+paths:
+  /resource/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+    get:
+      responses:
+        '200':
+          description: A text value
+          content:
+            text/plain:
+              schema:
+                type: string

--- a/core/src/test/resources/openapi/spec_with_unnamed_externalized_test_data_tests/test_in_file_name.json
+++ b/core/src/test/resources/openapi/spec_with_unnamed_externalized_test_data_tests/test_in_file_name.json
@@ -1,0 +1,9 @@
+{
+  "http-request": {
+    "method": "GET",
+    "path": "/resource/10"
+  },
+  "http-response": {
+    "status": 200
+  }
+}


### PR DESCRIPTION
**What**:

- Fixed the path in tests to work the same as in expectation files
- Test name can be provided in test
- If the test name is omitted, the file name without extension is the test name

**Why**:

This reduces confusion as there is only one format. This also means that samples and recordings can be used as both stub and test.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate
