### PR TITLE
Two seconds default grace period and timeout for HttpStub

### DIFF
--- a/application/src/main/kotlin/application/HTTPStubEngine.kt
+++ b/application/src/main/kotlin/application/HTTPStubEngine.kt
@@ -41,7 +41,8 @@ class HTTPStubEngine {
             passThroughTargetBase = passThroughTargetBase,
             httpClientFactory = httpClientFactory,
             workingDirectory = workingDirectory,
-            specmaticConfigPath = specmaticConfigPath
+            specmaticConfigPath = specmaticConfigPath,
+            timeoutMillis = 2000
         ).also {
             consoleLog(NewLineLogMessage)
             val protocol = if (keyStoreData != null) "https" else "http"

--- a/core/src/main/kotlin/in/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/in/specmatic/stub/HttpStub.kt
@@ -55,7 +55,8 @@ class HttpStub(
     val passThroughTargetBase: String = "",
     val httpClientFactory: HttpClientFactory = HttpClientFactory(),
     val workingDirectory: WorkingDirectory? = null,
-    val specmaticConfigPath: String? = null
+    val specmaticConfigPath: String? = null,
+    private val timeoutMillis: Long = 0
 ) : ContractStub {
     constructor(
         feature: Feature,
@@ -489,7 +490,7 @@ class HttpStub(
     }
 
     override fun close() {
-        server.stop(0, 5000)
+        server.stop(gracePeriodMillis = timeoutMillis, timeoutMillis = timeoutMillis)
         printUsageReport()
     }
 

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiIntegrationTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiIntegrationTest.kt
@@ -889,7 +889,10 @@ Feature: Authenticated
 
         @Test
         fun `should generate stub that authenticates with api key in header and query`() {
-            createStubFromContracts(listOf("src/test/resources/openapi/apiKeyAuth.yaml")).use {
+            createStubFromContracts(
+                listOf("src/test/resources/openapi/apiKeyAuth.yaml"),
+                timeoutMillis = 0L
+            ).use {
                 val requestWithHeader = HttpRequest(
                     method = "GET",
                     path = "/hello/10",

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -19,8 +19,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.swagger.v3.core.util.Yaml
 import io.swagger.v3.oas.models.OpenAPI
-import io.swagger.v3.parser.OpenAPIV3Parser
-import io.swagger.v3.parser.core.models.ParseOptions
 import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -5222,7 +5220,7 @@ paths:
 
             var testStatus: String
 
-            createStubFromContracts(listOf(openAPIFile.canonicalPath), "localhost", 9000).use {
+            createStubFromContracts(listOf(openAPIFile.canonicalPath), "localhost", 9000, timeoutMillis = 0).use {
                 testStatus = "test ran"
 
                 val request = HttpRequest(
@@ -5278,7 +5276,7 @@ paths:
 
             var testStatus: String
 
-            createStubFromContracts(listOf(openAPIFile.canonicalPath), "localhost", 9000).use {
+            createStubFromContracts(listOf(openAPIFile.canonicalPath), "localhost", 9000, timeoutMillis = 0).use {
                 testStatus = "test ran"
 
                 val request = HttpRequest(
@@ -5334,7 +5332,7 @@ paths:
 
             var testStatus: String
 
-            createStubFromContracts(listOf(openAPIFile.canonicalPath), "localhost", 9000).use {
+            createStubFromContracts(listOf(openAPIFile.canonicalPath), "localhost", 9000, timeoutMillis = 0).use {
                 testStatus = "test ran"
 
                 val request = HttpRequest(

--- a/core/src/test/kotlin/in/specmatic/stub/HttpStubKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/stub/HttpStubKtTest.kt
@@ -7,7 +7,6 @@ import `in`.specmatic.core.pattern.ContractException
 import `in`.specmatic.core.pattern.parsedJSON
 import `in`.specmatic.core.pattern.parsedJSONObject
 import `in`.specmatic.core.pattern.parsedValue
-import `in`.specmatic.core.utilities.ExternalCommand
 import `in`.specmatic.core.utilities.exceptionCauseMessage
 import `in`.specmatic.core.value.*
 import `in`.specmatic.mock.ScenarioStub
@@ -885,7 +884,7 @@ paths:
 
     @Test
     fun `transient stubs can be loaded from the file system`() {
-        createStubFromContracts(listOf("src/test/resources/openapi/contractWithTransientMock.yaml")).use { stub ->
+        createStubFromContracts(listOf("src/test/resources/openapi/contractWithTransientMock.yaml"), timeoutMillis = 0).use { stub ->
             with(stub.client.execute(HttpRequest("POST", "/test", body = parsedJSONObject("""{"item": "data"}""")))) {
                 assertThat(this.body.toStringLiteral()).isEqualTo("success")
             }
@@ -898,7 +897,7 @@ paths:
 
     @Test
     fun `multiple stubs for a non 200 with a value specified for a header will load and match incoming requests correctly`() {
-        createStubFromContracts(listOf("src/test/resources/openapi/multiple400StubsWithHeader.yaml")).use { stub ->
+        createStubFromContracts(listOf("src/test/resources/openapi/multiple400StubsWithHeader.yaml"), timeoutMillis = 0).use { stub ->
             val request = HttpRequest("POST", "/test", body = parsedJSONObject("""{"item": "data"}"""))
 
             with(stub.client.execute(request.copy(headers = mapOf("Authorization" to "valid")))) {
@@ -913,7 +912,7 @@ paths:
 
     @Test
     fun `stubs are loaded in order sorted by filename`() {
-        createStubFromContracts(listOf("src/test/resources/openapi/contractWithOrderedStubs.yaml")).use { stub ->
+        createStubFromContracts(listOf("src/test/resources/openapi/contractWithOrderedStubs.yaml"), timeoutMillis = 0).use { stub ->
             val request = HttpRequest("POST", "/test", body = parsedJSONObject("""{"item": "data"}"""))
 
             with(stub.client.execute(request)) {
@@ -928,7 +927,7 @@ paths:
 
     @Test
     fun `transient stubs are loaded in order sorted by filename across nested dirs where the first item in sorted order is the first item in the queue`() {
-        createStubFromContracts(listOf("src/test/resources/openapi/contractWithOrderedStubsInNestedDirs.yaml")).use { stub ->
+        createStubFromContracts(listOf("src/test/resources/openapi/contractWithOrderedStubsInNestedDirs.yaml"), timeoutMillis = 0).use { stub ->
             val request = HttpRequest("POST", "/test", body = parsedJSONObject("""{"item": "data"}"""))
 
             (0..4).map { ctr ->

--- a/core/src/test/kotlin/in/specmatic/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/in/specmatic/stub/HttpStubTest.kt
@@ -1032,7 +1032,7 @@ paths:
     fun `should load a stub with a space in the path and return the stubbed response`() {
         val pathWithSpace = "/da ta"
 
-        createStubFromContracts(listOf("src/test/resources/openapi/spec_with_space_in_path.yaml")).use { stub ->
+        createStubFromContracts(listOf("src/test/resources/openapi/spec_with_space_in_path.yaml"), timeoutMillis = 0).use { stub ->
             val request = HttpRequest("GET", pathWithSpace)
 
             val response = stub.client.execute(request)
@@ -1051,7 +1051,7 @@ paths:
     fun `should load a stub with query params and a space in the path and return the stubbed response`() {
         val pathWithSpace = "/da ta"
 
-        createStubFromContracts(listOf("src/test/resources/openapi/spec_with_query_and_space_in_path.yaml")).use { stub ->
+        createStubFromContracts(listOf("src/test/resources/openapi/spec_with_query_and_space_in_path.yaml"), timeoutMillis = 0).use { stub ->
             val request = HttpRequest("GET", pathWithSpace, queryParametersMap = mapOf("id" to "5"))
 
             val response = stub.client.execute(request)
@@ -1114,7 +1114,7 @@ paths:
 
     @Test
     fun `should stub out a request for boolean query param with capital T or F in the incoming request`() {
-        val specification = createStubFromContracts(listOf("src/test/resources/openapi/spec_with_boolean_query.yaml"))
+        val specification = createStubFromContracts(listOf("src/test/resources/openapi/spec_with_boolean_query.yaml"), timeoutMillis = 0)
 
         specification.use { stub ->
             val request = HttpRequest("GET", "/data", queryParametersMap = mapOf("enabled" to "True"))

--- a/core/src/test/kotlin/in/specmatic/stub/HttpStubWithArrayQueryParameterTest.kt
+++ b/core/src/test/kotlin/in/specmatic/stub/HttpStubWithArrayQueryParameterTest.kt
@@ -56,7 +56,7 @@ class HttpStubWithArrayQueryParameterTest {
 
     @Test
     fun `should match stub for mandatory query parameter with externalized json expectation`() {
-        createStubFromContracts(listOf("src/test/resources/openapi/spec_with_mandatory_array_query_parameter.yaml")).use { stub ->
+        createStubFromContracts(listOf("src/test/resources/openapi/spec_with_mandatory_array_query_parameter.yaml"), timeoutMillis = 0).use { stub ->
             val queryParameters = QueryParameters(paramPairs = listOf("brand_ids" to "1", "brand_ids" to "2", "brand_ids" to "3"))
             val response = stub.client.execute(HttpRequest("GET", "/products", queryParams = queryParameters) )
 
@@ -109,7 +109,7 @@ class HttpStubWithArrayQueryParameterTest {
 
     @Test
     fun `should match stub for string query parameter with externalized json expectation`() {
-        createStubFromContracts(listOf("src/test/resources/openapi/spec_with_string_array_query_parameter_with_stub.yaml")).use { stub ->
+        createStubFromContracts(listOf("src/test/resources/openapi/spec_with_string_array_query_parameter_with_stub.yaml"), timeoutMillis = 0).use { stub ->
             val queryParameters = QueryParameters(paramPairs = listOf("category" to "Pen", "category" to "Pencil", "category" to "Marker"))
             val response = stub.client.execute(HttpRequest("GET", "/products", queryParams = queryParameters) )
 

--- a/core/src/test/kotlin/utilities/UtilitiesTest.kt
+++ b/core/src/test/kotlin/utilities/UtilitiesTest.kt
@@ -529,7 +529,7 @@ internal class UtilitiesTest {
                                 type: string
             """.trimIndent())
 
-            createStub("localhost", 9000).use { stub ->
+            createStub("localhost", 9000, timeoutMillis = 0).use { stub ->
                 val response = stub.client.execute(HttpRequest("POST", "/random", body = parsedJSONObject("""{"id": 1}""")))
                 assertThat(response.status).isEqualTo(200)
             }
@@ -599,7 +599,7 @@ internal class UtilitiesTest {
 
             val stubPort = ServerSocket(0).use { it.localPort }
 
-            createStub("localhost", stubPort).use { stub ->
+            createStub("localhost", stubPort, timeoutMillis = 0).use { stub ->
                 val response = stub.client.execute(HttpRequest("POST", "/random", body = parsedJSONObject("""{"id": 1}""")))
                 assertThat(response.status).isEqualTo(200)
             }
@@ -666,7 +666,7 @@ internal class UtilitiesTest {
                                 type: string
             """.trimIndent())
 
-            val results = createStub("localhost", 9000).use { stub ->
+            val results = createStub("localhost", 9000, timeoutMillis = 0).use { stub ->
                 loadSources(specmaticJSON.path).flatMap { source ->
                     source.testContracts
                 }.map { specPath ->

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=1.3.21
+version=1.3.22


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
The contract test were passing but in the logs the following error was observed -
```
io.netty.channel.AbstractChannelHandlerContext invokeExceptionCaught
WARNING: Failed to submit an exceptionCaught() event.
java.util.concurrent.RejectedExecutionException: event executor terminated 
```
This PR introduces a fix which gets rid of such errors.


<!-- Why are these changes necessary? -->

**Why**:
These changes are necessary to ensure graceful shutdown of HttpStub. 
And also to provide cleaner test output logs.

<!-- How were these changes implemented? -->

**How**:
We use Netty server as a HttpStub. The stop method of Netty server expects two arguments.
1. **gracePeriodMillis** - Time for which the server waits for the ongoing tasks' completion before terminating them.
2. **timeoutMillis** - Time for which the server waits for tasks to get completely terminated before shutting itself down.

We were setting the `gracePeriodMillis` to `0` by default. Because of this, the ongoing tasks were getting interrupted leading to the errors in the test output logs.

**The fix :**
1. Change the default `gracePeriodMillis` from `0` to `2000` while creating the stub using `createStub` APIs


<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [x] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->


<!-- feel free to add additional comments -->
