### PR TITLE
Implemented web source so that specifications on the web can be declared in specmatic.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ perfiz/*_data
 **/.settings
 **/.project
 **/.classpath
+**/.specmatic

--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@ perfiz/*_data
 **/.settings
 **/.project
 **/.classpath
-**/.specmatic
+

--- a/application/src/main/kotlin/application/InstallCommand.kt
+++ b/application/src/main/kotlin/application/InstallCommand.kt
@@ -16,7 +16,7 @@ class InstallCommand: Callable<Unit> {
     var targetDirectory: String = System.getProperty("user.home")
     override fun call() {
         val userHome = File(targetDirectory)
-        val workingDirectory = userHome.resolve(".$APPLICATION_NAME_LOWER_CASE/repos")
+        val workingDirectory = userHome.resolve(".$APPLICATION_NAME_LOWER_CASE")
 
         val sources = try { loadSources(globalConfigFileName) } catch(e: ContractException) { exitWithMessage(e.failure().toReport().toText()) }
 

--- a/application/src/main/kotlin/application/PortUtil.kt
+++ b/application/src/main/kotlin/application/PortUtil.kt
@@ -20,14 +20,7 @@ fun portIsInUse(host: String, port: Int): Boolean {
 fun findRandomFreePort(): Int {
     logger.log("Checking for a free port")
 
-    var serverSocket: ServerSocket? = null
-
-    val port = try {
-        serverSocket = ServerSocket(0)
-        serverSocket.localPort
-    } finally {
-        serverSocket?.close()
-    }
+    val port = ServerSocket(0).use { it.localPort }
 
     if (port > 0) {
         logger.log("Free port found: $port")

--- a/application/src/main/kotlin/application/PushCommand.kt
+++ b/application/src/main/kotlin/application/PushCommand.kt
@@ -27,7 +27,15 @@ class PushCommand: Callable<Unit> {
         val manifestData = try { loadConfigJSON(manifestFile) } catch(e: ContractException) { exitWithMessage(e.failure().toReport().toText()) }
         val sources = try { loadSources(manifestData) } catch(e: ContractException) { exitWithMessage(e.failure().toReport().toText()) }
 
-        for (source in sources) {
+        val unsupportedSources = sources.filter { it !is GitSource }.mapNotNull { it.type }.distinct()
+
+        if(unsupportedSources.isNotEmpty()) {
+            println("The following types of sources are not supported: ${unsupportedSources.joinToString(", ")}")
+        }
+
+        val supportedSources = sources.filter { it is GitSource }
+
+        for (source in supportedSources) {
             val sourceDir = source.directoryRelativeTo(workingDirectory)
             val sourceGit = SystemGit(sourceDir.path)
 

--- a/application/src/main/kotlin/application/SubscribeCommand.kt
+++ b/application/src/main/kotlin/application/SubscribeCommand.kt
@@ -20,7 +20,15 @@ class SubscribeCommand: Callable<Unit> {
         val manifestData = try { loadConfigJSON(manifestFile) } catch(e: ContractException) { exitWithMessage(e.failure().toReport().toText()) }
         val sources = try { loadSources(manifestData) } catch(e: ContractException) { exitWithMessage(e.failure().toReport().toText()) }
 
-        for(source in sources) {
+        val unsupportedSources = sources.filter { it !is GitSource }.mapNotNull { it.type }.distinct()
+
+        if(unsupportedSources.isNotEmpty()) {
+            println("The following types of sources are not supported: ${unsupportedSources.joinToString(", ")}")
+        }
+
+        val supportedSources = sources.filter { it is GitSource }
+
+        for(source in supportedSources) {
             val sourceDir = source.directoryRelativeTo(workingDirectory)
             val sourceGit = SystemGit(sourceDir.path)
 

--- a/core/.specmatic/web/localhost/random.yaml
+++ b/core/.specmatic/web/localhost/random.yaml
@@ -1,0 +1,25 @@
+openapi: 3.0.1
+info:
+  title: Random
+  version: "1"
+paths:
+  /random:
+    post:
+      summary: Random
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              required:
+              - id
+              properties:
+                id:
+                  type: number
+      responses:
+        "200":
+          description: Random
+          content:
+            text/plain:
+              schema:
+                type: string

--- a/core/src/main/kotlin/in/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/in/specmatic/core/SpecmaticConfig.kt
@@ -65,7 +65,7 @@ data class Environment(
     val variables: Map<String, String>? = null
 )
 
-enum class SourceProvider { git, filesystem }
+enum class SourceProvider { git, filesystem, web }
 
 @Serializable
 data class Source(

--- a/core/src/main/kotlin/in/specmatic/core/utilities/GitMonoRepo.kt
+++ b/core/src/main/kotlin/in/specmatic/core/utilities/GitMonoRepo.kt
@@ -4,7 +4,7 @@ import `in`.specmatic.core.git.SystemGit
 import java.io.File
 
 data class GitMonoRepo(override val testContracts: List<String>, override val stubContracts: List<String>,
-                       override val type: String?) : ContractSource {
+                       override val type: String?) : ContractSource, GitSource {
     override fun pathDescriptor(path: String): String = path
     override fun install(workingDirectory: File) {
         println("Checking list of mono repo paths...")

--- a/core/src/main/kotlin/in/specmatic/core/utilities/GitRepo.kt
+++ b/core/src/main/kotlin/in/specmatic/core/utilities/GitRepo.kt
@@ -9,13 +9,15 @@ import `in`.specmatic.core.git.clone
 import `in`.specmatic.core.log.logger
 import java.io.File
 
+interface GitSource
+
 data class GitRepo(
     val gitRepositoryURL: String,
     val branchName: String?,
     override val testContracts: List<String>,
     override val stubContracts: List<String>,
     override val type: String?
-) : ContractSource {
+) : ContractSource, GitSource {
     private val repoName = gitRepositoryURL.split("/").last().removeSuffix(".git")
     override fun pathDescriptor(path: String): String {
         return "${repoName}:${path}"
@@ -136,7 +138,8 @@ data class GitRepo(
     private fun localRepoDir(workingDirectory: String): File = File(workingDirectory).resolve("repos")
 
     override fun install(workingDirectory: File) {
-        val sourceDir = workingDirectory.resolve(repoName)
+        val baseReposDirectory = workingDirectory.resolve("repos")
+        val sourceDir = baseReposDirectory.resolve(repoName)
         val sourceGit = SystemGit(sourceDir.path)
 
         try {

--- a/core/src/main/kotlin/in/specmatic/core/utilities/Utilities.kt
+++ b/core/src/main/kotlin/in/specmatic/core/utilities/Utilities.kt
@@ -173,6 +173,12 @@ fun loadSources(specmaticConfigJson: SpecmaticConfigJson): List<ContractSource> 
 
                 LocalFileSystemSource(source.directory ?: ".", testPaths, stubPaths)
             }
+            SourceProvider.web -> {
+                val stubPaths = source.stub ?: emptyList()
+                val testPaths = source.test ?: emptyList()
+
+                WebSource(testPaths, stubPaths)
+            }
         }
     }
 }
@@ -208,6 +214,11 @@ fun loadSources(configJson: JSONObjectValue): List<ContractSource> {
                 val testPaths = jsonArray(source, "test")
 
                 LocalFileSystemSource(directory, testPaths, stubPaths)
+            }
+            "web" -> {
+                val stubPaths = jsonArray(source, "stub")
+                val testPaths = jsonArray(source, "test")
+                WebSource(testPaths, stubPaths)
             }
             else -> throw ContractException("Provider ${nativeString(source.jsonObject, "provider")} not recognised in $globalConfigFileName")
         }

--- a/core/src/main/kotlin/in/specmatic/core/utilities/WebSource.kt
+++ b/core/src/main/kotlin/in/specmatic/core/utilities/WebSource.kt
@@ -1,0 +1,85 @@
+package `in`.specmatic.core.utilities
+
+import `in`.specmatic.core.CONTRACT_EXTENSIONS
+import `in`.specmatic.core.git.SystemGit
+import `in`.specmatic.core.log.logger
+import java.io.File
+import java.net.ServerSocket
+import java.net.URL
+
+class WebSource(override val testContracts: List<String>, override val stubContracts: List<String>) : ContractSource {
+    override val type: String = "web"
+    override fun pathDescriptor(path: String): String {
+        return ""
+    }
+
+    override fun install(workingDirectory: File) {
+    }
+
+    override fun directoryRelativeTo(workingDirectory: File): File {
+        return File(".")
+    }
+
+    override fun getLatest(sourceGit: SystemGit) {
+        logger.log("No need to get latest as this source is a URL")
+    }
+
+    override fun pushUpdates(sourceGit: SystemGit) {
+        logger.log("No need to push updates as this source is a URL")
+    }
+
+    fun findFreePort(): Int = ServerSocket(0).use { it.localPort }
+
+    override fun loadContracts(
+        selector: ContractsSelectorPredicate,
+        workingDirectory: String,
+        configFilePath: String
+    ): List<ContractPathData> {
+        val resolvedPath = File(workingDirectory).resolve("web")
+        return selector.select(this).map {
+            val url = URL(it)
+            val path = url.path.removePrefix("/")
+
+            val contractPath = resolvedPath.resolve(path).canonicalFile
+            contractPath.parentFile.mkdirs()
+
+            download(url, contractPath)
+
+            ContractPathData(
+                resolvedPath.path,
+                contractPath.path,
+                provider = type,
+                specificationPath = contractPath.canonicalPath
+            )
+        }
+    }
+
+    private fun download(url: URL, specificationFile: File): File {
+        val connection = url.openConnection()
+        connection.setRequestProperty("User-Agent", "Mozilla/5.0")
+        connection.connect()
+
+        val inputStream = connection.getInputStream()
+        val outputStream = specificationFile.outputStream()
+
+        inputStream.copyTo(outputStream)
+
+        inputStream.close()
+        outputStream.close()
+
+        if (specificationFile.extension in CONTRACT_EXTENSIONS)
+            return specificationFile
+
+        val text = specificationFile.readText().trim()
+        val extension = if (text.startsWith("{")) {
+            "json"
+        } else {
+            "yaml"
+        }
+
+        val renamedFile = File(specificationFile.path + ".$extension")
+        specificationFile.renameTo(renamedFile)
+
+        return renamedFile
+    }
+}

--- a/core/src/test/kotlin/in/specmatic/core/utilities/LocalFileSystemSourceTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/utilities/LocalFileSystemSourceTest.kt
@@ -2,9 +2,7 @@ package `in`.specmatic.core.utilities
 
 import `in`.specmatic.core.DEFAULT_WORKING_DIRECTORY
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
-import java.io.File
 
 class LocalFileSystemSourceTest {
     @Test
@@ -14,11 +12,9 @@ class LocalFileSystemSourceTest {
 
         assertThat(specSourceData).hasSize(1)
 
-        assertThat(specSourceData).allSatisfy(
-            {
-                assertThat(it.path).isEqualTo("dir/spec.yaml")
-            }
-        )
+        assertThat(specSourceData).allSatisfy {
+            assertThat(it.path).isEqualTo("dir/spec.yaml")
+        }
     }
 
 }

--- a/core/src/test/kotlin/in/specmatic/core/utilities/LocalFileSystemSourceTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/utilities/LocalFileSystemSourceTest.kt
@@ -1,0 +1,24 @@
+package `in`.specmatic.core.utilities
+
+import `in`.specmatic.core.DEFAULT_WORKING_DIRECTORY
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class LocalFileSystemSourceTest {
+    @Test
+    fun temp() {
+        val localFileSystemSource = LocalFileSystemSource("dir", emptyList(), listOf("spec.yaml"))
+        val specSourceData = localFileSystemSource.loadContracts({ source -> source.stubContracts }, DEFAULT_WORKING_DIRECTORY, "")
+
+        assertThat(specSourceData).hasSize(1)
+
+        assertThat(specSourceData).allSatisfy(
+            {
+                assertThat(it.path).isEqualTo("dir/spec.yaml")
+            }
+        )
+    }
+
+}

--- a/core/src/test/kotlin/in/specmatic/core/utilities/WebSourceTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/utilities/WebSourceTest.kt
@@ -1,0 +1,53 @@
+package `in`.specmatic.core.utilities
+
+import `in`.specmatic.core.DEFAULT_WORKING_DIRECTORY
+import io.ktor.server.application.*
+import io.ktor.server.engine.*
+import io.ktor.server.netty.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import java.io.File
+import java.net.ServerSocket
+
+class WebSourceTest {
+    @Test
+    fun `test downloading from a web source`() {
+        val port: Int = ServerSocket(0).use { it.localPort }
+
+        val server = embeddedServer(Netty, port = port) {
+            routing {
+                get("/spec.yaml") {
+                    call.respondText("data")
+                }
+            }
+        }.start(wait = false)
+
+
+        try {
+            val specificationOnTheWeb = "http://localhost:$port/spec.yaml"
+
+            val webSource = WebSource(
+                listOf(),
+                listOf(specificationOnTheWeb)
+            )
+
+            val contractData = webSource.loadContracts({ source -> source.stubContracts }, DEFAULT_WORKING_DIRECTORY, "")
+
+            assertThat(contractData).isNotEmpty
+            assertThat(contractData).allSatisfy {
+                val data = File(it.path).readText()
+                assertThat(data).isEqualTo("data")
+            }
+        } finally {
+            server.stop(0, 0)
+        }
+    }
+
+    @AfterEach
+    fun tearDown() {
+        File(DEFAULT_WORKING_DIRECTORY).deleteRecursively()
+    }
+}


### PR DESCRIPTION
**What**:

Specmatic can now use specifications from the web, by declaring them in specmatic.json like this:

```json
{
  "sources": [
    {
      "provider": "web",
      "stub": [
        "http://third.party.com/spec.yaml"
      ]
    }
  ]
}
```

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #925 
