### PR TITLE
Added example directories parameter to TestCommand and Specmatic Config, aliased in StubCommand.

### DIFF
--- a/application/src/main/kotlin/application/StubCommand.kt
+++ b/application/src/main/kotlin/application/StubCommand.kt
@@ -33,8 +33,8 @@ class StubCommand : Callable<Unit> {
     @Parameters(arity = "0..*", description = ["Contract file paths"])
     var contractPaths: List<String> = mutableListOf()
 
-    @Option(names = ["--data"], description = ["Directory in which contract data may be found"], required = false)
-    var dataDirs: List<String> = mutableListOf()
+    @Option(names = ["--data", "--examples"], description = ["Directories containing JSON examples"], required = false)
+    var exampleDirs: List<String> = mutableListOf()
 
     @Option(names = ["--host"], description = ["Host for the http stub"], defaultValue = DEFAULT_HTTP_STUB_HOST)
     lateinit var host: String
@@ -129,7 +129,7 @@ class StubCommand : Callable<Unit> {
 
             if(httpStub != null) {
                 addShutdownHook()
-                val watcher = watchMaker.make(contractPaths.plus(dataDirs))
+                val watcher = watchMaker.make(contractPaths.plus(exampleDirs))
                 watcher.watchForChanges {
                     restartServer()
                 }
@@ -168,7 +168,7 @@ class StubCommand : Callable<Unit> {
 
     private fun startServer() {
         val workingDirectory = WorkingDirectory()
-        val stubData = stubLoaderEngine.loadStubs(contractSources, dataDirs)
+        val stubData = stubLoaderEngine.loadStubs(contractSources, exampleDirs)
 
         val certInfo = CertInfo(keyStoreFile, keyStoreDir, keyStorePassword, keyStoreAlias, keyPassword)
 

--- a/application/src/main/kotlin/application/TestCommand.kt
+++ b/application/src/main/kotlin/application/TestCommand.kt
@@ -6,6 +6,7 @@ import io.specmatic.core.DEFAULT_TIMEOUT_IN_SECONDS
 import io.specmatic.core.log.Verbose
 import io.specmatic.core.log.logger
 import io.specmatic.core.pattern.ContractException
+import io.specmatic.core.utilities.Flags.Companion.EXAMPLE_DIRECTORIES
 import io.specmatic.core.utilities.Flags.Companion.SPECMATIC_TEST_PARALLELISM
 import io.specmatic.core.utilities.Flags.Companion.getStringValue
 import io.specmatic.core.utilities.exitWithMessage
@@ -101,6 +102,9 @@ class TestCommand : Callable<Unit> {
     @Option(names = ["--debug"], description = ["Debug logs"])
     var verboseMode: Boolean = false
 
+    @Option(names = ["--examples"], description = ["Directories containing JSON examples"], required = false)
+    var exampleDirs: List<String> = mutableListOf()
+
     override fun call() = try {
         setParallelism()
 
@@ -133,6 +137,10 @@ class TestCommand : Callable<Unit> {
         System.setProperty(INLINE_SUGGESTIONS, suggestions)
         System.setProperty(ENV_NAME, envName)
         System.setProperty("protocol", protocol)
+
+        if(exampleDirs.isNotEmpty()) {
+            System.setProperty(EXAMPLE_DIRECTORIES, exampleDirs.joinToString(","))
+        }
 
         if(filterName.isNotBlank()) {
             System.setProperty(FILTER_NAME_PROPERTY, filterName)

--- a/application/src/test/kotlin/application/TestCommandTest.kt
+++ b/application/src/test/kotlin/application/TestCommandTest.kt
@@ -105,10 +105,12 @@ internal class TestCommandTest {
             systemPropertyValue: String
     ) {
         every { specmaticConfig.contractTestPaths() }.returns(contractsToBeRunAsTests)
-
-        CommandLine(testCommand, factory).execute(optionName, optionValue)
-
-        assertThat(System.getProperty(systemPropertyName)).isEqualTo(systemPropertyValue)
+        try {
+            CommandLine(testCommand, factory).execute(optionName, optionValue)
+            assertThat(System.getProperty(systemPropertyName)).isEqualTo(systemPropertyValue)
+        } finally {
+            System.clearProperty(systemPropertyName)
+        }
     }
 
     @Test

--- a/application/src/test/kotlin/application/TestCommandTest.kt
+++ b/application/src/test/kotlin/application/TestCommandTest.kt
@@ -5,6 +5,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import io.specmatic.core.CONTRACT_EXTENSION
+import io.specmatic.core.utilities.Flags
 import io.specmatic.core.utilities.newXMLBuilder
 import io.specmatic.test.SpecmaticJUnitSupport.Companion.CONTRACT_PATHS
 import io.specmatic.test.SpecmaticJUnitSupport.Companion.HOST
@@ -28,7 +29,6 @@ import org.xml.sax.InputSource
 import picocli.CommandLine
 import java.io.StringReader
 import java.util.*
-import java.util.function.Consumer
 import java.util.stream.Stream
 
 
@@ -150,6 +150,7 @@ internal class TestCommandTest {
                 Arguments.of("--port", "9999", PORT, "9999"),
                 Arguments.of("--host", "10.10.10.10", HOST, "10.10.10.10"),
                 Arguments.of("--timeout", "33", TIMEOUT, "33"),
+                Arguments.of("--examples", "test/data", Flags.EXAMPLE_DIRECTORIES, "test/data")
         )
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -1404,7 +1404,7 @@ data class Feature(
     fun loadExternalisedExamples(): Feature {
         val testsDirectory = getTestsDirectory(File(this.path))
         val externalisedExamplesFromDefaultDirectory = loadExternalisedJSONExamples(testsDirectory)
-        val externalisedExampleDirsFromConfig = specmaticConfig.exampleDirectories
+        val externalisedExampleDirsFromConfig = specmaticConfig.examples
 
         val externalisedExamplesFromExampleDirs = externalisedExampleDirsFromConfig.flatMap { directory ->
             loadExternalisedJSONExamples(File(directory)).entries

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -19,8 +19,6 @@ import io.cucumber.messages.IdGenerator
 import io.cucumber.messages.IdGenerator.Incrementing
 import io.cucumber.messages.types.*
 import io.cucumber.messages.types.Examples
-import io.specmatic.core.utilities.Flags.Companion.LOCAL_TESTS_DIRECTORY
-import io.specmatic.core.utilities.Flags.Companion.getStringValue
 import io.swagger.v3.oas.models.*
 import io.swagger.v3.oas.models.headers.Header
 import io.swagger.v3.oas.models.info.Info
@@ -1406,11 +1404,13 @@ data class Feature(
     fun loadExternalisedExamples(): Feature {
         val testsDirectory = getTestsDirectory(File(this.path))
         val externalisedExamplesFromDefaultDirectory = loadExternalisedJSONExamples(testsDirectory)
-        val externalisedExamplesFromLocalDirectory = getStringValue(LOCAL_TESTS_DIRECTORY)?.let {
-            loadExternalisedJSONExamples(File(it))
-        } ?: emptyMap()
+        val externalisedExampleDirsFromConfig = specmaticConfig.exampleDirectories
 
-        val allExternalisedJSONExamples = externalisedExamplesFromDefaultDirectory + externalisedExamplesFromLocalDirectory
+        val externalisedExamplesFromExampleDirs = externalisedExampleDirsFromConfig.flatMap { directory ->
+            loadExternalisedJSONExamples(File(directory)).entries
+        }.associate { it.toPair() }
+
+        val allExternalisedJSONExamples = externalisedExamplesFromDefaultDirectory + externalisedExamplesFromExampleDirs
 
         if(allExternalisedJSONExamples.isEmpty())
             return this

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -69,7 +69,7 @@ data class SpecmaticConfig(
     val report: ReportConfiguration? = null,
     val security: SecurityConfiguration? = null,
     val test: TestConfiguration? = TestConfiguration(),
-    val exampleDirectories: List<String> = getStringValue(EXAMPLE_DIRECTORIES)?.split(",") ?: emptyList()
+    val examples: List<String> = getStringValue(EXAMPLE_DIRECTORIES)?.split(",") ?: emptyList()
 ) {
     fun isExtensibleSchemaEnabled(): Boolean {
         return (test?.allowExtensibleSchema == true)

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -10,11 +10,13 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import io.specmatic.core.Configuration.Companion.globalConfigFileName
 import io.specmatic.core.log.logger
 import io.specmatic.core.pattern.ContractException
+import io.specmatic.core.utilities.Flags.Companion.EXAMPLE_DIRECTORIES
 import io.specmatic.core.utilities.Flags.Companion.EXTENSIBLE_SCHEMA
 import io.specmatic.core.utilities.Flags.Companion.ONLY_POSITIVE
 import io.specmatic.core.utilities.Flags.Companion.SPECMATIC_GENERATIVE_TESTS
 import io.specmatic.core.utilities.Flags.Companion.VALIDATE_RESPONSE_VALUE
 import io.specmatic.core.utilities.Flags.Companion.getBooleanValue
+import io.specmatic.core.utilities.Flags.Companion.getStringValue
 import java.io.File
 
 const val APPLICATION_NAME = "Specmatic"
@@ -66,7 +68,8 @@ data class SpecmaticConfig(
     val repository: RepositoryInfo? = null,
     val report: ReportConfiguration? = null,
     val security: SecurityConfiguration? = null,
-    val test: TestConfiguration? = TestConfiguration()
+    val test: TestConfiguration? = TestConfiguration(),
+    val exampleDirectories: List<String> = getStringValue(EXAMPLE_DIRECTORIES)?.split(",") ?: emptyList()
 ) {
     fun isExtensibleSchemaEnabled(): Boolean {
         return (test?.allowExtensibleSchema == true)

--- a/core/src/main/kotlin/io/specmatic/core/utilities/Flags.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/Flags.kt
@@ -10,7 +10,7 @@ class Flags {
         const val SCHEMA_EXAMPLE_DEFAULT = "SCHEMA_EXAMPLE_DEFAULT"
         const val SPECMATIC_TEST_PARALLELISM = "SPECMATIC_TEST_PARALLELISM"
 
-        const val LOCAL_TESTS_DIRECTORY = "LOCAL_TESTS_DIRECTORY"
+        const val EXAMPLE_DIRECTORIES = "EXAMPLE_DIRECTORIES"
 
         fun getStringValue(flagName: String): String? = System.getenv(flagName) ?: System.getProperty(flagName)
 

--- a/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
+++ b/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
@@ -10,7 +10,7 @@ import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.log.*
 import io.specmatic.core.pattern.parsedJSONArray
 import io.specmatic.core.pattern.parsedJSONObject
-import io.specmatic.core.utilities.Flags.Companion.LOCAL_TESTS_DIRECTORY
+import io.specmatic.core.utilities.Flags.Companion.EXAMPLE_DIRECTORIES
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.Value
 import io.specmatic.test.TestExecutor
@@ -205,7 +205,7 @@ class LoadTestsFromExternalisedFiles {
                       description: Name of the person
         """.trimIndent()
 
-        System.setProperty(LOCAL_TESTS_DIRECTORY, "src/test/resources/local_tests")
+        System.setProperty(EXAMPLE_DIRECTORIES, "src/test/resources/local_tests")
         val feature = OpenApiSpecification
             .fromYAML(
                 spec,
@@ -227,7 +227,7 @@ class LoadTestsFromExternalisedFiles {
 
         assertThat(results.successCount).isEqualTo(1)
         assertThat(results.success()).withFailMessage(results.report()).isTrue()
-        System.clearProperty(LOCAL_TESTS_DIRECTORY)
+        System.clearProperty(EXAMPLE_DIRECTORIES)
     }
 
     @Test

--- a/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
+++ b/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
@@ -225,9 +225,12 @@ class LoadTestsFromExternalisedFiles {
             }
         })
 
-        assertThat(results.successCount).isEqualTo(1)
-        assertThat(results.success()).withFailMessage(results.report()).isTrue()
-        System.clearProperty(EXAMPLE_DIRECTORIES)
+        try {
+            assertThat(results.successCount).isEqualTo(1)
+            assertThat(results.success()).withFailMessage(results.report()).isTrue()
+        } finally {
+            System.clearProperty(EXAMPLE_DIRECTORIES)
+        }
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigKtTest.kt
@@ -60,7 +60,7 @@ internal class SpecmaticConfigKtTest {
 
         assertThat((config.security?.OpenAPI?.securitySchemes?.get("BasicAuth") as BasicAuthSecuritySchemeConfiguration).token).isEqualTo("Abc123")
 
-        assertThat(config.examples).isEqualTo(listOf("test/data", "stub/examples"))
+        assertThat(config.examples).isEqualTo(listOf("folder1/examples", "folder2/examples"))
 
         assertThat(config.isResiliencyTestingEnabled()).isEqualTo(true)
         assertThat(config.isExtensibleSchemaEnabled()).isTrue()
@@ -144,19 +144,19 @@ internal class SpecmaticConfigKtTest {
             EXTENSIBLE_SCHEMA to "false",
             SCHEMA_EXAMPLE_DEFAULT to "true",
             MAX_TEST_REQUEST_COMBINATIONS to "50",
-            EXAMPLE_DIRECTORIES to "test/data,stub/examples"
+            EXAMPLE_DIRECTORIES to "folder1/examples,folder2/examples"
         )
-        properties.forEach { System.setProperty(it.key, it.value) }
-
-        val config = SpecmaticConfig()
-
-        assertThat(config.isResiliencyTestingEnabled()).isTrue()
-        assertThat(config.isOnlyPositiveTestingEnabled()).isFalse()
-        assertThat(config.isResponseValueValidationEnabled()).isTrue()
-        assertThat(config.isExtensibleSchemaEnabled()).isFalse()
-        assertThat(config.examples).isEqualTo(listOf("test/data", "stub/examples"))
-
-        properties.forEach { System.clearProperty(it.key) }
+        try {
+            properties.forEach { System.setProperty(it.key, it.value) }
+            val config = SpecmaticConfig()
+            assertThat(config.isResiliencyTestingEnabled()).isTrue()
+            assertThat(config.isOnlyPositiveTestingEnabled()).isFalse()
+            assertThat(config.isResponseValueValidationEnabled()).isTrue()
+            assertThat(config.isExtensibleSchemaEnabled()).isFalse()
+            assertThat(config.examples).isEqualTo(listOf("folder1/examples", "folder2/examples"))
+        } finally {
+            properties.forEach { System.clearProperty(it.key) }
+        }
     }
 
     @Test
@@ -189,17 +189,15 @@ internal class SpecmaticConfigKtTest {
             SPECMATIC_GENERATIVE_TESTS to "false",
             VALIDATE_RESPONSE_VALUE to "false",
             EXTENSIBLE_SCHEMA to "false",
-            EXAMPLE_DIRECTORIES to "api/tests,api/stubs"
+            EXAMPLE_DIRECTORIES to "folder1/examples,folder2/examples"
         )
         try {
             props.forEach { System.setProperty(it.key, it.value) }
-
             val config: SpecmaticConfig = loadSpecmaticConfig(configFile)
-
             assertThat(config.isResiliencyTestingEnabled()).isTrue()
             assertThat(config.isResponseValueValidationEnabled()).isTrue()
             assertThat(config.isExtensibleSchemaEnabled()).isTrue()
-            assertThat(config.examples).isEqualTo(listOf("test/data", "stub/examples"))
+            assertThat(config.examples).isEqualTo(listOf("folder1/examples", "folder2/examples"))
         } finally {
             props.forEach { System.clearProperty(it.key) }
         }

--- a/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigKtTest.kt
@@ -2,6 +2,7 @@ package io.specmatic.core
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import io.specmatic.core.utilities.Flags.Companion.EXAMPLE_DIRECTORIES
 import io.specmatic.core.utilities.Flags.Companion.EXTENSIBLE_SCHEMA
 import io.specmatic.core.utilities.Flags.Companion.MAX_TEST_REQUEST_COMBINATIONS
 import io.specmatic.core.utilities.Flags.Companion.ONLY_POSITIVE
@@ -58,6 +59,8 @@ internal class SpecmaticConfigKtTest {
         assertThat((config.security?.OpenAPI?.securitySchemes?.get("ApiKeyAuthQuery") as APIKeySecuritySchemeConfiguration).value).isEqualTo("API-QUERY-PARAM-USER")
 
         assertThat((config.security?.OpenAPI?.securitySchemes?.get("BasicAuth") as BasicAuthSecuritySchemeConfiguration).token).isEqualTo("Abc123")
+
+        assertThat(config.exampleDirectories).isEqualTo(listOf("test/data", "stub/examples"))
 
         assertThat(config.isResiliencyTestingEnabled()).isEqualTo(true)
         assertThat(config.isExtensibleSchemaEnabled()).isTrue()
@@ -140,7 +143,8 @@ internal class SpecmaticConfigKtTest {
             VALIDATE_RESPONSE_VALUE to "true",
             EXTENSIBLE_SCHEMA to "false",
             SCHEMA_EXAMPLE_DEFAULT to "true",
-            MAX_TEST_REQUEST_COMBINATIONS to "50"
+            MAX_TEST_REQUEST_COMBINATIONS to "50",
+            EXAMPLE_DIRECTORIES to "test/data,stub/examples"
         )
         properties.forEach { System.setProperty(it.key, it.value) }
 
@@ -150,6 +154,7 @@ internal class SpecmaticConfigKtTest {
         assertThat(config.isOnlyPositiveTestingEnabled()).isFalse()
         assertThat(config.isResponseValueValidationEnabled()).isTrue()
         assertThat(config.isExtensibleSchemaEnabled()).isFalse()
+        assertThat(config.exampleDirectories).isEqualTo(listOf("test/data", "stub/examples"))
 
         properties.forEach { System.clearProperty(it.key) }
     }
@@ -183,7 +188,8 @@ internal class SpecmaticConfigKtTest {
         val props = mapOf(
             SPECMATIC_GENERATIVE_TESTS to "false",
             VALIDATE_RESPONSE_VALUE to "false",
-            EXTENSIBLE_SCHEMA to "false"
+            EXTENSIBLE_SCHEMA to "false",
+            EXAMPLE_DIRECTORIES to "api/tests,api/stubs"
         )
         try {
             props.forEach { System.setProperty(it.key, it.value) }
@@ -193,6 +199,7 @@ internal class SpecmaticConfigKtTest {
             assertThat(config.isResiliencyTestingEnabled()).isTrue()
             assertThat(config.isResponseValueValidationEnabled()).isTrue()
             assertThat(config.isExtensibleSchemaEnabled()).isTrue()
+            assertThat(config.exampleDirectories).isEqualTo(listOf("test/data", "stub/examples"))
         } finally {
             props.forEach { System.clearProperty(it.key) }
         }

--- a/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigKtTest.kt
@@ -60,7 +60,7 @@ internal class SpecmaticConfigKtTest {
 
         assertThat((config.security?.OpenAPI?.securitySchemes?.get("BasicAuth") as BasicAuthSecuritySchemeConfiguration).token).isEqualTo("Abc123")
 
-        assertThat(config.exampleDirectories).isEqualTo(listOf("test/data", "stub/examples"))
+        assertThat(config.examples).isEqualTo(listOf("test/data", "stub/examples"))
 
         assertThat(config.isResiliencyTestingEnabled()).isEqualTo(true)
         assertThat(config.isExtensibleSchemaEnabled()).isTrue()
@@ -154,7 +154,7 @@ internal class SpecmaticConfigKtTest {
         assertThat(config.isOnlyPositiveTestingEnabled()).isFalse()
         assertThat(config.isResponseValueValidationEnabled()).isTrue()
         assertThat(config.isExtensibleSchemaEnabled()).isFalse()
-        assertThat(config.exampleDirectories).isEqualTo(listOf("test/data", "stub/examples"))
+        assertThat(config.examples).isEqualTo(listOf("test/data", "stub/examples"))
 
         properties.forEach { System.clearProperty(it.key) }
     }
@@ -199,7 +199,7 @@ internal class SpecmaticConfigKtTest {
             assertThat(config.isResiliencyTestingEnabled()).isTrue()
             assertThat(config.isResponseValueValidationEnabled()).isTrue()
             assertThat(config.isExtensibleSchemaEnabled()).isTrue()
-            assertThat(config.exampleDirectories).isEqualTo(listOf("test/data", "stub/examples"))
+            assertThat(config.examples).isEqualTo(listOf("test/data", "stub/examples"))
         } finally {
             props.forEach { System.clearProperty(it.key) }
         }

--- a/core/src/test/resources/specmaticConfigFiles/specmatic.json
+++ b/core/src/test/resources/specmaticConfigFiles/specmatic.json
@@ -87,5 +87,5 @@
     "validateResponseValues": true,
     "allowExtensibleSchema": true
   },
-  "exampleDirectories": ["test/data", "stub/examples"]
+  "examples": ["test/data", "stub/examples"]
 }

--- a/core/src/test/resources/specmaticConfigFiles/specmatic.json
+++ b/core/src/test/resources/specmaticConfigFiles/specmatic.json
@@ -86,5 +86,6 @@
     },
     "validateResponseValues": true,
     "allowExtensibleSchema": true
-  }
+  },
+  "exampleDirectories": ["test/data", "stub/examples"]
 }

--- a/core/src/test/resources/specmaticConfigFiles/specmatic.json
+++ b/core/src/test/resources/specmaticConfigFiles/specmatic.json
@@ -87,5 +87,5 @@
     "validateResponseValues": true,
     "allowExtensibleSchema": true
   },
-  "examples": ["test/data", "stub/examples"]
+  "examples": ["folder1/examples", "folder2/examples"]
 }

--- a/core/src/test/resources/specmaticConfigFiles/specmatic.yaml
+++ b/core/src/test/resources/specmaticConfigFiles/specmatic.yaml
@@ -64,5 +64,5 @@ test:
   allowExtensibleSchema: true
 
 examples:
-  - test/data
-  - stub/examples
+  - folder1/examples
+  - folder2/examples

--- a/core/src/test/resources/specmaticConfigFiles/specmatic.yaml
+++ b/core/src/test/resources/specmaticConfigFiles/specmatic.yaml
@@ -63,6 +63,6 @@ test:
   validateResponseValues: true
   allowExtensibleSchema: true
 
-exampleDirectories:
+examples:
   - test/data
   - stub/examples

--- a/core/src/test/resources/specmaticConfigFiles/specmatic.yaml
+++ b/core/src/test/resources/specmaticConfigFiles/specmatic.yaml
@@ -62,3 +62,7 @@ test:
     enable: all
   validateResponseValues: true
   allowExtensibleSchema: true
+
+exampleDirectories:
+  - test/data
+  - stub/examples

--- a/core/src/test/resources/specmaticConfigFiles/specmatic.yml
+++ b/core/src/test/resources/specmaticConfigFiles/specmatic.yml
@@ -63,7 +63,7 @@ test:
   validateResponseValues: true
   allowExtensibleSchema: true
 
-exampleDirectories:
+examples:
   - test/data
   - stub/examples
 

--- a/core/src/test/resources/specmaticConfigFiles/specmatic.yml
+++ b/core/src/test/resources/specmaticConfigFiles/specmatic.yml
@@ -64,6 +64,6 @@ test:
   allowExtensibleSchema: true
 
 examples:
-  - test/data
-  - stub/examples
+  - folder1/examples
+  - folder2/examples
 

--- a/core/src/test/resources/specmaticConfigFiles/specmatic.yml
+++ b/core/src/test/resources/specmaticConfigFiles/specmatic.yml
@@ -62,3 +62,8 @@ test:
     enable: all
   validateResponseValues: true
   allowExtensibleSchema: true
+
+exampleDirectories:
+  - test/data
+  - stub/examples
+


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
-  Add `--examples` parameter to TestCommand, rename in StubCommand.
- Add `exampleDirectories` attribute to SpecmaticConfig.

<!-- Why are these changes necessary? -->

**Why**: Currently it is not possible to configure the examples directory within the test command or SpecmaticConfig.

<!-- How were these changes implemented? -->

**How**:
- Alias `examples` to `--data` argument in `StubCommand`.
- Add `--examples` in `TestCommand`.
- Refactor `loadExternalisedExamples` to use list of directories.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation N/A
- [x] Tests
- [ ] Sonar Quality Gate

<!-- feel free to add additional comments -->
