### PR TITLE
Recursive backward compatibility check

### DIFF
--- a/application/src/main/kotlin/application/BackwardCompatibilityCheckCommand.kt
+++ b/application/src/main/kotlin/application/BackwardCompatibilityCheckCommand.kt
@@ -3,6 +3,7 @@ package application
 import `in`.specmatic.conversions.OpenApiSpecification
 import `in`.specmatic.core.CONTRACT_EXTENSIONS
 import `in`.specmatic.core.git.GitCommand
+import `in`.specmatic.core.git.SystemGit
 import `in`.specmatic.core.testBackwardCompatibility
 import `in`.specmatic.core.utilities.exitWithMessage
 import org.springframework.stereotype.Component
@@ -17,7 +18,7 @@ import java.util.concurrent.Callable
     description = ["Checks backward compatibility of a directory across the current HEAD and the main branch"]
 )
 open class BackwardCompatibilityCheckCommand(
-    private val gitCommand: GitCommand,
+    private val gitCommand: GitCommand = SystemGit(),
 ) : Callable<Unit> {
 
     private val newLine = System.lineSeparator()

--- a/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandTest.kt
+++ b/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandTest.kt
@@ -2,6 +2,9 @@ package application
 
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.spyk
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import java.io.File
@@ -17,7 +20,7 @@ class BackwardCompatibilityCheckCommandTest {
 
     @Test
     fun `filesReferringToChangedSchemaFiles returns empty set when no files refer to changed schema files`() {
-        val command = BackwardCompatibilityCheckCommand(mockk(relaxed = true))
+        val command = spyk<BackwardCompatibilityCheckCommand>()
         every { command.allOpenApiSpecFiles() } returns listOf(
             File("file1.yaml").apply { writeText("content1") },
             File("file2.yaml").apply { writeText("content2") }
@@ -28,12 +31,19 @@ class BackwardCompatibilityCheckCommandTest {
 
     @Test
     fun `filesReferringToChangedSchemaFiles returns set of files that refer to changed schema files`() {
-        val command = mockk<BackwardCompatibilityCheckCommand>(relaxed = true)
+        val command = spyk<BackwardCompatibilityCheckCommand>()
         every { command.allOpenApiSpecFiles() } returns listOf(
             File("file1.yaml").apply { writeText("file3.yaml") },
             File("file2.yaml").apply { writeText("file4.yaml") }
         )
         val result = command.filesReferringToChangedSchemaFiles(setOf("file3.yaml"))
         assertEquals(setOf("file1.yaml"), result)
+    }
+
+    @AfterEach
+    fun `cleanup files`() {
+        listOf(File("file1.yaml"), File("file2.yaml")).forEach {
+            it.delete()
+        }
     }
 }

--- a/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandTest.kt
+++ b/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandTest.kt
@@ -1,0 +1,39 @@
+package application
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class BackwardCompatibilityCheckCommandTest {
+
+    @Test
+    fun `filesReferringToChangedSchemaFiles returns empty set when input is empty`() {
+        val command = BackwardCompatibilityCheckCommand(mockk())
+        val result = command.filesReferringToChangedSchemaFiles(emptySet())
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `filesReferringToChangedSchemaFiles returns empty set when no files refer to changed schema files`() {
+        val command = BackwardCompatibilityCheckCommand(mockk(relaxed = true))
+        every { command.allOpenApiSpecFiles() } returns listOf(
+            File("file1.yaml").apply { writeText("content1") },
+            File("file2.yaml").apply { writeText("content2") }
+        )
+        val result = command.filesReferringToChangedSchemaFiles(setOf("file3.yaml"))
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `filesReferringToChangedSchemaFiles returns set of files that refer to changed schema files`() {
+        val command = mockk<BackwardCompatibilityCheckCommand>(relaxed = true)
+        every { command.allOpenApiSpecFiles() } returns listOf(
+            File("file1.yaml").apply { writeText("file3.yaml") },
+            File("file2.yaml").apply { writeText("file4.yaml") }
+        )
+        val result = command.filesReferringToChangedSchemaFiles(setOf("file3.yaml"))
+        assertEquals(setOf("file1.yaml"), result)
+    }
+}

--- a/application/src/test/kotlin/application/CentralContractRepoReportCommandTestE2E.kt
+++ b/application/src/test/kotlin/application/CentralContractRepoReportCommandTestE2E.kt
@@ -23,6 +23,7 @@ class CentralContractRepoReportCommandTestE2E {
 
     @Test
     fun `test generates report json file`() {
+        centralContractRepoReportCommand.baseDir = ""
         centralContractRepoReportCommand.call()
         val reportJson: CentralContractRepoReportJson = Json.decodeFromString(reportFile.readText())
 

--- a/core/src/main/kotlin/in/specmatic/reports/CentralContractRepoReport.kt
+++ b/core/src/main/kotlin/in/specmatic/reports/CentralContractRepoReport.kt
@@ -10,7 +10,7 @@ import java.io.File
 
 class CentralContractRepoReport {
     fun generate(currentWorkingDir: String = ""): CentralContractRepoReportJson {
-        val searchPath = currentWorkingDir.takeIf { it.isNotEmpty() }.let { File(it).canonicalPath } ?: File("").canonicalPath
+        val searchPath = File(currentWorkingDir).canonicalPath
         logger.log("Searching for specification files at: $searchPath")
         val specifications = findSpecifications(searchPath)
         return CentralContractRepoReportJson(getSpecificationRows(specifications.sorted(), searchPath))


### PR DESCRIPTION
**What**:

If spec.yaml refers to component1.yaml which refers to component2.yaml, and the change is in component2.yaml, Specmatic's `backwardCompatibilityCheck` command will now identify this and test spec.yaml for backward compatibility correctly.

**Why**:

The code previously worked for only one level (spec.yaml -> component.yaml)

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

