### PR TITLE
Enable negativeBasedOn to generate negatives based on the config passed.

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/HttpPathPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpPathPattern.kt
@@ -157,7 +157,10 @@ data class HttpPathPattern(
     private fun negatively(patterns: List<URLPathSegmentPattern>, row: Row, resolver: Resolver): Sequence<ReturnValue<List<URLPathSegmentPattern>>> {
         val current = patterns.firstOrNull() ?: return emptySequence()
 
-        val negativesOfCurrent: Sequence<ReturnValue<List<URLPathSegmentPattern>>> = current.negativeBasedOn(row, resolver).map { negative ->
+        val negativesOfCurrent: Sequence<ReturnValue<List<URLPathSegmentPattern>>> = current.negativeBasedOn(
+            row,
+            resolver
+        ).map { negative ->
             listOf(negative) + positively(patterns.drop(1), row, resolver).map { HasValue(it) }
         }.sequenceListFold().map { it.ifValue { it.filterIsInstance<URLPathSegmentPattern>() } }
 

--- a/core/src/main/kotlin/in/specmatic/core/NoBodyPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/NoBodyPattern.kt
@@ -1,9 +1,10 @@
 package `in`.specmatic.core
 
+import `in`.specmatic.core.pattern.*
+import `in`.specmatic.core.pattern.config.NegativePatternConfiguration
 import `in`.specmatic.core.value.JSONArrayValue
 import `in`.specmatic.core.value.StringValue
 import `in`.specmatic.core.value.Value
-import `in`.specmatic.core.pattern.*
 
 object NoBodyPattern : Pattern {
     override fun matches(sampleData: Value?, resolver: Resolver): Result {
@@ -22,7 +23,7 @@ object NoBodyPattern : Pattern {
 
     override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> = emptySequence()
+    override fun negativeBasedOn(row: Row, resolver: Resolver, config: NegativePatternConfiguration): Sequence<ReturnValue<Pattern>> = emptySequence()
 
     override fun parse(value: String, resolver: Resolver): Value {
         return if(value.isBlank())

--- a/core/src/main/kotlin/in/specmatic/core/URLPathSegmentPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/URLPathSegmentPattern.kt
@@ -1,6 +1,7 @@
 package `in`.specmatic.core
 
 import `in`.specmatic.core.pattern.*
+import `in`.specmatic.core.pattern.config.NegativePatternConfiguration
 import `in`.specmatic.core.value.JSONArrayValue
 import `in`.specmatic.core.value.NullValue
 import `in`.specmatic.core.value.StringValue
@@ -32,7 +33,7 @@ data class URLPathSegmentPattern(override val pattern: Pattern, override val key
             pattern.newBasedOn(cyclePreventedResolver).map { URLPathSegmentPattern(it, key) }
         }
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver, config: NegativePatternConfiguration): Sequence<ReturnValue<Pattern>> {
         if(pattern is ExactValuePattern)
             return emptySequence()
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/AllNegativePatterns.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/AllNegativePatterns.kt
@@ -1,17 +1,23 @@
 package `in`.specmatic.core.pattern
 
 import `in`.specmatic.core.Resolver
+import `in`.specmatic.core.pattern.config.NegativePatternConfiguration
 
 class AllNegativePatterns : NegativePatternsTemplate() {
 
     override fun getNegativePatterns(
         patternMap: Map<String, Pattern>,
         resolver: Resolver,
-        row: Row
+        row: Row,
+        config: NegativePatternConfiguration
     ): Map<String, Sequence<ReturnValue<Pattern>>> {
         return patternMap.mapValues { (key, pattern) ->
             val resolvedPattern = resolvedHop(pattern, resolver)
-            resolvedPattern.negativeBasedOn(row.stepDownOneLevelInJSONHierarchy(withoutOptionality(key)), resolver)
+            resolvedPattern.negativeBasedOn(
+                row.stepDownOneLevelInJSONHierarchy(withoutOptionality(key)),
+                resolver,
+                config
+            )
         }
     }
 }

--- a/core/src/main/kotlin/in/specmatic/core/pattern/AnyPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/AnyPattern.kt
@@ -4,6 +4,7 @@ import `in`.specmatic.core.MismatchMessages
 import `in`.specmatic.core.Resolver
 import `in`.specmatic.core.Result
 import `in`.specmatic.core.mismatchResult
+import `in`.specmatic.core.pattern.config.NegativePatternConfiguration
 import `in`.specmatic.core.value.EmptyString
 import `in`.specmatic.core.value.NullValue
 import `in`.specmatic.core.value.ScalarValue
@@ -138,7 +139,7 @@ data class AnyPattern(
         }
     }
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver, config: NegativePatternConfiguration): Sequence<ReturnValue<Pattern>> {
         val nullable = pattern.any { it is NullPattern }
 
         val negativeTypeResults = pattern.asSequence().map {

--- a/core/src/main/kotlin/in/specmatic/core/pattern/AnythingPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/AnythingPattern.kt
@@ -2,6 +2,7 @@ package `in`.specmatic.core.pattern
 
 import `in`.specmatic.core.Resolver
 import `in`.specmatic.core.Result
+import `in`.specmatic.core.pattern.config.NegativePatternConfiguration
 import `in`.specmatic.core.value.StringValue
 import `in`.specmatic.core.value.Value
 
@@ -21,7 +22,7 @@ object AnythingPattern: Pattern {
         return sequenceOf(this)
     }
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver, config: NegativePatternConfiguration): Sequence<ReturnValue<Pattern>> {
         return sequenceOf(HasValue(this))
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/Base64StringPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/Base64StringPattern.kt
@@ -3,6 +3,7 @@ package `in`.specmatic.core.pattern
 import `in`.specmatic.core.Resolver
 import `in`.specmatic.core.Result
 import `in`.specmatic.core.mismatchResult
+import `in`.specmatic.core.pattern.config.NegativePatternConfiguration
 import `in`.specmatic.core.value.JSONArrayValue
 import `in`.specmatic.core.value.StringValue
 import `in`.specmatic.core.value.Value
@@ -41,7 +42,7 @@ data class Base64StringPattern(override val typeAlias: String? = null) : Pattern
 
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> = sequenceOf(HasValue(this))
     override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver, config: NegativePatternConfiguration): Sequence<ReturnValue<Pattern>> {
         // TODO ideally StringPattern should be in this list. However need to better understand how to generate
         //      strings that are not valid base64 strings (e.g. send an exact "]" which is not a base64 encoded value)
         return scalarAnnotation(this, sequenceOf(NullPattern, NumberPattern(), BooleanPattern()))

--- a/core/src/main/kotlin/in/specmatic/core/pattern/BinaryPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/BinaryPattern.kt
@@ -3,6 +3,7 @@ package `in`.specmatic.core.pattern
 import `in`.specmatic.core.Resolver
 import `in`.specmatic.core.Result
 import `in`.specmatic.core.mismatchResult
+import `in`.specmatic.core.pattern.config.NegativePatternConfiguration
 import `in`.specmatic.core.value.BinaryValue
 import `in`.specmatic.core.value.JSONArrayValue
 import `in`.specmatic.core.value.StringValue
@@ -43,7 +44,7 @@ data class BinaryPattern(
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> = sequenceOf(HasValue(this))
     override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver, config: NegativePatternConfiguration): Sequence<ReturnValue<Pattern>> {
         return scalarAnnotation(this, sequenceOf(NullPattern, NumberPattern(), BooleanPattern()))
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/BooleanPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/BooleanPattern.kt
@@ -3,6 +3,7 @@ package `in`.specmatic.core.pattern
 import `in`.specmatic.core.Resolver
 import `in`.specmatic.core.Result
 import `in`.specmatic.core.mismatchResult
+import `in`.specmatic.core.pattern.config.NegativePatternConfiguration
 import `in`.specmatic.core.value.BooleanValue
 import `in`.specmatic.core.value.JSONArrayValue
 import `in`.specmatic.core.value.Value
@@ -21,7 +22,7 @@ data class BooleanPattern(override val example: String? = null) : Pattern, Scala
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> = sequenceOf(HasValue(this))
     override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver, config: NegativePatternConfiguration): Sequence<ReturnValue<Pattern>> {
         return scalarAnnotation(this, sequenceOf(NullPattern))
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/CsvPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/CsvPattern.kt
@@ -2,6 +2,7 @@ package `in`.specmatic.core.pattern
 
 import `in`.specmatic.core.Resolver
 import `in`.specmatic.core.Result
+import `in`.specmatic.core.pattern.config.NegativePatternConfiguration
 import `in`.specmatic.core.utilities.exceptionCauseMessage
 import `in`.specmatic.core.value.JSONArrayValue
 import `in`.specmatic.core.value.StringValue
@@ -34,7 +35,7 @@ class CsvPattern(override val pattern: Pattern) : Pattern {
 
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> = sequenceOf(HasValue(this))
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver, config: NegativePatternConfiguration): Sequence<ReturnValue<Pattern>> {
         return StringPattern().negativeBasedOn(row, resolver)
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/DatePattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/DatePattern.kt
@@ -2,6 +2,7 @@ package `in`.specmatic.core.pattern
 
 import `in`.specmatic.core.Resolver
 import `in`.specmatic.core.Result
+import `in`.specmatic.core.pattern.config.NegativePatternConfiguration
 import `in`.specmatic.core.value.JSONArrayValue
 import `in`.specmatic.core.value.StringValue
 import `in`.specmatic.core.value.Value
@@ -21,7 +22,7 @@ object DatePattern : Pattern, ScalarType {
 
     override fun newBasedOn(resolver: Resolver): Sequence<DatePattern> = sequenceOf(this)
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver, config: NegativePatternConfiguration): Sequence<ReturnValue<Pattern>> {
         return scalarAnnotation(this, sequenceOf(NullPattern))
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/DateTimePattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/DateTimePattern.kt
@@ -2,6 +2,7 @@ package `in`.specmatic.core.pattern
 
 import `in`.specmatic.core.Resolver
 import `in`.specmatic.core.Result
+import `in`.specmatic.core.pattern.config.NegativePatternConfiguration
 import `in`.specmatic.core.value.JSONArrayValue
 import `in`.specmatic.core.value.StringValue
 import `in`.specmatic.core.value.Value
@@ -22,7 +23,7 @@ object DateTimePattern : Pattern, ScalarType {
 
     override fun newBasedOn(resolver: Resolver): Sequence<DateTimePattern> = sequenceOf(this)
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver, config: NegativePatternConfiguration): Sequence<ReturnValue<Pattern>> {
         return scalarAnnotation(this, sequenceOf(NullPattern))
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/DeferredPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/DeferredPattern.kt
@@ -2,6 +2,7 @@ package `in`.specmatic.core.pattern
 
 import `in`.specmatic.core.Resolver
 import `in`.specmatic.core.Result
+import `in`.specmatic.core.pattern.config.NegativePatternConfiguration
 import `in`.specmatic.core.value.EmptyString
 import `in`.specmatic.core.value.Value
 
@@ -39,7 +40,7 @@ data class DeferredPattern(override val pattern: String, val key: String? = null
         }
     }
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver, config: NegativePatternConfiguration): Sequence<ReturnValue<Pattern>> {
         return resolver.getPattern(pattern).negativeBasedOn(row, resolver)
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/DictionaryPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/DictionaryPattern.kt
@@ -3,6 +3,7 @@ package `in`.specmatic.core.pattern
 import `in`.specmatic.core.Resolver
 import `in`.specmatic.core.Result
 import `in`.specmatic.core.mismatchResult
+import `in`.specmatic.core.pattern.config.NegativePatternConfiguration
 import `in`.specmatic.core.value.JSONArrayValue
 import `in`.specmatic.core.value.JSONObjectValue
 import `in`.specmatic.core.value.StringValue
@@ -73,7 +74,7 @@ data class DictionaryPattern(val keyPattern: Pattern, val valuePattern: Pattern,
         }
     }
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver, config: NegativePatternConfiguration): Sequence<ReturnValue<Pattern>> {
         return sequenceOf(HasValue(this))
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/EmailPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/EmailPattern.kt
@@ -1,6 +1,7 @@
 package `in`.specmatic.core.pattern
 
 import `in`.specmatic.core.*
+import `in`.specmatic.core.pattern.config.NegativePatternConfiguration
 import `in`.specmatic.core.value.StringValue
 import `in`.specmatic.core.value.Value
 import java.util.*
@@ -41,7 +42,7 @@ class EmailPattern (private val stringPatternDelegate: StringPattern) :
         return sequenceOf(HasValue(this))
     }
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver, config: NegativePatternConfiguration): Sequence<ReturnValue<Pattern>> {
         val negativePatterns = stringPatternDelegate.negativeBasedOn(row, resolver).map { it.value }.plus(StringPattern())
         return scalarAnnotation(this, negativePatterns)
     }

--- a/core/src/main/kotlin/in/specmatic/core/pattern/EmptyStringPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/EmptyStringPattern.kt
@@ -3,6 +3,7 @@ package `in`.specmatic.core.pattern
 import `in`.specmatic.core.Resolver
 import `in`.specmatic.core.Result
 import `in`.specmatic.core.mismatchResult
+import `in`.specmatic.core.pattern.config.NegativePatternConfiguration
 import `in`.specmatic.core.value.*
 
 object EmptyStringPattern : Pattern {
@@ -16,7 +17,7 @@ object EmptyStringPattern : Pattern {
     override fun generate(resolver: Resolver): Value = StringValue("")
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> = sequenceOf(HasValue(this))
     override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver, config: NegativePatternConfiguration): Sequence<ReturnValue<Pattern>> {
         return sequenceOf(HasValue(this))
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/EnumPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/EnumPattern.kt
@@ -1,6 +1,7 @@
 package `in`.specmatic.core.pattern
 
 import `in`.specmatic.core.Resolver
+import `in`.specmatic.core.pattern.config.NegativePatternConfiguration
 import `in`.specmatic.core.value.NullValue
 import `in`.specmatic.core.value.Value
 
@@ -50,8 +51,13 @@ data class EnumPattern(
         }
     }
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
-        return scalarAnnotation(this, pattern.negativeBasedOn(row, resolver).map { it.value })
+    override fun negativeBasedOn(row: Row, resolver: Resolver, config: NegativePatternConfiguration): Sequence<ReturnValue<Pattern>> {
+        val current = this
+        return sequence {
+            if(config.withDataTypeNegatives) {
+                yieldAll(scalarAnnotation(current, pattern.negativeBasedOn(row, resolver).map { it.value }))
+            }
+        }
     }
 
     override fun equals(other: Any?): Boolean = other is EnumPattern && other.pattern == this.pattern

--- a/core/src/main/kotlin/in/specmatic/core/pattern/ExactValuePattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/ExactValuePattern.kt
@@ -3,6 +3,7 @@ package `in`.specmatic.core.pattern
 import `in`.specmatic.core.Resolver
 import `in`.specmatic.core.Result
 import `in`.specmatic.core.mismatchResult
+import `in`.specmatic.core.pattern.config.NegativePatternConfiguration
 import `in`.specmatic.core.value.Value
 
 data class ExactValuePattern(override val pattern: Value, override val typeAlias: String? = null) : Pattern {
@@ -32,7 +33,7 @@ data class ExactValuePattern(override val pattern: Value, override val typeAlias
     override fun generate(resolver: Resolver) = pattern
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> = sequenceOf(HasValue(this))
     override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver, config: NegativePatternConfiguration): Sequence<ReturnValue<Pattern>> {
         val nullPattern: ReturnValue<Pattern> = HasValue(NullPattern)
         return sequenceOf(nullPattern).plus(pattern.type().negativeBasedOn(Row(), resolver).filterValueIsNot { it == NullPattern })
     }

--- a/core/src/main/kotlin/in/specmatic/core/pattern/JSONArrayPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/JSONArrayPattern.kt
@@ -3,6 +3,7 @@ package `in`.specmatic.core.pattern
 import `in`.specmatic.core.Resolver
 import `in`.specmatic.core.Result
 import `in`.specmatic.core.mismatchResult
+import `in`.specmatic.core.pattern.config.NegativePatternConfiguration
 import `in`.specmatic.core.utilities.stringTooPatternArray
 import `in`.specmatic.core.utilities.withNullPattern
 import `in`.specmatic.core.utilities.withNumberType
@@ -79,7 +80,7 @@ data class JSONArrayPattern(override val pattern: List<Pattern> = emptyList(), o
         return newBasedOn(pattern, resolverWithNullType).map { JSONArrayPattern(it) }
     }
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> = sequenceOf(NullPattern).let {
+    override fun negativeBasedOn(row: Row, resolver: Resolver, config: NegativePatternConfiguration): Sequence<ReturnValue<Pattern>> = sequenceOf(NullPattern).let {
         if(pattern.size == 1)
             it.plus(pattern[0])
         else

--- a/core/src/main/kotlin/in/specmatic/core/pattern/JSONObjectPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/JSONObjectPattern.kt
@@ -1,6 +1,7 @@
 package `in`.specmatic.core.pattern
 
 import `in`.specmatic.core.*
+import `in`.specmatic.core.pattern.config.NegativePatternConfiguration
 import `in`.specmatic.core.utilities.mapZip
 import `in`.specmatic.core.utilities.stringToPatternMap
 import `in`.specmatic.core.utilities.withNullPattern
@@ -179,9 +180,9 @@ data class JSONObjectPattern(
                 newBasedOn(pattern, withNullPattern(resolver))
             }).map { it.value }.map { toJSONObjectPattern(it) }
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> =
+    override fun negativeBasedOn(row: Row, resolver: Resolver, config: NegativePatternConfiguration): Sequence<ReturnValue<Pattern>> =
         allOrNothingCombinationIn(pattern.minus("...")) { pattern ->
-            AllNegativePatterns().negativeBasedOn(pattern, row, withNullPattern(resolver))
+            AllNegativePatterns().negativeBasedOn(pattern, row, withNullPattern(resolver), config)
         }.map { it.ifValue { toJSONObjectPattern(it) } }
 
     override fun parse(value: String, resolver: Resolver): Value = parsedJSONObject(value, resolver.mismatchMessages)

--- a/core/src/main/kotlin/in/specmatic/core/pattern/ListPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/ListPattern.kt
@@ -3,6 +3,7 @@ package `in`.specmatic.core.pattern
 import `in`.specmatic.core.Resolver
 import `in`.specmatic.core.Result
 import `in`.specmatic.core.mismatchResult
+import `in`.specmatic.core.pattern.config.NegativePatternConfiguration
 import `in`.specmatic.core.value.JSONArrayValue
 import `in`.specmatic.core.value.ListValue
 import `in`.specmatic.core.value.Value
@@ -78,7 +79,7 @@ data class ListPattern(override val pattern: Pattern, override val typeAlias: St
         }
     }
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> = sequenceOf(HasValue(NullPattern))
+    override fun negativeBasedOn(row: Row, resolver: Resolver, config: NegativePatternConfiguration): Sequence<ReturnValue<Pattern>> = sequenceOf(HasValue(NullPattern))
 
     override fun parse(value: String, resolver: Resolver): Value = parsedJSONArray(value, resolver.mismatchMessages)
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/LookupRowPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/LookupRowPattern.kt
@@ -2,6 +2,7 @@ package `in`.specmatic.core.pattern
 
 import `in`.specmatic.core.Resolver
 import `in`.specmatic.core.Result
+import `in`.specmatic.core.pattern.config.NegativePatternConfiguration
 import `in`.specmatic.core.value.EmptyString
 import `in`.specmatic.core.value.Value
 
@@ -41,7 +42,7 @@ data class LookupRowPattern(override val pattern: Pattern, override val key: Str
         }
     }
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver, config: NegativePatternConfiguration): Sequence<ReturnValue<Pattern>> {
         return sequenceOf(HasValue(this))
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/NegativeNonStringlyPatterns.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/NegativeNonStringlyPatterns.kt
@@ -2,19 +2,25 @@ package `in`.specmatic.core.pattern
 
 import `in`.specmatic.core.Resolver
 import `in`.specmatic.core.Result
+import `in`.specmatic.core.pattern.config.NegativePatternConfiguration
 
 class NegativeNonStringlyPatterns : NegativePatternsTemplate() {
 
     override fun getNegativePatterns(
         patternMap: Map<String, Pattern>,
         resolver: Resolver,
-        row: Row
+        row: Row,
+        config: NegativePatternConfiguration
     ): Map<String, Sequence<ReturnValue<Pattern>>> {
         return patternMap.mapValues { (key, pattern) ->
             val resolvedPattern = resolvedHop(pattern, resolver)
 
             resolvedPattern
-                .negativeBasedOn(row.stepDownOneLevelInJSONHierarchy(withoutOptionality(key)), resolver)
+                .negativeBasedOn(
+                    row.stepDownOneLevelInJSONHierarchy(withoutOptionality(key)),
+                    resolver,
+                    config
+                )
                 .filterValueIsNot {
                     isStringly(resolvedPattern, it, resolver)
                 }.filterValueIsNot {

--- a/core/src/main/kotlin/in/specmatic/core/pattern/NegativePatternsTemplate.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/NegativePatternsTemplate.kt
@@ -1,15 +1,18 @@
 package `in`.specmatic.core.pattern
 
 import `in`.specmatic.core.Resolver
+import `in`.specmatic.core.pattern.config.NegativePatternConfiguration
 
 abstract class NegativePatternsTemplate {
     fun negativeBasedOn(
         patternMap: Map<String, Pattern>,
         row: Row,
-        resolver: Resolver
+        resolver: Resolver,
+        config: NegativePatternConfiguration = NegativePatternConfiguration()
     ): Sequence<ReturnValue<Map<String, Pattern>>> {
         val eachKeyMappedToPatternMap: Map<String, Map<String, Pattern>> = patternMap.mapValues { patternMap }
-        val negativePatternsForEachKey: Map<String, Sequence<ReturnValue<Pattern>>> = getNegativePatterns(patternMap, resolver, row)
+        val negativePatternsForEachKey: Map<String, Sequence<ReturnValue<Pattern>>> =
+            getNegativePatterns(patternMap, resolver, row, config)
 
         val modifiedPatternMap: Map<String, Map<String, Sequence<ReturnValue<Pattern>>>?> =
             eachKeyMappedToPatternMap.mapValues { (keyToNegate, patterns) ->
@@ -43,7 +46,8 @@ abstract class NegativePatternsTemplate {
     abstract fun getNegativePatterns(
         patternMap: Map<String, Pattern>,
         resolver: Resolver,
-        row: Row
+        row: Row,
+        config: NegativePatternConfiguration = NegativePatternConfiguration()
     ): Map<String, Sequence<ReturnValue<Pattern>>>
 
 }

--- a/core/src/main/kotlin/in/specmatic/core/pattern/NullPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/NullPattern.kt
@@ -3,6 +3,7 @@ package `in`.specmatic.core.pattern
 import `in`.specmatic.core.Resolver
 import `in`.specmatic.core.Result
 import `in`.specmatic.core.mismatchResult
+import `in`.specmatic.core.pattern.config.NegativePatternConfiguration
 import `in`.specmatic.core.value.JSONArrayValue
 import `in`.specmatic.core.value.NullValue
 import `in`.specmatic.core.value.StringValue
@@ -22,7 +23,7 @@ object NullPattern : Pattern, ScalarType {
 
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> = sequenceOf(HasValue(this))
     override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver, config: NegativePatternConfiguration): Sequence<ReturnValue<Pattern>> {
         return newBasedOn(row, resolver).map { it.value }.map { HasValue(it) }
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/Pattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/Pattern.kt
@@ -2,6 +2,7 @@ package `in`.specmatic.core.pattern
 
 import `in`.specmatic.core.Resolver
 import `in`.specmatic.core.Result
+import `in`.specmatic.core.pattern.config.NegativePatternConfiguration
 import `in`.specmatic.core.value.StringValue
 import `in`.specmatic.core.value.Value
 
@@ -18,7 +19,11 @@ interface Pattern {
     fun generate(resolver: Resolver): Value
     fun generateWithAll(resolver: Resolver) = resolver.withCyclePrevention(this, this::generate)
     fun newBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>>
-    fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>>
+    fun negativeBasedOn(
+        row: Row,
+        resolver: Resolver,
+        config: NegativePatternConfiguration = NegativePatternConfiguration()
+    ): Sequence<ReturnValue<Pattern>>
     fun newBasedOn(resolver: Resolver): Sequence<Pattern>
     fun parse(value: String, resolver: Resolver): Value
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/PatternInStringPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/PatternInStringPattern.kt
@@ -3,6 +3,7 @@ package `in`.specmatic.core.pattern
 import `in`.specmatic.core.Resolver
 import `in`.specmatic.core.Result
 import `in`.specmatic.core.mismatchResult
+import `in`.specmatic.core.pattern.config.NegativePatternConfiguration
 import `in`.specmatic.core.value.StringValue
 import `in`.specmatic.core.value.Value
 
@@ -34,7 +35,7 @@ data class PatternInStringPattern(override val pattern: Pattern = StringPattern(
             pattern.newBasedOn(cyclePreventedResolver).map { PatternInStringPattern(it) }
         }
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver, config: NegativePatternConfiguration): Sequence<ReturnValue<Pattern>> {
         return sequenceOf(HasValue(NullPattern))
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/QueryParameterArrayPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/QueryParameterArrayPattern.kt
@@ -3,6 +3,7 @@ package `in`.specmatic.core.pattern
 import `in`.specmatic.core.Resolver
 import `in`.specmatic.core.Result
 import `in`.specmatic.core.Result.Failure
+import `in`.specmatic.core.pattern.config.NegativePatternConfiguration
 import `in`.specmatic.core.value.JSONArrayValue
 import `in`.specmatic.core.value.ListValue
 import `in`.specmatic.core.value.StringValue
@@ -107,7 +108,7 @@ data class QueryParameterArrayPattern(override val pattern: List<Pattern>, val p
         return pattern.first().newBasedOn(resolver).map { QueryParameterArrayPattern(listOf(it), parameterName) }
     }
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver, config: NegativePatternConfiguration): Sequence<ReturnValue<Pattern>> {
         return pattern.first().negativeBasedOn(row, resolver).map { it.ifValue { QueryParameterArrayPattern(listOf(it), parameterName) } }
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/RestPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/RestPattern.kt
@@ -2,6 +2,7 @@ package `in`.specmatic.core.pattern
 
 import `in`.specmatic.core.Resolver
 import `in`.specmatic.core.Result
+import `in`.specmatic.core.pattern.config.NegativePatternConfiguration
 import `in`.specmatic.core.utilities.withNullPattern
 import `in`.specmatic.core.value.Value
 
@@ -24,7 +25,7 @@ data class RestPattern(override val pattern: Pattern, override val typeAlias: St
             pattern.newBasedOn(cyclePreventedResolver).map { RestPattern(it) }
         }
     }
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver, config: NegativePatternConfiguration): Sequence<ReturnValue<Pattern>> {
         return sequenceOf(HasValue(this))
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/TabularPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/TabularPattern.kt
@@ -1,6 +1,7 @@
 package `in`.specmatic.core.pattern
 
 import `in`.specmatic.core.*
+import `in`.specmatic.core.pattern.config.NegativePatternConfiguration
 import `in`.specmatic.core.utilities.mapZip
 import `in`.specmatic.core.utilities.stringToPatternMap
 import `in`.specmatic.core.utilities.withNullPattern
@@ -97,7 +98,7 @@ data class TabularPattern(
         return allOrNothingCombinationIn.map { toTabularPattern(it) }
     }
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver, config: NegativePatternConfiguration): Sequence<ReturnValue<Pattern>> {
         return this.newBasedOn(row, resolver).map { it.value }.map { HasValue(it) }
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/URLPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/URLPattern.kt
@@ -2,6 +2,7 @@ package `in`.specmatic.core.pattern
 
 import `in`.specmatic.core.Resolver
 import `in`.specmatic.core.Result
+import `in`.specmatic.core.pattern.config.NegativePatternConfiguration
 import `in`.specmatic.core.value.JSONArrayValue
 import `in`.specmatic.core.value.StringValue
 import `in`.specmatic.core.value.Value
@@ -27,7 +28,7 @@ data class URLPattern(val scheme: URLScheme = URLScheme.HTTPS, override val type
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> = sequenceOf(HasValue(this))
 
     override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver, config: NegativePatternConfiguration): Sequence<ReturnValue<Pattern>> {
         return newBasedOn(row, resolver)
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/UUIDPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/UUIDPattern.kt
@@ -2,6 +2,7 @@ package `in`.specmatic.core.pattern
 
 import `in`.specmatic.core.Resolver
 import `in`.specmatic.core.Result
+import `in`.specmatic.core.pattern.config.NegativePatternConfiguration
 import `in`.specmatic.core.value.JSONArrayValue
 import `in`.specmatic.core.value.StringValue
 import `in`.specmatic.core.value.Value
@@ -23,7 +24,7 @@ object UUIDPattern : Pattern, ScalarType {
 
     override fun newBasedOn(resolver: Resolver): Sequence<UUIDPattern> = sequenceOf(this)
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver, config: NegativePatternConfiguration): Sequence<ReturnValue<Pattern>> {
         return scalarAnnotation(this, sequenceOf(NullPattern))
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/XMLPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/XMLPattern.kt
@@ -3,6 +3,7 @@ package `in`.specmatic.core.pattern
 import `in`.specmatic.core.*
 import `in`.specmatic.core.Result.Failure
 import `in`.specmatic.core.Result.Success
+import `in`.specmatic.core.pattern.config.NegativePatternConfiguration
 import `in`.specmatic.core.utilities.mapZip
 import `in`.specmatic.core.utilities.parseXML
 import `in`.specmatic.core.value.*
@@ -425,7 +426,7 @@ data class XMLPattern(override val pattern: XMLTypeData = XMLTypeData(realName =
         }
     }
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+    override fun negativeBasedOn(row: Row, resolver: Resolver, config: NegativePatternConfiguration): Sequence<ReturnValue<Pattern>> {
         return newBasedOn(row, resolver).map { it.value as XMLPattern }.map { HasValue(it) }
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/config/NegativePatternConfiguration.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/config/NegativePatternConfiguration.kt
@@ -1,0 +1,5 @@
+package `in`.specmatic.core.pattern.config
+
+data class NegativePatternConfiguration(
+    val withDataTypeNegatives: Boolean = true
+)

--- a/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/in/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -7766,8 +7766,6 @@ paths:
             maxAge + BIG_DECIMAL_INC
         )
 
-        println(actualAges)
-
         assertThat(results.results.size).isEqualTo(8)
         assertThat(results.success()).withFailMessage(results.report()).isTrue()
     }

--- a/core/src/test/kotlin/in/specmatic/core/ResponseBuilderTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/ResponseBuilderTest.kt
@@ -4,6 +4,7 @@ import `in`.specmatic.core.pattern.Pattern
 import `in`.specmatic.core.pattern.ReturnValue
 import `in`.specmatic.core.pattern.Row
 import `in`.specmatic.core.pattern.TypeStack
+import `in`.specmatic.core.pattern.config.NegativePatternConfiguration
 import `in`.specmatic.core.value.NullValue
 import `in`.specmatic.core.value.Value
 import `in`.specmatic.stub.RequestContext
@@ -31,7 +32,7 @@ class ResponseBuilderTest {
                 TODO("Not yet implemented")
             }
 
-            override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+            override fun negativeBasedOn(row: Row, resolver: Resolver, config: NegativePatternConfiguration): Sequence<ReturnValue<Pattern>> {
                 TODO("Not yet implemented")
             }
 

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=1.3.38
+version=1.3.39


### PR DESCRIPTION
Currently 'withDataTypesNegatives' option is supported where negativeBasedOn will exclude data type based negatives.

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Added an argument `config` in the `negativeBasedOn` function which enables to generate different variations of negative patterns to be generated by the function.

**Why**:
Need this for a scenario where only constraint based negatives are required.
<!-- How were these changes implemented? -->


**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [x] Tested against sample project
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->


<!-- feel free to add additional comments -->
