### PR TITLE
Set local branch for backwardCompatibilityCheck

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/git/SystemGit.kt
+++ b/core/src/main/kotlin/in/specmatic/core/git/SystemGit.kt
@@ -157,6 +157,10 @@ class SystemGit(override val workingDirectory: String = ".", private val prefix:
     }
 
     override fun defaultBranch(): String {
+        System.getenv("LOCAL_GIT_BRANCH")?.let {
+            return it
+        }
+
         val defaultBranchName = System.getenv("GITHUB_BASE_REF") ?: defaultBranchFromGit()
         return "origin/${defaultBranchName}"
     }


### PR DESCRIPTION
**What**:

Use the environment variable LOCAL_GIT_BRANCH to set the default branch locally for debugging

**Why**:

It's an aid to debugging. This way we can set the local branch when we need to quickly test locally.

**How**:

Modification to SystemGit

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate
