### PR TITLE
Initiate TestFactory using SpecmaticContractTest interface

### DIFF
--- a/junit5-support/build.gradle
+++ b/junit5-support/build.gradle
@@ -106,3 +106,9 @@ javadoc {
         options.addBooleanOption('html5', true)
     }
 }
+
+compileKotlin {
+    compilerOptions {
+        freeCompilerArgs.add("-Xjvm-default=all")
+    }
+}

--- a/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticContractTest.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticContractTest.kt
@@ -1,0 +1,13 @@
+package `in`.specmatic.test
+
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.TestFactory
+import java.util.stream.Stream
+
+interface SpecmaticContractTest {
+
+    @TestFactory
+    fun contractTest(): Stream<DynamicTest> {
+        return SpecmaticJUnitSupport().contractTest()
+    }
+}


### PR DESCRIPTION
**What**:
Fixes #1073
The SpecmaticContractTest interface lets the users extend any other base class, unblocking them from doing so.

**How**:
This is achieved by creating an interface with a default function annotated with TestFactory.
The function returns the same set of dynamic tests that the SpecmaticJunitSupport class returns.

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [x] Sonar Quality Gate


**Issue ID**:
Closes: #1073
