### PR TITLE
Update the pattern used to parse RFC3339 compliant datetime

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/pattern/DateTimePattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/DateTimePattern.kt
@@ -28,7 +28,7 @@ object DateTimePattern : Pattern, ScalarType {
 
     override fun parse(value: String, resolver: Resolver): StringValue =
             attempt {
-                RFC3339.dateTimeFormatter.parse(value)
+                RFC3339.parse(value)
                 StringValue(value)
             }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/RFC3339.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/RFC3339.kt
@@ -4,18 +4,31 @@ import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
+import java.util.regex.Pattern
 
 private const val DATETIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ssXXX"
 private const val DATE_FORMAT = "yyyy-MM-dd"
 
+private val RFC3339_PATTERN: Pattern = Pattern.compile (
+    "^(\\d{4})-(\\d{2})-(\\d{2})" // yyyy-MM-dd
+            + "([Tt](\\d{2}):(\\d{2}):(\\d{2})(\\.\\d+)?)?" // 'T'HH:mm:ss.milliseconds
+            + "([Zz]|([+-])(\\d{2}):(\\d{2}))?" // 'Z' or time zone shift HH:mm following '+' or '-'
+)
+
 class RFC3339 {
     companion object{
-        val dateTimeFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern(DATETIME_FORMAT)
         val dateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern(DATE_FORMAT)
+
+        fun parse(dateTime: String) {
+            val matcher = RFC3339_PATTERN.matcher(dateTime)
+            if(!matcher.matches()) {
+                throw ContractException("Error while parsing the dateTime as per RFC 3339: $dateTime")
+            }
+        }
 
         fun currentDateTime(): String {
             val dateTimeWithSystemOffset = ZonedDateTime.of(LocalDateTime.now(), ZoneId.systemDefault())
-            return dateTimeWithSystemOffset.format(dateTimeFormatter)
+            return dateTimeWithSystemOffset.format(DateTimeFormatter.ofPattern(DATETIME_FORMAT))
         }
 
         fun currentDate(): String = LocalDateTime.now().format(

--- a/core/src/test/kotlin/in/specmatic/core/pattern/DateTimePatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/DateTimePatternTest.kt
@@ -9,6 +9,8 @@ import `in`.specmatic.shouldNotMatch
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 
 internal class DateTimePatternTest {
     @Test
@@ -46,15 +48,25 @@ internal class DateTimePatternTest {
         assertThat(datePatterns.first()).isEqualTo(DateTimePattern)
     }
 
-    @Test
-    fun `should match RFC3339 date time format`() {
-        val date1 = StringValue("2020-04-12T00:00:00+05:30")
-        val date2 = StringValue("2014-12-03T10:05:59+08:00")
-
-        assertThat(DateTimePattern.matches(date1, Resolver())).isInstanceOf(Result.Success::class.java)
-        assertThat(DateTimePattern.matches(date2, Resolver())).isInstanceOf(Result.Success::class.java)
+    @ParameterizedTest
+    @MethodSource("getRFC3339CompliantDateTimeData")
+    fun `should match RFC3339 date time format`(dateTime: String) {
+        assertThat(DateTimePattern.matches(
+            StringValue(dateTime),
+            Resolver()
+        )).isInstanceOf(Result.Success::class.java)
     }
 
+    @ParameterizedTest
+    @MethodSource("getRFC3339NonCompliantDateTimeData")
+    fun `should fail if the dateTime is not RFC3339 compliant`(dateTime: String) {
+        assertThat(
+            DateTimePattern.matches(
+                StringValue(dateTime),
+                Resolver()
+            )
+        ).isInstanceOf(Result.Failure::class.java)
+    }
 
     @Test
     @Tag(GENERATION)
@@ -63,5 +75,28 @@ internal class DateTimePatternTest {
         assertThat(result.map { it.typeName }).containsExactlyInAnyOrder(
             "null"
         )
+    }
+
+    companion object {
+        @JvmStatic
+        fun getRFC3339CompliantDateTimeData(): List<String> {
+           return listOf(
+               "2020-04-12T00:00:00+05:30",
+               "2014-12-03T10:05:59+08:00",
+               "2024-04-25T09:06:26Z",
+               "2024-04-25T09:06:26.57Z",
+               "2024-04-25T09:06:26.5732Z",
+               "2024-04-25T09:06:26.572577123456Z"
+           )
+        }
+
+        @JvmStatic
+        fun getRFC3339NonCompliantDateTimeData(): List<String> {
+            return listOf(
+                "2024-04-25 09:06:26Z",
+                "2024/04/25T09:06:26Z",
+                "25-04-2024T09:06:26Z",
+            )
+        }
     }
 }

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=1.3.12
+version=1.3.13


### PR DESCRIPTION
**What**:
Fixes the parsing of RFC3339 compliant datetime values.

**Why**:
The existing parsing logic of RFC3339 compliant datetime values used to fail for certain combinations. 
e.g. 2024-04-25T09:06:26.572577123456Z
This fix will make sure that the parsing succeeds for all those combinations.

**How**:
This is fixed by updating the pattern used to match the RFC3339 compliant strings.

**Checklist**:
- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [x] Sonar Quality Gate

**Issue ID**:
Closes: #1078 


