### PR TITLE
Resolve Config Issue in StubCommand.

### DIFF
--- a/application/src/main/kotlin/application/StubCommand.kt
+++ b/application/src/main/kotlin/application/StubCommand.kt
@@ -105,15 +105,16 @@ class StubCommand : Callable<Unit> {
         else
             NonVerbose(CompositePrinter(logPrinters))
 
-        configFileName?.let {
-            Configuration.globalConfigFileName = it
+        if (configFileName != null) {
+            Configuration.globalConfigFileName = configFileName as String
+        } else {
+            Configuration.globalConfigFileName = getConfigFileName()
         }
 
         try {
             contractSources = when (contractPaths.isEmpty()) {
                 true -> {
                     logger.debug("No contractPaths specified. Using configuration file named $configFileName")
-                    Configuration.globalConfigFileName = getConfigFileName()
                     specmaticConfigPath = File(Configuration.globalConfigFileName).canonicalPath
                     specmaticConfig.contractStubPathData()
                 }

--- a/application/src/main/kotlin/application/StubCommand.kt
+++ b/application/src/main/kotlin/application/StubCommand.kt
@@ -1,11 +1,8 @@
 package application
 
-import io.specmatic.core.APPLICATION_NAME_LOWER_CASE
-import io.specmatic.core.CONTRACT_EXTENSIONS
-import io.specmatic.core.Configuration
+import io.specmatic.core.*
 import io.specmatic.core.Configuration.Companion.DEFAULT_HTTP_STUB_HOST
 import io.specmatic.core.Configuration.Companion.DEFAULT_HTTP_STUB_PORT
-import io.specmatic.core.WorkingDirectory
 import io.specmatic.core.log.*
 import io.specmatic.core.utilities.ContractPathData
 import io.specmatic.core.utilities.exitIfAnyDoNotExist
@@ -116,6 +113,7 @@ class StubCommand : Callable<Unit> {
             contractSources = when (contractPaths.isEmpty()) {
                 true -> {
                     logger.debug("No contractPaths specified. Using configuration file named $configFileName")
+                    Configuration.globalConfigFileName = getConfigFileName()
                     specmaticConfigPath = File(Configuration.globalConfigFileName).canonicalPath
                     specmaticConfig.contractStubPathData()
                 }

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=2.0.0
+version=2.0.1


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Resolve YAML Config Issue in Command-line Stub

<!-- Why are these changes necessary? -->

**Why**: the command defaults to loading only specmatic.json files for configuration, which leads to a failure in processing YAML-based configurations

<!-- How were these changes implemented? -->

**How**: by utilizing the getConfigFileName function from specmatic.core, rather than defaulting to specmatic.json.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation N/A
- [ ] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #123

<!-- feel free to add additional comments -->
