### PR TITLE
Stream tests instead of generating them all before running

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@ perfiz/*_data
 **/.settings
 **/.project
 **/.classpath
-
+**/*.hprof

--- a/application/src/main/kotlin/application/test/ContractExecutionListener.kt
+++ b/application/src/main/kotlin/application/test/ContractExecutionListener.kt
@@ -48,11 +48,6 @@ class ContractExecutionListener : TestExecutionListener {
                     return
         }
 
-        totalRun += 1
-        logger.newLine()
-        logger.log(progressUpdate(totalRun, SpecmaticJUnitSupport.totalTestCount))
-        logger.newLine()
-
         printer.printTestSummary(testIdentifier, testExecutionResult)
 
         when(testExecutionResult?.status) {

--- a/application/src/test/kotlin/in/specmatic/test/SpecmaticJUnitSupportKtTest.kt
+++ b/application/src/test/kotlin/in/specmatic/test/SpecmaticJUnitSupportKtTest.kt
@@ -6,6 +6,15 @@ import `in`.specmatic.test.reports.coverage.Endpoint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
+fun <T> selectTestsToRunWrapper(
+    testScenarios: Sequence<T>,
+    filterName: String? = null,
+    filterNotName: String? = null,
+    getTestDescription: (T) -> String
+): List<T> {
+    return selectTestsToRun(testScenarios.asSequence(), filterName, filterNotName, getTestDescription).toList()
+}
+
 class SpecmaticJUnitSupportKtTest {
     val contract = OpenApiSpecification.fromYAML("""
 openapi: 3.0.0
@@ -57,14 +66,14 @@ paths:
 
     @Test
     fun `should select tests containing the value of filterName in testDescription`() {
-        val selected = selectTestsToRun(contractTests, "TEST1") { it.testDescription() }
+        val selected = selectTestsToRunWrapper(contractTests, "TEST1") { it.testDescription() }
         assertThat(selected).hasSize(1)
         assertThat(selected.first().testDescription()).contains("TEST1")
     }
 
     @Test
     fun `should select tests whose testDescriptions contain any of the multiple comma separate values in filterName`() {
-        val selected = selectTestsToRun(contractTests, "TEST1, TEST2") { it.testDescription() }
+        val selected = selectTestsToRunWrapper(contractTests, "TEST1, TEST2") { it.testDescription() }
         assertThat(selected).hasSize(2)
         assertThat(selected.map { it.testDescription() }).allMatch {
             it.contains("TEST1") || it.contains("TEST2")
@@ -73,7 +82,7 @@ paths:
 
     @Test
     fun `should omit tests containing the value of filterNotName in testDescription`() {
-        val selected = selectTestsToRun(contractTests, filterNotName = "TEST1") { it.testDescription() }
+        val selected = selectTestsToRunWrapper(contractTests, filterNotName = "TEST1") { it.testDescription() }
         assertThat(selected).hasSize(2)
         assertThat(selected.map { it.testDescription() }).allMatch {
             it.contains("TEST2") || it.contains("TEST3")
@@ -82,14 +91,14 @@ paths:
 
     @Test
     fun `should omit tests whose testDescriptions contain any of the multiple comma separate values in filterNotName`() {
-        val selected = selectTestsToRun(contractTests, filterNotName = "TEST1, TEST2") { it.testDescription() }
+        val selected = selectTestsToRunWrapper(contractTests, filterNotName = "TEST1, TEST2") { it.testDescription() }
         assertThat(selected).hasSize(1)
         assertThat(selected.first().testDescription()).contains("TEST3")
     }
 
     @Test
     fun `should not filter the tests if filterName is empty`() {
-        val selected = selectTestsToRun(contractTests, filterName = "") { it.testDescription() }
+        val selected = selectTestsToRunWrapper(contractTests, filterName = "") { it.testDescription() }
 
         assertThat(selected).hasSize(3)
 
@@ -102,7 +111,7 @@ paths:
 
     @Test
     fun `should not filter the tests if filterName is blank`() {
-        val selected = selectTestsToRun(contractTests, filterName = " ") { it.testDescription() }
+        val selected = selectTestsToRunWrapper(contractTests, filterName = " ") { it.testDescription() }
 
         assertThat(selected).hasSize(3)
 
@@ -115,7 +124,7 @@ paths:
 
     @Test
     fun `should not filter the tests if filterName is null`() {
-        val selected = selectTestsToRun(contractTests, filterName = null) { it.testDescription() }
+        val selected = selectTestsToRunWrapper(contractTests, filterName = null) { it.testDescription() }
 
         assertThat(selected).hasSize(3)
 
@@ -128,7 +137,7 @@ paths:
 
     @Test
     fun `should not filter the tests if filterNotName is not found in any of the test names`() {
-        val selected = selectTestsToRun(contractTests, filterNotName = "UNKNOWN_TEST_NAME_1, UNKNOWN_TEST_NAME_2") { it.testDescription() }
+        val selected = selectTestsToRunWrapper(contractTests, filterNotName = "UNKNOWN_TEST_NAME_1, UNKNOWN_TEST_NAME_2") { it.testDescription() }
 
         assertThat(selected).hasSize(3)
 
@@ -141,7 +150,7 @@ paths:
 
     @Test
     fun `should not filter the tests if filterNotName is null`() {
-        val selected = selectTestsToRun(contractTests, filterNotName = null) { it.testDescription() }
+        val selected = selectTestsToRunWrapper(contractTests, filterNotName = null) { it.testDescription() }
 
         assertThat(selected).hasSize(3)
 
@@ -154,7 +163,7 @@ paths:
 
     @Test
     fun `should not filter the tests if filterNotName is empty`() {
-        val selected = selectTestsToRun(contractTests, filterNotName = "") { it.testDescription() }
+        val selected = selectTestsToRunWrapper(contractTests, filterNotName = "") { it.testDescription() }
 
         assertThat(selected).hasSize(3)
 
@@ -167,7 +176,7 @@ paths:
 
     @Test
     fun `should not filter the tests if filterNotName is blank`() {
-        val selected = selectTestsToRun(contractTests, filterNotName = " ") { it.testDescription() }
+        val selected = selectTestsToRunWrapper(contractTests, filterNotName = " ") { it.testDescription() }
 
         assertThat(selected).hasSize(3)
 

--- a/core/src/main/kotlin/in/specmatic/core/HttpHeadersPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpHeadersPattern.kt
@@ -154,7 +154,7 @@ data class HttpHeadersPattern(
         }.map { (key, value) -> withoutOptionality(key) to value }.toMap()
     }
 
-    fun newBasedOn(row: Row, resolver: Resolver): List<HttpHeadersPattern> {
+    fun newBasedOn(row: Row, resolver: Resolver): Sequence<HttpHeadersPattern> {
         return forEachKeyCombinationIn(row.withoutOmittedKeys(pattern, resolver.defaultExampleResolver), row, resolver) { pattern ->
             newBasedOn(pattern, row, resolver)
         }.map { map -> HttpHeadersPattern(map.mapKeys { withoutOptionality(it.key) }, contentType = contentType) }
@@ -170,7 +170,7 @@ data class HttpHeadersPattern(
             )
         }
 
-    fun newBasedOn(resolver: Resolver): List<HttpHeadersPattern> =
+    fun newBasedOn(resolver: Resolver): Sequence<HttpHeadersPattern> =
         allOrNothingCombinationIn(pattern) { pattern ->
             newBasedOn(pattern, resolver)
         }.map { patternMap ->

--- a/core/src/main/kotlin/in/specmatic/core/HttpPathPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpPathPattern.kt
@@ -128,8 +128,7 @@ data class HttpPathPattern(
         }, row, resolver)
 
         //TODO: replace this with Generics
-        //TODO: STREAMING
-        return generatedPatterns.map { list -> list.map { it as URLPathSegmentPattern } }.asSequence()
+        return generatedPatterns.map { list -> list.map { it as URLPathSegmentPattern } }
     }
 
     fun newBasedOn(resolver: Resolver): Sequence<List<URLPathSegmentPattern>> {
@@ -140,8 +139,7 @@ data class HttpPathPattern(
         }, resolver)
 
         //TODO: replace this with Generics
-        //TODO: STREAMING
-        return generatedPatterns.map { list -> list.map { it as URLPathSegmentPattern } }.asSequence()
+        return generatedPatterns.map { list -> list.map { it as URLPathSegmentPattern } }
     }
 
     override fun toString(): String {
@@ -189,9 +187,9 @@ data class HttpPathPattern(
         patterns: List<URLPathSegmentPattern>,
         row: Row,
         resolver: Resolver
-    ): List<URLPathSegmentPattern> {
+    ): Sequence<URLPathSegmentPattern> {
         if(patterns.isEmpty())
-            return emptyList()
+            return emptySequence()
 
         val patternToPositively = patterns.first()
 
@@ -214,14 +212,14 @@ data class HttpPathPattern(
         row: Row,
         urlPathPattern: URLPathSegmentPattern,
         resolver: Resolver
-    ): List<Pattern> = when {
+    ): Sequence<Pattern> = when {
         key !== null && row.containsField(key) -> {
             val rowValue = row.getField(key)
             when {
                 isPatternToken(rowValue) -> attempt("Pattern mismatch in example of path param \"${urlPathPattern.key}\"") {
                     val rowPattern = resolver.getPattern(rowValue)
                     when (val result = urlPathPattern.encompasses(rowPattern, resolver, resolver)) {
-                        is Success -> listOf(urlPathPattern.copy(pattern = rowPattern))
+                        is Success -> sequenceOf(urlPathPattern.copy(pattern = rowPattern))
                         is Failure -> throw ContractException(result.toFailureReport())
                     }
                 }
@@ -233,7 +231,7 @@ data class HttpPathPattern(
                     if (matchResult is Failure)
                         throw ContractException("""Could not run contract test, the example value ${value.toStringLiteral()} provided "id" does not match the contract.""")
 
-                    listOf(
+                    sequenceOf(
                         URLPathSegmentPattern(
                             ExactValuePattern(
                                 value
@@ -244,8 +242,7 @@ data class HttpPathPattern(
             }
         }
 
-        //TODO: STREAMING
-        else -> (urlPathPattern.newBasedOn(row, resolver) + urlPathPattern.negativeBasedOn(row, resolver)).toList().distinct()
+        else -> (urlPathPattern.newBasedOn(row, resolver) + urlPathPattern.negativeBasedOn(row, resolver)).distinct()
     }
 
     fun extractPathParams(requestPath: String, resolver: Resolver): Map<String, String> {

--- a/core/src/main/kotlin/in/specmatic/core/HttpQueryParamPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpQueryParamPattern.kt
@@ -32,7 +32,7 @@ data class HttpQueryParamPattern(val queryPatterns: Map<String, Pattern>, val ad
     fun newBasedOn(
         row: Row,
         resolver: Resolver
-    ): List<Map<String, Pattern>> {
+    ): Sequence<Map<String, Pattern>> {
         val newQueryParamsList = attempt(breadCrumb = QUERY_PARAMS_BREADCRUMB) {
             val queryParams = queryPatterns.let {
                 if(additionalProperties != null)
@@ -103,7 +103,7 @@ data class HttpQueryParamPattern(val queryPatterns: Map<String, Pattern>, val ad
             Result.Success()
     }
 
-    fun newBasedOn(resolver: Resolver): List<Map<String, Pattern>> {
+    fun newBasedOn(resolver: Resolver): Sequence<Map<String, Pattern>> {
         return attempt(breadCrumb = QUERY_PARAMS_BREADCRUMB) {
             val queryParams = queryPatterns.let {
                 if(additionalProperties != null)
@@ -125,7 +125,7 @@ data class HttpQueryParamPattern(val queryPatterns: Map<String, Pattern>, val ad
         } else ""
     }
 
-    fun negativeBasedOn(row: Row, resolver: Resolver): List<Map<String, Pattern>> {
+    fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Map<String, Pattern>> {
         return attempt(breadCrumb = QUERY_PARAMS_BREADCRUMB) {
             val queryParams = queryPatterns.let {
                 if(additionalProperties != null)

--- a/core/src/main/kotlin/in/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpRequestPattern.kt
@@ -695,7 +695,6 @@ fun missingParam(missingValue: String): ContractException {
     return ContractException("$missingValue is missing. Can't generate the contract test.")
 }
 
-//TODO: STREAMING
 fun newMultiPartBasedOn(
     partList: List<MultiPartFormDataPattern>,
     row: Row,

--- a/core/src/main/kotlin/in/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpRequestPattern.kt
@@ -703,18 +703,18 @@ fun newMultiPartBasedOn(
 ): Sequence<List<MultiPartFormDataPattern>> {
     val values = partList.map { part ->
         attempt(breadCrumb = part.name) {
-            part.newBasedOn(row, resolver).toList()
+            part.newBasedOn(row, resolver)
         }
     }
 
-    return multiPartListCombinations(values).asSequence()
+    return multiPartListCombinations(values)
 }
 
-fun multiPartListCombinations(values: List<List<MultiPartFormDataPattern?>>): List<List<MultiPartFormDataPattern>> {
+fun multiPartListCombinations(values: List<Sequence<MultiPartFormDataPattern?>>): Sequence<List<MultiPartFormDataPattern>> {
     if (values.isEmpty())
-        return listOf(emptyList())
+        return sequenceOf(emptyList())
 
-    val value: List<MultiPartFormDataPattern?> = values.last()
+    val value: Sequence<MultiPartFormDataPattern?> = values.last()
     val subLists = multiPartListCombinations(values.dropLast(1))
 
     return subLists.flatMap { list ->

--- a/core/src/main/kotlin/in/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpRequestPattern.kt
@@ -454,7 +454,7 @@ data class HttpRequestPattern(
         }
     }
 
-    fun newBasedOn(row: Row, initialResolver: Resolver, status: Int = 0): List<HttpRequestPattern> {
+    fun newBasedOn(row: Row, initialResolver: Resolver, status: Int = 0): Sequence<HttpRequestPattern> {
         val resolver = when (status) {
             in invalidRequestStatuses -> initialResolver.invalidRequestResolver()
             else -> initialResolver
@@ -464,22 +464,22 @@ data class HttpRequestPattern(
             val newHttpPathPatterns = httpPathPattern?.let { httpPathPattern ->
                 val newURLPathSegmentPatternsList = httpPathPattern.newBasedOn(row, resolver)
                 newURLPathSegmentPatternsList.map { HttpPathPattern(it, httpPathPattern.path) }
-            } ?: listOf<HttpPathPattern?>(null)
+            } ?: sequenceOf<HttpPathPattern?>(null)
 
             val newQueryParamsPatterns = httpQueryParamPattern.newBasedOn(row, resolver).map { HttpQueryParamPattern(it) }
 
-            val newBodies: List<Pattern> = attempt(breadCrumb = "BODY") {
+            val newBodies: Sequence<Pattern> = attempt(breadCrumb = "BODY") {
                 body.let {
                     if (it is DeferredPattern && row.containsField(it.pattern)) {
                         val example = row.getField(it.pattern)
-                        listOf(ExactValuePattern(it.parse(example, resolver)))
+                        sequenceOf(ExactValuePattern(it.parse(example, resolver)))
                     } else if (it.typeAlias?.let { p -> isPatternToken(p) } == true && row.containsField(it.typeAlias!!)) {
                         val example = row.getField(it.typeAlias!!)
-                        listOf(ExactValuePattern(it.parse(example, resolver)))
+                        sequenceOf(ExactValuePattern(it.parse(example, resolver)))
                     } else if (it is XMLPattern && it.referredType?.let { referredType -> row.containsField("($referredType)") } == true) {
                         val referredType = "(${it.referredType})"
                         val example = row.getField(referredType)
-                        listOf(ExactValuePattern(it.parse(example, resolver)))
+                        sequenceOf(ExactValuePattern(it.parse(example, resolver)))
                     } else if (row.containsField("(REQUEST-BODY)")) {
                         val example = row.getField("(REQUEST-BODY)")
                         val value = it.parse(example, resolver)
@@ -541,12 +541,12 @@ data class HttpRequestPattern(
         return status in invalidRequestStatuses
     }
 
-    fun newBasedOn(resolver: Resolver): List<HttpRequestPattern> {
+    fun newBasedOn(resolver: Resolver): Sequence<HttpRequestPattern> {
         return attempt(breadCrumb = "REQUEST") {
             val newHttpPathPatterns = httpPathPattern?.let { httpPathPattern ->
                 val newURLPathSegmentPatternsList = httpPathPattern.newBasedOn(resolver)
                 newURLPathSegmentPatternsList.map { HttpPathPattern(it, httpPathPattern.path) }
-            } ?: listOf<HttpPathPattern?>(null)
+            } ?: sequenceOf<HttpPathPattern?>(null)
 
             val newQueryParamsPatterns = httpQueryParamPattern.newBasedOn(resolver).map { HttpQueryParamPattern(it) }
             val newBodies = attempt(breadCrumb = "BODY") {
@@ -591,27 +591,27 @@ data class HttpRequestPattern(
         return "$method ${httpPathPattern.toString()}"
     }
 
-    fun negativeBasedOn(row: Row, resolver: Resolver): List<HttpRequestPattern> {
+    fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<HttpRequestPattern> {
         return attempt(breadCrumb = "REQUEST") {
             val newHttpPathPatterns = httpPathPattern?.let { httpPathPattern ->
                 val newURLPathSegmentPatternsList = httpPathPattern.negativeBasedOn(row, resolver)
                 newURLPathSegmentPatternsList.map { HttpPathPattern(it, httpPathPattern.path) }
-            } ?: listOf<HttpPathPattern?>(null)
+            } ?: sequenceOf<HttpPathPattern?>(null)
 
             val newQueryParamsPatterns = httpQueryParamPattern.negativeBasedOn(row, resolver).map { HttpQueryParamPattern(it) }
 
-            val newBodies: List<Pattern> = attempt(breadCrumb = "BODY") {
+            val newBodies = attempt(breadCrumb = "BODY") {
                 body.let {
                     if (it is DeferredPattern && row.containsField(it.pattern)) {
                         val example = row.getField(it.pattern)
-                        listOf(ExactValuePattern(it.parse(example, resolver)))
+                        sequenceOf(ExactValuePattern(it.parse(example, resolver)))
                     } else if (it.typeAlias?.let { p -> isPatternToken(p) } == true && row.containsField(it.typeAlias!!)) {
                         val example = row.getField(it.typeAlias!!)
-                        listOf(ExactValuePattern(it.parse(example, resolver)))
+                        sequenceOf(ExactValuePattern(it.parse(example, resolver)))
                     } else if (it is XMLPattern && it.referredType?.let { referredType -> row.containsField("($referredType)") } == true) {
                         val referredType = "(${it.referredType})"
                         val example = row.getField(referredType)
-                        listOf(ExactValuePattern(it.parse(example, resolver)))
+                        sequenceOf(ExactValuePattern(it.parse(example, resolver)))
                     } else if (row.containsField("(REQUEST-BODY)")) {
                         val example = row.getField("(REQUEST-BODY)")
                         val value = it.parse(example, resolver)
@@ -622,10 +622,10 @@ data class HttpRequestPattern(
                         val originalRequest = if (value is JSONObjectValue) {
                             body.negativeBasedOn(row.noteRequestBody(), resolver)
                         } else {
-                            listOf(ExactValuePattern(value))
+                            sequenceOf(ExactValuePattern(value))
                         }
 
-                        val flattenedRequests: List<Pattern> =
+                        val flattenedRequests: Sequence<Pattern> =
                             resolver.withCyclePrevention(body) { cyclePreventedResolver ->
                                 body.newBasedOn(row.noteRequestBody(), cyclePreventedResolver)
                             }
@@ -644,43 +644,40 @@ data class HttpRequestPattern(
             val newFormDataPartLists = newMultiPartBasedOn(multiPartFormDataPattern, row, resolver)
 
             //TODO: figure out a way to optimise generating all positive scenarios
-            val positivePattern: HttpRequestPattern = newBasedOn(row, resolver).first()
 
-            val negativeRequestPatterns = mutableListOf<HttpRequestPattern>()
-            newHttpPathPatterns.forEach { pathParamPattern ->
-                negativeRequestPatterns.add(
-                    positivePattern.copy(httpPathPattern = pathParamPattern)
-                )
-            }
-            newQueryParamsPatterns.forEach { queryParamPattern ->
-                negativeRequestPatterns.add(
-                    positivePattern.copy(httpQueryParamPattern = queryParamPattern)
-                )
-            }
-            newBodies.forEach { newBodyPattern ->
-                negativeRequestPatterns.add(
-                    positivePattern.copy(body = newBodyPattern)
-                )
-            }
-            newHeadersPattern.forEach { newHeaderPattern ->
-                negativeRequestPatterns.add(
-                    positivePattern.copy(headersPattern = newHeaderPattern)
-                )
-            }
-            newFormFieldsPatterns.forEach { newFormFieldPattern ->
-                negativeRequestPatterns.add(
-                    positivePattern.copy(formFieldsPattern = newFormFieldPattern)
-                )
-            }
-            newFormDataPartLists.forEach { newFormDataPartListPattern ->
-                negativeRequestPatterns.add(
-                    positivePattern.copy(multiPartFormDataPattern = newFormDataPartListPattern)
-                )
-            }
-            // If security schemes are present, for now we'll just take the first scheme and assign it to each negative request pattern.
-            // Ideally we should generate negative patterns from the security schemes and use them.
-            negativeRequestPatterns.map {
-                it.copy(securitySchemes = listOf(securitySchemes.first()))
+            sequence {
+                // If security schemes are present, for now we'll just take the first scheme and assign it to each negative request pattern.
+                // Ideally we should generate negative patterns from the security schemes and use them.
+                val positivePattern: HttpRequestPattern = newBasedOn(row, resolver).first().copy(securitySchemes = listOf(securitySchemes.first()))
+
+                newHttpPathPatterns.forEach { pathParamPattern ->
+                    yield(positivePattern.copy(httpPathPattern = pathParamPattern))
+                }
+                newQueryParamsPatterns.forEach { queryParamPattern ->
+                    yield(
+                        positivePattern.copy(httpQueryParamPattern = queryParamPattern)
+                    )
+                }
+                newBodies.forEach { newBodyPattern ->
+                    yield(
+                        positivePattern.copy(body = newBodyPattern)
+                    )
+                }
+                newHeadersPattern.forEach { newHeaderPattern ->
+                    yield(
+                        positivePattern.copy(headersPattern = newHeaderPattern)
+                    )
+                }
+                newFormFieldsPatterns.forEach { newFormFieldPattern ->
+                    yield(
+                        positivePattern.copy(formFieldsPattern = newFormFieldPattern)
+                    )
+                }
+                newFormDataPartLists.forEach { newFormDataPartListPattern ->
+                    yield(
+                        positivePattern.copy(multiPartFormDataPattern = newFormDataPartListPattern)
+                    )
+                }
             }
         }
     }
@@ -698,18 +695,19 @@ fun missingParam(missingValue: String): ContractException {
     return ContractException("$missingValue is missing. Can't generate the contract test.")
 }
 
+//TODO: STREAMING
 fun newMultiPartBasedOn(
     partList: List<MultiPartFormDataPattern>,
     row: Row,
     resolver: Resolver
-): List<List<MultiPartFormDataPattern>> {
+): Sequence<List<MultiPartFormDataPattern>> {
     val values = partList.map { part ->
         attempt(breadCrumb = part.name) {
-            part.newBasedOn(row, resolver)
+            part.newBasedOn(row, resolver).toList()
         }
     }
 
-    return multiPartListCombinations(values)
+    return multiPartListCombinations(values).asSequence()
 }
 
 fun multiPartListCombinations(values: List<List<MultiPartFormDataPattern?>>): List<List<MultiPartFormDataPattern>> {

--- a/core/src/main/kotlin/in/specmatic/core/HttpResponsePattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpResponsePattern.kt
@@ -52,7 +52,7 @@ data class HttpResponsePattern(val headersPattern: HttpHeadersPattern = HttpHead
         }
     }
 
-    fun newBasedOn(row: Row, resolver: Resolver): List<HttpResponsePattern> =
+    fun newBasedOn(row: Row, resolver: Resolver): Sequence<HttpResponsePattern> =
         attempt(breadCrumb = "RESPONSE") {
             resolver.withCyclePrevention(body) { cyclePreventedResolver ->
                 body.newBasedOn(row, cyclePreventedResolver)

--- a/core/src/main/kotlin/in/specmatic/core/NoBodyPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/NoBodyPattern.kt
@@ -21,11 +21,11 @@ object NoBodyPattern : Pattern {
 
     override fun generate(resolver: Resolver): Value = NoBodyValue
 
-    override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> = listOf(this)
+    override fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
 
-    override fun newBasedOn(resolver: Resolver): List<Pattern> = listOf(this)
+    override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): List<Pattern> = emptyList()
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> = emptySequence()
 
     override fun parse(value: String, resolver: Resolver): Value {
         return if(value.isBlank())

--- a/core/src/main/kotlin/in/specmatic/core/Resolver.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Resolver.kt
@@ -158,7 +158,7 @@ data class Resolver(
         return this.copy(patternMatchStrategy = matchAnything, parseStrategy = alwaysReturnStringValue)
     }
 
-    fun generatedPatternsForGenerativeTests(pattern: Pattern, key: String): List<Pattern> {
+    fun generatedPatternsForGenerativeTests(pattern: Pattern, key: String): Sequence<Pattern> {
         return generation.generatedPatternsForGenerativeTests(this, pattern, key)
     }
 
@@ -174,11 +174,11 @@ data class Resolver(
         return defaultExampleResolver.resolveExample(example, pattern, this)
     }
 
-    fun generateHttpRequests(body: Pattern, row: Row, requestBodyAsIs: Pattern, value: Value): List<Pattern> {
+    fun generateHttpRequests(body: Pattern, row: Row, requestBodyAsIs: Pattern, value: Value): Sequence<Pattern> {
         return generation.generateHttpRequests(this, body, row, requestBodyAsIs, value)
     }
 
-    fun generateHttpRequests(body: Pattern, row: Row): List<Pattern> {
+    fun generateHttpRequests(body: Pattern, row: Row): Sequence<Pattern> {
         return generation.generateHttpRequests(this, body, row)
     }
 
@@ -186,7 +186,7 @@ data class Resolver(
         return generation.resolveRow(row)
     }
 
-    fun generateKeySubLists(key: String, subList: List<String>): List<List<String>> {
+    fun generateKeySubLists(key: String, subList: List<String>): Sequence<List<String>> {
         return generation.generateKeySubLists(key, subList)
     }
 }

--- a/core/src/main/kotlin/in/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Scenario.kt
@@ -268,7 +268,7 @@ data class Scenario(
         }
     }
 
-    private fun newBasedOn(row: Row, resolverStrategies: ResolverStrategies): List<Scenario> {
+    private fun newBasedOn(row: Row, resolverStrategies: ResolverStrategies): Sequence<Scenario> {
         val ignoreFailure = this.ignoreFailure || row.name.startsWith("[WIP]")
         val resolver =
             Resolver(expectedFacts, false, patterns)
@@ -295,7 +295,7 @@ data class Scenario(
         }
     }
 
-    private fun newBasedOnBackwardCompatibility(row: Row): List<Scenario> {
+    private fun newBasedOnBackwardCompatibility(row: Row): Sequence<Scenario> {
         val resolver = Resolver(expectedFacts, false, patterns)
 
         val newExpectedServerState = newExpectedServerStateBasedOn(row, expectedFacts, fixtures, resolver)
@@ -312,15 +312,15 @@ data class Scenario(
         resolverStrategies: ResolverStrategies,
         variables: Map<String, String> = emptyMap(),
         testBaseURLs: Map<String, String> = emptyMap(),
-    ): List<Scenario> {
+    ): Sequence<Scenario> {
         val referencesWithBaseURLs = references.mapValues { (_, reference) ->
             reference.copy(variables = variables, baseURLs = testBaseURLs)
         }
 
         return scenarioBreadCrumb(this) {
             when (examples.size) {
-                0 -> listOf(Row())
-                else -> examples.flatMap {
+                0 -> sequenceOf(Row())
+                else -> examples.asSequence().flatMap {
                     it.rows.map { row ->
                         row.copy(variables = variables, references = referencesWithBaseURLs)
                     }
@@ -337,15 +337,15 @@ data class Scenario(
         resolverStrategies: ResolverStrategies,
         variables: Map<String, String> = emptyMap(),
         testBaseURLs: Map<String, String> = emptyMap(),
-    ): List<ContractTest> {
+    ): Sequence<ContractTest> {
         val referencesWithBaseURLs = references.mapValues { (_, reference) ->
             reference.copy(variables = variables, baseURLs = testBaseURLs)
         }
 
         return scenarioBreadCrumb(this) {
             when (examples.size) {
-                0 -> listOf(Row())
-                else -> examples.flatMap {
+                0 -> sequenceOf(Row())
+                else -> examples.asSequence().flatMap {
                     it.rows.map { row ->
                         row.copy(variables = variables, references = referencesWithBaseURLs)
                     }
@@ -354,7 +354,7 @@ data class Scenario(
                 try {
                     newBasedOn(row, resolverStrategies).map { ScenarioTest(it, resolverStrategies) }
                 } catch (e: Throwable) {
-                    listOf(ScenarioTestGenerationFailure(this, e))
+                    sequenceOf(ScenarioTestGenerationFailure(this, e))
                 }
             }
         }

--- a/core/src/main/kotlin/in/specmatic/core/URLPathSegmentPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/URLPathSegmentPattern.kt
@@ -18,20 +18,20 @@ data class URLPathSegmentPattern(override val pattern: Pattern, override val key
         }
     }
 
-    override fun newBasedOn(row: Row, resolver: Resolver): List<URLPathSegmentPattern> =
+    override fun newBasedOn(row: Row, resolver: Resolver): Sequence<URLPathSegmentPattern> =
         resolver.withCyclePrevention(pattern) { cyclePreventedResolver ->
             pattern.newBasedOn(row, cyclePreventedResolver).map { URLPathSegmentPattern(it, key) }
         }
 
-    override fun newBasedOn(resolver: Resolver): List<URLPathSegmentPattern> =
+    override fun newBasedOn(resolver: Resolver): Sequence<URLPathSegmentPattern> =
         resolver.withCyclePrevention(pattern) { cyclePreventedResolver ->
             pattern.newBasedOn(cyclePreventedResolver).map { URLPathSegmentPattern(it, key) }
         }
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): List<Pattern> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
         return when (pattern) {
-            is ExactValuePattern -> emptyList()
-            is StringPattern -> emptyList()
+            is ExactValuePattern -> emptySequence()
+            is StringPattern -> emptySequence()
             else -> resolver.withCyclePrevention(pattern) { cyclePreventedResolver ->
                 pattern.negativeBasedOn(row, cyclePreventedResolver).filterNot { it is NullPattern }.map { URLPathSegmentPattern(it, key) }
             }

--- a/core/src/main/kotlin/in/specmatic/core/pattern/AllNegativePatterns.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/AllNegativePatterns.kt
@@ -7,7 +7,7 @@ class AllNegativePatterns : NegativePatternsTemplate() {
         key: String,
         negativePattern: Pattern,
         resolver: Resolver,
-    ): List<Pattern> {
+    ): Sequence<Pattern> {
         return newBasedOn(Row(), key, negativePattern, resolver)
     }
 
@@ -15,7 +15,7 @@ class AllNegativePatterns : NegativePatternsTemplate() {
         patternMap: Map<String, Pattern>,
         resolver: Resolver,
         row: Row
-    ): Map<String, List<Pattern>> {
+    ): Map<String, Sequence<Pattern>> {
         return patternMap.mapValues { (key, pattern) ->
             val resolvedPattern = resolvedHop(pattern, resolver)
             resolvedPattern.negativeBasedOn(row.stepDownOneLevelInJSONHierarchy(withoutOptionality(key)), resolver)

--- a/core/src/main/kotlin/in/specmatic/core/pattern/AnythingPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/AnythingPattern.kt
@@ -15,16 +15,16 @@ object AnythingPattern: Pattern {
         return StringValue(randomString(10))
     }
 
-    override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> {
-        return listOf(this)
+    override fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
+        return sequenceOf(this)
     }
 
-    override fun newBasedOn(resolver: Resolver): List<Pattern> {
-        return listOf(this)
+    override fun newBasedOn(resolver: Resolver): Sequence<Pattern> {
+        return sequenceOf(this)
     }
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): List<Pattern> {
-        return listOf(this)
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
+        return sequenceOf(this)
     }
 
     override fun parse(value: String, resolver: Resolver): Value {

--- a/core/src/main/kotlin/in/specmatic/core/pattern/Base64StringPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/Base64StringPattern.kt
@@ -39,13 +39,13 @@ data class Base64StringPattern(override val typeAlias: String? = null) : Pattern
         return StringValue(randomBase64String(randomStringLength))
     }
 
-    override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> = listOf(this)
-    override fun newBasedOn(resolver: Resolver): List<Pattern> = listOf(this)
-    override fun negativeBasedOn(row: Row, resolver: Resolver): List<Pattern> {
+    override fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
+    override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
         // TODO ideally StringPattern should be in this list. However need to better understand how to generate
         //      strings that are not valid base64 strings (e.g. send an exact "]" which is not a base64 encoded value)
 
-        return listOf(NullPattern, NumberPattern(), BooleanPattern())
+        return sequenceOf(NullPattern, NumberPattern(), BooleanPattern())
     }
 
     override fun parse(value: String, resolver: Resolver): Value {

--- a/core/src/main/kotlin/in/specmatic/core/pattern/BinaryPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/BinaryPattern.kt
@@ -40,10 +40,10 @@ data class BinaryPattern(
         return BinaryValue(bytes)
     }
 
-    override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> = listOf(this)
-    override fun newBasedOn(resolver: Resolver): List<Pattern> = listOf(this)
-    override fun negativeBasedOn(row: Row, resolver: Resolver): List<Pattern> {
-        return listOf(NullPattern, NumberPattern(), BooleanPattern())
+    override fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
+    override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
+        return sequenceOf(NullPattern, NumberPattern(), BooleanPattern())
     }
 
     override fun parse(value: String, resolver: Resolver): Value = StringValue(value)

--- a/core/src/main/kotlin/in/specmatic/core/pattern/BooleanPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/BooleanPattern.kt
@@ -18,10 +18,10 @@ data class BooleanPattern(override val example: String? = null) : Pattern, Scala
     override fun generate(resolver: Resolver): Value =
         resolver.resolveExample(example, this) ?: randomBoolean()
 
-    override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> = listOf(this)
-    override fun newBasedOn(resolver: Resolver): List<Pattern> = listOf(this)
-    override fun negativeBasedOn(row: Row, resolver: Resolver): List<Pattern> {
-        return listOf(NullPattern)
+    override fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
+    override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
+        return sequenceOf(NullPattern)
     }
 
     override fun parse(value: String, resolver: Resolver): Value = when (value.lowercase()) {

--- a/core/src/main/kotlin/in/specmatic/core/pattern/CombinationSpec.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/CombinationSpec.kt
@@ -34,7 +34,6 @@ class CombinationSpec<ValueType>(
         if (patternCollection.isEmpty())
             return emptySequence()
 
-        //TODO: STREAMING (we should be able to avoid maintaining cachedValues)
         val cachedValues = patternCollection.mapValues { mutableListOf<ValueType>() }
         val prioritisedGenerations = mutableSetOf<Map<String, ValueType>>()
 
@@ -47,7 +46,6 @@ class CombinationSpec<ValueType>(
         }
 
         return sequence {
-            //TODO: STREAMING (can we manage without this ctr?)
             var ctr = 0
 
             while (true) {

--- a/core/src/main/kotlin/in/specmatic/core/pattern/CsvPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/CsvPattern.kt
@@ -32,16 +32,16 @@ class CsvPattern(override val pattern: Pattern) : Pattern {
         }.joinToString(",") { it.toStringLiteral() })
     }
 
-    override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> {
-        return listOf(this)
+    override fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
+        return sequenceOf(this)
     }
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): List<Pattern> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
         return StringPattern().negativeBasedOn(row, resolver)
     }
 
-    override fun newBasedOn(resolver: Resolver): List<Pattern> {
-        return listOf(this)
+    override fun newBasedOn(resolver: Resolver): Sequence<Pattern> {
+        return sequenceOf(this)
     }
 
     override fun parse(value: String, resolver: Resolver): Value {

--- a/core/src/main/kotlin/in/specmatic/core/pattern/DatePattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/DatePattern.kt
@@ -17,11 +17,11 @@ object DatePattern : Pattern, ScalarType {
 
     override fun generate(resolver: Resolver): StringValue = StringValue(RFC3339.currentDate())
 
-    override fun newBasedOn(row: Row, resolver: Resolver): List<DatePattern> = listOf(this)
+    override fun newBasedOn(row: Row, resolver: Resolver): Sequence<DatePattern> = sequenceOf(this)
 
-    override fun newBasedOn(resolver: Resolver): List<DatePattern> = listOf(this)
-    override fun negativeBasedOn(row: Row, resolver: Resolver): List<Pattern> {
-        return listOf(NullPattern)
+    override fun newBasedOn(resolver: Resolver): Sequence<DatePattern> = sequenceOf(this)
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
+        return sequenceOf(NullPattern)
     }
 
     override fun parse(value: String, resolver: Resolver): StringValue =

--- a/core/src/main/kotlin/in/specmatic/core/pattern/DateTimePattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/DateTimePattern.kt
@@ -18,11 +18,11 @@ object DateTimePattern : Pattern, ScalarType {
 
     override fun generate(resolver: Resolver): StringValue = StringValue(RFC3339.currentDateTime())
 
-    override fun newBasedOn(row: Row, resolver: Resolver): List<DateTimePattern> = listOf(this)
+    override fun newBasedOn(row: Row, resolver: Resolver): Sequence<DateTimePattern> = sequenceOf(this)
 
-    override fun newBasedOn(resolver: Resolver): List<DateTimePattern> = listOf(this)
-    override fun negativeBasedOn(row: Row, resolver: Resolver): List<Pattern> {
-        return listOf(NullPattern)
+    override fun newBasedOn(resolver: Resolver): Sequence<DateTimePattern> = sequenceOf(this)
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
+        return sequenceOf(NullPattern)
     }
 
     override fun parse(value: String, resolver: Resolver): StringValue =

--- a/core/src/main/kotlin/in/specmatic/core/pattern/DeferredPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/DeferredPattern.kt
@@ -25,21 +25,21 @@ data class DeferredPattern(override val pattern: String, val key: String? = null
         }
     }
 
-    override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> {
+    override fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
         val resolvedPattern = resolvePattern(resolver)
         return resolver.withCyclePrevention(resolvedPattern) { cyclePreventedResolver ->
             resolvedPattern.newBasedOn(row, cyclePreventedResolver)
         }
     }
 
-    override fun newBasedOn(resolver: Resolver): List<Pattern> {
+    override fun newBasedOn(resolver: Resolver): Sequence<Pattern> {
         val resolvedPattern = resolvePattern(resolver)
         return resolver.withCyclePrevention(resolvedPattern) { cyclePreventedResolver ->
             resolvedPattern.newBasedOn(cyclePreventedResolver)
         }
     }
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): List<Pattern> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
         return resolver.getPattern(pattern).negativeBasedOn(row, resolver)
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/DictionaryPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/DictionaryPattern.kt
@@ -51,7 +51,7 @@ data class DictionaryPattern(val keyPattern: Pattern, val valuePattern: Pattern,
         })
     }
 
-    override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> {
+    override fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
         val newValuePatterns = resolver.withCyclePrevention(valuePattern) { cyclePreventedResolver ->
             valuePattern.newBasedOn(Row(), cyclePreventedResolver)
         }
@@ -61,7 +61,7 @@ data class DictionaryPattern(val keyPattern: Pattern, val valuePattern: Pattern,
         }
     }
 
-    override fun newBasedOn(resolver: Resolver): List<Pattern> {
+    override fun newBasedOn(resolver: Resolver): Sequence<Pattern> {
         val newValuePatterns = resolver.withCyclePrevention(valuePattern) { cyclePreventedResolver ->
             valuePattern.newBasedOn(cyclePreventedResolver)
         }
@@ -71,8 +71,8 @@ data class DictionaryPattern(val keyPattern: Pattern, val valuePattern: Pattern,
         }
     }
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): List<Pattern> {
-        return listOf(this)
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
+        return sequenceOf(this)
     }
 
     override fun parse(value: String, resolver: Resolver): Value = parsedJSONObject(value)

--- a/core/src/main/kotlin/in/specmatic/core/pattern/EmailPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/EmailPattern.kt
@@ -37,9 +37,9 @@ class EmailPattern (private val stringPatternDelegate: StringPattern) :
         return StringValue("$localPart@$domain.com")
     }
 
-    override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> = listOf(this)
+    override fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): List<Pattern> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
         return stringPatternDelegate.negativeBasedOn(row, resolver).plus(StringPattern())
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/EmptyStringPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/EmptyStringPattern.kt
@@ -14,10 +14,10 @@ object EmptyStringPattern : Pattern {
     }
 
     override fun generate(resolver: Resolver): Value = StringValue("")
-    override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> = listOf(this)
-    override fun newBasedOn(resolver: Resolver): List<Pattern> = listOf(this)
-    override fun negativeBasedOn(row: Row, resolver: Resolver): List<Pattern> {
-        return listOf(this)
+    override fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
+    override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
+        return sequenceOf(this)
     }
 
     override fun parse(value: String, resolver: Resolver): Value {

--- a/core/src/main/kotlin/in/specmatic/core/pattern/ExactValuePattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/ExactValuePattern.kt
@@ -30,10 +30,10 @@ data class ExactValuePattern(override val pattern: Value, override val typeAlias
     }
 
     override fun generate(resolver: Resolver) = pattern
-    override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> = listOf(this)
-    override fun newBasedOn(resolver: Resolver): List<Pattern> = listOf(this)
-    override fun negativeBasedOn(row: Row, resolver: Resolver): List<Pattern> {
-        return listOf(NullPattern).plus(pattern.type().negativeBasedOn(Row(), resolver).filterNot { it == NullPattern })
+    override fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
+    override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
+        return sequenceOf(NullPattern).plus(pattern.type().negativeBasedOn(Row(), resolver).filterNot { it == NullPattern })
     }
 
     override fun parse(value: String, resolver: Resolver): Value = pattern.type().parse(value, resolver)

--- a/core/src/main/kotlin/in/specmatic/core/pattern/JSONObjectPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/JSONObjectPattern.kt
@@ -154,7 +154,7 @@ data class JSONObjectPattern(
         )
     }
 
-    override fun newBasedOn(row: Row, resolver: Resolver): List<JSONObjectPattern> =
+    override fun newBasedOn(row: Row, resolver: Resolver): Sequence<JSONObjectPattern> =
         allOrNothingCombinationIn(
             pattern.minus("..."),
             resolver.resolveRow(row),
@@ -168,12 +168,12 @@ data class JSONObjectPattern(
             })
         }
 
-    override fun newBasedOn(resolver: Resolver): List<JSONObjectPattern> =
+    override fun newBasedOn(resolver: Resolver): Sequence<JSONObjectPattern> =
         allOrNothingCombinationIn(pattern.minus("...")) { pattern ->
             newBasedOn(pattern, withNullPattern(resolver))
         }.map { toJSONObjectPattern(it) }
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): List<Pattern> =
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> =
         allOrNothingCombinationIn(pattern.minus("...")) { pattern ->
             AllNegativePatterns().negativeBasedOn(pattern, row, withNullPattern(resolver))
         }.map { toJSONObjectPattern(it) }

--- a/core/src/main/kotlin/in/specmatic/core/pattern/ListPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/ListPattern.kt
@@ -48,7 +48,7 @@ data class ListPattern(override val pattern: Pattern, override val typeAlias: St
         }, resolver)
     }
 
-    override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> {
+    override fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
         val resolverWithEmptyType = withEmptyType(pattern, resolver)
         return attempt(breadCrumb = "[]") {
             resolverWithEmptyType.withCyclePrevention(pattern) { cyclePreventedResolver ->
@@ -57,7 +57,7 @@ data class ListPattern(override val pattern: Pattern, override val typeAlias: St
         }
     }
 
-    override fun newBasedOn(resolver: Resolver): List<Pattern> {
+    override fun newBasedOn(resolver: Resolver): Sequence<Pattern> {
         val resolverWithEmptyType = withEmptyType(pattern, resolver)
         return attempt(breadCrumb = "[]") {
             resolverWithEmptyType.withCyclePrevention(pattern) { cyclePreventedResolver ->
@@ -66,7 +66,7 @@ data class ListPattern(override val pattern: Pattern, override val typeAlias: St
         }
     }
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): List<Pattern> = listOf(NullPattern)
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> = sequenceOf(NullPattern)
 
     override fun parse(value: String, resolver: Resolver): Value = parsedJSONArray(value, resolver.mismatchMessages)
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/LookupRowPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/LookupRowPattern.kt
@@ -21,7 +21,7 @@ data class LookupRowPattern(override val pattern: Pattern, override val key: Str
         }
     }
 
-    override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> {
+    override fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
         return when(key) {
             null -> resolver.withCyclePrevention(pattern) { cyclePreventedResolver ->
                 pattern.newBasedOn(row, cyclePreventedResolver)
@@ -31,7 +31,7 @@ data class LookupRowPattern(override val pattern: Pattern, override val key: Str
         }
     }
 
-    override fun newBasedOn(resolver: Resolver): List<Pattern> {
+    override fun newBasedOn(resolver: Resolver): Sequence<Pattern> {
         return when(key) {
             null -> resolver.withCyclePrevention(pattern) { cyclePreventedResolver ->
                 pattern.newBasedOn(cyclePreventedResolver)
@@ -41,8 +41,8 @@ data class LookupRowPattern(override val pattern: Pattern, override val key: Str
         }
     }
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): List<Pattern> {
-        return listOf(this)
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
+        return sequenceOf(this)
     }
 
     override fun parse(value: String, resolver: Resolver): Value = pattern.parse(value, resolver)

--- a/core/src/main/kotlin/in/specmatic/core/pattern/NegativeNonStringlyPatterns.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/NegativeNonStringlyPatterns.kt
@@ -9,7 +9,7 @@ class NegativeNonStringlyPatterns : NegativePatternsTemplate() {
         key: String,
         negativePattern: Pattern,
         resolver: Resolver,
-    ): List<Pattern> {
+    ): Sequence<Pattern> {
         return if (patternIsEnum(negativePattern, resolver)) {
             negativeBasedOnForEnum(negativePattern)
         } else {
@@ -27,7 +27,7 @@ class NegativeNonStringlyPatterns : NegativePatternsTemplate() {
         patternMap: Map<String, Pattern>,
         resolver: Resolver,
         row: Row
-    ): Map<String, List<Pattern>> {
+    ): Map<String, Sequence<Pattern>> {
         return patternMap.mapValues { (key, pattern) ->
             val resolvedPattern = resolvedHop(pattern, resolver)
 
@@ -47,11 +47,11 @@ class NegativeNonStringlyPatterns : NegativePatternsTemplate() {
         resolver: Resolver
     ) = resolvedPattern.matches(it.generate(resolver).toStringValue(), resolver) is Result.Success
 
-    private fun negativeBasedOnForEnum(pattern: Pattern): List<Pattern> {
+    private fun negativeBasedOnForEnum(pattern: Pattern): Sequence<Pattern> {
         val enumPattern = (pattern as EnumPattern).pattern
         val firstEnumOption = enumPattern.pattern.first() as ExactValuePattern
         val valueOfFirstEnumOption = firstEnumOption.pattern
         val patternOfFirstValue = valueOfFirstEnumOption.type()
-        return listOf(patternOfFirstValue)
+        return sequenceOf(patternOfFirstValue)
     }
 }

--- a/core/src/main/kotlin/in/specmatic/core/pattern/NegativePatternsTemplate.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/NegativePatternsTemplate.kt
@@ -3,7 +3,6 @@ package `in`.specmatic.core.pattern
 import `in`.specmatic.core.Resolver
 
 abstract class NegativePatternsTemplate {
-    //TODO: STREAMING
     fun negativeBasedOn(patternMap: Map<String, Pattern>, row: Row, resolver: Resolver): Sequence<Map<String, Pattern>> {
         val eachKeyMappedToPatternMap = patternMap.mapValues { patternMap }
         val negativePatternsMap = getNegativePatterns(patternMap, resolver, row)
@@ -27,9 +26,9 @@ abstract class NegativePatternsTemplate {
         }
         if (modifiedPatternMap.values.isEmpty())
             return sequenceOf(emptyMap())
-        return modifiedPatternMap.values.map { list: Sequence<Map<String, Sequence<Pattern>>> ->
-            list.toList().map { patternList(it) }
-        }.flatten().asSequence().flatten()
+        return modifiedPatternMap.values.asSequence().flatMap { list: Sequence<Map<String, Sequence<Pattern>>> ->
+            list.flatMap { patternList(it) }
+        }
     }
 
     abstract fun getNegativePatterns(

--- a/core/src/main/kotlin/in/specmatic/core/pattern/NegativePatternsTemplate.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/NegativePatternsTemplate.kt
@@ -3,11 +3,12 @@ package `in`.specmatic.core.pattern
 import `in`.specmatic.core.Resolver
 
 abstract class NegativePatternsTemplate {
-    fun negativeBasedOn(patternMap: Map<String, Pattern>, row: Row, resolver: Resolver): List<Map<String, Pattern>> {
+    //TODO: STREAMING
+    fun negativeBasedOn(patternMap: Map<String, Pattern>, row: Row, resolver: Resolver): Sequence<Map<String, Pattern>> {
         val eachKeyMappedToPatternMap = patternMap.mapValues { patternMap }
         val negativePatternsMap = getNegativePatterns(patternMap, resolver, row)
 
-        val modifiedPatternMap: Map<String, List<Map<String, List<Pattern>>>> = eachKeyMappedToPatternMap.mapValues { (keyToNegate, patterns) ->
+        val modifiedPatternMap: Map<String, Sequence<Map<String, Sequence<Pattern>>>> = eachKeyMappedToPatternMap.mapValues { (keyToNegate, patterns) ->
             val negativePatterns = negativePatternsMap[keyToNegate]
             negativePatterns!!.map { negativePattern ->
                 patterns.mapValues { (key, pattern) ->
@@ -25,21 +26,21 @@ abstract class NegativePatternsTemplate {
             }
         }
         if (modifiedPatternMap.values.isEmpty())
-            return listOf(emptyMap())
-        return modifiedPatternMap.values.map { list: List<Map<String, List<Pattern>>> ->
-            list.toList().map { patternList(it) }.flatten()
-        }.flatten()
+            return sequenceOf(emptyMap())
+        return modifiedPatternMap.values.map { list: Sequence<Map<String, Sequence<Pattern>>> ->
+            list.toList().map { patternList(it) }
+        }.flatten().asSequence().flatten()
     }
 
     abstract fun getNegativePatterns(
         patternMap: Map<String, Pattern>,
         resolver: Resolver,
         row: Row
-    ): Map<String, List<Pattern>>
+    ): Map<String, Sequence<Pattern>>
 
     abstract fun negativePatternsForKey(
         key: String,
         negativePattern: Pattern,
         resolver: Resolver,
-    ): List<Pattern>
+    ): Sequence<Pattern>
 }

--- a/core/src/main/kotlin/in/specmatic/core/pattern/NullPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/NullPattern.kt
@@ -19,9 +19,9 @@ object NullPattern : Pattern, ScalarType {
             }
 
     override fun generate(resolver: Resolver): Value = NullValue
-    override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> = listOf(this)
-    override fun newBasedOn(resolver: Resolver): List<Pattern> = listOf(this)
-    override fun negativeBasedOn(row: Row, resolver: Resolver): List<Pattern> {
+    override fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
+    override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
         return newBasedOn(row, resolver)
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/NumberPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/NumberPattern.kt
@@ -54,10 +54,10 @@ data class NumberPattern(
 
     private fun randomPositiveDigit() = (Random().nextInt(9) + 1)
 
-    override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> = listOf(this)
-    override fun newBasedOn(resolver: Resolver): List<Pattern> = listOf(this)
-    override fun negativeBasedOn(row: Row, resolver: Resolver): List<Pattern> {
-        return listOf(NullPattern, BooleanPattern(), StringPattern())
+    override fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
+    override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
+        return sequenceOf(NullPattern, BooleanPattern(), StringPattern())
     }
 
     override fun parse(value: String, resolver: Resolver): Value {

--- a/core/src/main/kotlin/in/specmatic/core/pattern/Pattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/Pattern.kt
@@ -17,9 +17,9 @@ interface Pattern {
 
     fun generate(resolver: Resolver): Value
     fun generateWithAll(resolver: Resolver) = resolver.withCyclePrevention(this, this::generate)
-    fun newBasedOn(row: Row, resolver: Resolver): List<Pattern>
-    fun negativeBasedOn(row: Row, resolver: Resolver): List<Pattern>
-    fun newBasedOn(resolver: Resolver): List<Pattern>
+    fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern>
+    fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern>
+    fun newBasedOn(resolver: Resolver): Sequence<Pattern>
     fun parse(value: String, resolver: Resolver): Value
 
     fun patternSet(resolver: Resolver): List<Pattern> = listOf(this)

--- a/core/src/main/kotlin/in/specmatic/core/pattern/PatternInStringPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/PatternInStringPattern.kt
@@ -24,18 +24,18 @@ data class PatternInStringPattern(override val pattern: Pattern = StringPattern(
         return StringValue(resolver.withCyclePrevention(pattern, pattern::generate).toStringLiteral())
     }
 
-    override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> =
+    override fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> =
         resolver.withCyclePrevention(pattern) { cyclePreventedResolver ->
             pattern.newBasedOn(row, cyclePreventedResolver).map { PatternInStringPattern(it) }
         }
 
-    override fun newBasedOn(resolver: Resolver): List<Pattern> =
+    override fun newBasedOn(resolver: Resolver): Sequence<Pattern> =
         resolver.withCyclePrevention(pattern) { cyclePreventedResolver ->
             pattern.newBasedOn(cyclePreventedResolver).map { PatternInStringPattern(it) }
         }
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): List<Pattern> {
-        return listOf(NullPattern)
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
+        return sequenceOf(NullPattern)
     }
 
     override fun parse(value: String, resolver: Resolver): Value = StringValue(pattern.parse(value, resolver).toStringLiteral())

--- a/core/src/main/kotlin/in/specmatic/core/pattern/QueryParameterArrayPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/QueryParameterArrayPattern.kt
@@ -99,15 +99,15 @@ class QueryParameterArrayPattern(override val pattern: List<Pattern>, val parame
         }.map { StringValue(it.toStringLiteral()) })
     }
 
-    override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> {
+    override fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
         return pattern.first().newBasedOn(row, resolver).map { QueryParameterArrayPattern(listOf(it), parameterName) }
     }
 
-    override fun newBasedOn(resolver: Resolver): List<Pattern> {
+    override fun newBasedOn(resolver: Resolver): Sequence<Pattern> {
         return pattern.first().newBasedOn(resolver).map { QueryParameterArrayPattern(listOf(it), parameterName) }
     }
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): List<Pattern> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
         return pattern.first().negativeBasedOn(row, resolver).map { QueryParameterArrayPattern(listOf(it), parameterName) }
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/QueryParameterArrayPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/QueryParameterArrayPattern.kt
@@ -8,7 +8,7 @@ import `in`.specmatic.core.value.ListValue
 import `in`.specmatic.core.value.StringValue
 import `in`.specmatic.core.value.Value
 
-class QueryParameterArrayPattern(override val pattern: List<Pattern>, val parameterName: String): Pattern {
+data class QueryParameterArrayPattern(override val pattern: List<Pattern>, val parameterName: String): Pattern {
     override fun matches(sampleData: Value?, resolver: Resolver): Result {
         if(sampleData !is ListValue) {
             return resolver.mismatchMessages.valueMismatchFailure("Array", sampleData)

--- a/core/src/main/kotlin/in/specmatic/core/pattern/QueryParameterScalarPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/QueryParameterScalarPattern.kt
@@ -5,7 +5,7 @@ import `in`.specmatic.core.Result
 import `in`.specmatic.core.utilities.exceptionCauseMessage
 import `in`.specmatic.core.value.*
 
-class QueryParameterScalarPattern(override val pattern: Pattern): Pattern by pattern {
+data class QueryParameterScalarPattern(override val pattern: Pattern): Pattern by pattern {
     override fun matches(sampleData: Value?, resolver: Resolver): Result {
         if(sampleData == null){
             return Result.Failure("Null found, expected a scalar value")

--- a/core/src/main/kotlin/in/specmatic/core/pattern/RestPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/RestPattern.kt
@@ -12,18 +12,18 @@ data class RestPattern(override val pattern: Pattern, override val typeAlias: St
             listPattern.matches(sampleData, resolver)
 
     override fun generate(resolver: Resolver): Value = resolver.withCyclePrevention(listPattern, listPattern::generate)
-    override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> {
+    override fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
         return resolver.withCyclePrevention(pattern) { cyclePreventedResolver ->
             pattern.newBasedOn(row, cyclePreventedResolver).map { RestPattern(it) }
         }
     }
-    override fun newBasedOn(resolver: Resolver): List<Pattern> {
+    override fun newBasedOn(resolver: Resolver): Sequence<Pattern> {
         return resolver.withCyclePrevention(pattern) { cyclePreventedResolver ->
             pattern.newBasedOn(cyclePreventedResolver).map { RestPattern(it) }
         }
     }
-    override fun negativeBasedOn(row: Row, resolver: Resolver): List<Pattern> {
-        return listOf(this)
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
+        return sequenceOf(this)
     }
 
     override fun parse(value: String, resolver: Resolver): Value = listPattern.parse(value, resolver)

--- a/core/src/main/kotlin/in/specmatic/core/pattern/StringPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/StringPattern.kt
@@ -59,10 +59,10 @@ data class StringPattern (
     
     override fun generate(resolver: Resolver): Value = resolver.resolveExample(example, this) ?: StringValue(randomString(randomStringLength))
 
-    override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> = listOf(this)
-    override fun newBasedOn(resolver: Resolver): List<Pattern> = listOf(this)
-    override fun negativeBasedOn(row: Row, resolver: Resolver): List<Pattern> {
-        return listOf(NullPattern, NumberPattern(), BooleanPattern())
+    override fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
+    override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
+        return sequenceOf(NullPattern, NumberPattern(), BooleanPattern())
     }
 
     override fun parse(value: String, resolver: Resolver): Value = StringValue(value)

--- a/core/src/main/kotlin/in/specmatic/core/pattern/TabularPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/TabularPattern.kt
@@ -329,7 +329,6 @@ fun <ValueType> allOrNothingCombinationIn(
             } ?: propertyNames
         }
 
-        //TODO: STREAMING (review again)
         sequenceOf(allList, nothingList).distinct()
     } else {
         sequenceOf(patternMap.keys)

--- a/core/src/main/kotlin/in/specmatic/core/pattern/TabularPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/TabularPattern.kt
@@ -68,7 +68,7 @@ data class TabularPattern(
             })
         }
     }
-    override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> {
+    override fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
         val resolverWithNullType = withNullPattern(resolver)
         return allOrNothingCombinationIn(pattern, resolver.resolveRow(row)) { pattern ->
             newBasedOn(pattern, row, resolverWithNullType)
@@ -79,7 +79,7 @@ data class TabularPattern(
         }
     }
 
-    override fun newBasedOn(resolver: Resolver): List<Pattern> {
+    override fun newBasedOn(resolver: Resolver): Sequence<Pattern> {
         val resolverWithNullType = withNullPattern(resolver)
         val allOrNothingCombinationIn = allOrNothingCombinationIn(pattern) { pattern ->
             newBasedOn(pattern, resolverWithNullType)
@@ -87,7 +87,7 @@ data class TabularPattern(
         return allOrNothingCombinationIn.map { toTabularPattern(it) }
     }
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): List<Pattern> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
         return this.newBasedOn(row, resolver)
     }
 
@@ -129,8 +129,8 @@ data class TabularPattern(
     override val typeName: String = "json object"
 }
 
-fun newBasedOn(patternMap: Map<String, Pattern>, row: Row, resolver: Resolver): List<Map<String, Pattern>> {
-    val patternCollection: Map<String, List<Pattern>> = patternMap.mapValues { (key, pattern) ->
+fun newBasedOn(patternMap: Map<String, Pattern>, row: Row, resolver: Resolver): Sequence<Map<String, Pattern>> {
+    val patternCollection: Map<String, Sequence<Pattern>> = patternMap.mapValues { (key, pattern) ->
         attempt(breadCrumb = key) {
             newBasedOn(row, key, pattern, resolver)
         }
@@ -139,7 +139,7 @@ fun newBasedOn(patternMap: Map<String, Pattern>, row: Row, resolver: Resolver): 
     return patternList(patternCollection)
 }
 
-fun newBasedOn(patternMap: Map<String, Pattern>, resolver: Resolver): List<Map<String, Pattern>> {
+fun newBasedOn(patternMap: Map<String, Pattern>, resolver: Resolver): Sequence<Map<String, Pattern>> {
     val patternCollection = patternMap.mapValues { (key, pattern) ->
         attempt(breadCrumb = key) {
             newBasedOn(key, pattern, resolver)
@@ -149,7 +149,7 @@ fun newBasedOn(patternMap: Map<String, Pattern>, resolver: Resolver): List<Map<S
     return patternValues(patternCollection)
 }
 
-fun newBasedOn(row: Row, key: String, pattern: Pattern, resolver: Resolver): List<Pattern> {
+fun newBasedOn(row: Row, key: String, pattern: Pattern, resolver: Resolver): Sequence<Pattern> {
     val keyWithoutOptionality = key(pattern, key)
 
     return when {
@@ -166,7 +166,7 @@ fun newBasedOn(row: Row, key: String, pattern: Pattern, resolver: Resolver): Lis
                                 rowPattern.newBasedOn(row, cyclePreventedResolver)
                             }?:
                             // Handle cycle (represented by null value) by using empty list for optional properties
-                            listOf()
+                            emptySequence()
                         }
                         is Result.Failure -> throw ContractException(result.toFailureReport())
                     }
@@ -182,9 +182,9 @@ fun newBasedOn(row: Row, key: String, pattern: Pattern, resolver: Resolver): Lis
                         else -> ExactValuePattern(parsedRowValue)
                     }
 
-                val generativeTests: List<Pattern> = resolver.generatedPatternsForGenerativeTests(pattern, key)
+                val generativeTests: Sequence<Pattern> = resolver.generatedPatternsForGenerativeTests(pattern, key)
 
-                listOf(exactValuePattern) + generativeTests.filterNot {
+                sequenceOf(exactValuePattern) + generativeTests.filterNot {
                     it.encompasses(exactValuePattern, resolver, resolver) is Result.Success
                 }
             }
@@ -193,16 +193,16 @@ fun newBasedOn(row: Row, key: String, pattern: Pattern, resolver: Resolver): Lis
             pattern.newBasedOn(row.stepDownOneLevelInJSONHierarchy(keyWithoutOptionality), cyclePreventedResolver)
         }?:
         // Handle cycle (represented by null value) by using empty list for optional properties
-        listOf()
+        emptySequence()
     }
 }
 
-fun newBasedOn(key: String, pattern: Pattern, resolver: Resolver): List<Pattern> {
+fun newBasedOn(key: String, pattern: Pattern, resolver: Resolver): Sequence<Pattern> {
     return resolver.withCyclePrevention(pattern, isOptional(key)) { cyclePreventedResolver ->
         pattern.newBasedOn(cyclePreventedResolver)
     }?:
     // Handle cycle (represented by null value) by using empty list for optional properties
-    listOf()
+    emptySequence()
 }
 
 fun key(pattern: Pattern, key: String): String {
@@ -214,47 +214,70 @@ fun key(pattern: Pattern, key: String): String {
     )
 }
 
-fun <ValueType> patternList(patternCollection: Map<String, List<ValueType>>): List<Map<String, ValueType>> {
+fun <ValueType> patternList(patternCollection: Map<String, Sequence<ValueType>>): Sequence<Map<String, ValueType>> {
     if (patternCollection.isEmpty())
-        return listOf(emptyMap())
+        return sequenceOf(emptyMap())
 
     val spec = CombinationSpec(patternCollection, Flags.maxTestRequestCombinations())
     return spec.selectedCombinations
 }
 
-fun <ValueType> patternValues(patternCollection: Map<String, List<ValueType>>): List<Map<String, ValueType>> {
+fun <ValueType> patternValues(patternCollection: Map<String, Sequence<ValueType>>): Sequence<Map<String, ValueType>> {
     if (patternCollection.isEmpty())
-        return listOf(emptyMap())
+        return sequenceOf(emptyMap())
 
-    val maxKeyValues = patternCollection.map { (_, value) -> value.size }.maxOrNull() ?: 0
+    val first = mutableMapOf<String, ValueType>()
+    val ranOut = first.mapValues { false }.toMutableMap()
 
-    return (0 until maxKeyValues).map {
-        keyCombinations(patternCollection) { key, value ->
-            when {
-                value.size > it -> key to value[it]
-                else -> key to value[0]
+    val iterators = patternCollection.mapValues {
+        it.value.iterator()
+    }.filter {
+        it.value.hasNext()
+    }
+
+    return sequence {
+        while (true) {
+            val nextValue = iterators.mapValues { (key, iterator) ->
+                val nextValueFromIterator = if (iterator.hasNext()) {
+                    val value = iterator.next()
+
+                    first.putIfAbsent(key, value)
+
+                    value
+                } else {
+                    ranOut[key] = true
+                    first.getValue(key)
+                }
+
+                nextValueFromIterator
             }
+
+            if (ranOut.size == iterators.size && ranOut.all { it.value }) {
+                break
+            }
+
+            yield(nextValue)
         }
-    }.toList()
+    }
 }
 
 private fun <ValueType> keyCombinations(
-    patternCollection: Map<String, List<ValueType>>,
+    valuePatternOptions: Map<String, List<ValueType>>,
     optionalSelector: (String, List<ValueType>) -> Pair<String, ValueType>
 ): Map<String, ValueType> {
-    return patternCollection
+    return valuePatternOptions
         .filterValues { it.isNotEmpty() }
         .map { (key, value) ->
-        optionalSelector(key, value)
-    }.toMap()
+            optionalSelector(key, value)
+        }.toMap()
 }
 
 fun <ValueType> forEachKeyCombinationIn(
     patternMap: Map<String, ValueType>,
     row: Row,
     resolver: Resolver,
-    creator: (Map<String, ValueType>) -> List<Map<String, ValueType>>
-): List<Map<String, ValueType>> =
+    creator: (Map<String, ValueType>) -> Sequence<Map<String, ValueType>>
+): Sequence<Map<String, ValueType>> =
     keySets(patternMap.keys.toList(), row, resolver).map { keySet ->
         patternMap.filterKeys { key -> key in keySet }
     }.map { newPattern ->
@@ -264,8 +287,8 @@ fun <ValueType> forEachKeyCombinationIn(
 fun <ValueType> forEachKeyCombinationIn(
     patternMap: Map<String, ValueType>,
     row: Row,
-    creator: (Map<String, ValueType>) -> List<Map<String, ValueType>>
-): List<Map<String, ValueType>> =
+    creator: (Map<String, ValueType>) -> Sequence<Map<String, ValueType>>
+): Sequence<Map<String, ValueType>> =
     keySets(patternMap.keys.toList(), row).map { keySet ->
         patternMap.filterKeys { key -> key in keySet }
     }.map { newPattern ->
@@ -277,8 +300,8 @@ fun <ValueType> allOrNothingCombinationIn(
     row: Row = Row(),
     minPropertiesOrNull: Int? = null,
     maxPropertiesOrNull: Int? = null,
-    creator: (Map<String, ValueType>) -> List<Map<String, ValueType>>
-): List<Map<String, ValueType>> {
+    creator: (Map<String, ValueType>) -> Sequence<Map<String, ValueType>>
+): Sequence<Map<String, ValueType>> {
     val keyLists = if (patternMap.keys.any { isOptional(it) }) {
         val nothingList: Set<String> =
             patternMap.keys.filter { k -> !isOptional(k) || row.containsField(withoutOptionality(k)) }.toSet()
@@ -309,22 +332,22 @@ fun <ValueType> allOrNothingCombinationIn(
         listOf(allList, nothingList).distinct()
     } else {
         listOf(patternMap.keys)
-    }
+    }.asSequence()
 
-    val keySets: List<Map<String, ValueType>> = keyLists.map { keySet ->
+    val keySets: Sequence<Map<String, ValueType>> = keyLists.map { keySet ->
         patternMap.filterKeys { key -> key in keySet }
-    }
+    }.asSequence()
 
-    val keySetValues: List<List<Map<String, ValueType>>> = keySets.map { newPattern ->
+    val keySetValues: Sequence<Sequence<Map<String, ValueType>>> = keySets.map { newPattern ->
         creator(newPattern)
     }
 
     return keySetValues.flatten()
 }
 
-internal fun keySets(listOfKeys: List<String>, row: Row, resolver: Resolver): List<List<String>> {
+internal fun keySets(listOfKeys: List<String>, row: Row, resolver: Resolver): Sequence<List<String>> {
     if (listOfKeys.isEmpty())
-        return listOf(listOfKeys)
+        return sequenceOf(listOfKeys)
 
     val key = listOfKeys.last()
     val subLists = keySets(listOfKeys.dropLast(1), row)
@@ -333,15 +356,15 @@ internal fun keySets(listOfKeys: List<String>, row: Row, resolver: Resolver): Li
         when {
             row.containsField(withoutOptionality(key)) ->
                 resolver.generateKeySubLists(key, subList)
-            isOptional(key) -> listOf(subList, subList + key)
-            else -> listOf(subList + key)
+            isOptional(key) -> sequenceOf(subList, subList + key)
+            else -> sequenceOf(subList + key)
         }
     }
 }
 
-internal fun keySets(listOfKeys: List<String>, row: Row): List<List<String>> {
+internal fun keySets(listOfKeys: List<String>, row: Row): Sequence<List<String>> {
     if (listOfKeys.isEmpty())
-        return listOf(listOfKeys)
+        return sequenceOf(listOfKeys)
 
     val key = listOfKeys.last()
     val subLists = keySets(listOfKeys.dropLast(1), row)

--- a/core/src/main/kotlin/in/specmatic/core/pattern/TabularPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/TabularPattern.kt
@@ -329,6 +329,7 @@ fun <ValueType> allOrNothingCombinationIn(
             } ?: propertyNames
         }
 
+        //TODO: STREAMING (review again)
         sequenceOf(allList, nothingList).distinct()
     } else {
         sequenceOf(patternMap.keys)

--- a/core/src/main/kotlin/in/specmatic/core/pattern/TabularPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/TabularPattern.kt
@@ -165,7 +165,7 @@ fun newBasedOn(row: Row, key: String, pattern: Pattern, resolver: Resolver): Seq
                             resolver.withCyclePrevention(rowPattern, isOptional(key)) { cyclePreventedResolver ->
                                 rowPattern.newBasedOn(row, cyclePreventedResolver)
                             }?:
-                            // Handle cycle (represented by null value) by using empty list for optional properties
+                            // Handle cycle (represented by null value) by using empty sequence for optional properties
                             emptySequence()
                         }
                         is Result.Failure -> throw ContractException(result.toFailureReport())
@@ -329,10 +329,10 @@ fun <ValueType> allOrNothingCombinationIn(
             } ?: propertyNames
         }
 
-        listOf(allList, nothingList).distinct()
+        sequenceOf(allList, nothingList).distinct()
     } else {
-        listOf(patternMap.keys)
-    }.asSequence()
+        sequenceOf(patternMap.keys)
+    }
 
     val keySets: Sequence<Map<String, ValueType>> = keyLists.map { keySet ->
         patternMap.filterKeys { key -> key in keySet }

--- a/core/src/main/kotlin/in/specmatic/core/pattern/URLPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/URLPattern.kt
@@ -24,10 +24,10 @@ data class URLPattern(val scheme: URLScheme = URLScheme.HTTPS, override val type
     override fun generate(resolver: Resolver): StringValue =
             StringValue("${scheme.prefix}${randomString().lowercase()}.com/${randomString().lowercase()}")
 
-    override fun newBasedOn(row: Row, resolver: Resolver): List<Pattern> = listOf(this)
+    override fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
 
-    override fun newBasedOn(resolver: Resolver): List<Pattern> = listOf(this)
-    override fun negativeBasedOn(row: Row, resolver: Resolver): List<Pattern> {
+    override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
         return newBasedOn(row, resolver)
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/UUIDPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/UUIDPattern.kt
@@ -19,11 +19,11 @@ object UUIDPattern : Pattern, ScalarType {
 
     override fun generate(resolver: Resolver): StringValue = StringValue(UUID.randomUUID().toString())
 
-    override fun newBasedOn(row: Row, resolver: Resolver): List<UUIDPattern> = listOf(this)
+    override fun newBasedOn(row: Row, resolver: Resolver): Sequence<UUIDPattern> = sequenceOf(this)
 
-    override fun newBasedOn(resolver: Resolver): List<UUIDPattern> = listOf(this)
-    override fun negativeBasedOn(row: Row, resolver: Resolver): List<Pattern> {
-        return listOf(NullPattern)
+    override fun newBasedOn(resolver: Resolver): Sequence<UUIDPattern> = sequenceOf(this)
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
+        return sequenceOf(NullPattern)
     }
 
     override fun parse(value: String, resolver: Resolver): StringValue =

--- a/core/src/main/kotlin/in/specmatic/core/pattern/XMLPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/XMLPattern.kt
@@ -308,7 +308,7 @@ data class XMLPattern(override val pattern: XMLTypeData = XMLTypeData(realName =
         return XMLNode(pattern.realName, newAttributes, nodes)
     }
 
-    override fun newBasedOn(row: Row, resolver: Resolver): List<XMLPattern> {
+    override fun newBasedOn(row: Row, resolver: Resolver): Sequence<XMLPattern> {
         return forEachKeyCombinationIn(pattern.attributes, row) { attributePattern ->
             attempt(breadCrumb = this.pattern.name) {
                 newBasedOn(attributePattern, row, resolver).map {
@@ -330,7 +330,7 @@ data class XMLPattern(override val pattern: XMLTypeData = XMLTypeData(realName =
                         if (matchResult is Failure)
                             throw ContractException(matchResult.toFailureReport())
 
-                        listOf(listOf(ExactValuePattern(parsedData)))
+                        sequenceOf(listOf(ExactValuePattern(parsedData)))
                     }
                 }
                 else -> {
@@ -369,7 +369,7 @@ data class XMLPattern(override val pattern: XMLTypeData = XMLTypeData(realName =
         }
     }
 
-    override fun newBasedOn(resolver: Resolver): List<XMLPattern> {
+    override fun newBasedOn(resolver: Resolver): Sequence<XMLPattern> {
         return allOrNothingCombinationIn(pattern.attributes) { attributePattern ->
             attempt(breadCrumb = this.pattern.name) {
                 newBasedOn(attributePattern, resolver).map {
@@ -402,7 +402,9 @@ data class XMLPattern(override val pattern: XMLTypeData = XMLTypeData(realName =
                         }
                     }
                 }
-            })
+                //TODO: STREAMING
+            }.map { it.toList() }
+        )
 
             newNodesList.map { newNodes ->
                 XMLPattern(XMLTypeData(pattern.name, pattern.realName, newAttributes, newNodes))
@@ -410,7 +412,7 @@ data class XMLPattern(override val pattern: XMLTypeData = XMLTypeData(realName =
         }
     }
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): List<Pattern> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
         return newBasedOn(row, resolver)
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/XMLPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/XMLPattern.kt
@@ -402,12 +402,11 @@ data class XMLPattern(override val pattern: XMLTypeData = XMLTypeData(realName =
                         }
                     }
                 }
-                //TODO: STREAMING
-            }.map { it.toList() }
+            }
         )
 
             newNodesList.map { newNodes ->
-                XMLPattern(XMLTypeData(pattern.name, pattern.realName, newAttributes, newNodes))
+                XMLPattern(XMLTypeData(pattern.name, pattern.realName, newAttributes, newNodes.toList()))
             }
         }
     }

--- a/core/src/main/kotlin/in/specmatic/test/ContractTest.kt
+++ b/core/src/main/kotlin/in/specmatic/test/ContractTest.kt
@@ -21,7 +21,7 @@ data class TestResultRecord(
 
 interface ContractTest {
     fun testResultRecord(result: Result, response: HttpResponse?): TestResultRecord
-    fun generateTestScenarios(testVariables: Map<String, String>, testBaseURLs: Map<String, String>): List<ContractTest>
+    fun generateTestScenarios(testVariables: Map<String, String>, testBaseURLs: Map<String, String>): Sequence<ContractTest>
     fun testDescription(): String
     fun runTest(testBaseURL: String, timeOut: Int): Pair<Result, HttpResponse?>
 }

--- a/core/src/main/kotlin/in/specmatic/test/ScenarioTest.kt
+++ b/core/src/main/kotlin/in/specmatic/test/ScenarioTest.kt
@@ -23,7 +23,7 @@ class ScenarioTest(
     override fun generateTestScenarios(
         testVariables: Map<String, String>,
         testBaseURLs: Map<String, String>
-    ): List<ContractTest> {
+    ): Sequence<ContractTest> {
         return scenario.generateContractTests(resolverStrategies, testVariables, testBaseURLs)
     }
 

--- a/core/src/main/kotlin/in/specmatic/test/ScenarioTestGenerationFailure.kt
+++ b/core/src/main/kotlin/in/specmatic/test/ScenarioTestGenerationFailure.kt
@@ -11,8 +11,8 @@ class ScenarioTestGenerationFailure(val scenario: Scenario, val e: Throwable) : 
         return TestResultRecord(convertPathParameterStyle(scenario.path), scenario.method, scenario.httpResponsePattern.status, result.testResult())
     }
 
-    override fun generateTestScenarios(testVariables: Map<String, String>, testBaseURLs: Map<String, String>): List<ContractTest> {
-        return listOf(this)
+    override fun generateTestScenarios(testVariables: Map<String, String>, testBaseURLs: Map<String, String>): Sequence<ContractTest> {
+        return sequenceOf(this)
     }
 
     override fun testDescription(): String {

--- a/core/src/test/kotlin/in/specmatic/conversions/OneOfSupport.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OneOfSupport.kt
@@ -63,7 +63,7 @@ class OneOfSupport {
                               type: string
             """.trimIndent(), "").toFeature()
 
-        val tests = specification.generateContractTestScenarios(emptyList())
+        val tests = specification.generateContractTestScenariosL(emptyList())
 
         val requestBodies = listOf(
             parsedJSONObject("""{"name": "John", "address": "1st Street"}"""),

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
@@ -1315,18 +1315,18 @@ Background:
                                 }
 
                                 "POST" -> {
-                                    assertThat(request.bodyString).containsAnyOf(
-                                        """
+                                    assertThat(request.body).isIn(
+                                        parsedJSONObject("""
                                         {
                                             "tag": "testing",
                                             "name": "test"
                                         }
-                                    """.trimIndent(),
-                                        """
+                                    """.trimIndent()),
+                                        parsedJSONObject("""
                                         {
                                             "name": "test"
                                         }
-                                    """.trimIndent()
+                                    """.trimIndent())
                                     )
                                     HttpResponse(
                                         201,
@@ -1770,6 +1770,7 @@ Scenario: zero should return not found
 
         assertThat(results.success()).isTrue
         assertThat(queryParameters.size).isEqualTo(4)
+        println(queryParameters)
         assertThat(queryParameters.map { it.keys }).containsAll(
             listOf(
                 setOf("message"),
@@ -1778,10 +1779,10 @@ Scenario: zero should return not found
                 setOf("message", "another_message"),
             )
         )
-        assertThat(queryParameters.map { it.values.toList() }).containsAll(
+        assertThat(queryParameters.map { it.values.toSet() }).containsAll(
             listOf(
-                listOf("Hari", "hello"),
-                listOf("hello")
+                setOf("Hari", "hello"),
+                setOf("hello")
             )
         )
     }

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -4936,7 +4936,7 @@ paths:
 
         val feature = parseContractFileToFeature(specFile)
 
-        val testScenario = feature.generateContractTestScenarios(emptyList()).single()
+        val testScenario = feature.generateContractTestScenariosL(emptyList()).single()
 
         assertThat(testScenario.bindings).containsEntry("id", "response-body.id")
     }
@@ -5010,7 +5010,7 @@ paths:
 
         val feature = parseContractFileToFeature(specFile)
 
-        val testScenario = feature.generateContractTestScenarios(emptyList()).single()
+        val testScenario = feature.generateContractTestScenariosL(emptyList()).single()
 
         val requestPattern = testScenario.httpRequestPattern
         assertThat(requestPattern.multiPartFormDataPattern.single().name).isEqualTo("csv")
@@ -5489,7 +5489,7 @@ paths:
 
         val feature = OpenApiSpecification.fromYAML(contractString, "").toFeature()
 
-        val results: List<Result> = feature.generateContractTestScenarios(emptyList()).map {
+        val results: List<Result> = feature.generateContractTestScenariosL(emptyList()).map {
             executeTest(it, object : TestExecutor {
                 override fun execute(request: HttpRequest): HttpResponse {
                     assertThat(request.body).isInstanceOf(JSONObjectValue::class.java)
@@ -5555,7 +5555,7 @@ paths:
 
         val feature = OpenApiSpecification.fromYAML(contractString, "").toFeature()
 
-        val results: List<Result> = feature.generateContractTestScenarios(emptyList()).map {
+        val results: List<Result> = feature.generateContractTestScenariosL(emptyList()).map {
             executeTest(it, object : TestExecutor {
                 override fun execute(request: HttpRequest): HttpResponse {
                     assertThat(request.formFields).containsKey("Data")
@@ -5619,7 +5619,7 @@ paths:
 
         val feature = OpenApiSpecification.fromYAML(contractString, "").toFeature()
 
-        val results: List<Result> = feature.generateContractTestScenarios(emptyList()).map {
+        val results: List<Result> = feature.generateContractTestScenariosL(emptyList()).map {
             executeTest(it, object : TestExecutor {
                 override fun execute(request: HttpRequest): HttpResponse {
                     assertThat(request.formFields).containsKey("Data")
@@ -5678,7 +5678,7 @@ paths:
 
         val feature = OpenApiSpecification.fromYAML(contractString, "").toFeature()
 
-        val results: List<Result> = feature.generateContractTestScenarios(emptyList()).map {
+        val results: List<Result> = feature.generateContractTestScenariosL(emptyList()).map {
             executeTest(it, object : TestExecutor {
                 override fun execute(request: HttpRequest): HttpResponse {
                     assertThat(request.multiPartFormData.first().name).isEqualTo("Data")
@@ -7228,7 +7228,7 @@ components:
             .toFeature()
             .loadExternalisedExamples()
 
-        val tests = spec.generateContractTestScenarios(emptyList())
+        val tests = spec.generateContractTestScenariosL(emptyList())
         assertThat(tests.single().testDescription()).contains("file_name_as_test_label")
     }
 

--- a/core/src/test/kotlin/in/specmatic/conversions/StreamingTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/StreamingTest.kt
@@ -1,0 +1,45 @@
+package `in`.specmatic.conversions
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class StreamingTest {
+    @Test
+    fun `should stream tests`() {
+        val parameters = (1..30).joinToString("") {
+"""        - name: param$it
+          in: query
+          schema:
+            type: string
+"""
+        }
+
+        val specWith30QueryParams = """
+openapi: 3.0.0
+info:
+  title: "Test API"
+  version: "1.0.0"
+paths:
+  /test:
+    get:
+      parameters:
+$parameters
+      responses:
+        '200':
+          description: "A simple test"
+          content:
+            text/plain:
+              schema:
+                type: string
+""".trimIndent()
+
+        val feature = OpenApiSpecification.fromYAML(specWith30QueryParams, "").toFeature()
+
+        val streamOfTestsWithOverABillionTests = feature.generateContractTests(emptyList())
+        val first100TestsFromTheStreamingTest = streamOfTestsWithOverABillionTests.take(100)
+
+        assertThat(first100TestsFromTheStreamingTest.toList()).hasSize(100)
+    }
+
+
+}

--- a/core/src/test/kotlin/in/specmatic/core/FeatureKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/FeatureKtTest.kt
@@ -722,7 +722,7 @@ paths:
 
         val withGenerativeTestsEnabled = contract.enableGenerativeTesting()
 
-        val tests: List<Scenario> = withGenerativeTestsEnabled.generateContractTestScenarios(emptyList())
+        val tests: List<Scenario> = withGenerativeTestsEnabled.generateContractTestScenariosL(emptyList())
 
         val expectedRequestTypes: List<Pair<String, String>> = listOf(
             Pair("(string)", "(string)"),

--- a/core/src/test/kotlin/in/specmatic/core/FeatureTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/FeatureTest.kt
@@ -61,7 +61,7 @@ paths:
                     type: integer
 """.trimIndent(), "").toFeature()
 
-        val scenarios: List<Scenario> = contract.generateContractTestScenarios(emptyList())
+        val scenarios: List<Scenario> = contract.generateContractTestScenariosL(emptyList())
 
         assertThat(scenarios.map { it.testDescription() }).allSatisfy {
             assertThat(it).doesNotContain("|")
@@ -120,7 +120,7 @@ paths:
                     type: integer
 """.trimIndent(), "").toFeature()
 
-        val scenarios: List<Scenario> = contract.enableGenerativeTesting().generateContractTestScenarios(emptyList())
+        val scenarios: List<Scenario> = contract.enableGenerativeTesting().generateContractTestScenariosL(emptyList())
 
         assertThat(scenarios.map { it.testDescription() }).allSatisfy {
             assertThat(it).containsAnyOf("+ve", "-ve")
@@ -179,7 +179,7 @@ paths:
                     type: integer
 """.trimIndent(), "").toFeature()
 
-        val scenario: Scenario = contract.generateContractTestScenarios(emptyList()).first()
+        val scenario: Scenario = contract.generateContractTestScenariosL(emptyList()).first()
         assertThat(scenario.testDescription()).contains("SUCCESS")
     }
 
@@ -235,7 +235,7 @@ paths:
                     type: integer
 """.trimIndent(), "").toFeature()
 
-        val scenario: Scenario = contract.generateContractTestScenarios(emptyList()).first()
+        val scenario: Scenario = contract.generateContractTestScenariosL(emptyList()).first()
         assertThat(scenario.testDescription()).contains("[WIP] SUCCESS")
     }
     @DisplayName("Single Feature Contract")
@@ -1142,7 +1142,7 @@ Then status 200
                     | 10 | Justin |
         """.trimIndent(), "src/test/resources/test.spec")
 
-        val testScenarios: List<Scenario> = contract.generateContractTestScenarios(emptyList())
+        val testScenarios: List<Scenario> = contract.generateContractTestScenariosL(emptyList())
         assertThat(testScenarios).hasSize(1)
     }
 
@@ -1193,7 +1193,7 @@ paths:
                     type: string
 """.trimIndent(), "").toFeature()
 
-        val scenarios: List<Scenario> = contract.enableGenerativeTesting().generateContractTestScenarios(emptyList())
+        val scenarios: List<Scenario> = contract.enableGenerativeTesting().generateContractTestScenariosL(emptyList())
         assertThat(scenarios.count { it.testDescription().contains("-ve") }).isEqualTo(0)
     }
 
@@ -1244,7 +1244,7 @@ paths:
                     type: string
 """.trimIndent(), "").toFeature()
 
-        val scenarios: List<Scenario> = contract.enableGenerativeTesting().generateContractTestScenarios(emptyList())
+        val scenarios: List<Scenario> = contract.enableGenerativeTesting().generateContractTestScenariosL(emptyList())
         val negativeTestScenarios = scenarios.filter { it.testDescription().contains("-ve")}
         assertThat(negativeTestScenarios.count()).isEqualTo(2)
         val headerPattern = negativeTestScenarios.first().httpRequestPattern.headersPattern.pattern
@@ -1298,7 +1298,7 @@ paths:
                     type: string
 """.trimIndent(), "").toFeature()
 
-        val scenarios: List<Scenario> = contract.enableGenerativeTesting().generateContractTestScenarios(emptyList())
+        val scenarios: List<Scenario> = contract.enableGenerativeTesting().generateContractTestScenariosL(emptyList())
         val negativeTestScenarios = scenarios.filter { it.testDescription().contains("-ve")}
         assertThat(negativeTestScenarios.count()).isEqualTo(0)
     }
@@ -1378,7 +1378,7 @@ paths:
                     type: string
 """.trimIndent(), "").toFeature()
 
-        val scenarios: List<Scenario> = contract.enableGenerativeTesting().generateContractTestScenarios(emptyList())
+        val scenarios: List<Scenario> = contract.enableGenerativeTesting().generateContractTestScenariosL(emptyList())
         val negativeTestScenarios = scenarios.filter { it.testDescription().contains("-ve")}
         assertThat(negativeTestScenarios.count()).isEqualTo(10)
     }
@@ -1431,7 +1431,7 @@ paths:
                     type: integer
 """.trimIndent(), "").toFeature()
 
-        val scenarios: List<Scenario> = contract.enableGenerativeTesting().generateContractTestScenarios(emptyList())
+        val scenarios: List<Scenario> = contract.enableGenerativeTesting().generateContractTestScenariosL(emptyList())
         val negativeTestScenarios = scenarios.filter { it.testDescription().contains("-ve")}
         assertThat(negativeTestScenarios.map { it.testDescription() }).allSatisfy {
             assertThat(it).contains("-> 4xx")

--- a/core/src/test/kotlin/in/specmatic/core/HttpHeadersPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/HttpHeadersPatternTest.kt
@@ -172,7 +172,7 @@ internal class HttpHeadersPatternTest {
     @Test
     fun `should generate new header objects given an empty row`() {
         val headers = HttpHeadersPattern(mapOf("Content-Type" to stringToPattern("(string)", "Content-Type")))
-        val newHeaders = headers.newBasedOn(Row(), Resolver())
+        val newHeaders = headers.newBasedOn(Row(), Resolver()).toList()
         assertEquals("(string)", newHeaders[0].pattern.getValue("Content-Type").toString())
     }
 
@@ -180,7 +180,7 @@ internal class HttpHeadersPatternTest {
     @Test
     fun `should generate new header object with the value of the example in the given row`() {
         val headers = HttpHeadersPattern(mapOf("X-TraceID" to StringPattern()))
-        val newHeaders = headers.newBasedOn(Row(mapOf("X-TraceID" to "123")), Resolver())
+        val newHeaders = headers.newBasedOn(Row(mapOf("X-TraceID" to "123")), Resolver()).toList()
         assertThat(newHeaders[0].pattern.getValue("X-TraceID")).isEqualTo(ExactValuePattern(StringValue("123")))
     }
 
@@ -188,7 +188,7 @@ internal class HttpHeadersPatternTest {
     @Test
     fun `should generate two header object given one optional header and an empty row`() {
         val headers = HttpHeadersPattern(mapOf("X-TraceID" to StringPattern(), "X-Identifier?" to StringPattern()))
-        val newHeaders = headers.newBasedOn(Row(), Resolver())
+        val newHeaders = headers.newBasedOn(Row(), Resolver()).toList()
 
         assertThat(newHeaders).containsExactlyInAnyOrder(
             HttpHeadersPattern(mapOf("X-TraceID" to StringPattern())),
@@ -200,7 +200,7 @@ internal class HttpHeadersPatternTest {
     @Test
     fun `should generate two header object given one optional header an example of the mandatory header`() {
         val headers = HttpHeadersPattern(mapOf("X-TraceID" to StringPattern(), "X-Identifier?" to StringPattern()))
-        val newHeaders = headers.newBasedOn(Row(mapOf("X-TraceID" to "123")), Resolver())
+        val newHeaders = headers.newBasedOn(Row(mapOf("X-TraceID" to "123")), Resolver()).toList()
 
         assertThat(newHeaders).containsExactlyInAnyOrder(
             HttpHeadersPattern(mapOf("X-TraceID" to ExactValuePattern(StringValue("123")))),
@@ -212,7 +212,7 @@ internal class HttpHeadersPatternTest {
     @Test
     fun `should generate one header object given one optional header an example of the optional header`() {
         val headers = HttpHeadersPattern(mapOf("X-TraceID" to StringPattern()))
-        val newHeaders = headers.newBasedOn(Row(mapOf("X-TraceID" to "123")), Resolver())
+        val newHeaders = headers.newBasedOn(Row(mapOf("X-TraceID" to "123")), Resolver()).toList()
         assertThat(newHeaders[0].pattern.getValue("X-TraceID")).isEqualTo(ExactValuePattern(StringValue("123")))
     }
 
@@ -220,7 +220,7 @@ internal class HttpHeadersPatternTest {
     @Test
     fun `should generate negative values for a string`() {
         val headers = HttpHeadersPattern(mapOf("X-TraceID" to StringPattern()))
-        val newHeaders = headers.negativeBasedOn(Row(), Resolver())
+        val newHeaders = headers.negativeBasedOn(Row(), Resolver()).toList()
 
         assertThat(newHeaders).isEmpty()
     }
@@ -229,7 +229,7 @@ internal class HttpHeadersPatternTest {
     @Test
     fun `should generate negative values for a number`() {
         val headers = HttpHeadersPattern(mapOf("X-TraceID" to NumberPattern()))
-        val newHeaders = headers.negativeBasedOn(Row(), Resolver())
+        val newHeaders = headers.negativeBasedOn(Row(), Resolver()).toList()
 
         assertThat(newHeaders).containsExactlyInAnyOrder(
             HttpHeadersPattern(mapOf("X-TraceID" to StringPattern())),
@@ -265,7 +265,7 @@ internal class HttpHeadersPatternTest {
     @Test
     fun `an optional header should result in 2 new header patterns for newBasedOn`() {
         val pattern = HttpHeadersPattern(mapOf("X-Optional?" to StringPattern()))
-        val list = pattern.newBasedOn(Row(), Resolver())
+        val list = pattern.newBasedOn(Row(), Resolver()).toList()
 
         assertThat(list).hasSize(2)
 

--- a/core/src/test/kotlin/in/specmatic/core/HttpPathPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/HttpPathPatternTest.kt
@@ -166,7 +166,7 @@ internal class HttpPathPatternTest {
     @Tag(GENERATION)
     fun `should generate a path with a concrete value given a path pattern with newBasedOn`() {
         val matcher = buildHttpPathPattern(URI("/pets/(status:boolean)"))
-        val matchers = matcher.newBasedOn(Row(), Resolver())
+        val matchers = matcher.newBasedOn(Row(), Resolver()).toList()
         assertThat(matchers).hasSize(1)
         assertThat(matchers.single()).isEqualTo(
             listOf(
@@ -180,7 +180,7 @@ internal class HttpPathPatternTest {
     @Test
     fun `should generate negative values for a number`() {
         val headers = HttpHeadersPattern(mapOf("X-TraceID" to NumberPattern()))
-        val newHeaders = headers.negativeBasedOn(Row(), Resolver())
+        val newHeaders = headers.negativeBasedOn(Row(), Resolver()).toList()
 
         assertThat(newHeaders).containsExactlyInAnyOrder(
             HttpHeadersPattern(mapOf("X-TraceID" to StringPattern())),

--- a/core/src/test/kotlin/in/specmatic/core/HttpQueryParamPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/HttpQueryParamPatternTest.kt
@@ -123,7 +123,7 @@ class HttpQueryParamPatternTest {
     fun `should generate a valid query string when there is a single row with matching columns`() {
         val resolver = Resolver()
         val row = Row(listOf("status", "type"), listOf("available", "dog"))
-        val generatedPatterns = buildQueryPattern(URI("/pets?status=(string)&type=(string)")).newBasedOn(row, resolver)
+        val generatedPatterns = buildQueryPattern(URI("/pets?status=(string)&type=(string)")).newBasedOn(row, resolver).toList()
         assertEquals(1, generatedPatterns.size)
         val values = HttpQueryParamPattern(generatedPatterns.first()).generate(resolver)
         assertThat(values.single{ it.first == "status"}.second).isEqualTo("available")
@@ -159,7 +159,7 @@ class HttpQueryParamPatternTest {
     @Tag(GENERATION)
     fun `should generate a path with a concrete value given a query param with newBasedOn`() {
         val matcher = buildQueryPattern(URI("/pets?available=(boolean)"))
-        val matchers = matcher.newBasedOn(Row(), Resolver())
+        val matchers = matcher.newBasedOn(Row(), Resolver()).toList()
         assertThat(matchers).hasSize(2)
         assertThat(matchers).contains(emptyMap())
         assertThat(matchers).contains(mapOf("available" to BooleanPattern()))
@@ -178,7 +178,7 @@ class HttpQueryParamPatternTest {
     @Tag(GENERATION)
     @Test
     fun `should generate negative values for a string`() {
-        val urlMatchers = buildQueryPattern(URI("/pets?name=(string)")).negativeBasedOn(Row(), Resolver())
+        val urlMatchers = buildQueryPattern(URI("/pets?name=(string)")).negativeBasedOn(Row(), Resolver()).toList()
         assertThat(urlMatchers).containsExactly(emptyMap())
     }
 
@@ -186,7 +186,7 @@ class HttpQueryParamPatternTest {
     @Tag(GENERATION)
     fun `should create 2^n matchers on an empty Row`() {
         val patterns = buildQueryPattern(URI("/pets?status=(string)&type=(string)"))
-        val generatedPatterns = patterns.newBasedOn(Row(), Resolver())
+        val generatedPatterns = patterns.newBasedOn(Row(), Resolver()).toList()
         assertThat(generatedPatterns).containsExactlyInAnyOrder(
             emptyMap(),
             mapOf("status" to StringPattern()),
@@ -514,7 +514,7 @@ class HttpQueryParamPatternTest {
     fun `an additional query param should be added in a test`() {
         val queryPattern = HttpQueryParamPattern(mapOf("key" to QueryParameterScalarPattern(NumberPattern())), NumberPattern())
 
-        val generatedValue = queryPattern.newBasedOn(Row(), Resolver())
+        val generatedValue = queryPattern.newBasedOn(Row(), Resolver()).toList()
 
         assertThat(generatedValue).hasSize(1)
         assertThat(generatedValue.first()).hasSize(2)

--- a/core/src/test/kotlin/in/specmatic/core/HttpRequestPatternKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/HttpRequestPatternKtTest.kt
@@ -15,7 +15,7 @@ internal class HttpRequestPatternKtTest {
             AnyPattern(listOf(StringPattern(), NumberPattern())),
         ))
 
-        val newTypes = newMultiPartBasedOn(multiPartTypes, Row(), Resolver())
+        val newTypes = newMultiPartBasedOn(multiPartTypes, Row(), Resolver()).toList()
 
         assertThat(newTypes).hasSize(2)
 
@@ -27,7 +27,7 @@ internal class HttpRequestPatternKtTest {
     fun `when a part is optional there should be two lists generated in which one has the part and the other does not`() {
         val multiPartTypes = listOf(MultiPartContentPattern("data?", StringPattern()))
 
-        val newTypes = newMultiPartBasedOn(multiPartTypes, Row(), Resolver())
+        val newTypes = newMultiPartBasedOn(multiPartTypes, Row(), Resolver()).toList()
 
         assertThat(newTypes).hasSize(2)
 

--- a/core/src/test/kotlin/in/specmatic/core/HttpRequestPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/HttpRequestPatternTest.kt
@@ -80,7 +80,7 @@ internal class HttpRequestPatternTest {
                 method = "GET"
         )
 
-        val newPatterns = pattern.newBasedOn(Row(), Resolver())
+        val newPatterns = pattern.newBasedOn(Row(), Resolver()).toList()
         assertEquals("(string)", newPatterns[0].headersPattern.pattern["Test-Header"].toString())
     }
 
@@ -95,7 +95,7 @@ internal class HttpRequestPatternTest {
         val resolver = Resolver(newPatterns = mapOf("(Data)" to TabularPattern(mapOf("id" to NumberPattern()))))
         val data = """{"id": 10}"""
         val row = Row(columnNames = listOf("(Data)"), values = listOf(data))
-        val newPatterns = pattern.newBasedOn(row, resolver)
+        val newPatterns = pattern.newBasedOn(row, resolver).toList()
 
         assertThat((newPatterns.single().body as ExactValuePattern).pattern as JSONObjectValue).isEqualTo(parsedValue(data))
     }
@@ -104,7 +104,7 @@ internal class HttpRequestPatternTest {
     fun `a request with an optional header should result in 2 options for newBasedOn`() {
         val requests = HttpRequestPattern(method = "GET",
                 httpPathPattern = buildHttpPathPattern(URI("/")),
-                headersPattern = HttpHeadersPattern(mapOf("X-Optional?" to StringPattern()))).newBasedOn(Row(), Resolver())
+                headersPattern = HttpHeadersPattern(mapOf("X-Optional?" to StringPattern()))).newBasedOn(Row(), Resolver()).toList()
 
         assertThat(requests).hasSize(2)
 
@@ -157,7 +157,7 @@ internal class HttpRequestPatternTest {
             StringPattern(),
         ), MultiPartContentPattern("data2", StringPattern()))
         val requestPattern = HttpRequestPattern(method = "GET", httpPathPattern = buildHttpPathPattern("/"), multiPartFormDataPattern = parts)
-        val patterns = requestPattern.newBasedOn(Row(), Resolver())
+        val patterns = requestPattern.newBasedOn(Row(), Resolver()).toList()
 
         assertThat(patterns).hasSize(1)
 
@@ -169,7 +169,7 @@ internal class HttpRequestPatternTest {
         val part = MultiPartContentPattern("data?", StringPattern())
 
         val requestPattern = HttpRequestPattern(method = "GET", httpPathPattern = buildHttpPathPattern("/"), multiPartFormDataPattern = listOf(part))
-        val patterns = requestPattern.newBasedOn(Row(), Resolver())
+        val patterns = requestPattern.newBasedOn(Row(), Resolver()).toList()
 
         assertThat(patterns).hasSize(2)
 
@@ -183,7 +183,7 @@ internal class HttpRequestPatternTest {
         val example = Row(listOf("name"), listOf("John Doe"))
 
         val requestPattern = HttpRequestPattern(method = "GET", httpPathPattern = buildHttpPathPattern("/"), multiPartFormDataPattern = listOf(part))
-        val patterns = requestPattern.newBasedOn(example, Resolver())
+        val patterns = requestPattern.newBasedOn(example, Resolver()).toList()
 
         assertThat(patterns).hasSize(1)
 
@@ -200,7 +200,7 @@ internal class HttpRequestPatternTest {
         val example = Row(listOf("name"), listOf("John Doe"))
 
         val requestPattern = HttpRequestPattern(method = "GET", httpPathPattern = buildHttpPathPattern("/"), multiPartFormDataPattern = listOf(part))
-        val patterns = requestPattern.newBasedOn(example, Resolver())
+        val patterns = requestPattern.newBasedOn(example, Resolver()).toList()
 
         assertThat(patterns).hasSize(1)
 
@@ -217,7 +217,7 @@ internal class HttpRequestPatternTest {
         val example = Row(listOf("name"), listOf("John Doe"))
 
         val requestPattern = HttpRequestPattern(method = "GET", httpPathPattern = buildHttpPathPattern("/"), multiPartFormDataPattern = listOf(part))
-        val patterns = requestPattern.newBasedOn(example, Resolver())
+        val patterns = requestPattern.newBasedOn(example, Resolver()).toList()
 
         assertThat(patterns).hasSize(1)
 
@@ -244,7 +244,7 @@ internal class HttpRequestPatternTest {
         val example = Row(listOf("csv"), listOf("[1, 2, 3]"))
 
         val type = parsedPattern("""{"csv": "(number*)"}""")
-        val newTypes = type.newBasedOn(example, Resolver())
+        val newTypes = type.newBasedOn(example, Resolver()).toList()
 
         assertThat(newTypes).hasSize(1)
 
@@ -258,7 +258,7 @@ internal class HttpRequestPatternTest {
         val example = Row(listOf("data"), listOf("""{"one": 1}"""))
 
         val type = parsedPattern("""{"data": "(Data)"}""")
-        val newTypes = type.newBasedOn(example, Resolver(newPatterns = mapOf("(Data)" to toTabularPattern(mapOf("one" to NumberPattern())))))
+        val newTypes = type.newBasedOn(example, Resolver(newPatterns = mapOf("(Data)" to toTabularPattern(mapOf("one" to NumberPattern()))))).toList()
 
         assertThat(newTypes).hasSize(1)
 
@@ -272,7 +272,7 @@ internal class HttpRequestPatternTest {
         val example = Row(listOf("body"), listOf("[1, 2, 3]"))
 
         val requestType = HttpRequestPattern(httpPathPattern = buildHttpPathPattern("/"), body = parsedPattern("(body: RequestBody)"))
-        val newRequestTypes = requestType.newBasedOn(example, Resolver(newPatterns = mapOf("(RequestBody)" to parsedPattern("""(number*)"""))))
+        val newRequestTypes = requestType.newBasedOn(example, Resolver(newPatterns = mapOf("(RequestBody)" to parsedPattern("""(number*)""")))).toList()
 
         assertThat(newRequestTypes).hasSize(1)
 
@@ -287,7 +287,7 @@ internal class HttpRequestPatternTest {
         val example = Row(listOf("body"), listOf("""{"one": 1}"""))
 
         val requestType = HttpRequestPattern(httpPathPattern = buildHttpPathPattern("/"), body = parsedPattern("(body: RequestBody)"))
-        val newRequestTypes = requestType.newBasedOn(example, Resolver(newPatterns = mapOf("(RequestBody)" to toTabularPattern(mapOf("one" to NumberPattern())))))
+        val newRequestTypes = requestType.newBasedOn(example, Resolver(newPatterns = mapOf("(RequestBody)" to toTabularPattern(mapOf("one" to NumberPattern()))))).toList()
 
         assertThat(newRequestTypes).hasSize(1)
 
@@ -425,7 +425,7 @@ internal class HttpRequestPatternTest {
         val pattern = HttpRequestPattern(method = "POST", httpPathPattern = buildHttpPathPattern("http://helloworld.com/data"), body = JSONObjectPattern(mapOf("id" to NumberPattern())))
 
         val row = Row(listOf("(REQUEST-BODY)"), listOf("""{ "id": 10 }"""))
-        val patterns = pattern.newBasedOn(row, Resolver(generation = GenerativeTestsEnabled()))
+        val patterns = pattern.newBasedOn(row, Resolver(generation = GenerativeTestsEnabled())).toList()
 
         assertThat(patterns).hasSize(1)
     }

--- a/core/src/test/kotlin/in/specmatic/core/HttpResponsePatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/HttpResponsePatternTest.kt
@@ -8,7 +8,7 @@ import `in`.specmatic.core.value.StringValue
 internal class HttpResponsePatternTest {
     @Test
     fun `it should result in 2 tests` () {
-        val list = HttpResponsePattern(status = 200, headersPattern = HttpHeadersPattern(mapOf("X-Optional?" to StringPattern()))).newBasedOn(Row(), Resolver())
+        val list = HttpResponsePattern(status = 200, headersPattern = HttpHeadersPattern(mapOf("X-Optional?" to StringPattern()))).newBasedOn(Row(), Resolver()).toList()
 
         assertThat(list).hasSize(2)
 

--- a/core/src/test/kotlin/in/specmatic/core/KeySetsTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/KeySetsTest.kt
@@ -11,6 +11,6 @@ class KeySetsTest {
         val listOfKeys = listOf("key1", "key2?")
         val expectedKeySets = listOf(listOf("key1"), listOf("key1", "key2?"))
 
-        assertEquals(expectedKeySets, keySets(listOfKeys, Row()))
+        assertEquals(expectedKeySets, keySets(listOfKeys, Row()).toList())
     }
 }

--- a/core/src/test/kotlin/in/specmatic/core/MultiPartContentPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/MultiPartContentPatternTest.kt
@@ -59,7 +59,7 @@ internal class MultiPartContentPatternTest {
     fun `should generate a new pattern based on row values when the row has a column with the part name`() {
         val pattern = MultiPartContentPattern("id", NumberPattern())
         val row = Row(listOf("id"), listOf("10"))
-        val patterns = pattern.newBasedOn(row, Resolver()).map { it as MultiPartContentPattern }
+        val patterns = pattern.newBasedOn(row, Resolver()).map { it as MultiPartContentPattern }.toList()
 
         assertThat(patterns).hasSize(1)
 
@@ -73,7 +73,7 @@ internal class MultiPartContentPatternTest {
         fileContainingNumber.writeText("10")
         val pattern = MultiPartContentPattern("id", NumberPattern())
         val row = Row(listOf("id"), listOf("(@${fileContainingNumber.path})"))
-        val patterns = pattern.newBasedOn(row, Resolver()).map { it as MultiPartContentPattern }
+        val patterns = pattern.newBasedOn(row, Resolver()).map { it as MultiPartContentPattern }.toList()
 
         assertThat(patterns).hasSize(1)
 
@@ -85,7 +85,7 @@ internal class MultiPartContentPatternTest {
     fun `should generate a new pattern based on row values with the specified contentType when the row has a column with the part name`() {
         val pattern = MultiPartContentPattern("id", NumberPattern(), contentType = "application/json")
         val row = Row(listOf("id"), listOf("10"))
-        val patterns = pattern.newBasedOn(row, Resolver()).map { it as MultiPartContentPattern }
+        val patterns = pattern.newBasedOn(row, Resolver()).map { it as MultiPartContentPattern }.toList()
 
         assertThat(patterns).hasSize(1)
 

--- a/core/src/test/kotlin/in/specmatic/core/ScenarioTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/ScenarioTest.kt
@@ -27,7 +27,7 @@ internal class ScenarioTest {
             HashMap(),
         )
         scenario.generateTestScenarios(DefaultStrategies).let {
-            assertThat(it.size).isEqualTo(1)
+            assertThat(it.toList().size).isEqualTo(1)
         }
     }
 
@@ -44,7 +44,7 @@ internal class ScenarioTest {
             HashMap(),
         )
         scenario.generateTestScenarios(DefaultStrategies).let {
-            assertThat(it.size).isEqualTo(2)
+            assertThat(it.toList().size).isEqualTo(2)
         }
     }
 
@@ -436,7 +436,7 @@ And response-body (number)
                 it.value.copy(contractCache = mockCache)
             }
 
-            scenario.copy(references = updatedReferences).generateTestScenarios(DefaultStrategies, variables = mapOf("data" to "10"), testBaseURLs = mapOf("auth.spec" to "http://baseurl"))
+            scenario.copy(references = updatedReferences).generateTestScenarios(DefaultStrategies, variables = mapOf("data" to "10"), testBaseURLs = mapOf("auth.spec" to "http://baseurl")).toList()
         }.flatten()
 
         assertThat(testScenarios).allSatisfy(Consumer {

--- a/core/src/test/kotlin/in/specmatic/core/pattern/AllNegativePatternsTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/AllNegativePatternsTest.kt
@@ -11,7 +11,7 @@ class AllNegativePatternsTest {
         val resolver = Resolver()
         val row = Row()
 
-        val negativePatterns: List<Map<String, Pattern>> = AllNegativePatterns().negativeBasedOn(patternMap, row, resolver)
+        val negativePatterns: List<Map<String, Pattern>> = AllNegativePatterns().negativeBasedOn(patternMap, row, resolver).toList()
 
         assertThat(negativePatterns).containsExactlyInAnyOrder(
             mapOf("key" to NumberPattern()),
@@ -26,7 +26,7 @@ class AllNegativePatternsTest {
         val resolver = Resolver()
         val row = Row()
 
-        val negativePatterns: List<Map<String, Pattern>> = AllNegativePatterns().negativeBasedOn(patternMap, row, resolver)
+        val negativePatterns: List<Map<String, Pattern>> = AllNegativePatterns().negativeBasedOn(patternMap, row, resolver).toList()
 
         assertThat(negativePatterns).containsExactlyInAnyOrder(
             mapOf("key1" to BooleanPattern(), "key2" to StringPattern()),

--- a/core/src/test/kotlin/in/specmatic/core/pattern/AnyPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/AnyPatternTest.kt
@@ -66,7 +66,7 @@ internal class AnyPatternTest {
                 NumberPattern(),
                 EnumPattern(listOf(StringValue("one"), StringValue("two")))
             )
-        ).newBasedOn(Row(), Resolver()).let { patterns ->
+        ).newBasedOn(Row(), Resolver()).toList().let { patterns ->
             patterns.map { it.typeName } shouldContainInAnyOrder listOf("number", "\"one\"", "\"two\"")
         }
     }
@@ -219,7 +219,7 @@ internal class AnyPatternTest {
     @Test
     @Tag(GENERATION)
     fun `values for negative tests`() {
-        val negativeTypes = AnyPattern(listOf(NullPattern, StringPattern())).negativeBasedOn(Row(), Resolver())
+        val negativeTypes = AnyPattern(listOf(NullPattern, StringPattern())).negativeBasedOn(Row(), Resolver()).toList()
 
         assertThat(negativeTypes).containsExactlyInAnyOrder(
             NumberPattern(),

--- a/core/src/test/kotlin/in/specmatic/core/pattern/BinaryPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/BinaryPatternTest.kt
@@ -11,7 +11,7 @@ class BinaryPatternTest {
     @Test
     @Tag(GENERATION)
     fun `negative patterns should be generated`() {
-        val result = BinaryPattern().negativeBasedOn(Row(), Resolver())
+        val result = BinaryPattern().negativeBasedOn(Row(), Resolver()).toList()
         assertThat(result.map { it.typeName }).containsExactlyInAnyOrder(
             "null",
             "number",

--- a/core/src/test/kotlin/in/specmatic/core/pattern/BooleanPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/BooleanPatternTest.kt
@@ -25,7 +25,7 @@ internal class BooleanPatternTest {
     @Test
     @Tag(GENERATION)
     fun `negative patterns should be generated`() {
-        val result = BooleanPattern().negativeBasedOn(Row(), Resolver())
+        val result = BooleanPattern().negativeBasedOn(Row(), Resolver()).toList()
         assertThat(result.map { it.typeName }).containsExactlyInAnyOrder(
             "null"
         )

--- a/core/src/test/kotlin/in/specmatic/core/pattern/CombinationSpecTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/CombinationSpecTest.kt
@@ -14,26 +14,26 @@ class CombinationSpecTest {
 
   @Test
   fun `empty list when no candidate sets supplied`() {
-    assertThat(CombinationSpec<Long>(mapOf(), 50).selectedCombinations).isEmpty()
+    assertThat(CombinationSpec<Long>(mapOf(), 50).selectedCombinations.toList()).isEmpty()
   }
 
   @Test
   fun `combination omitted when candidate set empty`() {
-    val spec = CombinationSpec(mapOf("k1" to listOf(), "k2" to listOf(21, 22)), 50)
-    assertThat(spec.selectedCombinations).containsExactly(mapOf("k2" to 21), mapOf("k2" to 22))
+    val spec = CombinationSpec(mapOf("k1" to emptySequence(), "k2" to sequenceOf(21, 22)), 50)
+    assertThat(spec.selectedCombinations.toList()).containsExactly(mapOf("k2" to 21), mapOf("k2" to 22))
   }
 
   @Test
   fun `produces all combos and orders and prioritized first`() {
     val spec = CombinationSpec<Long>(
       mapOf(
-        "k1" to listOf(12, 14),
-        "k2" to listOf(25, 22, 28, 27),
-        "k3" to listOf(39, 33, 31),
+        "k1" to sequenceOf(12, 14),
+        "k2" to sequenceOf(25, 22, 28, 27),
+        "k3" to sequenceOf(39, 33, 31),
       ),
       50,
     )
-    assertThat(spec.selectedCombinations).containsExactly(
+    assertThat(spec.selectedCombinations.toList()).containsExactly(
       // Prioritized first
       mapOf("k1" to 12, "k2" to 25, "k3" to 39),
       mapOf("k1" to 14, "k2" to 22, "k3" to 33),
@@ -72,13 +72,13 @@ class CombinationSpecTest {
   fun `restricts combos when count too high and orders with prioritized first`() {
     val spec = CombinationSpec<Long>(
       mapOf(
-        "k1" to listOf(12, 14),
-        "k2" to listOf(25, 22, 28, 27),
-        "k3" to listOf(39, 33, 31),
+        "k1" to sequenceOf(12, 14),
+        "k2" to sequenceOf(25, 22, 28, 27),
+        "k3" to sequenceOf(39, 33, 31),
       ),
       23,
     )
-    assertThat(spec.selectedCombinations).containsExactly(
+    assertThat(spec.selectedCombinations.toList()).containsExactly(
       // Prioritized first
       mapOf("k1" to 12, "k2" to 25, "k3" to 39),
       mapOf("k1" to 14, "k2" to 22, "k3" to 33),
@@ -117,13 +117,13 @@ class CombinationSpecTest {
   fun `restricts combos even when prioritized count is too high`() {
     val spec = CombinationSpec<Long>(
       mapOf(
-        "k1" to listOf(12, 14),
-        "k2" to listOf(25, 22, 28, 27),
-        "k3" to listOf(39, 33, 31),
+        "k1" to sequenceOf(12, 14),
+        "k2" to sequenceOf(25, 22, 28, 27),
+        "k3" to sequenceOf(39, 33, 31),
       ),
       3,
     )
-    assertThat(spec.selectedCombinations).containsExactly(
+    assertThat(spec.selectedCombinations.toList()).containsExactly(
       // Prioritized first
       mapOf("k1" to 12, "k2" to 25, "k3" to 39),
       mapOf("k1" to 14, "k2" to 22, "k3" to 33),

--- a/core/src/test/kotlin/in/specmatic/core/pattern/CombinationSpecTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/CombinationSpecTest.kt
@@ -123,7 +123,7 @@ class CombinationSpecTest {
       ),
       3,
     )
-    assertThat(spec.selectedCombinations.toList()).containsExactly(
+    assertThat(spec.selectedCombinations.toList()).withFailMessage(spec.selectedCombinations.toString()).containsExactly(
       // Prioritized first
       mapOf("k1" to 12, "k2" to 25, "k3" to 39),
       mapOf("k1" to 14, "k2" to 22, "k3" to 33),

--- a/core/src/test/kotlin/in/specmatic/core/pattern/CsvPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/CsvPatternTest.kt
@@ -130,6 +130,7 @@ paths:
         contract.executeTests(object: TestExecutor {
             override fun execute(request: HttpRequest): HttpResponse {
                 count ++
+                println(request.toLogString())
                 params.addAll(request.queryParams.keys)
                 return HttpResponse.OK
             }
@@ -138,6 +139,9 @@ paths:
             }
 
         })
+
+        println(count)
+        println(params)
 
         assertThat(params).isEqualTo(listOf("data"))
         assertThat(count).isEqualTo(2)

--- a/core/src/test/kotlin/in/specmatic/core/pattern/CsvPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/CsvPatternTest.kt
@@ -50,13 +50,13 @@ internal class CsvPatternTest {
 
     @Test
     fun `generates values for negative tests`() {
-        val negativeTypes = CsvPattern(NumberPattern()).negativeBasedOn(Row(), Resolver())
+        val negativeTypes = CsvPattern(NumberPattern()).negativeBasedOn(Row(), Resolver()).toList()
         assertThat(negativeTypes).hasSize(3)
     }
 
     @Test
     fun `generates values for tests`() {
-        assertThat(CsvPattern(NumberPattern()).newBasedOn(Row(), Resolver())).satisfies(Consumer {
+        assertThat(CsvPattern(NumberPattern()).newBasedOn(Row(), Resolver()).toList()).satisfies(Consumer {
             assertThat(it).hasSize(1)
             assertThat(it.first()).isInstanceOf(CsvPattern::class.java)
             assertThat(it.first().pattern).isInstanceOf(NumberPattern::class.java)
@@ -65,7 +65,7 @@ internal class CsvPatternTest {
 
     @Test
     fun `generates values for backward compatibility check`() {
-        assertThat(CsvPattern(NumberPattern()).newBasedOn(Resolver())).satisfies(Consumer {
+        assertThat(CsvPattern(NumberPattern()).newBasedOn(Resolver()).toList()).satisfies(Consumer {
             assertThat(it).hasSize(1)
             assertThat(it.first()).isInstanceOf(CsvPattern::class.java)
             assertThat(it.first().pattern).isInstanceOf(NumberPattern::class.java)
@@ -224,7 +224,7 @@ paths:
     @Test
     @Tag(GENERATION)
     fun `negative patterns should be generated`() {
-        val result = StringPattern().negativeBasedOn(Row(), Resolver())
+        val result = StringPattern().negativeBasedOn(Row(), Resolver()).toList()
         assertThat(result.map { it.typeName }).containsExactlyInAnyOrder(
             "null",
             "number",

--- a/core/src/test/kotlin/in/specmatic/core/pattern/DatePatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/DatePatternTest.kt
@@ -42,7 +42,7 @@ internal class DatePatternTest {
 
     @Test
     fun `should return itself when generating a new pattern based on a row`() {
-        val datePatterns = DatePattern.newBasedOn(Row(), Resolver())
+        val datePatterns = DatePattern.newBasedOn(Row(), Resolver()).toList()
         assertThat(datePatterns.size).isEqualTo(1)
         assertThat(datePatterns.first() ).isEqualTo(DatePattern)
     }
@@ -60,7 +60,7 @@ internal class DatePatternTest {
     @Test
     @Tag(GENERATION)
     fun `negative patterns should be generated`() {
-        val result = BooleanPattern().negativeBasedOn(Row(), Resolver())
+        val result = BooleanPattern().negativeBasedOn(Row(), Resolver()).toList()
         assertThat(result.map { it.typeName }).containsExactlyInAnyOrder(
             "null"
         )

--- a/core/src/test/kotlin/in/specmatic/core/pattern/DateTimePatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/DateTimePatternTest.kt
@@ -41,7 +41,7 @@ internal class DateTimePatternTest {
 
     @Test
     fun `should return itself when generating a new pattern based on a row`() {
-        val datePatterns = DateTimePattern.newBasedOn(Row(), Resolver())
+        val datePatterns = DateTimePattern.newBasedOn(Row(), Resolver()).toList()
         assertThat(datePatterns.size).isEqualTo(1)
         assertThat(datePatterns.first()).isEqualTo(DateTimePattern)
     }
@@ -59,7 +59,7 @@ internal class DateTimePatternTest {
     @Test
     @Tag(GENERATION)
     fun `negative patterns should be generated`() {
-        val result = BooleanPattern().negativeBasedOn(Row(), Resolver())
+        val result = BooleanPattern().negativeBasedOn(Row(), Resolver()).toList()
         assertThat(result.map { it.typeName }).containsExactlyInAnyOrder(
             "null"
         )

--- a/core/src/test/kotlin/in/specmatic/core/pattern/DeferredPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/DeferredPatternTest.kt
@@ -25,7 +25,7 @@ internal class DeferredPatternTest {
     @Test
     @Tag(GENERATION)
     fun `negative patterns should be generated`() {
-        val result = DeferredPattern("(string)").negativeBasedOn(Row(), Resolver())
+        val result = DeferredPattern("(string)").negativeBasedOn(Row(), Resolver()).toList()
         assertThat(result.map { it.typeName }).containsExactlyInAnyOrder(
             "null",
             "number",

--- a/core/src/test/kotlin/in/specmatic/core/pattern/DictionaryPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/DictionaryPatternTest.kt
@@ -48,7 +48,7 @@ internal class DictionaryPatternTest {
         val jsonType = toTabularPattern(mapOf("data" to dictionaryType))
 
         val example = Row(listOf("data"), listOf("""{"1": "one"}"""))
-        val newJsonTypes = jsonType.newBasedOn(example, Resolver())
+        val newJsonTypes = jsonType.newBasedOn(example, Resolver()).toList()
 
         assertThat(newJsonTypes).hasSize(1)
 

--- a/core/src/test/kotlin/in/specmatic/core/pattern/EmailPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/EmailPatternTest.kt
@@ -12,7 +12,7 @@ class EmailPatternTest {
     @Test
     @Tag(GENERATION)
     fun `negative values should be generated`() {
-        val result = EmailPattern().negativeBasedOn(Row(), Resolver())
+        val result = EmailPattern().negativeBasedOn(Row(), Resolver()).toList()
         assertThat(result.map { it.typeName }).containsExactlyInAnyOrder(
             "null",
             "number",

--- a/core/src/test/kotlin/in/specmatic/core/pattern/EnumPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/EnumPatternTest.kt
@@ -74,7 +74,7 @@ class EnumPatternTest {
         fun `it should generate new patterns for all enum values when the row is empty`() {
             val enum = EnumPattern(listOf(StringValue("01"), StringValue("02")))
 
-            val newPatterns = enum.newBasedOn(Row(), Resolver())
+            val newPatterns = enum.newBasedOn(Row(), Resolver()).toList()
 
             assertThat(newPatterns).containsExactlyInAnyOrder(
                 ExactValuePattern(StringValue("01")),
@@ -88,7 +88,7 @@ class EnumPatternTest {
 
             val newPatterns = jsonPattern.newBasedOn(Row(listOf("type"), values = listOf("01")), Resolver())
 
-            val values = newPatterns.map { it.generate(Resolver()) }
+            val values = newPatterns.map { it.generate(Resolver()) }.toList()
 
             val strings = values.map { it.jsonObject.getValue("type") as StringValue }
 
@@ -100,7 +100,7 @@ class EnumPatternTest {
         @Test
         fun `it should use the inline example if present`() {
             val enum = EnumPattern(listOf(StringValue("01"), StringValue("02")), example = "01")
-            val patterns = enum.newBasedOn(Row(), Resolver(defaultExampleResolver = UseDefaultExample))
+            val patterns = enum.newBasedOn(Row(), Resolver(defaultExampleResolver = UseDefaultExample)).toList()
 
             assertThat(patterns).containsExactly(
                 ExactValuePattern(StringValue("01"))
@@ -112,7 +112,7 @@ class EnumPatternTest {
         fun `it should generate negative values for what is in the row`() {
             val jsonPattern = EnumPattern(listOf(StringValue("01"), StringValue("02")))
 
-            val newPatterns = jsonPattern.negativeBasedOn(Row(), Resolver())
+            val newPatterns = jsonPattern.negativeBasedOn(Row(), Resolver()).toList()
 
             val negativeTypes = newPatterns.map { it.typeName }
             println(negativeTypes)

--- a/core/src/test/kotlin/in/specmatic/core/pattern/ExactValuePatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/ExactValuePatternTest.kt
@@ -19,7 +19,7 @@ internal class ExactValuePatternTest {
     @Test
     @Tag(GENERATION)
     fun `negative patterns should be generated`() {
-        val result = ExactValuePattern(StringValue("data")).negativeBasedOn(Row(), Resolver())
+        val result = ExactValuePattern(StringValue("data")).negativeBasedOn(Row(), Resolver()).toList()
         assertThat(result.map { it.typeName }).containsExactlyInAnyOrder(
             "null",
             "number",

--- a/core/src/test/kotlin/in/specmatic/core/pattern/JSONArrayPatternKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/JSONArrayPatternKtTest.kt
@@ -24,7 +24,7 @@ internal class JSONArrayPatternKtTest {
     @Nested
     @DisplayName("Given [optional, required]")
     inner class FirstCompulsorySecondRequired {
-        private val combinations = allOrNothingListCombinations(listOf(listOf(StringPattern(), null), listOf(NumberPattern()))).toList()
+        private val combinations = allOrNothingListCombinations(listOf(sequenceOf(StringPattern(), null), sequenceOf(NumberPattern()))).toList()
 
         @Test
         fun `two results should be generated`() {
@@ -45,7 +45,14 @@ internal class JSONArrayPatternKtTest {
     @Nested
     @DisplayName("Given [optional, required, optional, required]")
     inner class OneCompulsoryAndOneRequired {
-        private val combinations = allOrNothingListCombinations(listOf(listOf(StringPattern(), null), listOf(NumberPattern()), listOf(BooleanPattern(), null), listOf(DateTimePattern))).toList()
+        private val combinations: List<List<Pattern>> = allOrNothingListCombinations(
+            listOf(
+                sequenceOf(StringPattern(), null),
+                sequenceOf(NumberPattern()),
+                sequenceOf(BooleanPattern(), null),
+                sequenceOf(DateTimePattern)
+            )
+        ).toList()
 
         @Test
         fun `two results should be generated`() {

--- a/core/src/test/kotlin/in/specmatic/core/pattern/JSONArrayPatternKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/JSONArrayPatternKtTest.kt
@@ -12,7 +12,7 @@ internal class JSONArrayPatternKtTest {
     fun `when there is one nullable in a list two array types should be generated`() {
         val arrayType = parsedPattern("""["(number?)", "(number)"]""")
 
-        val patterns = arrayType.newBasedOn(Row(), Resolver()).map { it as JSONArrayPattern }
+        val patterns = arrayType.newBasedOn(Row(), Resolver()).map { it as JSONArrayPattern }.toList()
         assertThat(patterns).hasSize(2)
         assertThat(patterns).contains(JSONArrayPattern(listOf<Pattern>(NullPattern, NumberPattern())))
         assertThat(patterns).contains(JSONArrayPattern(listOf<Pattern>(NullPattern, NumberPattern())))
@@ -24,7 +24,7 @@ internal class JSONArrayPatternKtTest {
     @Nested
     @DisplayName("Given [optional, required]")
     inner class FirstCompulsorySecondRequired {
-        private val combinations = allOrNothingListCombinations(listOf(listOf(StringPattern(), null), listOf(NumberPattern())))
+        private val combinations = allOrNothingListCombinations(listOf(listOf(StringPattern(), null), listOf(NumberPattern()))).toList()
 
         @Test
         fun `two results should be generated`() {
@@ -45,7 +45,7 @@ internal class JSONArrayPatternKtTest {
     @Nested
     @DisplayName("Given [optional, required, optional, required]")
     inner class OneCompulsoryAndOneRequired {
-        private val combinations = allOrNothingListCombinations(listOf(listOf(StringPattern(), null), listOf(NumberPattern()), listOf(BooleanPattern(), null), listOf(DateTimePattern)))
+        private val combinations = allOrNothingListCombinations(listOf(listOf(StringPattern(), null), listOf(NumberPattern()), listOf(BooleanPattern(), null), listOf(DateTimePattern))).toList()
 
         @Test
         fun `two results should be generated`() {

--- a/core/src/test/kotlin/in/specmatic/core/pattern/JSONObjectPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/JSONObjectPatternTest.kt
@@ -420,7 +420,7 @@ internal class JSONObjectPatternTest {
 
             System.setProperty("MAX_TEST_REQUEST_COMBINATIONS", "64")
             val newPatterns = try {
-                objPattern.newBasedOn(Row(), resolver)
+                objPattern.newBasedOn(Row(), resolver).toList()
             } finally {
                 System.clearProperty("MAX_TEST_REQUEST_COMBINATIONS")
             }
@@ -457,7 +457,7 @@ internal class JSONObjectPatternTest {
 
             val personPattern = parsedPattern("""{"name": "(string)", "address?": "(Address)"}""")
 
-            val combinations = personPattern.newBasedOn(resolver)
+            val combinations = personPattern.newBasedOn(resolver).toList()
 
             assertThat(combinations.size).isEqualTo(3)
 
@@ -478,7 +478,7 @@ internal class JSONObjectPatternTest {
 
             val personPattern = parsedPattern("""{"name": "(string)", "address?": "(Address)"}""")
 
-            val combinations = personPattern.newBasedOn(resolver)
+            val combinations = personPattern.newBasedOn(resolver).toList()
 
             assertThat(combinations.size).isEqualTo(4)
 
@@ -502,7 +502,7 @@ internal class JSONObjectPatternTest {
 
             val personPattern = parsedPattern("""{"name": "(string)", "address?": "(Address?)"}""")
 
-            val combinations = personPattern.newBasedOn(resolver)
+            val combinations = personPattern.newBasedOn(resolver).toList()
 
             assertThat(combinations.size).isEqualTo(5)
 
@@ -535,7 +535,7 @@ internal class JSONObjectPatternTest {
                 maxProperties = 3
             )
 
-            val newPatterns: List<JSONObjectPattern> = pattern.newBasedOn(Row(), Resolver())
+            val newPatterns: List<JSONObjectPattern> = pattern.newBasedOn(Row(), Resolver()).toList()
 
             assertThat(newPatterns).allSatisfy {
                 assertThat(it.pattern.keys).hasSizeGreaterThanOrEqualTo(2)
@@ -632,7 +632,7 @@ internal class JSONObjectPatternTest {
                 )
             )
 
-            val negativePatterns: List<Pattern> = pattern.negativeBasedOn(Row(), Resolver())
+            val negativePatterns: List<Pattern> = pattern.negativeBasedOn(Row(), Resolver()).toList()
 
             val jsonInternalPatterns = negativePatterns.filterIsInstance<JSONObjectPattern>().map { it.pattern }
 

--- a/core/src/test/kotlin/in/specmatic/core/pattern/ListPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/ListPatternTest.kt
@@ -103,7 +103,7 @@ Feature: Recursive test
     @Tag(GENERATION)
     @Test
     fun `negative pattern generation`() {
-        val negativePatterns = ListPattern(StringPattern()).negativeBasedOn(Row(), Resolver())
+        val negativePatterns = ListPattern(StringPattern()).negativeBasedOn(Row(), Resolver()).toList()
         assertThat(negativePatterns.map { it.typeName }).containsExactlyInAnyOrder(
             "null"
         )

--- a/core/src/test/kotlin/in/specmatic/core/pattern/NegativeNonStringlyPatternsTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/NegativeNonStringlyPatternsTest.kt
@@ -12,7 +12,7 @@ class NegativeNonStringlyPatternsTest {
         val resolver = Resolver()
         val row = Row()
 
-        val negativePatterns: List<Map<String, Pattern>> = NegativeNonStringlyPatterns().negativeBasedOn(patternMap, row, resolver)
+        val negativePatterns: List<Map<String, Pattern>> = NegativeNonStringlyPatterns().negativeBasedOn(patternMap, row, resolver).toList()
 
         assertThat(negativePatterns).isEmpty()
 
@@ -24,7 +24,7 @@ class NegativeNonStringlyPatternsTest {
         val resolver = Resolver()
         val row = Row()
 
-        val negativePatterns: List<Map<String, Pattern>> = NegativeNonStringlyPatterns().negativeBasedOn(patternMap, row, resolver)
+        val negativePatterns: List<Map<String, Pattern>> = NegativeNonStringlyPatterns().negativeBasedOn(patternMap, row, resolver).toList()
 
         assertThat(negativePatterns).containsExactlyInAnyOrder(
             mapOf("key" to BooleanPattern()),
@@ -38,7 +38,7 @@ class NegativeNonStringlyPatternsTest {
         val resolver = Resolver()
         val row = Row()
 
-        val negativePatterns: List<Map<String, Pattern>> = NegativeNonStringlyPatterns().negativeBasedOn(patternMap, row, resolver)
+        val negativePatterns: List<Map<String, Pattern>> = NegativeNonStringlyPatterns().negativeBasedOn(patternMap, row, resolver).toList()
         assertThat(negativePatterns).containsExactlyInAnyOrder(
             mapOf("key" to NumberPattern()),
             mapOf("key" to BooleanPattern())
@@ -52,7 +52,7 @@ class NegativeNonStringlyPatternsTest {
         val resolver = Resolver()
         val row = Row()
 
-        val negativePatterns: List<Map<String, Pattern>> = NegativeNonStringlyPatterns().negativeBasedOn(patternMap, row, resolver)
+        val negativePatterns: List<Map<String, Pattern>> = NegativeNonStringlyPatterns().negativeBasedOn(patternMap, row, resolver).toList()
 
         assertThat(negativePatterns).containsExactlyInAnyOrder(
             mapOf("key1" to BooleanPattern(), "key2" to StringPattern()),

--- a/core/src/test/kotlin/in/specmatic/core/pattern/NullPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/NullPatternTest.kt
@@ -31,6 +31,6 @@ internal class NullPatternTest {
 
     @Test
     fun `should create a new array of patterns containing itself`() {
-        assertEquals(listOf(NullPattern), NullPattern.newBasedOn(Row(), Resolver()))
+        assertEquals(listOf(NullPattern), NullPattern.newBasedOn(Row(), Resolver()).toList())
     }
 }

--- a/core/src/test/kotlin/in/specmatic/core/pattern/NumberPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/NumberPatternTest.kt
@@ -76,7 +76,7 @@ internal class NumberPatternTest {
     @Test
     @Tag(GENERATION)
     fun `negative values should be generated`() {
-        val result = NumberPattern().negativeBasedOn(Row(), Resolver())
+        val result = NumberPattern().negativeBasedOn(Row(), Resolver()).toList()
         assertThat(result.map { it.typeName }).containsExactlyInAnyOrder(
             "null",
             "string",

--- a/core/src/test/kotlin/in/specmatic/core/pattern/PatternInStringPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/PatternInStringPatternTest.kt
@@ -38,7 +38,7 @@ internal class PatternInStringPatternTest {
 
     @Test
     fun `should generate a list of patterns based on a Row`() {
-        val patterns = PatternInStringPattern(NumberPattern()).newBasedOn(Row(), Resolver())
+        val patterns = PatternInStringPattern(NumberPattern()).newBasedOn(Row(), Resolver()).toList()
 
         assertThat(patterns).hasSize(1)
 
@@ -93,7 +93,7 @@ internal class PatternInStringPatternTest {
     @Test
     @Tag(GENERATION)
     fun `negative values should be generated`() {
-        val result = PatternInStringPattern().negativeBasedOn(Row(), Resolver())
+        val result = PatternInStringPattern().negativeBasedOn(Row(), Resolver()).toList()
         assertThat(result.map { it.typeName }).containsExactlyInAnyOrder(
             "null"
         )

--- a/core/src/test/kotlin/in/specmatic/core/pattern/StringPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/StringPatternTest.kt
@@ -133,7 +133,7 @@ internal class StringPatternTest {
     @Test
     @Tag(GENERATION)
     fun `negative values should be generated`() {
-        val result = StringPattern().negativeBasedOn(Row(), Resolver())
+        val result = StringPattern().negativeBasedOn(Row(), Resolver()).toList()
         assertThat(result.map { it.typeName }).containsExactlyInAnyOrder(
             "null",
             "number",

--- a/core/src/test/kotlin/in/specmatic/core/pattern/TabularPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/TabularPatternTest.kt
@@ -271,7 +271,7 @@ Given request-body
 
         val patternWithNullValue = rowsToTabularPattern(scenario.steps[0].dataTable.rows)
         val example = Row(listOf("nothing"), listOf("(null)"))
-        val newPatterns = patternWithNullValue.newBasedOn(example, Resolver())
+        val newPatterns = patternWithNullValue.newBasedOn(example, Resolver()).toList()
 
         assertEquals(1, newPatterns.size)
 
@@ -296,7 +296,7 @@ Given request-body
 
         val patternWithNullValue = rowsToTabularPattern(scenario.steps[0].dataTable.rows)
         val example = Row(listOf("nothing"), listOf("(null)"))
-        assertThrows<ContractException> { patternWithNullValue.newBasedOn(example, Resolver()) }
+        assertThrows<ContractException> { patternWithNullValue.newBasedOn(example, Resolver()).toList() }
     }
 
     @Test

--- a/core/src/test/kotlin/in/specmatic/core/pattern/URLPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/URLPatternTest.kt
@@ -37,7 +37,7 @@ internal class URLPatternTest {
     @Test
     fun `should return itself when generating a new url based on a row`() {
         val pattern = URLPattern(URLScheme.HTTPS)
-        val newPatterns = pattern.newBasedOn(Row(), Resolver())
+        val newPatterns = pattern.newBasedOn(Row(), Resolver()).toList()
 
         assertEquals(pattern, newPatterns.first())
         assertEquals(1, newPatterns.size)

--- a/core/src/test/kotlin/in/specmatic/core/pattern/UUIDPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/UUIDPatternTest.kt
@@ -43,7 +43,7 @@ internal class UUIDPatternTest {
 
     @Test
     fun `should return itself when generating a new pattern based on a row`() {
-        val uuidPatterns = UUIDPattern.newBasedOn(Row(), Resolver())
+        val uuidPatterns = UUIDPattern.newBasedOn(Row(), Resolver()).toList()
         assertEquals(1, uuidPatterns.size)
         assertEquals(UUIDPattern, uuidPatterns.first())
     }
@@ -60,7 +60,7 @@ internal class UUIDPatternTest {
     @Test
     @Tag(GENERATION)
     fun `negative values should be generated`() {
-        val result = UUIDPattern.negativeBasedOn(Row(), Resolver())
+        val result = UUIDPattern.negativeBasedOn(Row(), Resolver()).toList()
         assertThat(result.map { it.typeName }).containsExactlyInAnyOrder(
             "null",
         )

--- a/core/src/test/kotlin/in/specmatic/core/pattern/XMLPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/XMLPatternTest.kt
@@ -237,7 +237,7 @@ internal class XMLPatternTest {
 
             val resolver = Resolver(newPatterns = mapOf("(Address)" to addressType))
 
-            val testTypes = personType.newBasedOn(resolver).map { it.toPrettyString() }
+            val testTypes = personType.newBasedOn(resolver).map { it.toPrettyString() }.toList()
 
             for (type in testTypes) {
                 println(type)
@@ -281,7 +281,7 @@ internal class XMLPatternTest {
 
             val resolver = Resolver(newPatterns = mapOf("(Address)" to addressType))
 
-            val testTypes = personType.newBasedOn(resolver).map { it.toPrettyString() }
+            val testTypes = personType.newBasedOn(resolver).map { it.toPrettyString() }.toList()
 
             for (type in testTypes) {
                 println(type)
@@ -530,7 +530,7 @@ internal class XMLPatternTest {
             val xmlType = XMLPattern("<data><name>(string)</name><age>(number)</age></data>")
             val example = Row(listOf("name", "age"), listOf("John Doe", "10"))
 
-            val newTypes = xmlType.newBasedOn(example, Resolver())
+            val newTypes = xmlType.newBasedOn(example, Resolver()).toList()
 
             val xmlNode = newTypes[0].generate(Resolver())
             assertThat(xmlNode.toStringLiteral()).isEqualTo("<data><name>John Doe</name><age>10</age></data>")
@@ -541,7 +541,7 @@ internal class XMLPatternTest {
             val xmlType = XMLPattern("""<data name="(string)" age="(number)"></data>""")
             val example = Row(listOf("name", "age"), listOf("John Doe", "10"))
 
-            val newTypes = xmlType.newBasedOn(example, Resolver())
+            val newTypes = xmlType.newBasedOn(example, Resolver()).toList()
 
             val xmlNode = newTypes[0].generate(Resolver())
             assertThat(xmlNode).isEqualTo(toXMLNode("""<data age="10" name="John Doe"/>"""))
@@ -552,7 +552,7 @@ internal class XMLPatternTest {
             val xmlType = XMLPattern("""<data name="(string?)" age="(number?)"></data>""")
             val example = Row(listOf("name", "age"), listOf("John Doe", "10"))
 
-            val newTypes = xmlType.newBasedOn(example, Resolver())
+            val newTypes = xmlType.newBasedOn(example, Resolver()).toList()
 
             val xmlNode = newTypes[0].generate(Resolver())
             assertThat(xmlNode).isEqualTo(toXMLNode("""<data age="10" name="John Doe"/>"""))
@@ -563,7 +563,7 @@ internal class XMLPatternTest {
             val xmlType = XMLPattern("""<data name="(string?)" age="(number?)"></data>""")
             val example = Row(listOf("name", "age"), listOf("", ""))
 
-            val newTypes = xmlType.newBasedOn(example, Resolver())
+            val newTypes = xmlType.newBasedOn(example, Resolver()).toList()
             assertThat(newTypes.size).isOne()
 
             val xmlNode = newTypes[0].generate(Resolver())
@@ -575,7 +575,7 @@ internal class XMLPatternTest {
             val type = XMLPattern("""<number val$XML_ATTR_OPTIONAL_SUFFIX="(number)"></number>""")
             val example = Row(listOf("val"), listOf("10"))
 
-            val newTypes = type.newBasedOn(example, Resolver())
+            val newTypes = type.newBasedOn(example, Resolver()).toList()
             assertThat(newTypes.size).isOne()
 
             val xmlNode = newTypes[0].generate(Resolver())
@@ -586,7 +586,7 @@ internal class XMLPatternTest {
         fun `optional attribute without examples should generate two tests`() {
             val type = XMLPattern("""<number val$XML_ATTR_OPTIONAL_SUFFIX="(number)"></number>""")
 
-            val newTypes = type.newBasedOn(Row(), Resolver())
+            val newTypes = type.newBasedOn(Row(), Resolver()).toList()
             assertThat(newTypes.size).isEqualTo(2)
 
             val flags = mutableListOf<String>()
@@ -607,7 +607,7 @@ internal class XMLPatternTest {
         fun `sanity test that double optional gets handled right`() {
             val type = XMLPattern("""<number val$XML_ATTR_OPTIONAL_SUFFIX$XML_ATTR_OPTIONAL_SUFFIX="(number)"></number>""")
 
-            val newTypes = type.newBasedOn(Row(), Resolver())
+            val newTypes = type.newBasedOn(Row(), Resolver()).toList()
             assertThat(newTypes.size).isEqualTo(2)
 
             val flags = mutableListOf<String>()
@@ -632,7 +632,7 @@ internal class XMLPatternTest {
             val xmlType = XMLPattern("<data><name>(string?)</name><age>(number?)</age></data>")
             val example = Row(listOf("name", "age"), listOf("John Doe", "10"))
 
-            val newTypes = xmlType.newBasedOn(example, Resolver())
+            val newTypes = xmlType.newBasedOn(example, Resolver()).toList()
 
             val xmlNode = newTypes[0].generate(Resolver())
             assertThat(xmlNode.toStringLiteral()).isEqualTo("<data><name>John Doe</name><age>10</age></data>")
@@ -643,7 +643,7 @@ internal class XMLPatternTest {
             val xmlType = XMLPattern("<data><name>(string?)</name><age>(number?)</age></data>")
             val example = Row(listOf("name", "age"), listOf("John Doe", "ABC"))
 
-            assertThatThrownBy { xmlType.newBasedOn(example, Resolver()) }.isInstanceOf(ContractException::class.java)
+            assertThatThrownBy { xmlType.newBasedOn(example, Resolver()).toList() }.isInstanceOf(ContractException::class.java)
         }
     }
 
@@ -732,7 +732,7 @@ internal class XMLPatternTest {
         @Test
         fun `xml with optional nodes generates 2 samples`() {
             val nameType = XMLPattern("<name><nameid $isOptional>(number)</nameid></name>")
-            val newTypes = nameType.newBasedOn(Row(), Resolver())
+            val newTypes = nameType.newBasedOn(Row(), Resolver()).toList()
 
             assertThat(newTypes.size).isEqualTo(2)
 
@@ -758,7 +758,7 @@ internal class XMLPatternTest {
         @Test
         fun `xml with optional node generates one sample with the node and one without`() {
             val nameType = XMLPattern("<name><nameid $isOptional>(number)</nameid></name>")
-            val newValues = nameType.newBasedOn(Row(), Resolver()).map { it.generate(Resolver()) }
+            val newValues = nameType.newBasedOn(Row(), Resolver()).map { it.generate(Resolver()) }.toList()
 
             assertThat(newValues).anySatisfy(Consumer {
                 assertThat(it.name).isEqualTo("name")
@@ -781,7 +781,7 @@ internal class XMLPatternTest {
             val nameIdType = XMLPattern("<nameid>(number)</nameid>")
             val resolver = Resolver(newPatterns = mapOf("(Nameid)" to nameIdType))
 
-            val newValues = nameType.newBasedOn(Row(), resolver).map { it.generate(resolver) }
+            val newValues = nameType.newBasedOn(Row(), resolver).map { it.generate(resolver) }.toList()
 
             assertThat(newValues).anySatisfy(Consumer {
                 assertThat(it.name).isEqualTo("name")
@@ -804,7 +804,7 @@ internal class XMLPatternTest {
             val nameIdType = XMLPattern("<nameid>(number)</nameid>")
             val resolver = Resolver(newPatterns = mapOf("(Nameid)" to nameIdType))
             val row = Row(listOf("nameid"), listOf("10"))
-            val newValues = nameType.newBasedOn(row, resolver).map { it.generate(resolver) }
+            val newValues = nameType.newBasedOn(row, resolver).map { it.generate(resolver) }.toList()
 
             assertThat(newValues.isNotEmpty())
 
@@ -840,7 +840,7 @@ internal class XMLPatternTest {
         @Test
         fun `xml with a node that occurs multiple times generates a single sample`() {
             val nameType = XMLPattern("<name><title $occursMultipleTimes>(number)</title></name>")
-            val newTypes = nameType.newBasedOn(Row(), Resolver())
+            val newTypes = nameType.newBasedOn(Row(), Resolver()).toList()
 
             assertThat(newTypes.size).isOne
         }
@@ -848,7 +848,7 @@ internal class XMLPatternTest {
         @Test
         fun `xml with a node that occurs multiple times generates multiple nodes`() {
             val nameType = XMLPattern("<name><title $occursMultipleTimes>(number)</title></name>")
-            val newValues = nameType.newBasedOn(Row(), Resolver()).map { it.generate(Resolver()) }
+            val newValues = nameType.newBasedOn(Row(), Resolver()).map { it.generate(Resolver()) }.toList()
 
             assertThat(newValues.isNotEmpty())
 
@@ -867,7 +867,7 @@ internal class XMLPatternTest {
             val nameType = XMLPattern("<name><nameid $occursMultipleTimes $TYPE_ATTRIBUTE_NAME=\"Nameid\" /></name>")
             val nameIdType = XMLPattern("<nameid>(number)</nameid>")
             val resolver = Resolver(newPatterns = mapOf("(Nameid)" to nameIdType))
-            val newValues = nameType.newBasedOn(Row(), resolver).map { it.generate(resolver) }
+            val newValues = nameType.newBasedOn(Row(), resolver).map { it.generate(resolver) }.toList()
 
             assertThat(newValues.isNotEmpty())
 
@@ -887,7 +887,7 @@ internal class XMLPatternTest {
             val nameIdType = XMLPattern("<nameid>(number)</nameid>")
             val resolver = Resolver(newPatterns = mapOf("(Nameid)" to nameIdType))
             val row = Row(listOf("nameid"), listOf("10"))
-            val newValues = nameType.newBasedOn(row, resolver).map { it.generate(resolver) }
+            val newValues = nameType.newBasedOn(row, resolver).map { it.generate(resolver) }.toList()
 
             assertThat(newValues.isNotEmpty())
 

--- a/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
@@ -29,6 +29,8 @@ import java.net.URI
 import java.net.URISyntaxException
 import java.net.URL
 import java.util.*
+import java.util.stream.Stream
+import kotlin.streams.asStream
 
 @Serializable
 data class API(val method: String, val path: String)
@@ -158,15 +160,15 @@ open class SpecmaticJUnitSupport {
         return envConfig
     }
 
-    private fun loadExceptionAsTestError(e: Throwable): Collection<DynamicTest> {
-        return listOf(DynamicTest.dynamicTest("Load Error") {
+    private fun loadExceptionAsTestError(e: Throwable): Stream<DynamicTest> {
+        return sequenceOf(DynamicTest.dynamicTest("Load Error") {
             logger.log(e)
             ResultAssert.assertThat(Result.Failure(exceptionCauseMessage(e))).isSuccess()
-        })
+        }).asStream()
     }
 
     @TestFactory
-    fun contractTest(): Collection<DynamicTest> {
+    fun contractTest(): Stream<DynamicTest> {
         val contractPaths = System.getProperty(CONTRACT_PATHS)
         val givenWorkingDirectory = System.getProperty(WORKING_DIRECTORY)
         val filterName: String? = System.getProperty(FILTER_NAME_PROPERTY) ?: System.getenv(FILTER_NAME_ENVIRONMENT_VARIABLE)
@@ -287,7 +289,7 @@ open class SpecmaticJUnitSupport {
                     }
                 }
             }
-        }.toList()
+        }.asStream()
     }
 
     fun constructTestBaseURL(): String {

--- a/junit5-support/src/main/kotlin/in/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
@@ -14,7 +14,7 @@ import kotlin.math.roundToInt
 
 class OpenApiCoverageReportInput(
     private var configFilePath:String,
-    private val testResultRecords: MutableList<TestResultRecord> = mutableListOf(),
+    internal val testResultRecords: MutableList<TestResultRecord> = mutableListOf(),
     private val applicationAPIs: MutableList<API> = mutableListOf(),
     private val excludedAPIs: MutableList<String> = mutableListOf(),
     private val allEndpoints: MutableList<Endpoint> = mutableListOf(),

--- a/junit5-support/src/test/kotlin/in/specmatic/test/SpecmaticJunitSupportTest.kt
+++ b/junit5-support/src/test/kotlin/in/specmatic/test/SpecmaticJunitSupportTest.kt
@@ -24,7 +24,7 @@ class SpecmaticJunitSupportTest {
 
     @Test
     fun `should retain open api path parameter convention for parameterized endpoints`() {
-        val result: Pair<List<ContractTest>, List<Endpoint>> = SpecmaticJUnitSupport().loadTestScenarios(
+        val result: Pair<Sequence<ContractTest>, List<Endpoint>> = SpecmaticJUnitSupport().loadTestScenarios(
             "./src/test/resources/spec_with_parameterized_paths.yaml",
             "",
             "",

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=1.2.22
+version=1.2.22-STREAMING


### PR DESCRIPTION
**What**:

Contract tests are now generated as a stream, instead of all being generated before the tests run.

Due to this:

1. Tests start running immediately, even for complex APIs, where previously it would have calculated all the tests before-hand.
2. Specmatic used to throw a JVM heap error even before running any tests for complex specifications, because it use to calculate all the tests as a first step before running the first one, but instead now the tests will be pulled from the stream and executed.

**How**:

1. All newBasedOn methods now return a Sequence instead of List.
2. Logic which used the length of a list has been updated to do without, as the length of a Sequence cannot be known without evaluating all elements of the Sequence, thus defeating the purpose of using Sequences.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

