### PR TITLE
Run both inline and external examples as test

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Scenario.kt
@@ -538,7 +538,7 @@ data class Scenario(
             listOf(Examples(columns, rowsWithPathData))
         }.flatten()
 
-        return this.copy(examples = newExamples)
+        return this.copy(examples = this.examples + newExamples)
     }
 
     private fun matchingRows(externalisedJSONExamples: Map<OpenApiSpecification.OperationIdentifier, List<Row>>) =

--- a/core/src/test/resources/openapi/has_inline_and_external_examples.yaml
+++ b/core/src/test/resources/openapi/has_inline_and_external_examples.yaml
@@ -1,0 +1,42 @@
+openapi: 3.0.3
+info:
+  title: Person API
+  description: API for retrieving person details
+  version: 1.0.0
+paths:
+  /person/{id}:
+    get:
+      summary: Get person details by ID
+      description: Retrieves the details of a person based on their unique identifier
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Unique identifier of the person
+          schema:
+            type: integer
+          examples:
+            johnDoe:
+              summary: Example ID for John Doe
+              value: 123
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  name:
+                    type: string
+                required:
+                  - id
+                  - name
+              examples:
+                johnDoe:
+                  summary: Example response for John Doe
+                  value:
+                    id: 123
+                    name: John Doe

--- a/core/src/test/resources/openapi/has_inline_and_external_examples_examples/details.json
+++ b/core/src/test/resources/openapi/has_inline_and_external_examples_examples/details.json
@@ -1,0 +1,13 @@
+{
+  "http-request": {
+    "method": "GET",
+    "path": "/person/456"
+  },
+  "http-response": {
+    "status": 200,
+    "body": {
+      "id": 456,
+      "name": "Alice Johnson"
+    }
+  }
+}


### PR DESCRIPTION
**What**:

External examples should not replace internal examples when running tests, both should run as tests.

**Why**:

Any example, whether inline or external, should be a valid example.

Validity may be determined based on on whether the example matches the spec (validated already by Specmatic), and whether the application can accept the request from the example and return a matching response. To ascertain the latter, both inline both external examples are run as contract tests.

**How**:

This PR modifies the Scenario.useExamples method to add externalised examples to the list that already contains inline examples, rather than replacing the inline examples in the list with the externalised ones.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate
