### PR TITLE
Proxy command should bind to 0.0.0.0 instead of localhost

### DIFF
--- a/application/src/main/kotlin/application/ProxyCommand.kt
+++ b/application/src/main/kotlin/application/ProxyCommand.kt
@@ -2,6 +2,8 @@ package application
 
 import picocli.CommandLine.*
 import `in`.specmatic.core.APPLICATION_NAME_LOWER_CASE
+import `in`.specmatic.core.Configuration.Companion.DEFAULT_PROXY_HOST
+import `in`.specmatic.core.Configuration.Companion.DEFAULT_PROXY_PORT
 import `in`.specmatic.core.log.*
 import `in`.specmatic.core.utilities.exceptionCauseMessage
 import `in`.specmatic.core.utilities.exitWithMessage
@@ -17,10 +19,10 @@ class ProxyCommand : Callable<Unit> {
     @Option(names = ["--target"], description = ["Base URL of the target to proxy"])
     var targetBaseURL: String = ""
 
-    @Option(names = ["--host"], description = ["Host for the proxy"], defaultValue = "localhost")
+    @Option(names = ["--host"], description = ["Host for the proxy"], defaultValue = DEFAULT_PROXY_HOST)
     lateinit var host: String
 
-    @Option(names = ["--port"], description = ["Port for the proxy"], defaultValue = "9000")
+    @Option(names = ["--port"], description = ["Port for the proxy"], defaultValue = DEFAULT_PROXY_PORT)
     var port: Int = 9000
 
     @Parameters(description = ["Store data from the proxy interactions into this dir"], index = "0")

--- a/core/src/main/kotlin/in/specmatic/core/Configuration.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Configuration.kt
@@ -46,5 +46,7 @@ class Configuration {
         private const val ALL_IPV4_ADDRESS_ON_LOCAL_MACHINE = "0.0.0.0"
         const val DEFAULT_HTTP_STUB_HOST = ALL_IPV4_ADDRESS_ON_LOCAL_MACHINE
         const val DEFAULT_HTTP_STUB_PORT = "9000"
+        const val DEFAULT_PROXY_PORT = DEFAULT_HTTP_STUB_PORT
+        const val DEFAULT_PROXY_HOST = ALL_IPV4_ADDRESS_ON_LOCAL_MACHINE
     }
 }

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=1.3.20
+version=1.3.21


### PR DESCRIPTION
Proxy command should bind to 0.0.0.0 instead of localhost so that we are able to reach proxy server from host machine

**What**:

Proxy command is not working when run as part of docker image.

**Why**:

Since proxy is binding to "localhost" Specmatic docker is not able to accept connections from outside.

**How**:

Binding proxy to `0.0.0.0`.

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [ ] Tests
- [ ] Sonar Quality Gate

**Issue ID**:
Closes: #1119

<!-- feel free to add additional comments -->
