### PR TITLE
Implemented type-less JSON key

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -998,10 +998,10 @@ class OpenApiSpecification(
                 else {
                     val schemaFragment = if(patternName.isNotBlank()) " in schema $patternName" else " in the schema"
 
-                    throw if(schema.javaClass.simpleName != "Schema")
-                        ContractException("${schemaFragment.capitalizeFirstChar()} is not yet supported, please raise an issue on https://github.com/znsio/specmatic/issues")
+                    if(schema.javaClass.simpleName != "Schema")
+                        throw ContractException("${schemaFragment.capitalizeFirstChar()} is not yet supported, please raise an issue on https://github.com/znsio/specmatic/issues")
                     else
-                        ContractException("\"type\" attribute was not provided$schemaFragment, please check the syntax of the specification")
+                        AnyNonNullJSONValue()
                 }
             }
         }.also {

--- a/core/src/main/kotlin/in/specmatic/core/pattern/AnyNonNullJSONValue.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/AnyNonNullJSONValue.kt
@@ -1,0 +1,28 @@
+package `in`.specmatic.core.pattern
+
+import `in`.specmatic.core.Resolver
+import `in`.specmatic.core.Result
+import `in`.specmatic.core.value.NullValue
+import `in`.specmatic.core.value.StringValue
+import `in`.specmatic.core.value.Value
+
+data class AnyNonNullJSONValue(override val pattern: Pattern = AnythingPattern): Pattern by pattern{
+    override fun matches(sampleData: Value?, resolver: Resolver): Result {
+        if(sampleData is NullValue)
+            return resolver.mismatchMessages.valueMismatchFailure("non-null value", sampleData)
+
+        return Result.Success()
+    }
+
+    override fun encompasses(
+        otherPattern: Pattern,
+        thisResolver: Resolver,
+        otherResolver: Resolver,
+        typeStack: TypeStack
+    ): Result {
+        return when(otherPattern) {
+            AnyNonNullJSONValue() -> Result.Success()
+            else -> Result.Failure("Changing from anyType to ${otherPattern.typeName} is a breaking change.")
+        }
+    }
+}


### PR DESCRIPTION
**What**:

When a JSON key has no type in an OpenAPI spec, it means that the value can be any valid JSON value. It cannot be null, unless marked `nullable: true`.

[Documentation here](https://swagger.io/docs/specification/data-models/data-types/#any).

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

