### PR TITLE
Ensure non-zero exit code for TestCommand on test failures.

### DIFF
--- a/application/src/main/kotlin/application/TestCommand.kt
+++ b/application/src/main/kotlin/application/TestCommand.kt
@@ -24,6 +24,7 @@ import io.specmatic.test.SpecmaticJUnitSupport.Companion.SUGGESTIONS_PATH
 import io.specmatic.test.SpecmaticJUnitSupport.Companion.TEST_BASE_URL
 import io.specmatic.test.SpecmaticJUnitSupport.Companion.TIMEOUT
 import io.specmatic.test.SpecmaticJUnitSupport.Companion.VARIABLES_FILE_NAME
+import io.specmatic.test.listeners.ContractExecutionListener
 import org.junit.platform.engine.discovery.DiscoverySelectors.selectClass
 import org.junit.platform.launcher.Launcher
 import org.junit.platform.launcher.LauncherDiscoveryRequest
@@ -174,6 +175,8 @@ class TestCommand : Callable<Unit> {
                 throw ContractException("Was expecting a JUnit report file called TEST-junit-jupiter.xml inside $junitReportDirName but could not find it.")
             }
         }
+
+        ContractExecutionListener.exitProcess()
     }
     catch (e: Throwable) {
         logger.log(e)

--- a/junit5-support/src/main/kotlin/io/specmatic/test/listeners/ContractExecutionListener.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/listeners/ContractExecutionListener.kt
@@ -23,18 +23,25 @@ private fun stdOutIsRedirected() = System.console() == null
 
 class ContractExecutionListener : TestExecutionListener {
 
-    private var totalRun: Int = 0
+    companion object {
+        private var totalRun: Int = 0
+        private var success: Int = 0
+        private var failure: Int = 0
+        private var aborted: Int = 0
 
-    private var success: Int = 0
-    private var failure: Int = 0
-    private var aborted: Int = 0
+        private val failedLog: MutableList<String> = mutableListOf()
+        private var couldNotStart = false
+        private val exceptionsThrown = mutableListOf<Throwable>()
+        private val printer: ContractExecutionPrinter = getContractExecutionPrinter()
 
-    private val failedLog: MutableList<String> = mutableListOf()
-
-    private var couldNotStart = false
-    private val exceptionsThrown = mutableListOf<Throwable>()
-
-    private val printer: ContractExecutionPrinter = getContractExecutionPrinter()
+        fun exitProcess() {
+            val exitStatus = when (failure != 0 || couldNotStart) {
+                true -> 1
+                false -> 0
+            }
+            exitProcess(exitStatus)
+        }
+    }
 
     override fun executionSkipped(testIdentifier: TestIdentifier?, reason: String?) {
         super.executionSkipped(testIdentifier, reason)
@@ -123,15 +130,6 @@ class ContractExecutionListener : TestExecutionListener {
         }
 
         printer.printFinalSummary(TestSummary(success, SpecmaticJUnitSupport.partialSuccesses.size, aborted, failure))
-    }
-
-    fun exitProcess() {
-        val exitStatus = when (failure != 0 || couldNotStart) {
-            true -> 1
-            false -> 0
-        }
-
-        exitProcess(exitStatus)
     }
 }
 

--- a/junit5-support/src/main/kotlin/io/specmatic/test/listeners/ContractExecutionListener.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/listeners/ContractExecutionListener.kt
@@ -24,7 +24,6 @@ private fun stdOutIsRedirected() = System.console() == null
 class ContractExecutionListener : TestExecutionListener {
 
     companion object {
-        private var totalRun: Int = 0
         private var success: Int = 0
         private var failure: Int = 0
         private var aborted: Int = 0
@@ -131,15 +130,4 @@ class ContractExecutionListener : TestExecutionListener {
 
         printer.printFinalSummary(TestSummary(success, SpecmaticJUnitSupport.partialSuccesses.size, aborted, failure))
     }
-}
-
-private fun progressUpdate(totalTestsRun: Int, countOfTests: Int): String {
-    return "Tests run: $totalTestsRun/$countOfTests (${percentage(totalTestsRun, countOfTests)}%)"
-}
-
-private fun percentage(totalTestsRun: Int, countOfTests: Int): String {
-    return if(countOfTests == 0)
-        "0"
-    else
-        ((totalTestsRun.toDouble() / countOfTests.toDouble()) * 100).toInt().toString()
 }

--- a/junit5-support/src/test/kotlin/io/specmatic/test/ApiCoverageReportInputTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/ApiCoverageReportInputTest.kt
@@ -48,7 +48,7 @@ class ApiCoverageReportInputTest {
                     OpenApiCoverageConsoleRow("", "", "401", "1", 0, Remarks.Covered),
                     OpenApiCoverageConsoleRow("GET", "/route2", 200, 1, 100, Remarks.Covered)
                 ),
-                2,  0, 0, 0, 0
+                totalEndpointsCount = 2, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 0
             )
         )
     }
@@ -91,7 +91,7 @@ class ApiCoverageReportInputTest {
                     OpenApiCoverageConsoleRow("GET", "/route3", 0, 0, 0, Remarks.Missed),
                     OpenApiCoverageConsoleRow("POST", "", 0, 0, 0, Remarks.Missed)
                 ),
-                3, 1, 0, 1, 0
+                totalEndpointsCount = 3, missedEndpointsCount = 1, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 1, partiallyNotImplementedAPICount = 0
             )
         )
     }
@@ -139,7 +139,7 @@ class ApiCoverageReportInputTest {
                     OpenApiCoverageConsoleRow("GET", "/route2", 200, 1, 100,  Remarks.Covered),
                     OpenApiCoverageConsoleRow("POST", "", 200, 1, 0,  Remarks.Covered)
                 ),
-                2,  0, 0, 0, 0
+                totalEndpointsCount = 2,  missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 0
             )
         )
     }
@@ -226,7 +226,7 @@ class ApiCoverageReportInputTest {
                     OpenApiCoverageConsoleRow("POST", "", 200, 1, 0, Remarks.NotImplemented),
                     OpenApiCoverageConsoleRow("", "", 404, 1, 0, Remarks.Missed)
                 ),
-                2, 0, 0, 1, 1
+                totalEndpointsCount = 2, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 1, partiallyNotImplementedAPICount = 1
             )
         )
     }
@@ -268,7 +268,7 @@ class ApiCoverageReportInputTest {
                     OpenApiCoverageConsoleRow("GET", "/route3/{route_id}", 0, 0, 0, Remarks.Missed),
                     OpenApiCoverageConsoleRow("POST", "", 0, 0, 0, Remarks.Missed)
                 ),
-                3, 1, 0, 1, 1
+                totalEndpointsCount = 3, missedEndpointsCount = 1, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 1, partiallyNotImplementedAPICount = 1
             )
         )
     }
@@ -344,7 +344,7 @@ class ApiCoverageReportInputTest {
                     OpenApiCoverageConsoleRow("", "", 404, 1, 0, Remarks.Covered),
                     OpenApiCoverageConsoleRow("POST", "", 500, 1, 0, Remarks.Covered)
                 ),
-                2, 0, 0, 0, 0
+                totalEndpointsCount = 2, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 0
             )
         )
     }

--- a/junit5-support/src/test/kotlin/io/specmatic/test/ApiCoverageReportTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/ApiCoverageReportTest.kt
@@ -49,7 +49,8 @@ class ApiCoverageReportTest {
                 listOf(
                     OpenApiCoverageConsoleRow("GET", "/order/{id}", 200, 1, 0, Remarks.NotImplemented),
                     OpenApiCoverageConsoleRow("", "", 404, 1, 0, Remarks.Missed),
-                ), 1, 0, 0, 1, 1
+                ),
+                totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 1, partiallyNotImplementedAPICount = 1
             )
         )
     }
@@ -72,7 +73,8 @@ class ApiCoverageReportTest {
                     OpenApiCoverageConsoleRow("POST", "/order/{id}", 201, 1, 0, Remarks.NotImplemented),
                     OpenApiCoverageConsoleRow("", "", 400, 1, 0, Remarks.NotImplemented),
                     OpenApiCoverageConsoleRow("", "", 404, 2, 0, Remarks.Missed)
-                ), 1, 0, 0, 1, 1
+                ),
+                totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 1, partiallyNotImplementedAPICount = 1
             )
         )
 
@@ -90,7 +92,7 @@ class ApiCoverageReportTest {
                 listOf(
                     OpenApiCoverageConsoleRow("GET", "/order/{id}", 200, 1, 0, Remarks.NotCovered),
                     OpenApiCoverageConsoleRow("", "", 404, 1, 0, Remarks.Missed),
-                ), 1, 0, 0, 1, 0
+                ), totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 1, partiallyNotImplementedAPICount = 0
             )
         )
     }
@@ -112,7 +114,7 @@ class ApiCoverageReportTest {
                     OpenApiCoverageConsoleRow("POST", "/order/{id}", 201, 1, 0, Remarks.NotCovered),
                     OpenApiCoverageConsoleRow("", "", 400, 1, 0, Remarks.NotCovered),
                     OpenApiCoverageConsoleRow("", "", 404, 2, 0, Remarks.Missed)
-                ), 1, 0, 0, 1, 0
+                ), totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 1, partiallyNotImplementedAPICount = 0
             )
         )
     }
@@ -133,7 +135,7 @@ class ApiCoverageReportTest {
                 listOf(
                     OpenApiCoverageConsoleRow("GET", "/order/{id}", 200, 1, 50, Remarks.NotImplemented),
                     OpenApiCoverageConsoleRow("", "", 404, 1, 0, Remarks.Covered),
-                ), 1, 0, 0, 0, 1
+                ), totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 1
             )
         )
     }
@@ -159,7 +161,7 @@ class ApiCoverageReportTest {
                     OpenApiCoverageConsoleRow("POST", "/order/{id}", 201, 1, 33, Remarks.NotImplemented),
                     OpenApiCoverageConsoleRow("", "", 400, 1, 0, Remarks.NotImplemented),
                     OpenApiCoverageConsoleRow("", "", 404, 2, 0, Remarks.Covered),
-                ), 1, 0, 0, 0, 1
+                ), totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 1
             )
         )
     }
@@ -179,7 +181,7 @@ class ApiCoverageReportTest {
                 listOf(
                     OpenApiCoverageConsoleRow("GET", "/order/{id}", 200, 1, 50, Remarks.NotCovered),
                     OpenApiCoverageConsoleRow("", "", 404, 1, 0, Remarks.Covered),
-                ), 1, 0, 0, 0, 0
+                ), totalEndpointsCount = 1, missedEndpointsCount =  0, notImplementedAPICount =  0, partiallyMissedEndpointsCount =  0, partiallyNotImplementedAPICount =  0
             )
         )
     }
@@ -203,7 +205,7 @@ class ApiCoverageReportTest {
                     OpenApiCoverageConsoleRow("POST", "/order/{id}", 201, 1, 33, Remarks.NotCovered),
                     OpenApiCoverageConsoleRow("", "", 400, 1, 0, Remarks.NotCovered),
                     OpenApiCoverageConsoleRow("", "", 404, 2, 0, Remarks.Covered),
-                ), 1, 0, 0, 0, 0
+                ), totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount =  0
             )
         )
     }
@@ -227,7 +229,7 @@ class ApiCoverageReportTest {
                 listOf(
                     OpenApiCoverageConsoleRow("GET", "/order/{id}", 200, 1, 50, Remarks.Covered),
                     OpenApiCoverageConsoleRow("", "", 404, 0, 0, Remarks.DidNotRun),
-                ), 1, 0, 0, 0, 0
+                ), totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 0
             )
         )
     }
@@ -254,7 +256,7 @@ class ApiCoverageReportTest {
                     OpenApiCoverageConsoleRow("POST", "/order/{id}", 201, 1, 67, Remarks.Covered),
                     OpenApiCoverageConsoleRow("", "", 400, 1, 0, Remarks.Covered),
                     OpenApiCoverageConsoleRow("", "", 404, 0, 0, Remarks.DidNotRun),
-                ), 1, 0, 0, 0, 0
+                ), totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 0
             )
         )
 
@@ -275,7 +277,7 @@ class ApiCoverageReportTest {
                 listOf(
                     OpenApiCoverageConsoleRow("GET", "/order/{id}", 200, 1, 50, Remarks.Covered),
                     OpenApiCoverageConsoleRow("", "", 400, 0, 0, Remarks.DidNotRun),
-                ), 1, 0, 0, 0, 0
+                ), totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 0
             )
         )
     }
@@ -299,7 +301,7 @@ class ApiCoverageReportTest {
                     OpenApiCoverageConsoleRow("POST", "/order/{id}", 201, 1, 67, Remarks.Covered),
                     OpenApiCoverageConsoleRow("", "", 400, 1, 0, Remarks.Covered),
                     OpenApiCoverageConsoleRow("", "", 404, 0, 0, Remarks.DidNotRun),
-                ), 1, 0, 0, 0, 0
+                ), totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 0
             )
         )
     }
@@ -324,7 +326,7 @@ class ApiCoverageReportTest {
                 listOf(
                     OpenApiCoverageConsoleRow("GET", "/order/{id}", 200, 1, 50, Remarks.Covered),
                     OpenApiCoverageConsoleRow("", "", 404, 1, 0, Remarks.Missed),
-                ), 1, 0, 0, 1, 0
+                ), totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 1, partiallyNotImplementedAPICount = 0
             )
         )
     }
@@ -344,7 +346,7 @@ class ApiCoverageReportTest {
                 listOf(
                     OpenApiCoverageConsoleRow("GET", "/order/{id}", 200, 1, 0, Remarks.NotCovered),
                     OpenApiCoverageConsoleRow("", "", 404, 1, 0, Remarks.Missed),
-                ), 1, 0, 0, 1, 0
+                ), totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 1, partiallyNotImplementedAPICount = 0
             )
         )
     }
@@ -367,7 +369,7 @@ class ApiCoverageReportTest {
                 listOf(
                     OpenApiCoverageConsoleRow("GET", "/order/{id}", 200, 1, 100, Remarks.Covered),
                     OpenApiCoverageConsoleRow("", "", 404, 1, 0, Remarks.Covered),
-                ), 1, 0, 0, 0, 0
+                ), totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 0
             )
         )
     }
@@ -387,7 +389,7 @@ class ApiCoverageReportTest {
                 listOf(
                     OpenApiCoverageConsoleRow("GET", "/order/{id}", 200, 1, 50, Remarks.NotCovered),
                     OpenApiCoverageConsoleRow("", "", 404, 1, 0, Remarks.Covered),
-                ), 1, 0, 0, 0, 0
+                ), totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 0
             )
         )
     }

--- a/junit5-support/src/test/kotlin/io/specmatic/test/OpenApiCoverageConsoleReportTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/OpenApiCoverageConsoleReportTest.kt
@@ -20,7 +20,7 @@ class OpenApiCoverageConsoleReportTest {
             OpenApiCoverageConsoleRow("GET", "/route3", 200, 0, 0, Remarks.DidNotRun),
         )
 
-        val coverageReport = OpenAPICoverageConsoleReport(rows, 3,0, 0, 1, 0)
+        val coverageReport = OpenAPICoverageConsoleReport(rows, totalEndpointsCount = 3, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 1, partiallyNotImplementedAPICount = 0)
 
         assertThat(coverageReport.totalCoveragePercentage).isEqualTo(28)
     }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Ensure non-zero exit code for TestCommand on test failures.

<!-- Why are these changes necessary? -->

**Why**: The exit code status for Commadline Test is consistently zero (0) even in case of test failures..

<!-- How were these changes implemented? -->

**How**:
- Use keywords on CoverageReport tests for clarity
- Move `exitProcess` and result vars to companion object in `ContractExecutionListener`.
- Call `ContractExecutionListener`'s `exitProcess` from TestCommand.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation N/A
- [ ] Tests
- [ ] Sonar Quality Gate

<!-- feel free to add additional comments -->
