### PR TITLE
Removed unnecessary jvmTarget 17 in kotlinOptions from all build.gradle files

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -114,12 +114,6 @@ jacocoTestReport {
 
 group = 'in.specmatic'
 
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-    kotlinOptions {
-        jvmTarget = "17"
-    }
-}
-
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -59,28 +59,10 @@ sonarqube {
     }
 }
 
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-    kotlinOptions {
-        jvmTarget = "17"
-    }
-}
-
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }
 
 repositories {
     mavenCentral()
-}
-
-compileKotlin {
-    kotlinOptions {
-        jvmTarget = "17"
-        freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
-    }
-}
-compileTestKotlin {
-    kotlinOptions {
-        jvmTarget = "17"
-    }
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -59,12 +59,6 @@ dependencies {
     testImplementation "io.ktor:ktor-client-mock-jvm:$ktor_version"
 }
 
-tasks.withType(KotlinCompile).configureEach {
-    kotlinOptions {
-        jvmTarget = "17"
-    }
-}
-
 test {
     useJUnitPlatform()
 }
@@ -137,13 +131,6 @@ tasks.withType(Sign).configureEach {
 javadoc {
     if(JavaVersion.current().isJava9Compatible()) {
         options.addBooleanOption('html5', true)
-    }
-}
-
-compileKotlin {
-    kotlinOptions {
-        jvmTarget = "17"
-        freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
     }
 }
 

--- a/junit5-support/build.gradle
+++ b/junit5-support/build.gradle
@@ -31,12 +31,6 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter-params:${junit_version}"
 }
 
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-    kotlinOptions {
-        jvmTarget = "17"
-    }
-}
-
 test {
     useJUnitPlatform()
 }


### PR DESCRIPTION
**What**:

Removed unnecessary jvmTarget 17 in kotlinOptions from all build.gradle files.
In some files this was even mentioned multiple times. Which is redundant.

**Why**:

It is redundant and confusing to set jvmTarget to 17

**How**:

**Checklist**:
- [x] Tests
