### PR TITLE
Updated the test generation logic for StringPattern to take minLength and maxLength into account

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/pattern/StringPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/StringPattern.kt
@@ -93,11 +93,34 @@ data class StringPattern (
 
         return StringValue(randomString(randomStringLength))
     }
-    override fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
+    override fun newBasedOn(row: Row, resolver: Resolver): Sequence<Pattern> {
+        val minLengthExample = minLength?.let {
+            ExactValuePattern(StringValue(randomString(it)))
+        }
+
+        val withinRangeExample = this
+
+        val maxLengthExample = minLength?.let {
+            ExactValuePattern(StringValue(randomString(it)))
+        }
+
+        return sequenceOf(minLengthExample, withinRangeExample, maxLengthExample).filterNotNull()
+    }
+
     override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
 
     override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
-        return scalarAnnotation(this, sequenceOf(NullPattern, NumberPattern(), BooleanPattern()))
+        val current = this
+
+        return sequence {
+            yieldAll(scalarAnnotation(current, sequenceOf(NullPattern, NumberPattern(), BooleanPattern())))
+
+            if(minLength != null)
+                yield(HasValue(ExactValuePattern(StringValue(randomString(minLength - 1)))))
+
+            if(maxLength != null)
+                yield(HasValue(ExactValuePattern(StringValue(randomString(maxLength + 1)))))
+        }
     }
 
     override fun parse(value: String, resolver: Resolver): Value = StringValue(value)

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiKtTest.kt
@@ -1323,7 +1323,7 @@ Background:
         assertThat(flags["/pets/0 GET executed"]).isEqualTo(1)
         assertThat(flags.keys.filter { it.matches(Regex("""/pets/\d+ GET executed""")) }.size).isEqualTo(2)
         assertThat(flags.keys.any { it.matches(Regex("""/pets/\d+ DELETE executed""")) }).isNotNull
-        assertThat(flags.filter {(path, _) -> path.matches(Regex("""/pets/\d+ PATCH executed""")) }.values.sum()).isEqualTo(7)
+        assertThat(flags.filter {(path, _) -> path.matches(Regex("""/pets/\d+ PATCH executed""")) }.values.sum()).isEqualTo(21)
         assertTrue(results.success(), results.report())
     }
 

--- a/core/src/test/kotlin/in/specmatic/core/pattern/StringPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/StringPatternTest.kt
@@ -8,6 +8,7 @@ import `in`.specmatic.core.value.StringValue
 import `in`.specmatic.shouldNotMatch
 import org.apache.commons.lang3.RandomStringUtils
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Condition
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -142,7 +143,41 @@ internal class StringPatternTest {
     }
 
     @Test
+    @Tag(GENERATION)
+    fun `positive values for lengths should be generated when lengths are provided`() {
+        val minLength = 10
+        val maxLength = 20
+
+        val result = StringPattern(minLength = minLength, maxLength = maxLength).newBasedOn(Row(), Resolver()).toList()
+
+        val randomlyGeneratedStrings = result.filterIsInstance<ExactValuePattern>().map { it.pattern.toString() }
+
+        assertThat(randomlyGeneratedStrings.filter { it.length == minLength}).hasSize(1)
+        assertThat(randomlyGeneratedStrings.filter { it.length == maxLength}).hasSize(1)
+    }
+
+    @Test
+    @Tag(GENERATION)
+    fun `negative values for lengths should be generated when lengths are provided`() {
+        val minLength = 10
+        val maxLength = 20
+
+        val result = StringPattern(minLength = minLength, maxLength = maxLength).negativeBasedOn(Row(), Resolver()).map { it.value }.toList()
+        assertThat(result.map { it.typeName }).contains(
+            "null",
+            "number",
+            "boolean",
+        )
+
+        val randomlyGeneratedStrings = result.filterIsInstance<ExactValuePattern>().map { it.pattern.toString() }
+
+        assertThat(randomlyGeneratedStrings.filter { it.length == minLength - 1 }).hasSize(1)
+        assertThat(randomlyGeneratedStrings.filter { it.length == maxLength + 1 }).hasSize(1)
+    }
+
+    @Test
     fun `string pattern encompasses email`() {
         assertThat(StringPattern().encompasses(EmailPattern(), Resolver(), Resolver())).isInstanceOf(Result.Success::class.java)
     }
+
 }

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=1.3.35
+version=1.3.36


### PR DESCRIPTION
**What**:

When minLength and maxLength are provided, there should be 2 additional positive and negative tests generated.

Say minLength is 10, and maxLength is 20.

A positive test with the minimum length of 10 and another with a maximum length of 20 should be generated.

Similarly, a negative test of minimum length 9 (minimum - 1) and another of maximum length 21 (maximum + 1) should be generated.

**Why**:

When the limits are provided, we should ensure that values within the limits, including those at the limits are honoured by the application, and that values that breach the limits are rejected by the application.

**How**:

- Modified StringPattern.newBasedOn to add the positive tests, and StringPattern.negativeBasedOn to add the negative tests.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

