### PR TITLE
Implemented required property of body

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -625,6 +625,8 @@ class OpenApiSpecification(
                 Pair(requestPattern.copy(body = NoBodyPattern), exampleRequestBuilder.examplesBasedOnParameters)
             )
 
+        val bodyIsRequired: Boolean = requestBody.required ?: false
+
         return requestBody.content.map { (contentType, mediaType) ->
             when (contentType.lowercase()) {
                 "multipart/form-data" -> {
@@ -688,10 +690,16 @@ class OpenApiSpecification(
 
                     val allExamples = exampleRequestBuilder.examplesWithRequestBodies(exampleBodies)
 
+                    val body = toSpecmaticPattern(mediaType, "request").let {
+                        if(bodyIsRequired)
+                            it
+                        else
+                            AnyPattern(listOf(it, NoBodyPattern))
+                    }
 
                     Pair(
                         requestPattern.copy(
-                            body = toSpecmaticPattern(mediaType, "request"),
+                            body = body,
                             headersPattern = headersPatternWithContentType(requestPattern, contentType)
                         ), allExamples
                     )

--- a/core/src/main/kotlin/in/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Feature.kt
@@ -736,6 +736,7 @@ data class Feature(
 
             if (requestBodySchema != null) {
                 operation.requestBody = RequestBody().apply {
+                    this.required = true
                     this.content = Content().apply {
                         this[requestBodySchema.first] = requestBodySchema.second
                     }

--- a/core/src/test/kotlin/in/specmatic/conversions/DefaultValuesInOpenapiSpecification.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/DefaultValuesInOpenapiSpecification.kt
@@ -37,6 +37,7 @@ class DefaultValuesInOpenapiSpecification {
           /employees:
             post:
               requestBody:
+                required: true
                 content:
                   application/json:
                     schema:
@@ -200,6 +201,7 @@ class DefaultValuesInOpenapiSpecification {
           /employees:
             post:
               requestBody:
+                required: true
                 content:
                   application/json:
                     schema:

--- a/core/src/test/kotlin/in/specmatic/conversions/GenerativeTests.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/GenerativeTests.kt
@@ -91,6 +91,7 @@ class GenerativeTests {
                 post:
                   summary: Create person record
                   requestBody:
+                    required: true
                     content:
                       application/json:
                         examples:
@@ -162,6 +163,7 @@ class GenerativeTests {
                         CREATE_PERSON:
                           value: 987
                   requestBody:
+                    required: true
                     content:
                       application/json:
                         examples:
@@ -224,6 +226,7 @@ class GenerativeTests {
                         CREATE_PERSON:
                           value: 987
                   requestBody:
+                    required: true
                     content:
                       application/json:
                         examples:
@@ -284,6 +287,7 @@ class GenerativeTests {
                         SUCCESS:
                           value: true
                   requestBody:
+                    required: true
                     content:
                       application/json:
                         examples:
@@ -471,6 +475,7 @@ class GenerativeTests {
                   summary: "Get person by id"
                   parameters: []
                   requestBody:
+                    required: true
                     content:
                       application/json:
                         examples:
@@ -536,6 +541,7 @@ class GenerativeTests {
             post:
               summary: Create a new product
               requestBody:
+                required: true
                 content:
                   application/json:
                     schema:

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -6408,6 +6408,7 @@ paths:
       summary: "Add person by id"
       parameters: []
       requestBody:
+        required: true
         content:
           application/json:
             schema:

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -425,6 +425,7 @@ Scenario: Get product by id
                               properties:
                                 id:
                                   type: "string"
+                        required: true
                       responses:
                         200:
                           description: "Get person by id"
@@ -481,6 +482,7 @@ Scenario: Get product by id
                               type: "string"
                             address:
                               ${"$"}ref: '#/components/schemas/Address'
+                    required: true
                   responses:
                     200:
                       description: "Add person by id"
@@ -563,6 +565,7 @@ Scenario: Get product by id
                               type: "array"
                               items:
                                 ${"$"}ref: '#/components/schemas/Address'
+                    required: true
                   responses:
                     200:
                       description: "Get person by id"
@@ -697,6 +700,7 @@ Scenario: Get product by id
                               - properties: {}
                                 nullable: true
                               - ${"$"}ref: '#/components/schemas/Address'
+                    required: true
                   responses:
                     200:
                       description: "Get person by id"
@@ -771,6 +775,7 @@ Scenario: Get product by id
                             id:
                               type: "string"
                               nullable: true
+                    required: true
                   responses:
                     200:
                       description: "Get person by id"
@@ -843,6 +848,7 @@ Scenario: Get product by id
                             id:
                               type: "string"
                               nullable: true
+                    required: true
                   responses:
                     200:
                       description: "Get person by id"
@@ -930,6 +936,7 @@ Scenario: Get product by id
                               nullable: true
                               items:
                                 ${"$"}ref: '#/components/schemas/Address'
+                    required: true
                   responses:
                     200:
                       description: "Get person by id"
@@ -1015,6 +1022,7 @@ Scenario: Get product by id
                                 - properties: {}
                                   nullable: true
                                 - ${"$"}ref: '#/components/schemas/Address'
+                    required: true
                   responses:
                     200:
                       description: "Get person by id"
@@ -1093,6 +1101,7 @@ Scenario: Get product by id
                         encoding:
                           person:
                             contentType: "application/json"
+                    required: true
                   responses:
                     200:
                       description: "Add Person"
@@ -1175,6 +1184,7 @@ Scenario: Get product by id
                           properties:
                             data:
                               type: "string"
+                    required: true
                   responses:
                     200:
                       description: "Add Data"
@@ -1239,6 +1249,7 @@ Scenario: Get product by id
                       application/json:
                         schema:
                           ${"$"}ref: '#/components/schemas/Person'
+                    required: true
                   responses:
                     200:
                       description: "Add Person"
@@ -1408,6 +1419,7 @@ Scenario: Get product by id
                       text/plain:
                         schema:
                           type: "string"
+                    required: true
                   responses:
                     200:
                       description: "Add Person"
@@ -1460,6 +1472,7 @@ Scenario: Get product by id
                           type: "string"
                           enum:
                           - "hello"
+                    required: true
                   responses:
                     200:
                       description: "Add Person"
@@ -1562,6 +1575,7 @@ Scenario: Get product by id
                       text/plain:
                         schema:
                           type: "number"
+                    required: true
                   responses:
                     200:
                       description: "Add Person"
@@ -1617,6 +1631,7 @@ Scenario: Get product by id
                           properties:
                             id:
                               type: "string"
+                    required: true
                   responses:
                     200:
                       description: "Add Person"
@@ -1672,6 +1687,7 @@ Scenario: Get product by id
                           properties:
                             id:
                               type: "string"
+                    required: true
                   responses:
                     200:
                       description: "Add Person"
@@ -1727,6 +1743,7 @@ Scenario: Get product by id
                       text/plain:
                         schema:
                           type: "string"
+                    required: true
                   responses:
                     200:
                       description: "Add Person"
@@ -1963,6 +1980,7 @@ Scenario: Get product by id
                       application/json:
                         schema:
                           ${"$"}ref: '#/components/schemas/Person'
+                    required: true
                   responses:
                     200:
                       description: "Add Person"
@@ -2030,6 +2048,7 @@ Scenario: Get product by id
                       application/json:
                         schema:
                           ${"$"}ref: '#/components/schemas/Person'
+                    required: true
                   responses:
                     200:
                       description: "Add Person"
@@ -2099,6 +2118,7 @@ Scenario: Get product by id
                       application/json:
                         schema:
                           ${"$"}ref: '#/components/schemas/Person'
+                    required: true
                   responses:
                     200:
                       description: "Add Person"
@@ -2637,6 +2657,7 @@ Scenario: Get product by id
                         encoding:
                           Data:
                             contentType: "application/json"
+                    required: true
                   responses:
                     200:
                       description: "Get details"
@@ -2824,6 +2845,7 @@ Scenario: Get product by id
                       application/json:
                         schema:
                           ${"$"}ref: '#/components/schemas/Data1_RequestBody'
+                    required: true
                   responses:
                     200:
                       description: API 1
@@ -2836,6 +2858,7 @@ Scenario: Get product by id
                       application/json:
                         schema:
                           ${"$"}ref: '#/components/schemas/Data2_RequestBody'
+                    required: true
                   responses:
                     200:
                       description: API 2
@@ -2920,6 +2943,7 @@ Scenario: Get product by id
                       application/json:
                         schema:
                           ${"$"}ref: '#/components/schemas/Data_RequestBody'
+                    required: true
                   responses:
                     200:
                       description: API 1
@@ -3001,6 +3025,7 @@ Scenario: Get product by id
                       application/json:
                         schema:
                           ${"$"}ref: '#/components/schemas/Data_RequestBody'
+                    required: true
                   responses:
                     200:
                       description: API 1
@@ -3090,6 +3115,7 @@ Scenario: Get product by id
                       application/json:
                         schema:
                           ${"$"}ref: '#/components/schemas/Data_RequestBody'
+                    required: true
                   responses:
                     200:
                       description: API 1
@@ -3159,6 +3185,7 @@ Scenario: Get product by id
                       text/plain:
                         schema:
                           type: string
+                    required: true
                   responses:
                     200:
                       description: API
@@ -3214,6 +3241,7 @@ Scenario: Get product by id
                       application/json:
                         schema:
                           ${"$"}ref: '#/components/schemas/Data'
+                    required: true
                   responses:
                     200:
                       description: API
@@ -3655,6 +3683,7 @@ paths:
       summary: API
       parameters: []
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -3708,6 +3737,7 @@ paths:
       summary: API
       parameters: []
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -4860,6 +4890,7 @@ paths:
                   summary: "Get person by id"
                   parameters: []
                   requestBody:
+                    required: true
                     content:
                       application/json:
                         schema:
@@ -6130,6 +6161,7 @@ paths:
                       application/json:
                         schema:
                           ${"$"}ref: '#/components/schemas/1_RequestBody'
+                    required: true
                   responses:
                     200:
                       description: API 1
@@ -6197,6 +6229,7 @@ paths:
                       application/json:
                         schema:
                           ${"$"}ref: '#/components/schemas/1_RequestBody'
+                    required: true
                   responses:
                     200:
                       description: API 1
@@ -6463,6 +6496,7 @@ paths:
                       application/json:
                         schema:
                           ${'$'}ref: '#/components/schemas/Request'
+                    required: true
                   responses:
                     "200":
                       description: New scenario
@@ -6544,6 +6578,7 @@ paths:
                   summary: "Get person by id"
                   parameters: []
                   requestBody:
+                    required: true
                     content:
                       application/json:
                         schema:

--- a/core/src/test/kotlin/in/specmatic/core/ContractTests.kt
+++ b/core/src/test/kotlin/in/specmatic/core/ContractTests.kt
@@ -757,6 +757,7 @@ Examples:
                       text/plain:
                         schema:
                           type: string
+                    required: true
                   responses:
                     '200':
                       description: OK
@@ -1029,6 +1030,7 @@ Examples:
                 post:
                   summary: Random
                   requestBody:
+                    required: true
                     content:
                       application/json:
                         schema:

--- a/core/src/test/kotlin/in/specmatic/core/CyclePrevention.kt
+++ b/core/src/test/kotlin/in/specmatic/core/CyclePrevention.kt
@@ -23,6 +23,7 @@ class CyclePrevention {
                 post:
                   description: Get data
                   requestBody:
+                    required: true
                     content:
                       application/json:
                         schema:
@@ -69,6 +70,7 @@ class CyclePrevention {
                 post:
                   description: Get data
                   requestBody:
+                    required: true
                     content:
                       application/json:
                         schema:

--- a/core/src/test/kotlin/in/specmatic/core/FeatureKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/FeatureKtTest.kt
@@ -327,6 +327,7 @@ class FeatureKtTest {
                     application/json:
                       schema:
                         ${"$"}ref: '#/components/schemas/Body_RequestBody'
+                  required: true
                 responses:
                   "200":
                     description: stub0
@@ -382,6 +383,7 @@ class FeatureKtTest {
                         application/json:
                           schema:
                             ${"$"}ref: '#/components/schemas/Data_RequestBody'
+                      required: true
                     responses:
                       "200":
                         description: http://localhost
@@ -696,6 +698,7 @@ paths:
       summary: hello world
       description: test
       requestBody:
+        required: true
         content:
           application/json:
             schema:

--- a/core/src/test/kotlin/in/specmatic/core/TestBackwardCompatibilityKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/TestBackwardCompatibilityKtTest.kt
@@ -1429,6 +1429,7 @@ paths:
       summary: hello world
       description: test
       requestBody:
+        required: true
         content:
           application/json:
             schema:

--- a/core/src/test/kotlin/in/specmatic/stub/HttpStubKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/stub/HttpStubKtTest.kt
@@ -847,6 +847,7 @@ paths:
       summary: hello world
       description: test
       requestBody:
+        required: true
         content:
           application/json:
             schema:

--- a/core/src/test/resources/openapi/has_invalid_externalized_test.yaml
+++ b/core/src/test/resources/openapi/has_invalid_externalized_test.yaml
@@ -13,6 +13,7 @@ paths:
               type: string
             description: Unique ID for the request
       requestBody:
+        required: true
         content:
           application/json:
             schema:

--- a/core/src/test/resources/openapi/post_with_default.yaml
+++ b/core/src/test/resources/openapi/post_with_default.yaml
@@ -14,6 +14,7 @@ paths:
       summary: hello world
       description: Optional extended description in CommonMark or HTML.
       requestBody:
+        required: true
         content:
           application/json:
             schema:

--- a/core/src/test/resources/openapi/post_with_default_and_400.yaml
+++ b/core/src/test/resources/openapi/post_with_default_and_400.yaml
@@ -14,6 +14,7 @@ paths:
       summary: hello world
       description: Optional extended description in CommonMark or HTML.
       requestBody:
+        required: true
         content:
           application/json:
             schema:

--- a/core/src/test/resources/openapi/spec_with_password_and_email_format_strings.yaml
+++ b/core/src/test/resources/openapi/spec_with_password_and_email_format_strings.yaml
@@ -10,6 +10,7 @@ paths:
       description: Register a new user
       operationId: CreateUser
       requestBody:
+        required: true
         content:
           application/json:
             schema:

--- a/core/src/test/resources/openapi/three_keys_one_mandatory.yaml
+++ b/core/src/test/resources/openapi/three_keys_one_mandatory.yaml
@@ -8,6 +8,7 @@ paths:
       summary: Test
       description: Test
       requestBody:
+        required: true
         content:
           application/json:
             schema:


### PR DESCRIPTION
**What**:

Implement support for an optional body. By default, a body is considered optional in OpenAPI. To make it mandatory, add the property `required`=`true` to the body.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

