### PR TITLE
Omit params with no examples

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/DefaultExampleResolver.kt
+++ b/core/src/main/kotlin/in/specmatic/core/DefaultExampleResolver.kt
@@ -9,4 +9,5 @@ interface DefaultExampleResolver {
     fun resolveExample(example: List<String?>?, pattern: Pattern, resolver: Resolver): JSONArrayValue?
     fun resolveExample(example: String?, pattern: List<Pattern>, resolver: Resolver): Value?
     fun theDefaultExampleForThisKeyIsNotOmit(valuePattern: Pattern): Boolean
+    fun hasExample(pattern: Pattern): Boolean
 }

--- a/core/src/main/kotlin/in/specmatic/core/DoNotUseDefaultExample.kt
+++ b/core/src/main/kotlin/in/specmatic/core/DoNotUseDefaultExample.kt
@@ -21,4 +21,8 @@ object DoNotUseDefaultExample : DefaultExampleResolver {
         return true
     }
 
+    override fun hasExample(pattern: Pattern): Boolean {
+        return false
+    }
+
 }

--- a/core/src/main/kotlin/in/specmatic/core/GenerationStrategies.kt
+++ b/core/src/main/kotlin/in/specmatic/core/GenerationStrategies.kt
@@ -1,9 +1,7 @@
 package `in`.specmatic.core
 
 import `in`.specmatic.core.Result.Success
-import `in`.specmatic.core.pattern.ExactValuePattern
-import `in`.specmatic.core.pattern.Pattern
-import `in`.specmatic.core.pattern.Row
+import `in`.specmatic.core.pattern.*
 import `in`.specmatic.core.pattern.isOptional
 import `in`.specmatic.core.value.Value
 
@@ -18,6 +16,13 @@ interface GenerationStrategies {
     fun generateKeySubLists(key: String, subList: List<String>): Sequence<List<String>>
     fun positiveTestScenarios(feature: Feature, suggestions: List<Scenario>): Sequence<Scenario>
     fun negativeTestScenarios(feature: Feature): Sequence<Scenario>
+    fun fillInTheMissingMapPatterns(
+        newQueryParamsList: Sequence<Map<String, Pattern>>,
+        queryPatterns: Map<String, Pattern>,
+        additionalProperties: Pattern?,
+        row: Row,
+        resolver: Resolver
+    ): Sequence<Map<String, Pattern>>
 }
 
 data class GenerativeTestsEnabled(private val positiveOnly: Boolean = Flags.onlyPositive()) : GenerationStrategies {
@@ -87,6 +92,31 @@ data class GenerativeTestsEnabled(private val positiveOnly: Boolean = Flags.only
         else
             feature.negativeTestScenarios()
     }
+
+    override fun fillInTheMissingMapPatterns(
+        newQueryParamsList: Sequence<Map<String, Pattern>>,
+        queryPatterns: Map<String, Pattern>,
+        additionalProperties: Pattern?,
+        row: Row,
+        resolver: Resolver
+    ): Sequence<Map<String, Pattern>> {
+        return attempt(breadCrumb = QUERY_PARAMS_BREADCRUMB) {
+            val queryParams = queryPatterns.let {
+                if(additionalProperties != null)
+                    it.plus(randomString(5) to additionalProperties)
+                else
+                    it
+            }
+
+            forEachKeyCombinationIn(queryParams, row) { entry ->
+                newBasedOn(entry, row, resolver)
+            }.map {
+                it.mapKeys { withoutOptionality(it.key) }
+            }
+        }.map {
+            noOverlapBetween(it, newQueryParamsList, resolver)
+        }.filterNotNull()
+    }
 }
 
 object NonGenerativeTests : GenerationStrategies {
@@ -122,4 +152,35 @@ object NonGenerativeTests : GenerationStrategies {
     override fun negativeTestScenarios(feature: Feature): Sequence<Scenario> {
         return sequenceOf()
     }
+
+    override fun fillInTheMissingMapPatterns(
+        newQueryParamsList: Sequence<Map<String, Pattern>>,
+        queryPatterns: Map<String, Pattern>,
+        additionalProperties: Pattern?,
+        row: Row,
+        resolver: Resolver
+    ): Sequence<Map<String, Pattern>> {
+        return emptySequence()
+    }
+}
+
+internal fun noOverlapBetween(
+    item: Map<String, Pattern>,
+    otherItems: Sequence<Map<String, Pattern>>,
+    resolver: Resolver
+): Map<String, Pattern>? {
+    val otherItemWithSameKeys = otherItems.find { it.keys.map(::withoutOptionality) == item.keys.map(::withoutOptionality) } ?: return item
+
+    val itemWithoutOptionality = item.mapKeys { withoutOptionality(it.key) }
+
+    val results: List<Result> = otherItemWithSameKeys.mapKeys { withoutOptionality(it.key) }.map { (key, otherPattern) ->
+        val itemPattern = itemWithoutOptionality.getValue(key)
+
+        itemPattern.encompasses(otherPattern, resolver, resolver)
+    }
+
+    if(results.all { it is Result.Success })
+        return null
+
+    return item
 }

--- a/core/src/main/kotlin/in/specmatic/core/HttpHeadersPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpHeadersPattern.kt
@@ -165,9 +165,7 @@ data class HttpHeadersPattern(
             null,
             row,
             resolver
-        ).map {
-            noOverlapBetween(it, basedOnExamples, resolver)
-        }.filterNotNull()
+        )
 
         return (basedOnExamples + generatedWithoutExamples).map { map -> HttpHeadersPattern(map.mapKeys { withoutOptionality(it.key) }, contentType = contentType) }
     }

--- a/core/src/main/kotlin/in/specmatic/core/HttpHeadersPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpHeadersPattern.kt
@@ -6,6 +6,8 @@ import `in`.specmatic.core.value.StringValue
 import `in`.specmatic.core.value.Value
 import io.ktor.http.*
 
+const val HEADERS_BREADCRUMB = "HEADERS"
+
 data class HttpHeadersPattern(
     val pattern: Map<String, Pattern> = emptyMap(),
     val ancestorHeaders: Map<String, Pattern>? = null,
@@ -225,6 +227,31 @@ data class HttpHeadersPattern(
         }
 
         return Result.fromFailures(failures)
+    }
+
+    fun addComplimentaryPatterns(basePatterns: Sequence<HttpHeadersPattern>, row: Row, resolver: Resolver): Sequence<HttpHeadersPattern> {
+        return `in`.specmatic.core.addComplimentaryPatterns(
+            basePatterns.map {it.pattern},
+            pattern,
+            null,
+            row,
+            resolver,
+        ).map {
+            HttpHeadersPattern(it, contentType = contentType)
+        }
+    }
+
+    fun matches(row: Row, resolver: Resolver): Result {
+        return matches(this.pattern, row, resolver, "header")
+    }
+
+    fun readFrom(row: Row, resolver: Resolver): Sequence<HttpHeadersPattern> {
+        return attempt(breadCrumb = HEADERS_BREADCRUMB) {
+            readFrom(this.pattern, row, resolver)
+        }.map {
+            HttpHeadersPattern(it, contentType = contentType)
+
+        }
     }
 }
 

--- a/core/src/main/kotlin/in/specmatic/core/HttpQueryParamPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpQueryParamPattern.kt
@@ -42,7 +42,9 @@ data class HttpQueryParamPattern(val queryPatterns: Map<String, Pattern>, val ad
             }
 
             forEachKeyCombinationIn(row.withoutOmittedKeys(queryParams, resolver.defaultExampleResolver), row) { entry ->
-                newBasedOn(entry.mapKeys { withoutOptionality(it.key) }, row, resolver)
+                newBasedOn(entry, row, resolver)
+            }.map {
+                it.mapKeys { withoutOptionality(it.key) }
             }
         }
         return newQueryParamsList

--- a/core/src/main/kotlin/in/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpRequestPattern.kt
@@ -5,7 +5,6 @@ import `in`.specmatic.conversions.OpenAPISecurityScheme
 import `in`.specmatic.core.Result.Failure
 import `in`.specmatic.core.Result.Success
 import `in`.specmatic.core.pattern.*
-import `in`.specmatic.core.value.JSONObjectValue
 import `in`.specmatic.core.value.StringValue
 import io.ktor.util.*
 
@@ -487,9 +486,9 @@ data class HttpRequestPattern(
 
                         val requestBodyAsIs = ExactValuePattern(value)
 
-                        resolver.generateHttpRequests(body, row, requestBodyAsIs, value)
+                        resolver.generateHttpRequestbodies(body, row, requestBodyAsIs, value)
                     } else {
-                        resolver.generateHttpRequests(body, row)
+                        resolver.generateHttpRequestbodies(body, row)
                     }
                 }
             }

--- a/core/src/main/kotlin/in/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpRequestPattern.kt
@@ -460,7 +460,32 @@ data class HttpRequestPattern(
                 newURLPathSegmentPatternsList.map { HttpPathPattern(it, httpPathPattern.path) }
             } ?: sequenceOf<HttpPathPattern?>(null)
 
-            val newQueryParamsPatterns = httpQueryParamPattern.newBasedOn(row, resolver).map { HttpQueryParamPattern(it) }
+            val newQueryParamsPatterns =
+                if(status.toString().startsWith("2")) {
+                    val new = httpQueryParamPattern.newBasedOn(row, resolver)
+                    httpQueryParamPattern.addComplimentaryPatterns(new, row, resolver)
+                } else {
+                    if(status.toString().startsWith("4")) {
+                        httpQueryParamPattern.matches(row, resolver).throwOnFailure()
+                    }
+
+                    httpQueryParamPattern.readFrom(row, resolver)
+                }.map {
+                    HttpQueryParamPattern(it)
+                }
+
+            val newHeadersPattern = if(status.toString().startsWith("2")) {
+                val new = headersPattern.newBasedOn(row, resolver)
+                headersPattern.addComplimentaryPatterns(new, row, resolver)
+            } else {
+                if(status.toString().startsWith("4")) {
+                    headersPattern.matches(row, resolver).throwOnFailure()
+                }
+
+                headersPattern.readFrom(row, resolver)
+            }
+
+//            val newHeadersPattern = headersPattern.newBasedOn(row, resolver)
 
             val newBodies: Sequence<Pattern> = attempt(breadCrumb = "BODY") {
                 body.let {
@@ -486,14 +511,16 @@ data class HttpRequestPattern(
 
                         val requestBodyAsIs = ExactValuePattern(value)
 
-                        resolver.generateHttpRequestbodies(body, row, requestBodyAsIs, value)
+                        if(status.toString().startsWith("2"))
+                            resolver.generateHttpRequestbodies(body, row, requestBodyAsIs, value)
+                        else
+                            sequenceOf(requestBodyAsIs)
                     } else {
                         resolver.generateHttpRequestbodies(body, row)
                     }
                 }
             }
 
-            val newHeadersPattern = headersPattern.newBasedOn(row, resolver)
             val newFormFieldsPatterns = newBasedOn(formFieldsPattern, row, resolver)
             val newFormDataPartLists = newMultiPartBasedOn(multiPartFormDataPattern, row, resolver)
 

--- a/core/src/main/kotlin/in/specmatic/core/Resolver.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Resolver.kt
@@ -174,11 +174,11 @@ data class Resolver(
         return defaultExampleResolver.resolveExample(example, pattern, this)
     }
 
-    fun generateHttpRequests(body: Pattern, row: Row, requestBodyAsIs: Pattern, value: Value): Sequence<Pattern> {
+    fun generateHttpRequestbodies(body: Pattern, row: Row, requestBodyAsIs: Pattern, value: Value): Sequence<Pattern> {
         return generation.generateHttpRequests(this, body, row, requestBodyAsIs, value)
     }
 
-    fun generateHttpRequests(body: Pattern, row: Row): Sequence<Pattern> {
+    fun generateHttpRequestbodies(body: Pattern, row: Row): Sequence<Pattern> {
         return generation.generateHttpRequests(this, body, row)
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/Result.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Result.kt
@@ -1,6 +1,7 @@
 package `in`.specmatic.core
 
 import `in`.specmatic.core.Result.Failure
+import `in`.specmatic.core.pattern.ContractException
 import `in`.specmatic.core.pattern.Pattern
 import `in`.specmatic.core.utilities.capitalizeFirstChar
 import `in`.specmatic.core.value.Value
@@ -70,6 +71,7 @@ sealed class Result {
 
     abstract fun testResult(): TestResult
     abstract fun withFailureReason(urlPathMisMatch: FailureReason): Result
+    abstract fun throwOnFailure(): Success
 
     data class FailureCause(val message: String="", var cause: Failure? = null)
 
@@ -114,6 +116,10 @@ sealed class Result {
 
         override fun withFailureReason(failureReason: FailureReason): Result {
             return copy(failureReason = failureReason)
+        }
+
+        override fun throwOnFailure(): Success {
+            throw ContractException(this.toFailureReport())
         }
 
         fun reason(errorMessage: String) = Failure(errorMessage, this)
@@ -185,6 +191,10 @@ sealed class Result {
         }
 
         override fun withFailureReason(urlPathMisMatch: FailureReason): Result {
+            return this
+        }
+
+        override fun throwOnFailure(): Success {
             return this
         }
     }

--- a/core/src/main/kotlin/in/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Scenario.kt
@@ -558,6 +558,8 @@ fun executeTestAndReturnResultAndResponse(
     return try {
         testExecutor.setServerState(testScenario.serverState)
 
+        testExecutor.preExecuteScenario(testScenario, request)
+
         val response = testExecutor.execute(request)
 
         val result = testResult(response, testScenario)

--- a/core/src/main/kotlin/in/specmatic/core/UseDefaultExample.kt
+++ b/core/src/main/kotlin/in/specmatic/core/UseDefaultExample.kt
@@ -59,6 +59,10 @@ object UseDefaultExample : DefaultExampleResolver {
         return true
     }
 
+    override fun hasExample(pattern: Pattern): Boolean {
+        return pattern is HasDefaultExample && pattern.example != null
+    }
+
     override fun resolveExample(example: List<String?>?, pattern: Pattern, resolver: Resolver): JSONArrayValue? {
         if(example == null)
             return null

--- a/core/src/main/kotlin/in/specmatic/core/pattern/Row.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/Row.kt
@@ -71,7 +71,7 @@ data class Row(
     fun containsField(key: String): Boolean = requestBodyJSONExample?.hasScalarValueForKey(key) ?: cells.containsKey(key)
 
     fun withoutOmittedKeys(keys: Map<String, Pattern>, defaultExampleResolver: DefaultExampleResolver): Map<String, Pattern> {
-        if(this.hasNoRequestExamples())
+        if(this.hasNoRequestExamples() && this.fileSource == null)
             return keys
 
         return keys.filter { (key, pattern) ->

--- a/core/src/main/kotlin/in/specmatic/core/pattern/TabularPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/TabularPattern.kt
@@ -159,7 +159,7 @@ fun newBasedOn(row: Row, key: String, pattern: Pattern, resolver: Resolver): Seq
             if (isPatternToken(rowValue)) {
                 val rowPattern = resolver.getPattern(rowValue)
 
-                attempt(breadCrumb = key) {
+                attempt(breadCrumb = keyWithoutOptionality) {
                     when (val result = pattern.encompasses(rowPattern, resolver, resolver)) {
                         is Result.Success -> {
                             resolver.withCyclePrevention(rowPattern, isOptional(key)) { cyclePreventedResolver ->

--- a/core/src/main/kotlin/in/specmatic/test/TestExecutor.kt
+++ b/core/src/main/kotlin/in/specmatic/test/TestExecutor.kt
@@ -2,12 +2,15 @@ package `in`.specmatic.test
 
 import `in`.specmatic.core.HttpRequest
 import `in`.specmatic.core.HttpResponse
+import `in`.specmatic.core.Scenario
 import `in`.specmatic.core.value.Value
 
 interface TestExecutor {
     fun execute(request: HttpRequest): HttpResponse
 
     fun setServerState(serverState: Map<String, Value>) {
+    }
 
+    fun preExecuteScenario(scenario: Scenario, request: HttpRequest) {
     }
 }

--- a/core/src/test/kotlin/in/specmatic/conversions/GenerativeTests.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/GenerativeTests.kt
@@ -490,7 +490,7 @@ class GenerativeTests {
     }
 
     @Test
-    fun `generative tests with one optional and one mandatory query params with no examples`() {
+    fun `generative tests with one optional and one mandatory query param with no examples`() {
         val feature = OpenApiSpecification.fromYAML(
             """
             ---
@@ -541,7 +541,7 @@ class GenerativeTests {
     }
 
     @Test
-    fun `generative tests with one optional query param with no example and one mandatory query params with an example`() {
+    fun `generative tests with one optional query param with no example and one mandatory query param with an example`() {
         val feature = OpenApiSpecification.fromYAML(
             """
             ---
@@ -592,7 +592,67 @@ class GenerativeTests {
 
         try {
             val results = runGenerativeTests(feature)
-            assertThat(results.results).hasSize(12)
+            assertThat(results.results).hasSize(8)
+        } catch (e: ContractException) {
+            println(e.report())
+            throw e
+        }
+    }
+
+
+    @Test
+    fun `generative tests with one optional header with no example and one mandatory header with an example`() {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+            ---
+            openapi: "3.0.1"
+            info:
+              title: "Person API"
+              version: "1"
+            paths:
+              /person:
+                get:
+                  summary: Fetch person's record
+                  parameters:
+                    - name: X-Category
+                      in: header
+                      required: false
+                      schema:
+                        type: integer
+                    - name: X-Status
+                      in: header
+                      required: true
+                      schema:
+                        type: integer
+                      examples:
+                        FETCH:
+                          value: 10
+                  responses:
+                    200:
+                      description: Person's record
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                            required:
+                              - id
+                              - name
+                            properties:
+                              id:
+                                type: integer
+                              name:
+                                type: string
+                          examples:
+                            FETCH:
+                              value:
+                                id: 123
+                                name: "John Doe"
+            """.trimIndent(), ""
+        ).toFeature()
+
+        try {
+            val results = runGenerativeTests(feature)
+            assertThat(results.results).hasSize(8)
         } catch (e: ContractException) {
             println(e.report())
             throw e

--- a/core/src/test/kotlin/in/specmatic/conversions/GenerativeTests.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/GenerativeTests.kt
@@ -398,7 +398,7 @@ class GenerativeTests {
     }
 
     @Test
-    fun `generative tests for query params with no examples`() {
+    fun `generative tests for mandatory query params with no examples`() {
         val feature = OpenApiSpecification.fromYAML(
             """
             ---
@@ -437,6 +437,162 @@ class GenerativeTests {
         try {
             val results = runGenerativeTests(feature)
             assertThat(results.results).hasSize(3)
+        } catch (e: ContractException) {
+            println(e.report())
+            throw e
+        }
+    }
+
+    @Test
+    fun `generative tests for optional query params with no examples`() {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+            ---
+            openapi: "3.0.1"
+            info:
+              title: "Person API"
+              version: "1"
+            paths:
+              /person:
+                get:
+                  summary: Fetch person's record
+                  parameters:
+                    - name: id
+                      in: query
+                      required: false
+                      schema:
+                        type: integer
+                  responses:
+                    200:
+                      description: Person's record
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                            required:
+                              - id
+                              - name
+                            properties:
+                              id:
+                                type: integer
+                              name:
+                                type: string
+            """.trimIndent(), ""
+        ).toFeature()
+
+        try {
+            val results = runGenerativeTests(feature)
+            assertThat(results.results).hasSize(4)
+        } catch (e: ContractException) {
+            println(e.report())
+            throw e
+        }
+    }
+
+    @Test
+    fun `generative tests with one optional and one mandatory query params with no examples`() {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+            ---
+            openapi: "3.0.1"
+            info:
+              title: "Person API"
+              version: "1"
+            paths:
+              /person:
+                get:
+                  summary: Fetch person's record
+                  parameters:
+                    - name: category
+                      in: query
+                      required: true
+                      schema:
+                        type: integer
+                    - name: status
+                      in: query
+                      required: false
+                      schema:
+                        type: integer
+                  responses:
+                    200:
+                      description: Person's record
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                            required:
+                              - id
+                              - name
+                            properties:
+                              id:
+                                type: integer
+                              name:
+                                type: string
+            """.trimIndent(), ""
+        ).toFeature()
+
+        try {
+            val results = runGenerativeTests(feature)
+            assertThat(results.results).hasSize(8)
+        } catch (e: ContractException) {
+            println(e.report())
+            throw e
+        }
+    }
+
+    @Test
+    fun `generative tests with one optional query param with no example and one mandatory query params with an example`() {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+            ---
+            openapi: "3.0.1"
+            info:
+              title: "Person API"
+              version: "1"
+            paths:
+              /person:
+                get:
+                  summary: Fetch person's record
+                  parameters:
+                    - name: category
+                      in: query
+                      required: false
+                      schema:
+                        type: integer
+                    - name: status
+                      in: query
+                      required: true
+                      schema:
+                        type: integer
+                      examples:
+                        FETCH:
+                          value: 10
+                  responses:
+                    200:
+                      description: Person's record
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                            required:
+                              - id
+                              - name
+                            properties:
+                              id:
+                                type: integer
+                              name:
+                                type: string
+                          examples:
+                            FETCH:
+                              value:
+                                id: 123
+                                name: "John Doe"
+            """.trimIndent(), ""
+        ).toFeature()
+
+        try {
+            val results = runGenerativeTests(feature)
+            assertThat(results.results).hasSize(12)
         } catch (e: ContractException) {
             println(e.report())
             throw e

--- a/core/src/test/kotlin/in/specmatic/conversions/GenerativeTests.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/GenerativeTests.kt
@@ -344,6 +344,106 @@ class GenerativeTests {
     }
 
     @Test
+    fun `generative tests for query params with an example`() {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+            ---
+            openapi: "3.0.1"
+            info:
+              title: "Person API"
+              version: "1"
+            paths:
+              /person:
+                get:
+                  summary: Fetch person's record
+                  parameters:
+                    - name: id
+                      in: query
+                      required: true
+                      schema:
+                        type: integer
+                      examples:
+                        DETAILS:
+                          value: 987
+                  responses:
+                    200:
+                      description: Person's record
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                            required:
+                              - id
+                              - name
+                            properties:
+                              id:
+                                type: integer
+                              name:
+                                type: string
+                          examples:
+                            DETAILS:
+                              value:
+                                id: 123
+                                name: "John Doe"
+            """.trimIndent(), ""
+        ).toFeature()
+
+        try {
+            val results = runGenerativeTests(feature)
+            assertThat(results.results).hasSize(3)
+        } catch (e: ContractException) {
+            println(e.report())
+            throw e
+        }
+    }
+
+    @Test
+    fun `generative tests for query params with no examples`() {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+            ---
+            openapi: "3.0.1"
+            info:
+              title: "Person API"
+              version: "1"
+            paths:
+              /person:
+                get:
+                  summary: Fetch person's record
+                  parameters:
+                    - name: id
+                      in: query
+                      required: true
+                      schema:
+                        type: integer
+                  responses:
+                    200:
+                      description: Person's record
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                            required:
+                              - id
+                              - name
+                            properties:
+                              id:
+                                type: integer
+                              name:
+                                type: string
+            """.trimIndent(), ""
+        ).toFeature()
+
+        try {
+            val results = runGenerativeTests(feature)
+            assertThat(results.results).hasSize(3)
+        } catch (e: ContractException) {
+            println(e.report())
+            throw e
+        }
+    }
+
+    @Test
     fun `generative tests should correctly generate values of the right type where the same key appears with different types in the request payload`() {
         val feature = OpenApiSpecification.fromYAML(
             """

--- a/core/src/test/kotlin/in/specmatic/conversions/GenerativeTests.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/GenerativeTests.kt
@@ -344,7 +344,7 @@ class GenerativeTests {
     }
 
     @Test
-    fun `generative tests for query params with an example`() {
+    fun `generative mandatory tests for query params with an example`() {
         val feature = OpenApiSpecification.fromYAML(
             """
             ---

--- a/core/src/test/kotlin/in/specmatic/conversions/GenerativeTests.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/GenerativeTests.kt
@@ -660,6 +660,200 @@ class GenerativeTests {
     }
 
     @Test
+    fun `generative tests with one optional query param that is an enum and has no examples`() {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+            ---
+            openapi: "3.0.1"
+            info:
+              title: "Products API"
+              version: "1"
+            paths:
+              /products:
+                get:
+                  summary: GET Products based on type
+                  parameters:
+                    - name: type
+                      in: query
+                      schema:
+                        type: string
+                        enum:
+                          - gadget
+                          - book
+                  responses:
+                    "200":
+                      description: List of products in the response
+                      content:
+                        text/plain:
+                          schema:
+                            type: string
+
+            """.trimIndent(), ""
+        ).toFeature()
+
+        try {
+            val results = runGenerativeTests(feature)
+            assertThat(results.results).hasSize(5)
+        } catch (e: ContractException) {
+            println(e.report())
+            throw e
+        }
+    }
+
+    @Test
+    fun `generative tests with one optional query param that is an enum and has an example`() {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+            ---
+            openapi: "3.0.1"
+            info:
+              title: "Person API"
+              version: "1"
+            paths:
+              /person:
+                get:
+                  summary: Fetch person's record
+                  parameters:
+                    - name: category
+                      in: query
+                      schema:
+                        type: string
+                        enum:
+                          - active
+                          - inactive
+                      examples:
+                        FETCH:
+                          value: active
+                  responses:
+                    200:
+                      description: Person's record
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                            required:
+                              - id
+                              - name
+                            properties:
+                              id:
+                                type: integer
+                              name:
+                                type: string
+                          examples:
+                            FETCH:
+                              value:
+                                id: 123
+                                name: "John Doe"
+            """.trimIndent(), ""
+        ).toFeature()
+
+        try {
+            val results = runGenerativeTests(feature)
+            assertThat(results.results).hasSize(5)
+        } catch (e: ContractException) {
+            println(e.report())
+            throw e
+        }
+    }
+
+    @Test
+    fun `generative tests with one optional header that is an enum and has no examples`() {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+            ---
+            openapi: "3.0.1"
+            info:
+              title: "Products API"
+              version: "1"
+            paths:
+              /products:
+                get:
+                  summary: GET Products based on type
+                  parameters:
+                    - name: type
+                      in: header
+                      schema:
+                        type: string
+                        enum:
+                          - gadget
+                          - book
+                  responses:
+                    "200":
+                      description: List of products in the response
+                      content:
+                        text/plain:
+                          schema:
+                            type: string
+
+            """.trimIndent(), ""
+        ).toFeature()
+
+        try {
+            val results = runGenerativeTests(feature)
+            assertThat(results.results).hasSize(5)
+        } catch (e: ContractException) {
+            println(e.report())
+            throw e
+        }
+    }
+
+    @Test
+    fun `generative tests with one optional header that is an enum and has an example`() {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+            ---
+            openapi: "3.0.1"
+            info:
+              title: "Person API"
+              version: "1"
+            paths:
+              /person:
+                get:
+                  summary: Fetch person's record
+                  parameters:
+                    - name: category
+                      in: header
+                      schema:
+                        type: string
+                        enum:
+                          - active
+                          - inactive
+                      examples:
+                        FETCH:
+                          value: active
+                  responses:
+                    200:
+                      description: Person's record
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                            required:
+                              - id
+                              - name
+                            properties:
+                              id:
+                                type: integer
+                              name:
+                                type: string
+                          examples:
+                            FETCH:
+                              value:
+                                id: 123
+                                name: "John Doe"
+            """.trimIndent(), ""
+        ).toFeature()
+
+        try {
+            val results = runGenerativeTests(feature)
+            assertThat(results.results).hasSize(5)
+        } catch (e: ContractException) {
+            println(e.report())
+            throw e
+        }
+    }
+
+    @Test
     fun `generative tests should correctly generate values of the right type where the same key appears with different types in the request payload`() {
         val feature = OpenApiSpecification.fromYAML(
             """

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
@@ -1736,58 +1736,6 @@ Scenario: zero should return not found
     }
 
     @Test
-    fun `should not send query params that have been explicitly omitted in examples`() {
-        val openAPISpec = """
-Feature: Hello world
-
-Background:
-  Given openapi openapi/helloWithQueryParams.yaml            
-
-Scenario: zero should return not found
-  When GET /hello
-  Then status 200
-  Examples:
-      | message | name |
-      | hello   | Hari |
-      | hello   | (omit) |
-        """.trimIndent()
-
-        val feature = parseGherkinStringToFeature(openAPISpec, sourceSpecPath)
-
-        val queryParameters: MutableList<Map<String, String>> = mutableListOf()
-
-        val results = feature.enableGenerativeTesting().executeTests(
-            object : TestExecutor {
-                override fun execute(request: HttpRequest): HttpResponse {
-                    queryParameters.add(request.queryParams.asMap())
-                    return HttpResponse.OK
-                }
-
-                override fun setServerState(serverState: Map<String, Value>) {
-                }
-            }
-        )
-
-        assertThat(results.success()).isTrue
-        assertThat(queryParameters.size).isEqualTo(4)
-        println(queryParameters)
-        assertThat(queryParameters.map { it.keys }).containsAll(
-            listOf(
-                setOf("message"),
-                setOf("message", "name"),
-                setOf("message", "name", "another_message"),
-                setOf("message", "another_message"),
-            )
-        )
-        assertThat(queryParameters.map { it.values.toSet() }).containsAll(
-            listOf(
-                setOf("Hari", "hello"),
-                setOf("hello")
-            )
-        )
-    }
-
-    @Test
     fun `default response should be used to match an unexpected response status code and body in stub`() {
         val openAPISpec = """
             Feature: With default
@@ -2591,51 +2539,6 @@ components:
         })
 
         assertThat(result.success()).withFailMessage(result.report()).isTrue
-    }
-
-    @Test
-    fun `should handle omit correctly when it is a default value in the parameter section if the schemaExampleDefault flag is set`() {
-        val feature =
-            OpenApiSpecification.fromFile("src/test/resources/openapi/helloWithOmitAsDefault.yaml").toFeature()
-                .enableSchemaExampleDefault()
-
-        val results = feature.executeTests(object : TestExecutor {
-            override fun execute(request: HttpRequest): HttpResponse {
-                assertThat(request.queryParams.asMap()).doesNotContainKey("id")
-                assertThat(request.headers).doesNotContainKey("traceId")
-                return HttpResponse.OK
-            }
-
-            override fun setServerState(serverState: Map<String, Value>) {
-            }
-        })
-
-        assertThat(results.hasFailures()).isFalse()
-        assertThat(results.success()).isTrue()
-    }
-
-    @Test
-    fun `should ignore omit when it is a default value in the parameter section if the schemaExampleDefault flag NOT set`() {
-        val feature =
-            OpenApiSpecification.fromFile("src/test/resources/openapi/helloWithOmitAsDefault.yaml").toFeature()
-
-        val queryParamsSeen = mutableListOf<String>()
-        val headersSeen = mutableListOf<String>()
-
-        feature.executeTests(object : TestExecutor {
-            override fun execute(request: HttpRequest): HttpResponse {
-                queryParamsSeen.addAll(request.queryParams.keys)
-                headersSeen.addAll(request.headers.keys)
-
-                return HttpResponse.OK
-            }
-
-            override fun setServerState(serverState: Map<String, Value>) {
-            }
-        })
-
-        assertThat(queryParamsSeen.sorted().distinct()).isEqualTo(listOf("id", "name"))
-        assertThat(headersSeen.sorted().distinct()).isEqualTo(listOf("traceId"))
     }
 
     @Test

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
@@ -20,6 +20,7 @@ import `in`.specmatic.core.value.Value
 import `in`.specmatic.jsonBody
 import `in`.specmatic.stub.HttpStub
 import `in`.specmatic.test.TestExecutor
+import net.bytebuddy.implementation.bytecode.Throw
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -2125,21 +2126,25 @@ components:
 
         var contractInvalidValueReceived = false
 
-        contract.executeTests(object : TestExecutor {
-            override fun execute(request: HttpRequest): HttpResponse {
-                val dataHeaderValue: String? = request.queryParams.getValues("data").first()
+        try {
+            contract.executeTests(object : TestExecutor {
+                override fun execute(request: HttpRequest): HttpResponse {
+                    val dataHeaderValue: String? = request.queryParams.getValues("data").first()
 
-                if (dataHeaderValue == "hello")
-                    contractInvalidValueReceived = true
+                    if (dataHeaderValue == "hello")
+                        contractInvalidValueReceived = true
 
-                return HttpResponse(400, body = parsedJSONObject("""{"message": "invalid request"}"""))
-            }
+                    return HttpResponse(400, body = parsedJSONObject("""{"message": "invalid request"}"""))
+                }
 
-            override fun setServerState(serverState: Map<String, Value>) {
-            }
-        })
+                override fun setServerState(serverState: Map<String, Value>) {
+                }
+            })
 
-        assertThat(contractInvalidValueReceived).isTrue
+            assertThat(contractInvalidValueReceived).isTrue
+        } catch(e: Throwable) {
+            throw e
+        }
     }
 
     @Test

--- a/core/src/test/kotlin/in/specmatic/conversions/StreamingTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/StreamingTest.kt
@@ -33,7 +33,7 @@ $parameters
                 type: string
 """.trimIndent()
 
-        val feature = OpenApiSpecification.fromYAML(specWith30QueryParams, "").toFeature()
+        val feature = OpenApiSpecification.fromYAML(specWith30QueryParams, "").toFeature().enableGenerativeTesting()
 
         val streamOfTestsWithOverABillionTests = feature.generateContractTests(emptyList())
         val first100TestsFromTheStreamingTest = streamOfTestsWithOverABillionTests.take(100)

--- a/core/src/test/kotlin/in/specmatic/core/HttpHeadersPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/HttpHeadersPatternTest.kt
@@ -198,13 +198,12 @@ internal class HttpHeadersPatternTest {
 
     @Tag(GENERATION)
     @Test
-    fun `should generate two header object given one optional header an example of the mandatory header`() {
+    fun `should generate only one header object given one optional header an example of only the mandatory header`() {
         val headers = HttpHeadersPattern(mapOf("X-TraceID" to StringPattern(), "X-Identifier?" to StringPattern()))
         val newHeaders = headers.newBasedOn(Row(mapOf("X-TraceID" to "123")), Resolver()).toList()
 
-        assertThat(newHeaders).containsExactlyInAnyOrder(
+        assertThat(newHeaders).containsExactly(
             HttpHeadersPattern(mapOf("X-TraceID" to ExactValuePattern(StringValue("123")))),
-            HttpHeadersPattern(mapOf("X-TraceID" to ExactValuePattern(StringValue("123")), "X-Identifier" to StringPattern()))
         )
     }
 

--- a/core/src/test/kotlin/in/specmatic/core/HttpRequestPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/HttpRequestPatternTest.kt
@@ -80,7 +80,7 @@ internal class HttpRequestPatternTest {
                 method = "GET"
         )
 
-        val newPatterns = pattern.newBasedOn(Row(), Resolver()).toList()
+        val newPatterns = pattern.newBasedOn(Row(), Resolver(), 200).toList()
         assertEquals("(string)", newPatterns[0].headersPattern.pattern["Test-Header"].toString())
     }
 
@@ -101,10 +101,10 @@ internal class HttpRequestPatternTest {
     }
 
     @Test
-    fun `a request with an optional header should result in 2 options for newBasedOn`() {
+    fun `a 200 request with an optional header should result in 2 options for newBasedOn`() {
         val requests = HttpRequestPattern(method = "GET",
                 httpPathPattern = buildHttpPathPattern(URI("/")),
-                headersPattern = HttpHeadersPattern(mapOf("X-Optional?" to StringPattern()))).newBasedOn(Row(), Resolver()).toList()
+                headersPattern = HttpHeadersPattern(mapOf("X-Optional?" to StringPattern()))).newBasedOn(Row(), Resolver(), 200).toList()
 
         assertThat(requests).hasSize(2)
 
@@ -116,6 +116,42 @@ internal class HttpRequestPatternTest {
         }
 
         flagsContain(flags, listOf("with", "without"))
+    }
+
+    @Test
+    fun `a 400 request with an optional header should result in 1 options for newBasedOn`() {
+        val requests = HttpRequestPattern(method = "GET",
+            httpPathPattern = buildHttpPathPattern(URI("/")),
+            headersPattern = HttpHeadersPattern(mapOf("X-Optional?" to StringPattern()))).newBasedOn(Row(), Resolver(), 400).toList()
+
+        assertThat(requests).hasSize(1)
+
+        val flags = requests.map {
+            when {
+                it.headersPattern.pattern.containsKey("X-Optional") -> "with"
+                else -> "without"
+            }
+        }
+
+        flagsContain(flags, listOf("without"))
+    }
+
+    @Test
+    fun `a 500 request with an optional header should result in 1 options for newBasedOn`() {
+        val requests = HttpRequestPattern(method = "GET",
+            httpPathPattern = buildHttpPathPattern(URI("/")),
+            headersPattern = HttpHeadersPattern(mapOf("X-Optional?" to StringPattern()))).newBasedOn(Row(), Resolver(), 500).toList()
+
+        assertThat(requests).hasSize(1)
+
+        val flags = requests.map {
+            when {
+                it.headersPattern.pattern.containsKey("X-Optional") -> "with"
+                else -> "without"
+            }
+        }
+
+        flagsContain(flags, listOf("without"))
     }
 
     @Test

--- a/core/src/test/kotlin/integration_tests/DefaultValuesInOpenapiSpecification.kt
+++ b/core/src/test/kotlin/integration_tests/DefaultValuesInOpenapiSpecification.kt
@@ -1,5 +1,6 @@
-package `in`.specmatic.conversions
+package integration_tests
 
+import `in`.specmatic.conversions.OpenApiSpecification
 import `in`.specmatic.core.Flags
 import `in`.specmatic.core.HttpRequest
 import `in`.specmatic.core.HttpResponse
@@ -361,7 +362,8 @@ class DefaultValuesInOpenapiSpecification {
                           format: float
                           description: The price of the product
                           example: 10
-                    """, "").toFeature()
+                    """, ""
+            ).toFeature()
 
             val results = feature.executeTests(object : TestExecutor {
                 override fun execute(request: HttpRequest): HttpResponse {

--- a/core/src/test/kotlin/integration_tests/ExamplesAsStubTest.kt
+++ b/core/src/test/kotlin/integration_tests/ExamplesAsStubTest.kt
@@ -1,12 +1,10 @@
-package `in`.specmatic.conversions
+package integration_tests
 
+import `in`.specmatic.conversions.OpenApiSpecification
 import `in`.specmatic.core.HttpRequest
-import `in`.specmatic.core.HttpResponse
 import `in`.specmatic.core.pattern.parsedJSONArray
 import `in`.specmatic.core.pattern.parsedJSONObject
-import `in`.specmatic.mock.ScenarioStub
 import `in`.specmatic.stub.HttpStub
-import `in`.specmatic.stub.HttpStubData
 import `in`.specmatic.stub.captureStandardOutput
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -177,7 +175,8 @@ paths:
 
     @Test
     fun `any value should match the given security scheme`() {
-        val feature = OpenApiSpecification.fromYAML("""
+        val feature = OpenApiSpecification.fromYAML(
+            """
 openapi: 3.0.0
 info:
   title: Sample API
@@ -226,7 +225,8 @@ components:
 
 security:
   - BearerAuth: []
-         """.trimIndent(), "").toFeature()
+         """.trimIndent(), ""
+        ).toFeature()
 
         val credentials = "Basic " + Base64.getEncoder().encodeToString("user:password".toByteArray())
 
@@ -244,7 +244,8 @@ security:
 
     @Test
     fun `examples as stub should work for request with body when there are no security schemes`() {
-        val feature = OpenApiSpecification.fromYAML("""
+        val feature = OpenApiSpecification.fromYAML(
+            """
 openapi: 3.0.0
 info:
   title: Sample API
@@ -285,7 +286,8 @@ paths:
                 SUCCESS:
                   value:
                     Hello to you!
-         """.trimIndent(), "").toFeature()
+         """.trimIndent(), ""
+        ).toFeature()
 
         HttpStub(feature).use {
             val response = it.client.execute(HttpRequest(
@@ -300,7 +302,8 @@ paths:
 
     @Test
     fun `any value should match the given security scheme when request body does not exist`() {
-        val feature = OpenApiSpecification.fromYAML("""
+        val feature = OpenApiSpecification.fromYAML(
+            """
 openapi: 3.0.0
 info:
   title: Sample API
@@ -343,7 +346,8 @@ components:
 
 security:
   - BearerAuth: []
-         """.trimIndent(), "").toFeature()
+         """.trimIndent(), ""
+        ).toFeature()
 
         val credentials = "Basic " + Base64.getEncoder().encodeToString("user:password".toByteArray())
 

--- a/core/src/test/kotlin/integration_tests/GenerativeTests.kt
+++ b/core/src/test/kotlin/integration_tests/GenerativeTests.kt
@@ -11,7 +11,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 
-private val Results.testCount: Int
+internal val Results.testCount: Int
     get() {
         return this.successCount + this.failureCount
     }

--- a/core/src/test/kotlin/integration_tests/GenerativeTests.kt
+++ b/core/src/test/kotlin/integration_tests/GenerativeTests.kt
@@ -1,6 +1,7 @@
-package `in`.specmatic.conversions
+package integration_tests
 
 import `in`.specmatic.GENERATION
+import `in`.specmatic.conversions.OpenApiSpecification
 import `in`.specmatic.core.*
 import `in`.specmatic.core.pattern.ContractException
 import `in`.specmatic.core.value.*

--- a/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
+++ b/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
@@ -1,5 +1,6 @@
-package `in`.specmatic.conversions
+package integration_tests
 
+import `in`.specmatic.conversions.OpenApiSpecification
 import `in`.specmatic.core.HttpRequest
 import `in`.specmatic.core.HttpResponse
 import `in`.specmatic.core.log.*
@@ -16,7 +17,8 @@ import java.util.function.Consumer
 class LoadTestsFromExternalisedFiles {
     @Test
     fun `should load and execute externalized tests for header and request body from _tests directory`() {
-        val feature = OpenApiSpecification.fromFile("src/test/resources/openapi/has_externalized_test_and_no_example.yaml").toFeature().loadExternalisedExamples()
+        val feature = OpenApiSpecification.fromFile("src/test/resources/openapi/has_externalized_test_and_no_example.yaml")
+            .toFeature().loadExternalisedExamples()
 
         val results = feature.executeTests(object : TestExecutor {
             override fun execute(request: HttpRequest): HttpResponse {
@@ -39,7 +41,8 @@ class LoadTestsFromExternalisedFiles {
 
     @Test
     fun `externalized tests should replace example tests`() {
-        val feature = OpenApiSpecification.fromFile("src/test/resources/openapi/has_externalized_test_and_one_example.yaml").toFeature().loadExternalisedExamples()
+        val feature = OpenApiSpecification.fromFile("src/test/resources/openapi/has_externalized_test_and_one_example.yaml")
+            .toFeature().loadExternalisedExamples()
 
         val results = feature.executeTests(object : TestExecutor {
             override fun execute(request: HttpRequest): HttpResponse {
@@ -96,7 +99,8 @@ class LoadTestsFromExternalisedFiles {
 
     @Test
     fun `externalized tests with query parameters`() {
-        val feature = OpenApiSpecification.fromFile("src/test/resources/openapi/has_externalised_test_with_query_params.yaml").toFeature().loadExternalisedExamples()
+        val feature = OpenApiSpecification.fromFile("src/test/resources/openapi/has_externalised_test_with_query_params.yaml")
+            .toFeature().loadExternalisedExamples()
 
         val results = feature.executeTests(object : TestExecutor {
             override fun execute(request: HttpRequest): HttpResponse {
@@ -130,7 +134,8 @@ class LoadTestsFromExternalisedFiles {
         try {
             logger = testLogger
 
-            val feature = OpenApiSpecification.fromFile("src/test/resources/openapi/has_irrelevant_externalized_test.yaml").toFeature().loadExternalisedExamples()
+            val feature = OpenApiSpecification.fromFile("src/test/resources/openapi/has_irrelevant_externalized_test.yaml")
+                .toFeature().loadExternalisedExamples()
 
             feature.executeTests(object : TestExecutor {
                 override fun execute(request: HttpRequest): HttpResponse {

--- a/core/src/test/kotlin/integration_tests/OmittedParameterExamples.kt
+++ b/core/src/test/kotlin/integration_tests/OmittedParameterExamples.kt
@@ -1,0 +1,174 @@
+package integration_tests
+
+import `in`.specmatic.conversions.OpenApiSpecification
+import `in`.specmatic.core.HttpRequest
+import `in`.specmatic.core.HttpResponse
+import `in`.specmatic.core.pattern.ContractException
+import `in`.specmatic.core.pattern.parsedJSONArray
+import `in`.specmatic.core.utilities.exceptionCauseMessage
+import `in`.specmatic.test.TestExecutor
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+class OmittedParameterExamples {
+    @Test
+    fun `omitted optional query params should not be sent in any contract test`() {
+        val productSpec = OpenApiSpecification.fromYAML("""
+openapi: 3.0.3
+info:
+  title: Product Search Service
+  description: API for searching product details
+  version: 1.0.0
+servers:
+  - url: 'https://localhost:8080'
+paths:
+  /product/search:
+    get:
+      summary: Search for product details
+      parameters:
+        - name: productName
+          in: query
+          description: Name of the product to search for
+          required: false
+          schema:
+            type: string
+        - name: productCategory
+          in: query
+          description: Category of the product to search for
+          required: true
+          schema:
+            type: string
+          examples:
+            PRODUCT_SEARCH:
+              value: "Electronics"
+        - name: priceRange
+          in: query
+          description: Price range of the product to search for
+          required: false
+          schema:
+            type: string
+          examples:
+            PRODUCT_SEARCH:
+              value: "1000-2000"
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  ${"$"}ref: '#/components/schemas/Product'
+              examples:
+                PRODUCT_SEARCH:
+                    value:
+                      - id: 1
+                        name: "Product 1"
+                      - id: 2
+                        name: "Product 2"
+components:
+  schemas:
+    Product:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        """.trimIndent(), "").toFeature()
+
+        val optionalQueryParam = "productName"
+
+        val results = productSpec.executeTests(object : TestExecutor {
+            override fun execute(request: HttpRequest): HttpResponse {
+                assertThat(request.queryParams.keys).doesNotContain(optionalQueryParam)
+                return HttpResponse(200, body = parsedJSONArray("""[{"id": 1, "name": "Product 1"}, {"id": 2, "name": "Product 2"}]"""))
+            }
+        })
+
+        assertThat(results.success()).isTrue()
+        assertThat(results.successCount).isPositive()
+    }
+
+    @Test
+    fun `omitted mandatory query params should be generated in a test`() {
+        val productSpec = OpenApiSpecification.fromYAML(
+            """
+openapi: 3.0.3
+info:
+  title: Product Search Service
+  description: API for searching product details
+  version: 1.0.0
+servers:
+  - url: 'https://localhost:8080'
+paths:
+  /product/search:
+    get:
+      summary: Search for product details
+      parameters:
+        - name: productName
+          in: query
+          description: Name of the product to search for
+          required: false
+          schema:
+            type: string
+        - name: productCategory
+          in: query
+          description: Category of the product to search for
+          required: true
+          schema:
+            type: string
+        - name: priceRange
+          in: query
+          description: Price range of the product to search for
+          required: false
+          schema:
+            type: string
+          examples:
+            PRODUCT_SEARCH:
+              value: "1000-2000"
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  ${"$"}ref: '#/components/schemas/Product'
+              examples:
+                PRODUCT_SEARCH:
+                    value:
+                      - id: 1
+                        name: "Product 1"
+                      - id: 2
+                        name: "Product 2"
+components:
+  schemas:
+    Product:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        """.trimIndent(), ""
+        ).toFeature()
+
+        val mandatoryQueryParam = "productCategory"
+
+        val results = productSpec.executeTests(object : TestExecutor {
+            override fun execute(request: HttpRequest): HttpResponse {
+                assertThat(request.queryParams.keys).contains(mandatoryQueryParam)
+
+                return HttpResponse(
+                    200,
+                    body = parsedJSONArray("""[{"id": 1, "name": "Product 1"}, {"id": 2, "name": "Product 2"}]""")
+                )
+            }
+        })
+
+        assertThat(results.success()).isTrue()
+    }
+}

--- a/core/src/test/kotlin/integration_tests/OmittedParameterExamples.kt
+++ b/core/src/test/kotlin/integration_tests/OmittedParameterExamples.kt
@@ -92,6 +92,93 @@ components:
     }
 
     @Test
+    fun `omitted optional query params should be sent when generative tests are switch on`() {
+        val productSpec = OpenApiSpecification.fromYAML("""
+openapi: 3.0.3
+info:
+  title: Product Search Service
+  description: API for searching product details
+  version: 1.0.0
+servers:
+  - url: 'https://localhost:8080'
+paths:
+  /product/search:
+    get:
+      summary: Search for product details
+      parameters:
+        - name: productName
+          in: query
+          description: Name of the product to search for
+          required: false
+          schema:
+            type: string
+        - name: productCategory
+          in: query
+          description: Category of the product to search for
+          required: true
+          schema:
+            type: string
+          examples:
+            PRODUCT_SEARCH:
+              value: "Electronics"
+        - name: priceRange
+          in: query
+          description: Price range of the product to search for
+          required: false
+          schema:
+            type: string
+          examples:
+            PRODUCT_SEARCH:
+              value: "1000-2000"
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  ${"$"}ref: '#/components/schemas/Product'
+              examples:
+                PRODUCT_SEARCH:
+                    value:
+                      - id: 1
+                        name: "Product 1"
+                      - id: 2
+                        name: "Product 2"
+components:
+  schemas:
+    Product:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        """.trimIndent(), "").toFeature().enableGenerativeTesting()
+
+        val optionalQueryParam = "productName"
+
+        val optionalQueryParamObserved = mutableListOf<String>()
+
+        val results = productSpec.executeTests(object : TestExecutor {
+            override fun execute(request: HttpRequest): HttpResponse {
+                if(optionalQueryParam in request.queryParams.keys) {
+                    optionalQueryParamObserved.add("yes")
+                } else {
+                    optionalQueryParamObserved.add("no")
+                }
+
+                return HttpResponse(200, body = parsedJSONArray("""[{"id": 1, "name": "Product 1"}, {"id": 2, "name": "Product 2"}]"""))
+            }
+        })
+
+        println(optionalQueryParamObserved)
+        assertThat(results.successCount).isPositive()
+        assertThat(results.success()).isTrue()
+    }
+
+    @Test
     fun `omitted mandatory query params should be generated in a test`() {
         val productSpec = OpenApiSpecification.fromYAML(
             """

--- a/core/src/test/kotlin/integration_tests/OmittedParameterExamples.kt
+++ b/core/src/test/kotlin/integration_tests/OmittedParameterExamples.kt
@@ -92,6 +92,144 @@ components:
     }
 
     @Test
+    fun `mandatory query param without example should be generated`() {
+        val productSpec = OpenApiSpecification.fromYAML("""
+openapi: 3.0.3
+info:
+  title: Product Search Service
+  description: API for searching product details
+  version: 1.0.0
+servers:
+  - url: 'https://localhost:8080'
+paths:
+  /product/search:
+    get:
+      summary: Search for product details
+      parameters:
+        - name: productCategory
+          in: query
+          description: Category of the product to search for
+          required: true
+          schema:
+            type: string
+        - name: priceRange
+          in: query
+          description: Price range of the product to search for
+          required: false
+          schema:
+            type: string
+          examples:
+            PRODUCT_SEARCH:
+              value: "1000-2000"
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  ${"$"}ref: '#/components/schemas/Product'
+              examples:
+                PRODUCT_SEARCH:
+                    value:
+                      - id: 1
+                        name: "Product 1"
+                      - id: 2
+                        name: "Product 2"
+components:
+  schemas:
+    Product:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        """.trimIndent(), "").toFeature()
+
+        val optionalQueryParam = "productName"
+
+        val results = productSpec.executeTests(object : TestExecutor {
+            override fun execute(request: HttpRequest): HttpResponse {
+                assertThat(request.queryParams.keys).contains("productCategory")
+                return HttpResponse(200, body = parsedJSONArray("""[{"id": 1, "name": "Product 1"}, {"id": 2, "name": "Product 2"}]"""))
+            }
+        })
+
+        assertThat(results.success()).isTrue()
+        assertThat(results.successCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `mandatory header without example should be generated`() {
+        val productSpec = OpenApiSpecification.fromYAML("""
+openapi: 3.0.3
+info:
+  title: Product Search Service
+  description: API for searching product details
+  version: 1.0.0
+servers:
+  - url: 'https://localhost:8080'
+paths:
+  /product/search:
+    get:
+      summary: Search for product details
+      parameters:
+        - name: productCategory
+          in: header
+          description: Category of the product to search for
+          required: true
+          schema:
+            type: string
+        - name: priceRange
+          in: header
+          description: Price range of the product to search for
+          required: false
+          schema:
+            type: string
+          examples:
+            PRODUCT_SEARCH:
+              value: "1000-2000"
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  ${"$"}ref: '#/components/schemas/Product'
+              examples:
+                PRODUCT_SEARCH:
+                    value:
+                      - id: 1
+                        name: "Product 1"
+                      - id: 2
+                        name: "Product 2"
+components:
+  schemas:
+    Product:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        """.trimIndent(), "").toFeature()
+
+        val results = productSpec.executeTests(object : TestExecutor {
+            override fun execute(request: HttpRequest): HttpResponse {
+                assertThat(request.headers.keys).contains("productCategory")
+                return HttpResponse(200, body = parsedJSONArray("""[{"id": 1, "name": "Product 1"}, {"id": 2, "name": "Product 2"}]"""))
+            }
+        })
+
+        assertThat(results.success()).isTrue()
+        assertThat(results.successCount).isEqualTo(1)
+    }
+
+    @Test
     fun `omitted optional query params should be sent when generative tests are switch on`() {
         val productSpec = OpenApiSpecification.fromYAML("""
 openapi: 3.0.3

--- a/core/src/test/kotlin/integration_tests/ReferencedExamplesAsStubTest.kt
+++ b/core/src/test/kotlin/integration_tests/ReferencedExamplesAsStubTest.kt
@@ -1,5 +1,6 @@
-package `in`.specmatic.conversions
+package integration_tests
 
+import `in`.specmatic.conversions.OpenApiSpecification
 import `in`.specmatic.core.HttpRequest
 import `in`.specmatic.core.HttpResponse
 import `in`.specmatic.core.pattern.parsedJSONArray

--- a/core/src/test/kotlin/integration_tests/StreamingTest.kt
+++ b/core/src/test/kotlin/integration_tests/StreamingTest.kt
@@ -1,5 +1,6 @@
-package `in`.specmatic.conversions
+package integration_tests
 
+import `in`.specmatic.conversions.OpenApiSpecification
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 

--- a/core/src/test/resources/openapi/helloWithExamples.yaml
+++ b/core/src/test/resources/openapi/helloWithExamples.yaml
@@ -40,8 +40,6 @@ paths:
               value: "test-trace-id"
             404_NOT_FOUND:
               value: "test-trace-id"
-            400_BAD_REQUEST:
-              value: "(OMIT)"
       responses:
         '200':
           description: Says hello

--- a/core/src/test/resources/openapi/mandatory_and_omitted_optional_query_params.yaml
+++ b/core/src/test/resources/openapi/mandatory_and_omitted_optional_query_params.yaml
@@ -1,0 +1,26 @@
+openapi: 3.0.0
+info:
+  title: Sample API
+  version: 0.1.9
+paths:
+  /products:
+    get:
+      summary: get products
+      description: Get multiple products filtered by Brand Ids
+      parameters:
+        - name: brand_id
+          in: query
+          schema:
+            type: string
+        - name: source
+          in: query
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: string

--- a/core/src/test/resources/openapi/mandatory_and_omitted_optional_query_params_tests/stub.json
+++ b/core/src/test/resources/openapi/mandatory_and_omitted_optional_query_params_tests/stub.json
@@ -1,0 +1,15 @@
+{
+  "http-request": {
+    "method": "GET",
+    "path": "/products",
+    "query": {
+      "source": "farm"
+    }
+  },
+  "http-response": {
+    "status": 200,
+    "body": {
+      "id": 10
+    }
+  }
+}

--- a/core/src/test/resources/openapi/one_omitted_mandatory_query_param.yaml
+++ b/core/src/test/resources/openapi/one_omitted_mandatory_query_param.yaml
@@ -1,0 +1,22 @@
+openapi: 3.0.0
+info:
+  title: Sample API
+  version: 0.1.9
+paths:
+  /products:
+    get:
+      summary: get products
+      description: Get multiple products filtered by Brand Ids
+      parameters:
+        - name: brand_id
+          in: query
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: OK
+          content:
+            text/plain:
+              schema:
+                type: string

--- a/core/src/test/resources/openapi/one_omitted_mandatory_query_param_tests/stub.json
+++ b/core/src/test/resources/openapi/one_omitted_mandatory_query_param_tests/stub.json
@@ -1,0 +1,12 @@
+{
+  "http-request": {
+    "method": "GET",
+    "path": "/products"
+  },
+  "http-response": {
+    "status": 200,
+    "body": {
+      "id": 10
+    }
+  }
+}

--- a/core/src/test/resources/openapi/one_omitted_optional_query_param.yaml
+++ b/core/src/test/resources/openapi/one_omitted_optional_query_param.yaml
@@ -1,0 +1,21 @@
+openapi: 3.0.0
+info:
+  title: Sample API
+  version: 0.1.9
+paths:
+  /products:
+    get:
+      summary: get products
+      description: Get multiple products filtered by Brand Ids
+      parameters:
+        - name: brand_id
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: string

--- a/core/src/test/resources/openapi/one_omitted_optional_query_param_tests/stub.json
+++ b/core/src/test/resources/openapi/one_omitted_optional_query_param_tests/stub.json
@@ -1,0 +1,12 @@
+{
+  "http-request": {
+    "method": "GET",
+    "path": "/products"
+  },
+  "http-response": {
+    "status": 200,
+    "body": {
+      "id": 10
+    }
+  }
+}

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=1.2.25
+version=1.2.25-WITHOUT-OMIT


### PR DESCRIPTION
**What**:

Eliminate the "(omit)" feature. Now if an optional query parameter or header has to be omitted in a contract test, just omit the example.

If a mandatory query parameter or header are omitted, they will be generated.

**Why**:

This is a more elegant way to avoid sending a query parameter..

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate
