### PR TITLE
Log error when invalid contract paths are selected by user

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/utilities/Utilities.kt
+++ b/core/src/main/kotlin/in/specmatic/core/utilities/Utilities.kt
@@ -343,6 +343,15 @@ fun examplesDirFor(openApiFilePath: String, alternateSuffix: String): File {
         getExamplesDir(openApiFilePath, alternateSuffix)
 }
 
+fun checkIfContractPathsAreValid(contractPaths: List<String>) {
+    val validContractPaths = contractPaths.filter { path ->
+        File(path).extension in CONTRACT_EXTENSIONS
+    }
+    if (validContractPaths.isEmpty()) {
+        throw ContractException("No valid specification file found at given paths : ${contractPaths.joinToString(", ")}")
+    }
+}
+
 private fun getExamplesDir(openApiFilePath: String, suffix: String): File =
     File(openApiFilePath).canonicalFile.let {
         it.parentFile.resolve("${it.parent}/${it.nameWithoutExtension}$suffix")

--- a/core/src/main/kotlin/in/specmatic/stub/api.kt
+++ b/core/src/main/kotlin/in/specmatic/stub/api.kt
@@ -6,6 +6,7 @@ import `in`.specmatic.core.git.SystemGit
 import `in`.specmatic.core.log.StringLog
 import `in`.specmatic.core.log.consoleLog
 import `in`.specmatic.core.log.logger
+import `in`.specmatic.core.pattern.ContractException
 import `in`.specmatic.core.utilities.ContractPathData
 import `in`.specmatic.core.utilities.contractStubPaths
 import `in`.specmatic.core.utilities.examplesDirFor
@@ -70,6 +71,13 @@ fun createStubFromContracts(
     host: String = "localhost",
     port: Int = 9000
 ): ContractStub {
+    val validContractPaths = contractPaths.filter { path ->
+        File(path).extension in CONTRACT_EXTENSIONS
+    }
+    if (validContractPaths.isEmpty()) {
+        throw ContractException("No valid specification file found at given paths : $contractPaths")
+    }
+
     return createStubFromContracts(
         contractPaths,
         dataDirPaths,
@@ -81,6 +89,13 @@ fun createStubFromContracts(
 
 // Used by stub client code
 fun createStubFromContracts(contractPaths: List<String>, host: String = "localhost", port: Int = 9000): ContractStub {
+    val validContractPaths = contractPaths.filter { path ->
+        File(path).extension in CONTRACT_EXTENSIONS
+    }
+    if (validContractPaths.isEmpty()) {
+        throw ContractException("No valid specification file found at given paths : $contractPaths")
+    }
+
     return createStubFromContracts(
         contractPaths,
         host,

--- a/core/src/main/kotlin/in/specmatic/stub/api.kt
+++ b/core/src/main/kotlin/in/specmatic/stub/api.kt
@@ -6,11 +6,7 @@ import `in`.specmatic.core.git.SystemGit
 import `in`.specmatic.core.log.StringLog
 import `in`.specmatic.core.log.consoleLog
 import `in`.specmatic.core.log.logger
-import `in`.specmatic.core.pattern.ContractException
-import `in`.specmatic.core.utilities.ContractPathData
-import `in`.specmatic.core.utilities.contractStubPaths
-import `in`.specmatic.core.utilities.examplesDirFor
-import `in`.specmatic.core.utilities.exitIfDoesNotExist
+import `in`.specmatic.core.utilities.*
 import `in`.specmatic.core.value.StringValue
 import `in`.specmatic.mock.NoMatchingScenario
 import `in`.specmatic.mock.ScenarioStub
@@ -71,12 +67,7 @@ fun createStubFromContracts(
     host: String = "localhost",
     port: Int = 9000
 ): ContractStub {
-    val validContractPaths = contractPaths.filter { path ->
-        File(path).extension in CONTRACT_EXTENSIONS
-    }
-    if (validContractPaths.isEmpty()) {
-        throw ContractException("No valid specification file found at given paths : $contractPaths")
-    }
+    checkIfContractPathsAreValid(contractPaths)
 
     return createStubFromContracts(
         contractPaths,
@@ -89,12 +80,7 @@ fun createStubFromContracts(
 
 // Used by stub client code
 fun createStubFromContracts(contractPaths: List<String>, host: String = "localhost", port: Int = 9000): ContractStub {
-    val validContractPaths = contractPaths.filter { path ->
-        File(path).extension in CONTRACT_EXTENSIONS
-    }
-    if (validContractPaths.isEmpty()) {
-        throw ContractException("No valid specification file found at given paths : $contractPaths")
-    }
+    checkIfContractPathsAreValid(contractPaths)
 
     return createStubFromContracts(
         contractPaths,

--- a/core/src/test/kotlin/utilities/UtilitiesTest.kt
+++ b/core/src/test/kotlin/utilities/UtilitiesTest.kt
@@ -8,6 +8,7 @@ import `in`.specmatic.core.git.GitCommand
 import `in`.specmatic.core.git.SystemGit
 import `in`.specmatic.core.git.checkout
 import `in`.specmatic.core.git.clone
+import `in`.specmatic.core.pattern.ContractException
 import `in`.specmatic.core.pattern.parsedJSON
 import `in`.specmatic.core.pattern.parsedJSONObject
 import `in`.specmatic.core.utilities.*
@@ -22,10 +23,7 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.mockk.*
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Nested
-import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.*
 import java.io.File
 import java.net.ServerSocket
 
@@ -532,6 +530,29 @@ internal class UtilitiesTest {
         } finally {
             specDir.deleteRecursively()
             specmaticJSON.delete()
+        }
+    }
+
+    @Nested
+    inner class CheckIfContractPathsAreValidTests {
+        @Test
+        fun `should not throw an exception if the contract paths are valid`() {
+            val contractPaths = listOf("first.yaml", "second.yml", "third.json")
+
+            assertDoesNotThrow {
+                checkIfContractPathsAreValid(contractPaths)
+            }
+        }
+
+        @Test
+        fun `should throw an exception if none of the contract paths is valid`() {
+            val contractPaths = listOf("first.random", "second.random", "third.random")
+
+            val e = assertThrows<ContractException> {
+                checkIfContractPathsAreValid(contractPaths)
+            }
+
+            assertThat(e.errorMessage == "No valid specification file found at given paths: first.random, second.random, third.random")
         }
     }
 

--- a/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
@@ -186,14 +186,8 @@ open class SpecmaticJUnitSupport {
         if(!mbs.isRegistered(name))
             mbs.registerMBean(statistics, name)
 
-        val contractPaths = System.getProperty(CONTRACT_PATHS)?.let { paths ->
-            paths.split(",").filter { path ->
-                File(path).extension in CONTRACT_EXTENSIONS
-            }
-        }
-        if(contractPaths != null && contractPaths.isEmpty()) {
-            throw ContractException("No valid specification file found at given paths : ${System.getProperty(CONTRACT_PATHS)}")
-        }
+        val contractPaths = System.getProperty(CONTRACT_PATHS)?.split(",").orEmpty()
+        checkIfContractPathsAreValid(contractPaths)
 
         val givenWorkingDirectory = System.getProperty(WORKING_DIRECTORY)
         val filterName: String? = System.getProperty(FILTER_NAME_PROPERTY) ?: System.getenv(FILTER_NAME_ENVIRONMENT_VARIABLE)

--- a/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
@@ -186,7 +186,15 @@ open class SpecmaticJUnitSupport {
         if(!mbs.isRegistered(name))
             mbs.registerMBean(statistics, name)
 
-        val contractPaths = System.getProperty(CONTRACT_PATHS)
+        val contractPaths = System.getProperty(CONTRACT_PATHS)?.let { paths ->
+            paths.split(",").filter { path ->
+                File(path).extension in CONTRACT_EXTENSIONS
+            }
+        }
+        if(contractPaths != null && contractPaths.isEmpty()) {
+            throw ContractException("No valid specification file found at given paths : ${System.getProperty(CONTRACT_PATHS)}")
+        }
+
         val givenWorkingDirectory = System.getProperty(WORKING_DIRECTORY)
         val filterName: String? = System.getProperty(FILTER_NAME_PROPERTY) ?: System.getenv(FILTER_NAME_ENVIRONMENT_VARIABLE)
         val filterNotName: String? = System.getProperty(FILTER_NOT_NAME_PROPERTY) ?: System.getenv(FILTER_NOT_NAME_ENVIRONMENT_VARIABLE)
@@ -206,10 +214,8 @@ open class SpecmaticJUnitSupport {
         }
         val testScenarios = try {
             val (testScenarios, allEndpoints) = when {
-                contractPaths != null -> {
-                    val testScenariosAndEndpointsPairList = contractPaths.split(",").filter {
-                        File(it).extension in CONTRACT_EXTENSIONS
-                    }.map {
+                (contractPaths != null) -> {
+                    val testScenariosAndEndpointsPairList = contractPaths.map {
                         loadTestScenarios(
                             it,
                             suggestionsPath,


### PR DESCRIPTION
**What**:
If we run the test against a folder (i.e. not a valid contract file path),
we get following log messages -
```
Endpoints API not found, cannot calculate actual coverage

Could not load report configuration, coverage will be calculated but no coverage threshold will be enforced
The Open API coverage report generated is blank.
This can happen if you have included all the endpoints in the 'excludedEndpoints' array in the report section in specmatic.json, or if your open api specification does not have any paths documented.
```

It does not mention that it is failing because a file with valid extension was not selected.

With this change, we will get additional error message as follows -
```
Endpoints API not found, cannot calculate actual coverage

Could not load report configuration, coverage will be calculated but no coverage threshold will be enforced
The Open API coverage report generated is blank.
This can happen if you have included all the endpoints in the 'excludedEndpoints' array in the report section in specmatic.json, or if your open api specification does not have any paths documented.

No valid specification file found at given paths : /Users/yogeshanandanikam/personal_projects/specmatic-intellij-plugin
```


<!-- Why are these changes necessary? -->

**Why**:
Better user experience.

<!-- How were these changes implemented? -->

**How**:
Logs a message when the contract paths are not empty but none of them is valid.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->


<!-- feel free to add additional comments -->
