### PR TITLE
Updated Release Workflow For Version Upgrade Automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
   push:
     tags:
       - '*.*.*'
-      - 'SNAPSHOT'
+      - 'SNAPSHOT'      
 
 jobs:
   build:
@@ -40,10 +40,17 @@ jobs:
         repository: [znsio/specmatic-documentation]
     runs-on: ubuntu-latest
     steps:
+      - name: Extracting Latest Release Version From Github Ref
+        run: |
+          GITHUB_REF=${{ github.ref }}
+          echo "GITHUB_REF: ${GITHUB_REF}"
+          echo "SPECMATIC_LATEST_RELEASE_VERSION=${GITHUB_REF#refs/tags/}"
+          echo "SPECMATIC_LATEST_RELEASE_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v3
+
         with:
           token: ${{ secrets.SPECMATIC_CORE_VERSION_UPDATE_TOKEN }}
           repository: ${{ matrix.repository }}
           event-type: specmatic-core-release
-          client-payload: '{"version": "${{ github.ref }}"}'
+          client-payload: '{"latest-release": "${{ env.SPECMATIC_LATEST_RELEASE_VERSION }}"}'


### PR DESCRIPTION
- Updated the way payload is being passed in the repository_dispatch trigger job to pass stripped-down latest Specmatic release version number only from the `github.ref`