### PR TITLE
Fixed issue with array matching

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/pattern/JSONArrayPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/JSONArrayPattern.kt
@@ -35,12 +35,15 @@ data class JSONArrayPattern(override val pattern: List<Pattern> = emptyList(), o
         if (sampleData !is JSONArrayValue)
             return mismatchResult(this, sampleData, resolver.mismatchMessages)
 
-        if (sampleData.list.isEmpty())
+        if (sampleData.list.isEmpty() && (pattern.isEmpty()))
             return Result.Success()
 
         val resolverWithNumberType = withNumberType(withNullPattern(resolver))
-
         val resolvedTypes = pattern.map { resolvedHop(it, resolverWithNumberType) }
+
+        if(resolvedTypes.singleOrNull() is ListPattern) {
+            return resolvedTypes.single().matches(sampleData, resolver)
+        }
 
         return resolvedTypes.asSequence().mapIndexed { index, patternValue ->
             when {


### PR DESCRIPTION
**What**:

Empty arrays were matched by JSONArrayPattern by default even if there was an element in the array pattern, which is wrong. This was due to an assumption made for Gherkin that JSONArrayPattern would always contain (number*) or something similar. This PR fixes it.


**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

