### PR TITLE
Do exact schema file name match in backwardCompatibilityCheckCommand

### DIFF
--- a/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandTest.kt
+++ b/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandTest.kt
@@ -40,10 +40,36 @@ class BackwardCompatibilityCheckCommandTest {
         assertEquals(setOf("file1.yaml"), result)
     }
 
+    @Test
+    fun `filesReferringToChangedSchemaFiles returns set of files which are referring to a changed schema that is one level down`() {
+        val command = spyk<BackwardCompatibilityCheckCommand>()
+        every { command.allOpenApiSpecFiles() } returns listOf(
+            File("file1.yaml").apply { referTo("schema_file1.yaml") },
+            File("schema_file2.yaml").apply { referTo("schema_file1.yaml") }, // schema within a schema
+            File("file2.yaml").apply { referTo("schema_file2.yaml") }
+        )
+        val result = command.filesReferringToChangedSchemaFiles(setOf("schema_file1.yaml"))
+        assertEquals(setOf("file1.yaml", "file2.yaml"), result)
+    }
+
     @AfterEach
     fun `cleanup files`() {
-        listOf(File("file1.yaml"), File("file2.yaml")).forEach {
-            it.delete()
+        listOf("file1.yaml", "file2.yaml", "file3.yaml", "file4.yaml", "schema_file1.yaml", "schema_file2.yaml").forEach {
+            File(it).delete()
         }
+    }
+
+    private fun File.referTo(schemaFileName: String) {
+       val specContent = """
+           openapi: 3.1.0  # OpenAPI version specified here
+           info:
+             title: My API
+             version: 1.0.0
+           components:
+             schemas:
+               User:
+                 ${"$"}ref: '#/components/schemas/$schemaFileName' 
+       """.trimIndent()
+        this.writeText(specContent)
     }
 }

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=1.3.22
+version=1.3.23


### PR DESCRIPTION


<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
This fixes a bug in `backwardCompatibilityCheckCommand` where while finding the files referring to a schema file,
it was not doing an exact file name match.

<!-- Why are these changes necessary? -->

**Why**:
These changes resolve the above mentioned bug.

<!-- How were these changes implemented? -->

**How**:
To implement the fix, word boundary matching is used.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [x] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->


<!-- feel free to add additional comments -->
