### PR TITLE
Fix issues with structural validation of response headers and example subdirectories when running test

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -1385,7 +1385,14 @@ data class Feature(
         if (files.isNullOrEmpty())
             return emptyMap()
 
-        return files.map { ExampleFromFile(it) }.mapNotNull { exampleFromFile ->
+        val examlesInSubdirectories: Map<OpenApiSpecification.OperationIdentifier, List<Row>> =
+            files.filter {
+                it.isDirectory
+            }.fold(emptyMap()) { acc, item ->
+                acc + loadExternalisedJSONExamples(item)
+            }
+
+        return examlesInSubdirectories + files.filterNot { it.isDirectory }.map { ExampleFromFile(it) }.mapNotNull { exampleFromFile ->
             try {
                 with(exampleFromFile) {
                     OpenApiSpecification.OperationIdentifier(

--- a/core/src/main/kotlin/io/specmatic/core/HttpResponsePattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpResponsePattern.kt
@@ -72,7 +72,8 @@ data class HttpResponsePattern(
 
             val expectedResponseValue: HttpResponsePattern =
                 HttpResponsePattern(
-                    HttpHeadersPattern(responseExample.responseExample.headers.mapValues { stringToPattern(it.value, it.key) }),
+                    responseExample.headersPattern(),
+//                    HttpHeadersPattern(responseExample.responseExample.headers.mapValues { stringToPattern(it.value, it.key) }),
                     responseExample.responseExample.status,
                     responseExample.bodyPattern()
                 )

--- a/core/src/main/kotlin/io/specmatic/core/HttpResponsePattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpResponsePattern.kt
@@ -73,7 +73,6 @@ data class HttpResponsePattern(
             val expectedResponseValue: HttpResponsePattern =
                 HttpResponsePattern(
                     responseExample.headersPattern(),
-//                    HttpHeadersPattern(responseExample.responseExample.headers.mapValues { stringToPattern(it.value, it.key) }),
                     responseExample.responseExample.status,
                     responseExample.bodyPattern()
                 )

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ResponseExample.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ResponseExample.kt
@@ -1,8 +1,11 @@
 package io.specmatic.core.pattern
 
+import io.specmatic.core.HttpHeadersPattern
 import io.specmatic.core.HttpResponse
 
 interface ResponseExample {
     fun bodyPattern(): Pattern
+    fun headersPattern(): HttpHeadersPattern
+
     val responseExample: HttpResponse
 }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ResponseSchemaExample.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ResponseSchemaExample.kt
@@ -1,9 +1,14 @@
 package io.specmatic.core.pattern
 
+import io.specmatic.core.HttpHeadersPattern
 import io.specmatic.core.HttpResponse
 
 class ResponseSchemaExample(override val responseExample: HttpResponse) : ResponseExample {
     override fun bodyPattern(): Pattern {
         return responseExample.body.deepPattern()
+    }
+
+    override fun headersPattern(): HttpHeadersPattern {
+        return HttpHeadersPattern(responseExample.headers.mapValues { AnythingPattern })
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ResponseValueExample.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ResponseValueExample.kt
@@ -1,9 +1,14 @@
 package io.specmatic.core.pattern
 
+import io.specmatic.core.HttpHeadersPattern
 import io.specmatic.core.HttpResponse
 
 class ResponseValueExample(override val responseExample: HttpResponse) : ResponseExample {
     override fun bodyPattern(): Pattern {
         return responseExample.body.exactMatchElseType()
+    }
+
+    override fun headersPattern(): HttpHeadersPattern {
+        return HttpHeadersPattern(responseExample.headers.mapValues { stringToPattern(it.value, it.key) })
     }
 }

--- a/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
+++ b/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
@@ -75,6 +75,30 @@ class LoadTestsFromExternalisedFiles {
     }
 
     @Test
+    fun `should load and execute externalized tests for header and request body from _examples sub-directory`() {
+        val feature = OpenApiSpecification.fromFile("src/test/resources/openapi/has_externalized_tests_in_subdirectories.yaml")
+            .toFeature().loadExternalisedExamples()
+
+        val results = feature.executeTests(object : TestExecutor {
+            override fun execute(request: HttpRequest): HttpResponse {
+                assertThat(request.path).isEqualTo("/order_action_figure")
+                assertThat(request.method).isEqualTo("POST")
+                assertThat(request.headers).containsEntry("X-Request-ID", "12345")
+                assertThat(request.body).isEqualTo(parsedJSONObject("""{"name": "Master Yoda", "description": "Head of the Jedi Council"}"""))
+
+                return HttpResponse.ok(parsedJSONObject("""{"id": 1}"""))
+            }
+
+            override fun setServerState(serverState: Map<String, Value>) {
+            }
+        })
+
+        println(results.report())
+        assertThat(results.successCount).isEqualTo(2)
+        assertThat(results.failureCount).isEqualTo(0)
+    }
+
+    @Test
     fun `externalized tests be converted to rows`() {
         val feature = OpenApiSpecification.fromFile("src/test/resources/openapi/has_two_externalised_tests.yaml").toFeature().loadExternalisedExamples()
         assertThat(feature.scenarios.first().examples.first().rows.size).isEqualTo(2)

--- a/core/src/test/kotlin/integration_tests/ValidateResponseSchemaTest.kt
+++ b/core/src/test/kotlin/integration_tests/ValidateResponseSchemaTest.kt
@@ -5,6 +5,7 @@ import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpResponse
 import io.specmatic.core.pattern.parsedJSONArray
 import io.specmatic.core.pattern.parsedJSONObject
+import io.specmatic.core.utilities.Flags
 import io.specmatic.test.TestExecutor
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -195,5 +196,174 @@ class ValidateResponseSchemaTest {
         })
 
         assertThat(results.success()).withFailMessage(results.report()).isTrue()
+    }
+
+    @Test
+    fun `response header schema validation should be done if a key in the response headers example is missing in the actual response headers`() {
+        val personSpec = """
+openapi: 3.0.3
+info:
+  title: Person API
+  version: 1.0.0
+  description: API for creating new people
+
+servers:
+  - url: http://localhost:5000  # Replace with your server URL
+
+paths:
+  /person/{id}:
+    get:
+      summary: Create a new person
+      parameters:
+        - in: path
+          required: true
+          name: id
+          schema:
+            type: number
+          examples:
+            GET_DETAILS:
+              value: 10
+      responses:
+        '200':
+          description: Person created successfully
+          headers:
+            X-Rate-Limit-Limit:
+              schema:
+                type: integer
+              description: The number of allowed requests in the current period
+              examples:
+                GET_DETAILS:
+                  value: 10
+            X-Rate-Limit-Remaining:
+              schema:
+                type: integer
+              description: The number of remaining requests in the current period
+              examples:
+                GET_DETAILS:
+                  value: 100
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - name
+                properties:
+                  name:
+                    type: string
+                  address:
+                    type: string        
+              examples:
+                GET_DETAILS:
+                  value:
+                    name: "Sherlock Holmes"
+                    address: "221B Baker Street"
+        """.trimIndent()
+
+        val feature = OpenApiSpecification.fromYAML(personSpec, "").toFeature()
+
+        val results = feature.executeTests(object : TestExecutor {
+            override fun execute(request: HttpRequest): HttpResponse {
+                val headers = mapOf<String, String>(
+                    "X-Rate-Limit-Limit" to "10"
+                )
+
+                return HttpResponse(200, headers, parsedJSONObject("""{"name": "Sherlock Holmes", "address": "221B Baker Street"}"""))
+            }
+        })
+
+        assertThat(results.failureCount).isEqualTo(1)
+
+        assertThat(results.report())
+            .contains("RESPONSE.HEADERS.X-Rate-Limit-Remaining")
+            .contains("header X-Rate-Limit-Remaining was missing")
+    }
+
+    @Test
+    fun `response header value validation should be done when value validation is enabled`() {
+        val personSpec = """
+openapi: 3.0.3
+info:
+  title: Person API
+  version: 1.0.0
+  description: API for creating new people
+
+servers:
+  - url: http://localhost:5000  # Replace with your server URL
+
+paths:
+  /person/{id}:
+    get:
+      summary: Create a new person
+      parameters:
+        - in: path
+          required: true
+          name: id
+          schema:
+            type: number
+          examples:
+            GET_DETAILS:
+              value: 10
+      responses:
+        '200':
+          description: Person created successfully
+          headers:
+            X-Rate-Limit-Limit:
+              schema:
+                type: integer
+              description: The number of allowed requests in the current period
+              examples:
+                GET_DETAILS:
+                  value: 10
+            X-Rate-Limit-Remaining:
+              schema:
+                type: integer
+              description: The number of remaining requests in the current period
+              examples:
+                GET_DETAILS:
+                  value: 100
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - name
+                properties:
+                  name:
+                    type: string
+                  address:
+                    type: string        
+              examples:
+                GET_DETAILS:
+                  value:
+                    name: "Sherlock Holmes"
+                    address: "221B Baker Street"
+        """.trimIndent()
+
+        val results = try {
+            System.setProperty(Flags.VALIDATE_RESPONSE_VALUE, "true")
+
+            val feature = OpenApiSpecification.fromYAML(personSpec, "").toFeature()
+
+            feature.executeTests(object : TestExecutor {
+                override fun execute(request: HttpRequest): HttpResponse {
+                    val headers = mapOf<String, String>(
+                        "X-Rate-Limit-Limit" to "10",
+                        "X-Rate-Limit-Remaining" to "200"
+                    )
+
+                    return HttpResponse(200, headers, parsedJSONObject("""{"name": "Sherlock Holmes", "address": "221B Baker Street"}"""))
+                }
+            })
+        } finally {
+            System.clearProperty(Flags.VALIDATE_RESPONSE_VALUE)
+        }
+
+        assertThat(results.failureCount).isEqualTo(1)
+
+        println(results.report())
+
+        assertThat(results.report())
+            .contains("RESPONSE.HEADERS.X-Rate-Limit-Remaining")
+            .contains("Expected \"100\", got value \"200\"")
     }
 }

--- a/core/src/test/resources/openapi/has_externalized_tests_in_subdirectories.yaml
+++ b/core/src/test/resources/openapi/has_externalized_tests_in_subdirectories.yaml
@@ -1,0 +1,37 @@
+openapi: 3.0.0
+info:
+  title: Order API
+  version: 1.0.0
+paths:
+  /order_action_figure:
+    post:
+      summary: Create a new order
+      parameters:
+          - in: header
+            name: X-Request-ID
+            schema:
+              type: string
+            description: Unique ID for the request
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                description:
+                  type: string
+              required:
+                - name
+                - description
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer

--- a/core/src/test/resources/openapi/has_externalized_tests_in_subdirectories_examples/subdirectory/test1.json
+++ b/core/src/test/resources/openapi/has_externalized_tests_in_subdirectories_examples/subdirectory/test1.json
@@ -1,0 +1,17 @@
+{
+  "http-request": {
+    "method": "POST",
+    "path": "/order_action_figure",
+    "headers": {
+      "X-Request-ID": "12345"
+    },
+    "body": {
+      "name": "Master Yoda",
+      "description": "Head of the Jedi Council"
+    }
+  },
+  "http-response": {
+    "status": 200
+  },
+  "name": "Create Order"
+}

--- a/core/src/test/resources/openapi/has_externalized_tests_in_subdirectories_examples/subdirectory/test2.json
+++ b/core/src/test/resources/openapi/has_externalized_tests_in_subdirectories_examples/subdirectory/test2.json
@@ -1,0 +1,17 @@
+{
+  "http-request": {
+    "method": "POST",
+    "path": "/order_action_figure",
+    "headers": {
+      "X-Request-ID": "12345"
+    },
+    "body": {
+      "name": "Master Yoda",
+      "description": "Head of the Jedi Council"
+    }
+  },
+  "http-response": {
+    "status": 200
+  },
+  "name": "Create Order"
+}


### PR DESCRIPTION
**What**:

1. When the VALIDATE_RESPONSE flag is not set, Specmatic was validating the values of response headers, instead of performing a structural validating (checking only the presence of headers in the response).
2. When running tests, examples in sub directories were not being loaded. Specmatic threw an error on encountering a subdirectory in a directory where it was expecting to see examples.

This PR fixes both the above issues.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate
