### PR TITLE
Fixed cycles detection across arrays

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/value/JSONArrayValue.kt
+++ b/core/src/main/kotlin/in/specmatic/core/value/JSONArrayValue.kt
@@ -60,4 +60,22 @@ data class JSONArrayValue(override val list: List<Value>) : Value, ListValue, JS
             typeDeclaration(exampleKey, types, exampleDeclarations) { value, innerKey, innerTypes, newExamples -> value.typeDeclarationWithoutKey(innerKey, innerTypes, newExamples) }
 
     override fun toString() = valueArrayToJsonString(list)
+    fun getElementAtIndex(first: String, rest: List<String>): Value? {
+        val trimmed = first.trim()
+
+        if(trimmed.first() != '[' || trimmed.last() != ']')
+            return null
+
+        val index = trimmed.trim().removeSurrounding("[", "]").toIntOrNull() ?: return null
+
+        val value = list[index]
+
+        return when {
+            rest.isEmpty() -> value
+            value is JSONObjectValue -> value.findFirstChildByPath(rest)
+            value is JSONArrayValue -> value.getElementAtIndex(rest.first(), rest.drop(1))
+            else -> null
+        }
+
+    }
 }

--- a/core/src/main/kotlin/in/specmatic/core/value/JSONObjectValue.kt
+++ b/core/src/main/kotlin/in/specmatic/core/value/JSONObjectValue.kt
@@ -68,7 +68,7 @@ data class JSONObjectValue(val jsonObject: Map<String, Value> = emptyMap()) : Va
     fun findFirstChildByPath(path: String): Value? =
         findFirstChildByPath(path.split("."))
 
-    private fun findFirstChildByPath(path: List<String>): Value? =
+    fun findFirstChildByPath(path: List<String>): Value? =
         findFirstChildByPath(path.first(), path.drop(1))
 
     private fun findFirstChildByPath(first: String, rest: List<String>): Value? {
@@ -76,6 +76,7 @@ data class JSONObjectValue(val jsonObject: Map<String, Value> = emptyMap()) : Va
             when {
                 rest.isEmpty() -> it
                 it is JSONObjectValue -> it.findFirstChildByPath(rest)
+                it is JSONArrayValue -> it.getElementAtIndex(rest.first(), rest.drop(1))
                 else -> null
             }
         }

--- a/core/src/test/kotlin/in/specmatic/core/CyclePrevention.kt
+++ b/core/src/test/kotlin/in/specmatic/core/CyclePrevention.kt
@@ -3,6 +3,8 @@ package `in`.specmatic.core
 import `in`.specmatic.conversions.OpenApiSpecification
 import `in`.specmatic.core.Result.Success
 import `in`.specmatic.core.pattern.parsedJSON
+import `in`.specmatic.core.utilities.exceptionCauseMessage
+import `in`.specmatic.core.value.JSONObjectValue
 import `in`.specmatic.core.value.Value
 import `in`.specmatic.stub.HttpStub
 import `in`.specmatic.test.TestExecutor
@@ -13,7 +15,8 @@ import org.junit.jupiter.api.Test
 class CyclePrevention {
     @Test
     fun `one level test`() {
-        val contract = OpenApiSpecification.fromYAML("""
+        val contract = OpenApiSpecification.fromYAML(
+            """
             openapi: "3.0.0"
             info:
               version: 1.0.0
@@ -39,11 +42,12 @@ class CyclePrevention {
                   properties:
                     key:
                       ${'$'}ref: '#/components/schemas/TopLevel'
-        """.trimIndent(), "").toFeature()
+        """.trimIndent(), ""
+        ).toFeature()
 
         var testCount = 0
 
-        contract.executeTests(object: TestExecutor {
+        contract.executeTests(object : TestExecutor {
             override fun execute(request: HttpRequest): HttpResponse {
                 testCount += 1
                 println(request.toLogString())
@@ -60,7 +64,8 @@ class CyclePrevention {
 
     @Test
     fun `two level test`() {
-        val contract = OpenApiSpecification.fromYAML("""
+        val contract = OpenApiSpecification.fromYAML(
+            """
             openapi: "3.0.0"
             info:
               version: 1.0.0
@@ -92,11 +97,12 @@ class CyclePrevention {
                   properties:
                     subkey:
                       ${'$'}ref: '#/components/schemas/TopLevel'
-        """.trimIndent(), "").toFeature()
+        """.trimIndent(), ""
+        ).toFeature()
 
         var testCount = 0
 
-        contract.executeTests(object: TestExecutor {
+        contract.executeTests(object : TestExecutor {
             override fun execute(request: HttpRequest): HttpResponse {
                 testCount += 1
                 println(request.toLogString())
@@ -113,7 +119,8 @@ class CyclePrevention {
 
     @RepeatedTest(5)
     fun `test cycle in optional key to circular ref`() {
-        val stubContract = OpenApiSpecification.fromYAML("""
+        val stubContract = OpenApiSpecification.fromYAML(
+            """
             openapi: "3.0.0"
             info:
               version: 1.0.0
@@ -136,7 +143,8 @@ class CyclePrevention {
                   properties:
                     key:
                       ${'$'}ref: '#/components/schemas/TopLevel'
-        """.trimIndent(), "").toFeature()
+        """.trimIndent(), ""
+        ).toFeature()
 
         HttpStub(stubContract).use { stub ->
             val randomResponse = stub.client.execute(HttpRequest("GET", "/data"))
@@ -183,7 +191,8 @@ class CyclePrevention {
 
     @RepeatedTest(5)
     fun `test cycle in required key to nullable ref`() {
-        val feature = OpenApiSpecification.fromYAML("""
+        val feature = OpenApiSpecification.fromYAML(
+            """
             openapi: "3.0.0"
             info:
               version: 1.0.0
@@ -212,7 +221,8 @@ class CyclePrevention {
                           properties: {}
                           nullable: true
                         - ${'$'}ref: '#/components/schemas/TopLevel'
-        """.trimIndent(), "").toFeature()
+        """.trimIndent(), ""
+        ).toFeature()
 
         HttpStub(feature).use { stub ->
             val response = stub.client.execute(HttpRequest("GET", "/data"))
@@ -247,13 +257,15 @@ class CyclePrevention {
                             }
                         }
                     """.trimIndent(), stub
-                ).status).isEqualTo(200)
+                ).status
+            ).isEqualTo(200)
         }
     }
 
     @RepeatedTest(5)
     fun `test cycle in optional key to nullable ref`() {
-        val feature = OpenApiSpecification.fromYAML("""
+        val feature = OpenApiSpecification.fromYAML(
+            """
             openapi: "3.0.0"
             info:
               version: 1.0.0
@@ -277,13 +289,21 @@ class CyclePrevention {
                   properties:
                     key:
                       ${'$'}ref: '#/components/schemas/TopLevel'
-        """.trimIndent(), "").toFeature()
+        """.trimIndent(), ""
+        ).toFeature()
 
         HttpStub(feature).use { stub ->
             val response = stub.client.execute(HttpRequest("GET", "/data"))
 
-            assertThat(feature.scenarios.first().let { scenario -> scenario.httpResponsePattern.matches(response, scenario.resolver) }).isInstanceOf(
-                Success::class.java)
+            assertThat(
+                feature.scenarios.first().let { scenario ->
+                    scenario.httpResponsePattern.matches(
+                        response,
+                        scenario.resolver
+                    )
+                }).isInstanceOf(
+                Success::class.java
+            )
 
             assertThat(
                 setExpectation(
@@ -305,7 +325,8 @@ class CyclePrevention {
                             }
                         }
                     """.trimIndent(), stub
-                ).status).isEqualTo(200)
+                ).status
+            ).isEqualTo(200)
 
             assertThat(
                 setExpectation(
@@ -327,7 +348,8 @@ class CyclePrevention {
                             }
                         }
                     """.trimIndent(), stub
-                ).status).isEqualTo(200)
+                ).status
+            ).isEqualTo(200)
         }
     }
 
@@ -388,13 +410,15 @@ class CyclePrevention {
                             }
                         }
                     """.trimIndent(), it
-                ).status).isEqualTo(400)
+                ).status
+            ).isEqualTo(400)
         }
     }
 
     @RepeatedTest(5)
     fun `test cycle in required key to optional key to circular ref`() {
-        val feature = OpenApiSpecification.fromYAML("""
+        val feature = OpenApiSpecification.fromYAML(
+            """
             openapi: "3.0.0"
             info:
               version: 1.0.0
@@ -424,19 +448,23 @@ class CyclePrevention {
                   properties:
                     key2:
                       ${'$'}ref: '#/components/schemas/TopLevel'
-        """.trimIndent(), "").toFeature()
+        """.trimIndent(), ""
+        ).toFeature()
 
         val response = HttpStub(feature).use {
             it.client.execute(HttpRequest("GET", "/data"))
         }
 
-        assertThat(feature.scenarios.first().let { it.httpResponsePattern.matches(response, it.resolver) }).isInstanceOf(
-            Success::class.java)
+        assertThat(
+            feature.scenarios.first().let { it.httpResponsePattern.matches(response, it.resolver) }).isInstanceOf(
+            Success::class.java
+        )
     }
 
     @RepeatedTest(5)
     fun `test cycle in required key to required key to nullable circular ref`() {
-        val feature = OpenApiSpecification.fromYAML("""
+        val feature = OpenApiSpecification.fromYAML(
+            """
             openapi: "3.0.0"
             info:
               version: 1.0.0
@@ -472,19 +500,23 @@ class CyclePrevention {
                           properties: {}
                           nullable: true
                         - ${'$'}ref: '#/components/schemas/TopLevel'
-        """.trimIndent(), "").toFeature()
+        """.trimIndent(), ""
+        ).toFeature()
 
         val response = HttpStub(feature).use {
             it.client.execute(HttpRequest("GET", "/data"))
         }
 
-        assertThat(feature.scenarios.first().let { it.httpResponsePattern.matches(response, it.resolver) }).isInstanceOf(
-            Success::class.java)
+        assertThat(
+            feature.scenarios.first().let { it.httpResponsePattern.matches(response, it.resolver) }).isInstanceOf(
+            Success::class.java
+        )
     }
 
     @RepeatedTest(5)
     fun `test cycle in required key to optional key to nullable circular ref`() {
-        val feature = OpenApiSpecification.fromYAML("""
+        val feature = OpenApiSpecification.fromYAML(
+            """
             openapi: "3.0.0"
             info:
               version: 1.0.0
@@ -518,21 +550,25 @@ class CyclePrevention {
                           properties: {}
                           nullable: true
                         - ${'$'}ref: '#/components/schemas/TopLevel'
-        """.trimIndent(), "").toFeature()
+        """.trimIndent(), ""
+        ).toFeature()
 
         val response = HttpStub(feature).use {
             it.client.execute(HttpRequest("GET", "/data"))
         }
 
-        assertThat(feature.scenarios.first().let { it.httpResponsePattern.matches(response, it.resolver) }).isInstanceOf(
-            Success::class.java)
+        assertThat(
+            feature.scenarios.first().let { it.httpResponsePattern.matches(response, it.resolver) }).isInstanceOf(
+            Success::class.java
+        )
     }
 
     @Test
     fun `test cycle in required key to required key to circular ref`() {
 //        key1 -> { key2 -> circular-ref-value }
 
-        val feature = OpenApiSpecification.fromYAML("""
+        val feature = OpenApiSpecification.fromYAML(
+            """
             openapi: "3.0.0"
             info:
               version: 1.0.0
@@ -564,12 +600,240 @@ class CyclePrevention {
                   properties:
                     key2:
                       ${'$'}ref: '#/components/schemas/TopLevel'
-        """.trimIndent(), "").toFeature()
+        """.trimIndent(), ""
+        ).toFeature()
 
         val response = HttpStub(feature).use {
             it.client.execute(HttpRequest("GET", "/data"))
         }
 
         assertThat(response.status).isEqualTo(400)
+    }
+
+    @Test
+    fun `cycle prevention across arrays`() {
+        val spec = """
+openapi: 3.0.0
+info:
+  title: Add Person API
+  version: 1.0.0
+
+# Path for adding a person
+paths:
+  /person:
+    post:
+      summary: Add a new person
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              ${"$"}ref: '#/components/schemas/Person'
+      responses:
+        '200':
+          description: Person created successfully
+          content:
+            text/plain:
+              schema:
+                type: string
+components:
+  schemas:
+    Person:
+      type: object
+      required:
+        - name
+        - relatives
+      properties:
+        name:
+          type: string
+          description: Name of the person
+        relatives:
+          type: array
+          items:
+            ${"$"}ref: '#/components/schemas/Person'
+          description: Array of relative Person objects (optional)
+
+        """.trimIndent()
+
+        try {
+            val feature = OpenApiSpecification.fromYAML(spec, "").toFeature()
+            val results = feature.executeTests(object : TestExecutor {
+                override fun execute(request: HttpRequest): HttpResponse {
+                    println(request.toLogString())
+
+                    val relatives = (request.body as JSONObjectValue).getJSONArray("relatives")
+                    relatives.forEach {
+                        assertThat((it as JSONObjectValue).jsonObject).containsKeys("relatives")
+                    }
+
+                    return HttpResponse.Companion.OK
+                }
+            })
+
+            assertThat(results.successCount).withFailMessage(results.report()).isPositive()
+            assertThat(results.success()).withFailMessage(results.report()).isTrue()
+        } catch (e: Throwable) {
+            println(exceptionCauseMessage(e))
+            throw e
+        }
+
+    }
+
+    @Test
+    fun `cycle prevention across array of objects pointing to parent via a mandatory key`() {
+        val spec = """
+openapi: 3.0.0
+info:
+  title: Add Person API
+  version: 1.0.0
+
+# Path for adding a person
+paths:
+  /person:
+    post:
+      summary: Add a new person
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              ${"$"}ref: '#/components/schemas/Person'
+      responses:
+        '200':
+          description: Person created successfully
+          content:
+            text/plain:
+              schema:
+                type: string
+components:
+  schemas:
+    Person:
+      type: object
+      required:
+        - name
+        - relatives
+      properties:
+        name:
+          type: string
+          description: Name of the person
+        relatives:
+          type: array
+          items:
+            ${"$"}ref: '#/components/schemas/Relative'
+    Relative:
+      type: object
+      required:
+        - id
+        - person
+      properties:
+        id:
+          type: number
+        person:
+          ${"$"}ref: '#/components/schemas/Person'
+
+        """.trimIndent()
+
+        try {
+            val feature = OpenApiSpecification.fromYAML(spec, "").toFeature()
+            val results = feature.executeTests(object : TestExecutor {
+                override fun execute(request: HttpRequest): HttpResponse {
+                    println(request.toLogString())
+
+                    return HttpResponse.Companion.OK
+                }
+            })
+
+            assertThat(results.successCount).withFailMessage(results.report()).isPositive()
+            assertThat(results.success()).withFailMessage(results.report()).isTrue()
+        } catch (e: Throwable) {
+            println(exceptionCauseMessage(e))
+            throw e
+        }
+
+    }
+
+    @Test
+    fun `cycle prevention across array of array of objects pointing to parent via a mandatory key`() {
+        val spec = """
+openapi: 3.0.0
+info:
+  title: Add Person API
+  version: 1.0.0
+
+# Path for adding a person
+paths:
+  /person:
+    post:
+      summary: Add a new person
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              ${"$"}ref: '#/components/schemas/Person'
+      responses:
+        '200':
+          description: Person created successfully
+          content:
+            text/plain:
+              schema:
+                type: string
+components:
+  schemas:
+    Person:
+      type: object
+      required:
+        - name
+        - relatives
+      properties:
+        name:
+          type: string
+          description: Name of the person
+        relatives:
+          type: array
+          items:
+            ${"$"}ref: '#/components/schemas/Relative'
+    Relative:
+      type: object
+      required:
+        - id
+        - acquaintances
+      properties:
+        id:
+          type: number
+        acquaintances:
+          type: array
+          items:
+            ${"$"}ref: '#/components/schemas/Acquaintance'
+    Acquaintance:
+      type: object
+      required:
+        - id
+        - relative
+      properties:
+        id:
+          type: number
+        relative:
+          ${"$"}ref: '#/components/schemas/Person'
+
+        """.trimIndent()
+
+        try {
+            val feature = OpenApiSpecification.fromYAML(spec, "").toFeature()
+            val results = feature.executeTests(object : TestExecutor {
+                override fun execute(request: HttpRequest): HttpResponse {
+                    println(request.toLogString())
+
+                    return HttpResponse.Companion.OK
+                }
+            })
+
+            assertThat(results.successCount).withFailMessage(results.report()).isPositive()
+            assertThat(results.success()).withFailMessage(results.report()).isTrue()
+        } catch (e: Throwable) {
+            println(exceptionCauseMessage(e))
+            throw e
+        }
+
     }
 }


### PR DESCRIPTION
**What**:

The PR contains a bug fix that ensures that a cyclical reference across arrays was not considered invalid when generating examples.

**Why**:

An array can be empty, which means that a cycle can be broken when generating examples by returning an empty array.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate
