### PR TITLE
Ensure that NumberPattern generates a 3 digit number

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/pattern/NumberPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/NumberPattern.kt
@@ -74,8 +74,13 @@ data class NumberPattern(
     }
 
     override fun generate(resolver: Resolver): Value {
-        if (minAndMaxValuesNotSet())
-            return resolver.resolveExample(example, this) ?: NumberValue(randomNumber(3))
+        if (minAndMaxValuesNotSet()) {
+            val length =
+                if(minLength > 3) minLength
+                else if(maxLength < 3) maxLength
+                else 3
+            return resolver.resolveExample(example, this) ?: NumberValue(randomNumber(length))
+        }
 
         val min = if (minimum == LOWEST_DECIMAL) {
             if (maximum < smallestIncValue)

--- a/core/src/main/kotlin/in/specmatic/core/pattern/NumberPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/NumberPattern.kt
@@ -75,7 +75,7 @@ data class NumberPattern(
 
     override fun generate(resolver: Resolver): Value {
         if (minAndMaxValuesNotSet())
-            return resolver.resolveExample(example, this) ?: NumberValue(randomNumber(minLength))
+            return resolver.resolveExample(example, this) ?: NumberValue(randomNumber(3))
 
         val min = if (minimum == LOWEST_DECIMAL) {
             if (maximum < smallestIncValue)

--- a/core/src/test/kotlin/in/specmatic/core/pattern/NumberPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/NumberPatternTest.kt
@@ -123,14 +123,35 @@ internal class NumberPatternTest {
 
     @Test
     fun `should generate 1 digit long random number when min and max length are not specified`() {
-        assertThat(NumberPattern().generate(Resolver()).toStringLiteral().length).isEqualTo(1)
+        assertThat(NumberPattern().generate(Resolver()).toStringLiteral().length).isEqualTo(3)
     }
 
     @Test
-    fun `should generate random number when minLength`() {
+    fun `should generate random number of minLength length when minLength is greater than 3`() {
         assertThat(
             NumberPattern(minLength = 8, maxLength = 12).generate(Resolver()).toStringLiteral().length
         ).isEqualTo(8)
+    }
+
+    @Test
+    fun `should generate random number of maxLength length when maxLength is less than 3`() {
+        assertThat(
+            NumberPattern(minLength = 1, maxLength = 2).generate(Resolver()).toStringLiteral().length
+        ).isEqualTo(2)
+    }
+
+    @Test
+    fun `should generate random number of length 3 when minLength is less than 3 is less than maxLength`() {
+        assertThat(
+            NumberPattern(minLength = 1, maxLength = 5).generate(Resolver()).toStringLiteral().length
+        ).isEqualTo(3)
+    }
+
+    @Test
+    fun `should generate random number of length 3 when minLength and maxLength are both equal to 3`() {
+        assertThat(
+            NumberPattern(minLength = 3, maxLength = 3).generate(Resolver()).toStringLiteral().length
+        ).isEqualTo(3)
     }
 
     @Test

--- a/core/src/test/kotlin/in/specmatic/core/pattern/NumberPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/NumberPatternTest.kt
@@ -278,4 +278,10 @@ internal class NumberPatternTest {
             ExactValuePattern(NumberValue(BigDecimal(20) + NumberPattern.BIG_DECIMAL_INC))
         )
     }
+
+    @Test
+    fun `NumberPattern with no constraints must generate a 3 digit number to ensure that Spring Boot is not able to convert it into an enum`() {
+        val number = NumberPattern().generate(Resolver()).toStringLiteral()
+        assertThat(number).hasSize(3)
+    }
 }

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=1.3.35
+version=1.3.36


### PR DESCRIPTION
**What**:

When no keywords are used (minimum or maximum), NumberPattern.generate will now generate 3-digit number values.

**Why**:

Spring Boot is able to convert numbers into enums.

Let's say there's an enum like this:

```yaml
type: string
enum:
  - junior
  - senior
  - manager
```

The negative values generated for this will be null, a boolean, and a single digit number (minLength is usually 1). If the single digit number happens to be 0, 1 or 2, it will be converted by Spring to junior, senior or manager respectively.

To avoid this behaviour, we send a 3-digit number. Thereby, Spring fails to convert it, and if validations are in place, a 400 error is returned.

The length is adjust appropriately if minLength andmaxLength are specified.

```kotlin
if(minLength > 3) minLength
else if(maxLength < 3) maxLength
else 3
```

**How**:

- Modified NumberPattern.generate to generate a number of the right length if neither maximum nor minimum keywords have been used. This works because for a number with no constraints, any number generated by NumberPattern as a positive test is acceptable, and if used as a negative test for an enum, a number with more than 1 (ideally 3) digits is high enough that it would prevent Spring from converting it to an enum. Most enums won't have that many values.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

