### PR TITLE
[BUG FIX] breadCrumb key getting printed even though there is no message associated with it

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/pattern/ValueDetails.kt
+++ b/core/src/main/kotlin/in/specmatic/core/pattern/ValueDetails.kt
@@ -35,7 +35,9 @@ data class ValueDetails(val messages: List<String> = emptyList(), private val br
 }
 
 fun List<ValueDetails>.singleLineDescription(): String {
-    return this.joinToString(", ") {
-        "${it.breadCrumbs} ${it.messages.joinToString(" ").trim()}"
-    }
+    return this.mapNotNull {
+        val message = it.messages.joinToString(" ").trim()
+        if (message.isBlank()) null
+        else "${it.breadCrumbs} $message"
+    }.joinToString(", ")
 }

--- a/core/src/test/kotlin/in/specmatic/core/pattern/ValueDetailsKtTest.kt
+++ b/core/src/test/kotlin/in/specmatic/core/pattern/ValueDetailsKtTest.kt
@@ -1,0 +1,35 @@
+package `in`.specmatic.core.pattern
+
+import org.assertj.core.api.AssertionsForClassTypes.assertThat
+import org.junit.jupiter.api.Test
+
+class ValueDetailsKtTest {
+
+    @Test
+    fun `should return singleLineDescription of valueDetails when messages list is not empty`() {
+        val valueDetails = listOf(
+            ValueDetails(
+                messages = listOf("mutated to null"),
+                breadCrumbData = listOf("price")
+            )
+        )
+
+        val singleLineDescription = valueDetails.singleLineDescription()
+
+        assertThat(singleLineDescription).isEqualTo("price mutated to null")
+    }
+
+    @Test
+    fun `should return singleLineDescription of valueDetails as empty when messages list is empty`() {
+        val valueDetails = listOf(
+            ValueDetails(
+                messages = emptyList(),
+                breadCrumbData = listOf("price")
+            )
+        )
+
+        val singleLineDescription = valueDetails.singleLineDescription()
+
+        assertThat(singleLineDescription).isEqualTo("")
+    }
+}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Fixes a minor bug in the `singleLineDescription` method of `ValueDetails` which was printing the breadCrumb key even though there is no message associated with it.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

**How**:
Added a condition where we are returning the singleLineDescription as empty if there is no message associated with a breadCrumb key.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [x] Tested against sample project
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->


<!-- feel free to add additional comments -->
