### PR TITLE
Handle 400 named response examples with no corresponding named request example

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -428,30 +428,29 @@ class OpenApiSpecification(
             else key to value
         }.toMap()
 
-        when {
-            requestExamples.isNotEmpty() -> {
-                val  resolvedResponseExample =
-                    if (environmentAndPropertiesConfiguration.validateResponseValue())
-                        ResponseValueExample(responseExample)
-                    else
-                        ResponseSchemaExample(responseExample)
+        if(requestExamples.isEmpty())
+            return@mapNotNull null
 
-                Row(
-                    requestExamples.keys.toList().map { keyName: String -> keyName },
-                    requestExamples.values.toList().map { value: Any? -> value?.toString() ?: "" }
-                        .map { valueString: String ->
-                            if (valueString.contains("externalValue")) {
-                                ObjectMapper().readValue(valueString, Map::class.java).values.first()
-                                    .toString()
-                            } else valueString
-                        },
-                    name = exampleName,
-                    responseExample = resolvedResponseExample.takeIf { it.responseExample.isNotEmpty() }
-                )
+        val  resolvedResponseExample =
+            when {
+                environmentAndPropertiesConfiguration.validateResponseValue() ->
+                    ResponseValueExample(responseExample)
+                else ->
+                    ResponseSchemaExample(responseExample)
             }
 
-            else -> null
-        }
+        Row(
+            requestExamples.keys.toList().map { keyName: String -> keyName },
+            requestExamples.values.toList().map { value: Any? -> value?.toString() ?: "" }
+                .map { valueString: String ->
+                    if (valueString.contains("externalValue")) {
+                        ObjectMapper().readValue(valueString, Map::class.java).values.first()
+                            .toString()
+                    } else valueString
+                },
+            name = exampleName,
+            responseExample = resolvedResponseExample.takeIf { it.responseExample.isNotEmpty() }
+        )
     }
 
     data class OperationIdentifier(val requestMethod: String, val requestPath: String, val responseStatus: Int)

--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -417,7 +417,7 @@ class OpenApiSpecification(
         responseExamples: Map<String, HttpResponse>,
         operation: Operation,
         openApiRequest: Pair<String, MediaType>?
-    ): List<Row> = responseExamples.map { (exampleName, responseExample) ->
+    ): List<Row> = responseExamples.mapNotNull { (exampleName, responseExample) ->
         val parameterExamples: Map<String, Any> = parameterExamples(operation, exampleName)
 
         val requestBodyExample: Map<String, Any> =
@@ -450,7 +450,7 @@ class OpenApiSpecification(
                 )
             }
 
-            else -> Row()
+            else -> null
         }
     }
 


### PR DESCRIPTION
**What**:

For any named response example, the corresponding named request example should be in the spec. If not found, the named response example should be ignored and no test generated from it.

**Why**:

Current behaviour is that given a spec with a 400 response named example, but no corresponding request example, a test is run with a randomised request, expecting a 400 status response. 

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

