### PR TITLE
Enable generation of double value when isDoubleFormat is true and min and max are not set

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/pattern/NumberPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/NumberPattern.kt
@@ -19,7 +19,7 @@ data class NumberPattern(
     val maximum: BigDecimal = HIGHEST_DECIMAL,
     val exclusiveMaximum: Boolean = false,
     override val example: String? = null,
-    val isDoubleFormat: Boolean = true
+    val isDoubleFormat: Boolean = false
 ) : Pattern, ScalarType, HasDefaultExample {
 
   companion object {
@@ -79,11 +79,15 @@ data class NumberPattern(
 
     override fun generate(resolver: Resolver): Value {
         if (minAndMaxValuesNotSet()) {
-            val length =
-                if(minLength > 3) minLength
-                else if(maxLength < 3) maxLength
-                else 3
-            return resolver.resolveExample(example, this) ?: NumberValue(randomNumber(length))
+            val exampleValue = resolver.resolveExample(example, this)
+            if (exampleValue != null) return exampleValue
+            val length = when {
+                minLength > 3 -> minLength
+                maxLength < 3 -> maxLength
+                else -> 3
+            }
+            if (isDoubleFormat) return NumberValue(randomNumber(length).toDouble())
+            return NumberValue(randomNumber(length))
         }
 
         val min = if (minimum == LOWEST_DECIMAL) {

--- a/core/src/test/kotlin/in/specmatic/core/pattern/NumberPatternTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/NumberPatternTest.kt
@@ -123,7 +123,14 @@ internal class NumberPatternTest {
 
     @Test
     fun `should generate 1 digit long random number when min and max length are not specified`() {
-        assertThat(NumberPattern().generate(Resolver()).toStringLiteral().length).isEqualTo(3)
+        assertThat(NumberPattern(isDoubleFormat = false).generate(Resolver()).toStringLiteral().length).isEqualTo(3)
+    }
+
+    @Test
+    fun `should generate a random double number when min and max length are not specified`() {
+        val numberValue = NumberPattern(isDoubleFormat = true).generate(Resolver()) as NumberValue
+
+        assertThat((numberValue.number is Double)).isTrue()
     }
 
     @Test
@@ -190,7 +197,7 @@ internal class NumberPatternTest {
 
     @Test
     fun `should generate a number greater than minimum and maximum when are set and exclusive keywords are both true`() {
-        val generatedValues = (0..5).map { NumberPattern(minimum = BigDecimal(5.0), exclusiveMinimum = true, maximum = BigDecimal(10.0), exclusiveMaximum = true).generate(Resolver()) }
+        val generatedValues = (0..5).map { NumberPattern(minimum = BigDecimal(5.0), exclusiveMinimum = true, maximum = BigDecimal(10.0), exclusiveMaximum = true, isDoubleFormat = true).generate(Resolver()) }
         assertThat(generatedValues).allSatisfy {
             it as NumberValue
             assertThat(it.number.toDouble()).isGreaterThan(5.0)
@@ -288,7 +295,7 @@ internal class NumberPatternTest {
     @Tag(GENERATION)
     fun `negative values generated should include a value greater than minimum and maximum keyword values`() {
         val result =
-            NumberPattern(minimum = BigDecimal(10.0), maximum = BigDecimal(20.0)).negativeBasedOn(Row(), Resolver())
+            NumberPattern(minimum = BigDecimal(10.0), maximum = BigDecimal(20.0), isDoubleFormat = true).negativeBasedOn(Row(), Resolver())
                 .map { it.value }.toList()
 
         assertThat(result).containsExactlyInAnyOrder(
@@ -302,7 +309,7 @@ internal class NumberPatternTest {
 
     @Test
     fun `NumberPattern with no constraints must generate a 3 digit number to ensure that Spring Boot is not able to convert it into an enum`() {
-        val number = NumberPattern().generate(Resolver()).toStringLiteral()
+        val number = NumberPattern(isDoubleFormat = false).generate(Resolver()).toStringLiteral()
         assertThat(number).hasSize(3)
     }
 }


### PR DESCRIPTION
**What**:
NumberPattern was not generating a double value when min and max were not set even though isDoubleFormat is true.

**Why**:
It was a missing scenario.

**How**:
Fixed it by explicitly adding a check for isDoubleFormat in NumberPattern's generate method.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->


<!-- feel free to add additional comments -->
