### PR TITLE
Evaluate env var in git repo URL before running clone command

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/git/GitOperations.kt
+++ b/core/src/main/kotlin/in/specmatic/core/git/GitOperations.kt
@@ -119,9 +119,13 @@ fun evaluateEnvVariablesInGitRepoURI(gitRepositoryURI: String, environmentVariab
     val envVariableMatches = envVariableRegex.findAll(gitRepositoryURI)
     envVariableMatches.forEach { matchResult ->
         val envVariable = matchResult.groupValues[1]
-        val envVariableValue = environmentVariables.getValue(envVariable)
-        logger.log("Evaluating $envVariable in $gitRepositoryURI")
-        evaluatedGitRepoUrl = evaluatedGitRepoUrl.replace("\${$envVariable}", envVariableValue)
+        if (environmentVariables.containsKey(envVariable)) {
+            val envVariableValue = environmentVariables.getValue(envVariable)
+            logger.log("Evaluating $envVariable in $gitRepositoryURI")
+            evaluatedGitRepoUrl = evaluatedGitRepoUrl.replace("\${$envVariable}", envVariableValue)
+        } else {
+            logger.log("$envVariable in $gitRepositoryURI resembles an environment variable, but it is not available in the environment variables. Skipping evaluation.")
+        }
     }
     return evaluatedGitRepoUrl
 }

--- a/core/src/main/kotlin/in/specmatic/core/git/GitOperations.kt
+++ b/core/src/main/kotlin/in/specmatic/core/git/GitOperations.kt
@@ -119,13 +119,11 @@ fun evaluateEnvVariablesInGitRepoURI(gitRepositoryURI: String, environmentVariab
     val envVariableMatches = envVariableRegex.findAll(gitRepositoryURI)
     envVariableMatches.forEach { matchResult ->
         val envVariable = matchResult.groupValues[1]
-        if (environmentVariables.containsKey(envVariable)) {
-            val envVariableValue = environmentVariables.getValue(envVariable)
+        environmentVariables[envVariable]?.let { envVariableValue ->
             logger.log("Evaluating $envVariable in $gitRepositoryURI")
             evaluatedGitRepoUrl = evaluatedGitRepoUrl.replace("\${$envVariable}", envVariableValue)
-        } else {
-            logger.log("$envVariable in $gitRepositoryURI resembles an environment variable, but it is not available in the environment variables. Skipping evaluation.")
         }
+            ?: logger.log("$envVariable in $gitRepositoryURI resembles an environment variable, but skipping evaluation since value for the same is not set.")
     }
     return evaluatedGitRepoUrl
 }

--- a/core/src/main/kotlin/in/specmatic/core/git/GitOperations.kt
+++ b/core/src/main/kotlin/in/specmatic/core/git/GitOperations.kt
@@ -114,7 +114,6 @@ private fun jgitClone(gitRepositoryURI: String, cloneDirectory: File) {
 }
 
 fun evaluateEnvVariablesInGitRepoURI(gitRepositoryURI: String, environmentVariables: Map<String, String>): String {
-    logger.log("Evaluating any environment variables in $gitRepositoryURI")
     var evaluatedGitRepoUrl = gitRepositoryURI
     val envVariableRegex = Regex("\\$\\{([^}]+)}")
     val envVariableMatches = envVariableRegex.findAll(gitRepositoryURI)

--- a/core/src/main/kotlin/in/specmatic/core/git/SystemGit.kt
+++ b/core/src/main/kotlin/in/specmatic/core/git/SystemGit.kt
@@ -48,7 +48,7 @@ class SystemGit(override val workingDirectory: String = ".", private val prefix:
     override fun checkout(branchName: String): SystemGit = this.also { execute(Configuration.gitCommand, "checkout", branchName) }
     override fun merge(branchName: String): SystemGit = this.also { execute(Configuration.gitCommand, "merge", branchName) }
     override fun clone(gitRepositoryURI: String, cloneDirectory: File): SystemGit =
-        this.also { executeWithAuth("clone", gitRepositoryURI, cloneDirectory.absolutePath) }
+        this.also { executeWithAuth("clone", evaluateEnvVariablesInGitRepoURI(gitRepositoryURI, System.getenv()), cloneDirectory.absolutePath) }
     override fun exists(treeish: String, relativePath: String): Boolean {
         return try {
             show(treeish, relativePath)

--- a/core/src/main/kotlin/in/specmatic/core/utilities/GitRepo.kt
+++ b/core/src/main/kotlin/in/specmatic/core/utilities/GitRepo.kt
@@ -124,7 +124,7 @@ data class GitRepo(
                 addSpecmaticFolderToGitIgnoreFile(gitIgnoreFile)
             }
             else{
-                logger.log("Creating a gitignore file file as it is missing for the current project.")
+                logger.log("Creating a gitignore file as it is missing for the current project.")
                 addSpecmaticFolderToGitIgnoreFile(gitIgnoreFile, false)
             }
         }

--- a/core/src/test/kotlin/in/specmatic/core/git/GitOperationsTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/git/GitOperationsTest.kt
@@ -30,4 +30,15 @@ class GitOperationsTest {
             )
         assertThat(evaluatedGitRepositoryURI).isEqualTo("https://john:password@gitlab.com/group/project.git")
     }
+
+    @Test
+    fun shouldNotEvaluatePatternsThatResembleEnvVarsWhenTheValueIsNotAvailable() {
+        val gitRepositoryURI = "https://gitlab-ci-token:${'$'}{CI_JOB_TOKEN}@gitlab.com/group/${'$'}{do-not-eval}/project.git"
+        val evaluatedGitRepositoryURI =
+            evaluateEnvVariablesInGitRepoURI(
+                gitRepositoryURI = gitRepositoryURI,
+                mapOf("CI_JOB_TOKEN" to "token")
+            )
+        assertThat(evaluatedGitRepositoryURI).isEqualTo("https://gitlab-ci-token:token@gitlab.com/group/${'$'}{do-not-eval}/project.git")
+    }
 }

--- a/core/src/test/kotlin/in/specmatic/core/git/GitOperationsTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/git/GitOperationsTest.kt
@@ -1,0 +1,33 @@
+package `in`.specmatic.core.git
+
+import org.assertj.core.api.AssertionsForClassTypes.assertThat
+import org.junit.jupiter.api.Test
+
+class GitOperationsTest {
+    @Test
+    fun shouldNotChangeGitRepoUrlWhenThereAreNoEnvVariables() {
+        val gitRepositoryURI = "https://gitlab.com/group/project.git"
+        val evaluatedGitRepositoryURI =
+            evaluateEnvVariablesInGitRepoURI(gitRepositoryURI = gitRepositoryURI, emptyMap<String, String>())
+        assertThat(evaluatedGitRepositoryURI).isEqualTo(gitRepositoryURI)
+    }
+
+    @Test
+    fun shouldChangeGitRepoUrlWhenThereIsOneEnvVariable() {
+        val gitRepositoryURI = "https://gitlab-ci-token:${'$'}{CI_JOB_TOKEN}@gitlab.com/group/project.git"
+        val evaluatedGitRepositoryURI =
+            evaluateEnvVariablesInGitRepoURI(gitRepositoryURI = gitRepositoryURI, mapOf("CI_JOB_TOKEN" to "token"))
+        assertThat(evaluatedGitRepositoryURI).isEqualTo("https://gitlab-ci-token:token@gitlab.com/group/project.git")
+    }
+
+    @Test
+    fun shouldChangeGitRepoUrlWhenThereAreMultipleEnvVariable() {
+        val gitRepositoryURI = "https://${'$'}{USER_NAME}:${'$'}{PASSWORD}@gitlab.com/group/project.git"
+        val evaluatedGitRepositoryURI =
+            evaluateEnvVariablesInGitRepoURI(
+                gitRepositoryURI = gitRepositoryURI,
+                mapOf("USER_NAME" to "john", "PASSWORD" to "password")
+            )
+        assertThat(evaluatedGitRepositoryURI).isEqualTo("https://john:password@gitlab.com/group/project.git")
+    }
+}

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=1.3.17
+version=1.3.18


### PR DESCRIPTION
**What**:

Evaluate env var in git repo URL before running clone command

**Why**:

With private central contract repositories, in order to allow Specmatic to clone the repo for Contract Testing and Stubbing in CI pipelines, in some scenarios we need authentication information to be provided as part of Git Repo URI. Examples:

- `https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.com/group/project.git`
- `https://${USER_NAME}:${PASSWORD}@gitlab.com/group/project.git`

These env vars in these repository URLs in `specmatic.json` need to be evaluated before the clone command is run. Otherwise authentication will fail.

**How**:

Right now it is a simple find and replace approach which is being done in both `SystemGit` as well as `JGit`.

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [x] Sonar Quality Gate

**Related Discussion**

#1098 