### PR TITLE
Fix: proxy uses response header for html response instead of inferring xml type

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/HttpResponse.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpResponse.kt
@@ -225,5 +225,5 @@ fun toGherkinClauses(
 
 fun dropContentAndCORSResponseHeaders(response: HttpResponse) =
     response.copy(headers = response.headers.filterNot {
-        it.key in responseHeadersToExcludeFromConversion || it.key.lowercase() in listOf("content-type", "content-encoding") || it.key.startsWith("Access-Control-")
+        it.key in responseHeadersToExcludeFromConversion || it.key.lowercase() in listOf("content-type", "content-encoding", "content-length", "content-disposition") || it.key.startsWith("Access-Control-")
     })

--- a/core/src/main/kotlin/in/specmatic/core/HttpResponse.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpResponse.kt
@@ -194,6 +194,13 @@ fun toGherkinClauses(
             }
             Triple(clauses.plus(GherkinClause("status $status", Then)), types, examples)
         }.let { (clauses, types, _) ->
+            val contentTypeHeader: List<GherkinClause> = response.headers.entries.find {
+                it.key.equals(CONTENT_TYPE, ignoreCase = true)
+            }?.let {
+                val contentType = it.value.split(";")[0]
+                listOf(GherkinClause("response-header ${it.key} $contentType", Then))
+            } ?: emptyList()
+
             val (newClauses, newTypes, _) = headersToGherkin(
                 cleanedUpResponse.headers,
                 "response-header",
@@ -201,7 +208,7 @@ fun toGherkinClauses(
                 DiscardExampleDeclarations(),
                 Then
             )
-            Triple(clauses.plus(newClauses), newTypes, DiscardExampleDeclarations())
+            Triple(clauses.plus(newClauses).plus(contentTypeHeader), newTypes, DiscardExampleDeclarations())
         }.let { (clauses, types, examples) ->
             when (val result = responseBodyToGherkinClauses("ResponseBody", guessType(cleanedUpResponse.body), types)) {
                 null -> Triple(clauses, types, examples)
@@ -218,7 +225,5 @@ fun toGherkinClauses(
 
 fun dropContentAndCORSResponseHeaders(response: HttpResponse) =
     response.copy(headers = response.headers.filterNot {
-        it.key in responseHeadersToExcludeFromConversion || it.key.startsWith(
-            "Content-"
-        ) || it.key.startsWith("Access-Control-")
+        it.key in responseHeadersToExcludeFromConversion || it.key.lowercase() in listOf("content-type", "content-encoding") || it.key.startsWith("Access-Control-")
     })

--- a/core/src/main/kotlin/in/specmatic/core/HttpResponsePattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpResponsePattern.kt
@@ -3,6 +3,7 @@ package `in`.specmatic.core
 import `in`.specmatic.core.pattern.*
 import `in`.specmatic.core.value.JSONObjectValue
 import `in`.specmatic.core.value.StringValue
+import `in`.specmatic.core.value.Value
 import `in`.specmatic.stub.softCastValueToXML
 
 const val DEFAULT_RESPONSE_CODE = 1000
@@ -115,5 +116,15 @@ data class HttpResponsePattern(val headersPattern: HttpHeadersPattern = HttpHead
         val bodyResult = resolvedHop(body, olderResolver).encompasses(resolvedHop(other.body, newerResolver), olderResolver, newerResolver).breadCrumb("BODY")
 
         return Result.fromResults(listOf(headerResult, bodyResult)).breadCrumb("RESPONSE")
+    }
+
+    companion object {
+        fun fromResponseExpectation(response: HttpResponse): HttpResponsePattern {
+            return HttpResponsePattern(
+                HttpHeadersPattern(response.headers.mapValues { stringToPattern(it.value, it.key) }),
+                response.status,
+                response.body.exactMatchElseType()
+            )
+        }
     }
 }

--- a/core/src/main/kotlin/in/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Scenario.kt
@@ -427,11 +427,11 @@ data class Scenario(
         }
     }
 
-    fun resolverAndResponseFrom(response: HttpResponse): Pair<Resolver, HttpResponse> =
+    fun resolverAndResponseForExpectation(response: HttpResponse): Pair<Resolver, HttpResponse> =
         scenarioBreadCrumb(this) {
             attempt(breadCrumb = "RESPONSE") {
                 val resolver = Resolver(expectedFacts, false, patterns)
-                Pair(resolver, HttpResponsePattern(response).generateResponse(resolver))
+                Pair(resolver, HttpResponsePattern.fromResponseExpectation(response).generateResponse(resolver))
             }
         }
 

--- a/core/src/main/kotlin/in/specmatic/core/value/StringValue.kt
+++ b/core/src/main/kotlin/in/specmatic/core/value/StringValue.kt
@@ -18,7 +18,8 @@ data class StringValue(val string: String = "") : Value, ScalarValue, XMLValue {
     override fun exactMatchElseType(): Pattern {
         return when {
             isPatternToken() -> DeferredPattern(string)
-            string.trim().startsWith("{") || string.trim().startsWith("<")-> parsedPattern(string)
+            string.trim().startsWith("{") || string.trim().startsWith("<")-> try { parsedPattern(string) } catch(e: Throwable) { ExactValuePattern(this) }
+//            string.trim().startsWith("{") || string.trim().startsWith("<")-> parsedPattern(string)
             else -> ExactValuePattern(this)
         }
     }

--- a/core/src/test/kotlin/in/specmatic/core/PostmanKtTests.kt
+++ b/core/src/test/kotlin/in/specmatic/core/PostmanKtTests.kt
@@ -467,6 +467,7 @@ class PostmanKtTests {
     When GET /stuff
     Then status 200
     And response-header Connection (string)
+    And response-header Content-Type text/plain
     And response-body (number)
   
   Scenario: With JSON body
@@ -476,6 +477,7 @@ class PostmanKtTests {
     And request-body (RequestBody)
     Then status 200
     And response-header Connection (string)
+    And response-header Content-Type text/plain
     And response-body (number)
   
     Examples:
@@ -486,6 +488,7 @@ class PostmanKtTests {
     When GET /stuff?one=(number)
     Then status 200
     And response-header Connection (string)
+    And response-header Content-Type text/plain
     And response-body (number)
   
     Examples:
@@ -497,6 +500,7 @@ class PostmanKtTests {
     And request-body (RequestBody: number)
     Then status 200
     And response-header Connection (number)
+    And response-header Content-Type text/plain
     And response-body (number)
   
     Examples:
@@ -508,6 +512,7 @@ class PostmanKtTests {
     And form-field field1 (number)
     Then status 200
     And response-header Connection (string)
+    And response-header Content-Type text/plain
     And response-body (number)
   
     Examples:
@@ -519,6 +524,7 @@ class PostmanKtTests {
     And request-part part1 (number)
     Then status 200
     And response-header Connection (string)
+    And response-header Content-Type text/plain
     And response-body (number)
   
     Examples:
@@ -527,7 +533,7 @@ class PostmanKtTests {
 
         assertThat(gherkinString.trim()).isEqualTo(expectedGherkinString.trim())
 
-        validate(gherkinString, stubs)
+        validate(gherkinString, stubs, mapOf("Content-Type" to "text/plain"))
     }
 
     @Test
@@ -614,9 +620,9 @@ class PostmanKtTests {
         assertThat(response.headers.getOrDefault("X-Header", "does not exist")).isEqualTo("right value")
     }
 
-    private fun validate(gherkinString: String, stubs: List<NamedStub>) {
+    private fun validate(gherkinString: String, stubs: List<NamedStub>, additionalHeaders: Map<String, String> = emptyMap()) {
         val behaviour = parseGherkinStringToFeature(gherkinString)
-        val cleanedUpStubs = stubs.map { it.stub }.map { it.copy(response = dropContentAndCORSResponseHeaders(it.response) ) }
+        val cleanedUpStubs = stubs.map { it.stub }.map { it.copy(response = dropContentAndCORSResponseHeaders(it.response).let { it.copy(headers = it.headers + additionalHeaders)} ) }
         for(stub in cleanedUpStubs) {
             behaviour.matchingStub(stub)
         }


### PR DESCRIPTION
**What**:

The Specmatic proxy would consider HTML responses to be XML through guesswork based on how the response content looked, even though the `Content-Type` header in the response said `text/html`. With this PR, it will leverage the response type of the response instead of guessing.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

