### PR TITLE
BackwardCompatibilityCheckCommand validates externalized examples

### DIFF
--- a/application/src/main/kotlin/application/BackwardCompatibilityCheckCommand.kt
+++ b/application/src/main/kotlin/application/BackwardCompatibilityCheckCommand.kt
@@ -159,12 +159,16 @@ class BackwardCompatibilityCheckCommand(
                             )
                         )
 
+                        println()
+
                         if(!examplesAreValid(newer, "newer")) {
                             println(
                                 "$newLine *** Examples in $specFilePath are not valid. ***$newLine".prependIndent(
                                     MARGIN_SPACE
                                 )
                             )
+
+                            println()
 
                             FAILED
                         }
@@ -177,6 +181,9 @@ class BackwardCompatibilityCheckCommand(
                                 MARGIN_SPACE
                             )
                         )
+
+                        println()
+
                         FAILED
                     }
                 } finally {

--- a/application/src/main/kotlin/application/BackwardCompatibilityCheckCommand.kt
+++ b/application/src/main/kotlin/application/BackwardCompatibilityCheckCommand.kt
@@ -2,12 +2,11 @@ package application
 
 import application.BackwardCompatibilityCheckCommand.CompatibilityResult.*
 import io.specmatic.conversions.OpenApiSpecification
-import io.specmatic.core.CONTRACT_EXTENSIONS
-import io.specmatic.core.Feature
+import io.specmatic.core.*
 import io.specmatic.core.git.GitCommand
 import io.specmatic.core.git.SystemGit
-import io.specmatic.core.testBackwardCompatibility
 import io.specmatic.core.utilities.exitWithMessage
+import io.specmatic.stub.isOpenAPI
 import org.springframework.stereotype.Component
 import picocli.CommandLine.Command
 import java.io.File
@@ -16,6 +15,8 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.concurrent.Callable
 import java.util.regex.Pattern
+import kotlin.io.path.extension
+import kotlin.io.path.pathString
 import kotlin.system.exitProcess
 
 const val ONE_INDENT = "  "
@@ -121,9 +122,9 @@ class BackwardCompatibilityCheckCommand(
     }
 
     private fun findSpecFiles(path: Path): List<Path> {
-        val extensions = listOf(".yml", ".yaml", ".spec", ".wsdl")
+        val extensions = CONTRACT_EXTENSIONS
         return extensions.map { path.resolveSibling(path.fileName.toString() + it) }
-            .filter { Files.exists(it) }
+            .filter { Files.exists(it) && (isOpenAPI(it.pathString) || it.extension in listOf(WSDL, CONTRACT_EXTENSION)) }
     }
 
     private fun runBackwardCompatibilityCheckFor(files: Set<String>): CompatibilityReport {

--- a/application/src/main/kotlin/application/BackwardCompatibilityCheckCommand.kt
+++ b/application/src/main/kotlin/application/BackwardCompatibilityCheckCommand.kt
@@ -5,6 +5,7 @@ import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.core.*
 import io.specmatic.core.git.GitCommand
 import io.specmatic.core.git.SystemGit
+import io.specmatic.core.log.logger
 import io.specmatic.core.utilities.exitWithMessage
 import io.specmatic.stub.isOpenAPI
 import org.springframework.stereotype.Component
@@ -56,7 +57,14 @@ class BackwardCompatibilityCheckCommand(
 
         val specificationsToCheck: Set<String> = filesChangedInCurrentBranch + filesReferringToChangedSchemaFiles + specificationsOfChangedExternalisedExamples
 
-        val result = runBackwardCompatibilityCheckFor(specificationsToCheck)
+        val result = try {
+            runBackwardCompatibilityCheckFor(specificationsToCheck)
+        } catch(e: Throwable) {
+            logger.newLine()
+            logger.newLine()
+            logger.log(e)
+            exitProcess(1)
+        }
 
         println()
         println(result.report)

--- a/application/src/main/kotlin/application/BackwardCompatibilityCheckCommand.kt
+++ b/application/src/main/kotlin/application/BackwardCompatibilityCheckCommand.kt
@@ -145,7 +145,7 @@ class BackwardCompatibilityCheckCommand(
                     println("${index.inc()}. Running the check for $specFilePath:")
 
                     // newer => the file with changes on the branch
-                    val newer = OpenApiSpecification.fromFile(specFilePath).toFeature().loadExternalisedExamples()
+                    val (newer, unusedExamples) = OpenApiSpecification.fromFile(specFilePath).toFeature().loadExternalisedExamplesAndListUnloadableExamples()
 
                     val olderFile = gitCommand.getFileInTheDefaultBranch(specFilePath, treeishWithChanges)
                     if (olderFile == null) {
@@ -169,6 +169,8 @@ class BackwardCompatibilityCheckCommand(
 
                         println()
 
+                        var errorsFound = false
+
                         if(!examplesAreValid(newer, "newer")) {
                             println(
                                 "$newLine *** Examples in $specFilePath are not valid. ***$newLine".prependIndent(
@@ -178,6 +180,23 @@ class BackwardCompatibilityCheckCommand(
 
                             println()
 
+                            errorsFound = true
+                        }
+
+                        if(unusedExamples.isNotEmpty()) {
+                            println(
+                                "$newLine *** Some examples for $specFilePath could not be loaded. ***$newLine".prependIndent(
+                                    MARGIN_SPACE
+                                )
+                            )
+
+                            println()
+
+                            errorsFound = true
+
+                        }
+
+                        if(errorsFound) {
                             FAILED
                         }
                         else

--- a/core/src/main/kotlin/io/specmatic/conversions/ExampleFromFile.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/ExampleFromFile.kt
@@ -1,5 +1,6 @@
 package io.specmatic.conversions
 
+import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpResponse
 import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.log.logger
@@ -7,6 +8,8 @@ import io.specmatic.core.pattern.*
 import io.specmatic.core.value.EmptyString
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.Value
+import io.specmatic.mock.mockFromJSON
+import io.specmatic.stub.stringToMockScenario
 import java.io.File
 
 class ExampleFromFile(val json: JSONObjectValue, val file: File) {
@@ -36,12 +39,15 @@ class ExampleFromFile(val json: JSONObjectValue, val file: File) {
 
         }
 
+        val mockFromJSON = mockFromJSON(json.jsonObject)
+
         return Row(
             columnNames,
             values,
             name = testName,
             fileSource = this.file.canonicalPath,
-            responseExample = responseExample
+            responseExample = responseExample,
+            requestExample = mockFromJSON.request
         )
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -1481,7 +1481,12 @@ data class Feature(
 
     fun validateExamplesOrException() {
         val errors = scenarios.map { scenario ->
-            nullOrExceptionString { scenario.validExamplesOrException(flagsBased.copy(generation = NonGenerativeTests)) }
+            try {
+                scenario.validExamplesOrException(flagsBased.copy(generation = NonGenerativeTests))
+                null
+            } catch(e: Throwable) {
+                exceptionCauseMessage(e)
+            }
         }.filterNotNull()
 
         if(errors.isNotEmpty())

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -1446,7 +1446,11 @@ data class Feature(
             unusedExternalizedExamples.sorted().forEach {
                 logger.log("  $it")
             }
+
+            throw ContractException("Aborting, as externalised examples could not be loaded. Please ensure that all examples are for APIs in this specification. Validate the methods, paths and status codes.")
         }
+
+
 
         return featureWithExternalisedExamples
     }

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -4,10 +4,6 @@ import io.specmatic.conversions.*
 import io.specmatic.core.log.logger
 import io.specmatic.core.pattern.*
 import io.specmatic.core.pattern.Examples.Companion.examplesFrom
-import io.specmatic.core.utilities.capitalizeFirstChar
-import io.specmatic.core.utilities.examplesDirFor
-import io.specmatic.core.utilities.jsonStringToValueMap
-import io.specmatic.core.utilities.readEnvVarOrProperty
 import io.specmatic.core.value.*
 import io.specmatic.mock.NoMatchingScenario
 import io.specmatic.mock.ScenarioStub
@@ -19,6 +15,7 @@ import io.cucumber.messages.IdGenerator
 import io.cucumber.messages.IdGenerator.Incrementing
 import io.cucumber.messages.types.*
 import io.cucumber.messages.types.Examples
+import io.specmatic.core.utilities.*
 import io.swagger.v3.oas.models.*
 import io.swagger.v3.oas.models.headers.Header
 import io.swagger.v3.oas.models.info.Info
@@ -1483,9 +1480,12 @@ data class Feature(
     }
 
     fun validateExamplesOrException() {
-        scenarios.forEach { scenario ->
-            scenario.validExamplesOrException(flagsBased.copy(generation = NonGenerativeTests))
-        }
+        val errors = scenarios.map { scenario ->
+            nullOrExceptionString { scenario.validExamplesOrException(flagsBased.copy(generation = NonGenerativeTests)) }
+        }.filterNotNull()
+
+        if(errors.isNotEmpty())
+            throw ContractException(errors.joinToString("${System.lineSeparator()}${System.lineSeparator()}"))
     }
 }
 

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -1405,7 +1405,7 @@ data class Feature(
             .mapValues { (_, value) -> value.map { it.second } }
     }
 
-    fun loadExternalisedExamples(): Feature {
+    fun loadExternalisedExamplesAndListUnloadableExamples(): Pair<Feature, Set<String>> {
         val testsDirectory = getTestsDirectory(File(this.path))
         val externalisedExamplesFromDefaultDirectory = loadExternalisedJSONExamples(testsDirectory)
         val externalisedExampleDirsFromConfig = specmaticConfig.examples
@@ -1417,7 +1417,7 @@ data class Feature(
         val allExternalisedJSONExamples = externalisedExamplesFromDefaultDirectory + externalisedExamplesFromExampleDirs
 
         if(allExternalisedJSONExamples.isEmpty())
-            return this
+            return this to emptySet()
 
         val featureWithExternalisedExamples = useExamples(allExternalisedJSONExamples)
 
@@ -1446,13 +1446,13 @@ data class Feature(
             unusedExternalizedExamples.sorted().forEach {
                 logger.log("  $it")
             }
-
-            throw ContractException("Aborting, as externalised examples could not be loaded. Please ensure that all examples are for APIs in this specification. Validate the methods, paths and status codes.")
         }
 
+        return featureWithExternalisedExamples to unusedExternalizedExamples
+    }
 
-
-        return featureWithExternalisedExamples
+    fun loadExternalisedExamples(): Feature {
+        return loadExternalisedExamplesAndListUnloadableExamples().first
     }
 
     private fun testDirectoryFileFromEnvironmentVariable(): File? {

--- a/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
@@ -71,7 +71,7 @@ data class HttpHeadersPattern(
         }
 
         val keyErrorResults: List<Result.Failure> = keyErrors.map {
-            it.missingKeyToResult("header", resolver.mismatchMessages).breadCrumb(it.name)
+            it.missingKeyToResult("header", resolver.mismatchMessages).breadCrumb(withoutOptionality(it.name))
         }
 
         val lowercasedHeadersWithRelevantKeys = headersWithRelevantKeys.mapKeys { it.key.lowercase() }

--- a/core/src/main/kotlin/io/specmatic/core/HttpPathPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpPathPattern.kt
@@ -99,7 +99,7 @@ data class HttpPathPattern(
         val generatedPatterns = newListBasedOn(pathSegmentPatterns.mapIndexed { index, urlPathParamPattern ->
                 val key = urlPathParamPattern.key
                 if (key === null || !row.containsField(key)) return@mapIndexed urlPathParamPattern
-                attempt(breadCrumb = "[$index]") {
+                attempt(breadCrumb = "PATH.${withoutOptionality(key)}") {
                     val rowValue = row.getField(key)
                     when {
                         isPatternToken(rowValue) -> attempt("Pattern mismatch in example of path param \"${urlPathParamPattern.key}\"") {

--- a/core/src/main/kotlin/io/specmatic/core/HttpPathPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpPathPattern.kt
@@ -36,7 +36,7 @@ data class HttpPathPattern(
 
     fun matches(path: String, resolver: Resolver): Result {
         val httpRequest = HttpRequest(path = path)
-        return matches(httpRequest, resolver).withFailureReason(FailureReason.URLPathMisMatch)
+        return matches(httpRequest, resolver)
     }
 
     fun matches(httpRequest: HttpRequest, resolver: Resolver): Result {
@@ -46,7 +46,8 @@ data class HttpPathPattern(
         if (pathSegmentPatterns.size != pathSegments.size)
             return Failure(
                 "Expected $path (having ${pathSegments.size} path segments) to match ${this.path} (which has ${pathSegmentPatterns.size} path segments).",
-                breadCrumb = "PATH"
+                breadCrumb = "PATH",
+                failureReason = FailureReason.URLPathMisMatch
             )
 
         pathSegmentPatterns.zip(pathSegments).forEach { (urlPathPattern, token) ->
@@ -55,8 +56,8 @@ data class HttpPathPattern(
                 val result = resolver.matchesPattern(urlPathPattern.key, urlPathPattern.pattern, parsedValue)
                 if (result is Failure) {
                     return when (urlPathPattern.key) {
-                        null -> result.breadCrumb("PATH ($path)")
-                        else -> result.breadCrumb("PATH ($path)").breadCrumb(urlPathPattern.key)
+                        null -> result.breadCrumb("PATH ($path)").withFailureReason(FailureReason.URLPathMisMatch)
+                        else -> result.breadCrumb(urlPathPattern.key).breadCrumb("PATH")
                     }
                 }
             } catch (e: ContractException) {

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -356,12 +356,11 @@ data class Scenario(
             val errors = listOf(requestError, responseError).filterNotNull().map { it.prependIndent("  ") }
 
             if(errors.isNotEmpty()) {
-                val title = "Error loading test data for ${this.apiDescription.trim()}".plus(
-                    if(row.fileSource != null)
-                        " from ${row.fileSource}"
-                    else
-                        " from inline example ${row.name}"
-                )
+                val title = if(row.fileSource != null) {
+                    "Error loading example for ${this.apiDescription.trim()} from ${row.fileSource}"
+                } else {
+                    "Error loading example named ${row.name} for ${this.apiDescription.trim()}"
+                }
 
                 listOf(title).plus(errors).joinToString("${System.lineSeparator()}${System.lineSeparator()}").also { message ->
                     logger.log(message)

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -396,25 +396,29 @@ data class Scenario(
         mockMode = true
     )
 
-    private fun validateResponseExample(row: Row, resolverForExample: Resolver) {
+    private fun validateResponseExample(row: Row, resolverForExample: Resolver): Result {
         val responseExample: ResponseExample? = row.responseExample
 
         if (responseExample != null) {
             val responseMatchResult =
                 httpResponsePattern.matches(responseExample.responseExample, resolverForExample)
 
-            responseMatchResult.throwOnFailure()
+            return responseMatchResult
         }
+
+        return Result.Success()
     }
 
-    private fun validateRequestExample(row: Row, resolverForExample: Resolver) {
+    private fun validateRequestExample(row: Row, resolverForExample: Resolver): Result {
         if(row.requestExample != null) {
             val result = httpRequestPattern.matches(row.requestExample, resolver, resolver)
-            if(!status.toString().startsWith("4"))
-                result.throwOnFailure()
+            if(result is Result.Failure && !status.toString().startsWith("4"))
+                return result
         } else {
             httpRequestPattern.newBasedOn(row, resolverForExample, status).first().value
         }
+
+        return Result.Success()
     }
 
     fun generateTestScenarios(

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -408,7 +408,13 @@ data class Scenario(
     }
 
     private fun validateRequestExample(row: Row, resolverForExample: Resolver) {
-        httpRequestPattern.newBasedOn(row, resolverForExample, status).first().value
+        if(row.requestExample != null) {
+            val result = httpRequestPattern.matches(row.requestExample, resolver, resolver)
+            if(!status.toString().startsWith("4"))
+                result.throwOnFailure()
+        } else {
+            httpRequestPattern.newBasedOn(row, resolverForExample, status).first().value
+        }
     }
 
     fun generateTestScenarios(

--- a/core/src/main/kotlin/io/specmatic/core/pattern/Row.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/Row.kt
@@ -1,9 +1,7 @@
 package io.specmatic.core.pattern
 
-import io.specmatic.core.DefaultExampleResolver
-import io.specmatic.core.HttpResponse
-import io.specmatic.core.OMIT
-import io.specmatic.core.References
+import io.specmatic.conversions.ExampleFromFile
+import io.specmatic.core.*
 import io.specmatic.core.value.JSONArrayValue
 import io.specmatic.core.value.JSONComposite
 import io.specmatic.core.value.JSONObjectValue
@@ -19,7 +17,8 @@ data class Row(
     val name: String = "",
     val fileSource: String? = null,
     val requestBodyJSONExample: JSONExample? = null,
-    val responseExample: ResponseExample? = null
+    val responseExample: ResponseExample? = null,
+    val requestExample: HttpRequest? = null
 ) {
     constructor(examples: Map<String, String>) :this(examples.keys.toList(), examples.values.toList())
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/TabularPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/TabularPattern.kt
@@ -144,7 +144,7 @@ data class TabularPattern(
 
 fun newMapBasedOn(patternMap: Map<String, Pattern>, row: Row, resolver: Resolver): Sequence<ReturnValue<Map<String, Pattern>>> {
     val patternCollection: Map<String, Sequence<ReturnValue<Pattern>>> = patternMap.mapValues { (key, pattern) ->
-        attempt(breadCrumb = key) {
+        attempt(breadCrumb = withoutOptionality(key)) {
             newPatternsBasedOn(row, key, pattern, resolver)
         }
     }
@@ -154,7 +154,7 @@ fun newMapBasedOn(patternMap: Map<String, Pattern>, row: Row, resolver: Resolver
 
 fun newBasedOn(patternMap: Map<String, Pattern>, resolver: Resolver): Sequence<Map<String, Pattern>> {
     val patternCollection = patternMap.mapValues { (key, pattern) ->
-        attempt(breadCrumb = key) {
+        attempt(breadCrumb = withoutOptionality(key)) {
             newBasedOn(key, pattern, resolver)
         }
     }

--- a/core/src/main/kotlin/io/specmatic/core/utilities/Utilities.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/Utilities.kt
@@ -347,3 +347,12 @@ private fun getExamplesDir(openApiFilePath: String, suffix: String): File =
     File(openApiFilePath).canonicalFile.let {
         it.parentFile.resolve("${it.parent}/${it.nameWithoutExtension}$suffix")
     }
+
+fun nullOrExceptionString(fn: () -> Unit): String? {
+    return try {
+        fn()
+        null
+    } catch(t: Throwable) {
+        logger.exceptionString(t)
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/core/utilities/Utilities.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/Utilities.kt
@@ -348,11 +348,15 @@ private fun getExamplesDir(openApiFilePath: String, suffix: String): File =
         it.parentFile.resolve("${it.parent}/${it.nameWithoutExtension}$suffix")
     }
 
-fun nullOrExceptionString(fn: () -> Unit): String? {
+fun nullOrExceptionString(fn: () -> Result): String? {
     return try {
-        fn()
-        null
-    } catch(t: Throwable) {
+        val result = fn()
+        if(result is Result.Failure)
+            return result.reportString()
+
+        return null
+    }
+    catch(t: Throwable) {
         logger.exceptionString(t)
     }
 }

--- a/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
+++ b/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
@@ -14,8 +14,7 @@ import io.specmatic.core.utilities.Flags.Companion.EXAMPLE_DIRECTORIES
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.Value
 import io.specmatic.test.TestExecutor
-import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.fail
+import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -153,7 +152,7 @@ class LoadTestsFromExternalisedFiles {
     }
 
     @Test
-    fun `unUtilized externalized tests should be logged`() {
+    fun `unUtilized externalized tests should be logged and an exception thrown`() {
         val defaultLogger = logger
         val logBuffer = object : CompositePrinter(emptyList()) {
             var buffer: MutableList<String> = mutableListOf()
@@ -167,17 +166,13 @@ class LoadTestsFromExternalisedFiles {
         try {
             logger = testLogger
 
-            val feature = OpenApiSpecification.fromFile("src/test/resources/openapi/has_irrelevant_externalized_test.yaml")
-                .toFeature().loadExternalisedExamples()
+            assertThatThrownBy {
+                OpenApiSpecification
+                    .fromFile("src/test/resources/openapi/has_irrelevant_externalized_test.yaml")
+                    .toFeature()
+                    .loadExternalisedExamples()
+            }.hasMessageContaining("externalised examples could not be loaded")
 
-            feature.executeTests(object : TestExecutor {
-                override fun execute(request: HttpRequest): HttpResponse {
-                    return HttpResponse.ok(parsedJSONArray("""[{"name": "Master Yoda", "description": "Head of the Jedi Council"}]"""))
-                }
-
-                override fun setServerState(serverState: Map<String, Value>) {
-                }
-            })
         } finally {
             logger = defaultLogger
         }

--- a/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
+++ b/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
@@ -166,13 +166,14 @@ class LoadTestsFromExternalisedFiles {
         try {
             logger = testLogger
 
-            assertThatThrownBy {
+            val (_, unusedExamplesFilePaths) =
                 OpenApiSpecification
                     .fromFile("src/test/resources/openapi/has_irrelevant_externalized_test.yaml")
                     .toFeature()
-                    .loadExternalisedExamples()
-            }.hasMessageContaining("externalised examples could not be loaded")
+                    .loadExternalisedExamplesAndListUnloadableExamples()
 
+            assertThat(unusedExamplesFilePaths).hasSize(1)
+            assertThat(unusedExamplesFilePaths.first()).endsWith("irrelevant_test.json")
         } finally {
             logger = defaultLogger
         }

--- a/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
@@ -2155,9 +2155,8 @@ paths:
         ).toFeature()
 
         assertThatThrownBy { feature.validateExamplesOrException() }.satisfies(Consumer { exception ->
-            assertThat(exceptionCauseMessage(exception)).contains(">> REQUEST.BODY")
-            assertThat(exceptionCauseMessage(exception)).contains(">> data")
-            assertThat(exceptionCauseMessage(exception)).contains(">> info")
+            assertThat(exceptionCauseMessage(exception)).contains(">> REQUEST.BODY.data")
+            assertThat(exceptionCauseMessage(exception)).contains(">> REQUEST.BODY.info")
             assertThat(exceptionCauseMessage(exception)).contains("RESPONSE.HEADERS.X-Value")
             assertThat(exceptionCauseMessage(exception)).contains("RESPONSE.BODY")
         })

--- a/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
@@ -1681,7 +1681,7 @@ components:
 
 
     @Test
-    fun `invalid requests should be caught by the validator` () {
+    fun `invalid request body example should be caught by the validator` () {
         val feature = OpenApiSpecification.fromYAML(
             """
 openapi: 3.0.0
@@ -1726,7 +1726,385 @@ paths:
     }
 
     @Test
-    fun `invalid responses should be caught by the validator` () {
+    fun `invalid mandatory request header example should be caught by the validator` () {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+openapi: 3.0.0
+info:
+  title: Sample API
+  version: 0.1.9
+paths:
+  /data:
+    parameters:
+      - in: header
+        name: X-Test-Header
+        schema:
+          type: number
+        required: true
+        examples:
+          200_OK:
+            value: "abc"
+    post:
+      summary: hello world
+      description: test
+      requestBody:
+        content:
+          application/json:
+            examples:
+              200_OK:
+                value:
+                  data: 10
+            schema:
+              type: object
+              properties:
+                data:
+                  type: number
+              required:
+                - data
+      responses:
+        '200':
+          description: Says hello
+          content:
+            text/plain:
+              examples:
+                200_OK:
+                  value: 10
+              schema:
+                type: number
+""".trimIndent(), ""
+        ).toFeature()
+
+        assertThatThrownBy { feature.validateExamplesOrException() }.satisfies(Consumer { exception ->
+            assertThat(exceptionCauseMessage(exception)).contains("REQUEST.HEADERS.X-Test-Header")
+        })
+    }
+
+    @Test
+    fun `invalid optional request header example should be caught by the validator` () {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+openapi: 3.0.0
+info:
+  title: Sample API
+  version: 0.1.9
+paths:
+  /data:
+    parameters:
+      - in: header
+        name: X-Test-Header
+        schema:
+          type: number
+        examples:
+          200_OK:
+            value: "abc"
+    post:
+      summary: hello world
+      description: test
+      requestBody:
+        content:
+          application/json:
+            examples:
+              200_OK:
+                value:
+                  data: 10
+            schema:
+              type: object
+              properties:
+                data:
+                  type: number
+              required:
+                - data
+      responses:
+        '200':
+          description: Says hello
+          content:
+            text/plain:
+              examples:
+                200_OK:
+                  value: 10
+              schema:
+                type: number
+""".trimIndent(), ""
+        ).toFeature()
+
+        assertThatThrownBy { feature.validateExamplesOrException() }.satisfies(Consumer { exception ->
+            assertThat(exceptionCauseMessage(exception)).contains("REQUEST.HEADERS.X-Test-Header")
+            assertThat(exceptionCauseMessage(exception)).doesNotContain("REQUEST.HEADERS.X-Test-Header?")
+        })
+    }
+
+    @Test
+    fun `invalid mandatory query parameter example should be caught by the validator` () {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+openapi: 3.0.0
+info:
+  title: Sample API
+  version: 0.1.9
+paths:
+  /data:
+    parameters:
+      - in: query
+        name: enabled
+        schema:
+          type: boolean
+        required: true
+        examples:
+          200_OK:
+            value: "abc"
+    post:
+      summary: hello world
+      description: test
+      requestBody:
+        content:
+          application/json:
+            examples:
+              200_OK:
+                value:
+                  data: 10
+            schema:
+              type: object
+              properties:
+                data:
+                  type: number
+              required:
+                - data
+      responses:
+        '200':
+          description: Says hello
+          content:
+            text/plain:
+              examples:
+                200_OK:
+                  value: 10
+              schema:
+                type: number
+""".trimIndent(), ""
+        ).toFeature()
+
+        assertThatThrownBy { feature.validateExamplesOrException() }.satisfies(Consumer { exception ->
+            assertThat(exceptionCauseMessage(exception)).contains("REQUEST.QUERY.enabled")
+        })
+    }
+
+    @Test
+    fun `invalid optional query parameter example should be caught by the validator` () {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+openapi: 3.0.0
+info:
+  title: Sample API
+  version: 0.1.9
+paths:
+  /data:
+    parameters:
+      - in: query
+        name: enabled
+        schema:
+          type: boolean
+        examples:
+          200_OK:
+            value: "abc"
+    post:
+      summary: hello world
+      description: test
+      requestBody:
+        content:
+          application/json:
+            examples:
+              200_OK:
+                value:
+                  data: 10
+            schema:
+              type: object
+              properties:
+                data:
+                  type: number
+              required:
+                - data
+      responses:
+        '200':
+          description: Says hello
+          content:
+            text/plain:
+              examples:
+                200_OK:
+                  value: 10
+              schema:
+                type: number
+""".trimIndent(), ""
+        ).toFeature()
+
+        assertThatThrownBy { feature.validateExamplesOrException() }.satisfies(Consumer { exception ->
+            assertThat(exceptionCauseMessage(exception)).contains("REQUEST.QUERY.enabled")
+        })
+    }
+
+    @Test
+    fun `invalid mandatory response header example should be caught by the validator` () {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+openapi: 3.0.0
+info:
+  title: Sample API
+  version: 0.1.9
+paths:
+  /data:
+    post:
+      summary: hello world
+      description: test
+      requestBody:
+        content:
+          application/json:
+            examples:
+              200_OK:
+                value:
+                  data: 10
+            schema:
+              type: object
+              properties:
+                data:
+                  type: number
+              required:
+                - data
+      responses:
+        '200':
+          description: Says hello
+          headers:
+            X-Value:
+              schema:
+                type: integer
+              required: true
+              examples:
+                200_OK:
+                  value:
+                    "abc"
+          content:
+            text/plain:
+              examples:
+                200_OK:
+                  value: 10
+              schema:
+                type: number
+""".trimIndent(), ""
+        ).toFeature()
+
+        assertThatThrownBy { feature.validateExamplesOrException() }.satisfies(Consumer { exception ->
+            assertThat(exceptionCauseMessage(exception)).contains("RESPONSE.HEADERS.X-Value")
+        })
+    }
+
+    @Test
+    fun `invalid optional response header example should be caught by the validator` () {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+openapi: 3.0.0
+info:
+  title: Sample API
+  version: 0.1.9
+paths:
+  /data:
+    post:
+      summary: hello world
+      description: test
+      requestBody:
+        content:
+          application/json:
+            examples:
+              200_OK:
+                value:
+                  data: 10
+            schema:
+              type: object
+              properties:
+                data:
+                  type: number
+              required:
+                - data
+      responses:
+        '200':
+          description: Says hello
+          headers:
+            X-Value:
+              schema:
+                type: integer
+              examples:
+                200_OK:
+                  value:
+                    "abc"
+          content:
+            text/plain:
+              examples:
+                200_OK:
+                  value: 10
+              schema:
+                type: number
+""".trimIndent(), ""
+        ).toFeature()
+
+        assertThatThrownBy { feature.validateExamplesOrException() }.satisfies(Consumer { exception ->
+            assertThat(exceptionCauseMessage(exception)).contains("RESPONSE.HEADERS.X-Value")
+            assertThat(exceptionCauseMessage(exception)).doesNotContain("RESPONSE.HEADERS.X-Value?")
+        })
+    }
+
+    @Test
+    fun `all errors across request and response should be caught and returned together` () {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+openapi: 3.0.0
+info:
+  title: Sample API
+  version: 0.1.9
+paths:
+  /data:
+    post:
+      summary: hello world
+      description: test
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                data:
+                  type: number
+              required:
+                - data
+            examples:
+              200_OK:
+                value:
+                  data: "abc"
+      responses:
+        '200':
+          description: Says hello
+          headers:
+            X-Value:
+              schema:
+                type: integer
+              examples:
+                200_OK:
+                  value:
+                    "abc"
+          content:
+            text/plain:
+              examples:
+                200_OK:
+                  value: "abc"
+              schema:
+                type: number
+""".trimIndent(), ""
+        ).toFeature()
+
+        assertThatThrownBy { feature.validateExamplesOrException() }.satisfies(Consumer { exception ->
+            assertThat(exceptionCauseMessage(exception)).contains("REQUEST.BODY.data")
+            assertThat(exceptionCauseMessage(exception)).contains("RESPONSE.HEADERS.X-Value")
+            assertThat(exceptionCauseMessage(exception)).contains("RESPONSE.BODY")
+        })
+    }
+
+    @Test
+    fun `invalid response body example should be caught by the validator` () {
         val feature = OpenApiSpecification.fromYAML(
             """
 openapi: 3.0.0

--- a/core/src/test/kotlin/io/specmatic/core/HttpPathPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpPathPatternTest.kt
@@ -162,6 +162,24 @@ internal class HttpPathPatternTest {
     }
 
     @Test
+    fun `should return all path param errors together`() {
+        val pattern = buildHttpPathPattern("/pets/(petid:number)/file/(fileid:number)")
+        val mismatchResult = pattern.matches(URI("/pets/abc/file/def")) as Result.Failure
+
+        assertThat(mismatchResult.failureReason).isNotEqualTo(FailureReason.URLPathMisMatch)
+        assertThat(mismatchResult.reportString())
+            .contains("PATH.petid")
+            .contains("PATH.fileid")
+    }
+
+    @Test
+    fun `should return failure reason as url mismatch if there is even one literal path segment mismatch`() {
+        val pattern = buildHttpPathPattern("/pets/(id:number)/data")
+        val mismatchResult = pattern.matches(URI("/pets/abc/info")) as Result.Failure
+        assertThat(mismatchResult.failureReason).isEqualTo(FailureReason.URLPathMisMatch)
+    }
+
+    @Test
     @Tag(GENERATION)
     fun `should generate a path with a concrete value given a path pattern with newBasedOn`() {
         val matcher = buildHttpPathPattern(URI("/pets/(status:boolean)"))


### PR DESCRIPTION
**What**:

When an externalised example has been changed, the example is validated against the spec. In fact, all the examples of this spec, both internal and internal, are validated.

**Why**:

It's important for any example to match the spec. If the spec changes, the example is no longer valid if it is out of sync, and will be misleading. No PR with invalid examples should be allowed to merge, and the backwardCompatibilityCheck now makes that easier by validating the externalised examples as well.

**How**:

First the following changes were made:
1. BackwardCompatibilityCheckCommand now also looks for the spec of any example that has been changed, and adds it to the list of specifications to validate.
2. When a spec is validated, now all examples, external and internal, are validated.

In addition, we needed to have all the errors across all parts of the request and response appear together in one report. For example, if a query param example, path param example and response body json key value did not match their schemas, all three should be highlighted together by the `backwardCompatibilityCheck` command.

We started by adding tests to lock down the validation behaviour. In the process, we realised that if there were errors in both the request and response in the example, all the response errors appeared, but only the first request error would appear.

It turns out that there were a number of cut-outs causing this, which required the following changes.
1. `newBasedOn` currently fails on the first error, and fixing this wasn't easy. So we made slight modifications to `Row`, `OpenApiSpecification` and `ExampleFromFile`, to ensure that every row, whether from the spec or from an example, has an `HttpRequest` constructed out of the data in the example. This `HttpRequest` object now gets validated using the `HttpRequestPattern.matches` method.
2. `HttpRequestPattern` assumes that a path mismatch means that the example is not valid. But that may not be the case when the path mismatch is due to a path param example mismatch. So we modified `HttpPathPattern` to signal whether the mismatch was due to a constant mismatch or pattern mismatch, and then modified `HttpRequestPattern` to avoid cutting out if the path mismatch was due to a path param mismatch.
3. `HttpPathPattern` used to return the first error that it found. For example if there are two path parameters and the first example is bad, it would return that. Now it waits and accumulates all the errors before returning them. This logic takes the above point into account. So in the case of a path pattern for `/hello/(id:number/world`, given the path `/hello/abc/hello`, the error will be that the path does not match. The path parameters are not considered as a constant part of the path does not match, in which case it doesn't make sense to go deeper.

Some changes were needed to improve logging.
1. We modified the approach taken to `Scenario` to logging to eliminate tabbing issues in the report on the console, and since this required a change to a common function with `Feature`, we made a small change to Feature to avoid using this function.
2. `HttpHeadersPattern` logged optional headers with the `?` suffix, which had to be removed.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate
