### PR TITLE
Improved the error message for response schema

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -498,7 +498,7 @@ class OpenApiSpecification(
             if(!isNumber(status) && status != "default")
                 throw ContractException("Response status codes are expected to be numbers, but \"$status\" was found")
 
-            attempt(breadCrumb = "200") { openAPIResponseToSpecmatic(response, status, headersMap) }
+            attempt(breadCrumb = status) { openAPIResponseToSpecmatic(response, status, headersMap) }
         }.flatten()
     }
 

--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -294,7 +294,7 @@ class OpenApiSpecification(
 
                     val requestBody: RequestBody? = resolveRequestBody(operation)
 
-                    val httpResponsePatterns: List<ResponseData> = attempt("In $httpMethod $openApiPath response") {
+                    val httpResponsePatterns: List<ResponseData> = attempt(breadCrumb = "$httpMethod $openApiPath -> RESPONSE") {
                         toHttpResponsePatterns(operation.responses)
                     }
 
@@ -498,7 +498,7 @@ class OpenApiSpecification(
             if(!isNumber(status) && status != "default")
                 throw ContractException("Response status codes are expected to be numbers, but \"$status\" was found")
 
-            attempt("in $status response") { openAPIResponseToSpecmatic(response, status, headersMap) }
+            attempt(breadCrumb = "200") { openAPIResponseToSpecmatic(response, status, headersMap) }
         }.flatten()
     }
 
@@ -972,12 +972,12 @@ class OpenApiSpecification(
                     DeferredPattern("(${componentName})")
                 }
                 else {
-                    val schemaFragment = if(patternName.isNotBlank()) "schema $patternName" else "in one of the schemas"
+                    val schemaFragment = if(patternName.isNotBlank()) " in schema $patternName" else " in the schema"
 
                     throw if(schema.javaClass.simpleName != "Schema")
                         ContractException("${schemaFragment.capitalizeFirstChar()} is not yet supported, please raise an issue on https://github.com/znsio/specmatic/issues")
                     else
-                        ContractException("\"type\" attribute was not provided in $schemaFragment, please check the syntax of the specification")
+                        ContractException("\"type\" attribute was not provided$schemaFragment, please check the syntax of the specification")
                 }
             }
         }.also {
@@ -1242,7 +1242,7 @@ class OpenApiSpecification(
             propertyName to ExactValuePattern(StringValue(patternName))
         else {
             val optional = !requiredFields.contains(propertyName)
-            toSpecmaticParamName(optional, propertyName) to toSpecmaticPattern(propertyType, typeStack)
+            toSpecmaticParamName(optional, propertyName) to attempt(breadCrumb = propertyName) { toSpecmaticPattern(propertyType, typeStack) }
         }
     }.toMap()
 

--- a/core/src/main/kotlin/in/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpRequestPattern.kt
@@ -630,8 +630,6 @@ data class HttpRequestPattern(
             val newFormFieldsPatterns = newBasedOn(formFieldsPattern, row, resolver)
             val newFormDataPartLists = newMultiPartBasedOn(multiPartFormDataPattern, row, resolver)
 
-            //TODO: figure out a way to optimise generating all positive scenarios
-
             sequence {
                 // If security schemes are present, for now we'll just take the first scheme and assign it to each negative request pattern.
                 // Ideally we should generate negative patterns from the security schemes and use them.

--- a/core/src/main/kotlin/in/specmatic/stub/api.kt
+++ b/core/src/main/kotlin/in/specmatic/stub/api.kt
@@ -89,7 +89,7 @@ fun loadContractStubsFromImplicitPaths(contractPathDataList: List<ContractPathDa
                                     try {
                                         Pair(it.path, stringToMockScenario(StringValue(it.readText())))
                                     } catch (e: Throwable) {
-                                        logger.log(e, "  Could not load stub file ${it.canonicalPath}")
+                                        logger.log(e, "Could not load stub file ${it.canonicalPath}...")
                                         null
                                     }
                                 }
@@ -100,7 +100,8 @@ fun loadContractStubsFromImplicitPaths(contractPathDataList: List<ContractPathDa
 
                     loadContractStubs(listOf(Pair(contractPath.path, feature)), stubData)
                 } catch(e: Throwable) {
-                    logger.log(e, "  Could not load ${contractPath.canonicalPath}")
+                    logger.log("Could not load ${contractPath.canonicalPath}")
+                    logger.log(e)
                     emptyList()
                 }
             }


### PR DESCRIPTION
**What**:

When there is an error in the response of a spec (say the `type` attribute is not provided), show the error with breadcrumbs indicating where the issue is in the spec.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

