### PR TITLE
Fixed the socket_timeout error when request timeout is greater than socket timeout

### DIFF
--- a/core/src/main/kotlin/in/specmatic/test/RealHttpClientFactory.kt
+++ b/core/src/main/kotlin/in/specmatic/test/RealHttpClientFactory.kt
@@ -7,6 +7,8 @@ import org.apache.http.conn.ssl.NoopHostnameVerifier
 import org.apache.http.conn.ssl.TrustAllStrategy
 import org.apache.http.ssl.SSLContextBuilder
 
+const val BREATHING_ROOM_FOR_REQUEST_TIMEOUT_TO_KICK_IN_FIRST = 1
+
 object RealHttpClientFactory: HttpClientFactory {
     override fun create(timeout: Int): HttpClient = HttpClient(Apache) {
         expectSuccess = false
@@ -25,7 +27,10 @@ object RealHttpClientFactory: HttpClientFactory {
         }
 
         install(HttpTimeout) {
-            requestTimeoutMillis = (timeout * 1000).toLong()
+            socketTimeoutMillis = secondsToMillis(timeout + BREATHING_ROOM_FOR_REQUEST_TIMEOUT_TO_KICK_IN_FIRST)
+            requestTimeoutMillis = secondsToMillis(timeout)
         }
     }
 }
+
+private fun secondsToMillis(seconds: Int): Long = seconds * 1000L

--- a/core/src/test/kotlin/in/specmatic/test/HttpClientTest.kt
+++ b/core/src/test/kotlin/in/specmatic/test/HttpClientTest.kt
@@ -1,5 +1,12 @@
 package `in`.specmatic.test
 
+import `in`.specmatic.core.HttpRequest
+import io.ktor.client.plugins.*
+import io.ktor.server.application.*
+import io.ktor.server.engine.*
+import io.ktor.server.netty.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
 import io.ktor.utils.io.charsets.*
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
@@ -37,5 +44,28 @@ internal class HttpClientTest {
 
         Assertions.assertThat(headers).isEmpty()
         Assertions.assertThat(body).isEqualTo("hello world")
+    }
+
+    @Test
+    fun `Request should timeout after given timeout argument`() {
+
+        val server = embeddedServer(Netty, port = 8080) {
+            routing {
+                get("/data") {
+                    Thread.sleep(3000)
+                    call.respondText("Hello, world!")
+                }
+            }
+        }
+
+        server.start();
+
+        Assertions.assertThatThrownBy {
+            val request = HttpRequest("GET", "/data")
+            HttpClient("http://localhost:8080", timeout = 1).execute(request)
+        }.isInstanceOf(HttpRequestTimeoutException::class.java)
+
+        Thread.sleep(2000)
+        server.stop()
     }
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Added socket timeout with +1 second breathing room duration compared to request timeout duration, so that request timeout will happen before socket timeout.

<!-- Why are these changes necessary? -->

**Why**: Socket timeout is 10 seconds by default. When given a `--timeout` argument of more than 10 seconds and in a scenario where the request was taking more than 10 seconds, socket timeout would kick in which would result in the unsuccessful contract test scenario. 

<!-- How were these changes implemented? -->

**How**: By making sure we have enough breathing duration between the request and socket timeout we would be making sure the socket timeout won't occur before the request is timed out. 

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [x] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #1052

<!-- feel free to add additional comments -->
