### PR TITLE
Add an alias named 'virtualize' for the stub command

### DIFF
--- a/application/src/main/kotlin/application/StubCommand.kt
+++ b/application/src/main/kotlin/application/StubCommand.kt
@@ -15,9 +15,12 @@ import java.io.File
 import java.util.concurrent.Callable
 
 
-@Command(name = "stub",
-        mixinStandardHelpOptions = true,
-        description = ["Start a stub server with contract"])
+@Command(
+    name = "stub",
+    aliases = ["virtualize"],
+    mixinStandardHelpOptions = true,
+    description = ["Start a stub server with contract"]
+)
 class StubCommand : Callable<Unit> {
     var httpStub: ContractStub? = null
 

--- a/version.properties
+++ b/version.properties
@@ -1,2 +1,2 @@
-version=2.0.7
+version=2.0.8
 


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Add an alias for the stub command.

<!-- Why are these changes necessary? -->

**Why**:
To have a consistent way to virtualize a service irrespective of the protocol underneath. The same command will be used across other Specmatic features.

<!-- How were these changes implemented? -->

**How**:
Added an alias for the stub command.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [x] Tested against the sample project
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->


<!-- feel free to add additional comments -->
