### PR TITLE
Fix inaccurate test counts in coverage report.

### DIFF
--- a/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
@@ -21,11 +21,10 @@ data class ScenarioAsTest(
     override fun testResultRecord(result: Result, response: HttpResponse?): TestResultRecord {
         val resultStatus = result.testResult()
 
-        val responseStatus = scenario.getStatus(response)
         return TestResultRecord(
             convertPathParameterStyle(scenario.path),
             scenario.method,
-            responseStatus,
+            scenario.status,
             resultStatus,
             sourceProvider,
             sourceRepository,

--- a/core/src/main/kotlin/io/specmatic/test/TestResultRecord.kt
+++ b/core/src/main/kotlin/io/specmatic/test/TestResultRecord.kt
@@ -12,7 +12,8 @@ data class TestResultRecord(
     val sourceRepositoryBranch: String? = null,
     val specification: String? = null,
     val serviceType: String? = null,
-    val actualResponseStatus: Int = 0
+    val actualResponseStatus: Int = 0,
+    val isValid: Boolean = true,
 ) {
     val isExercised = result !in setOf(TestResult.Skipped, TestResult.DidNotRun)
     val isCovered = result in setOf(TestResult.Success, TestResult.Error, TestResult.Failed, TestResult.Covered)

--- a/core/src/main/kotlin/io/specmatic/test/TestResultRecord.kt
+++ b/core/src/main/kotlin/io/specmatic/test/TestResultRecord.kt
@@ -17,4 +17,5 @@ data class TestResultRecord(
 ) {
     val isExercised = result !in setOf(TestResult.Skipped, TestResult.DidNotRun)
     val isCovered = result in setOf(TestResult.Success, TestResult.Error, TestResult.Failed, TestResult.Covered)
+    fun isConnectionRefused() = actualResponseStatus == 0
 }

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
@@ -204,50 +204,39 @@ class OpenApiCoverageReportInput(
 
     private fun identifyFailedTestsDueToUnimplementedEndpointsAddMissingTests(testResults: List<TestResultRecord>): List<TestResultRecord> {
         val notImplementedAndMissingTests = mutableListOf<TestResultRecord>()
-        val failedTests = testResults.filter { it.result == TestResult.Failed }
+        val failedTestResults = testResults.filter { it.result == TestResult.Failed }
 
-        for (test in failedTests) {
+        for (failedTestResult in failedTestResults) {
 
             val pathHasErrorResponse = allEndpoints.any {
-                it.path == test.path && it.method == test.method && it.responseStatus == test.actualResponseStatus
+                it.path == failedTestResult.path && it.method == failedTestResult.method && it.responseStatus == failedTestResult.actualResponseStatus
             }
 
-            if(test.actualResponseStatus != 0) {
+            if(!failedTestResult.isConnectionRefused()) {
                 notImplementedAndMissingTests.add(
-                    test.copy(
-                        responseStatus = test.actualResponseStatus,
+                    failedTestResult.copy(
+                        responseStatus = failedTestResult.actualResponseStatus,
                         result = if (pathHasErrorResponse) TestResult.Covered else TestResult.MissingInSpec,
-                        actualResponseStatus = test.actualResponseStatus
+                        actualResponseStatus = failedTestResult.actualResponseStatus
                     )
                 )
             }
 
             if (!endpointsAPISet) {
-                notImplementedAndMissingTests.add(test.copy(result = TestResult.NotCovered))
+                notImplementedAndMissingTests.add(failedTestResult.copy(result = TestResult.NotCovered))
                 continue
             }
 
-            val isInApplicationAPI = applicationAPIs.any { api -> api.path == test.path && api.method == test.method }
-            notImplementedAndMissingTests.add(test.copy(result = if (isInApplicationAPI) TestResult.Failed else TestResult.NotImplemented))
+            val isInApplicationAPI = applicationAPIs.any { api -> api.path == failedTestResult.path && api.method == failedTestResult.method }
+            notImplementedAndMissingTests.add(failedTestResult.copy(result = if (isInApplicationAPI) TestResult.Failed else TestResult.NotImplemented))
         }
 
-        return testResults.minus(failedTests.toSet()).plus(notImplementedAndMissingTests)
+        return testResults.minus(failedTestResults.toSet()).plus(notImplementedAndMissingTests)
     }
 
     private fun checkForInvalidTestsAndUpdateResult(allTests: List<TestResultRecord>): List<TestResultRecord> {
-        val invalidTestResults = mutableListOf<TestResultRecord>()
-
-        allTests.forEach {
-            if (!isTestResultValid(it)) {
-                invalidTestResults.add(it)
-            }
-        }
-
-        val updatedInvalidTestResults = invalidTestResults.map {
-            it.copy(
-                isValid = false
-            )
-        }
+        val invalidTestResults = allTests.filterNot(::isTestResultValid)
+        val updatedInvalidTestResults = invalidTestResults.map { it.copy( isValid = false ) }
 
         return allTests.minus(invalidTestResults.toSet()).plus(updatedInvalidTestResults)
     }
@@ -255,15 +244,12 @@ class OpenApiCoverageReportInput(
     private fun isTestResultValid(testResultRecord: TestResultRecord): Boolean {
         val paramRegex = Regex("\\{.+}")
         val isPathWithParams = paramRegex.find(testResultRecord.path) != null
+        if (isPathWithParams) return true
 
-        if(!isPathWithParams) {
-            return when (testResultRecord.responseStatus) {
-                404 -> false
-                else -> true
-            }
+        return when (testResultRecord.responseStatus) {
+            404 -> false
+            else -> true
         }
-
-        return true
     }
 }
 

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/console/Remarks.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/console/Remarks.kt
@@ -18,7 +18,7 @@ enum class Remarks(val value: String) {
 
     companion object{
         fun resolve(testResultRecords: List<TestResultRecord>): Remarks {
-            if(!testResultRecords.first().isValid) {
+            if(!testResultRecords.any { it.isValid }) {
                 return when (testResultRecords.first().result) {
                     TestResult.MissingInSpec -> Missed
                     else -> Invalid

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/console/Remarks.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/console/Remarks.kt
@@ -9,7 +9,8 @@ enum class Remarks(val value: String) {
     Missed("missing in spec"),
     NotImplemented("not implemented"),
     DidNotRun("did not run"),
-    NotCovered("not covered");
+    NotCovered("not covered"),
+    Invalid("invalid");
 
     override fun toString(): String {
         return value
@@ -17,6 +18,13 @@ enum class Remarks(val value: String) {
 
     companion object{
         fun resolve(testResultRecords: List<TestResultRecord>): Remarks {
+            if(!testResultRecords.first().isValid) {
+                return when (testResultRecords.first().result) {
+                    TestResult.MissingInSpec -> Missed
+                    else -> Invalid
+                }
+            }
+
             if (testResultRecords.any { it.isExercised }) {
                 return when (testResultRecords.first().result) {
                     TestResult.NotImplemented -> NotImplemented
@@ -25,6 +33,7 @@ enum class Remarks(val value: String) {
                     else -> Covered
                 }
             }
+
             return when (val result = testResultRecords.first().result) {
                 TestResult.Skipped -> Missed
                 TestResult.DidNotRun -> DidNotRun

--- a/junit5-support/src/test/kotlin/io/specmatic/test/ApiCoverageReportInputTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/ApiCoverageReportInputTest.kt
@@ -341,7 +341,7 @@ class ApiCoverageReportInputTest {
                     OpenApiCoverageConsoleRow("", "", "401", "1", 0, Remarks.Covered),
                     OpenApiCoverageConsoleRow("GET", "/route2", 200, 1, 75, Remarks.Covered),
                     OpenApiCoverageConsoleRow("", "", 400, 0, 0, Remarks.DidNotRun),
-                    OpenApiCoverageConsoleRow("", "", 404, 1, 0, Remarks.Covered),
+                    OpenApiCoverageConsoleRow("", "", 404, 1, 0, Remarks.Invalid),
                     OpenApiCoverageConsoleRow("POST", "", 500, 1, 0, Remarks.Covered)
                 ),
                 totalEndpointsCount = 2, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 0

--- a/junit5-support/src/test/kotlin/io/specmatic/test/ApiCoverageReportTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/ApiCoverageReportTest.kt
@@ -393,4 +393,77 @@ class ApiCoverageReportTest {
             )
         )
     }
+
+    // FOLLOWING TESTS ARE FOR INVALID REMARK (Actuator Doesn't Matter)
+
+    @Test
+    fun `No Param GET 200 in spec not implemented with actuator`() {
+        val endpointsInSpec = mutableListOf(
+            Endpoint("/orders", "GET", 200)
+        )
+        val applicationAPIs = mutableListOf<API>()
+
+        val testResultRecords = mutableListOf(
+            TestResultRecord("/orders", "GET", 200, TestResult.Failed, actualResponseStatus = 404)
+        )
+        val apiCoverageReport = generateCoverageReport(testResultRecords, endpointsInSpec, applicationAPIs)
+
+        assertThat(apiCoverageReport).isEqualTo(
+            OpenAPICoverageConsoleReport(
+                listOf(
+                    OpenApiCoverageConsoleRow("GET", "/orders", 200, 1, 0, Remarks.NotImplemented),
+                    OpenApiCoverageConsoleRow("", "", 404, 1, 0, Remarks.Missed),
+                ), totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 1, partiallyNotImplementedAPICount = 1
+            )
+        )
+    }
+
+    @Test
+    fun `No Param GET 200 and 404 in spec not implemented without actuator`() {
+        val endpointsInSpec = mutableListOf(
+            Endpoint("/orders", "GET", 200), Endpoint("/orders", "GET", 404)
+        )
+
+        val testResultRecords = mutableListOf(
+            TestResultRecord("/orders", "GET", 200, TestResult.Failed, actualResponseStatus = 404)
+        )
+        val apiCoverageReport = generateCoverageReport(testResultRecords, endpointsInSpec)
+
+        assertThat(
+            apiCoverageReport
+        ).isEqualTo(
+            OpenAPICoverageConsoleReport(
+                listOf(
+                    OpenApiCoverageConsoleRow("GET", "/orders", 200, 1, 50, Remarks.NotCovered),
+                    OpenApiCoverageConsoleRow("", "", 404, 1, 0, Remarks.Invalid),
+                ), totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 0
+            )
+        )
+    }
+
+    @Test
+    fun `No Param GET 200 and 404 in spec implemented with actuator`() {
+        val endpointsInSpec = mutableListOf(
+            Endpoint("/orders", "GET", 200), Endpoint("/orders", "GET", 404)
+        )
+        val applicationAPIs = mutableListOf<API>(
+            API("GET", "/orders")
+        )
+
+        val testResultRecords = mutableListOf(
+            TestResultRecord("/orders", "GET", 200, TestResult.Success, actualResponseStatus = 200)
+        )
+        val apiCoverageReport = generateCoverageReport(testResultRecords, endpointsInSpec, applicationAPIs)
+
+        assertThat(
+            apiCoverageReport
+        ).isEqualTo(
+            OpenAPICoverageConsoleReport(
+                listOf(
+                    OpenApiCoverageConsoleRow("GET", "/orders", 200, 1, 50, Remarks.Covered),
+                    OpenApiCoverageConsoleRow("", "", 404, 0, 0, Remarks.Invalid),
+                ), totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 0
+            )
+        )
+    }
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Fix inaccurate test counts in coverage report.

<!-- Why are these changes necessary? -->

**Why**: 
- The `exercise` count for `responses` in the console coverage report is inaccurate.
- The `status` of a scenario was being overridden by the actual response in the case of a `negative` test scenario, leading to an inaccurate count when generating the reports.

<!-- How were these changes implemented? -->

**How**:
- Removed call to `Scenario.getStatus`.
- Avoid overriding scenario status code.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation N/A
- [ ] Tests
- [ ] Sonar Quality Gate

<!-- feel free to add additional comments -->
