### PR TITLE
Added an error message explaining what was backward incompatible

### DIFF
--- a/application/src/main/kotlin/application/BackwardCompatibilityCheckCommand.kt
+++ b/application/src/main/kotlin/application/BackwardCompatibilityCheckCommand.kt
@@ -54,6 +54,8 @@ class BackwardCompatibilityCheckCommand(
 
         val defaultBranch = gitCommand.defaultBranch()
 
+        val marginSpace = "  "
+
         try {
             val failures = files.mapIndexed { index, specFilePath ->
                 println("${index.inc()}. Running the check for $specFilePath:")
@@ -75,11 +77,15 @@ class BackwardCompatibilityCheckCommand(
                 val backwardCompatibilityResult = testBackwardCompatibility(older, newer)
 
                 if (backwardCompatibilityResult.success()) {
-                    println("The file $specFilePath is backward compatible.")
+                    println()
+                    println("The file $specFilePath is backward compatible.".prependIndent(marginSpace))
                     println()
                     SUCCESS
                 } else {
-                    println("*** The file $specFilePath is NOT backward compatible. ***")
+                    println()
+                    println(backwardCompatibilityResult.report().prependIndent(marginSpace))
+                    println()
+                    println("*** The file $specFilePath is NOT backward compatible. ***".prependIndent(marginSpace))
                     println()
                     FAILED
                 }


### PR DESCRIPTION
**What**:

Added an error message describing the errors for each spec where backward incompatible changes were detected.

**Why**:

Currently, the message only says that the changes were not backward compatible, without describing what the change was and why it was backward incompatible.

**How**:

Done with a small modification to the command.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

