### PR TITLE
Extensible schema generative tests

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/GenerationStrategies.kt
+++ b/core/src/main/kotlin/in/specmatic/core/GenerationStrategies.kt
@@ -52,7 +52,8 @@ data class GenerativeTestsEnabled(private val positiveOnly: Boolean = Flags.only
             while(iterator.hasNext()) {
                 val next = iterator.next()
 
-                if(next.encompasses(requestBodyAsIs, resolver, resolver, emptySet()) is Success)
+                val strictResolver = resolver.copy(findKeyErrorCheck = DefaultKeyCheck)
+                if(next.encompasses(requestBodyAsIs, strictResolver, strictResolver, emptySet()) is Success)
                     matchFound = true
 
                 yield(next)

--- a/core/src/main/kotlin/in/specmatic/core/ResolverStrategies.kt
+++ b/core/src/main/kotlin/in/specmatic/core/ResolverStrategies.kt
@@ -9,17 +9,16 @@ data class ResolverStrategies(
     val unexpectedKeyCheck: UnexpectedKeyCheck?
 ) {
     fun update(resolver: Resolver): Resolver {
+        val findKeyErrorCheck = if(unexpectedKeyCheck != null) {
+            resolver.findKeyErrorCheck.copy(unexpectedKeyCheck = unexpectedKeyCheck)
+        } else
+            resolver.findKeyErrorCheck
+
         return resolver.copy(
             defaultExampleResolver = defaultExampleResolver,
-            generation = generation
-        ).let {
-            if(unexpectedKeyCheck != null) {
-                val keyCheck = resolver.findKeyErrorCheck
-                val updatedKeyCheck = keyCheck.copy(unexpectedKeyCheck = unexpectedKeyCheck)
-                resolver.copy(findKeyErrorCheck = updatedKeyCheck)
-            } else
-                it
-        }
+            generation = generation,
+            findKeyErrorCheck = findKeyErrorCheck
+        )
     }
 
     fun withoutGenerativeTests(): ResolverStrategies {

--- a/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
@@ -345,14 +345,10 @@ open class SpecmaticJUnitSupport {
 
         val urlConstructedFromProtocolHostAndPort = "$protocol://$host:$port"
 
-        if (urlConstructedFromProtocolHostAndPort != null) {
-            when (validateURI(urlConstructedFromProtocolHostAndPort)) {
-                Success -> return urlConstructedFromProtocolHostAndPort
-                else -> throw TestAbortedException("Please specify a valid $PROTOCOL, $HOST and $PORT environment variables")
-            }
+        return when (validateURI(urlConstructedFromProtocolHostAndPort)) {
+            Success -> urlConstructedFromProtocolHostAndPort
+            else -> throw TestAbortedException("Please specify a valid $PROTOCOL, $HOST and $PORT environment variables")
         }
-
-        return urlConstructedFromProtocolHostAndPort
     }
 
     private fun isNumeric(port: String?): Boolean {


### PR DESCRIPTION
**What**:

Fixes a bug that stopped generative test generation when the `EXTENSIBLE_SCHEMA` environment variable was set to true.

**How**:

This was caused by the way in which the resolver was constructed when the above flag was set.

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate
