### PR TITLE
Warning for missing named request example

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -37,11 +37,14 @@ const val testDirectoryProperty = "specmaticTestsDirectory"
 
 const val NO_SECURITY_SCHEMA_IN_SPECIFICATION = "NO-SECURITY-SCHEME-IN-SPECIFICATION"
 
+var missingRequestExampleErrorMessageForTest: String = "WARNING: Ignoring response example named %s for test or stub data, because no associated request example named %s was found."
+var missingResponseExampleErrorMessageForTest: String = "WARNING: Ignoring request example named %s for test or stub data, because no associated response example named %s was found."
+
 internal fun missingRequestExampleErrorMessageForTest(exampleName: String): String =
-    "WARNING: Ignoring response example named $exampleName for test or stub data, because no associated request example named $exampleName was found."
+    missingRequestExampleErrorMessageForTest.format(exampleName, exampleName)
 
 internal fun missingResponseExampleErrorMessageForTest(exampleName: String): String =
-    "WARNING: Ignoring request example named $exampleName for test or stub data, because no associated response example named $exampleName was found."
+    missingResponseExampleErrorMessageForTest.format(exampleName, exampleName)
 
 class OpenApiSpecification(
     private val openApiFilePath: String,

--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -38,10 +38,10 @@ const val testDirectoryProperty = "specmaticTestsDirectory"
 const val NO_SECURITY_SCHEMA_IN_SPECIFICATION = "NO-SECURITY-SCHEME-IN-SPECIFICATION"
 
 internal fun missingRequestExampleErrorMessageForTest(exampleName: String): String =
-    "WARNING: No request example named $exampleName found, so response example named $exampleName will be ignored."
+    "WARNING: Ignoring response example named $exampleName for test or stub data, because no associated request example named $exampleName was found."
 
 internal fun missingResponseExampleErrorMessageForTest(exampleName: String): String =
-    "WARNING: No response example named $exampleName found, so request example named $exampleName will be ignored."
+    "WARNING: Ignoring request example named $exampleName for test or stub data, because no associated response example named $exampleName was found."
 
 class OpenApiSpecification(
     private val openApiFilePath: String,

--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -428,8 +428,10 @@ class OpenApiSpecification(
             else key to value
         }.toMap()
 
-        if(requestExamples.isEmpty())
+        if(requestExamples.isEmpty()) {
+            logger.log("WARNING: No request example named $exampleName found. Response example by the same name will be ignored. A contract test requires an example of the same name in both request and response.")
             return@mapNotNull null
+        }
 
         val  resolvedResponseExample =
             when {

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -7970,7 +7970,7 @@ paths:
         println(stdout)
 
         assertThat(stdout)
-            .contains("WARNING: No request example named SUCCESSFUL_API_CALLj found")
+            .contains("WARNING: No request example named SUCCESSFUL_API_CALL found")
     }
 
     private fun ignoreButLogException(function: () -> OpenApiSpecification) {

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -10,10 +10,8 @@ import `in`.specmatic.core.utilities.exceptionCauseMessage
 import `in`.specmatic.core.value.*
 import `in`.specmatic.mock.NoMatchingScenario
 import `in`.specmatic.mock.ScenarioStub
-import `in`.specmatic.stub.HttpStub
-import `in`.specmatic.stub.HttpStubData
+import `in`.specmatic.stub.*
 import `in`.specmatic.stub.createStubFromContracts
-import `in`.specmatic.stub.stringToMockScenario
 import `in`.specmatic.test.TestExecutor
 import `in`.specmatic.trimmedLinesString
 import integration_tests.testCount
@@ -7930,6 +7928,49 @@ paths:
             assertThat(response.status).isEqualTo(200)
             assertThat(response.body.toStringLiteral()).contains("msgId")
         }
+    }
+
+    @Test
+    fun `check that a console warning is printed when a named response example has no corresponding named request example`() {
+        val (stdout, _) = captureStandardOutput {
+            OpenApiSpecification.fromYAML(
+                """
+                    ---
+                    openapi: "3.0.1"
+                    info:
+                      title: "Person API"
+                      version: "1"
+                    paths:
+                      /person:
+                        post:
+                          summary: "Get person by id"
+                          requestBody:
+                            content:
+                              application/json:
+                                schema:
+                                  required:
+                                  - age
+                                  properties:
+                                    age:
+                                      description: age of the person
+                                      type: number
+                          responses:
+                            200:
+                              description: "Get person by id"
+                              content:
+                                text/plain:
+                                  schema:
+                                    type: string
+                                  examples:
+                                    SUCCESSFUL_API_CALL: added
+                    """.trimIndent(), ""
+            ).toFeature()
+        }
+
+        println(stdout)
+
+        assertThat(stdout)
+            .contains("WARNING: No request example named SUCCESSFUL_API_CALLj found")
     }
 
     private fun ignoreButLogException(function: () -> OpenApiSpecification) {

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -7962,7 +7962,8 @@ paths:
                                   schema:
                                     type: string
                                   examples:
-                                    SUCCESSFUL_API_CALL: added
+                                    SUCCESSFUL_API_CALL:
+                                      value: added
                     """.trimIndent(), ""
             ).toFeature()
         }
@@ -7971,6 +7972,51 @@ paths:
 
         assertThat(stdout)
             .contains("WARNING: No request example named SUCCESSFUL_API_CALL found")
+    }
+
+    @Test
+    fun `check that a console warning is printed when a named request example has no corresponding named responsee example`() {
+        val (stdout, _) = captureStandardOutput {
+            OpenApiSpecification.fromYAML(
+                """
+                    ---
+                    openapi: "3.0.1"
+                    info:
+                      title: "Person API"
+                      version: "1"
+                    paths:
+                      /person:
+                        post:
+                          summary: "Get person by id"
+                          requestBody:
+                            content:
+                              application/json:
+                                schema:
+                                  required:
+                                  - age
+                                  properties:
+                                    age:
+                                      description: age of the person
+                                      type: number
+                                examples:
+                                  SUCCESSFUL_API_CALL:
+                                    value:
+                                      age: 10
+                          responses:
+                            200:
+                              description: "Get person by id"
+                              content:
+                                text/plain:
+                                  schema:
+                                    type: string
+                    """.trimIndent(), ""
+            ).toFeature()
+        }
+
+        println(stdout)
+
+        assertThat(stdout)
+            .contains("WARNING: No response example named SUCCESSFUL_API_CALL found")
     }
 
     private fun ignoreButLogException(function: () -> OpenApiSpecification) {

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -7970,8 +7970,9 @@ paths:
 
         println(stdout)
 
+        val exampleName = "SUCCESSFUL_API_CALL"
         assertThat(stdout)
-            .contains("WARNING: No request example named SUCCESSFUL_API_CALL found")
+            .contains("Ignoring response example named $exampleName for test or stub data, because no associated request example named $exampleName was found.")
     }
 
     @Test
@@ -8015,8 +8016,10 @@ paths:
 
         println(stdout)
 
+        val exampleName = "SUCCESSFUL_API_CALL"
+
         assertThat(stdout)
-            .contains("WARNING: No response example named SUCCESSFUL_API_CALL found")
+            .contains("WARNING: Ignoring request example named $exampleName for test or stub data, because no associated response example named $exampleName was found.")
     }
 
     private fun ignoreButLogException(function: () -> OpenApiSpecification) {


### PR DESCRIPTION
**What**:

Print a warning on the console when a named response example is found without a named request example.

**Why**:

The user may have forgotten to add a request example, and may wonder why a test has not run.

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

