### PR TITLE
Pass contract path data to stub

### DIFF
--- a/core/src/main/kotlin/in/specmatic/stub/api.kt
+++ b/core/src/main/kotlin/in/specmatic/stub/api.kt
@@ -45,8 +45,8 @@ fun createStub(host: String = "localhost", port: Int = 9000): ContractStub {
 
 // Used by stub client code
 fun createStub(dataDirPaths: List<String>, host: String = "localhost", port: Int = 9000): ContractStub {
-    val contractPaths = contractStubPaths().map { it.path }
-    val contractInfo = loadContractStubsFromFiles(contractPaths.map { ContractPathData("", it) }, dataDirPaths)
+    val contractPathData = contractStubPaths()
+    val contractInfo = loadContractStubsFromFiles(contractPathData, dataDirPaths)
     val features = contractInfo.map { it.first }
     val httpExpectations = contractInfoToHttpExpectations(contractInfo)
 

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=1.3.18
+version=1.3.19


### PR DESCRIPTION
**What**:

Include Specification details in Stub Usage Report when running HTTP Stub programmatically.

**Why**:

This makes it consistent with Stub Usage Report generated when running HTTP Stub from command line.

**How**:

Using the same code in both places

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [ ] Tests
- [ ] Sonar Quality Gate
