### PR TITLE
Implemented support for mandatory query params

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -1293,7 +1293,12 @@ class OpenApiSpecification(
                 QueryParameterScalarPattern(toSpecmaticPattern(schema = it.schema, typeStack = emptyList(), patternName = it.name))
             }
 
-            "${it.name}?" to specmaticPattern
+            val queryParamKey = if(it.required == true)
+                it.name
+            else
+                "${it.name}?"
+
+            queryParamKey to specmaticPattern
         }
         return HttpQueryParamPattern(queryPattern)
     }

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -7400,6 +7400,58 @@ paths:
         )
     }
 
+    @Test
+    fun `backward compatibility should fail when a new mandatory query parameter is added`() {
+        val oldSpec = OpenApiSpecification.fromYAML(
+            """
+openapi: 3.0.3
+info:
+  title: My service
+  description: My service
+  version: 1.0.0
+servers:
+  - url: 'https://localhost:8080'
+paths:
+  /data:
+    get:
+      responses:
+        204:
+          description: No content
+            """.trimIndent(), ""
+        ).toFeature()
+
+
+        val newSpec = OpenApiSpecification.fromYAML(
+            """
+openapi: 3.0.3
+info:
+  title: My service
+  description: My service
+  version: 1.0.0
+servers:
+  - url: 'https://localhost:8080'
+paths:
+  /data:
+    get:
+      parameters:
+      - in: query
+        name: id
+        schema:
+          type: integer
+        required: true
+      responses:
+        204:
+          description: No content
+            """.trimIndent(), ""
+        ).toFeature()
+
+        val result = testBackwardCompatibility(oldSpec, newSpec)
+
+        assertThat(result.success()).isFalse()
+
+        assertThat(result.report()).contains("expects query param named \"id\"")
+    }
+
     private fun ignoreButLogException(function: () -> OpenApiSpecification) {
         try {
             function()

--- a/core/src/test/kotlin/in/specmatic/stub/HttpStubWithArrayQueryParameterTest.kt
+++ b/core/src/test/kotlin/in/specmatic/stub/HttpStubWithArrayQueryParameterTest.kt
@@ -277,6 +277,10 @@ class HttpStubWithArrayQueryParameterTest {
             In scenario "get products. Response: OK"
             API: GET /products -> 200
             
+              >> REQUEST.QUERY-PARAMS.brand_ids
+              
+                 Query param named brand_ids in the contract was not found in the request
+              
               >> REQUEST.QUERY-PARAMS.category_id
               
                  Query param named category_id in the request was not in the contract

--- a/core/src/test/resources/openapi/helloWithQueryParams.yaml
+++ b/core/src/test/resources/openapi/helloWithQueryParams.yaml
@@ -18,19 +18,16 @@ paths:
           name: message
           schema:
             type: string
-          required: true
           description: Greeting Message
         - in: query
           name: name
           schema:
             type: string
-          required: true
           description: Name of person to greet
         - in: query
           name: another_message
           schema:
             type: string
-          required: true
           description: additional message
       responses:
         '200':


### PR DESCRIPTION
**What**:

This PR adds support mandatory query parameters (query parameters having the property `required`=`true`)


**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

