### PR TITLE
Fix the bug where coverage report was not getting generated when Spec…

### DIFF
--- a/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticContractTest.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticContractTest.kt
@@ -2,12 +2,23 @@ package `in`.specmatic.test
 
 import org.junit.jupiter.api.DynamicTest
 import org.junit.jupiter.api.TestFactory
+import org.junit.jupiter.api.extension.AfterTestExecutionCallback
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.ExtensionContext
 import java.util.stream.Stream
 
+@ExtendWith(AfterSpecmaticContractTestExecutionCallback::class)
 interface SpecmaticContractTest {
 
     @TestFactory
     fun contractTest(): Stream<DynamicTest> {
         return SpecmaticJUnitSupport().contractTest()
+    }
+}
+
+
+class AfterSpecmaticContractTestExecutionCallback : AfterTestExecutionCallback {
+    override fun afterTestExecution(context: ExtensionContext?) {
+        SpecmaticJUnitSupport.report()
     }
 }

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=1.3.19
+version=1.3.20


### PR DESCRIPTION
…maticContractTest interface is used

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Makes SpecmaticContractTest interface generate the API Coverage Report.
<!-- Why are these changes necessary? -->

**Why**:
SpecmaticContractTest was not previously generating the API Coverage Report.
<!-- How were these changes implemented? -->

**How**:
Added an AfterTestExecutionCallback extension to fix this.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->


<!-- feel free to add additional comments -->
