### PR TITLE
Annotations

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -56,7 +56,7 @@ dependencies {
         exclude group: 'ch.qos.logback', module: 'logback-core'
     }
     implementation('org.springframework.boot:spring-boot-autoconfigure:3.2.4')
-    implementation('org.springframework:spring-core:6.1.5')
+    implementation('org.springframework:spring-core:6.1.6')
     implementation 'info.picocli:picocli:4.7.5'
     implementation "io.ktor:ktor-client-core-jvm:${ktor_version}"
     implementation "io.ktor:ktor-network-tls:$ktor_version"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junit_version"
     testImplementation "org.junit.jupiter:junit-jupiter-params:$junit_version"
     testImplementation 'org.json:json:20240303'
-    testImplementation 'org.springframework:spring-web:5.3.33'
+    testImplementation 'org.springframework:spring-web:5.3.34'
     testImplementation 'io.mockk:mockk:1.13.10'
     testImplementation 'org.assertj:assertj-core:3.25.3'
     testImplementation "io.ktor:ktor-client-mock-jvm:$ktor_version"

--- a/core/src/main/kotlin/in/specmatic/conversions/EnvironmentAndPropertiesConfiguration.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/EnvironmentAndPropertiesConfiguration.kt
@@ -13,6 +13,7 @@ data class EnvironmentAndPropertiesConfiguration(val environmentVariables: Map<S
     val ONLY_POSITIVE = "ONLY_POSITIVE"
     val SPECMATIC_TEST_PARALLELISM = "SPECMATIC_TEST_PARALLELISM"
     val LOCAL_TESTS_DIRECTORY = "LOCAL_TESTS_DIRECTORY"
+    private val ANNOTATIONS_ENABLED = "ANNOTATIONS_ENABLED"
 
     val EXTENSIBLE_SCHEMA = "EXTENSIBLE_SCHEMA"
 
@@ -78,5 +79,9 @@ data class EnvironmentAndPropertiesConfiguration(val environmentVariables: Map<S
 
     fun localTestsDirectory(): String? {
         return getCachedSetting(LOCAL_TESTS_DIRECTORY)
+    }
+
+    fun annotationsEnabled(): Boolean {
+        return booleanFlag(ANNOTATIONS_ENABLED, "false")
     }
 }

--- a/core/src/main/kotlin/in/specmatic/conversions/EnvironmentAndPropertiesConfiguration.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/EnvironmentAndPropertiesConfiguration.kt
@@ -13,7 +13,7 @@ data class EnvironmentAndPropertiesConfiguration(val environmentVariables: Map<S
     val ONLY_POSITIVE = "ONLY_POSITIVE"
     val SPECMATIC_TEST_PARALLELISM = "SPECMATIC_TEST_PARALLELISM"
     val LOCAL_TESTS_DIRECTORY = "LOCAL_TESTS_DIRECTORY"
-    private val ANNOTATIONS_ENABLED = "ANNOTATIONS_ENABLED"
+    private val NEGATIVE_TEST_ANNOTATIONS = "ANNOTATIONS_ENABLED"
 
     val EXTENSIBLE_SCHEMA = "EXTENSIBLE_SCHEMA"
 
@@ -82,6 +82,6 @@ data class EnvironmentAndPropertiesConfiguration(val environmentVariables: Map<S
     }
 
     fun annotationsEnabled(): Boolean {
-        return booleanFlag(ANNOTATIONS_ENABLED, "false")
+        return booleanFlag(NEGATIVE_TEST_ANNOTATIONS, "false")
     }
 }

--- a/core/src/main/kotlin/in/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Feature.kt
@@ -299,15 +299,16 @@ data class Feature(
     fun generateContractTests(suggestions: List<Scenario>): Sequence<ContractTest> {
         return generateContractTestScenarios(suggestions).map { (originalScenario, returnValue) ->
             returnValue.realise(
-                hasValue = {
+                hasValue = { concreteTestScenario, comment ->
                     ScenarioTest(
-                        it,
+                        concreteTestScenario,
                         flagsBased,
-                        it.sourceProvider,
-                        it.sourceRepository,
-                        it.sourceRepositoryBranch,
-                        it.specification,
-                        it.serviceType
+                        concreteTestScenario.sourceProvider,
+                        concreteTestScenario.sourceRepository,
+                        concreteTestScenario.sourceRepositoryBranch,
+                        concreteTestScenario.specification,
+                        concreteTestScenario.serviceType,
+                        comment
                     )
                 },
                 orFailure = {

--- a/core/src/main/kotlin/in/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Feature.kt
@@ -308,7 +308,7 @@ data class Feature(
                         concreteTestScenario.sourceRepositoryBranch,
                         concreteTestScenario.specification,
                         concreteTestScenario.serviceType,
-                        comment
+                        if(Flags.annotationsEnabled()) comment else null
                     )
                 },
                 orFailure = {

--- a/core/src/main/kotlin/in/specmatic/core/HttpHeadersPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpHeadersPattern.kt
@@ -201,14 +201,13 @@ data class HttpHeadersPattern(
 
     fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<HttpHeadersPattern>> {
         return allOrNothingCombinationInR(pattern, row, null, null) { pattern ->
-            NegativeNonStringlyPatterns().negativeBasedOn(pattern, row, resolver)
+            NegativeNonStringlyPatterns().negativeBasedOn(pattern, row, resolver).map { it.breadCrumb("HEADER") }
         }.map { patternMapR ->
             patternMapR.ifValue { patternMap ->
                 HttpHeadersPattern(
                     patternMap.mapKeys { withoutOptionality(it.key) },
                     contentType = contentType
                 )
-
             }
         }
     }

--- a/core/src/main/kotlin/in/specmatic/core/HttpHeadersPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpHeadersPattern.kt
@@ -200,14 +200,21 @@ data class HttpHeadersPattern(
     }
 
     fun negativeBasedOn(row: Row, resolver: Resolver) =
-        forEachKeyCombinationIn(pattern, row, resolver) { pattern ->
-            NegativeNonStringlyPatterns().negativeBasedOn(pattern, row, resolver)
-        }.map { patternMap ->
-            HttpHeadersPattern(
-                patternMap.mapKeys { withoutOptionality(it.key) },
-                contentType = contentType
-            )
+        negativeBasedOnR(row, resolver).map { it.value }
+
+    fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<HttpHeadersPattern>> {
+        return allOrNothingCombinationInR(pattern, row, null, null) { pattern ->
+            NegativeNonStringlyPatterns().negativeBasedOnR(pattern, row, resolver)
+        }.map { patternMapR ->
+            patternMapR.ifValue { patternMap ->
+                HttpHeadersPattern(
+                    patternMap.mapKeys { withoutOptionality(it.key) },
+                    contentType = contentType
+                )
+
+            }
         }
+    }
 
     fun newBasedOn(resolver: Resolver): Sequence<HttpHeadersPattern> =
         allOrNothingCombinationIn(pattern) { pattern ->

--- a/core/src/main/kotlin/in/specmatic/core/HttpHeadersPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpHeadersPattern.kt
@@ -199,10 +199,7 @@ data class HttpHeadersPattern(
         return (basedOnExamples + generatedWithoutExamples).map { map -> HttpHeadersPattern(map.mapKeys { withoutOptionality(it.key) }, contentType = contentType) }
     }
 
-    fun negativeBasedOn(row: Row, resolver: Resolver) =
-        negativeBasedOnR(row, resolver).map { it.value }
-
-    fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<HttpHeadersPattern>> {
+    fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<HttpHeadersPattern>> {
         return allOrNothingCombinationInR(pattern, row, null, null) { pattern ->
             NegativeNonStringlyPatterns().negativeBasedOnR(pattern, row, resolver)
         }.map { patternMapR ->

--- a/core/src/main/kotlin/in/specmatic/core/HttpHeadersPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpHeadersPattern.kt
@@ -201,7 +201,7 @@ data class HttpHeadersPattern(
 
     fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<HttpHeadersPattern>> {
         return allOrNothingCombinationInR(pattern, row, null, null) { pattern ->
-            NegativeNonStringlyPatterns().negativeBasedOnR(pattern, row, resolver)
+            NegativeNonStringlyPatterns().negativeBasedOn(pattern, row, resolver)
         }.map { patternMapR ->
             patternMapR.ifValue { patternMap ->
                 HttpHeadersPattern(

--- a/core/src/main/kotlin/in/specmatic/core/HttpPathPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpPathPattern.kt
@@ -159,7 +159,7 @@ data class HttpPathPattern(
     private fun negatively(patterns: List<URLPathSegmentPattern>, row: Row, resolver: Resolver): Sequence<ReturnValue<List<URLPathSegmentPattern>>> {
         val current = patterns.firstOrNull() ?: return emptySequence()
 
-        val negativesOfCurrent: Sequence<ReturnValue<List<URLPathSegmentPattern>>> = current.negativeBasedOnR(row, resolver).map { negative ->
+        val negativesOfCurrent: Sequence<ReturnValue<List<URLPathSegmentPattern>>> = current.negativeBasedOn(row, resolver).map { negative ->
             listOf(negative) + positively(patterns.drop(1), row, resolver).map { HasValue(it) }
         }.sequenceListFold().map { it.ifValue { it.filterIsInstance<URLPathSegmentPattern>() } }
 
@@ -242,7 +242,7 @@ data class HttpPathPattern(
             }
         }
 
-        else -> (urlPathPattern.newBasedOn(row, resolver) + urlPathPattern.negativeBasedOnR(row, resolver).map { it.value }).distinct()
+        else -> (urlPathPattern.newBasedOn(row, resolver) + urlPathPattern.negativeBasedOn(row, resolver).map { it.value }).distinct()
     }
 
     fun extractPathParams(requestPath: String, resolver: Resolver): Map<String, String> {

--- a/core/src/main/kotlin/in/specmatic/core/HttpPathPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpPathPattern.kt
@@ -242,7 +242,7 @@ data class HttpPathPattern(
             }
         }
 
-        else -> (urlPathPattern.newBasedOn(row, resolver) + urlPathPattern.negativeBasedOn(row, resolver)).distinct()
+        else -> (urlPathPattern.newBasedOn(row, resolver) + urlPathPattern.negativeBasedOnR(row, resolver).map { it.value }).distinct()
     }
 
     fun extractPathParams(requestPath: String, resolver: Resolver): Map<String, String> {

--- a/core/src/main/kotlin/in/specmatic/core/HttpQueryParamPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpQueryParamPattern.kt
@@ -153,7 +153,7 @@ data class HttpQueryParamPattern(val queryPatterns: Map<String, Pattern>, val ad
             }
 
             forEachKeyCombinationInR(queryParams, row) { entry ->
-                NegativeNonStringlyPatterns().negativeBasedOnR(
+                NegativeNonStringlyPatterns().negativeBasedOn(
                     entry.mapKeys { withoutOptionality(it.key) },
                     row,
                     resolver

--- a/core/src/main/kotlin/in/specmatic/core/HttpQueryParamPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpQueryParamPattern.kt
@@ -143,26 +143,7 @@ data class HttpQueryParamPattern(val queryPatterns: Map<String, Pattern>, val ad
         } else ""
     }
 
-    fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Map<String, Pattern>> {
-        return attempt(breadCrumb = QUERY_PARAMS_BREADCRUMB) {
-            val queryParams = queryPatterns.let {
-                if (additionalProperties != null)
-                    it.plus(randomString(5) to additionalProperties)
-                else
-                    it
-            }
-
-            forEachKeyCombinationIn(queryParams, row) { entry ->
-                NegativeNonStringlyPatterns().negativeBasedOn(
-                    entry.mapKeys { withoutOptionality(it.key) },
-                    row,
-                    resolver
-                )
-            }
-        }
-    }
-
-    fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Map<String, Pattern>>> {
+    fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Map<String, Pattern>>> {
         return attempt(breadCrumb = QUERY_PARAMS_BREADCRUMB) {
             val queryParams: Map<String, Pattern> = queryPatterns.let {
                 if (additionalProperties != null)

--- a/core/src/main/kotlin/in/specmatic/core/HttpQueryParamPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpQueryParamPattern.kt
@@ -162,6 +162,25 @@ data class HttpQueryParamPattern(val queryPatterns: Map<String, Pattern>, val ad
         }
     }
 
+    fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Map<String, Pattern>>> {
+        return attempt(breadCrumb = QUERY_PARAMS_BREADCRUMB) {
+            val queryParams: Map<String, Pattern> = queryPatterns.let {
+                if (additionalProperties != null)
+                    it.plus(randomString(5) to additionalProperties)
+                else
+                    it
+            }
+
+            forEachKeyCombinationInR(queryParams, row) { entry ->
+                NegativeNonStringlyPatterns().negativeBasedOnR(
+                    entry.mapKeys { withoutOptionality(it.key) },
+                    row,
+                    resolver
+                )
+            }
+        }
+    }
+
     fun matches(uri: URI, queryParams: Map<String, String>, resolver: Resolver = Resolver()): Result {
         return matches(HttpRequest(path = uri.path, queryParametersMap =  queryParams), resolver)
     }

--- a/core/src/main/kotlin/in/specmatic/core/HttpQueryParamPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpQueryParamPattern.kt
@@ -157,7 +157,7 @@ data class HttpQueryParamPattern(val queryPatterns: Map<String, Pattern>, val ad
                     entry.mapKeys { withoutOptionality(it.key) },
                     row,
                     resolver
-                )
+                ).map { it.breadCrumb("QUERY-PARAM") }
             }
         }
     }

--- a/core/src/main/kotlin/in/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpRequestPattern.kt
@@ -651,9 +651,9 @@ data class HttpRequestPattern(
                         if (result is Failure)
                             throw ContractException(result.toFailureReport())
 
-                        body.negativeBasedOnR(row.noteRequestBody(), resolver)
+                        body.negativeBasedOn(row.noteRequestBody(), resolver)
                     } else {
-                        body.negativeBasedOnR(row, resolver)
+                        body.negativeBasedOn(row, resolver)
                     }
                 }
             }

--- a/core/src/main/kotlin/in/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpRequestPattern.kt
@@ -626,11 +626,11 @@ data class HttpRequestPattern(
         return returnValue(breadCrumb = "REQUEST") {
             val newHttpPathPatterns: Sequence<ReturnValue<HttpPathPattern>?> =
                 httpPathPattern?.let { httpPathPattern ->
-                    httpPathPattern.negativeBasedOnR(row, resolver)
+                    httpPathPattern.negativeBasedOn(row, resolver)
                         .map { it.ifValue { HttpPathPattern(it, httpPathPattern.path) } }
                 } ?: sequenceOf(null)
 
-            val newQueryParamsPatterns = httpQueryParamPattern.negativeBasedOnR(row, resolver).map { it.ifValue { HttpQueryParamPattern(it) } }
+            val newQueryParamsPatterns = httpQueryParamPattern.negativeBasedOn(row, resolver).map { it.ifValue { HttpQueryParamPattern(it) } }
 
             val newBodies: Sequence<ReturnValue<out Pattern>> = returnValue(breadCrumb = "BODY") {
                 body.let {
@@ -658,7 +658,7 @@ data class HttpRequestPattern(
                 }
             }
 
-            val newHeadersPattern = headersPattern.negativeBasedOnR(row, resolver)
+            val newHeadersPattern = headersPattern.negativeBasedOn(row, resolver)
             val newFormFieldsPatterns = newBasedOn(formFieldsPattern, row, resolver)
             val newFormDataPartLists = newMultiPartBasedOn(multiPartFormDataPattern, row, resolver)
 

--- a/core/src/main/kotlin/in/specmatic/core/NoBodyPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/NoBodyPattern.kt
@@ -7,6 +7,7 @@ import `in`.specmatic.core.value.JSONArrayValue
 import `in`.specmatic.core.value.StringValue
 import `in`.specmatic.core.value.Value
 import `in`.specmatic.core.NoBodyValue
+import `in`.specmatic.core.pattern.ReturnValue
 
 object NoBodyPattern : Pattern {
     override fun matches(sampleData: Value?, resolver: Resolver): Result {
@@ -25,7 +26,7 @@ object NoBodyPattern : Pattern {
 
     override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> = emptySequence()
+    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> = emptySequence()
 
     override fun parse(value: String, resolver: Resolver): Value {
         return if(value.isBlank())

--- a/core/src/main/kotlin/in/specmatic/core/NoBodyPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/NoBodyPattern.kt
@@ -26,7 +26,7 @@ object NoBodyPattern : Pattern {
 
     override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
 
-    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> = emptySequence()
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> = emptySequence()
 
     override fun parse(value: String, resolver: Resolver): Value {
         return if(value.isBlank())

--- a/core/src/main/kotlin/in/specmatic/core/URLPathSegmentPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/URLPathSegmentPattern.kt
@@ -36,7 +36,7 @@ data class URLPathSegmentPattern(override val pattern: Pattern, override val key
             return emptySequence()
 
         return resolver.withCyclePrevention(pattern) { cyclePreventedResolver ->
-            pattern.negativeBasedOn(row, cyclePreventedResolver)
+            pattern.negativeBasedOn(row, cyclePreventedResolver).map { it.breadCrumb(key).breadCrumb("PATH") }
                 .filterNot {
                     it.withDefault(false) { it is NullPattern }
                 }.map {

--- a/core/src/main/kotlin/in/specmatic/core/URLPathSegmentPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/URLPathSegmentPattern.kt
@@ -28,7 +28,7 @@ data class URLPathSegmentPattern(override val pattern: Pattern, override val key
             pattern.newBasedOn(cyclePreventedResolver).map { URLPathSegmentPattern(it, key) }
         }
 
-    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
         if(pattern is ExactValuePattern)
             return emptySequence()
 
@@ -36,7 +36,7 @@ data class URLPathSegmentPattern(override val pattern: Pattern, override val key
             return emptySequence()
 
         return resolver.withCyclePrevention(pattern) { cyclePreventedResolver ->
-            pattern.negativeBasedOnR(row, cyclePreventedResolver)
+            pattern.negativeBasedOn(row, cyclePreventedResolver)
                 .filterNot {
                     it.withDefault(false) { it is NullPattern }
                 }.map {

--- a/core/src/main/kotlin/in/specmatic/core/log/HttpLogMessage.kt
+++ b/core/src/main/kotlin/in/specmatic/core/log/HttpLogMessage.kt
@@ -7,7 +7,7 @@ import `in`.specmatic.core.value.StringValue
 import `in`.specmatic.core.value.Value
 import `in`.specmatic.stub.HttpStubResponse
 
-class HttpLogMessage(private var requestTime: String = "", var request: HttpRequest = HttpRequest(), private var responseTime: String = "", var response: HttpResponse = HttpResponse.OK, var contractPath: String = "", val targetServer: String = ""):
+data class HttpLogMessage(private var requestTime: String = "", var request: HttpRequest = HttpRequest(), private var responseTime: String = "", var response: HttpResponse = HttpResponse.OK, var contractPath: String = "", val targetServer: String = "", val comment: String?  =null):
     LogMessage {
     fun addRequest(httpRequest: HttpRequest) {
         requestTime = CurrentDate().toLogString()
@@ -33,6 +33,17 @@ class HttpLogMessage(private var requestTime: String = "", var request: HttpRequ
             "--------------------",
         )
 
+        val commentLines = if(comment != null) {
+            listOf(
+                "${linePrefix}",
+                "${comment.prependIndent(linePrefix)}",
+                "${linePrefix}",
+                "${linePrefix}-----",
+                "${linePrefix}")
+        } else {
+            emptyList()
+        }
+
         val contractPathLines = if(contractPath.isNotBlank()) {
             listOf(
                 "${linePrefix}Contract matched: $contractPath",
@@ -52,7 +63,7 @@ class HttpLogMessage(private var requestTime: String = "", var request: HttpRequ
 
         val messageSuffix = listOf("")
 
-        return (messagePrefix + contractPathLines + mainMessage + messageSuffix).joinToString(System.lineSeparator())
+        return (messagePrefix + commentLines + contractPathLines + mainMessage + messageSuffix).joinToString(System.lineSeparator())
     }
 
     override fun toJSONObject(): JSONObjectValue {

--- a/core/src/main/kotlin/in/specmatic/core/pattern/AllNegativePatterns.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/AllNegativePatterns.kt
@@ -18,7 +18,7 @@ class AllNegativePatterns : NegativePatternsTemplate() {
     ): Map<String, Sequence<ReturnValue<Pattern>>> {
         return patternMap.mapValues { (key, pattern) ->
             val resolvedPattern = resolvedHop(pattern, resolver)
-            resolvedPattern.negativeBasedOnR(row.stepDownOneLevelInJSONHierarchy(withoutOptionality(key)), resolver)
+            resolvedPattern.negativeBasedOn(row.stepDownOneLevelInJSONHierarchy(withoutOptionality(key)), resolver)
         }
     }
 }

--- a/core/src/main/kotlin/in/specmatic/core/pattern/AllNegativePatterns.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/AllNegativePatterns.kt
@@ -15,10 +15,10 @@ class AllNegativePatterns : NegativePatternsTemplate() {
         patternMap: Map<String, Pattern>,
         resolver: Resolver,
         row: Row
-    ): Map<String, Sequence<Pattern>> {
+    ): Map<String, Sequence<ReturnValue<Pattern>>> {
         return patternMap.mapValues { (key, pattern) ->
             val resolvedPattern = resolvedHop(pattern, resolver)
-            resolvedPattern.negativeBasedOn(row.stepDownOneLevelInJSONHierarchy(withoutOptionality(key)), resolver)
+            resolvedPattern.negativeBasedOnR(row.stepDownOneLevelInJSONHierarchy(withoutOptionality(key)), resolver)
         }
     }
 }

--- a/core/src/main/kotlin/in/specmatic/core/pattern/AnyPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/AnyPattern.kt
@@ -142,7 +142,7 @@ data class AnyPattern(
         val negativeTypeResults = pattern.asSequence().map {
             try {
                 val patterns =
-                    it.negativeBasedOn(row, resolver)
+                    it.negativeBasedOnR(row, resolver).map { it.value }
                 Pair(patterns, null)
             } catch(e: Throwable) {
                 Pair(null, e)

--- a/core/src/main/kotlin/in/specmatic/core/pattern/AnyPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/AnyPattern.kt
@@ -165,10 +165,6 @@ data class AnyPattern(
             negativeTypes
     }
 
-    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
-        return scalarAnnotation(this, negativeBasedOn(row, resolver))
-    }
-
     override fun parse(value: String, resolver: Resolver): Value {
         val resolvedTypes = pattern.map { resolvedHop(it, resolver) }
         val nonNullTypesFirst = resolvedTypes.filterNot { it is NullPattern }.plus(resolvedTypes.filterIsInstance<NullPattern>())

--- a/core/src/main/kotlin/in/specmatic/core/pattern/AnyPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/AnyPattern.kt
@@ -136,7 +136,7 @@ data class AnyPattern(
         }
     }
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
+    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
         val nullable = pattern.any { it is NullPattern }
 
         val negativeTypeResults = pattern.asSequence().map {
@@ -160,9 +160,9 @@ data class AnyPattern(
         }
 
         return if(negativeTypes.all { it is ScalarType })
-            negativeTypes.distinct()
+            negativeTypes.distinct().map { HasValue(it) }
         else
-            negativeTypes
+            negativeTypes.map { HasValue(it) }
     }
 
     override fun parse(value: String, resolver: Resolver): Value {

--- a/core/src/main/kotlin/in/specmatic/core/pattern/AnyPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/AnyPattern.kt
@@ -136,13 +136,13 @@ data class AnyPattern(
         }
     }
 
-    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
         val nullable = pattern.any { it is NullPattern }
 
         val negativeTypeResults = pattern.asSequence().map {
             try {
                 val patterns =
-                    it.negativeBasedOnR(row, resolver).map { it.value }
+                    it.negativeBasedOn(row, resolver).map { it.value }
                 Pair(patterns, null)
             } catch(e: Throwable) {
                 Pair(null, e)

--- a/core/src/main/kotlin/in/specmatic/core/pattern/AnyPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/AnyPattern.kt
@@ -165,6 +165,10 @@ data class AnyPattern(
             negativeTypes
     }
 
+    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+        return scalarAnnotation(this, negativeBasedOn(row, resolver))
+    }
+
     override fun parse(value: String, resolver: Resolver): Value {
         val resolvedTypes = pattern.map { resolvedHop(it, resolver) }
         val nonNullTypesFirst = resolvedTypes.filterNot { it is NullPattern }.plus(resolvedTypes.filterIsInstance<NullPattern>())

--- a/core/src/main/kotlin/in/specmatic/core/pattern/AnythingPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/AnythingPattern.kt
@@ -23,8 +23,8 @@ object AnythingPattern: Pattern {
         return sequenceOf(this)
     }
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
-        return sequenceOf(this)
+    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+        return sequenceOf(HasValue(this))
     }
 
     override fun parse(value: String, resolver: Resolver): Value {

--- a/core/src/main/kotlin/in/specmatic/core/pattern/AnythingPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/AnythingPattern.kt
@@ -23,7 +23,7 @@ object AnythingPattern: Pattern {
         return sequenceOf(this)
     }
 
-    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
         return sequenceOf(HasValue(this))
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/Base64StringPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/Base64StringPattern.kt
@@ -41,15 +41,10 @@ data class Base64StringPattern(override val typeAlias: String? = null) : Pattern
 
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
     override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
+    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
         // TODO ideally StringPattern should be in this list. However need to better understand how to generate
         //      strings that are not valid base64 strings (e.g. send an exact "]" which is not a base64 encoded value)
-
-        return sequenceOf(NullPattern, NumberPattern(), BooleanPattern())
-    }
-
-    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
-        return scalarAnnotation(this, negativeBasedOn(row, resolver))
+        return scalarAnnotation(this, sequenceOf(NullPattern, NumberPattern(), BooleanPattern()))
     }
 
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/Base64StringPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/Base64StringPattern.kt
@@ -48,6 +48,11 @@ data class Base64StringPattern(override val typeAlias: String? = null) : Pattern
         return sequenceOf(NullPattern, NumberPattern(), BooleanPattern())
     }
 
+    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+        return scalarAnnotation(this, negativeBasedOn(row, resolver))
+    }
+
+
     override fun parse(value: String, resolver: Resolver): Value {
         if(! Base64.isBase64(value))
             throw ContractException("Expected a base64 string but got \"$value\"")

--- a/core/src/main/kotlin/in/specmatic/core/pattern/Base64StringPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/Base64StringPattern.kt
@@ -41,7 +41,7 @@ data class Base64StringPattern(override val typeAlias: String? = null) : Pattern
 
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
     override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
-    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
         // TODO ideally StringPattern should be in this list. However need to better understand how to generate
         //      strings that are not valid base64 strings (e.g. send an exact "]" which is not a base64 encoded value)
         return scalarAnnotation(this, sequenceOf(NullPattern, NumberPattern(), BooleanPattern()))

--- a/core/src/main/kotlin/in/specmatic/core/pattern/BinaryPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/BinaryPattern.kt
@@ -42,12 +42,9 @@ data class BinaryPattern(
 
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
     override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
-        return sequenceOf(NullPattern, NumberPattern(), BooleanPattern())
-    }
 
     override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
-        return scalarAnnotation(this, negativeBasedOn(row, resolver))
+        return scalarAnnotation(this, sequenceOf(NullPattern, NumberPattern(), BooleanPattern()))
     }
 
     override fun parse(value: String, resolver: Resolver): Value = StringValue(value)

--- a/core/src/main/kotlin/in/specmatic/core/pattern/BinaryPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/BinaryPattern.kt
@@ -43,7 +43,7 @@ data class BinaryPattern(
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
     override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
 
-    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
         return scalarAnnotation(this, sequenceOf(NullPattern, NumberPattern(), BooleanPattern()))
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/BinaryPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/BinaryPattern.kt
@@ -46,6 +46,10 @@ data class BinaryPattern(
         return sequenceOf(NullPattern, NumberPattern(), BooleanPattern())
     }
 
+    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+        return scalarAnnotation(this, negativeBasedOn(row, resolver))
+    }
+
     override fun parse(value: String, resolver: Resolver): Value = StringValue(value)
     override val typeName: String = "string"
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/BooleanPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/BooleanPattern.kt
@@ -22,13 +22,11 @@ data class BooleanPattern(override val example: String? = null) : Pattern, Scala
     override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
 
     override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
-        return sequenceOf(NullPattern).map {
-            HasValue(it, "Expected type in spec was $typeName, trying out a ${it.typeName}")
-        }
+        return scalarAnnotation(this, negativeBasedOn(row, resolver))
     }
 
     override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
-        return negativeBasedOnR(row, resolver).map { it.value }
+        return sequenceOf(NullPattern)
     }
 
     override fun parse(value: String, resolver: Resolver): Value = when (value.lowercase()) {

--- a/core/src/main/kotlin/in/specmatic/core/pattern/BooleanPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/BooleanPattern.kt
@@ -22,11 +22,7 @@ data class BooleanPattern(override val example: String? = null) : Pattern, Scala
     override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
 
     override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
-        return scalarAnnotation(this, negativeBasedOn(row, resolver))
-    }
-
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
-        return sequenceOf(NullPattern)
+        return scalarAnnotation(this, sequenceOf(NullPattern))
     }
 
     override fun parse(value: String, resolver: Resolver): Value = when (value.lowercase()) {

--- a/core/src/main/kotlin/in/specmatic/core/pattern/BooleanPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/BooleanPattern.kt
@@ -21,7 +21,7 @@ data class BooleanPattern(override val example: String? = null) : Pattern, Scala
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
     override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
 
-    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
         return scalarAnnotation(this, sequenceOf(NullPattern))
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/BooleanPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/BooleanPattern.kt
@@ -20,8 +20,15 @@ data class BooleanPattern(override val example: String? = null) : Pattern, Scala
 
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
     override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
+
+    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+        return sequenceOf(NullPattern).map {
+            HasValue(it, "Expected type in spec was $typeName, trying out a ${it.typeName}")
+        }
+    }
+
     override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
-        return sequenceOf(NullPattern)
+        return negativeBasedOnR(row, resolver).map { it.value }
     }
 
     override fun parse(value: String, resolver: Resolver): Value = when (value.lowercase()) {

--- a/core/src/main/kotlin/in/specmatic/core/pattern/CombinationSpec.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/CombinationSpec.kt
@@ -19,14 +19,23 @@ package `in`.specmatic.core.pattern
  * same way as before.
  */
 class CombinationSpec<ValueType>(
-    keyToCandidatesOrig: Map<String, Sequence<ValueType>>,
-    private val maxCombinations: Int,
+    keyToCandidatesOrig: Map<String, Sequence<ReturnValue<ValueType>>>,
+    private val maxCombinations: Int
 ) {
+    companion object {
+        fun <ValueType> from(keyToCandidates: Map<String, Sequence<ValueType>>, maxCombinations: Int): CombinationSpec<ValueType> {
+            return CombinationSpec(keyToCandidates.mapValues { it.value.map { HasValue(it) } }, maxCombinations)
+        }
+    }
+
+    val keyToCandidates: Map<String, Sequence<ReturnValue<ValueType>>> = keyToCandidatesOrig
+
     init {
         if (maxCombinations < 1) throw IllegalArgumentException("maxCombinations must be > 0 and <= ${Int.MAX_VALUE}")
     }
 
-    val selectedCombinations: Sequence<Map<String, ValueType>> = toSelectedCombinations(keyToCandidatesOrig, maxCombinations)
+    val selectedCombinations: Sequence<Map<String, ValueType>> = toSelectedCombinations(keyToCandidates.mapValues { it.value.map { it.value } }, maxCombinations)
+    val selectedCombinationsR: Sequence<ReturnValue<Map<String, ValueType>>> = toSelectedCombinationsR(keyToCandidates, maxCombinations)
 
     fun <ValueType> toSelectedCombinations(rawPatternCollection: Map<String, Sequence<ValueType>>, maxCombinations: Int): Sequence<Map<String, ValueType>> {
         val patternCollection = rawPatternCollection.filterValues { it.any() }
@@ -93,6 +102,76 @@ class CombinationSpec<ValueType>(
             yieldAll(limited)
         }
     }
+
+    fun <ValueType> toSelectedCombinationsR(rawPatternCollection: Map<String, Sequence<ReturnValue<ValueType>>>, maxCombinations: Int): Sequence<ReturnValue<Map<String, ValueType>>> {
+        val patternCollection = rawPatternCollection.filterValues { it.any() }
+
+        if (patternCollection.isEmpty())
+            return emptySequence()
+
+        val cachedValues = patternCollection.mapValues { mutableListOf<ReturnValue<ValueType>>() }
+        val prioritisedGenerations = mutableSetOf<ReturnValue<Map<String, ValueType>>>()
+
+        val ranOut = cachedValues.mapValues { false }.toMutableMap()
+
+        val iterators = patternCollection.mapValues {
+            it.value.iterator()
+        }.filter {
+            it.value.hasNext()
+        }
+
+        return sequence {
+            var ctr = 0
+
+            while (true) {
+                val nextValue: Map<String, ReturnValue<ValueType>> = iterators.mapValues { (key, iterator) ->
+                    val nextValueFromIterator = if (iterator.hasNext()) {
+                        val value = iterator.next()
+
+                        cachedValues.getValue(key).add(value)
+
+                        value
+                    } else {
+                        ranOut[key] = true
+
+                        val cachedValuesForKey = cachedValues.getValue(key)
+                        val value = cachedValuesForKey.get(ctr % cachedValuesForKey.size)
+
+                        value
+                    }
+
+                    nextValueFromIterator
+                }
+
+                val _nextValue: ReturnValue<Map<String, ValueType>> = nextValue.mapFold()
+
+                if(ranOut.all { it.value })
+                    break
+
+                ctr ++
+
+                yield(_nextValue)
+                prioritisedGenerations.add(_nextValue)
+
+                if(prioritisedGenerations.size == maxCombinations)
+                    break
+            }
+
+            if(prioritisedGenerations.size == maxCombinations)
+                return@sequence
+
+            val otherPatterns: Sequence<ReturnValue<Map<String, ValueType>>> = allCombinations(patternCollection).map { it.mapFold() }
+
+            val maxCountOfUnPrioritisedGenerations = maxCombinations - prioritisedGenerations.size
+
+            // TODO Handle equality between return values to ignore the messages and breadcrumbs
+            val filtered = otherPatterns.filter { it !in prioritisedGenerations }
+            val limited = filtered.take(maxCountOfUnPrioritisedGenerations)
+
+            yieldAll(limited)
+        }
+    }
+
     fun <ValueType> allCombinations(patternCollection: Map<String, Sequence<ValueType>>): Sequence<Map<String, ValueType>> {
         if(patternCollection.isEmpty())
             return sequenceOf(emptyMap())

--- a/core/src/main/kotlin/in/specmatic/core/pattern/CsvPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/CsvPattern.kt
@@ -36,8 +36,8 @@ class CsvPattern(override val pattern: Pattern) : Pattern {
         return sequenceOf(this)
     }
 
-    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
-        return StringPattern().negativeBasedOnR(row, resolver)
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+        return StringPattern().negativeBasedOn(row, resolver)
     }
 
     override fun newBasedOn(resolver: Resolver): Sequence<Pattern> {

--- a/core/src/main/kotlin/in/specmatic/core/pattern/CsvPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/CsvPattern.kt
@@ -36,8 +36,8 @@ class CsvPattern(override val pattern: Pattern) : Pattern {
         return sequenceOf(this)
     }
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
-        return StringPattern().negativeBasedOn(row, resolver)
+    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+        return StringPattern().negativeBasedOnR(row, resolver)
     }
 
     override fun newBasedOn(resolver: Resolver): Sequence<Pattern> {

--- a/core/src/main/kotlin/in/specmatic/core/pattern/DatePattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/DatePattern.kt
@@ -24,6 +24,10 @@ object DatePattern : Pattern, ScalarType {
         return sequenceOf(NullPattern)
     }
 
+    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+        return scalarAnnotation(this, negativeBasedOn(row, resolver))
+    }
+
     override fun parse(value: String, resolver: Resolver): StringValue =
         attempt {
             RFC3339.dateFormatter.parse(value)

--- a/core/src/main/kotlin/in/specmatic/core/pattern/DatePattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/DatePattern.kt
@@ -20,12 +20,9 @@ object DatePattern : Pattern, ScalarType {
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<DatePattern> = sequenceOf(this)
 
     override fun newBasedOn(resolver: Resolver): Sequence<DatePattern> = sequenceOf(this)
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
-        return sequenceOf(NullPattern)
-    }
 
     override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
-        return scalarAnnotation(this, negativeBasedOn(row, resolver))
+        return scalarAnnotation(this, sequenceOf(NullPattern))
     }
 
     override fun parse(value: String, resolver: Resolver): StringValue =

--- a/core/src/main/kotlin/in/specmatic/core/pattern/DatePattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/DatePattern.kt
@@ -21,7 +21,7 @@ object DatePattern : Pattern, ScalarType {
 
     override fun newBasedOn(resolver: Resolver): Sequence<DatePattern> = sequenceOf(this)
 
-    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
         return scalarAnnotation(this, sequenceOf(NullPattern))
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/DateTimePattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/DateTimePattern.kt
@@ -25,6 +25,10 @@ object DateTimePattern : Pattern, ScalarType {
         return sequenceOf(NullPattern)
     }
 
+    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+        return scalarAnnotation(this, negativeBasedOn(row, resolver))
+    }
+
     override fun parse(value: String, resolver: Resolver): StringValue =
             attempt {
                 RFC3339.dateTimeFormatter.parse(value)

--- a/core/src/main/kotlin/in/specmatic/core/pattern/DateTimePattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/DateTimePattern.kt
@@ -21,12 +21,9 @@ object DateTimePattern : Pattern, ScalarType {
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<DateTimePattern> = sequenceOf(this)
 
     override fun newBasedOn(resolver: Resolver): Sequence<DateTimePattern> = sequenceOf(this)
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
-        return sequenceOf(NullPattern)
-    }
 
     override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
-        return scalarAnnotation(this, negativeBasedOn(row, resolver))
+        return scalarAnnotation(this, sequenceOf(NullPattern))
     }
 
     override fun parse(value: String, resolver: Resolver): StringValue =

--- a/core/src/main/kotlin/in/specmatic/core/pattern/DateTimePattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/DateTimePattern.kt
@@ -22,7 +22,7 @@ object DateTimePattern : Pattern, ScalarType {
 
     override fun newBasedOn(resolver: Resolver): Sequence<DateTimePattern> = sequenceOf(this)
 
-    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
         return scalarAnnotation(this, sequenceOf(NullPattern))
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/DeferredPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/DeferredPattern.kt
@@ -43,6 +43,10 @@ data class DeferredPattern(override val pattern: String, val key: String? = null
         return resolver.getPattern(pattern).negativeBasedOn(row, resolver)
     }
 
+    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+        return resolver.getPattern(pattern).negativeBasedOnR(row, resolver)
+    }
+
     override fun encompasses(otherPattern: Pattern, thisResolver: Resolver, otherResolver: Resolver, typeStack: TypeStack): Result {
         return thisResolver.getPattern(pattern).encompasses(resolvedHop(otherPattern, otherResolver), thisResolver, otherResolver, typeStack)
     }

--- a/core/src/main/kotlin/in/specmatic/core/pattern/DeferredPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/DeferredPattern.kt
@@ -39,8 +39,8 @@ data class DeferredPattern(override val pattern: String, val key: String? = null
         }
     }
 
-    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
-        return resolver.getPattern(pattern).negativeBasedOnR(row, resolver)
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+        return resolver.getPattern(pattern).negativeBasedOn(row, resolver)
     }
 
     override fun encompasses(otherPattern: Pattern, thisResolver: Resolver, otherResolver: Resolver, typeStack: TypeStack): Result {

--- a/core/src/main/kotlin/in/specmatic/core/pattern/DeferredPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/DeferredPattern.kt
@@ -39,10 +39,6 @@ data class DeferredPattern(override val pattern: String, val key: String? = null
         }
     }
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
-        return resolver.getPattern(pattern).negativeBasedOn(row, resolver)
-    }
-
     override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
         return resolver.getPattern(pattern).negativeBasedOnR(row, resolver)
     }

--- a/core/src/main/kotlin/in/specmatic/core/pattern/DictionaryPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/DictionaryPattern.kt
@@ -71,8 +71,8 @@ data class DictionaryPattern(val keyPattern: Pattern, val valuePattern: Pattern,
         }
     }
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
-        return sequenceOf(this)
+    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+        return sequenceOf(HasValue(this))
     }
 
     override fun parse(value: String, resolver: Resolver): Value = parsedJSONObject(value)

--- a/core/src/main/kotlin/in/specmatic/core/pattern/DictionaryPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/DictionaryPattern.kt
@@ -71,7 +71,7 @@ data class DictionaryPattern(val keyPattern: Pattern, val valuePattern: Pattern,
         }
     }
 
-    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
         return sequenceOf(HasValue(this))
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/EmailPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/EmailPattern.kt
@@ -40,7 +40,7 @@ class EmailPattern (private val stringPatternDelegate: StringPattern) :
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
 
     override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
-        val negativePatterns = stringPatternDelegate.negativeBasedOn(row, resolver).plus(StringPattern())
+        val negativePatterns = stringPatternDelegate.negativeBasedOnR(row, resolver).map { it.value }.plus(StringPattern())
         return scalarAnnotation(this, negativePatterns)
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/EmailPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/EmailPattern.kt
@@ -39,12 +39,9 @@ class EmailPattern (private val stringPatternDelegate: StringPattern) :
 
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
-        return stringPatternDelegate.negativeBasedOn(row, resolver).plus(StringPattern())
-    }
-
     override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
-        return scalarAnnotation(this, negativeBasedOn(row, resolver))
+        val negativePatterns = stringPatternDelegate.negativeBasedOn(row, resolver).plus(StringPattern())
+        return scalarAnnotation(this, negativePatterns)
     }
 
     override fun encompasses(

--- a/core/src/main/kotlin/in/specmatic/core/pattern/EmailPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/EmailPattern.kt
@@ -39,8 +39,8 @@ class EmailPattern (private val stringPatternDelegate: StringPattern) :
 
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
 
-    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
-        val negativePatterns = stringPatternDelegate.negativeBasedOnR(row, resolver).map { it.value }.plus(StringPattern())
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+        val negativePatterns = stringPatternDelegate.negativeBasedOn(row, resolver).map { it.value }.plus(StringPattern())
         return scalarAnnotation(this, negativePatterns)
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/EmailPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/EmailPattern.kt
@@ -43,6 +43,10 @@ class EmailPattern (private val stringPatternDelegate: StringPattern) :
         return stringPatternDelegate.negativeBasedOn(row, resolver).plus(StringPattern())
     }
 
+    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+        return scalarAnnotation(this, negativeBasedOn(row, resolver))
+    }
+
     override fun encompasses(
         otherPattern: Pattern,
         thisResolver: Resolver,

--- a/core/src/main/kotlin/in/specmatic/core/pattern/EmptyStringPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/EmptyStringPattern.kt
@@ -16,7 +16,7 @@ object EmptyStringPattern : Pattern {
     override fun generate(resolver: Resolver): Value = StringValue("")
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
     override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
-    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
         return sequenceOf(HasValue(this))
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/EmptyStringPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/EmptyStringPattern.kt
@@ -16,8 +16,8 @@ object EmptyStringPattern : Pattern {
     override fun generate(resolver: Resolver): Value = StringValue("")
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
     override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
-        return sequenceOf(this)
+    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+        return sequenceOf(HasValue(this))
     }
 
     override fun parse(value: String, resolver: Resolver): Value {

--- a/core/src/main/kotlin/in/specmatic/core/pattern/EnumPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/EnumPattern.kt
@@ -43,7 +43,7 @@ data class EnumPattern(
     }
 
     override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
-        return scalarAnnotation(this, negativeBasedOn(row, resolver))
+        return scalarAnnotation(this, pattern.negativeBasedOnR(row, resolver).map { it.value })
     }
 
     override fun equals(other: Any?): Boolean = other is EnumPattern && other.pattern == this.pattern

--- a/core/src/main/kotlin/in/specmatic/core/pattern/EnumPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/EnumPattern.kt
@@ -1,5 +1,6 @@
 package `in`.specmatic.core.pattern
 
+import `in`.specmatic.core.Resolver
 import `in`.specmatic.core.value.NullValue
 import `in`.specmatic.core.value.Value
 
@@ -39,6 +40,10 @@ data class EnumPattern(
 
     fun withExample(example: String?): EnumPattern {
         return this.copy(pattern = pattern.copy(example = example))
+    }
+
+    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+        return scalarAnnotation(this, negativeBasedOn(row, resolver))
     }
 
     override fun equals(other: Any?): Boolean = other is EnumPattern && other.pattern == this.pattern

--- a/core/src/main/kotlin/in/specmatic/core/pattern/EnumPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/EnumPattern.kt
@@ -42,8 +42,8 @@ data class EnumPattern(
         return this.copy(pattern = pattern.copy(example = example))
     }
 
-    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
-        return scalarAnnotation(this, pattern.negativeBasedOnR(row, resolver).map { it.value })
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+        return scalarAnnotation(this, pattern.negativeBasedOn(row, resolver).map { it.value })
     }
 
     override fun equals(other: Any?): Boolean = other is EnumPattern && other.pattern == this.pattern

--- a/core/src/main/kotlin/in/specmatic/core/pattern/ExactValuePattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/ExactValuePattern.kt
@@ -32,9 +32,9 @@ data class ExactValuePattern(override val pattern: Value, override val typeAlias
     override fun generate(resolver: Resolver) = pattern
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
     override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
-    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
         val nullPattern: ReturnValue<Pattern> = HasValue(NullPattern)
-        return sequenceOf(nullPattern).plus(pattern.type().negativeBasedOnR(Row(), resolver).filterNot { it.withDefault(false) { it == NullPattern } })
+        return sequenceOf(nullPattern).plus(pattern.type().negativeBasedOn(Row(), resolver).filterNot { it.withDefault(false) { it == NullPattern } })
     }
 
     override fun parse(value: String, resolver: Resolver): Value = pattern.type().parse(value, resolver)

--- a/core/src/main/kotlin/in/specmatic/core/pattern/ExactValuePattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/ExactValuePattern.kt
@@ -32,8 +32,9 @@ data class ExactValuePattern(override val pattern: Value, override val typeAlias
     override fun generate(resolver: Resolver) = pattern
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
     override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
-        return sequenceOf(NullPattern).plus(pattern.type().negativeBasedOn(Row(), resolver).filterNot { it == NullPattern })
+    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+        val nullPattern: ReturnValue<Pattern> = HasValue(NullPattern)
+        return sequenceOf(nullPattern).plus(pattern.type().negativeBasedOnR(Row(), resolver).filterNot { it.withDefault(false) { it == NullPattern } })
     }
 
     override fun parse(value: String, resolver: Resolver): Value = pattern.type().parse(value, resolver)

--- a/core/src/main/kotlin/in/specmatic/core/pattern/HasException.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/HasException.kt
@@ -1,9 +1,6 @@
 package `in`.specmatic.core.pattern
 
-import `in`.specmatic.core.Result
-import `in`.specmatic.core.utilities.exceptionCauseMessage
-
-class HasException<T>(val t: Throwable, val message: String = "", val breadCrumb: String? = null) : ReturnValue<T>, ReturnFailure {
+data class HasException<T>(val t: Throwable, val message: String = "", val breadCrumb: String? = null) : ReturnValue<T>, ReturnFailure {
     override fun <U> withDefault(default: U, fn: (T) -> U): U {
         return default
     }
@@ -11,10 +8,6 @@ class HasException<T>(val t: Throwable, val message: String = "", val breadCrumb
     override fun <U> ifValue(fn: (T) -> U): ReturnValue<U> {
         return cast()
 
-    }
-
-    override fun <U> sequenceOf(fn: (T) -> Sequence<ReturnValue<U>>): Sequence<ReturnValue<U>> {
-        return sequenceOf(cast())
     }
 
     override fun update(fn: (T) -> T): ReturnValue<T> {
@@ -32,8 +25,8 @@ class HasException<T>(val t: Throwable, val message: String = "", val breadCrumb
     override val value: T
         get() = throw t
 
-    override fun addDetails(errorMessage: String, breadCrumb: String): ReturnValue<T> {
-        val newE = toException(errorMessage, breadCrumb, toException())
+    override fun addDetails(message: String, breadCrumb: String): ReturnValue<T> {
+        val newE = toException(message, breadCrumb, toException())
 
         return HasException<T>(newE)
     }
@@ -55,7 +48,7 @@ class HasException<T>(val t: Throwable, val message: String = "", val breadCrumb
         return newE
     }
 
-    override fun <U> realise(hasValue: (T) -> U, orFailure: (HasFailure<T>) -> U, orException: (HasException<T>) -> U): U {
+    override fun <U> realise(hasValue: (T, String?) -> U, orFailure: (HasFailure<T>) -> U, orException: (HasException<T>) -> U): U {
         return orException(this)
     }
 }

--- a/core/src/main/kotlin/in/specmatic/core/pattern/HasFailure.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/HasFailure.kt
@@ -2,17 +2,13 @@ package `in`.specmatic.core.pattern
 
 import `in`.specmatic.core.Result
 
-class HasFailure<T>(val failure: Result.Failure, val message: String = "") : ReturnValue<T>, ReturnFailure {
+data class HasFailure<T>(val failure: Result.Failure, val message: String = "") : ReturnValue<T>, ReturnFailure {
     override fun <U> withDefault(default: U, fn: (T) -> U): U {
         return default
     }
 
     override fun <U> ifValue(fn: (T) -> U): ReturnValue<U> {
         return HasFailure<U>(failure)
-    }
-
-    override fun <U> sequenceOf(fn: (T) -> Sequence<ReturnValue<U>>): Sequence<ReturnValue<U>> {
-        return sequenceOf(cast())
     }
 
     override fun update(fn: (T) -> T): ReturnValue<T> {
@@ -34,11 +30,11 @@ class HasFailure<T>(val failure: Result.Failure, val message: String = "") : Ret
         return Result.Failure(message, failure)
     }
 
-    override fun addDetails(errorMessage: String, breadCrumb: String): ReturnValue<T> {
-        return HasFailure<T>(Result.Failure(errorMessage, this.toFailure(), breadCrumb))
+    override fun addDetails(message: String, breadCrumb: String): ReturnValue<T> {
+        return HasFailure<T>(Result.Failure(message, this.toFailure(), breadCrumb))
     }
 
-    override fun <U> realise(hasValue: (T) -> U, orFailure: (HasFailure<T>) -> U, orException: (HasException<T>) -> U): U {
+    override fun <U> realise(hasValue: (T, String?) -> U, orFailure: (HasFailure<T>) -> U, orException: (HasException<T>) -> U): U {
         return orFailure(this)
     }
 }

--- a/core/src/main/kotlin/in/specmatic/core/pattern/HasValue.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/HasValue.kt
@@ -71,6 +71,9 @@ class HasValue<T>(override val value: T, val valueDetails: List<ValueDetails> = 
     }
 
     override fun addDetails(message: String, breadCrumb: String): ReturnValue<T> {
+        if(message.isBlank() && breadCrumb.isBlank())
+            return this
+
         return HasValue<T>(
             value,
             valueDetails.map { it.addDetails(message, breadCrumb) })

--- a/core/src/main/kotlin/in/specmatic/core/pattern/HasValue.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/HasValue.kt
@@ -1,7 +1,5 @@
 package `in`.specmatic.core.pattern
 
-import io.ktor.util.reflect.*
-
 class HasValue<T>(override val value: T, val valueDetails: List<ValueDetails> = emptyList()): ReturnValue<T> {
     constructor(value: T, message: String): this(value, listOf(ValueDetails(listOf(message))))
     constructor(value: T, message: String, key: String): this(value, listOf(ValueDetails(listOf(message), listOf(key))))

--- a/core/src/main/kotlin/in/specmatic/core/pattern/JSONArrayPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/JSONArrayPattern.kt
@@ -77,12 +77,12 @@ data class JSONArrayPattern(override val pattern: List<Pattern> = emptyList(), o
         return newBasedOn(pattern, resolverWithNullType).map { JSONArrayPattern(it) }
     }
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> = sequenceOf(NullPattern).let {
+    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> = sequenceOf(NullPattern).let {
         if(pattern.size == 1)
             it.plus(pattern[0])
         else
             it
-    }
+    }.map { HasValue(it) }
 
     override fun parse(value: String, resolver: Resolver): Value = parsedJSONArray(value, resolver.mismatchMessages)
     override fun encompasses(otherPattern: Pattern, thisResolver: Resolver, otherResolver: Resolver, typeStack: TypeStack): Result {

--- a/core/src/main/kotlin/in/specmatic/core/pattern/JSONArrayPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/JSONArrayPattern.kt
@@ -77,7 +77,7 @@ data class JSONArrayPattern(override val pattern: List<Pattern> = emptyList(), o
         return newBasedOn(pattern, resolverWithNullType).map { JSONArrayPattern(it) }
     }
 
-    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> = sequenceOf(NullPattern).let {
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> = sequenceOf(NullPattern).let {
         if(pattern.size == 1)
             it.plus(pattern[0])
         else

--- a/core/src/main/kotlin/in/specmatic/core/pattern/JSONObjectPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/JSONObjectPattern.kt
@@ -173,9 +173,9 @@ data class JSONObjectPattern(
             newBasedOn(pattern, withNullPattern(resolver))
         }.map { toJSONObjectPattern(it) }
 
-    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> =
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> =
         allOrNothingCombinationInR(pattern.minus("...")) { pattern ->
-            AllNegativePatterns().negativeBasedOnR(pattern, row, withNullPattern(resolver))
+            AllNegativePatterns().negativeBasedOn(pattern, row, withNullPattern(resolver))
         }.map { it.ifValue { toJSONObjectPattern(it) } }
 
     override fun parse(value: String, resolver: Resolver): Value = parsedJSONObject(value, resolver.mismatchMessages)

--- a/core/src/main/kotlin/in/specmatic/core/pattern/JSONObjectPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/JSONObjectPattern.kt
@@ -173,11 +173,6 @@ data class JSONObjectPattern(
             newBasedOn(pattern, withNullPattern(resolver))
         }.map { toJSONObjectPattern(it) }
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> =
-        allOrNothingCombinationIn(pattern.minus("...")) { pattern ->
-            AllNegativePatterns().negativeBasedOn(pattern, row, withNullPattern(resolver))
-        }.map { toJSONObjectPattern(it) }
-
     override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> =
         allOrNothingCombinationInR(pattern.minus("...")) { pattern ->
             AllNegativePatterns().negativeBasedOnR(pattern, row, withNullPattern(resolver))

--- a/core/src/main/kotlin/in/specmatic/core/pattern/JSONObjectPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/JSONObjectPattern.kt
@@ -178,6 +178,11 @@ data class JSONObjectPattern(
             AllNegativePatterns().negativeBasedOn(pattern, row, withNullPattern(resolver))
         }.map { toJSONObjectPattern(it) }
 
+    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> =
+        allOrNothingCombinationInR(pattern.minus("...")) { pattern ->
+            AllNegativePatterns().negativeBasedOnR(pattern, row, withNullPattern(resolver))
+        }.map { it.ifValue { toJSONObjectPattern(it) } }
+
     override fun parse(value: String, resolver: Resolver): Value = parsedJSONObject(value, resolver.mismatchMessages)
     override fun hashCode(): Int = pattern.hashCode()
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/ListPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/ListPattern.kt
@@ -76,7 +76,7 @@ data class ListPattern(override val pattern: Pattern, override val typeAlias: St
         }
     }
 
-    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> = sequenceOf(HasValue(NullPattern))
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> = sequenceOf(HasValue(NullPattern))
 
     override fun parse(value: String, resolver: Resolver): Value = parsedJSONArray(value, resolver.mismatchMessages)
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/ListPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/ListPattern.kt
@@ -76,7 +76,7 @@ data class ListPattern(override val pattern: Pattern, override val typeAlias: St
         }
     }
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> = sequenceOf(NullPattern)
+    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> = sequenceOf(HasValue(NullPattern))
 
     override fun parse(value: String, resolver: Resolver): Value = parsedJSONArray(value, resolver.mismatchMessages)
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/LookupRowPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/LookupRowPattern.kt
@@ -41,7 +41,7 @@ data class LookupRowPattern(override val pattern: Pattern, override val key: Str
         }
     }
 
-    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
         return sequenceOf(HasValue(this))
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/LookupRowPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/LookupRowPattern.kt
@@ -41,8 +41,8 @@ data class LookupRowPattern(override val pattern: Pattern, override val key: Str
         }
     }
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
-        return sequenceOf(this)
+    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+        return sequenceOf(HasValue(this))
     }
 
     override fun parse(value: String, resolver: Resolver): Value = pattern.parse(value, resolver)

--- a/core/src/main/kotlin/in/specmatic/core/pattern/NegativeNonStringlyPatterns.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/NegativeNonStringlyPatterns.kt
@@ -27,16 +27,20 @@ class NegativeNonStringlyPatterns : NegativePatternsTemplate() {
         patternMap: Map<String, Pattern>,
         resolver: Resolver,
         row: Row
-    ): Map<String, Sequence<Pattern>> {
+    ): Map<String, Sequence<ReturnValue<Pattern>>> {
         return patternMap.mapValues { (key, pattern) ->
             val resolvedPattern = resolvedHop(pattern, resolver)
 
             resolvedPattern
-                .negativeBasedOn(row.stepDownOneLevelInJSONHierarchy(withoutOptionality(key)), resolver)
+                .negativeBasedOnR(row.stepDownOneLevelInJSONHierarchy(withoutOptionality(key)), resolver)
                 .filterNot {
-                    isStringly(resolvedPattern, it, resolver)
+                    it.withDefault(false) {
+                        isStringly(resolvedPattern, it, resolver)
+                    }
                 }.filterNot {
-                    it is NullPattern
+                    it.withDefault(false) {
+                        it is NullPattern
+                    }
                 }
         }
     }

--- a/core/src/main/kotlin/in/specmatic/core/pattern/NegativeNonStringlyPatterns.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/NegativeNonStringlyPatterns.kt
@@ -32,7 +32,7 @@ class NegativeNonStringlyPatterns : NegativePatternsTemplate() {
             val resolvedPattern = resolvedHop(pattern, resolver)
 
             resolvedPattern
-                .negativeBasedOnR(row.stepDownOneLevelInJSONHierarchy(withoutOptionality(key)), resolver)
+                .negativeBasedOn(row.stepDownOneLevelInJSONHierarchy(withoutOptionality(key)), resolver)
                 .filterNot {
                     it.withDefault(false) {
                         isStringly(resolvedPattern, it, resolver)

--- a/core/src/main/kotlin/in/specmatic/core/pattern/NegativePatternsTemplate.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/NegativePatternsTemplate.kt
@@ -50,6 +50,8 @@ abstract class NegativePatternsTemplate {
                     when (key) {
                         keyToNegate -> negativePatterns
                         else -> newBasedOn(row, key, pattern, resolver).map { HasValue(it) }
+                    }.map {
+                        it.addDetails("", key)
                     }
                 }
             }

--- a/core/src/main/kotlin/in/specmatic/core/pattern/NegativePatternsTemplate.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/NegativePatternsTemplate.kt
@@ -26,7 +26,7 @@ abstract class NegativePatternsTemplate {
                         }
                         else -> newBasedOn(row, key, pattern, resolver).map { HasValue(it) }
                     }.map {
-                        it.addDetails("", key)
+                        it.breadCrumb(key)
                     }
                 }
             }

--- a/core/src/main/kotlin/in/specmatic/core/pattern/NegativePatternsTemplate.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/NegativePatternsTemplate.kt
@@ -4,16 +4,13 @@ import `in`.specmatic.core.Resolver
 
 abstract class NegativePatternsTemplate {
     fun negativeBasedOn(patternMap: Map<String, Pattern>, row: Row, resolver: Resolver): Sequence<Map<String, Pattern>> {
-        val eachKeyMappedToPatternMap: Map<String, Map<String, Pattern>> = patternMap.mapValues { patternMap }
-        val negativePatternsForEachKey: Map<String, Sequence<ReturnValue<Pattern>>> = getNegativePatterns(patternMap, resolver, row)
+        val eachKeyMappedToPatternMap = patternMap.mapValues { patternMap }
+        val negativePatternsMap = getNegativePatterns(patternMap, resolver, row).mapValues { it.value.map { it.value } }
 
-        val modifiedPatternMap: Map<String, Sequence<Map<String, Sequence<Pattern>>>> = eachKeyMappedToPatternMap.mapValues { (keyToNegate, negatablePatternMap) ->
-            val negativePatterns: Sequence<ReturnValue<Pattern>> = negativePatternsForEachKey.getValue(keyToNegate)
-
-            negativePatterns.map { negativePatternR ->
-                val negativePattern: Pattern = negativePatternR.value
-
-                negatablePatternMap.mapValues { (key, pattern) ->
+        val modifiedPatternMap: Map<String, Sequence<Map<String, Sequence<Pattern>>>> = eachKeyMappedToPatternMap.mapValues { (keyToNegate, patterns) ->
+            val negativePatterns = negativePatternsMap[keyToNegate]
+            negativePatterns!!.map { negativePattern ->
+                patterns.mapValues { (key, pattern) ->
                     attempt(breadCrumb = key) {
                         when (key == keyToNegate) {
                             true ->

--- a/core/src/main/kotlin/in/specmatic/core/pattern/NegativePatternsTemplate.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/NegativePatternsTemplate.kt
@@ -39,13 +39,19 @@ abstract class NegativePatternsTemplate {
         val eachKeyMappedToPatternMap: Map<String, Map<String, Pattern>> = patternMap.mapValues { patternMap }
         val negativePatternsForEachKey: Map<String, Sequence<ReturnValue<Pattern>>> = getNegativePatterns(patternMap, resolver, row)
 
-        val modifiedPatternMap: Map<String, Map<String, Sequence<ReturnValue<Pattern>>>> =
+        val modifiedPatternMap: Map<String, Map<String, Sequence<ReturnValue<Pattern>>>?> =
             eachKeyMappedToPatternMap.mapValues { (keyToNegate, patterns) ->
                 val negativePatterns: Sequence<ReturnValue<Pattern>> = negativePatternsForEachKey.getValue(keyToNegate)
 
+                if(!negativePatterns.any())
+                    return@mapValues null
+
                 patterns.mapValues { (key, pattern) ->
                     when (key) {
-                        keyToNegate -> negativePatterns
+                        keyToNegate -> {
+                            val result: Sequence<ReturnValue<Pattern>> = negativePatterns
+                            result
+                        }
                         else -> newBasedOn(row, key, pattern, resolver).map { HasValue(it) }
                     }.map {
                         it.addDetails("", key)
@@ -56,7 +62,7 @@ abstract class NegativePatternsTemplate {
         if (modifiedPatternMap.values.isEmpty())
             return sequenceOf(HasValue(emptyMap()))
 
-        return modifiedPatternMap.values.asSequence().flatMap {
+        return modifiedPatternMap.values.asSequence().filterNotNull().flatMap {
             patternListR(it)
         }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/NegativePatternsTemplate.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/NegativePatternsTemplate.kt
@@ -3,35 +3,7 @@ package `in`.specmatic.core.pattern
 import `in`.specmatic.core.Resolver
 
 abstract class NegativePatternsTemplate {
-    fun negativeBasedOn(patternMap: Map<String, Pattern>, row: Row, resolver: Resolver): Sequence<Map<String, Pattern>> {
-        val eachKeyMappedToPatternMap = patternMap.mapValues { patternMap }
-        val negativePatternsMap = getNegativePatterns(patternMap, resolver, row).mapValues { it.value.map { it.value } }
-
-        val modifiedPatternMap: Map<String, Sequence<Map<String, Sequence<Pattern>>>> = eachKeyMappedToPatternMap.mapValues { (keyToNegate, patterns) ->
-            val negativePatterns = negativePatternsMap[keyToNegate]
-            negativePatterns!!.map { negativePattern ->
-                patterns.mapValues { (key, pattern) ->
-                    attempt(breadCrumb = key) {
-                        when (key == keyToNegate) {
-                            true ->
-                                attempt(breadCrumb = "Setting $key to $negativePattern for negative test scenario") {
-                                    negativePatternsForKey(key, negativePattern, resolver)
-                                }
-
-                            else -> newBasedOn(row, key, pattern, resolver)
-                        }
-                    }
-                }
-            }
-        }
-        if (modifiedPatternMap.values.isEmpty())
-            return sequenceOf(emptyMap())
-        return modifiedPatternMap.values.asSequence().flatMap { list: Sequence<Map<String, Sequence<Pattern>>> ->
-            list.flatMap { patternList(it) }
-        }
-    }
-
-    fun negativeBasedOnR(
+    fun negativeBasedOn(
         patternMap: Map<String, Pattern>,
         row: Row,
         resolver: Resolver

--- a/core/src/main/kotlin/in/specmatic/core/pattern/NullPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/NullPattern.kt
@@ -21,7 +21,7 @@ object NullPattern : Pattern, ScalarType {
     override fun generate(resolver: Resolver): Value = NullValue
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
     override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
-    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
         return newBasedOn(row, resolver).map { HasValue(it) }
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/NullPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/NullPattern.kt
@@ -21,8 +21,8 @@ object NullPattern : Pattern, ScalarType {
     override fun generate(resolver: Resolver): Value = NullValue
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
     override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
-        return newBasedOn(row, resolver)
+    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+        return newBasedOn(row, resolver).map { HasValue(it) }
     }
 
     override fun parse(value: String, resolver: Resolver): Value {

--- a/core/src/main/kotlin/in/specmatic/core/pattern/NumberPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/NumberPattern.kt
@@ -57,7 +57,7 @@ data class NumberPattern(
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
     override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
 
-    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
         return scalarAnnotation(this, sequenceOf(NullPattern, BooleanPattern(), StringPattern()))
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/NumberPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/NumberPattern.kt
@@ -58,13 +58,11 @@ data class NumberPattern(
     override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
 
     override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
-        return sequenceOf(NullPattern, BooleanPattern(), StringPattern()).map {
-            HasValue(it, "Expected type in spec was $typeName, trying out a ${it.typeName}")
-        }
+        return scalarAnnotation(this, negativeBasedOn(row, resolver))
     }
 
     override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
-        return negativeBasedOnR(row, resolver).map { it.value }
+        return sequenceOf(NullPattern, BooleanPattern(), StringPattern())
     }
 
     override fun parse(value: String, resolver: Resolver): Value {

--- a/core/src/main/kotlin/in/specmatic/core/pattern/NumberPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/NumberPattern.kt
@@ -56,8 +56,15 @@ data class NumberPattern(
 
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
     override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
+
+    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+        return sequenceOf(NullPattern, BooleanPattern(), StringPattern()).map {
+            HasValue(it, "Expected type in spec was $typeName, trying out a ${it.typeName}")
+        }
+    }
+
     override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
-        return sequenceOf(NullPattern, BooleanPattern(), StringPattern())
+        return negativeBasedOnR(row, resolver).map { it.value }
     }
 
     override fun parse(value: String, resolver: Resolver): Value {

--- a/core/src/main/kotlin/in/specmatic/core/pattern/NumberPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/NumberPattern.kt
@@ -58,11 +58,7 @@ data class NumberPattern(
     override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
 
     override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
-        return scalarAnnotation(this, negativeBasedOn(row, resolver))
-    }
-
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
-        return sequenceOf(NullPattern, BooleanPattern(), StringPattern())
+        return scalarAnnotation(this, sequenceOf(NullPattern, BooleanPattern(), StringPattern()))
     }
 
     override fun parse(value: String, resolver: Resolver): Value {

--- a/core/src/main/kotlin/in/specmatic/core/pattern/Pattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/Pattern.kt
@@ -18,9 +18,7 @@ interface Pattern {
     fun generate(resolver: Resolver): Value
     fun generateWithAll(resolver: Resolver) = resolver.withCyclePrevention(this, this::generate)
     fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern>
-
     fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>>
-
     fun newBasedOn(resolver: Resolver): Sequence<Pattern>
     fun parse(value: String, resolver: Resolver): Value
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/Pattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/Pattern.kt
@@ -18,7 +18,12 @@ interface Pattern {
     fun generate(resolver: Resolver): Value
     fun generateWithAll(resolver: Resolver) = resolver.withCyclePrevention(this, this::generate)
     fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern>
+
     fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern>
+    fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+        return negativeBasedOn(row, resolver).map { HasValue(it) }
+    }
+
     fun newBasedOn(resolver: Resolver): Sequence<Pattern>
     fun parse(value: String, resolver: Resolver): Value
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/Pattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/Pattern.kt
@@ -23,9 +23,7 @@ interface Pattern {
         return negativeBasedOnR(row, resolver).map { it.value }
     }
 
-    fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
-        return negativeBasedOn(row, resolver).map { HasValue(it) }
-    }
+    fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>>
 
     fun newBasedOn(resolver: Resolver): Sequence<Pattern>
     fun parse(value: String, resolver: Resolver): Value

--- a/core/src/main/kotlin/in/specmatic/core/pattern/Pattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/Pattern.kt
@@ -19,7 +19,10 @@ interface Pattern {
     fun generateWithAll(resolver: Resolver) = resolver.withCyclePrevention(this, this::generate)
     fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern>
 
-    fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern>
+    fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
+        return negativeBasedOnR(row, resolver).map { it.value }
+    }
+
     fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
         return negativeBasedOn(row, resolver).map { HasValue(it) }
     }

--- a/core/src/main/kotlin/in/specmatic/core/pattern/Pattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/Pattern.kt
@@ -19,11 +19,7 @@ interface Pattern {
     fun generateWithAll(resolver: Resolver) = resolver.withCyclePrevention(this, this::generate)
     fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern>
 
-    fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
-        return negativeBasedOnR(row, resolver).map { it.value }
-    }
-
-    fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>>
+    fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>>
 
     fun newBasedOn(resolver: Resolver): Sequence<Pattern>
     fun parse(value: String, resolver: Resolver): Value

--- a/core/src/main/kotlin/in/specmatic/core/pattern/PatternInStringPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/PatternInStringPattern.kt
@@ -34,8 +34,8 @@ data class PatternInStringPattern(override val pattern: Pattern = StringPattern(
             pattern.newBasedOn(cyclePreventedResolver).map { PatternInStringPattern(it) }
         }
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
-        return sequenceOf(NullPattern)
+    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+        return sequenceOf(HasValue(NullPattern))
     }
 
     override fun parse(value: String, resolver: Resolver): Value = StringValue(pattern.parse(value, resolver).toStringLiteral())

--- a/core/src/main/kotlin/in/specmatic/core/pattern/PatternInStringPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/PatternInStringPattern.kt
@@ -34,7 +34,7 @@ data class PatternInStringPattern(override val pattern: Pattern = StringPattern(
             pattern.newBasedOn(cyclePreventedResolver).map { PatternInStringPattern(it) }
         }
 
-    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
         return sequenceOf(HasValue(NullPattern))
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/QueryParameterArrayPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/QueryParameterArrayPattern.kt
@@ -107,8 +107,8 @@ data class QueryParameterArrayPattern(override val pattern: List<Pattern>, val p
         return pattern.first().newBasedOn(resolver).map { QueryParameterArrayPattern(listOf(it), parameterName) }
     }
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
-        return pattern.first().negativeBasedOn(row, resolver).map { QueryParameterArrayPattern(listOf(it), parameterName) }
+    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+        return pattern.first().negativeBasedOn(row, resolver).map { HasValue(QueryParameterArrayPattern(listOf(it), parameterName)) }
     }
 
     override fun parse(value: String, resolver: Resolver): Value {

--- a/core/src/main/kotlin/in/specmatic/core/pattern/QueryParameterArrayPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/QueryParameterArrayPattern.kt
@@ -107,8 +107,8 @@ data class QueryParameterArrayPattern(override val pattern: List<Pattern>, val p
         return pattern.first().newBasedOn(resolver).map { QueryParameterArrayPattern(listOf(it), parameterName) }
     }
 
-    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
-        return pattern.first().negativeBasedOnR(row, resolver).map { it.ifValue { QueryParameterArrayPattern(listOf(it), parameterName) } }
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+        return pattern.first().negativeBasedOn(row, resolver).map { it.ifValue { QueryParameterArrayPattern(listOf(it), parameterName) } }
     }
 
     override fun parse(value: String, resolver: Resolver): Value {

--- a/core/src/main/kotlin/in/specmatic/core/pattern/QueryParameterArrayPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/QueryParameterArrayPattern.kt
@@ -108,7 +108,7 @@ data class QueryParameterArrayPattern(override val pattern: List<Pattern>, val p
     }
 
     override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
-        return pattern.first().negativeBasedOn(row, resolver).map { HasValue(QueryParameterArrayPattern(listOf(it), parameterName)) }
+        return pattern.first().negativeBasedOnR(row, resolver).map { it.ifValue { QueryParameterArrayPattern(listOf(it), parameterName) } }
     }
 
     override fun parse(value: String, resolver: Resolver): Value {

--- a/core/src/main/kotlin/in/specmatic/core/pattern/RestPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/RestPattern.kt
@@ -22,8 +22,8 @@ data class RestPattern(override val pattern: Pattern, override val typeAlias: St
             pattern.newBasedOn(cyclePreventedResolver).map { RestPattern(it) }
         }
     }
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
-        return sequenceOf(this)
+    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+        return sequenceOf(HasValue(this))
     }
 
     override fun parse(value: String, resolver: Resolver): Value = listPattern.parse(value, resolver)

--- a/core/src/main/kotlin/in/specmatic/core/pattern/RestPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/RestPattern.kt
@@ -22,7 +22,7 @@ data class RestPattern(override val pattern: Pattern, override val typeAlias: St
             pattern.newBasedOn(cyclePreventedResolver).map { RestPattern(it) }
         }
     }
-    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
         return sequenceOf(HasValue(this))
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/ReturnValue.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/ReturnValue.kt
@@ -36,3 +36,18 @@ fun <K, ValueType> Map<K, ReturnValue<ValueType>>.mapFold(): ReturnValue<Map<K, 
         }
     }
 }
+
+fun <T> Sequence<List<ReturnValue<out T>>>.sequenceListFold(): Sequence<ReturnValue<List<T>>> {
+    val data: Sequence<List<ReturnValue<out T>>> = this
+
+    return data.map { listOfReturnValues ->
+        val error: ReturnValue<out T>? = listOfReturnValues.firstOrNull { it !is HasValue }
+
+        if (error != null)
+            listOf(error)
+
+        val valueDetails: List<ValueDetails> = listOfReturnValues.map { (it as HasValue).valueDetails }.flatten()
+        HasValue(listOfReturnValues.map { it.value }, valueDetails)
+    }
+}
+

--- a/core/src/main/kotlin/in/specmatic/core/pattern/ReturnValue.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/ReturnValue.kt
@@ -51,3 +51,9 @@ fun <T> Sequence<List<ReturnValue<out T>>>.sequenceListFold(): Sequence<ReturnVa
     }
 }
 
+fun <T> ReturnValue<T>.breadCrumb(breadCrumb: String?): ReturnValue<T> {
+    if(breadCrumb == null)
+        return this
+
+    return this.addDetails("", breadCrumb)
+}

--- a/core/src/main/kotlin/in/specmatic/core/pattern/ReturnValue.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/ReturnValue.kt
@@ -7,11 +7,10 @@ sealed interface ReturnValue<T> {
 
     abstract fun <U> withDefault(default: U, fn: (T) -> U): U
     abstract fun <U> ifValue(fn: (T) -> U): ReturnValue<U>
-    fun <U> sequenceOf(fn: (T) -> Sequence<ReturnValue<U>>): Sequence<ReturnValue<U>>
     fun update(fn: (T) -> T): ReturnValue<T>
     fun <U> combineWith(valueResult: ReturnValue<U>, fn: (T, U) -> T): ReturnValue<T>
-    fun <U> realise(hasValue: (T) -> U, orFailure: (HasFailure<T>) -> U, orException: (HasException<T>) -> U): U
-    fun addDetails(errorMessage: String, breadCrumb: String): ReturnValue<T>
+    fun <U> realise(hasValue: (T, String?) -> U, orFailure: (HasFailure<T>) -> U, orException: (HasException<T>) -> U): U
+    fun addDetails(message: String, breadCrumb: String): ReturnValue<T>
 }
 
 fun <ReturnType> returnValue(errorMessage: String = "", breadCrumb: String = "", f: ()->Sequence<ReturnValue<ReturnType>>): Sequence<ReturnValue<ReturnType>> {
@@ -28,3 +27,12 @@ fun <ReturnType> returnValue(errorMessage: String = "", breadCrumb: String = "",
     }
 }
 
+fun <K, ValueType> Map<K, ReturnValue<ValueType>>.mapFold(): ReturnValue<Map<K, ValueType>> {
+    val initial: ReturnValue<Map<K, ValueType>> = HasValue<Map<K, ValueType>>(emptyMap())
+
+    return this.entries.fold(initial) { accR: ReturnValue<Map<K, ValueType>>, (key: K, valueR: ReturnValue<ValueType>) ->
+        accR.combineWith(valueR) { acc, value ->
+            acc.plus(key to value)
+        }
+    }
+}

--- a/core/src/main/kotlin/in/specmatic/core/pattern/ScalarType.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/ScalarType.kt
@@ -4,7 +4,7 @@ interface ScalarType
 
 fun scalarAnnotation(pattern: Pattern, negativePatterns: Sequence<Pattern>): Sequence<ReturnValue<Pattern>> {
     return negativePatterns.map {
-        HasValue(it, "Expected type in spec was ${pattern.typeName}, trying out a ${it.typeName}")
+        HasValue(it, "Schema in spec was ${pattern.typeName}, mutating to a ${it.typeName}")
     }
 }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/ScalarType.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/ScalarType.kt
@@ -1,3 +1,11 @@
 package `in`.specmatic.core.pattern
 
 interface ScalarType
+
+fun scalarAnnotation(pattern: Pattern, negativePatterns: Sequence<Pattern>): Sequence<ReturnValue<Pattern>> {
+    return negativePatterns.map {
+        HasValue(it, "Expected type in spec was ${pattern.typeName}, trying out a ${it.typeName}")
+    }
+}
+
+

--- a/core/src/main/kotlin/in/specmatic/core/pattern/StringPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/StringPattern.kt
@@ -61,8 +61,15 @@ data class StringPattern (
 
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
     override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
+
+    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+        return sequenceOf(NullPattern, NumberPattern(), BooleanPattern()).map {
+            HasValue(it, "Expected type in spec was $typeName, trying out a ${it.typeName}")
+        }
+    }
+
     override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
-        return sequenceOf(NullPattern, NumberPattern(), BooleanPattern())
+        return negativeBasedOnR(row, resolver).map { it.value }
     }
 
     override fun parse(value: String, resolver: Resolver): Value = StringValue(value)

--- a/core/src/main/kotlin/in/specmatic/core/pattern/StringPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/StringPattern.kt
@@ -63,13 +63,11 @@ data class StringPattern (
     override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
 
     override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
-        return sequenceOf(NullPattern, NumberPattern(), BooleanPattern()).map {
-            HasValue(it, "Expected type in spec was $typeName, trying out a ${it.typeName}")
-        }
+        return scalarAnnotation(this, negativeBasedOn(row, resolver))
     }
 
     override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
-        return negativeBasedOnR(row, resolver).map { it.value }
+        return sequenceOf(NullPattern, NumberPattern(), BooleanPattern())
     }
 
     override fun parse(value: String, resolver: Resolver): Value = StringValue(value)

--- a/core/src/main/kotlin/in/specmatic/core/pattern/StringPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/StringPattern.kt
@@ -97,11 +97,7 @@ data class StringPattern (
     override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
 
     override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
-        return scalarAnnotation(this, negativeBasedOn(row, resolver))
-    }
-
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
-        return sequenceOf(NullPattern, NumberPattern(), BooleanPattern())
+        return scalarAnnotation(this, sequenceOf(NullPattern, NumberPattern(), BooleanPattern()))
     }
 
     override fun parse(value: String, resolver: Resolver): Value = StringValue(value)

--- a/core/src/main/kotlin/in/specmatic/core/pattern/StringPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/StringPattern.kt
@@ -96,7 +96,7 @@ data class StringPattern (
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
     override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
 
-    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
         return scalarAnnotation(this, sequenceOf(NullPattern, NumberPattern(), BooleanPattern()))
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/TabularPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/TabularPattern.kt
@@ -299,6 +299,17 @@ fun <ValueType> forEachKeyCombinationIn(
         creator(newPattern)
     }.flatten()
 
+fun <ValueType> forEachKeyCombinationInR(
+    patternMap: Map<String, ValueType>,
+    row: Row,
+    creator: (Map<String, ValueType>) -> Sequence<ReturnValue<Map<String, ValueType>>>
+): Sequence<ReturnValue<Map<String, ValueType>>> =
+    keySets(patternMap.keys.toList(), row).map { keySet ->
+        patternMap.filterKeys { key -> key in keySet }
+    }.map { newPattern ->
+        creator(newPattern)
+    }.flatten()
+
 fun <ValueType> allOrNothingCombinationIn(
     patternMap: Map<String, ValueType>,
     row: Row = Row(),

--- a/core/src/main/kotlin/in/specmatic/core/pattern/TabularPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/TabularPattern.kt
@@ -87,8 +87,8 @@ data class TabularPattern(
         return allOrNothingCombinationIn.map { toTabularPattern(it) }
     }
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
-        return this.newBasedOn(row, resolver)
+    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+        return this.newBasedOn(row, resolver).map { HasValue(it) }
     }
 
     override fun parse(value: String, resolver: Resolver): Value = parsedJSONObject(value, resolver.mismatchMessages)

--- a/core/src/main/kotlin/in/specmatic/core/pattern/TabularPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/TabularPattern.kt
@@ -87,7 +87,7 @@ data class TabularPattern(
         return allOrNothingCombinationIn.map { toTabularPattern(it) }
     }
 
-    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
         return this.newBasedOn(row, resolver).map { HasValue(it) }
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/TabularPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/TabularPattern.kt
@@ -6,7 +6,6 @@ import `in`.specmatic.core.utilities.stringToPatternMap
 import `in`.specmatic.core.utilities.withNullPattern
 import `in`.specmatic.core.value.*
 import io.cucumber.messages.types.TableRow
-import kotlin.math.min
 
 fun toTabularPattern(jsonContent: String, typeAlias: String? = null): TabularPattern =
     toTabularPattern(stringToPatternMap(jsonContent), typeAlias)
@@ -220,7 +219,7 @@ fun <ValueType> patternListR(patternCollection: Map<String, Sequence<ReturnValue
         return sequenceOf(HasValue(emptyMap()))
 
     val spec = CombinationSpec(patternCollection, Flags.maxTestRequestCombinations())
-    return spec.selectedCombinationsR
+    return spec.selectedCombinations
 }
 
 fun <ValueType> patternList(patternCollection: Map<String, Sequence<ValueType>>): Sequence<Map<String, ValueType>> {

--- a/core/src/main/kotlin/in/specmatic/core/pattern/URLPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/URLPattern.kt
@@ -27,7 +27,7 @@ data class URLPattern(val scheme: URLScheme = URLScheme.HTTPS, override val type
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
 
     override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
-    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
         return newBasedOn(row, resolver).map { HasValue(it) }
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/URLPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/URLPattern.kt
@@ -27,8 +27,8 @@ data class URLPattern(val scheme: URLScheme = URLScheme.HTTPS, override val type
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
 
     override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
-        return newBasedOn(row, resolver)
+    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+        return newBasedOn(row, resolver).map { HasValue(it) }
     }
 
     override fun parse(value: String, resolver: Resolver): StringValue = StringValue(URI.create(value).toString())

--- a/core/src/main/kotlin/in/specmatic/core/pattern/UUIDPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/UUIDPattern.kt
@@ -22,12 +22,9 @@ object UUIDPattern : Pattern, ScalarType {
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<UUIDPattern> = sequenceOf(this)
 
     override fun newBasedOn(resolver: Resolver): Sequence<UUIDPattern> = sequenceOf(this)
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
-        return sequenceOf(NullPattern)
-    }
 
     override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
-        return scalarAnnotation(this, negativeBasedOn(row, resolver))
+        return scalarAnnotation(this, sequenceOf(NullPattern))
     }
 
     override fun parse(value: String, resolver: Resolver): StringValue =

--- a/core/src/main/kotlin/in/specmatic/core/pattern/UUIDPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/UUIDPattern.kt
@@ -26,6 +26,10 @@ object UUIDPattern : Pattern, ScalarType {
         return sequenceOf(NullPattern)
     }
 
+    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+        return scalarAnnotation(this, negativeBasedOn(row, resolver))
+    }
+
     override fun parse(value: String, resolver: Resolver): StringValue =
         attempt {
             UUID.fromString(value)

--- a/core/src/main/kotlin/in/specmatic/core/pattern/UUIDPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/UUIDPattern.kt
@@ -23,7 +23,7 @@ object UUIDPattern : Pattern, ScalarType {
 
     override fun newBasedOn(resolver: Resolver): Sequence<UUIDPattern> = sequenceOf(this)
 
-    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
         return scalarAnnotation(this, sequenceOf(NullPattern))
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/ValueDetails.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/ValueDetails.kt
@@ -1,0 +1,31 @@
+package `in`.specmatic.core.pattern
+
+class ValueDetails(val messages: List<String> = emptyList(), val breadCrumbs: List<String> = emptyList()) {
+    fun addDetails(message: String, breadCrumb: String): ValueDetails {
+        return ValueDetails(
+            messages.addNonBlank(message),
+            breadCrumbs.addNonBlank(breadCrumb)
+        )
+    }
+
+    fun comments(): String? {
+        if(messages.isEmpty())
+            return null
+
+        val breadCrumbs = breadCrumbs.reversed().joinToString(".")
+        val body = messages.joinToString(System.lineSeparator())
+
+        return """
+            >> $breadCrumbs
+            
+               $body
+        """.trimIndent()
+    }
+
+    private fun List<String>.addNonBlank(
+        errorMessage: String
+    ) = if (errorMessage.isNotBlank())
+        this.plus(errorMessage)
+    else
+        this
+}

--- a/core/src/main/kotlin/in/specmatic/core/pattern/XMLPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/XMLPattern.kt
@@ -411,8 +411,8 @@ data class XMLPattern(override val pattern: XMLTypeData = XMLTypeData(realName =
         }
     }
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
-        return newBasedOn(row, resolver)
+    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+        return newBasedOn(row, resolver).map { HasValue(it) }
     }
 
     private fun dereferenceType(resolver: Resolver): XMLPattern {

--- a/core/src/main/kotlin/in/specmatic/core/pattern/XMLPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/XMLPattern.kt
@@ -411,7 +411,7 @@ data class XMLPattern(override val pattern: XMLTypeData = XMLTypeData(realName =
         }
     }
 
-    override fun negativeBasedOnR(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
         return newBasedOn(row, resolver).map { HasValue(it) }
     }
 

--- a/core/src/main/kotlin/in/specmatic/test/ScenarioTest.kt
+++ b/core/src/main/kotlin/in/specmatic/test/ScenarioTest.kt
@@ -2,6 +2,7 @@ package `in`.specmatic.test
 
 import `in`.specmatic.conversions.convertPathParameterStyle
 import `in`.specmatic.core.*
+import `in`.specmatic.core.log.logger
 
 class ScenarioTest(
     val scenario: Scenario,
@@ -11,6 +12,7 @@ class ScenarioTest(
     private val sourceRepositoryBranch: String? = null,
     private val specification: String? = null,
     private val serviceType: String? = null,
+    private val comment: String? = null
 ) : ContractTest {
     override fun testResultRecord(result: Result, response: HttpResponse?): TestResultRecord {
         val resultStatus = result.testResult()
@@ -25,6 +27,10 @@ class ScenarioTest(
     }
 
     override fun runTest(testBaseURL: String, timeOut: Int): Pair<Result, HttpResponse?> {
+        if(comment != null) {
+            logger.log(comment)
+        }
+
         val httpClient = HttpClient(testBaseURL, timeout = timeOut)
         val (result, response) = executeTestAndReturnResultAndResponse(scenario, httpClient, flagsBased)
         return Pair(result.updateScenario(scenario), response)

--- a/core/src/main/kotlin/in/specmatic/test/ScenarioTest.kt
+++ b/core/src/main/kotlin/in/specmatic/test/ScenarioTest.kt
@@ -2,6 +2,8 @@ package `in`.specmatic.test
 
 import `in`.specmatic.conversions.convertPathParameterStyle
 import `in`.specmatic.core.*
+import `in`.specmatic.core.log.HttpLogMessage
+import `in`.specmatic.core.log.LogMessage
 import `in`.specmatic.core.log.logger
 
 class ScenarioTest(
@@ -12,14 +14,23 @@ class ScenarioTest(
     private val sourceRepositoryBranch: String? = null,
     private val specification: String? = null,
     private val serviceType: String? = null,
-    private val comment: String? = null
+    private val annotations: String? = null
 ) : ContractTest {
     override fun testResultRecord(result: Result, response: HttpResponse?): TestResultRecord {
         val resultStatus = result.testResult()
 
         val responseStatus = scenario.getStatus(response)
-        return TestResultRecord(convertPathParameterStyle(scenario.path), scenario.method,
-            responseStatus, resultStatus, sourceProvider, sourceRepository, sourceRepositoryBranch, specification, serviceType)
+        return TestResultRecord(
+            convertPathParameterStyle(scenario.path),
+            scenario.method,
+            responseStatus,
+            resultStatus,
+            sourceProvider,
+            sourceRepository,
+            sourceRepositoryBranch,
+            specification,
+            serviceType
+        )
     }
 
     override fun testDescription(): String {
@@ -27,13 +38,27 @@ class ScenarioTest(
     }
 
     override fun runTest(testBaseURL: String, timeOut: Int): Pair<Result, HttpResponse?> {
-        if(comment != null) {
-            logger.log(comment)
+        val log: (LogMessage) -> Unit = { logMessage ->
+            logger.log(logMessage.withComment(this.annotations))
         }
 
-        val httpClient = HttpClient(testBaseURL, timeout = timeOut)
+        val httpClient = HttpClient(testBaseURL, log = log, timeout = timeOut)
         val (result, response) = executeTestAndReturnResultAndResponse(scenario, httpClient, flagsBased)
         return Pair(result.updateScenario(scenario), response)
     }
 
+    private fun logComment() {
+        if (annotations != null) {
+            logger.log(annotations)
+        }
+    }
+
+}
+
+private fun LogMessage.withComment(comment: String?): LogMessage {
+    return if (this is HttpLogMessage) {
+        this.copy(comment = comment)
+    } else {
+        this
+    }
 }

--- a/core/src/test/kotlin/in/specmatic/core/HttpHeadersPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/HttpHeadersPatternTest.kt
@@ -219,7 +219,7 @@ internal class HttpHeadersPatternTest {
     @Test
     fun `should generate negative values for a string`() {
         val headers = HttpHeadersPattern(mapOf("X-TraceID" to StringPattern()))
-        val newHeaders = headers.negativeBasedOn(Row(), Resolver()).toList()
+        val newHeaders = headers.negativeBasedOn(Row(), Resolver()).map { it.value }.toList()
 
         assertThat(newHeaders).isEmpty()
     }
@@ -228,7 +228,7 @@ internal class HttpHeadersPatternTest {
     @Test
     fun `should generate negative values for a number`() {
         val headers = HttpHeadersPattern(mapOf("X-TraceID" to NumberPattern()))
-        val newHeaders = headers.negativeBasedOn(Row(), Resolver()).toList()
+        val newHeaders = headers.negativeBasedOn(Row(), Resolver()).map { it.value }.toList()
 
         assertThat(newHeaders).containsExactlyInAnyOrder(
             HttpHeadersPattern(mapOf("X-TraceID" to StringPattern())),

--- a/core/src/test/kotlin/in/specmatic/core/HttpPathPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/HttpPathPatternTest.kt
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.Tag
 import java.io.UnsupportedEncodingException
 import java.net.URI
 import java.net.URISyntaxException
-import java.util.*
 
 internal class HttpPathPatternTest {
     @Test
@@ -180,7 +179,7 @@ internal class HttpPathPatternTest {
     @Test
     fun `should generate negative values for a number`() {
         val headers = HttpHeadersPattern(mapOf("X-TraceID" to NumberPattern()))
-        val newHeaders = headers.negativeBasedOn(Row(), Resolver()).toList()
+        val newHeaders = headers.negativeBasedOn(Row(), Resolver()).map { it.value }.toList()
 
         assertThat(newHeaders).containsExactlyInAnyOrder(
             HttpHeadersPattern(mapOf("X-TraceID" to StringPattern())),

--- a/core/src/test/kotlin/in/specmatic/core/HttpQueryParamPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/HttpQueryParamPatternTest.kt
@@ -178,7 +178,8 @@ class HttpQueryParamPatternTest {
     @Tag(GENERATION)
     @Test
     fun `should generate negative values for a string`() {
-        val urlMatchers = buildQueryPattern(URI("/pets?name=(string)")).negativeBasedOn(Row(), Resolver()).toList()
+        val urlMatchers =
+            buildQueryPattern(URI("/pets?name=(string)")).negativeBasedOn(Row(), Resolver()).toList()
         assertThat(urlMatchers).containsExactly(emptyMap())
     }
 

--- a/core/src/test/kotlin/in/specmatic/core/HttpQueryParamPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/HttpQueryParamPatternTest.kt
@@ -179,7 +179,7 @@ class HttpQueryParamPatternTest {
     @Test
     fun `should generate negative values for a string`() {
         val urlMatchers =
-            buildQueryPattern(URI("/pets?name=(string)")).negativeBasedOn(Row(), Resolver()).toList()
+            buildQueryPattern(URI("/pets?name=(string)")).negativeBasedOn(Row(), Resolver()).toList().map { it.value }
         assertThat(urlMatchers).containsExactly(emptyMap())
     }
 

--- a/core/src/test/kotlin/in/specmatic/core/pattern/AllNegativePatternsTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/AllNegativePatternsTest.kt
@@ -11,7 +11,8 @@ class AllNegativePatternsTest {
         val resolver = Resolver()
         val row = Row()
 
-        val negativePatterns: List<Map<String, Pattern>> = AllNegativePatterns().negativeBasedOn(patternMap, row, resolver).toList()
+        val negativePatterns: List<Map<String, Pattern>> =
+            AllNegativePatterns().negativeBasedOn(patternMap, row, resolver).map { it.value }.toList()
 
         assertThat(negativePatterns).containsExactlyInAnyOrder(
             mapOf("key" to NumberPattern()),
@@ -26,7 +27,8 @@ class AllNegativePatternsTest {
         val resolver = Resolver()
         val row = Row()
 
-        val negativePatterns: List<Map<String, Pattern>> = AllNegativePatterns().negativeBasedOn(patternMap, row, resolver).toList()
+        val negativePatterns: List<Map<String, Pattern>> =
+            AllNegativePatterns().negativeBasedOn(patternMap, row, resolver).map { it.value }.toList()
 
         assertThat(negativePatterns).containsExactlyInAnyOrder(
             mapOf("key1" to BooleanPattern(), "key2" to StringPattern()),

--- a/core/src/test/kotlin/in/specmatic/core/pattern/AnyPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/AnyPatternTest.kt
@@ -219,7 +219,9 @@ internal class AnyPatternTest {
     @Test
     @Tag(GENERATION)
     fun `values for negative tests`() {
-        val negativeTypes = AnyPattern(listOf(NullPattern, StringPattern())).negativeBasedOn(Row(), Resolver()).toList()
+        val negativeTypes =
+            AnyPattern(listOf(NullPattern, StringPattern())).negativeBasedOn(Row(), Resolver()).map { it.value }
+                .toList()
 
         assertThat(negativeTypes).containsExactlyInAnyOrder(
             NumberPattern(),

--- a/core/src/test/kotlin/in/specmatic/core/pattern/BinaryPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/BinaryPatternTest.kt
@@ -11,7 +11,7 @@ class BinaryPatternTest {
     @Test
     @Tag(GENERATION)
     fun `negative patterns should be generated`() {
-        val result = BinaryPattern().negativeBasedOn(Row(), Resolver()).toList()
+        val result = BinaryPattern().negativeBasedOn(Row(), Resolver()).map { it.value }.toList()
         assertThat(result.map { it.typeName }).containsExactlyInAnyOrder(
             "null",
             "number",

--- a/core/src/test/kotlin/in/specmatic/core/pattern/BooleanPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/BooleanPatternTest.kt
@@ -25,7 +25,7 @@ internal class BooleanPatternTest {
     @Test
     @Tag(GENERATION)
     fun `negative patterns should be generated`() {
-        val result = BooleanPattern().negativeBasedOn(Row(), Resolver()).toList()
+        val result = BooleanPattern().negativeBasedOn(Row(), Resolver()).map { it.value }.toList()
         assertThat(result.map { it.typeName }).containsExactlyInAnyOrder(
             "null"
         )

--- a/core/src/test/kotlin/in/specmatic/core/pattern/CombinationSpecTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/CombinationSpecTest.kt
@@ -14,13 +14,20 @@ class CombinationSpecTest {
 
   @Test
   fun `empty list when no candidate sets supplied`() {
-    assertThat(CombinationSpec<Long>(mapOf(), 50).selectedCombinations.toList()).isEmpty()
+    val combinationSpec = CombinationSpec<Long>(mapOf(), 50)
+    assertThat(
+      combinationSpec.toSelectedCombinations(combinationSpec.keyToCandidates, 50)
+        .map { it.value }.toList()
+ ).isEmpty()
   }
 
   @Test
   fun `combination omitted when candidate set empty`() {
     val spec = CombinationSpec.from(mapOf("k1" to emptySequence(), "k2" to sequenceOf(21, 22)), 50)
-    assertThat(spec.selectedCombinations.toList()).containsExactly(mapOf("k2" to 21), mapOf("k2" to 22))
+    assertThat(
+      spec.toSelectedCombinations(spec.keyToCandidates, 50)
+        .map { it.value }.toList()
+    ).containsExactly(mapOf("k2" to 21), mapOf("k2" to 22))
   }
 
   @Test
@@ -33,7 +40,10 @@ class CombinationSpecTest {
       ),
       50,
     )
-    assertThat(spec.selectedCombinations.toList()).containsExactly(
+    assertThat(
+      spec.toSelectedCombinations(spec.keyToCandidates, 50)
+        .map { it.value }.toList()
+    ).containsExactly(
       // Prioritized first
       mapOf("k1" to 12, "k2" to 25, "k3" to 39),
       mapOf("k1" to 14, "k2" to 22, "k3" to 33),
@@ -78,7 +88,10 @@ class CombinationSpecTest {
       ),
       23,
     )
-    assertThat(spec.selectedCombinations.toList()).containsExactly(
+    assertThat(
+      spec.toSelectedCombinations(spec.keyToCandidates, 23)
+        .map { it.value }.toList()
+    ).containsExactly(
       // Prioritized first
       mapOf("k1" to 12, "k2" to 25, "k3" to 39),
       mapOf("k1" to 14, "k2" to 22, "k3" to 33),
@@ -123,7 +136,13 @@ class CombinationSpecTest {
       ),
       3,
     )
-    assertThat(spec.selectedCombinations.toList()).withFailMessage(spec.selectedCombinations.toString()).containsExactly(
+    assertThat(
+      spec.toSelectedCombinations(spec.keyToCandidates, 3)
+        .map { it.value }.toList()
+    ).withFailMessage(
+      spec.toSelectedCombinations(spec.keyToCandidates, 3)
+        .map { it.value }.toString()
+    ).containsExactly(
       // Prioritized first
       mapOf("k1" to 12, "k2" to 25, "k3" to 39),
       mapOf("k1" to 14, "k2" to 22, "k3" to 33),

--- a/core/src/test/kotlin/in/specmatic/core/pattern/CombinationSpecTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/CombinationSpecTest.kt
@@ -19,17 +19,17 @@ class CombinationSpecTest {
 
   @Test
   fun `combination omitted when candidate set empty`() {
-    val spec = CombinationSpec(mapOf("k1" to emptySequence(), "k2" to sequenceOf(21, 22)), 50)
+    val spec = CombinationSpec.from(mapOf("k1" to emptySequence(), "k2" to sequenceOf(21, 22)), 50)
     assertThat(spec.selectedCombinations.toList()).containsExactly(mapOf("k2" to 21), mapOf("k2" to 22))
   }
 
   @Test
   fun `produces all combos and orders and prioritized first`() {
-    val spec = CombinationSpec<Long>(
+    val spec = CombinationSpec.from(
       mapOf(
-        "k1" to sequenceOf(12, 14),
-        "k2" to sequenceOf(25, 22, 28, 27),
-        "k3" to sequenceOf(39, 33, 31),
+        "k1" to sequenceOf(12L, 14L),
+        "k2" to sequenceOf(25L, 22L, 28L, 27L),
+        "k3" to sequenceOf(39L, 33L, 31L),
       ),
       50,
     )
@@ -70,7 +70,7 @@ class CombinationSpecTest {
 
   @Test
   fun `restricts combos when count too high and orders with prioritized first`() {
-    val spec = CombinationSpec<Long>(
+    val spec = CombinationSpec.from(
       mapOf(
         "k1" to sequenceOf(12, 14),
         "k2" to sequenceOf(25, 22, 28, 27),
@@ -115,7 +115,7 @@ class CombinationSpecTest {
 
   @Test
   fun `restricts combos even when prioritized count is too high`() {
-    val spec = CombinationSpec<Long>(
+    val spec = CombinationSpec.from(
       mapOf(
         "k1" to sequenceOf(12, 14),
         "k2" to sequenceOf(25, 22, 28, 27),

--- a/core/src/test/kotlin/in/specmatic/core/pattern/CsvPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/CsvPatternTest.kt
@@ -50,7 +50,7 @@ internal class CsvPatternTest {
 
     @Test
     fun `generates values for negative tests`() {
-        val negativeTypes = CsvPattern(NumberPattern()).negativeBasedOn(Row(), Resolver()).toList()
+        val negativeTypes = CsvPattern(NumberPattern()).negativeBasedOn(Row(), Resolver()).map { it.value }.toList()
         assertThat(negativeTypes).hasSize(3)
     }
 
@@ -228,7 +228,7 @@ paths:
     @Test
     @Tag(GENERATION)
     fun `negative patterns should be generated`() {
-        val result = StringPattern().negativeBasedOn(Row(), Resolver()).toList()
+        val result = StringPattern().negativeBasedOn(Row(), Resolver()).map { it.value }.toList()
         assertThat(result.map { it.typeName }).containsExactlyInAnyOrder(
             "null",
             "number",

--- a/core/src/test/kotlin/in/specmatic/core/pattern/DatePatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/DatePatternTest.kt
@@ -60,7 +60,7 @@ internal class DatePatternTest {
     @Test
     @Tag(GENERATION)
     fun `negative patterns should be generated`() {
-        val result = BooleanPattern().negativeBasedOn(Row(), Resolver()).toList()
+        val result = BooleanPattern().negativeBasedOn(Row(), Resolver()).map { it.value }.toList()
         assertThat(result.map { it.typeName }).containsExactlyInAnyOrder(
             "null"
         )

--- a/core/src/test/kotlin/in/specmatic/core/pattern/DateTimePatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/DateTimePatternTest.kt
@@ -59,7 +59,7 @@ internal class DateTimePatternTest {
     @Test
     @Tag(GENERATION)
     fun `negative patterns should be generated`() {
-        val result = BooleanPattern().negativeBasedOn(Row(), Resolver()).toList()
+        val result = BooleanPattern().negativeBasedOn(Row(), Resolver()).map { it.value }.toList()
         assertThat(result.map { it.typeName }).containsExactlyInAnyOrder(
             "null"
         )

--- a/core/src/test/kotlin/in/specmatic/core/pattern/DeferredPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/DeferredPatternTest.kt
@@ -25,7 +25,7 @@ internal class DeferredPatternTest {
     @Test
     @Tag(GENERATION)
     fun `negative patterns should be generated`() {
-        val result = DeferredPattern("(string)").negativeBasedOn(Row(), Resolver()).toList()
+        val result = DeferredPattern("(string)").negativeBasedOn(Row(), Resolver()).map { it.value }.toList()
         assertThat(result.map { it.typeName }).containsExactlyInAnyOrder(
             "null",
             "number",

--- a/core/src/test/kotlin/in/specmatic/core/pattern/EmailPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/EmailPatternTest.kt
@@ -12,7 +12,7 @@ class EmailPatternTest {
     @Test
     @Tag(GENERATION)
     fun `negative values should be generated`() {
-        val result = EmailPattern().negativeBasedOn(Row(), Resolver()).toList()
+        val result = EmailPattern().negativeBasedOnR(Row(), Resolver()).toList().map { it.value }
         assertThat(result.map { it.typeName }).containsExactlyInAnyOrder(
             "null",
             "number",

--- a/core/src/test/kotlin/in/specmatic/core/pattern/EmailPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/EmailPatternTest.kt
@@ -4,7 +4,6 @@ import `in`.specmatic.GENERATION
 import `in`.specmatic.core.Resolver
 import `in`.specmatic.core.Result
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 
@@ -12,7 +11,7 @@ class EmailPatternTest {
     @Test
     @Tag(GENERATION)
     fun `negative values should be generated`() {
-        val result = EmailPattern().negativeBasedOnR(Row(), Resolver()).toList().map { it.value }
+        val result = EmailPattern().negativeBasedOn(Row(), Resolver()).toList().map { it.value }
         assertThat(result.map { it.typeName }).containsExactlyInAnyOrder(
             "null",
             "number",

--- a/core/src/test/kotlin/in/specmatic/core/pattern/EnumPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/EnumPatternTest.kt
@@ -112,7 +112,7 @@ class EnumPatternTest {
         fun `it should generate negative values for what is in the row`() {
             val jsonPattern = EnumPattern(listOf(StringValue("01"), StringValue("02")))
 
-            val newPatterns = jsonPattern.negativeBasedOn(Row(), Resolver()).toList()
+            val newPatterns = jsonPattern.negativeBasedOn(Row(), Resolver()).map { it.value }.toList()
 
             val negativeTypes = newPatterns.map { it.typeName }
             println(negativeTypes)

--- a/core/src/test/kotlin/in/specmatic/core/pattern/ExactValuePatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/ExactValuePatternTest.kt
@@ -19,7 +19,8 @@ internal class ExactValuePatternTest {
     @Test
     @Tag(GENERATION)
     fun `negative patterns should be generated`() {
-        val result = ExactValuePattern(StringValue("data")).negativeBasedOn(Row(), Resolver()).toList()
+        val result =
+            ExactValuePattern(StringValue("data")).negativeBasedOn(Row(), Resolver()).map { it.value }.toList()
         assertThat(result.map { it.typeName }).containsExactlyInAnyOrder(
             "null",
             "number",

--- a/core/src/test/kotlin/in/specmatic/core/pattern/JSONObjectPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/JSONObjectPatternTest.kt
@@ -632,7 +632,7 @@ internal class JSONObjectPatternTest {
                 )
             )
 
-            val negativePatterns: List<Pattern> = pattern.negativeBasedOn(Row(), Resolver()).toList()
+            val negativePatterns: List<Pattern> = pattern.negativeBasedOn(Row(), Resolver()).map { it.value }.toList()
 
             val jsonInternalPatterns = negativePatterns.filterIsInstance<JSONObjectPattern>().map { it.pattern }
 

--- a/core/src/test/kotlin/in/specmatic/core/pattern/ListPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/ListPatternTest.kt
@@ -103,7 +103,8 @@ Feature: Recursive test
     @Tag(GENERATION)
     @Test
     fun `negative pattern generation`() {
-        val negativePatterns = ListPattern(StringPattern()).negativeBasedOn(Row(), Resolver()).toList()
+        val negativePatterns =
+            ListPattern(StringPattern()).negativeBasedOn(Row(), Resolver()).map { it.value }.toList()
         assertThat(negativePatterns.map { it.typeName }).containsExactlyInAnyOrder(
             "null"
         )

--- a/core/src/test/kotlin/in/specmatic/core/pattern/NegativeNonStringlyPatternsTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/NegativeNonStringlyPatternsTest.kt
@@ -12,7 +12,8 @@ class NegativeNonStringlyPatternsTest {
         val resolver = Resolver()
         val row = Row()
 
-        val negativePatterns: List<Map<String, Pattern>> = NegativeNonStringlyPatterns().negativeBasedOn(patternMap, row, resolver).toList()
+        val negativePatterns: List<Map<String, Pattern>> =
+            NegativeNonStringlyPatterns().negativeBasedOn(patternMap, row, resolver).map { it.value }.toList()
 
         assertThat(negativePatterns).isEmpty()
 
@@ -24,7 +25,8 @@ class NegativeNonStringlyPatternsTest {
         val resolver = Resolver()
         val row = Row()
 
-        val negativePatterns: List<Map<String, Pattern>> = NegativeNonStringlyPatterns().negativeBasedOn(patternMap, row, resolver).toList()
+        val negativePatterns: List<Map<String, Pattern>> =
+            NegativeNonStringlyPatterns().negativeBasedOn(patternMap, row, resolver).map { it.value }.toList()
 
         assertThat(negativePatterns).containsExactlyInAnyOrder(
             mapOf("key" to BooleanPattern()),
@@ -38,7 +40,8 @@ class NegativeNonStringlyPatternsTest {
         val resolver = Resolver()
         val row = Row()
 
-        val negativePatterns: List<Map<String, Pattern>> = NegativeNonStringlyPatterns().negativeBasedOn(patternMap, row, resolver).toList()
+        val negativePatterns: List<Map<String, Pattern>> =
+            NegativeNonStringlyPatterns().negativeBasedOn(patternMap, row, resolver).map { it.value }.toList()
         assertThat(negativePatterns).containsExactlyInAnyOrder(
             mapOf("key" to NumberPattern()),
             mapOf("key" to BooleanPattern())
@@ -52,7 +55,8 @@ class NegativeNonStringlyPatternsTest {
         val resolver = Resolver()
         val row = Row()
 
-        val negativePatterns: List<Map<String, Pattern>> = NegativeNonStringlyPatterns().negativeBasedOn(patternMap, row, resolver).toList()
+        val negativePatterns: List<Map<String, Pattern>> =
+            NegativeNonStringlyPatterns().negativeBasedOn(patternMap, row, resolver).map { it.value }.toList()
 
         assertThat(negativePatterns).containsExactlyInAnyOrder(
             mapOf("key1" to BooleanPattern(), "key2" to StringPattern()),

--- a/core/src/test/kotlin/in/specmatic/core/pattern/NumberPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/NumberPatternTest.kt
@@ -76,7 +76,7 @@ internal class NumberPatternTest {
     @Test
     @Tag(GENERATION)
     fun `negative values should be generated`() {
-        val result = NumberPattern().negativeBasedOn(Row(), Resolver()).toList()
+        val result = NumberPattern().negativeBasedOn(Row(), Resolver()).map { it.value }.toList()
         assertThat(result.map { it.typeName }).containsExactlyInAnyOrder(
             "null",
             "string",

--- a/core/src/test/kotlin/in/specmatic/core/pattern/PatternInStringPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/PatternInStringPatternTest.kt
@@ -93,7 +93,7 @@ internal class PatternInStringPatternTest {
     @Test
     @Tag(GENERATION)
     fun `negative values should be generated`() {
-        val result = PatternInStringPattern().negativeBasedOn(Row(), Resolver()).toList()
+        val result = PatternInStringPattern().negativeBasedOn(Row(), Resolver()).map { it.value }.toList()
         assertThat(result.map { it.typeName }).containsExactlyInAnyOrder(
             "null"
         )

--- a/core/src/test/kotlin/in/specmatic/core/pattern/StringPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/StringPatternTest.kt
@@ -133,7 +133,7 @@ internal class StringPatternTest {
     @Test
     @Tag(GENERATION)
     fun `negative values should be generated`() {
-        val result = StringPattern().negativeBasedOn(Row(), Resolver()).toList()
+        val result = StringPattern().negativeBasedOn(Row(), Resolver()).map { it.value }.toList()
         assertThat(result.map { it.typeName }).containsExactlyInAnyOrder(
             "null",
             "number",

--- a/core/src/test/kotlin/in/specmatic/core/pattern/UUIDPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/UUIDPatternTest.kt
@@ -60,7 +60,7 @@ internal class UUIDPatternTest {
     @Test
     @Tag(GENERATION)
     fun `negative values should be generated`() {
-        val result = UUIDPattern.negativeBasedOn(Row(), Resolver()).toList()
+        val result = UUIDPattern.negativeBasedOn(Row(), Resolver()).map { it.value }.toList()
         assertThat(result.map { it.typeName }).containsExactlyInAnyOrder(
             "null",
         )

--- a/core/src/test/kotlin/integration_tests/OmittedParameterExamples.kt
+++ b/core/src/test/kotlin/integration_tests/OmittedParameterExamples.kt
@@ -753,11 +753,17 @@ components:
 
                 return HttpResponse(200, body = parsedJSONArray("""[{"id": 1, "name": "Product 1"}, {"id": 2, "name": "Product 2"}]"""))
             }
+
+            override fun preExecuteScenario(scenario: Scenario, request: HttpRequest) {
+                println(scenario.testDescription())
+                println(request.toLogString())
+                println()
+            }
         })
 
         println(optionalQueryParamObserved)
         assertThat(results.successCount).isPositive()
-        assertThat(results.success()).isTrue()
+        assertThat(results.success()).withFailMessage(results.report()).isTrue()
     }
 
     @Test

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=1.3.11
+version=1.3.11-ANNOTATIONS


### PR DESCRIPTION
**What**:

Implemented a first cut of annotations, in which negativeBasedOn across the code now returns `Sequence<ReturnValue<Pattern>>` instead of `Sequence<Pattern>`, where on successful generation of a negative pattern, `HasValue<Pattern>` contains breadcrumbs indicating what was mutated along with details of the original type and the mutated type.

**Why**:

It's hard to debug negative tests unless this information is available.

**How**:

We've used the ReturnValue to ferry back annotations alongside the result. 

NOTE: This is behind a flag for now. Specmatic will only print the annotations if `ANNOTATIONS_ENABLED` is set to `true`, either as an environment variable or a Java system property.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

