### PR TITLE
Ancillary test generation functions cleanup

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/GenerativeTestsEnabled.kt
+++ b/core/src/main/kotlin/in/specmatic/core/GenerativeTestsEnabled.kt
@@ -120,7 +120,7 @@ data class GenerativeTestsEnabled(private val positiveOnly: Boolean = Flags.only
             }
 
             forEachKeyCombinationIn(queryParams, Row()) { entry ->
-                newBasedOn(entry, row, resolver)
+                newMapBasedOn(entry, row, resolver).map { it.value }
             }.map {
                 it.mapKeys { withoutOptionality(it.key) }
             }

--- a/core/src/main/kotlin/in/specmatic/core/GenerativeTestsEnabled.kt
+++ b/core/src/main/kotlin/in/specmatic/core/GenerativeTestsEnabled.kt
@@ -119,9 +119,9 @@ data class GenerativeTestsEnabled(private val positiveOnly: Boolean = Flags.only
                     it
             }
 
-            forEachKeyCombinationIn(queryParams, Row()) { entry ->
+            forEachKeyCombinationIn<Pattern>(queryParams, Row(), returnValues<Pattern> { entry: Map<String, Pattern> ->
                 newMapBasedOn(entry, row, resolver).map { it.value }
-            }.map {
+            }).map { it.value }.map {
                 it.mapKeys { withoutOptionality(it.key) }
             }
         }

--- a/core/src/main/kotlin/in/specmatic/core/HttpHeadersPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpHeadersPattern.kt
@@ -200,7 +200,7 @@ data class HttpHeadersPattern(
     }
 
     fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<HttpHeadersPattern>> {
-        return allOrNothingCombinationInR(pattern, row, null, null) { pattern ->
+        return allOrNothingCombinationIn(pattern, row, null, null) { pattern ->
             NegativeNonStringlyPatterns().negativeBasedOn(pattern, row, resolver).map { it.breadCrumb("HEADER") }
         }.map { patternMapR ->
             patternMapR.ifValue { patternMap ->
@@ -213,9 +213,13 @@ data class HttpHeadersPattern(
     }
 
     fun newBasedOn(resolver: Resolver): Sequence<HttpHeadersPattern> =
-        allOrNothingCombinationIn(pattern) { pattern ->
-            newBasedOn(pattern, resolver)
-        }.map { patternMap ->
+        allOrNothingCombinationIn<Pattern>(
+            pattern,
+            Row(),
+            null,
+            null, returnValues<Pattern> { pattern: Map<String, Pattern> ->
+                newBasedOn(pattern, resolver)
+            }).map { it.value }.map { patternMap ->
             HttpHeadersPattern(
                 patternMap.mapKeys { withoutOptionality(it.key) },
                 contentType = contentType

--- a/core/src/main/kotlin/in/specmatic/core/HttpHeadersPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpHeadersPattern.kt
@@ -184,7 +184,7 @@ data class HttpHeadersPattern(
     }
 
     fun newBasedOn(row: Row, resolver: Resolver): Sequence<HttpHeadersPattern> {
-        val basedOnExamples = forEachKeyCombinationIn(row.withoutOmittedKeys(pattern, resolver.defaultExampleResolver), row, resolver) { pattern ->
+        val basedOnExamples = forEachKeyCombinationGivenRowIn(row.withoutOmittedKeys(pattern, resolver.defaultExampleResolver), row, resolver) { pattern ->
             newMapBasedOn(pattern, row, resolver).map { it.value }
         }
 

--- a/core/src/main/kotlin/in/specmatic/core/HttpHeadersPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpHeadersPattern.kt
@@ -185,7 +185,7 @@ data class HttpHeadersPattern(
 
     fun newBasedOn(row: Row, resolver: Resolver): Sequence<HttpHeadersPattern> {
         val basedOnExamples = forEachKeyCombinationIn(row.withoutOmittedKeys(pattern, resolver.defaultExampleResolver), row, resolver) { pattern ->
-            newBasedOn(pattern, row, resolver)
+            newMapBasedOn(pattern, row, resolver).map { it.value }
         }
 
         val generatedWithoutExamples: Sequence<Map<String, Pattern>> = resolver.generation.fillInTheMissingMapPatterns(

--- a/core/src/main/kotlin/in/specmatic/core/HttpQueryParamPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpQueryParamPattern.kt
@@ -44,7 +44,7 @@ data class HttpQueryParamPattern(val queryPatterns: Map<String, Pattern>, val ad
             }
 
             val combinations = forEachKeyCombinationIn(row.withoutOmittedKeys(queryParams, resolver.defaultExampleResolver), row) { entry ->
-                newBasedOn(entry, row, resolver)
+                newMapBasedOn(entry, row, resolver).map { it.value }
             }
 
             combinations.map {

--- a/core/src/main/kotlin/in/specmatic/core/HttpQueryParamPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpQueryParamPattern.kt
@@ -129,9 +129,13 @@ data class HttpQueryParamPattern(val queryPatterns: Map<String, Pattern>, val ad
                 else
                     it
             }
-            allOrNothingCombinationIn(queryParams) { entry ->
-                newBasedOn(entry.mapKeys { withoutOptionality(it.key) }, resolver)
-            }
+            allOrNothingCombinationIn<Pattern>(
+                queryParams,
+                Row(),
+                null,
+                null, returnValues<Pattern> { entry: Map<String, Pattern> ->
+                    newBasedOn(entry.mapKeys { withoutOptionality(it.key) }, resolver)
+                }).map { it.value }
         }
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/HttpQueryParamPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/HttpQueryParamPattern.kt
@@ -43,9 +43,11 @@ data class HttpQueryParamPattern(val queryPatterns: Map<String, Pattern>, val ad
                     it
             }
 
-            val combinations = forEachKeyCombinationIn(row.withoutOmittedKeys(queryParams, resolver.defaultExampleResolver), row) { entry ->
-                newMapBasedOn(entry, row, resolver).map { it.value }
-            }
+            val combinations = forEachKeyCombinationIn<Pattern>(
+                row.withoutOmittedKeys(queryParams, resolver.defaultExampleResolver),
+                row, returnValues<Pattern> { entry: Map<String, Pattern> ->
+                    newMapBasedOn(entry, row, resolver).map { it.value }
+                }).map { it.value }
 
             combinations.map {
                 it.mapKeys { withoutOptionality(it.key) }
@@ -156,7 +158,7 @@ data class HttpQueryParamPattern(val queryPatterns: Map<String, Pattern>, val ad
                     it
             }
 
-            forEachKeyCombinationInR(queryParams, row) { entry ->
+            forEachKeyCombinationIn(queryParams, row) { entry ->
                 NegativeNonStringlyPatterns().negativeBasedOn(
                     entry.mapKeys { withoutOptionality(it.key) },
                     row,

--- a/core/src/main/kotlin/in/specmatic/core/pattern/JSONArrayPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/JSONArrayPattern.kt
@@ -138,7 +138,7 @@ fun newBasedOn(patterns: List<Pattern>, row: Row, resolver: Resolver): Sequence<
         }
     }
 
-    return listCombinations(values)
+    return listCombinations(values.map<Sequence<Pattern?>, HasValue<Sequence<Pattern?>>> { HasValue(it) }).map { it.value }
 }
 
 fun newBasedOnR(patterns: List<Pattern>, row: Row, resolver: Resolver): Sequence<ReturnValue<List<Pattern>>> {
@@ -150,7 +150,7 @@ fun newBasedOnR(patterns: List<Pattern>, row: Row, resolver: Resolver): Sequence
         }
     }.map { it.foldIntoReturnValueOfSequence().ifValue { it.map { it as Pattern? } } }
 
-    return listCombinationsR(values).distinct()
+    return listCombinations(values).distinct()
 }
 
 fun newBasedOn(patterns: List<Pattern>, resolver: Resolver): Sequence<List<Pattern>> {
@@ -162,15 +162,15 @@ fun newBasedOn(patterns: List<Pattern>, resolver: Resolver): Sequence<List<Patte
         }
     }
 
-    return listCombinations(values)
+    return listCombinations(values.map<Sequence<Pattern?>, HasValue<Sequence<Pattern?>>> { HasValue(it) }).map { it.value }
 }
 
-fun listCombinationsR(values: List<ReturnValue<Sequence<Pattern?>>>): Sequence<ReturnValue<List<Pattern>>> {
+fun listCombinations(values: List<ReturnValue<Sequence<Pattern?>>>): Sequence<ReturnValue<List<Pattern>>> {
     if (values.isEmpty())
         return sequenceOf(HasValue(emptyList()))
 
     val lastValueTypesR: ReturnValue<Sequence<Pattern?>> = values.last()
-    val subLists = listCombinationsR(values.dropLast(1))
+    val subLists = listCombinations(values.dropLast(1))
 
     return subLists.map { subListR ->
         subListR.combine(lastValueTypesR) { subList, lastValueTypes ->
@@ -182,23 +182,6 @@ fun listCombinationsR(values: List<ReturnValue<Sequence<Pattern?>>>): Sequence<R
             }.toList()
         }
     }.foldToSequenceOfReturnValueList()
-}
-
-fun listCombinations(values: List<Sequence<Pattern?>>): Sequence<List<Pattern>> {
-    if (values.isEmpty())
-        return sequenceOf(emptyList())
-
-    val lastValueTypes: Sequence<Pattern?> = values.last()
-    val subLists = listCombinations(values.dropLast(1))
-
-    return subLists.flatMap { subList ->
-        lastValueTypes.map { lastValueType ->
-            if (lastValueType != null)
-                subList.plus(lastValueType)
-            else
-                subList
-        }
-    }
 }
 
 private enum class ValueSource {

--- a/core/src/main/kotlin/in/specmatic/core/pattern/JSONArrayPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/JSONArrayPattern.kt
@@ -69,7 +69,7 @@ data class JSONArrayPattern(override val pattern: List<Pattern> = emptyList(), o
 
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
         val resolverWithNullType = withNullPattern(resolver)
-        val returnValues = newBasedOnR(pattern, row, resolverWithNullType)
+        val returnValues = newListBasedOn(pattern, row, resolverWithNullType)
 
         return returnValues.map { it.ifValue { JSONArrayPattern(it) } }
     }
@@ -129,19 +129,7 @@ data class JSONArrayPattern(override val pattern: List<Pattern> = emptyList(), o
     override val typeName: String = "json array"
 }
 
-fun newBasedOn(patterns: List<Pattern>, row: Row, resolver: Resolver): Sequence<List<Pattern>> {
-    val values = patterns.mapIndexed { index, pattern ->
-        attempt(breadCrumb = "[$index]") {
-            resolver.withCyclePrevention(pattern) { cyclePreventedResolver ->
-                pattern.newBasedOn(row, cyclePreventedResolver).map { it.value }
-            }
-        }
-    }
-
-    return listCombinations(values.map<Sequence<Pattern?>, HasValue<Sequence<Pattern?>>> { HasValue(it) }).map { it.value }
-}
-
-fun newBasedOnR(patterns: List<Pattern>, row: Row, resolver: Resolver): Sequence<ReturnValue<List<Pattern>>> {
+fun newListBasedOn(patterns: List<Pattern>, row: Row, resolver: Resolver): Sequence<ReturnValue<List<Pattern>>> {
     val values = patterns.mapIndexed { index, pattern ->
         attempt(breadCrumb = "[$index]") {
             resolver.withCyclePrevention(pattern) { cyclePreventedResolver ->

--- a/core/src/main/kotlin/in/specmatic/core/pattern/JSONObjectPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/JSONObjectPattern.kt
@@ -155,7 +155,7 @@ data class JSONObjectPattern(
     }
 
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> =
-        allOrNothingCombinationInR(
+        allOrNothingCombinationIn(
             pattern.minus("..."),
             resolver.resolveRow(row),
             minProperties,
@@ -171,12 +171,16 @@ data class JSONObjectPattern(
     }
 
     override fun newBasedOn(resolver: Resolver): Sequence<JSONObjectPattern> =
-        allOrNothingCombinationIn(pattern.minus("...")) { pattern ->
-            newBasedOn(pattern, withNullPattern(resolver))
-        }.map { toJSONObjectPattern(it) }
+        allOrNothingCombinationIn<Pattern>(
+            pattern.minus("..."),
+            Row(),
+            null,
+            null, returnValues<Pattern> { pattern: Map<String, Pattern> ->
+                newBasedOn(pattern, withNullPattern(resolver))
+            }).map { it.value }.map { toJSONObjectPattern(it) }
 
     override fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> =
-        allOrNothingCombinationInR(pattern.minus("...")) { pattern ->
+        allOrNothingCombinationIn(pattern.minus("...")) { pattern ->
             AllNegativePatterns().negativeBasedOn(pattern, row, withNullPattern(resolver))
         }.map { it.ifValue { toJSONObjectPattern(it) } }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/JSONObjectPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/JSONObjectPattern.kt
@@ -161,7 +161,7 @@ data class JSONObjectPattern(
             minProperties,
             maxProperties
         ) { pattern ->
-            newBasedOnR(pattern, row, withNullPattern(resolver))
+            newMapBasedOn(pattern, row, withNullPattern(resolver))
         }.map { it: ReturnValue<Map<String, Pattern>> ->
             it.ifValue {
                 toJSONObjectPattern(it.mapKeys { (key, _) ->

--- a/core/src/main/kotlin/in/specmatic/core/pattern/LookupRowPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/LookupRowPattern.kt
@@ -27,7 +27,7 @@ data class LookupRowPattern(override val pattern: Pattern, override val key: Str
                 pattern.newBasedOn(row, cyclePreventedResolver)
             }
             // Cycle prevention handled in helper method
-            else -> newBasedOnR(row, key, pattern, resolver)
+            else -> newPatternsBasedOn(row, key, pattern, resolver)
         }
     }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/NegativePatternsTemplate.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/NegativePatternsTemplate.kt
@@ -24,7 +24,7 @@ abstract class NegativePatternsTemplate {
                             val result: Sequence<ReturnValue<Pattern>> = negativePatterns
                             result
                         }
-                        else -> newBasedOnR(row, key, pattern, resolver)
+                        else -> newPatternsBasedOn(row, key, pattern, resolver)
                     }.map {
                         it.breadCrumb(withoutOptionality(key))
                     }

--- a/core/src/main/kotlin/in/specmatic/core/pattern/NegativePatternsTemplate.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/NegativePatternsTemplate.kt
@@ -35,7 +35,7 @@ abstract class NegativePatternsTemplate {
             return sequenceOf(HasValue(emptyMap()))
 
         return modifiedPatternMap.values.asSequence().filterNotNull().flatMap {
-            patternListR(it)
+            patternList(it)
         }
 
     }

--- a/core/src/main/kotlin/in/specmatic/core/pattern/TabularPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/TabularPattern.kt
@@ -137,7 +137,7 @@ fun newMapBasedOn(patternMap: Map<String, Pattern>, row: Row, resolver: Resolver
         }
     }
 
-    return patternListR(patternCollection)
+    return patternList(patternCollection)
 }
 
 fun newBasedOn(patternMap: Map<String, Pattern>, resolver: Resolver): Sequence<Map<String, Pattern>> {
@@ -222,16 +222,12 @@ fun key(pattern: Pattern, key: String): String {
     )
 }
 
-fun <ValueType> patternListR(patternCollection: Map<String, Sequence<ReturnValue<ValueType>>>): Sequence<ReturnValue<Map<String, ValueType>>> {
+fun <ValueType> patternList(patternCollection: Map<String, Sequence<ReturnValue<ValueType>>>): Sequence<ReturnValue<Map<String, ValueType>>> {
     if (patternCollection.isEmpty())
         return sequenceOf(HasValue(emptyMap()))
 
     val spec = CombinationSpec(patternCollection, Flags.maxTestRequestCombinations())
     return spec.selectedCombinations
-}
-
-fun <ValueType> patternList(patternCollection: Map<String, Sequence<ValueType>>): Sequence<Map<String, ValueType>> {
-    return patternListR(patternCollection.mapValues { it.value.map { HasValue(it) } }).map { it.value }
 }
 
 fun <ValueType> patternValues(patternCollection: Map<String, Sequence<ValueType>>): Sequence<Map<String, ValueType>> {

--- a/core/src/main/kotlin/in/specmatic/core/pattern/TabularPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/TabularPattern.kt
@@ -289,7 +289,7 @@ private fun <ValueType> keyCombinations(
         }.toMap()
 }
 
-fun <ValueType> forEachKeyCombinationIn(
+fun <ValueType> forEachKeyCombinationGivenRowIn(
     patternMap: Map<String, ValueType>,
     row: Row,
     resolver: Resolver,
@@ -302,17 +302,6 @@ fun <ValueType> forEachKeyCombinationIn(
     }.flatten()
 
 fun <ValueType> forEachKeyCombinationIn(
-    patternMap: Map<String, ValueType>,
-    row: Row,
-    creator: (Map<String, ValueType>) -> Sequence<Map<String, ValueType>>
-): Sequence<Map<String, ValueType>> =
-    keySets(patternMap.keys.toList(), row).map { keySet ->
-        patternMap.filterKeys { key -> key in keySet }
-    }.map { newPattern ->
-        creator(newPattern)
-    }.flatten()
-
-fun <ValueType> forEachKeyCombinationInR(
     patternMap: Map<String, ValueType>,
     row: Row,
     creator: (Map<String, ValueType>) -> Sequence<ReturnValue<Map<String, ValueType>>>

--- a/core/src/main/kotlin/in/specmatic/core/pattern/XMLPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/XMLPattern.kt
@@ -378,13 +378,17 @@ data class XMLPattern(override val pattern: XMLTypeData = XMLTypeData(realName =
     }
 
     override fun newBasedOn(resolver: Resolver): Sequence<XMLPattern> {
-        return allOrNothingCombinationIn(pattern.attributes) { attributePattern ->
-            attempt(breadCrumb = this.pattern.name) {
-                newBasedOn(attributePattern, resolver).map {
-                    it.mapKeys { entry -> withoutOptionality(entry.key) }
+        return allOrNothingCombinationIn<Pattern>(
+            pattern.attributes,
+            Row(),
+            null,
+            null, returnValues<Pattern> { attributePattern: Map<String, Pattern> ->
+                attempt(breadCrumb = this.pattern.name) {
+                    newBasedOn(attributePattern, resolver).map {
+                        it.mapKeys { entry -> withoutOptionality(entry.key) }
+                    }
                 }
-            }
-        }.flatMap { newAttributes ->
+            }).map { it.value }.flatMap { newAttributes ->
             val newNodesList = allOrNothingListCombinations(pattern.nodes.map { childPattern ->
                 attempt(breadCrumb = this.pattern.name) {
                     when (childPattern) {

--- a/core/src/main/kotlin/in/specmatic/core/pattern/XMLPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/XMLPattern.kt
@@ -339,35 +339,35 @@ data class XMLPattern(override val pattern: XMLTypeData = XMLTypeData(realName =
 
                 else -> {
                     listCombinations(pattern.nodes.map { childPattern ->
-                        attempt(breadCrumb = pattern.name) {
-                            when (childPattern) {
-                                is XMLPattern -> {
-                                    val dereferenced: XMLPattern = childPattern.dereferenceType(resolver)
+                                        attempt(breadCrumb = pattern.name) {
+                                            when (childPattern) {
+                                                is XMLPattern -> {
+                                                    val dereferenced: XMLPattern = childPattern.dereferenceType(resolver)
 
-                                    resolver.withCyclePrevention(dereferenced) { cyclePreventedResolver ->
-                                        when {
-                                            dereferenced.occurMultipleTimes() -> {
-                                                dereferenced.newBasedOn(row, cyclePreventedResolver)
-                                                    .map { it.value as XMLPattern }
+                                                    resolver.withCyclePrevention(dereferenced) { cyclePreventedResolver ->
+                                                        when {
+                                                            dereferenced.occurMultipleTimes() -> {
+                                                                dereferenced.newBasedOn(row, cyclePreventedResolver)
+                                                                    .map { it.value as XMLPattern }
+                                                            }
+
+                                                            dereferenced.isOptional() -> {
+                                                                dereferenced.newBasedOn(row, cyclePreventedResolver)
+                                                                    .map { it.value as XMLPattern }.plus(null)
+                                                            }
+
+                                                            else -> dereferenced.newBasedOn(row, cyclePreventedResolver)
+                                                                .map { it.value as XMLPattern }
+                                                        }
+                                                    }
+                                                }
+
+                                                else -> resolver.withCyclePrevention(childPattern) { cyclePreventedResolver ->
+                                                    childPattern.newBasedOn(row, cyclePreventedResolver).map { it.value }
+                                                }
                                             }
-
-                                            dereferenced.isOptional() -> {
-                                                dereferenced.newBasedOn(row, cyclePreventedResolver)
-                                                    .map { it.value as XMLPattern }.plus(null)
-                                            }
-
-                                            else -> dereferenced.newBasedOn(row, cyclePreventedResolver)
-                                                .map { it.value as XMLPattern }
                                         }
-                                    }
-                                }
-
-                                else -> resolver.withCyclePrevention(childPattern) { cyclePreventedResolver ->
-                                    childPattern.newBasedOn(row, cyclePreventedResolver).map { it.value }
-                                }
-                            }
-                        }
-                    })
+                                    }.map { HasValue(it) }).map { it.value }
                 }
             }
 

--- a/core/src/main/kotlin/in/specmatic/core/pattern/XMLPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/XMLPattern.kt
@@ -314,7 +314,7 @@ data class XMLPattern(override val pattern: XMLTypeData = XMLTypeData(realName =
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
         return forEachKeyCombinationIn(pattern.attributes, row) { attributePattern ->
             attempt(breadCrumb = pattern.name) {
-                newBasedOn(attributePattern, row, resolver).map {
+                newMapBasedOn(attributePattern, row, resolver).map { it.value }.map {
                     it.mapKeys { entry -> withoutOptionality(entry.key) }
                 }
             }

--- a/core/src/main/kotlin/in/specmatic/core/pattern/XMLPattern.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/XMLPattern.kt
@@ -312,13 +312,15 @@ data class XMLPattern(override val pattern: XMLTypeData = XMLTypeData(realName =
     }
 
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
-        return forEachKeyCombinationIn(pattern.attributes, row) { attributePattern ->
-            attempt(breadCrumb = pattern.name) {
-                newMapBasedOn(attributePattern, row, resolver).map { it.value }.map {
-                    it.mapKeys { entry -> withoutOptionality(entry.key) }
+        return forEachKeyCombinationIn<Pattern>(
+            pattern.attributes,
+            row, returnValues<Pattern> { attributePattern: Map<String, Pattern> ->
+                attempt(breadCrumb = pattern.name) {
+                    newMapBasedOn(attributePattern, row, resolver).map { it.value }.map {
+                        it.mapKeys { entry -> withoutOptionality(entry.key) }
+                    }
                 }
-            }
-        }.flatMap { newAttributes ->
+            }).map { it.value }.flatMap { newAttributes ->
             val newNodesList = when {
                 row.containsField(pattern.name) -> {
                     attempt(breadCrumb = pattern.name) {


### PR DESCRIPTION
**What**:

Cleaned up duplicate ancillary test generation functions. Related to #1180

**How**:

Previously, there were to flavours: allOrNothingCombinationR and allOrNothingCombination. 

This PR eliminates the duplication and ensures that all the functions return ReturnValues. 


**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

