### PR TITLE
Fix sequence logic and 204 response body handling

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -556,7 +556,7 @@ class OpenApiSpecification(
         status: String,
         headersMap: Map<String, Pattern>
     ): List<ResponsePatternData> {
-        if (response.content == null) {
+        if (response.content == null || response.content.isEmpty()) {
             val responsePattern = HttpResponsePattern(
                 headersPattern = HttpHeadersPattern(headersMap),
                 status = status.toIntOrNull() ?: DEFAULT_RESPONSE_CODE

--- a/core/src/main/kotlin/in/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Feature.kt
@@ -339,7 +339,7 @@ data class Feature(
 
     fun validateExampleRows() {
         scenarios.forEach { scenario ->
-            scenario.validateExamples(resolverStrategies)
+            scenario.validateExamples(resolverStrategies.copy(generation = NonGenerativeTests))
         }
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Feature.kt
@@ -220,6 +220,9 @@ data class Feature(
     }
 
     fun matchResult(request: HttpRequest, response: HttpResponse): Result {
+        if(scenarios.isEmpty())
+            return Result.Failure("No operations found")
+
         val matchResults = scenarios.map {
             it.matches(
                 request,

--- a/core/src/main/kotlin/in/specmatic/core/GenerationStrategies.kt
+++ b/core/src/main/kotlin/in/specmatic/core/GenerationStrategies.kt
@@ -61,18 +61,6 @@ data class GenerativeTestsEnabled(private val positiveOnly: Boolean = Flags.only
             if(!matchFound)
                 yield(requestBodyAsIs)
         }
-
-//        requestsFromFlattenedRow.map { requestsFromFlattenedRow ->
-//            if(requestsFromFlattenedRow.encompasses(requestBodyAsIs, resolver, resolver, emptySet()) is Success)
-//                matchFound = true
-//
-//
-//        }
-//        return if(requestsFromFlattenedRow.none { p -> p.encompasses(requestBodyAsIs, resolver, resolver, emptySet()) is Success }) {
-//            requestsFromFlattenedRow.plus(listOf(requestBodyAsIs))
-//        } else {
-//            requestsFromFlattenedRow
-//        }
     }
 
     override fun generateHttpRequests(resolver: Resolver, body: Pattern, row: Row): Sequence<Pattern> {

--- a/core/src/main/kotlin/in/specmatic/core/GenerationStrategies.kt
+++ b/core/src/main/kotlin/in/specmatic/core/GenerationStrategies.kt
@@ -43,11 +43,36 @@ data class GenerativeTestsEnabled(private val positiveOnly: Boolean = Flags.only
                 body.newBasedOn(row.noteRequestBody(), cyclePreventedResolver)
             }
 
-        return if(requestsFromFlattenedRow.none { p -> p.encompasses(requestBodyAsIs, resolver, resolver, emptySet()) is Success }) {
-            requestsFromFlattenedRow.plus(listOf(requestBodyAsIs))
-        } else {
-            requestsFromFlattenedRow
+        var matchFound = false
+
+        val iterator = requestsFromFlattenedRow.iterator()
+
+        return sequence {
+
+            while(iterator.hasNext()) {
+                val next = iterator.next()
+
+                if(next.encompasses(requestBodyAsIs, resolver, resolver, emptySet()) is Success)
+                    matchFound = true
+
+                yield(next)
+            }
+
+            if(!matchFound)
+                yield(requestBodyAsIs)
         }
+
+//        requestsFromFlattenedRow.map { requestsFromFlattenedRow ->
+//            if(requestsFromFlattenedRow.encompasses(requestBodyAsIs, resolver, resolver, emptySet()) is Success)
+//                matchFound = true
+//
+//
+//        }
+//        return if(requestsFromFlattenedRow.none { p -> p.encompasses(requestBodyAsIs, resolver, resolver, emptySet()) is Success }) {
+//            requestsFromFlattenedRow.plus(listOf(requestBodyAsIs))
+//        } else {
+//            requestsFromFlattenedRow
+//        }
     }
 
     override fun generateHttpRequests(resolver: Resolver, body: Pattern, row: Row): Sequence<Pattern> {

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -6,10 +6,7 @@ import `in`.specmatic.core.log.LogMessage
 import `in`.specmatic.core.log.LogStrategy
 import `in`.specmatic.core.pattern.*
 import `in`.specmatic.core.utilities.exceptionCauseMessage
-import `in`.specmatic.core.value.JSONObjectValue
-import `in`.specmatic.core.value.NumberValue
-import `in`.specmatic.core.value.StringValue
-import `in`.specmatic.core.value.Value
+import `in`.specmatic.core.value.*
 import `in`.specmatic.mock.NoMatchingScenario
 import `in`.specmatic.mock.ScenarioStub
 import `in`.specmatic.stub.HttpStub
@@ -7757,6 +7754,43 @@ paths:
         feature.matchResult(
             HttpRequest("POST", "/person", body = parsedJSONObject("""{"id": null}""")),
             HttpResponse.OK
+        ).let { matchResult ->
+            assertThat(matchResult).withFailMessage(matchResult.reportString()).isInstanceOf(Result.Success::class.java)
+        }
+    }
+
+    @Test
+    fun `a response body with empty content should be considered an empty response`() {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+                ---
+                openapi: "3.0.1"
+                info:
+                  title: "Person API"
+                  version: "1"
+                paths:
+                  /person:
+                    post:
+                      summary: "Get person by id"
+                      requestBody:
+                        content:
+                          application/json:
+                            schema:
+                              required:
+                              - id
+                              properties:
+                                id:
+                                  description: id of the person
+                                  type: string
+                      responses:
+                        204:
+                          description: "Get person by id"
+                          content: {}
+                """.trimIndent(), "").toFeature()
+
+        feature.matchResult(
+            HttpRequest("POST", "/person", body = parsedJSONObject("""{"id": "abc123"}""")),
+            HttpResponse(204, EmptyString)
         ).let { matchResult ->
             assertThat(matchResult).withFailMessage(matchResult.reportString()).isInstanceOf(Result.Success::class.java)
         }


### PR DESCRIPTION
**What**:

1. Fix the logic for handling 204 response bodies defined like this:

  ```yaml
  '204':
    content: {}
  ```
2. Fix logic that eagerly evaluated patterns. There was a snippet that eagerly evaluated of the sequence before returning the first value, and for certain complicated APIs this took a lot of time before even seeing the first test.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate
