### PR TITLE
Ensure that all tests have a prefix when the SPECMATIC_GENERATIVE_TESTS=true

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Feature.kt
@@ -349,12 +349,12 @@ data class Feature(
 
     fun positiveTestScenarios(suggestions: List<Scenario>) =
         scenarios.asSequence().filter { it.isA2xxScenario() || it.examples.isNotEmpty() || it.isGherkinScenario }.map {
-            it.newBasedOn(suggestions)
-        }.flatMap {
-            val (scenario, resolverStrategies) = if(it.isA2xxScenario())
-                Pair(it, resolverStrategies)
+            it.newBasedOn(suggestions, resolverStrategies)
+        }.flatMap { scenario ->
+            val resolverStrategies = if(scenario.isA2xxScenario())
+                resolverStrategies
             else
-                Pair(it.copy(generativePrefix = resolverStrategies.generation.positivePrefix), resolverStrategies.withoutGenerativeTests())
+                resolverStrategies.withoutGenerativeTests()
 
             scenario.generateTestScenarios(resolverStrategies, testVariables, testBaseURLs)
         }

--- a/core/src/main/kotlin/in/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Feature.kt
@@ -351,12 +351,12 @@ data class Feature(
         scenarios.asSequence().filter { it.isA2xxScenario() || it.examples.isNotEmpty() || it.isGherkinScenario }.map {
             it.newBasedOn(suggestions)
         }.flatMap {
-            val resolverStrategies = if(it.isA2xxScenario())
-                resolverStrategies
+            val (scenario, resolverStrategies) = if(it.isA2xxScenario())
+                Pair(it, resolverStrategies)
             else
-                resolverStrategies.withoutGenerativeTests()
+                Pair(it.copy(generativePrefix = resolverStrategies.generation.positivePrefix), resolverStrategies.withoutGenerativeTests())
 
-            it.generateTestScenarios(resolverStrategies, testVariables, testBaseURLs)
+            scenario.generateTestScenarios(resolverStrategies, testVariables, testBaseURLs)
         }
 
     fun negativeTestScenarios() =

--- a/core/src/main/kotlin/in/specmatic/core/FlagsBased.kt
+++ b/core/src/main/kotlin/in/specmatic/core/FlagsBased.kt
@@ -2,9 +2,8 @@ package `in`.specmatic.core
 
 import `in`.specmatic.conversions.EnvironmentAndPropertiesConfiguration
 import `in`.specmatic.core.pattern.IgnoreUnexpectedKeys
-import net.bytebuddy.implementation.ToStringMethod.PrefixResolver
 
-data class ResolverStrategies(
+data class FlagsBased(
     val defaultExampleResolver: DefaultExampleResolver,
     val generation: GenerationStrategies,
     val unexpectedKeyCheck: UnexpectedKeyCheck?,
@@ -24,19 +23,19 @@ data class ResolverStrategies(
         )
     }
 
-    fun withoutGenerativeTests(): ResolverStrategies {
+    fun withoutGenerativeTests(): FlagsBased {
         return this.copy(generation = NonGenerativeTests)
     }
 }
 
-fun strategiesFromFlags(flags: EnvironmentAndPropertiesConfiguration): ResolverStrategies {
+fun strategiesFromFlags(flags: EnvironmentAndPropertiesConfiguration): FlagsBased {
     val (positivePrefix, negativePrefix) =
         if (flags.generativeTestingEnabled())
             Pair(POSITIVE_TEST_DESCRIPTION_PREFIX, NEGATIVE_TEST_DESCRIPTION_PREFIX)
         else
             Pair("", "")
 
-    return ResolverStrategies(
+    return FlagsBased(
         defaultExampleResolver = if (flags.schemaExampleDefaultEnabled()) UseDefaultExample else DoNotUseDefaultExample,
         generation = if (flags.generativeTestingEnabled()) GenerativeTestsEnabled() else NonGenerativeTests,
         unexpectedKeyCheck = if (flags.extensibleSchema()) IgnoreUnexpectedKeys else null,
@@ -45,7 +44,7 @@ fun strategiesFromFlags(flags: EnvironmentAndPropertiesConfiguration): ResolverS
     )
 }
 
-val DefaultStrategies = ResolverStrategies (
+val DefaultStrategies = FlagsBased (
     DoNotUseDefaultExample,
     NonGenerativeTests,
     null,

--- a/core/src/main/kotlin/in/specmatic/core/GenerationStrategies.kt
+++ b/core/src/main/kotlin/in/specmatic/core/GenerationStrategies.kt
@@ -6,9 +6,6 @@ import `in`.specmatic.core.pattern.isOptional
 import `in`.specmatic.core.value.Value
 
 interface GenerationStrategies {
-    val negativePrefix: String
-    val positivePrefix: String
-
     fun generatedPatternsForGenerativeTests(resolver: Resolver, pattern: Pattern, key: String): Sequence<Pattern>
     fun generateHttpRequests(resolver: Resolver, body: Pattern, row: Row, requestBodyAsIs: Pattern, value: Value): Sequence<Pattern>
     fun generateHttpRequests(resolver: Resolver, body: Pattern, row: Row): Sequence<Pattern>
@@ -26,9 +23,6 @@ interface GenerationStrategies {
 }
 
 data class GenerativeTestsEnabled(private val positiveOnly: Boolean = Flags.onlyPositive()) : GenerationStrategies {
-    override val negativePrefix: String = "-ve "
-    override val positivePrefix: String = "+ve "
-
     override fun generatedPatternsForGenerativeTests(resolver: Resolver, pattern: Pattern, key: String): Sequence<Pattern> {
         // TODO generate value outside
         return resolver.withCyclePrevention(pattern, isOptional(key)) { cyclePreventedResolver ->
@@ -136,9 +130,6 @@ data class GenerativeTestsEnabled(private val positiveOnly: Boolean = Flags.only
 }
 
 object NonGenerativeTests : GenerationStrategies {
-    override val negativePrefix: String = ""
-    override val positivePrefix: String = ""
-
     override fun generatedPatternsForGenerativeTests(resolver: Resolver, pattern: Pattern, key: String): Sequence<Pattern> {
         return sequenceOf()
     }

--- a/core/src/main/kotlin/in/specmatic/core/ResolverStrategies.kt
+++ b/core/src/main/kotlin/in/specmatic/core/ResolverStrategies.kt
@@ -2,11 +2,14 @@ package `in`.specmatic.core
 
 import `in`.specmatic.conversions.EnvironmentAndPropertiesConfiguration
 import `in`.specmatic.core.pattern.IgnoreUnexpectedKeys
+import net.bytebuddy.implementation.ToStringMethod.PrefixResolver
 
 data class ResolverStrategies(
     val defaultExampleResolver: DefaultExampleResolver,
     val generation: GenerationStrategies,
-    val unexpectedKeyCheck: UnexpectedKeyCheck?
+    val unexpectedKeyCheck: UnexpectedKeyCheck?,
+    val positivePrefix: String,
+    val negativePrefix: String
 ) {
     fun update(resolver: Resolver): Resolver {
         val findKeyErrorCheck = if(unexpectedKeyCheck != null) {
@@ -26,14 +29,26 @@ data class ResolverStrategies(
     }
 }
 
-fun strategiesFromFlags(flags: EnvironmentAndPropertiesConfiguration) = ResolverStrategies(
-    defaultExampleResolver = if(flags.schemaExampleDefaultEnabled()) UseDefaultExample else DoNotUseDefaultExample,
-    generation = if(flags.generativeTestingEnabled()) GenerativeTestsEnabled() else NonGenerativeTests,
-    unexpectedKeyCheck = if(flags.extensibleSchema()) IgnoreUnexpectedKeys else null
-)
+fun strategiesFromFlags(flags: EnvironmentAndPropertiesConfiguration): ResolverStrategies {
+    val (positivePrefix, negativePrefix) =
+        if (flags.generativeTestingEnabled())
+            Pair(POSITIVE_TEST_DESCRIPTION_PREFIX, NEGATIVE_TEST_DESCRIPTION_PREFIX)
+        else
+            Pair("", "")
+
+    return ResolverStrategies(
+        defaultExampleResolver = if (flags.schemaExampleDefaultEnabled()) UseDefaultExample else DoNotUseDefaultExample,
+        generation = if (flags.generativeTestingEnabled()) GenerativeTestsEnabled() else NonGenerativeTests,
+        unexpectedKeyCheck = if (flags.extensibleSchema()) IgnoreUnexpectedKeys else null,
+        positivePrefix = positivePrefix,
+        negativePrefix = negativePrefix
+    )
+}
 
 val DefaultStrategies = ResolverStrategies (
     DoNotUseDefaultExample,
     NonGenerativeTests,
-    null
+    null,
+    "",
+    ""
 )

--- a/core/src/main/kotlin/in/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Scenario.kt
@@ -340,8 +340,6 @@ data class Scenario(
                 }
             }.flatMap { row ->
                 newBasedOn(row, resolverStrategies)
-            }.map {
-                it.copy(generativePrefix = resolverStrategies.generation.positivePrefix)
             }
         }
     }
@@ -458,22 +456,24 @@ data class Scenario(
         return "$generativePrefix Scenario: $method $path ${disambiguate()}-> $statusInDescription$exampleIdentifier"
     }
 
-    fun newBasedOn(scenario: Scenario): Scenario {
+    fun newBasedOn(scenario: Scenario, resolverStrategies: ResolverStrategies): Scenario {
         return this.copy(
             examples = scenario.examples,
-            references = scenario.references
+            references = scenario.references,
+            generativePrefix = resolverStrategies.generation.positivePrefix
         )
     }
 
-    fun newBasedOn(suggestions: List<Scenario>) =
-        this.newBasedOn(suggestions.find { it.name == this.name } ?: this)
+    fun newBasedOn(suggestions: List<Scenario>, resolverStrategies: ResolverStrategies) =
+        this.newBasedOn(suggestions.find { it.name == this.name } ?: this, resolverStrategies)
 
     fun isA2xxScenario(): Boolean = this.httpResponsePattern.status in 200..299
     fun negativeBasedOn(badRequestOrDefault: BadRequestOrDefault?): Scenario {
         return this.copy(
             isNegative = true,
             badRequestOrDefault = badRequestOrDefault,
-            statusInDescription = "4xx"
+            statusInDescription = "4xx",
+            generativePrefix = "-ve"
         )
     }
 

--- a/core/src/main/kotlin/in/specmatic/test/ScenarioTest.kt
+++ b/core/src/main/kotlin/in/specmatic/test/ScenarioTest.kt
@@ -5,7 +5,7 @@ import `in`.specmatic.core.*
 
 class ScenarioTest(
     val scenario: Scenario,
-    private val resolverStrategies: ResolverStrategies,
+    private val flagsBased: FlagsBased,
     private val sourceProvider: String? = null,
     private val sourceRepository: String? = null,
     private val sourceRepositoryBranch: String? = null,
@@ -26,7 +26,7 @@ class ScenarioTest(
 
     override fun runTest(testBaseURL: String, timeOut: Int): Pair<Result, HttpResponse?> {
         val httpClient = HttpClient(testBaseURL, timeout = timeOut)
-        val (result, response) = executeTestAndReturnResultAndResponse(scenario, httpClient, resolverStrategies)
+        val (result, response) = executeTestAndReturnResultAndResponse(scenario, httpClient, flagsBased)
         return Pair(result.updateScenario(scenario), response)
     }
 

--- a/core/src/test/kotlin/in/specmatic/TestUtilities.kt
+++ b/core/src/test/kotlin/in/specmatic/TestUtilities.kt
@@ -132,7 +132,7 @@ infix fun <E> List<E>.shouldContainInAnyOrder(elementList: List<E>) {
     assertThat(this).containsExactlyInAnyOrderElementsOf(elementList)
 }
 
-val DefaultStrategies = ResolverStrategies (
+val DefaultStrategies = FlagsBased (
     DoNotUseDefaultExample,
     NonGenerativeTests,
     null,

--- a/core/src/test/kotlin/in/specmatic/TestUtilities.kt
+++ b/core/src/test/kotlin/in/specmatic/TestUtilities.kt
@@ -135,5 +135,7 @@ infix fun <E> List<E>.shouldContainInAnyOrder(elementList: List<E>) {
 val DefaultStrategies = ResolverStrategies (
     DoNotUseDefaultExample,
     NonGenerativeTests,
-    null
+    null,
+    "",
+    ""
 )

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=1.3.10
+version=1.3.11


### PR DESCRIPTION
**What**:

This fixes an issue introduced in 1.3.8 in which the names of non-2xx positive tests did not start with the `+ve` prefix.

**How**:

The fix cleans up the logic for deciding whether or not to prefix a test description with `+ve` or `-ve`.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate
