### PR TITLE
Fix the issue with logging when there are multiple error causes

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/FailureReport.kt
+++ b/core/src/main/kotlin/in/specmatic/core/FailureReport.kt
@@ -3,8 +3,7 @@ package `in`.specmatic.core
 data class FailureReport(val contractPath: String?, private val scenarioMessage: String?, val scenario: ScenarioDetailsForResult?, private val matchFailureDetailList: List<MatchFailureDetails>): Report {
     fun errorMessage(): String {
         if(matchFailureDetailList.size != 1)
-            toText()
-
+            return toText()
         return errorMessagesToString(matchFailureDetailList.first().errorMessages)
     }
 

--- a/core/src/test/kotlin/in/specmatic/core/FailureReportTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/FailureReportTest.kt
@@ -56,4 +56,43 @@ internal class FailureReportTest {
 
         assertThat(reportText).contains("addresses[0].street")
     }
+
+    @Test
+    fun `should return error message containing all the errors if there are multiple error causes`() {
+        val matchFailureDetailList = listOf(
+            MatchFailureDetails(errorMessages =  listOf("first error message")),
+            MatchFailureDetails(errorMessages = listOf("second error message"))
+        )
+        val failureReport = FailureReport(
+            contractPath = null,
+            scenarioMessage = null,
+            scenario = null,
+            matchFailureDetailList =  matchFailureDetailList
+        )
+
+        val expectedErrorMessage = """
+            first error message
+
+            second error message
+        """.trimIndent()
+        assertThat(failureReport.errorMessage()).isEqualTo(expectedErrorMessage)
+    }
+
+    @Test
+    fun `should return error message containing single error if there is single error cause`() {
+        val matchFailureDetailList = listOf(
+            MatchFailureDetails(errorMessages =  listOf("error message")),
+        )
+        val failureReport = FailureReport(
+            contractPath = null,
+            scenarioMessage = null,
+            scenario = null,
+            matchFailureDetailList =  matchFailureDetailList
+        )
+
+        val expectedErrorMessage = """
+            error message
+        """.trimIndent()
+        assertThat(failureReport.errorMessage()).isEqualTo(expectedErrorMessage)
+    }
 }


### PR DESCRIPTION
**What**:
When we have multiple error causes, Specmatic used to log only the single cause out of it as an error message.
This PR fixes that issue and logs all the error messages encountered.

e.g. Suppose we have a schema with examples as follows -
```yaml
openapi: 3.0.1
info:
  title: OpenAPI definition
  version: v0
servers:
  - url: http://localhost:8080
    description: Generated server url
paths:
  /customers:
    post:
      tags:
        - customer-controller
      operationId: saveCustomer
      requestBody:
        required: true
        content:
          application/json:
            schema:
              oneOf:
                - $ref: '#/components/schemas/CustomerAddress'
                - $ref: '#/components/schemas/Customer'
            examples:
              CUSTOMER_ADDRESS:
                summary: Example of a customer address object
                value:
                  id: 1
                  customerId: 1005
                  houseNo: '1234'
                  street: 'B.St'
                  city: 'Melbourne'
                  state: 'Victoria'
                  postCode: '3000'
                  requestType: 'address'
              CUSTOMER:
                summary: Example of a customer object
                value:
                  id: 104
                  customerId: 1004
                  initial: J
                  #firstName: John
                  secondName: Doe
                  customerType: GOLD
      responses:
        "200":
          description: OK
          content:
            'application/json':
              schema:
                oneOf:
                  - $ref: '#/components/schemas/CustomerAddress'
                  - $ref: '#/components/schemas/Customer'
              examples:
                CUSTOMER_ADDRESS:
                  summary: Example of a customer address object
                  value:
                    id: 1
                    customerId: 1005
                    houseNo: '1234'
                    street: 'B.St'
                    city: 'Melbourne'
                    state: 'Victoria'
                    postCode: '3000'
                    requestType: 'address'
                CUSTOMER:
                  summary: Example of a customer object
                  value:
                    id: 104
                    customerId: 1004
                    initial: J
                    firstName: John
                    secondName: Doe
                    customerType: GOLD
components:
  schemas:
    Customer:
      required:
        - customerType
        - firstName
        - initial
        - secondName
      type: object
      properties:
        id:
          type: integer
          format: int32
        customerId:
          type: integer
          format: int32
        initial:
          type: string
        firstName:
          type: string
        secondName:
          type: string
        customerType:
          type: string
          enum:
            - BRONZE
            - SILVER
            - GOLD
            - PLATINUM
        verified:
          type: boolean
    CustomerAddress:
      type: object
      properties:
        id:
          type: integer
          format: int32
        customerId:
          type: integer
          format: int32
        houseNo:
          type: string
        street:
          type: string
        city:
          type: string
        state:
          type: string
        postCode:
          type: string
        requestType:
          type: string
```

In the above specification, I have **commented out the firstName** key from the CUSTOMER example.
If we try to run Specmatic tests using such schema, it should definitely break **since the CUSTOMER example is not satisfying any of the schemas defined**.

Ideally, Specmatic should compare this example with both the oneOf schemas and log the respective error messages.

Specmatic does compare the example with both the schemas but while logging it logs only a single error message as follows -
<img width="811" alt="Screenshot 2024-05-03 at 11 11 07 AM" src="https://github.com/znsio/specmatic/assets/60032699/a7cc25d3-d099-44d3-9554-958d768653d2">

This PR fixes that and logs all the respective error messages -
<img width="1077" alt="Screenshot 2024-05-03 at 11 11 35 AM" src="https://github.com/znsio/specmatic/assets/60032699/f9e387ee-179f-4dd2-9f49-21d4e8be946b">



**Why**:
Specmatic was not logging all the error message due to a very minor bug where we were not returning the error message when there are multiple error causes.


**How**:
The PR fixes the bug by simply returning that error message.

**Checklist**:

- [] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [x] Sonar Quality Gate

