### PR TITLE
Fix for case in which the example does not contain a response content-type

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/HttpResponsePattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpResponsePattern.kt
@@ -144,14 +144,19 @@ data class HttpResponsePattern(
         return Result.fromResults(listOf(headerResult, bodyResult)).breadCrumb("RESPONSE")
     }
 
-    companion object {
-        fun fromResponseExpectation(response: HttpResponse): HttpResponsePattern {
-            return HttpResponsePattern(
-                HttpHeadersPattern(response.headers.mapValues { stringToPattern(it.value, it.key) }),
-                response.status,
-                response.body.exactMatchElseType()
-            )
-        }
+    fun fromResponseExpectation(response: HttpResponse): HttpResponsePattern {
+        val responseHeaders = response.headers.mapValues { stringToPattern(it.value, it.key) }
+
+        val contentTypeHeader = if("content-type" !in responseHeaders.keys.map { it.lowercase() } && headersPattern.contentType != null)
+            mapOf("Content-Type" to ExactValuePattern(StringValue(headersPattern.contentType)))
+        else
+            emptyMap()
+
+        return HttpResponsePattern(
+            HttpHeadersPattern(responseHeaders + contentTypeHeader),
+            response.status,
+            response.body.exactMatchElseType()
+        )
     }
 }
 

--- a/core/src/main/kotlin/in/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Scenario.kt
@@ -493,7 +493,7 @@ data class Scenario(
         scenarioBreadCrumb(this) {
             attempt(breadCrumb = "RESPONSE") {
                 val resolver = Resolver(expectedFacts, false, patterns)
-                Pair(resolver, HttpResponsePattern.fromResponseExpectation(response).generateResponse(resolver))
+                Pair(resolver, httpResponsePattern.fromResponseExpectation(response).generateResponse(resolver))
             }
         }
 

--- a/core/src/main/kotlin/in/specmatic/stub/api.kt
+++ b/core/src/main/kotlin/in/specmatic/stub/api.kt
@@ -116,10 +116,10 @@ internal fun createStub(
     )
 }
 
-internal fun createStub(host: String = "localhost", port: Int = 9000, timeoutMillis: Long, strict: Boolean = false): ContractStub {
+internal fun createStub(host: String = "localhost", port: Int = 9000, timeoutMillis: Long, strict: Boolean = false, givenConfigFileName: String? = null): ContractStub {
     val workingDirectory = WorkingDirectory()
     // TODO - see if these two can be extracted out.
-    val configFileName = getConfigFileName()
+    val configFileName = givenConfigFileName ?: getConfigFileName()
     exitIfDoesNotExist("config file", configFileName)
 
     val stubs = loadContractStubsFromImplicitPaths(contractStubPaths(configFileName))

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -8022,6 +8022,29 @@ paths:
             .contains("WARNING: Ignoring request example named $exampleName for test or stub data, because no associated response example named $exampleName was found.")
     }
 
+    @Test
+    fun `when a header is missing in an expectation the header from the spec should be used`() {
+        val defaultSpecmaticConfig = Configuration.globalConfigFileName
+
+        try {
+            Configuration.globalConfigFileName = "src/test/resources/openapi/response_expectation_missing_content_type/specmatic.yaml"
+
+            createStub("localhost", 9000, 1000, false, "src/test/resources/openapi/response_expectation_missing_content_type/specmatic.yaml").use { stub ->
+                val response = stub.client.execute(
+                    HttpRequest("POST", "/person", body = StringValue("hello"))
+                )
+
+                val responseContentType = response.headers["Content-Type"]
+
+                assertThat(responseContentType).isEqualTo("text/something_else")
+
+                assertThat(response.body.toStringLiteral()).isEqualTo("world")
+            }
+        } finally {
+            Configuration.globalConfigFileName = defaultSpecmaticConfig
+        }
+    }
+
     private fun ignoreButLogException(function: () -> OpenApiSpecification) {
         try {
             function()

--- a/core/src/test/resources/openapi/response_expectation_missing_content_type/response_expectation_missing_content_type.yaml
+++ b/core/src/test/resources/openapi/response_expectation_missing_content_type/response_expectation_missing_content_type.yaml
@@ -1,0 +1,20 @@
+  openapi: "3.0.1"
+  info:
+    title: "Person API"
+    version: "1"
+  paths:
+    /person:
+      post:
+        summary: "Get person by id"
+        requestBody:
+          content:
+            text/plain:
+              schema:
+                type: string
+        responses:
+          200:
+            description: "Get person by id"
+            content:
+              text/something_else:
+                schema:
+                  type: string

--- a/core/src/test/resources/openapi/response_expectation_missing_content_type/response_expectation_missing_content_type_examples/get_details.json
+++ b/core/src/test/resources/openapi/response_expectation_missing_content_type/response_expectation_missing_content_type_examples/get_details.json
@@ -1,0 +1,11 @@
+{
+  "http-request": {
+    "method": "POST",
+    "path": "/person",
+    "body": "hello"
+  },
+  "http-response": {
+    "status": 200,
+    "body": "world"
+  }
+}

--- a/core/src/test/resources/openapi/response_expectation_missing_content_type/specmatic.yaml
+++ b/core/src/test/resources/openapi/response_expectation_missing_content_type/specmatic.yaml
@@ -1,0 +1,4 @@
+sources:
+  - provider: filesystem
+    stub:
+      - src/test/resources/openapi/response_expectation_missing_content_type/response_expectation_missing_content_type.yaml


### PR DESCRIPTION
**What**:

When a response content type is not provided in the expectation, Specamtic currently infers the response body data type rather than using the Content-Type from the spec.

Note that if the header is provided, is being validated as per the spec. However if it is not, it was being inferred.

**Why**:

OpenAPI always provides a content type, so there is never any reason to infer it, and a Content-Type should always be provided in the examples.

However, to support older functionality, if any externalised example is missing a Content-Type header,  the media type of the first response in the spec will be used.

**How**:

- Scenario.resolverAndResponseForExpectation now uses the httpResponsePattern.fromResponseExpectation (object method) to generated a response. Previously it was HttpResponsePattern.fromResponseExpectation, where fromResponseExpectation was in the companion object.
- HttpResponsePattern.fromResponseExpectation has become an instance method, and adds the media type to the response object if an example is missing the Content-Type header.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate
