### PR TITLE
Implemented Basic Authentication

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/APIKeyInHeaderSecurityScheme.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/APIKeyInHeaderSecurityScheme.kt
@@ -28,11 +28,4 @@ data class APIKeyInHeaderSecurityScheme(val name: String, private val apiKey:Str
     }
 
     override fun isInRow(row: Row): Boolean = row.containsField(name)
-    override fun headerInRequest(request: HttpRequest, resolver: Resolver): Map<String, Pattern> {
-        return headerPatternFromRequest(request, name)
-    }
-
-    override fun queryInRequest(request: HttpRequest, resolver: Resolver): Map<String, Pattern> {
-        return emptyMap()
-    }
 }

--- a/core/src/main/kotlin/in/specmatic/conversions/APIKeyInHeaderSecurityScheme.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/APIKeyInHeaderSecurityScheme.kt
@@ -4,10 +4,13 @@ import `in`.specmatic.core.HttpRequest
 import `in`.specmatic.core.HttpRequestPattern
 import `in`.specmatic.core.Resolver
 import `in`.specmatic.core.Result
+import `in`.specmatic.core.pattern.ExactValuePattern
+import `in`.specmatic.core.pattern.Pattern
 import `in`.specmatic.core.pattern.Row
 import `in`.specmatic.core.pattern.StringPattern
+import `in`.specmatic.core.value.StringValue
 
-class APIKeyInHeaderSecurityScheme(val name: String, private val apiKey:String?) : OpenAPISecurityScheme {
+data class APIKeyInHeaderSecurityScheme(val name: String, private val apiKey:String?) : OpenAPISecurityScheme {
     override fun matches(httpRequest: HttpRequest): Result {
         return if (httpRequest.headers.containsKey(name)) Result.Success() else Result.Failure("API-key named $name was not present as a header")
     }
@@ -25,4 +28,11 @@ class APIKeyInHeaderSecurityScheme(val name: String, private val apiKey:String?)
     }
 
     override fun isInRow(row: Row): Boolean = row.containsField(name)
+    override fun headerInRequest(request: HttpRequest, resolver: Resolver): Map<String, Pattern> {
+        return headerPatternFromRequest(request, name)
+    }
+
+    override fun queryInRequest(request: HttpRequest, resolver: Resolver): Map<String, Pattern> {
+        return emptyMap()
+    }
 }

--- a/core/src/main/kotlin/in/specmatic/conversions/APIKeyInQueryParamSecurityScheme.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/APIKeyInQueryParamSecurityScheme.kt
@@ -7,7 +7,7 @@ import `in`.specmatic.core.Result
 import `in`.specmatic.core.pattern.*
 import `in`.specmatic.core.value.StringValue
 
-class APIKeyInQueryParamSecurityScheme(val name: String, private val apiKey:String?) : OpenAPISecurityScheme {
+data class APIKeyInQueryParamSecurityScheme(val name: String, private val apiKey:String?) : OpenAPISecurityScheme {
     override fun matches(httpRequest: HttpRequest): Result {
         return if (httpRequest.queryParams.containsKey(name)) Result.Success() else Result.Failure("API-key named $name was not present in query string")
     }
@@ -36,4 +36,11 @@ class APIKeyInQueryParamSecurityScheme(val name: String, private val apiKey:Stri
     }
 
     override fun isInRow(row: Row): Boolean = row.containsField(name)
+    override fun headerInRequest(request: HttpRequest, resolver: Resolver): Map<String, Pattern> {
+        return emptyMap()
+    }
+
+    override fun queryInRequest(request: HttpRequest, resolver: Resolver): Map<String, Pattern> {
+        return queryPatternFromRequest(request, name)
+    }
 }

--- a/core/src/main/kotlin/in/specmatic/conversions/APIKeyInQueryParamSecurityScheme.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/APIKeyInQueryParamSecurityScheme.kt
@@ -36,11 +36,4 @@ data class APIKeyInQueryParamSecurityScheme(val name: String, private val apiKey
     }
 
     override fun isInRow(row: Row): Boolean = row.containsField(name)
-    override fun headerInRequest(request: HttpRequest, resolver: Resolver): Map<String, Pattern> {
-        return emptyMap()
-    }
-
-    override fun queryInRequest(request: HttpRequest, resolver: Resolver): Map<String, Pattern> {
-        return queryPatternFromRequest(request, name)
-    }
 }

--- a/core/src/main/kotlin/in/specmatic/conversions/BasicAuthSecurityScheme.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/BasicAuthSecurityScheme.kt
@@ -1,0 +1,87 @@
+package `in`.specmatic.conversions
+
+import `in`.specmatic.core.*
+import `in`.specmatic.core.pattern.ContractException
+import `in`.specmatic.core.pattern.Pattern
+import `in`.specmatic.core.pattern.Row
+import `in`.specmatic.core.pattern.StringPattern
+import org.apache.http.HttpHeaders.AUTHORIZATION
+import java.util.Base64
+
+data class BasicAuthSecurityScheme(private val token: String? = null) : OpenAPISecurityScheme {
+    override fun matches(httpRequest: HttpRequest): Result {
+        val authHeaderValue: String = httpRequest.headers[AUTHORIZATION]
+            ?: return Result.Failure("$AUTHORIZATION header is missing in request")
+
+        if (!authHeaderValue.lowercase().startsWith("basic"))
+            return Result.Failure("$AUTHORIZATION header must be prefixed with \"Basic\"")
+
+        val base64Credentials = authHeaderValue.substringAfter(" ").trim()
+
+        return validateBase64EncodedCredentials(base64Credentials)
+    }
+
+    private fun validateBase64EncodedCredentials(base64Credentials: String): Result {
+        try {
+            val decodedBytes = Base64.getDecoder().decode(base64Credentials)
+            val credentials = String(decodedBytes)
+
+            if (!credentials.contains(":"))
+                return Result.Failure("Base64-encoded credentials in $AUTHORIZATION header is not in the form username:password")
+        } catch (e: IllegalArgumentException) {
+            return Result.Failure("Invalid base64 encoding in $AUTHORIZATION header")
+        }
+
+        return Result.Success()
+    }
+
+    override fun removeParam(httpRequest: HttpRequest): HttpRequest {
+        return httpRequest.copy(headers = httpRequest.headers.minus(AUTHORIZATION))
+    }
+
+    override fun addTo(httpRequest: HttpRequest): HttpRequest {
+        return httpRequest.copy(
+            headers = httpRequest.headers.plus(
+                AUTHORIZATION to getAuthorizationHeaderValue()
+            )
+        )
+    }
+
+    override fun addTo(requestPattern: HttpRequestPattern, row: Row): HttpRequestPattern {
+        return addToHeaderType(AUTHORIZATION, row, requestPattern)
+    }
+
+    override fun isInRow(row: Row): Boolean = row.containsField(AUTHORIZATION)
+    override fun headerInRequest(request: HttpRequest, resolver: Resolver): Map<String, Pattern> {
+        return headerPatternFromRequest(request, AUTHORIZATION)
+    }
+
+    override fun queryInRequest(request: HttpRequest, resolver: Resolver): Map<String, Pattern> {
+        return emptyMap()
+    }
+
+    private fun getAuthorizationHeaderValue(): String {
+        val validToken = if(token != null)
+            validatedToken(token)
+        else
+            randomBasicAuthCredentials()
+
+        return "Basic $validToken"
+    }
+
+    private fun validatedToken(token: String): String {
+        val result = validateBase64EncodedCredentials(token)
+
+        if(result is Result.Failure)
+            throw ContractException(result.reportString())
+
+        return token
+    }
+
+    private fun randomBasicAuthCredentials(): String =
+        StringPattern()
+            .generate(Resolver())
+            .toStringLiteral().let {
+                String(Base64.getEncoder().encode("$it:$it".toByteArray()))
+            }
+}

--- a/core/src/main/kotlin/in/specmatic/conversions/BasicAuthSecurityScheme.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/BasicAuthSecurityScheme.kt
@@ -52,14 +52,6 @@ data class BasicAuthSecurityScheme(private val token: String? = null) : OpenAPIS
     }
 
     override fun isInRow(row: Row): Boolean = row.containsField(AUTHORIZATION)
-    override fun headerInRequest(request: HttpRequest, resolver: Resolver): Map<String, Pattern> {
-        return headerPatternFromRequest(request, AUTHORIZATION)
-    }
-
-    override fun queryInRequest(request: HttpRequest, resolver: Resolver): Map<String, Pattern> {
-        return emptyMap()
-    }
-
     private fun getAuthorizationHeaderValue(): String {
         val validToken = if(token != null)
             validatedToken(token)

--- a/core/src/main/kotlin/in/specmatic/conversions/BasicAuthSecurityScheme.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/BasicAuthSecurityScheme.kt
@@ -2,9 +2,10 @@ package `in`.specmatic.conversions
 
 import `in`.specmatic.core.*
 import `in`.specmatic.core.pattern.ContractException
-import `in`.specmatic.core.pattern.Pattern
 import `in`.specmatic.core.pattern.Row
 import `in`.specmatic.core.pattern.StringPattern
+import `in`.specmatic.core.pattern.randomString
+import io.ktor.util.*
 import org.apache.http.HttpHeaders.AUTHORIZATION
 import java.util.Base64
 
@@ -70,10 +71,10 @@ data class BasicAuthSecurityScheme(private val token: String? = null) : OpenAPIS
         return token
     }
 
-    private fun randomBasicAuthCredentials(): String =
-        StringPattern()
-            .generate(Resolver())
-            .toStringLiteral().let {
-                String(Base64.getEncoder().encode("$it:$it".toByteArray()))
-            }
+    private fun randomBasicAuthCredentials(): String {
+        val randomUsername = randomString()
+        val randomPassword = randomString()
+
+        return Base64.getEncoder().encodeToString("$randomUsername:$randomPassword".toByteArray())
+    }
 }

--- a/core/src/main/kotlin/in/specmatic/conversions/BearerSecurityScheme.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/BearerSecurityScheme.kt
@@ -1,11 +1,12 @@
 package `in`.specmatic.conversions
 
 import `in`.specmatic.core.*
+import `in`.specmatic.core.pattern.Pattern
 import `in`.specmatic.core.pattern.Row
 import `in`.specmatic.core.pattern.StringPattern
 import org.apache.http.HttpHeaders.AUTHORIZATION
 
-class BearerSecurityScheme(private val token: String? = null) : OpenAPISecurityScheme {
+data class BearerSecurityScheme(private val configuredToken: String? = null) : OpenAPISecurityScheme {
     override fun matches(httpRequest: HttpRequest): Result {
         httpRequest.headers.let {
             val authHeaderValue: String = it[AUTHORIZATION]
@@ -34,8 +35,15 @@ class BearerSecurityScheme(private val token: String? = null) : OpenAPISecurityS
     }
 
     override fun isInRow(row: Row): Boolean = row.containsField(AUTHORIZATION)
+    override fun headerInRequest(request: HttpRequest, resolver: Resolver): Map<String, Pattern> {
+        return headerPatternFromRequest(request, AUTHORIZATION)
+    }
+
+    override fun queryInRequest(request: HttpRequest, resolver: Resolver): Map<String, Pattern> {
+        return emptyMap()
+    }
 
     private fun getAuthorizationHeaderValue(): String {
-        return "Bearer " + (token ?: StringPattern().generate(Resolver()).toStringLiteral())
+        return "Bearer " + (configuredToken ?: StringPattern().generate(Resolver()).toStringLiteral())
     }
 }

--- a/core/src/main/kotlin/in/specmatic/conversions/BearerSecurityScheme.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/BearerSecurityScheme.kt
@@ -45,13 +45,6 @@ data class BearerSecurityScheme(private val configuredToken: String? = null) : O
     override fun isInRow(row: Row): Boolean {
         return row.columnNames.any { it.equals(AUTHORIZATION, ignoreCase = true) }
     }
-    override fun headerInRequest(request: HttpRequest, resolver: Resolver): Map<String, Pattern> {
-        return headerPatternFromRequest(request, AUTHORIZATION)
-    }
-
-    override fun queryInRequest(request: HttpRequest, resolver: Resolver): Map<String, Pattern> {
-        return emptyMap()
-    }
 
     private fun getAuthorizationHeaderValue(): String {
         return "Bearer " + (configuredToken ?: StringPattern().generate(Resolver()).toStringLiteral())

--- a/core/src/main/kotlin/in/specmatic/conversions/NoSecurityScheme.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/NoSecurityScheme.kt
@@ -35,12 +35,4 @@ class NoSecurityScheme : OpenAPISecurityScheme {
     override fun isInRow(row: Row): Boolean {
         return false
     }
-
-    override fun headerInRequest(request: HttpRequest, resolver: Resolver): Map<String, Pattern> {
-        return emptyMap()
-    }
-
-    override fun queryInRequest(request: HttpRequest, resolver: Resolver): Map<String, Pattern> {
-        return emptyMap()
-    }
 }

--- a/core/src/main/kotlin/in/specmatic/conversions/NoSecurityScheme.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/NoSecurityScheme.kt
@@ -2,7 +2,9 @@ package `in`.specmatic.conversions
 
 import `in`.specmatic.core.HttpRequest
 import `in`.specmatic.core.HttpRequestPattern
+import `in`.specmatic.core.Resolver
 import `in`.specmatic.core.Result
+import `in`.specmatic.core.pattern.Pattern
 import `in`.specmatic.core.pattern.Row
 
 class NoSecurityScheme : OpenAPISecurityScheme {
@@ -32,5 +34,13 @@ class NoSecurityScheme : OpenAPISecurityScheme {
 
     override fun isInRow(row: Row): Boolean {
         return false
+    }
+
+    override fun headerInRequest(request: HttpRequest, resolver: Resolver): Map<String, Pattern> {
+        return emptyMap()
+    }
+
+    override fun queryInRequest(request: HttpRequest, resolver: Resolver): Map<String, Pattern> {
+        return emptyMap()
     }
 }

--- a/core/src/main/kotlin/in/specmatic/conversions/OpenAPISecurityScheme.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenAPISecurityScheme.kt
@@ -2,11 +2,9 @@ package `in`.specmatic.conversions
 
 import `in`.specmatic.core.HttpRequest
 import `in`.specmatic.core.HttpRequestPattern
+import `in`.specmatic.core.Resolver
 import `in`.specmatic.core.Result
-import `in`.specmatic.core.pattern.ExactValuePattern
-import `in`.specmatic.core.pattern.Row
-import `in`.specmatic.core.pattern.isPatternToken
-import `in`.specmatic.core.pattern.parsedPattern
+import `in`.specmatic.core.pattern.*
 import `in`.specmatic.core.value.StringValue
 
 interface OpenAPISecurityScheme {
@@ -15,6 +13,8 @@ interface OpenAPISecurityScheme {
     fun addTo(httpRequest: HttpRequest): HttpRequest
     fun addTo(requestPattern: HttpRequestPattern, row: Row): HttpRequestPattern
     fun isInRow(row: Row): Boolean
+    fun headerInRequest(request: HttpRequest, resolver: Resolver): Map<String, Pattern>
+    fun queryInRequest(request: HttpRequest, resolver: Resolver): Map<String, Pattern>
 }
 
 fun addToHeaderType(
@@ -33,5 +33,32 @@ fun addToHeaderType(
         headersPattern = requestPattern.headersPattern.copy(
             pattern = requestPattern.headersPattern.pattern.plus(headerName to headerValueType)
         )
+    )
+}
+
+internal fun headerPatternFromRequest(
+    request: HttpRequest,
+    headerName: String
+): Map<String, Pattern> {
+    val headerValue = request.headers[headerName]
+
+    if (headerValue != null) {
+        return mapOf(headerName to ExactValuePattern(StringValue(headerValue)))
+    }
+
+    return emptyMap()
+}
+
+internal fun queryPatternFromRequest(
+    request: HttpRequest,
+    queryParamName: String
+): Map<String, Pattern> {
+    val queryParamValue = request.queryParams.getValues(queryParamName)
+
+    if(queryParamValue.isEmpty())
+        return emptyMap()
+
+    return mapOf(
+        queryParamName to ExactValuePattern(StringValue(queryParamValue.first()))
     )
 }

--- a/core/src/main/kotlin/in/specmatic/conversions/OpenAPISecurityScheme.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenAPISecurityScheme.kt
@@ -13,8 +13,6 @@ interface OpenAPISecurityScheme {
     fun addTo(httpRequest: HttpRequest): HttpRequest
     fun addTo(requestPattern: HttpRequestPattern, row: Row): HttpRequestPattern
     fun isInRow(row: Row): Boolean
-    fun headerInRequest(request: HttpRequest, resolver: Resolver): Map<String, Pattern>
-    fun queryInRequest(request: HttpRequest, resolver: Resolver): Map<String, Pattern>
 }
 
 fun addToHeaderType(

--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -736,6 +736,9 @@ class OpenApiSpecification(
                 return APIKeyInQueryParamSecurityScheme(securityScheme.name, apiKey)
         }
 
+        if(securityScheme.type == SecurityScheme.Type.HTTP && securityScheme.scheme == "basic")
+            return toBasicAuthSecurityScheme(securitySchemeConfiguration, schemeName)
+
         throw ContractException("Specmatic only supports oauth2, bearer, and api key authentication (header, query) security schemes at the moment")
     }
 
@@ -745,6 +748,14 @@ class OpenApiSpecification(
     ): BearerSecurityScheme {
         val token = getSecurityTokenForBearerScheme(securitySchemeConfiguration, environmentVariable, environment)
         return BearerSecurityScheme(token)
+    }
+
+    private fun toBasicAuthSecurityScheme(
+        securitySchemeConfiguration: SecuritySchemeConfiguration?,
+        environmentVariable: String,
+    ): BasicAuthSecurityScheme {
+        val token = getSecurityTokenForBasicAuthScheme(securitySchemeConfiguration, environmentVariable, environment)
+        return BasicAuthSecurityScheme(token)
     }
 
     private fun toFormFields(mediaType: MediaType): Map<String, Pattern> {

--- a/core/src/main/kotlin/in/specmatic/conversions/SecurityToken.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/SecurityToken.kt
@@ -7,6 +7,15 @@ import `in`.specmatic.core.SecuritySchemeWithOAuthToken
 @Deprecated("This will be deprecated shortly.Use the security scheme name as the environment variable.")
 const val SPECMATIC_OAUTH2_TOKEN = "SPECMATIC_OAUTH2_TOKEN"
 
+const val SPECMATIC_BASIC_AUTH_TOKEN = "SPECMATIC_BASIC_AUTH_TOKEN"
+
+fun getSecurityTokenForBasicAuthScheme(
+    securitySchemeConfiguration: SecuritySchemeConfiguration?,
+    environmentVariable: String,
+    environment: Environment
+): String? {
+    return environment.getEnvironmentVariable(environmentVariable) ?: environment.getEnvironmentVariable(SPECMATIC_BASIC_AUTH_TOKEN)
+}
 
 fun getSecurityTokenForBearerScheme(
     securitySchemeConfiguration: SecuritySchemeConfiguration?,

--- a/core/src/main/kotlin/in/specmatic/conversions/SecurityToken.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/SecurityToken.kt
@@ -1,6 +1,7 @@
 package `in`.specmatic.conversions
 
 import `in`.specmatic.core.APIKeySecuritySchemeConfiguration
+import `in`.specmatic.core.BasicAuthSecuritySchemeConfiguration
 import `in`.specmatic.core.SecuritySchemeConfiguration
 import `in`.specmatic.core.SecuritySchemeWithOAuthToken
 
@@ -14,7 +15,9 @@ fun getSecurityTokenForBasicAuthScheme(
     environmentVariable: String,
     environment: Environment
 ): String? {
-    return environment.getEnvironmentVariable(environmentVariable) ?: environment.getEnvironmentVariable(SPECMATIC_BASIC_AUTH_TOKEN)
+    return environment.getEnvironmentVariable(environmentVariable) ?: securitySchemeConfiguration?.let {
+        (securitySchemeConfiguration as BasicAuthSecuritySchemeConfiguration).token
+    } ?: environment.getEnvironmentVariable(SPECMATIC_BASIC_AUTH_TOKEN)
 }
 
 fun getSecurityTokenForBearerScheme(

--- a/core/src/main/kotlin/in/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpRequestPattern.kt
@@ -234,11 +234,7 @@ data class HttpRequestPattern(
             requestPattern = attempt(breadCrumb = "URL") {
                 val path = request.path ?: ""
                 val pathTypes = pathToPattern(path)
-                val queryParamTypes = toTypeMapForQueryParameters(request.queryParams, httpQueryParamPattern, resolver).plus(
-                    requestPattern.securitySchemes.fold(emptyMap()) { acc, securityScheme ->
-                        acc.plus(securityScheme.queryInRequest(request, resolver))
-                    }
-                )
+                val queryParamTypes = toTypeMapForQueryParameters(request.queryParams, httpQueryParamPattern, resolver)
                 requestPattern.copy(httpPathPattern = HttpPathPattern(pathTypes, path), httpQueryParamPattern = HttpQueryParamPattern(queryParamTypes))
             }
 
@@ -247,10 +243,6 @@ data class HttpRequestPattern(
                     toLowerCaseKeys(request.headers) as Map<String, String>,
                     toLowerCaseKeys(headersPattern.pattern) as Map<String, Pattern>,
                     resolver
-                ).plus(
-                    this.securitySchemes.fold(emptyMap()) { acc, securityScheme ->
-                        acc.plus(securityScheme.headerInRequest(request, resolver))
-                    }
                 )
 
                 requestPattern.copy(headersPattern = HttpHeadersPattern(headersFromRequest))

--- a/core/src/main/kotlin/in/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/in/specmatic/core/SpecmaticConfig.kt
@@ -168,6 +168,10 @@ interface SecuritySchemeWithOAuthToken {
 data class OAuth2SecuritySchemeConfiguration(override val type: String, override val token: String) : SecuritySchemeConfiguration(), SecuritySchemeWithOAuthToken
 
 @Serializable
+@SerialName("basicAuth")
+data class BasicAuthSecuritySchemeConfiguration(override val type: String, val token: String) : SecuritySchemeConfiguration()
+
+@Serializable
 @SerialName("bearer")
 data class BearerSecuritySchemeConfiguration(override val type: String, override val token: String) : SecuritySchemeConfiguration(), SecuritySchemeWithOAuthToken
 

--- a/core/src/main/kotlin/in/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/in/specmatic/stub/HttpStub.kt
@@ -796,7 +796,7 @@ private fun stubThatMatchesRequest(
         }
     }
 
-        val mock = listMatchResults.find { (result, _) -> result is Result.Success }
+    val mock = listMatchResults.find { (result, _) -> result is Result.Success }
 
     return Pair(mock?.second, listMatchResults)
 }

--- a/core/src/test/kotlin/in/specmatic/conversions/BasicAuthSecuritySchemeTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/BasicAuthSecuritySchemeTest.kt
@@ -1,0 +1,97 @@
+package `in`.specmatic.conversions
+
+import `in`.specmatic.core.HttpRequest
+import `in`.specmatic.core.Result.*
+import `in`.specmatic.core.pattern.Row
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import java.util.*
+
+class BasicAuthSecuritySchemeTest {
+    private val basicAuthSecurityScheme = BasicAuthSecurityScheme()
+
+    @Test
+    fun `matches should return failure when authorization header is missing`() {
+        val httpRequest = HttpRequest(headers = emptyMap())
+
+        val result = basicAuthSecurityScheme.matches(httpRequest)
+
+        assertTrue(result is Failure, "Expected failure when authorization header is missing")
+    }
+
+    @Test
+    fun `matches should return failure when authorization header is not prefixed with Basic`() {
+        val httpRequest = HttpRequest(headers = mapOf("Authorization" to "Bearer token"))
+
+        val result = basicAuthSecurityScheme.matches(httpRequest)
+
+        assertTrue(result is Failure, "Expected failure when authorization header is not prefixed with Basic")
+    }
+
+    @Test
+    fun `matches should return success when authorization header is correctly prefixed`() {
+        val credentials = "charlie123:pqrxyz"
+        val httpRequest = HttpRequest(headers = mapOf("Authorization" to "Basic ${String(Base64.getEncoder().encode(credentials.toByteArray()))}"))
+
+        val result = basicAuthSecurityScheme.matches(httpRequest)
+
+        assertThat(result).withFailMessage(result.reportString()).isInstanceOf(Success::class.java)
+    }
+
+    @Test
+    fun `match should fail when decoded basic auth token does not have a colon`() {
+        val credentialsWithoutPassword = "charlie123"
+        val httpRequest = HttpRequest(headers = mapOf("Authorization" to "Basic ${String(Base64.getEncoder().encode(credentialsWithoutPassword.toByteArray()))}"))
+
+        val result = basicAuthSecurityScheme.matches(httpRequest)
+
+        assertThat(result).withFailMessage(result.reportString()).isInstanceOf(Failure::class.java)
+    }
+
+    @Test
+    fun `match should fail when basic auth token is note a base64 value`() {
+        val nonBase64String = "!@#$%"
+        val httpRequest = HttpRequest(headers = mapOf("Authorization" to "Basic $nonBase64String"))
+
+        val result = basicAuthSecurityScheme.matches(httpRequest)
+
+        assertThat(result.reportString()).contains("Invalid base64 encoding")
+    }
+
+    @Test
+    fun `removeParam should remove authorization header from request`() {
+        val httpRequest = HttpRequest(headers = mapOf("Authorization" to "Basic token"))
+
+        val result = basicAuthSecurityScheme.removeParam(httpRequest)
+
+        assertFalse(result.headers.containsKey("Authorization"), "Expected authorization header to be removed")
+    }
+
+    @Test
+    fun `addTo should add authorization header to request`() {
+        val httpRequest = HttpRequest(headers = emptyMap())
+
+        val result = basicAuthSecurityScheme.addTo(httpRequest)
+
+        assertTrue(result.headers.containsKey("Authorization"), "Expected authorization header to be added")
+    }
+
+    @Test
+    fun `isInRow should return true when authorization header is present in row`() {
+        val row = Row(mapOf("Authorization" to "Basic token"))
+
+        val result = basicAuthSecurityScheme.isInRow(row)
+
+        assertTrue(result, "Expected true when authorization header is present in row")
+    }
+
+    @Test
+    fun `isInRow should return false when authorization header is not present in row`() {
+        val row = Row(emptyMap())
+
+        val result = basicAuthSecurityScheme.isInRow(row)
+
+        assertFalse(result, "Expected false when authorization header is not present in row")
+    }
+}

--- a/core/src/test/kotlin/in/specmatic/conversions/ExamplesAsStubTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/ExamplesAsStubTest.kt
@@ -10,6 +10,7 @@ import `in`.specmatic.stub.HttpStubData
 import `in`.specmatic.stub.captureStandardOutput
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import java.util.*
 
 class ExamplesAsStubTest {
     private val featureWithQueryParamExamples = OpenApiSpecification.fromYAML(
@@ -227,11 +228,13 @@ security:
   - BearerAuth: []
          """.trimIndent(), "").toFeature()
 
+        val credentials = "Basic " + Base64.getEncoder().encodeToString("user:password".toByteArray())
+
         HttpStub(feature).use {
             val response = it.client.execute(HttpRequest(
                 "POST",
                 "/hello",
-                mapOf("Authorization" to "Bearer 1234"),
+                mapOf("Authorization" to "Bearer $credentials"),
                 parsedJSONObject("""{"message": "Hello World!"}""")
             ))
 
@@ -342,11 +345,13 @@ security:
   - BearerAuth: []
          """.trimIndent(), "").toFeature()
 
+        val credentials = "Basic " + Base64.getEncoder().encodeToString("user:password".toByteArray())
+
         HttpStub(feature).use {
             val response = it.client.execute(HttpRequest(
                 "GET",
                 "/hello",
-                mapOf("Authorization" to "Bearer 1234"),
+                mapOf("Authorization" to "Bearer $credentials"),
                 queryParametersMap = mapOf("greeting" to "Hello")
             ))
 

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiIntegrationTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiIntegrationTest.kt
@@ -692,14 +692,6 @@ Background:
                     assertThat(response.status).isEqualTo(200)
                     assertThat(response.body.toStringLiteral()).isEqualTo("success")
                 }
-
-                val unexpectedCredentials = "frankie:abcdef"
-                val unexpectedBase64EncodedCredentials = String(java.util.Base64.getEncoder().encode(unexpectedCredentials.toByteArray()))
-
-                stub.client.execute(HttpRequest("GET", "/hello", headers = mapOf("Authorization" to "Basic $unexpectedBase64EncodedCredentials"))).let { response ->
-                    assertThat(response.status).isEqualTo(200)
-                    assertThat(response.body.toStringLiteral()).isNotEqualTo("success")
-                }
             }
         }
     }

--- a/core/src/test/kotlin/in/specmatic/core/SpecmaticConfigKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/SpecmaticConfigKtTest.kt
@@ -40,6 +40,8 @@ internal class SpecmaticConfigKtTest {
         assertThat((config.security?.OpenAPI?.securitySchemes?.get("BearerAuth") as BearerSecuritySchemeConfiguration).token).isEqualTo("BEARER1234")
         assertThat((config.security?.OpenAPI?.securitySchemes?.get("ApiKeyAuthHeader") as APIKeySecuritySchemeConfiguration).value).isEqualTo("API-HEADER-USER")
         assertThat((config.security?.OpenAPI?.securitySchemes?.get("ApiKeyAuthQuery") as APIKeySecuritySchemeConfiguration).value).isEqualTo("API-QUERY-PARAM-USER")
+
+        assertThat((config.security?.OpenAPI?.securitySchemes?.get("BasicAuth") as BasicAuthSecuritySchemeConfiguration).token).isEqualTo("Abc123")
     }
 
     @Test
@@ -48,7 +50,7 @@ internal class SpecmaticConfigKtTest {
             {
                 "sources": [
                     {
-                        "provider": "git"
+                        "provider": "git",
                         "test": [
                             "path/to/contract.spec"
                         ]

--- a/core/src/test/resources/openapi/unsupported-authentication.yaml
+++ b/core/src/test/resources/openapi/unsupported-authentication.yaml
@@ -43,5 +43,5 @@ paths:
 components:
   securitySchemes:
     basicAuth:
-      type: http
+      type: openIdConnect
       scheme: basic

--- a/core/src/test/resources/specmaticConfigFiles/specmatic.json
+++ b/core/src/test/resources/specmaticConfigFiles/specmatic.json
@@ -72,6 +72,10 @@
         "ApiKeyAuthQuery": {
           "type": "apiKey",
           "value": "API-QUERY-PARAM-USER"
+        },
+        "BasicAuth": {
+          "type": "basicAuth",
+          "token": "Abc123"
         }
       }
     }


### PR DESCRIPTION
**What**:

Add support for Basic Authentication.

This means support for a header named Authorization with the value `Basic <base64 encoded token>`

If the token cannot be base64 decoded, or does not contain a `:`, Specmatic stub and test will reject it.

[Documentation here](https://specmatic.in/documentation/authentication.html).

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [ ] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #123

<!-- feel free to add additional comments -->
