### PR TITLE
Optional body match error message improvement

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -694,7 +694,7 @@ class OpenApiSpecification(
                         if(bodyIsRequired)
                             it
                         else
-                            AnyPattern(listOf(it, NoBodyPattern))
+                            OptionalBodyPattern.fromPattern(it)
                     }
 
                     Pair(

--- a/core/src/main/kotlin/in/specmatic/conversions/OptionalBodyPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OptionalBodyPattern.kt
@@ -1,13 +1,31 @@
 package `in`.specmatic.conversions
 
 import `in`.specmatic.core.NoBodyPattern
+import `in`.specmatic.core.Resolver
+import `in`.specmatic.core.Result
 import `in`.specmatic.core.pattern.AnyPattern
 import `in`.specmatic.core.pattern.Pattern
+import `in`.specmatic.core.value.Value
 
-class OptionalBodyPattern(override val pattern: AnyPattern) : Pattern by pattern {
+data class OptionalBodyPattern(override val pattern: AnyPattern, private val bodyPattern: Pattern) : Pattern by pattern {
     companion object {
         fun fromPattern(bodyPattern: Pattern): OptionalBodyPattern {
-            return OptionalBodyPattern(AnyPattern(listOf(bodyPattern, NoBodyPattern)))
+            return OptionalBodyPattern(AnyPattern(listOf(bodyPattern, NoBodyPattern)), bodyPattern)
         }
+    }
+
+
+    override fun matches(sampleData: Value?, resolver: Resolver): Result {
+        val bodyPatternMatchResult = bodyPattern.matches(sampleData, resolver)
+
+        if(bodyPatternMatchResult is Result.Success)
+            return bodyPatternMatchResult
+
+        val nobodyPatternMatchResult = NoBodyPattern.matches(sampleData, resolver)
+
+        if(nobodyPatternMatchResult is Result.Success)
+            return nobodyPatternMatchResult
+
+        return bodyPatternMatchResult
     }
 }

--- a/core/src/main/kotlin/in/specmatic/conversions/OptionalBodyPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OptionalBodyPattern.kt
@@ -1,0 +1,13 @@
+package `in`.specmatic.conversions
+
+import `in`.specmatic.core.NoBodyPattern
+import `in`.specmatic.core.pattern.AnyPattern
+import `in`.specmatic.core.pattern.Pattern
+
+class OptionalBodyPattern(override val pattern: AnyPattern) : Pattern by pattern {
+    companion object {
+        fun fromPattern(bodyPattern: Pattern): OptionalBodyPattern {
+            return OptionalBodyPattern(AnyPattern(listOf(bodyPattern, NoBodyPattern)))
+        }
+    }
+}

--- a/core/src/test/kotlin/in/specmatic/conversions/OptionalBodyPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OptionalBodyPatternTest.kt
@@ -1,0 +1,18 @@
+package `in`.specmatic.conversions
+
+import `in`.specmatic.core.Resolver
+import `in`.specmatic.core.pattern.NumberPattern
+import `in`.specmatic.core.value.StringValue
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class OptionalBodyPatternTest {
+    @Test
+    fun `optional body error match`() {
+        val body = OptionalBodyPattern.fromPattern(NumberPattern())
+
+        val matchResult = body.matches(StringValue("abc"), Resolver())
+        assertThat(matchResult.reportString().trim()).isEqualTo("Expected number, actual was \"abc\"")
+    }
+}

--- a/core/src/test/kotlin/in/specmatic/conversions/OptionalBodyPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OptionalBodyPatternTest.kt
@@ -4,7 +4,6 @@ import `in`.specmatic.core.Resolver
 import `in`.specmatic.core.pattern.NumberPattern
 import `in`.specmatic.core.value.StringValue
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 
 class OptionalBodyPatternTest {


### PR DESCRIPTION
**What**:

When a `requestBody` (say a JSON customer object with `name: string`) is not marked required (`required: true`), it is represented internally as an `OptionalBodyPattern`, which itself composes and delegates to `AnyPattern(JSONObjectPattern, NoBodyPattern)`.

Now in the `matches` method, when a `Value` object does not match an `OptionalBodyPattern` (say REQUEST.BODY.customer.name should have been a string but was a number), the error message indicates both the mismatch in the `name`, as well as the fact that no body was also acceptable.

In other words, something like this:

```
>> REQUEST.BODY.customer.name

  Expected string but was a number

>> REQUEST.BODY

  Expected no body but was a JSON object
```

But in the context of a match, the second error really is meaningless. So modified this to remove it.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #123

<!-- feel free to add additional comments -->
