### PR TITLE
Array match simplified

### DIFF
--- a/core/src/main/kotlin/in/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/in/specmatic/stub/HttpStub.kt
@@ -703,16 +703,6 @@ fun getHttpResponse(
         } else {
             fakeHttpResponse(features, httpRequest)
         }
-
-//        matchingStubResponse?.let { FoundStubbedResponse(matchingStubResponse) }
-//            ?: if (httpClientFactory != null && passThroughTargetBase.isNotBlank()) {
-//                NotStubbed(passThroughResponse(httpRequest, passThroughTargetBase, httpClientFactory))
-//            } else {
-//                if (strictMode)
-//                    NotStubbed(HttpStubResponse(strictModeHttp400Response(httpRequest, matchResults)))
-//                else
-//                    fakeHttpResponse(features, httpRequest)
-//            }
     } finally {
         features.forEach { feature ->
             feature.clearServerState()

--- a/core/src/test/kotlin/in/specmatic/core/pattern/JSONArrayPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/JSONArrayPatternTest.kt
@@ -15,11 +15,19 @@ import org.junit.jupiter.api.Test
 
 internal class JSONArrayPatternTest {
     @Test
-    fun `An empty array should match an array pattern`() {
-        val value = parsedValue("[]")
-        val pattern = parsedPattern("""["(number*)"]""")
+    fun `An array with a number should match an array pattern with a number pattern`() {
+        val value = parsedValue("[1]")
+        val pattern = parsedPattern("""["(number)"]""")
 
         value shouldMatch pattern
+    }
+
+    @Test
+    fun `An array with a string should not match an array pattern with a number pattern`() {
+        val value = parsedValue("""["abc"]""")
+        val pattern = parsedPattern("""["(number)"]""")
+
+        value shouldNotMatch pattern
     }
 
     @Test
@@ -44,6 +52,14 @@ internal class JSONArrayPatternTest {
         val pattern = parsedPattern("""[]""")
 
         value shouldNotMatch pattern
+    }
+
+    @Test
+    fun `An empty array should match an array pattern`() {
+        val value = parsedValue("[]")
+        val pattern = parsedPattern("""["(number*)"]""")
+
+        value shouldMatch pattern
     }
 
     @Test

--- a/core/src/test/kotlin/in/specmatic/core/pattern/JSONArrayPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/JSONArrayPatternTest.kt
@@ -84,14 +84,6 @@ internal class JSONArrayPatternTest {
     }
 
     @Test
-    fun `should match the rest even if there are no more elements`() {
-        val pattern = JSONArrayPattern(listOf(StringPattern(), RestPattern(NumberPattern())))
-        val value = JSONArrayValue(listOf(StringValue("hello")))
-
-        value shouldMatch pattern
-    }
-
-    @Test
     fun `should fail to match nulls gracefully`() {
         NullValue shouldNotMatch JSONArrayPattern(listOf(StringPattern(), StringPattern()))
     }


### PR DESCRIPTION
**What**:

Removed support for legacy / unused usage of `...` in Gherkin, which made it possible to greatly simplify the logic in JSONArrayPattern.matches, making it easier to reason about.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #123

<!-- feel free to add additional comments -->
