### PR TITLE
Resolver context

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/Context.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Context.kt
@@ -1,0 +1,5 @@
+package `in`.specmatic.core
+
+interface Context
+
+val NoContext = object : Context {}

--- a/core/src/main/kotlin/in/specmatic/core/Resolver.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Resolver.kt
@@ -27,7 +27,7 @@ data class Resolver(
     val mockMode: Boolean = false,
     val newPatterns: Map<String, Pattern> = emptyMap(),
     val findKeyErrorCheck: KeyCheck = DefaultKeyCheck,
-    val context: Map<String, String> = emptyMap(),
+    val context: Context = NoContext,
     val mismatchMessages: MismatchMessages = DefaultMismatchMessages,
     val isNegative: Boolean = false,
     val patternMatchStrategy: (resolver: Resolver, factKey: String?, pattern: Pattern, sampleValue: Value) -> Result = actualMatch,
@@ -39,7 +39,10 @@ data class Resolver(
     constructor(facts: Map<String, Value> = emptyMap(), mockMode: Boolean = false, newPatterns: Map<String, Pattern> = emptyMap()) : this(CheckFacts(facts), mockMode, newPatterns)
     constructor() : this(emptyMap(), false)
 
-    val patterns = builtInPatterns.plus(newPatterns)
+    val patterns: Map<String, Pattern>
+        get() {
+            return builtInPatterns.plus(newPatterns)
+        }
 
     fun withUnexpectedKeyCheck(unexpectedKeyCheck: UnexpectedKeyCheck): Resolver {
         return this.copy(findKeyErrorCheck = this.findKeyErrorCheck.withUnexpectedKeyCheck(unexpectedKeyCheck))

--- a/core/src/main/kotlin/in/specmatic/core/ResponseBuilder.kt
+++ b/core/src/main/kotlin/in/specmatic/core/ResponseBuilder.kt
@@ -1,9 +1,10 @@
 package `in`.specmatic.core
 
 import `in`.specmatic.core.value.Value
+import `in`.specmatic.stub.RequestContext
 
 class ResponseBuilder(val scenario: Scenario, val serverState: Map<String, Value>) {
-    fun build(): HttpResponse {
-        return scenario.generateHttpResponse(serverState)
+    fun build(requestContext: RequestContext): HttpResponse {
+        return scenario.generateHttpResponse(serverState, requestContext)
     }
 }

--- a/core/src/main/kotlin/in/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Scenario.kt
@@ -7,6 +7,7 @@ import `in`.specmatic.core.utilities.capitalizeFirstChar
 import `in`.specmatic.core.utilities.exceptionCauseMessage
 import `in`.specmatic.core.utilities.mapZip
 import `in`.specmatic.core.value.*
+import `in`.specmatic.stub.RequestContext
 import `in`.specmatic.test.TestExecutor
 
 object ContractAndStubMismatchMessages : MismatchMessages {
@@ -158,13 +159,13 @@ data class Scenario(
         }
     }
 
-    fun generateHttpResponse(actualFacts: Map<String, Value>): HttpResponse =
+    fun generateHttpResponse(actualFacts: Map<String, Value>, requestContext: Context = NoContext): HttpResponse =
         scenarioBreadCrumb(this) {
             Resolver(emptyMap(), false, patterns)
             val resolver = Resolver(actualFacts, false, patterns)
             val facts = combineFacts(expectedFacts, actualFacts, resolver)
 
-            httpResponsePattern.generateResponse(resolver.copy(factStore = CheckFacts(facts)))
+            httpResponsePattern.generateResponse(resolver.copy(factStore = CheckFacts(facts), context = requestContext))
         }
 
     private fun combineFacts(

--- a/core/src/main/kotlin/in/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/in/specmatic/stub/HttpStub.kt
@@ -44,6 +44,10 @@ data class HttpStubResponse(
     val scenario: Scenario? = null
 )
 
+interface RequestInterceptor {
+    fun interceptRequest(httpRequest: HttpRequest): HttpRequest?
+}
+
 class HttpStub(
     private val features: List<Feature>,
     rawHttpStubs: List<HttpStubData> = emptyList(),
@@ -156,6 +160,12 @@ class HttpStub(
 
     private val broadcastChannels: Vector<BroadcastChannel<SseEvent>> = Vector(50, 10)
 
+    private val requestInterceptors: MutableList<RequestInterceptor> = mutableListOf()
+
+    fun registerRequestInterceptor(requestInterceptor: RequestInterceptor) {
+        requestInterceptors.add(requestInterceptor)
+    }
+
     private val environment = applicationEngineEnvironment {
         module {
             install(DoubleReceive)
@@ -182,8 +192,13 @@ class HttpStub(
                 val httpLogMessage = HttpLogMessage()
 
                 try {
-                    val httpRequest = ktorHttpRequestToHttpRequest(call)
-                    httpLogMessage.addRequest(httpRequest)
+                    val rawHttpRequest = ktorHttpRequestToHttpRequest(call)
+                    httpLogMessage.addRequest(rawHttpRequest)
+
+                    val httpRequest = requestInterceptors.fold(rawHttpRequest) { request, requestInterceptor ->
+                        requestInterceptor.interceptRequest(request) ?: request
+                    }
+
 
                     val responseFromRequestHandler = requestHandlers.map { it.handleRequest(httpRequest) }.firstOrNull()
 

--- a/core/src/main/kotlin/in/specmatic/stub/RequestHandler.kt
+++ b/core/src/main/kotlin/in/specmatic/stub/RequestHandler.kt
@@ -1,0 +1,8 @@
+package `in`.specmatic.stub
+
+import `in`.specmatic.core.HttpRequest
+
+interface RequestHandler {
+    val name: String
+    fun handleRequest(httpRequest: HttpRequest): HttpStubResponse?
+}

--- a/core/src/test/kotlin/in/specmatic/core/ResponseBuilderTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/ResponseBuilderTest.kt
@@ -1,0 +1,73 @@
+package `in`.specmatic.core
+
+import `in`.specmatic.core.pattern.Pattern
+import `in`.specmatic.core.pattern.ReturnValue
+import `in`.specmatic.core.pattern.Row
+import `in`.specmatic.core.pattern.TypeStack
+import `in`.specmatic.core.value.NullValue
+import `in`.specmatic.core.value.Value
+import `in`.specmatic.stub.RequestContext
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ResponseBuilderTest {
+    @Test
+    fun `should ferry request context to scenario`() {
+        val responsePattern = object : Pattern {
+            override fun matches(sampleData: Value?, resolver: Resolver): Result {
+                TODO("Not yet implemented")
+            }
+
+            override fun generate(resolver: Resolver): Value {
+                assertThat(resolver.context).isEqualTo(RequestContext(HttpRequest(path = "testPath")))
+                return NullValue
+            }
+
+            override fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
+                TODO("Not yet implemented")
+            }
+
+            override fun newBasedOn(resolver: Resolver): Sequence<Pattern> {
+                TODO("Not yet implemented")
+            }
+
+            override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+                TODO("Not yet implemented")
+            }
+
+            override fun parse(value: String, resolver: Resolver): Value {
+                TODO("Not yet implemented")
+            }
+
+            override fun encompasses(
+                otherPattern: Pattern,
+                thisResolver: Resolver,
+                otherResolver: Resolver,
+                typeStack: TypeStack
+            ): Result {
+                TODO("Not yet implemented")
+            }
+
+            override fun listOf(valueList: List<Value>, resolver: Resolver): Value {
+                TODO("Not yet implemented")
+            }
+
+            override val typeAlias: String?
+                get() = TODO("Not yet implemented")
+            override val typeName: String
+                get() = TODO("Not yet implemented")
+            override val pattern: Any
+                get() = TODO("Not yet implemented")
+
+        }
+
+        val scenario = Scenario(
+            "test scenario",
+            HttpRequest("GET", "/").toPattern(),
+            HttpResponsePattern(body = responsePattern),
+            emptyMap(), emptyList(), emptyMap(), emptyMap()
+        )
+
+        ResponseBuilder(scenario, emptyMap()).build(RequestContext(HttpRequest(path = "testPath")))
+    }
+}

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=1.3.25
+version=1.3.26


### PR DESCRIPTION
**What**:

- Hooks - Hooks core for extensions to be able to customise matching
- Context - Passing context of the request to the response

**Why**:

- Hooks - Some extensions require custom matching to ignore fields which is not applicable to others
- Context - Response schema rendering to be influenced by request context

**How**:



**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

