### PR TITLE
Fetch auth tokens from both environment and settings

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/SecurityToken.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/SecurityToken.kt
@@ -15,7 +15,7 @@ fun getSecurityTokenForBasicAuthScheme(
     environmentVariable: String,
     environmentAndPropertiesConfiguration: EnvironmentAndPropertiesConfiguration
 ): String? {
-    return environmentAndPropertiesConfiguration.getCachedEnvironmentVariable(environmentVariable) ?: securitySchemeConfiguration?.let {
+    return environmentAndPropertiesConfiguration.getCachedSetting(environmentVariable) ?: securitySchemeConfiguration?.let {
         (securitySchemeConfiguration as BasicAuthSecuritySchemeConfiguration).token
     } ?: environmentAndPropertiesConfiguration.getCachedEnvironmentVariable(SPECMATIC_BASIC_AUTH_TOKEN)
 }
@@ -25,7 +25,7 @@ fun getSecurityTokenForBearerScheme(
     environmentVariable: String,
     environmentAndPropertiesConfiguration: EnvironmentAndPropertiesConfiguration
 ): String? {
-    return environmentAndPropertiesConfiguration.getCachedEnvironmentVariable(environmentVariable) ?: securitySchemeConfiguration?.let {
+    return environmentAndPropertiesConfiguration.getCachedSetting(environmentVariable) ?: securitySchemeConfiguration?.let {
         (it as SecuritySchemeWithOAuthToken).token
     } ?: environmentAndPropertiesConfiguration.getCachedEnvironmentVariable(SPECMATIC_OAUTH2_TOKEN)
 }
@@ -35,7 +35,7 @@ fun getSecurityTokenForApiKeyScheme(
     environmentVariable: String,
     environmentAndPropertiesConfiguration: EnvironmentAndPropertiesConfiguration
 ): String? {
-    return environmentAndPropertiesConfiguration.getCachedEnvironmentVariable(environmentVariable) ?: securitySchemeConfiguration?.let {
+    return environmentAndPropertiesConfiguration.getCachedSetting(environmentVariable) ?: securitySchemeConfiguration?.let {
         (it as APIKeySecuritySchemeConfiguration).value
     }
 }


### PR DESCRIPTION
This makes it possible to create a token before running tests with SpecmaticJUnitSupport

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Look for auth tokens in both environment and settings

<!-- Why are these changes necessary? -->

**Why**: I want to be able to create tokens at runtime, before running contract tests with `SpecmaticJUnitSupport`

<!-- How were these changes implemented? -->

**How**: Use the getter that checks both environment and settings.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [ ] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #123

<!-- feel free to add additional comments -->
