### PR TITLE
#1158 Handling precision loss due to conversion to Double

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/pattern/NumberPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/NumberPattern.kt
@@ -60,7 +60,7 @@ data class NumberPattern(
         if (sampleData.toStringLiteral().length > maxLength)
             return mismatchResult("number with maxLength $maxLength", sampleData, resolver.mismatchMessages)
 
-        val sampleNumber = BigDecimal(sampleData.number.toDouble())
+        val sampleNumber = BigDecimal(sampleData.number.toString())
 
         val minOp = if (exclusiveMinimum) ">" else ">="
         if (!eval(sampleNumber, minOp, minimum))

--- a/core/src/test/kotlin/in/specmatic/core/pattern/NumberPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/NumberPatternTest.kt
@@ -217,6 +217,14 @@ internal class NumberPatternTest {
     }
 
     @Test
+    fun `test`() {
+        val pointZeroOne = ".01"
+        val minimumPointZeroOne = NumberPattern(minimum = BigDecimal(pointZeroOne))
+        val result = minimumPointZeroOne.matches(NumberValue(convertToNumber(pointZeroOne)), Resolver())
+        assertThat(result.isSuccess()).withFailMessage(result.reportString()).isTrue()
+    }
+
+    @Test
     @Tag(GENERATION)
     fun `negative values should be generated`() {
         val result = NumberPattern().negativeBasedOn(Row(), Resolver()).map { it.value }.toList()


### PR DESCRIPTION
 Handling precision loss due to conversion to Double by instead using BigDecimal

**What**:

Handling precision loss because of conversion toDouble in NumberPattern.matches

**Why**:

This was leading to incorrect interpretation of decimal values such as `0.01` as `0.009999..`, which in turn leads to mismatch errors

**How**:

Constructing `Bigdecimal` directly from the underlying String value of the `sampleData` instead of converting it to `Double`.

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [x] Sonar Quality Gate

**Issue ID**:
Closes: #1158
