### PR TITLE
Added support for loading externalised tests from a local directory

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/EnvironmentAndPropertiesConfiguration.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/EnvironmentAndPropertiesConfiguration.kt
@@ -12,6 +12,7 @@ data class EnvironmentAndPropertiesConfiguration(val environmentVariables: Map<S
     val SCHEMA_EXAMPLE_DEFAULT = "SCHEMA_EXAMPLE_DEFAULT"
     val ONLY_POSITIVE = "ONLY_POSITIVE"
     val SPECMATIC_TEST_PARALLELISM = "SPECMATIC_TEST_PARALLELISM"
+    val LOCAL_TESTS_DIRECTORY = "LOCAL_TESTS_DIRECTORY"
 
     val EXTENSIBLE_SCHEMA = "EXTENSIBLE_SCHEMA"
 
@@ -73,5 +74,9 @@ data class EnvironmentAndPropertiesConfiguration(val environmentVariables: Map<S
 
     fun getCachedSetting(variableName: String): String? {
         return getCachedEnvironmentVariable(variableName) ?: getCachedSystemProperty(variableName)
+    }
+
+    fun localTestsDirectory(): String? {
+        return getCachedSetting(LOCAL_TESTS_DIRECTORY)
     }
 }

--- a/core/src/main/kotlin/in/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Feature.kt
@@ -1366,15 +1366,20 @@ data class Feature(
 
     fun loadExternalisedExamples(): Feature {
         val testsDirectory = getTestsDirectory(File(this.path))
-        val externalisedJSONExamples = loadExternalisedJSONExamples(testsDirectory)
+        val externalisedExamplesFromDefaultDirectory = loadExternalisedJSONExamples(testsDirectory)
+        val externalisedExamplesFromLocalDirectory = environmentAndPropertiesConfiguration.localTestsDirectory()?.let {
+            loadExternalisedJSONExamples(File(it))
+        } ?: emptyMap()
 
-        if(externalisedJSONExamples.isEmpty())
+        val allExternalisedJSONExamples = externalisedExamplesFromDefaultDirectory + externalisedExamplesFromLocalDirectory
+
+        if(allExternalisedJSONExamples.isEmpty())
             return this
 
-        val featureWithExternalisedExamples = useExamples(externalisedJSONExamples)
+        val featureWithExternalisedExamples = useExamples(allExternalisedJSONExamples)
 
         val externalizedExampleFilePaths =
-            externalisedJSONExamples.entries.flatMap { (_, rows) ->
+            allExternalisedJSONExamples.entries.flatMap { (_, rows) ->
                 rows.map {
                     it.fileSource
                 }

--- a/core/src/test/resources/local_tests/test.json
+++ b/core/src/test/resources/local_tests/test.json
@@ -1,0 +1,15 @@
+{
+  "http-request": {
+    "method": "POST",
+    "path": "/person",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "name": "Jack"
+    }
+  },
+  "http-response": {
+    "status": 201
+  }
+}


### PR DESCRIPTION
**What**:

What if some tests require dynamic values from test data generated just in time? For example, if an API adding a new product into the database returns a GUID for a product ID, the value of the product ID can't be predicted ahead of time, and put into contract test files.

One way to resolve this easily is to setup the test data just in time, and then create the necessary contract test file in a local test directory, which can be provided to Specmatic via the environment variable `LOCAL_TESTS_DIRECTORY`. Specmatic will load the test files there in addition to the ones found in `specification_name_tests`

This feature is experimental for now.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate
