### PR TITLE
Revert invalid contract path check

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/utilities/Utilities.kt
+++ b/core/src/main/kotlin/in/specmatic/core/utilities/Utilities.kt
@@ -343,15 +343,6 @@ fun examplesDirFor(openApiFilePath: String, alternateSuffix: String): File {
         getExamplesDir(openApiFilePath, alternateSuffix)
 }
 
-fun checkIfContractPathsAreValid(contractPaths: List<String>) {
-    val validContractPaths = contractPaths.filter { path ->
-        File(path).extension in CONTRACT_EXTENSIONS
-    }
-    if (validContractPaths.isEmpty()) {
-        throw ContractException("No valid specification file found at given paths : ${contractPaths.joinToString(", ")}")
-    }
-}
-
 private fun getExamplesDir(openApiFilePath: String, suffix: String): File =
     File(openApiFilePath).canonicalFile.let {
         it.parentFile.resolve("${it.parent}/${it.nameWithoutExtension}$suffix")

--- a/core/src/main/kotlin/in/specmatic/stub/api.kt
+++ b/core/src/main/kotlin/in/specmatic/stub/api.kt
@@ -6,7 +6,6 @@ import `in`.specmatic.core.git.SystemGit
 import `in`.specmatic.core.log.StringLog
 import `in`.specmatic.core.log.consoleLog
 import `in`.specmatic.core.log.logger
-import `in`.specmatic.core.pattern.ContractException
 import `in`.specmatic.core.utilities.ContractPathData
 import `in`.specmatic.core.utilities.contractStubPaths
 import `in`.specmatic.core.utilities.examplesDirFor
@@ -71,13 +70,6 @@ fun createStubFromContracts(
     host: String = "localhost",
     port: Int = 9000
 ): ContractStub {
-    val validContractPaths = contractPaths.filter { path ->
-        File(path).extension in CONTRACT_EXTENSIONS
-    }
-    if (validContractPaths.isEmpty()) {
-        throw ContractException("No valid specification file found at given paths : $contractPaths")
-    }
-
     return createStubFromContracts(
         contractPaths,
         dataDirPaths,
@@ -89,13 +81,6 @@ fun createStubFromContracts(
 
 // Used by stub client code
 fun createStubFromContracts(contractPaths: List<String>, host: String = "localhost", port: Int = 9000): ContractStub {
-    val validContractPaths = contractPaths.filter { path ->
-        File(path).extension in CONTRACT_EXTENSIONS
-    }
-    if (validContractPaths.isEmpty()) {
-        throw ContractException("No valid specification file found at given paths : $contractPaths")
-    }
-
     return createStubFromContracts(
         contractPaths,
         host,

--- a/core/src/main/kotlin/in/specmatic/stub/api.kt
+++ b/core/src/main/kotlin/in/specmatic/stub/api.kt
@@ -6,7 +6,11 @@ import `in`.specmatic.core.git.SystemGit
 import `in`.specmatic.core.log.StringLog
 import `in`.specmatic.core.log.consoleLog
 import `in`.specmatic.core.log.logger
-import `in`.specmatic.core.utilities.*
+import `in`.specmatic.core.pattern.ContractException
+import `in`.specmatic.core.utilities.ContractPathData
+import `in`.specmatic.core.utilities.contractStubPaths
+import `in`.specmatic.core.utilities.examplesDirFor
+import `in`.specmatic.core.utilities.exitIfDoesNotExist
 import `in`.specmatic.core.value.StringValue
 import `in`.specmatic.mock.NoMatchingScenario
 import `in`.specmatic.mock.ScenarioStub
@@ -67,7 +71,12 @@ fun createStubFromContracts(
     host: String = "localhost",
     port: Int = 9000
 ): ContractStub {
-    checkIfContractPathsAreValid(contractPaths)
+    val validContractPaths = contractPaths.filter { path ->
+        File(path).extension in CONTRACT_EXTENSIONS
+    }
+    if (validContractPaths.isEmpty()) {
+        throw ContractException("No valid specification file found at given paths : $contractPaths")
+    }
 
     return createStubFromContracts(
         contractPaths,
@@ -80,7 +89,12 @@ fun createStubFromContracts(
 
 // Used by stub client code
 fun createStubFromContracts(contractPaths: List<String>, host: String = "localhost", port: Int = 9000): ContractStub {
-    checkIfContractPathsAreValid(contractPaths)
+    val validContractPaths = contractPaths.filter { path ->
+        File(path).extension in CONTRACT_EXTENSIONS
+    }
+    if (validContractPaths.isEmpty()) {
+        throw ContractException("No valid specification file found at given paths : $contractPaths")
+    }
 
     return createStubFromContracts(
         contractPaths,

--- a/core/src/test/kotlin/utilities/UtilitiesTest.kt
+++ b/core/src/test/kotlin/utilities/UtilitiesTest.kt
@@ -8,7 +8,6 @@ import `in`.specmatic.core.git.GitCommand
 import `in`.specmatic.core.git.SystemGit
 import `in`.specmatic.core.git.checkout
 import `in`.specmatic.core.git.clone
-import `in`.specmatic.core.pattern.ContractException
 import `in`.specmatic.core.pattern.parsedJSON
 import `in`.specmatic.core.pattern.parsedJSONObject
 import `in`.specmatic.core.utilities.*
@@ -23,7 +22,10 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.mockk.*
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.*
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 import java.io.File
 import java.net.ServerSocket
 
@@ -530,29 +532,6 @@ internal class UtilitiesTest {
         } finally {
             specDir.deleteRecursively()
             specmaticJSON.delete()
-        }
-    }
-
-    @Nested
-    inner class CheckIfContractPathsAreValidTests {
-        @Test
-        fun `should not throw an exception if the contract paths are valid`() {
-            val contractPaths = listOf("first.yaml", "second.yml", "third.json")
-
-            assertDoesNotThrow {
-                checkIfContractPathsAreValid(contractPaths)
-            }
-        }
-
-        @Test
-        fun `should throw an exception if none of the contract paths is valid`() {
-            val contractPaths = listOf("first.random", "second.random", "third.random")
-
-            val e = assertThrows<ContractException> {
-                checkIfContractPathsAreValid(contractPaths)
-            }
-
-            assertThat(e.errorMessage == "No valid specification file found at given paths: first.random, second.random, third.random")
         }
     }
 

--- a/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
@@ -186,15 +186,7 @@ open class SpecmaticJUnitSupport {
         if(!mbs.isRegistered(name))
             mbs.registerMBean(statistics, name)
 
-        val contractPaths = System.getProperty(CONTRACT_PATHS)?.let { paths ->
-            paths.split(",").filter { path ->
-                File(path).extension in CONTRACT_EXTENSIONS
-            }
-        }
-        if(contractPaths != null && contractPaths.isEmpty()) {
-            throw ContractException("No valid specification file found at given paths : ${System.getProperty(CONTRACT_PATHS)}")
-        }
-
+        val contractPaths = System.getProperty(CONTRACT_PATHS)
         val givenWorkingDirectory = System.getProperty(WORKING_DIRECTORY)
         val filterName: String? = System.getProperty(FILTER_NAME_PROPERTY) ?: System.getenv(FILTER_NAME_ENVIRONMENT_VARIABLE)
         val filterNotName: String? = System.getProperty(FILTER_NOT_NAME_PROPERTY) ?: System.getenv(FILTER_NOT_NAME_ENVIRONMENT_VARIABLE)
@@ -214,8 +206,10 @@ open class SpecmaticJUnitSupport {
         }
         val testScenarios = try {
             val (testScenarios, allEndpoints) = when {
-                (contractPaths != null) -> {
-                    val testScenariosAndEndpointsPairList = contractPaths.map {
+                contractPaths != null -> {
+                    val testScenariosAndEndpointsPairList = contractPaths.split(",").filter {
+                        File(it).extension in CONTRACT_EXTENSIONS
+                    }.map {
                         loadTestScenarios(
                             it,
                             suggestionsPath,

--- a/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/in/specmatic/test/SpecmaticJUnitSupport.kt
@@ -186,8 +186,14 @@ open class SpecmaticJUnitSupport {
         if(!mbs.isRegistered(name))
             mbs.registerMBean(statistics, name)
 
-        val contractPaths = System.getProperty(CONTRACT_PATHS)?.split(",").orEmpty()
-        checkIfContractPathsAreValid(contractPaths)
+        val contractPaths = System.getProperty(CONTRACT_PATHS)?.let { paths ->
+            paths.split(",").filter { path ->
+                File(path).extension in CONTRACT_EXTENSIONS
+            }
+        }
+        if(contractPaths != null && contractPaths.isEmpty()) {
+            throw ContractException("No valid specification file found at given paths : ${System.getProperty(CONTRACT_PATHS)}")
+        }
 
         val givenWorkingDirectory = System.getProperty(WORKING_DIRECTORY)
         val filterName: String? = System.getProperty(FILTER_NAME_PROPERTY) ?: System.getenv(FILTER_NAME_ENVIRONMENT_VARIABLE)

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=1.3.36
+version=1.3.37


### PR DESCRIPTION
**What**:
Revert the check where we were throwing an exception if all contract paths are invalid.

**Why**:
This change has some bug which needs some investigation to resolve.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate
- [x] Tested against sample projects

<!-- Kindly link the issue that this PR will be addressing -->


<!-- feel free to add additional comments -->
