### PR TITLE
400 validation

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Scenario.kt
@@ -321,7 +321,7 @@ data class Scenario(
         val updatedResolver = flagsBased.update(resolver)
 
         rowsToValidate.forEach { row ->
-            httpRequestPattern.newBasedOn(row, updatedResolver).first().value
+            httpRequestPattern.newBasedOn(row, updatedResolver, status).first().value
         }
     }
 

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
@@ -1904,6 +1904,8 @@ components:
 """.trimIndent(), ""
         ).toFeature()
 
+        contract.validateExamplesOrException()
+
         var contractInvalidValueReceived = false
 
         contract.executeTests(object : TestExecutor {
@@ -1916,7 +1918,9 @@ components:
                 return HttpResponse(400, body = parsedJSONObject("""{"message": "invalid request"}"""))
             }
 
-            override fun setServerState(serverState: Map<String, Value>) {
+            override fun preExecuteScenario(scenario: Scenario, request: HttpRequest) {
+                println(scenario.testDescription())
+                println(request.toLogString())
             }
         })
 

--- a/core/src/test/kotlin/in/specmatic/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/in/specmatic/stub/HttpStubTest.kt
@@ -1369,7 +1369,7 @@ paths:
     }
 
     @Test
-    fun `should fail contract test with incorrect response Content-Type`() {
+    fun `should fail request with incorrect response Content-Type`() {
         val feature = OpenApiSpecification.fromYAML(
             """
             openapi: 3.0.1


### PR DESCRIPTION
**What**:

```yaml
openapi: 3.0.3
info:
  title: Employee Details API
  description: This API retrieves details of an employee.
  version: "1.0.0"
servers:
  - url: https://api.example.com/v1
    description: Production server
paths:
  /employees:
    post:
      summary: Get Employee Details
      description: Fetches details of a specific employee by their unique employee ID.
      operationId: getEmployeeById
      requestBody:
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/Employee'
            examples:
              GOOD_REQUEST:
                value:
                  id: 10
              BAD_REQUEST:
                value:
                  id: "pqr"
      responses:
        '200':
          description: Successful response with the details of the employee.
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/Employee'
              examples:
                GOOD_REQUEST:
                  value:
                    id: 10
        '400':
          description: Employee not found
          content:
            text/plain:
              schema:
                type: string
              examples:
                BAD_REQUEST:
                  value: "Bad request"
components:
  schemas:
    Employee:
      type: object
      required:
        - id
      properties:
        id:
          type: number
          description: The unique identifier of the employee
```

In this example, when running a test, the `BAD_REQUEST` test gets rejected because the request does not match the spec. However, the request should be permitted, even though invalid, since the test is meant to trigger a 400. This is a regression. Fixing for now, but need to put in a cleaner fix later.

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate
