### PR TITLE
Add indexes to test names so that Specmatic always generates tests with unique names.

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Feature.kt
@@ -371,7 +371,7 @@ data class Feature(
                     originalScenario.httpRequestPattern.matches(sampleRequest, originalScenario.resolver).isSuccess()
                 }
             }
-            addIndexes(originalScenario, filtered, flagsBased.negativePrefix)
+            addIndexes(negativeScenario, filtered, flagsBased.negativePrefix)
         }
     }
 
@@ -405,7 +405,7 @@ data class Feature(
             val indexLabel: () -> String = if (sequenceHasZeroOrOne) {
                 { "" }
             } else {
-                { "[${(index + 1)}]" }
+                { "[${(index + 1)}] " }
             }
             Pair(
                 originalScenario.addIndexLabelAndPrefix(prefix, indexLabel),

--- a/core/src/main/kotlin/in/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Feature.kt
@@ -365,8 +365,8 @@ data class Feature(
             val negativeTestScenarios =
                 negativeScenario.generateTestScenarios(flagsBased, testVariables, testBaseURLs)
 
-            val nonMatchingNegativeTestScenarios = negativeTestScenarios.filterNot { negativeTestScenarioR ->
-                negativeTestScenarioR.withDefault(false) { negativeTestScenario ->
+            val nonMatchingNegativeTestScenarios = negativeTestScenarios.filterNot { currentNegativeTestScenario ->
+                currentNegativeTestScenario.withDefault(false) { negativeTestScenario ->
                     val sampleRequest = negativeTestScenario.httpRequestPattern.generate(negativeTestScenario.resolver)
                     originalScenario.httpRequestPattern.matches(sampleRequest, originalScenario.resolver).isSuccess()
                 }

--- a/core/src/main/kotlin/in/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Feature.kt
@@ -365,13 +365,13 @@ data class Feature(
             val negativeTestScenarios =
                 negativeScenario.generateTestScenarios(flagsBased, testVariables, testBaseURLs)
 
-            val filtered = negativeTestScenarios.filterNot { negativeTestScenarioR ->
+            val nonMatchingNegativeTestScenarios = negativeTestScenarios.filterNot { negativeTestScenarioR ->
                 negativeTestScenarioR.withDefault(false) { negativeTestScenario ->
                     val sampleRequest = negativeTestScenario.httpRequestPattern.generate(negativeTestScenario.resolver)
                     originalScenario.httpRequestPattern.matches(sampleRequest, originalScenario.resolver).isSuccess()
                 }
             }
-            addIndexes(negativeScenario, filtered, flagsBased.negativePrefix)
+            addIndexes(negativeScenario, nonMatchingNegativeTestScenarios, flagsBased.negativePrefix)
         }
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Scenario.kt
@@ -430,7 +430,7 @@ data class Scenario(
 
         val generativePrefix = this.generativePrefix
 
-        return "$generativePrefix Scenario: $method $path ${indexLabel()}-> $statusInDescription$exampleIdentifier"
+        return "$generativePrefix Scenario: $method $path -> $statusInDescription$exampleIdentifier ${indexLabel()}"
     }
 
     fun newBasedOn(scenario: Scenario): Scenario {

--- a/core/src/main/kotlin/in/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Scenario.kt
@@ -56,7 +56,7 @@ data class Scenario(
     val serviceType:String? = null,
     val generativePrefix: String = "",
     val statusInDescription: String = httpResponsePattern.status.toString(),
-    val disambiguate: () -> String = { "" }
+    val indexLabel: () -> String = { "" }
 ): ScenarioDetailsForResult {
     constructor(scenarioInfo: ScenarioInfo) : this(
         scenarioInfo.scenarioName,
@@ -430,7 +430,7 @@ data class Scenario(
 
         val generativePrefix = this.generativePrefix
 
-        return "$generativePrefix Scenario: $method $path ${disambiguate()}-> $statusInDescription$exampleIdentifier"
+        return "$generativePrefix Scenario: $method $path ${indexLabel()}-> $statusInDescription$exampleIdentifier"
     }
 
     fun newBasedOn(scenario: Scenario): Scenario {
@@ -485,6 +485,14 @@ data class Scenario(
                     && operationId.responseStatus == status
                     && httpRequestPattern.matchesPath(operationId.requestPath, resolver).isSuccess()
         }
+
+    fun addIndexLabelAndPrefix(
+        prefix: String,
+        indexLabel: () -> String
+    ) = this.copy(
+        generativePrefix = prefix,
+        indexLabel = indexLabel
+    )
 }
 
 fun newExpectedServerStateBasedOn(

--- a/core/src/test/kotlin/in/specmatic/core/FeatureTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/FeatureTest.kt
@@ -1514,26 +1514,24 @@ paths:
           content:
             text/plain:
               schema:
-                type: string
-                 
-             
+                type: string                 
 """.trimIndent(), "").toFeature()
 
         val contractTests = specification.generateContractTestScenarios(emptyList())
         val testNames = contractTests.map { it.first.testDescription().trim() }.toList()
         assertThat(testNames).isEqualTo(
             listOf(
-                "Scenario: GET /products [1]-> 200",
-                "Scenario: GET /products [2]-> 200",
-                "Scenario: GET /products [3]-> 200",
-                "Scenario: GET /products [4]-> 200",
-                "Scenario: GET /products [5]-> 200",
+                "Scenario: GET /products [1] -> 200",
+                "Scenario: GET /products [2] -> 200",
+                "Scenario: GET /products [3] -> 200",
+                "Scenario: GET /products [4] -> 200",
+                "Scenario: GET /products [5] -> 200",
             )
         )
     }
 
     @Test
-    fun `positive tests with distinct name should not have an index suffix`() {
+    fun `positive tests with distinct names should not have an index suffix`() {
         val specification = OpenApiSpecification.fromYAML("""
 openapi: 3.0.0
 info:
@@ -1588,6 +1586,53 @@ paths:
             listOf(
                 "Scenario: GET /products -> 200",
                 "Scenario: GET /orders -> 200"
+            )
+        )
+    }
+
+    @Test
+    fun `multiple negative tests with same names should have an index suffix`() {
+        val specification = OpenApiSpecification.fromYAML("""
+openapi: 3.0.0
+info:
+  title: Sample Product API
+  description: Optional multiline or single-line description in [CommonMark](http://commonmark.org/help/) or HTML.
+  version: 0.1.9
+servers:
+  - url: http://localhost:8080
+    description: Local
+paths:
+  /products:
+    get:
+      summary: Search for products
+      description: get-products
+      parameters:
+        - name: type
+          in: query
+          schema:
+            type: string
+            enum:
+              - gadget
+              - book
+          required: true
+      responses:
+        '200':
+          description: List of products in the response
+          content:
+            text/plain:
+              schema:
+                type: string
+""".trimIndent(), "").toFeature()
+
+        val contractTests = specification.enableGenerativeTesting().generateContractTestScenarios(emptyList())
+        val testNames = contractTests.map { it.first.testDescription().trim() }.toList()
+
+        assertThat(testNames).isEqualTo(
+            listOf(
+                "+ve  Scenario: GET /products [1] -> 200",
+                "+ve  Scenario: GET /products [2] -> 200",
+                "-ve  Scenario: GET /products [1] -> 4xx",
+                "-ve  Scenario: GET /products [2] -> 4xx"
             )
         )
     }

--- a/core/src/test/kotlin/in/specmatic/core/FeatureTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/FeatureTest.kt
@@ -1476,8 +1476,8 @@ paths:
             assertThat(it).contains("-> 4xx")
         }
 
-        negativeTestScenarios.zip((1..negativeTestScenarios.size).toList()).forEach { (scenario, index) ->
-            assertThat(scenario.testDescription()).contains("[$index] -> 4xx")
+        negativeTestScenarios.zip((1..negativeTestScenarios.size).toList()).forEach { (scenario,index) ->
+            assertThat(scenario.testDescription()).contains(" -> 4xx | EX:SUCCESS [$index]")
         }
     }
 
@@ -1521,11 +1521,11 @@ paths:
         val testNames = contractTests.map { it.first.testDescription().trim() }.toList()
         assertThat(testNames).isEqualTo(
             listOf(
-                "Scenario: GET /products [1] -> 200",
-                "Scenario: GET /products [2] -> 200",
-                "Scenario: GET /products [3] -> 200",
-                "Scenario: GET /products [4] -> 200",
-                "Scenario: GET /products [5] -> 200",
+                "Scenario: GET /products -> 200 [1]",
+                "Scenario: GET /products -> 200 [2]",
+                "Scenario: GET /products -> 200 [3]",
+                "Scenario: GET /products -> 200 [4]",
+                "Scenario: GET /products -> 200 [5]",
             )
         )
     }
@@ -1629,10 +1629,10 @@ paths:
 
         assertThat(testNames).isEqualTo(
             listOf(
-                "+ve  Scenario: GET /products [1] -> 200",
-                "+ve  Scenario: GET /products [2] -> 200",
-                "-ve  Scenario: GET /products [1] -> 4xx",
-                "-ve  Scenario: GET /products [2] -> 4xx"
+                "+ve  Scenario: GET /products -> 200 [1]",
+                "+ve  Scenario: GET /products -> 200 [2]",
+                "-ve  Scenario: GET /products -> 4xx [1]",
+                "-ve  Scenario: GET /products -> 4xx [2]"
             )
         )
     }

--- a/core/src/test/kotlin/in/specmatic/core/FeatureTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/FeatureTest.kt
@@ -1,13 +1,10 @@
 package `in`.specmatic.core
-
 import `in`.specmatic.conversions.OpenApiSpecification
 import `in`.specmatic.core.pattern.NumberPattern
 import `in`.specmatic.core.pattern.StringPattern
 import `in`.specmatic.core.value.*
-import `in`.specmatic.test.ContractTest
 import `in`.specmatic.test.ScenarioTestGenerationException
 import `in`.specmatic.test.ScenarioTestGenerationFailure
-import `in`.specmatic.test.TestExecutor
 import org.assertj.core.api.Assertions.assertThat
 import org.json.JSONObject
 import org.junit.jupiter.api.Assertions.*

--- a/core/src/test/kotlin/in/specmatic/core/FeatureTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/FeatureTest.kt
@@ -5,6 +5,7 @@ import `in`.specmatic.core.pattern.StringPattern
 import `in`.specmatic.core.value.*
 import `in`.specmatic.test.ScenarioTestGenerationException
 import `in`.specmatic.test.ScenarioTestGenerationFailure
+import `in`.specmatic.test.TestExecutor
 import org.assertj.core.api.Assertions.assertThat
 import org.json.JSONObject
 import org.junit.jupiter.api.Assertions.*
@@ -1476,6 +1477,89 @@ paths:
         negativeTestScenarios.zip((1..negativeTestScenarios.size).toList()).forEach { (scenario,index) ->
             assertThat(scenario.testDescription()).contains(" -> 4xx | EX:SUCCESS [$index]")
         }
+    }
+
+    @Test
+    fun `positive examples of 4xx should be able to have non-string non-spec-conformant examples`() {
+        val specification = OpenApiSpecification.fromYAML("""
+openapi: 3.0.0
+info:
+  title: Sample Product API
+  description: Optional multiline or single-line description in [CommonMark](http://commonmark.org/help/) or HTML.
+  version: 0.1.9
+servers:
+  - url: http://localhost:8080
+    description: Local
+paths:
+  /products:
+    post:
+      summary: Add Product
+      description: Add Product
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+            examples:
+              SUCCESS:
+                value:
+                  name: 'abc'
+              BAD_REQUEST_NUMBER:
+                value:
+                  name: 10
+              BAD_REQUEST_NULL:
+                value:
+                  name: null
+      responses:
+        '200':
+          description: Returns Id
+          content:
+            text/plain:
+              schema:
+                type: string
+              examples:
+                SUCCESS:
+                  value: 10
+        '422':
+          description: Bad Request
+          content:
+            text/plain:
+              schema:
+                type: string
+              examples:
+                BAD_REQUEST_NUMBER:
+                  value: "Bad request was received and could not be handled"
+                BAD_REQUEST_NULL:
+                  value: "Bad request was received and could not be handled"
+""".trimIndent(), "").toFeature()
+
+        val results = specification.executeTests(object : TestExecutor {
+            override fun execute(request: HttpRequest): HttpResponse {
+                print(request.toLogString())
+                return when(val body = request.body) {
+                    is JSONObjectValue -> {
+                        if(body.jsonObject["name"] is StringValue) {
+                            HttpResponse.ok("10")
+                        } else {
+                            HttpResponse(422, "Bad request was received and could not be handled")
+                        }
+                    }
+
+                    else -> HttpResponse(422, "Bad request was received and could not be handled")
+                }
+            }
+
+           override fun setServerState(serverState: Map<String, Value>) {
+            }
+        })
+
+        assertThat(results.success()).isTrue()
+        assertThat(results.failureCount).isZero()
     }
 
     @Test


### PR DESCRIPTION
**What**:

At present, Specmatic adds an index suffix to all negative tests with the same name, however this behaviour is not implemented for positive tests. This results in Specmatic generating positive tests with the same name duplicated.
This PR enforces a consistent behaviour so that, whenever a group of tests [ Positive or Negative ] with the same name are generated, an index is suffixed to the test name so that all tests have unique names.

**Why**:

Duplicate test names result in python wrapper reporting an incorrect test count. 

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [x] Sonar Quality Gate
