### PR TITLE
Programmatic strict http stub

### DIFF
--- a/core/src/main/kotlin/in/specmatic/stub/api.kt
+++ b/core/src/main/kotlin/in/specmatic/stub/api.kt
@@ -52,7 +52,16 @@ fun createStub(
     host: String = "localhost",
     port: Int = 9000
 ): ContractStub {
-    return createStub(dataDirPaths, host, port, timeoutMillis = HTTP_STUB_SHUTDOWN_TIMEOUT)
+    return createStub(dataDirPaths, host, port, false)
+}
+
+fun createStub(
+    dataDirPaths: List<String>,
+    host: String = "localhost",
+    port: Int = 9000,
+    strict: Boolean = false
+): ContractStub {
+    return createStub(dataDirPaths, host, port, timeoutMillis = HTTP_STUB_SHUTDOWN_TIMEOUT, strict = strict)
 }
 
 fun createStubFromContracts(
@@ -84,7 +93,8 @@ internal fun createStub(
     dataDirPaths: List<String>,
     host: String = "localhost",
     port: Int = 9000,
-    timeoutMillis: Long
+    timeoutMillis: Long,
+    strict: Boolean = false
 ): ContractStub {
     // TODO - see if these two can be extracted out.
     val configFileName = getConfigFileName()
@@ -101,7 +111,8 @@ internal fun createStub(
         port,
         ::consoleLog,
         specmaticConfigPath = File(configFileName).canonicalPath,
-        timeoutMillis = timeoutMillis
+        timeoutMillis = timeoutMillis,
+        strictMode = strict
     )
 }
 
@@ -123,7 +134,8 @@ internal fun createStub(host: String = "localhost", port: Int = 9000, timeoutMil
         log = ::consoleLog,
         workingDirectory = workingDirectory,
         specmaticConfigPath = File(configFileName).canonicalPath,
-        timeoutMillis = timeoutMillis
+        timeoutMillis = timeoutMillis,
+        strictMode = strict
     )
 }
 

--- a/core/src/main/kotlin/in/specmatic/stub/api.kt
+++ b/core/src/main/kotlin/in/specmatic/stub/api.kt
@@ -39,7 +39,11 @@ fun allContractsFromDirectory(dirContainingContracts: String): List<String> =
     File(dirContainingContracts).listFiles()?.filter { it.extension == CONTRACT_EXTENSION }?.map { it.absolutePath } ?: emptyList()
 
 fun createStub(host: String = "localhost", port: Int = 9000): ContractStub {
-    return createStub(host, port, timeoutMillis = HTTP_STUB_SHUTDOWN_TIMEOUT)
+    return createStub(host, port, false)
+}
+
+fun createStub(host: String = "localhost", port: Int = 9000, strict: Boolean = false): ContractStub {
+    return createStub(host, port, timeoutMillis = HTTP_STUB_SHUTDOWN_TIMEOUT, strict)
 }
 
 // Used by stub client code
@@ -101,7 +105,7 @@ internal fun createStub(
     )
 }
 
-internal fun createStub(host: String = "localhost", port: Int = 9000, timeoutMillis: Long): ContractStub {
+internal fun createStub(host: String = "localhost", port: Int = 9000, timeoutMillis: Long, strict: Boolean = false): ContractStub {
     val workingDirectory = WorkingDirectory()
     // TODO - see if these two can be extracted out.
     val configFileName = getConfigFileName()


### PR DESCRIPTION
**What**:

Run HttpStub in strict mode programmatically in Java

**Why**:

In order to fail fast on the stub where expectations are not already set

**How**:

Adding optional strict parameter with default set to false to both createStub methods

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [ ] Tests
- [ ] Sonar Quality Gate
