### PR TITLE
External examples should override inline examples

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/ExampleFromFile.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/ExampleFromFile.kt
@@ -10,6 +10,14 @@ import io.specmatic.core.value.Value
 import java.io.File
 
 class ExampleFromFile(val json: JSONObjectValue, val file: File) {
+    fun toOpenAPIOperationIdentifier(): OpenApiSpecification.OperationIdentifier {
+        return OpenApiSpecification.OperationIdentifier(
+            requestMethod,
+            requestPath,
+            responseStatus
+        )
+    }
+
     fun toRow(specmaticConfig: SpecmaticConfig = SpecmaticConfig()): Row {
         logger.log("Loading test file ${this.expectationFilePath}")
 

--- a/core/src/main/kotlin/io/specmatic/conversions/ExampleFromFile.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/ExampleFromFile.kt
@@ -19,8 +19,6 @@ class ExampleFromFile(val json: JSONObjectValue, val file: File) {
     }
 
     fun toRow(specmaticConfig: SpecmaticConfig = SpecmaticConfig()): Row {
-        logger.log("Loading test file ${this.expectationFilePath}")
-
         val examples: Map<String, String> =
             headers
                 .plus(queryParams)

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -1371,7 +1371,7 @@ data class Feature(
         return this.copy(scenarios = scenariosWithExamples)
     }
 
-    private fun loadExternalisedJSONExamples(testsDirectory: File?): List<ExampleFromFile> {
+    private fun getExternalisedExampleFromFiles(testsDirectory: File?): List<ExampleFromFile> {
         if (testsDirectory == null)
             return emptyList()
 
@@ -1387,39 +1387,22 @@ data class Feature(
             files.filter {
                 it.isDirectory
             }.fold(emptyList()) { acc, item ->
-                acc + loadExternalisedJSONExamples(item)
+                acc + getExternalisedExampleFromFiles(item)
             }
 
         return examlesInSubdirectories + files.filterNot { it.isDirectory }.map { ExampleFromFile(it) }
-
-//        return examlesInSubdirectories + files.filterNot { it.isDirectory }.map { ExampleFromFile(it) }.mapNotNull { exampleFromFile ->
-//            try {
-//                with(exampleFromFile) {
-//                    OpenApiSpecification.OperationIdentifier(
-//                        requestMethod,
-//                        requestPath,
-//                        responseStatus
-//                    ) to exampleFromFile.toRow(specmaticConfig)
-//                }
-//            } catch (e: Throwable) {
-//                logger.log(e, "Error reading file ${exampleFromFile.expectationFilePath}")
-//                null
-//            }
-//        }
-//            .groupBy { (operationIdentifier, _) -> operationIdentifier }
-//            .mapValues { (_, value) -> value.map { it.second } }
     }
 
     fun loadExternalisedExamples(): Feature {
         val externalisedExampleDirsFromConfig = specmaticConfig.examples
         val externalisedExamplesFromExampleDirs = externalisedExampleDirsFromConfig.flatMap { directory ->
-            loadExternalisedJSONExamples(File(directory))
+            getExternalisedExampleFromFiles(File(directory))
         }
 
         val namesOfExamplesFromExampleDirs = externalisedExamplesFromExampleDirs.map { it.testName }.toSet()
 
         val testsDirectory = getTestsDirectory(File(this.path))
-        val externalisedExamplesFromDefaultDirectory = loadExternalisedJSONExamples(testsDirectory).filterNot {
+        val externalisedExamplesFromDefaultDirectory = getExternalisedExampleFromFiles(testsDirectory).filterNot {
             it.testName in namesOfExamplesFromExampleDirs
         }
 

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -545,9 +545,13 @@ data class Scenario(
                 it.value.map { it.toRow(specmaticConfig) }
             }
 
-        val matchingTestData: Map<OpenApiSpecification.OperationIdentifier, List<Row>> = matchingRows(externalisedExamplesMap)
+        val matchingExamples: Map<OpenApiSpecification.OperationIdentifier, List<Row>> = matchingRows(externalisedExamplesMap)
 
-        val newExamples: List<Examples> = matchingTestData.map { (operationId, rows) ->
+        matchingExamples.flatMap { it.value }.map { it.fileSource }.forEach { exampleFilePath ->
+            logger.log("Loading test file $exampleFilePath")
+        }
+
+        val newExamples: List<Examples> = matchingExamples.map { (operationId, rows) ->
             if(rows.isEmpty())
                 return@map emptyList()
 

--- a/core/src/test/resources/openapi/externalised_examples_to_override_inline_and_external_implicit/johnDoe.json
+++ b/core/src/test/resources/openapi/externalised_examples_to_override_inline_and_external_implicit/johnDoe.json
@@ -1,0 +1,13 @@
+{
+  "http-request": {
+    "method": "GET",
+    "path": "/person/456"
+  },
+  "http-response": {
+    "status": 200,
+    "body": {
+      "id": 456,
+      "name": "Johnny Jones"
+    }
+  }
+}

--- a/core/src/test/resources/openapi/has_inline_and_external_examples_with_same_name.yaml
+++ b/core/src/test/resources/openapi/has_inline_and_external_examples_with_same_name.yaml
@@ -1,0 +1,42 @@
+openapi: 3.0.3
+info:
+  title: Person API
+  description: API for retrieving person details
+  version: 1.0.0
+paths:
+  /person/{id}:
+    get:
+      summary: Get person details by ID
+      description: Retrieves the details of a person based on their unique identifier
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Unique identifier of the person
+          schema:
+            type: integer
+          examples:
+            johnDoe:
+              summary: Example ID for John Doe
+              value: 123
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  name:
+                    type: string
+                required:
+                  - id
+                  - name
+              examples:
+                johnDoe:
+                  summary: Example response for John Doe
+                  value:
+                    id: 123
+                    name: John Doe

--- a/core/src/test/resources/openapi/has_inline_and_external_examples_with_same_name_examples/johnDoe.json
+++ b/core/src/test/resources/openapi/has_inline_and_external_examples_with_same_name_examples/johnDoe.json
@@ -1,0 +1,13 @@
+{
+  "http-request": {
+    "method": "GET",
+    "path": "/person/456"
+  },
+  "http-response": {
+    "status": 200,
+    "body": {
+      "id": 456,
+      "name": "John Marsh Doe"
+    }
+  }
+}


### PR DESCRIPTION
**What**:

External examples override inline examples of the same name.

This means that if an external example exists in a file name `fetch_details.json` for a spec that has an inline example named `fetch_details`, the test will be run from `fetch_details.json`.

Similarly, an externalised example specified explicitly to Specmatic such as via the `--examples` parameter will override an externalised example in an implicit directory.

**Why**:

This allows contextual examples to override canned ones if needed, this could be useful when a provider is not able to easily setup the test data given in the specification, and cannot modify the spec to update the examples (such as when a spec is provided by a third party, such as an industry standards body).

**How**:

Feature and Scenario have been modified to add the overriding behaviour.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate
