### PR TITLE
Response value schema validation

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -438,7 +438,7 @@ class OpenApiSpecification(
                             } else valueString
                         },
                     name = exampleName,
-                    responseExample = resolvedResponseExample
+                    responseExample = resolvedResponseExample.takeIf { it.responseExample.isNotEmpty() }
                 )
             }
 

--- a/core/src/main/kotlin/in/specmatic/core/HttpResponse.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpResponse.kt
@@ -155,6 +155,15 @@ data class HttpResponse(
     }
 
     fun withoutDynamicHeaders(): HttpResponse = copy(headers = headers.withoutDynamicHeaders())
+    fun isNotEmpty(): Boolean {
+        // TODO: This check should change to NoBodyValue once responses support having no body
+        val bodyIsEmpty = body == StringValue()
+        val headersIsEmpty = headers.isEmpty() ||  headersHasOnlyTextPlainContentTypeHeader()
+
+        return (!bodyIsEmpty) || (!headersIsEmpty)
+    }
+
+    private fun headersHasOnlyTextPlainContentTypeHeader() = headers.size == 1 && headers[CONTENT_TYPE] == "text/plain"
 }
 
 fun nativeInteger(json: Map<String, Value>, key: String): Int? {

--- a/core/src/main/kotlin/in/specmatic/core/HttpResponse.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpResponse.kt
@@ -160,7 +160,9 @@ data class HttpResponse(
         val bodyIsEmpty = body == StringValue()
         val headersIsEmpty = headers.isEmpty() ||  headersHasOnlyTextPlainContentTypeHeader()
 
-        return (!bodyIsEmpty) || (!headersIsEmpty)
+        val responseIsEmpty = bodyIsEmpty && headersIsEmpty
+
+        return !responseIsEmpty
     }
 
     private fun headersHasOnlyTextPlainContentTypeHeader() = headers.size == 1 && headers[CONTENT_TYPE] == "text/plain"

--- a/core/src/main/kotlin/in/specmatic/core/HttpResponsePattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpResponsePattern.kt
@@ -166,11 +166,11 @@ private val valueMismatchMessages = object : MismatchMessages {
     }
 
     override fun unexpectedKey(keyLabel: String, keyName: String): String {
-        return "Value mismatch: $keyLabel $$keyName in value was unexpected"
+        return "Value mismatch: $keyLabel $keyName in value was unexpected"
     }
 
     override fun expectedKeyWasMissing(keyLabel: String, keyName: String): String {
-        return "Value mismatch: $keyLabel $$keyName was missing"
+        return "Value mismatch: $keyLabel $keyName was missing"
     }
 
 }

--- a/core/src/main/kotlin/in/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Scenario.kt
@@ -330,7 +330,7 @@ data class Scenario(
                     }
 
                     override fun unexpectedKey(keyLabel: String, keyName: String): String {
-                        return "The $keyLabel $keyName was found the in the example ${row.name} but was not in the specification."
+                        return "The $keyLabel $keyName was found in the example ${row.name} but was not in the specification."
                     }
 
                     override fun expectedKeyWasMissing(keyLabel: String, keyName: String): String {

--- a/core/src/main/kotlin/in/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Scenario.kt
@@ -322,6 +322,19 @@ data class Scenario(
 
         rowsToValidate.forEach { row ->
             httpRequestPattern.newBasedOn(row, updatedResolver, status).first().value
+            val responseExample: ResponseExample? = row.responseExample
+
+            if (responseExample != null) {
+                val responseMatchResult =
+                    httpResponsePattern.matches(responseExample.responseExample, updatedResolver)
+
+                if(responseMatchResult is Result.Failure) {
+                    println("Error in example for ${this.testDescription()}")
+                    logger.log(responseMatchResult.reportString())
+                }
+
+                responseMatchResult.throwOnFailure()
+            }
         }
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/value/JSONArrayValue.kt
+++ b/core/src/main/kotlin/in/specmatic/core/value/JSONArrayValue.kt
@@ -1,9 +1,7 @@
 package `in`.specmatic.core.value
 
 import `in`.specmatic.core.ExampleDeclarations
-import `in`.specmatic.core.pattern.JSONArrayPattern
-import `in`.specmatic.core.pattern.Pattern
-import `in`.specmatic.core.pattern.withoutPatternDelimiters
+import `in`.specmatic.core.pattern.*
 import `in`.specmatic.core.utilities.valueArrayToJsonString
 
 typealias TypeDeclarationsCallType = (Value, String, Map<String, Pattern>, ExampleDeclarations) -> Pair<TypeDeclaration, ExampleDeclarations>
@@ -16,7 +14,7 @@ data class JSONArrayValue(override val list: List<Value>) : Value, ListValue, JS
     override fun displayableType(): String = "json array"
     override fun exactMatchElseType(): Pattern = JSONArrayPattern(list.map { it.exactMatchElseType() })
     override fun type(): Pattern = JSONArrayPattern()
-    override fun deepPattern(): Pattern = JSONArrayPattern(list.map { it.deepPattern() })
+    override fun deepPattern(): Pattern = ListPattern(AnythingPattern)
 
     private fun typeDeclaration(key: String, types: Map<String, Pattern>, exampleDeclarations: ExampleDeclarations, typeDeclarationsStoreCall: TypeDeclarationsCallType): Pair<TypeDeclaration, ExampleDeclarations> = when {
         list.isEmpty() -> Pair(TypeDeclaration("[]", types), exampleDeclarations)

--- a/core/src/test/kotlin/in/specmatic/core/FeatureTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/FeatureTest.kt
@@ -1776,6 +1776,56 @@ paths:
         })
     }
 
+    @Test
+    fun `validation errors should contain the name of the test` () {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+openapi: 3.0.0
+info:
+  title: Sample API
+  version: 0.1.9
+paths:
+  /data:
+    post:
+      summary: hello world
+      description: test
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - data
+              properties:
+                data:
+                  type: number
+            examples:
+              200_OK:
+                value:
+                  data: 10
+      responses:
+        '200':
+          description: Says hello
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    type: number
+              examples:
+                200_OK:
+                  value:
+                    data: "abc"
+""".trimIndent(), ""
+        ).toFeature()
+
+        assertThatThrownBy { feature.validateExamplesOrException() }.satisfies(Consumer { exception ->
+            assertThat(exceptionCauseMessage(exception)).contains("200_OK")
+        })
+    }
 
     companion object {
         @JvmStatic

--- a/core/src/test/kotlin/integration_tests/ValidateResponseSchemaTest.kt
+++ b/core/src/test/kotlin/integration_tests/ValidateResponseSchemaTest.kt
@@ -74,7 +74,6 @@ class ValidateResponseSchemaTest {
     }
 
     @Test
-    @Disabled
     fun `response body schema validation should be skipped if the response example value is empty`() {
         val personSpec = """
             openapi: 3.0.3
@@ -130,7 +129,6 @@ class ValidateResponseSchemaTest {
             }
         })
 
-        assertThat(results.success()).withFailMessage("The tests passed, but they should have failed.").isFalse()
-        assertThat(results.report()).withFailMessage(results.report()).contains("RESPONSE.BODY.address")
+        assertThat(results.success()).withFailMessage(results.report()).isTrue()
     }
 }

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=1.3.13
+version=1.3.14


### PR DESCRIPTION
**What**:

Implemented support for empty value.

```yaml
openapi: 3.0.3
info:
  title: Person API
  version: 1.0.0
  description: Person API

servers:
  - url: http://localhost:5000

paths:
  /person/{id}:
    get:
      summary: Fetch person details
      parameters:
        - in: path
          required: true
          name: id
          schema:
            type: number
          examples:
            GET_DETAILS:
              value: 10
      responses:
        '200':
          description: Details fetched
          content:
            application/json:
              schema:
                ${"$"}ref: "#/components/schemas/PersonData"
              examples:
                GET_DETAILS:
                  value:
components:
  schemas:
    PersonData:
      type: object
      required:
        - name
      properties:
        name:
          type: string
        address:
          type: string        
```

If value is empty, value-related validations will be skipped.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

