### PR TITLE
Added negative tests for the minimum and maximum keywords in NumberPattern

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/in/specmatic/core/SpecmaticConfig.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import `in`.specmatic.core.Configuration.Companion.globalConfigFileName
+import `in`.specmatic.core.log.logger
 import `in`.specmatic.core.pattern.ContractException
 import java.io.File
 
@@ -192,8 +193,9 @@ fun loadSpecmaticConfig(configFileName: String? = null): SpecmaticConfig {
     }
     try {
         return ObjectMapper(YAMLFactory()).readValue(configFile.readText(), SpecmaticConfig::class.java)
-    } catch(e: NoClassDefFoundError) {
-        throw Exception("This usually means that there's a dependency version conflict. If you are using Spring in a maven project, the most common resolution is to set the property <kotlin.version></kotlin.version> to your pom project.", e)
+    } catch(e: LinkageError) {
+        logger.log(e, "A dependency version conflict has been detected. If you are using Spring in a maven project, a common resolution is to set the property <kotlin.version></kotlin.version> to your pom project.")
+        throw e
     } catch (e: Throwable) {
         throw Exception("Your configuration file may have some missing configuration sections. Please ensure that the $configFileName file adheres to the schema described at: https://specmatic.in/documentation/specmatic_json.html", e)
     }

--- a/core/src/test/kotlin/in/specmatic/core/pattern/NumberPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/NumberPatternTest.kt
@@ -225,4 +225,17 @@ internal class NumberPatternTest {
             "boolean"
         )
     }
+
+    @Test
+    @Tag(GENERATION)
+    fun `negative values generated should include a value greater than minimum and maximum keyword values`() {
+        val result = NumberPattern(minimum = 10.0, maximum = 20.0).negativeBasedOn(Row(), Resolver()).map { it.value }.toList()
+        assertThat(result).containsExactlyInAnyOrder(
+            NullPattern,
+            StringPattern(),
+            BooleanPattern(),
+            ExactValuePattern(NumberValue(9.0)),
+            ExactValuePattern(NumberValue(21.0))
+        )
+    }
 }

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=1.3.27
+version=1.3.28


### PR DESCRIPTION
**What**:

When the `minimum` keyword is used in a number type in the specification, negativeBasedOn should generate a value that is below the minimum, as a negative value for the number.

When the `maximum` keyword is used in a number type in the specification, negativeBasedOn should generate a value that is above the maximum, as a negative value for the number.

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate
