### PR TITLE
Validate examples before running the backward compatibility check

### DIFF
--- a/application/src/main/kotlin/application/BackwardCompatibilityCheckCommand.kt
+++ b/application/src/main/kotlin/application/BackwardCompatibilityCheckCommand.kt
@@ -80,7 +80,7 @@ class BackwardCompatibilityCheckCommand(
                     gitCommand.checkout(gitCommand.defaultBranch())
 
                     // older => the same file on the default (e.g. main) branch
-                    val older = OpenApiSpecification.fromFile(olderFile.path).toFeature().loadExternalisedExamples()
+                    val older = OpenApiSpecification.fromFile(olderFile.path).toFeature()
 
                     val backwardCompatibilityResult = testBackwardCompatibility(older, newer)
 


### PR DESCRIPTION
**What**:

When running a backward compatibility check, first validate the examples, both inline and in the `_examples` directory. Fail the check if any of them are invalid.

**Why**:

Examples that are inline or in the `_examples` directory should never be out of sync with the spec. So when the spec is being changed, the examples should also be changed to go with it.

**How**:

Added a couple of lines of code to the `BackwardCompatiblityCheckCommand` class to validate examples and fail the check if the validation fails.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate
