### PR TITLE
Validate externalized example responses

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Scenario.kt
@@ -355,8 +355,8 @@ data class Scenario(
                     override fun expectedKeyWasMissing(keyLabel: String, keyName: String): String {
                         return "The $keyLabel $keyName in the specification was missing in example ${row.name}"
                     }
-
-                }
+                },
+                mockMode = true
             )
 
             try {

--- a/core/src/test/kotlin/in/specmatic/core/ScenarioTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/ScenarioTest.kt
@@ -1,0 +1,254 @@
+package `in`.specmatic.core
+
+import com.fasterxml.jackson.annotation.JsonFormat.Value
+import `in`.specmatic.core.pattern.*
+import org.assertj.core.api.Assertions.*
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import java.util.function.Consumer
+
+class ScenarioTest {
+    @Test
+    fun `should validate and reject an invalid response in an example row`() {
+        val scenario = Scenario(
+            "",
+            HttpRequestPattern(
+                method = "POST",
+                body = JSONObjectPattern(
+                    pattern = mapOf(
+                        "id" to NumberPattern()
+                    )
+                )
+            ),
+            HttpResponsePattern(
+                status = 200,
+                body = JSONObjectPattern(
+                    pattern = mapOf(
+                        "id" to NumberPattern()
+                    )
+                )
+            ),
+            emptyMap(),
+            listOf<Examples>(
+                Examples(
+                    listOf("(REQUEST-BODY)"),
+                    listOf(Row(
+                        mapOf("(REQUEST-BODY)" to """{"id": 10}""")
+                    ).copy(responseExample = ResponseSchemaExample(HttpResponse(200, """{"id": "abc123"}"""))))
+                )
+            ),
+            emptyMap(),
+            emptyMap()
+        )
+
+        assertThatThrownBy {
+            scenario.validExamplesOrException(DefaultStrategies)
+        }.satisfies(Consumer {
+            assertThat(it)
+                .hasMessageContaining("abc123")
+                .hasMessageContaining("RESPONSE.BODY.id")
+        })
+    }
+
+    @Test
+    fun `should validate and reject an invalid request in an example row`() {
+        val scenario = Scenario(
+            "",
+            HttpRequestPattern(
+                method = "POST",
+                body = JSONObjectPattern(
+                    pattern = mapOf(
+                        "id" to NumberPattern()
+                    )
+                )
+            ),
+            HttpResponsePattern(
+                status = 200,
+                body = JSONObjectPattern(
+                    pattern = mapOf(
+                        "id" to NumberPattern()
+                    )
+                )
+            ),
+            emptyMap(),
+            listOf<Examples>(
+                Examples(
+                    listOf("(REQUEST-BODY)"),
+                    listOf(Row(
+                        mapOf("(REQUEST-BODY)" to """{"id": "abc123" }""")
+                    ).copy(responseExample = ResponseSchemaExample(HttpResponse(200, """{"id": 10}"""))))
+                )
+            ),
+            emptyMap(),
+            emptyMap()
+        )
+
+        assertThatThrownBy {
+            scenario.validExamplesOrException(DefaultStrategies)
+        }.satisfies(Consumer {
+            assertThat(it)
+                .hasMessageContaining("abc123")
+                .hasMessageContaining("REQUEST.BODY.id")
+        })
+    }
+
+    @Test
+    fun `should validate and accept a response in an example row with pattern specification as value`() {
+        val scenario = Scenario(
+            "",
+            HttpRequestPattern(
+                method = "POST",
+                body = JSONObjectPattern(
+                    pattern = mapOf(
+                        "id" to NumberPattern()
+                    )
+                )
+            ),
+            HttpResponsePattern(
+                status = 200,
+                body = JSONObjectPattern(
+                    pattern = mapOf(
+                        "id" to NumberPattern()
+                    )
+                )
+            ),
+            emptyMap(),
+            listOf<Examples>(
+                Examples(
+                    listOf("(REQUEST-BODY)"),
+                    listOf(Row(
+                        mapOf("(REQUEST-BODY)" to """{"id": 10}""")
+                    ).copy(responseExample = ResponseSchemaExample(HttpResponse(200, """{"id": "(number)"}"""))))
+                )
+            ),
+            emptyMap(),
+            emptyMap()
+        )
+
+        assertThatCode {
+            scenario.validExamplesOrException(DefaultStrategies)
+        }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `should validate and accept a request in an example row  with pattern specification as value`() {
+        val scenario = Scenario(
+            "",
+            HttpRequestPattern(
+                method = "POST",
+                body = JSONObjectPattern(
+                    pattern = mapOf(
+                        "id" to NumberPattern()
+                    )
+                )
+            ),
+            HttpResponsePattern(
+                status = 200,
+                body = JSONObjectPattern(
+                    pattern = mapOf(
+                        "id" to NumberPattern()
+                    )
+                )
+            ),
+            emptyMap(),
+            listOf<Examples>(
+                Examples(
+                    listOf("(REQUEST-BODY)"),
+                    listOf(Row(
+                        mapOf("(REQUEST-BODY)" to """{"id": "(number)" }""")
+                    ).copy(responseExample = ResponseSchemaExample(HttpResponse(200, """{"id": 10}"""))))
+                )
+            ),
+            emptyMap(),
+            emptyMap()
+        )
+
+        assertThatCode {
+            scenario.validExamplesOrException(DefaultStrategies)
+        }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `should validate and reject a response in an example row with a non-matching pattern specification as value`() {
+        val scenario = Scenario(
+            "",
+            HttpRequestPattern(
+                method = "POST",
+                body = JSONObjectPattern(
+                    pattern = mapOf(
+                        "id" to NumberPattern()
+                    )
+                )
+            ),
+            HttpResponsePattern(
+                status = 200,
+                body = JSONObjectPattern(
+                    pattern = mapOf(
+                        "id" to NumberPattern()
+                    )
+                )
+            ),
+            emptyMap(),
+            listOf<Examples>(
+                Examples(
+                    listOf("(REQUEST-BODY)"),
+                    listOf(Row(
+                        mapOf("(REQUEST-BODY)" to """{"id": 10}""")
+                    ).copy(responseExample = ResponseSchemaExample(HttpResponse(200, """{"id": "(string)"}"""))))
+                )
+            ),
+            emptyMap(),
+            emptyMap()
+        )
+
+        assertThatCode {
+            scenario.validExamplesOrException(DefaultStrategies)
+        }.satisfies(Consumer {
+            assertThat(it)
+                .hasMessageContaining("string")
+                .hasMessageContaining("RESPONSE.BODY.id")
+        })
+    }
+
+    @Test
+    fun `should validate and accept a request in an example row  with a non-matching pattern specification as value`() {
+        val scenario = Scenario(
+            "",
+            HttpRequestPattern(
+                method = "POST",
+                body = JSONObjectPattern(
+                    pattern = mapOf(
+                        "id" to NumberPattern()
+                    )
+                )
+            ),
+            HttpResponsePattern(
+                status = 200,
+                body = JSONObjectPattern(
+                    pattern = mapOf(
+                        "id" to NumberPattern()
+                    )
+                )
+            ),
+            emptyMap(),
+            listOf<Examples>(
+                Examples(
+                    listOf("(REQUEST-BODY)"),
+                    listOf(Row(
+                        mapOf("(REQUEST-BODY)" to """{"id": "(string)" }""")
+                    ).copy(responseExample = ResponseSchemaExample(HttpResponse(200, """{"id": 10}"""))))
+                )
+            ),
+            emptyMap(),
+            emptyMap()
+        )
+
+        assertThatThrownBy {
+            scenario.validExamplesOrException(DefaultStrategies)
+        }.satisfies(Consumer {
+            assertThat(it)
+                .hasMessageContaining("string")
+                .hasMessageContaining("REQUEST.BODY.id")
+        })
+    }
+}

--- a/core/src/test/resources/openapi/mandatory_and_omitted_optional_query_params_examples/stub.json
+++ b/core/src/test/resources/openapi/mandatory_and_omitted_optional_query_params_examples/stub.json
@@ -8,8 +8,6 @@
   },
   "http-response": {
     "status": 200,
-    "body": {
-      "id": 10
-    }
+    "body": "success"
   }
 }


### PR DESCRIPTION
**What**:

When running tests, match responses of externalised examples against the spec, and if any response does not conform to the spec, print an error and exit without running any tests.

**Why**:

An example of a request or response must match the spec. If it does not match the spec, it is not truly an example.

With this PR, Specmatic will matches externalised response examples, which in test mode were previously not done.

**How**:

* Modified class ExampleFromFile to load the response
* Modified class Scenario to validate it

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate
