### PR TITLE
Generative stub

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -59,8 +59,7 @@ fun String.loadContract(): Feature {
     return parseContractFileToFeature(File(this))
 }
 
-data class StubConfiguration(
-    val generative: Boolean = false
+data class StubConfiguration(val generative: Boolean = false)
 
 data class WorkflowIDOperation(
     val extract: String? = null,

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -59,6 +59,10 @@ fun String.loadContract(): Feature {
     return parseContractFileToFeature(File(this))
 }
 
+data class StubConfiguration(
+    val generative: Boolean = false
+)
+
 data class SpecmaticConfig(
     val sources: List<Source> = emptyList(),
     val auth: Auth? = null,
@@ -69,6 +73,7 @@ data class SpecmaticConfig(
     val report: ReportConfiguration? = null,
     val security: SecurityConfiguration? = null,
     val test: TestConfiguration? = TestConfiguration(),
+    val stub: StubConfiguration = StubConfiguration(),
     val examples: List<String> = getStringValue(EXAMPLE_DIRECTORIES)?.split(",") ?: emptyList()
 ) {
     fun isExtensibleSchemaEnabled(): Boolean {

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -1,19 +1,6 @@
 package io.specmatic.stub
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import io.specmatic.core.*
-import io.specmatic.core.log.*
-import io.specmatic.core.pattern.ContractException
-import io.specmatic.core.pattern.parsedValue
-import io.specmatic.core.utilities.*
-import io.specmatic.core.value.EmptyString
-import io.specmatic.core.value.StringValue
-import io.specmatic.core.value.Value
-import io.specmatic.core.value.toXMLNode
-import io.specmatic.mock.*
-import io.specmatic.stub.report.StubEndpoint
-import io.specmatic.stub.report.StubUsageReport
-import io.specmatic.test.HttpClient
 import io.ktor.http.*
 import io.ktor.http.content.*
 import io.ktor.server.application.*
@@ -24,6 +11,16 @@ import io.ktor.server.plugins.doublereceive.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.util.*
+import io.specmatic.core.*
+import io.specmatic.core.log.*
+import io.specmatic.core.pattern.ContractException
+import io.specmatic.core.pattern.parsedValue
+import io.specmatic.core.utilities.*
+import io.specmatic.core.value.*
+import io.specmatic.mock.*
+import io.specmatic.stub.report.StubEndpoint
+import io.specmatic.stub.report.StubUsageReport
+import io.specmatic.test.HttpClient
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.*
 import kotlinx.coroutines.delay
@@ -43,10 +40,6 @@ data class HttpStubResponse(
     val feature: Feature? = null,
     val scenario: Scenario? = null
 )
-
-interface RequestInterceptor {
-    fun interceptRequest(httpRequest: HttpRequest): HttpRequest?
-}
 
 class HttpStub(
     private val features: List<Feature>,
@@ -842,9 +835,6 @@ object ContractAndRequestsMismatch : MismatchMessages {
     }
 }
 
-data class RequestContext(val httpRequest: HttpRequest) : Context
-
-
 private fun fakeHttpResponse(features: List<Feature>, httpRequest: HttpRequest): StubbedResponseResult {
     data class ResponseDetails(val feature: Feature, val successResponse: ResponseBuilder?, val results: Results)
 
@@ -861,11 +851,33 @@ private fun fakeHttpResponse(features: List<Feature>, httpRequest: HttpRequest):
         null -> {
             val failureResults = responses.filter { it.successResponse == null }.map { it.results }
 
-            val httpFailureResponse = failureResults.reduce { first, second ->
+            val combinedFailureResult = failureResults.reduce { first, second ->
                 first.plus(second)
-            }.withoutFluff().generateErrorHttpResponse(httpRequest)
+            }.withoutFluff()
 
-            NotStubbed(HttpStubResponse(httpFailureResponse))
+            val firstScenarioWith400Response = failureResults.flatMap { it.results }.filter {
+                it is Result.Failure
+                    && it.failureReason == null
+                    && it.scenario?.let { it.status == 400 || it.status == 422 } == true
+            }.map { it.scenario!! }.firstOrNull()
+
+            if(firstScenarioWith400Response != null && Flags.getBooleanValue("SPECMATIC_GENERATIVE_STUB") == true) {
+                val httpResponse = (firstScenarioWith400Response as Scenario).generateHttpResponse(emptyMap())
+                val updatedResponse: HttpResponse = dumpIntoFirstAvailableStringField(httpResponse, combinedFailureResult.report())
+
+                FoundStubbedResponse(
+                    HttpStubResponse(
+                        updatedResponse,
+                        contractPath = "",
+                        feature = fakeResponse?.feature,
+                        scenario = fakeResponse?.successResponse?.scenario
+                    )
+                )
+            } else {
+                val httpFailureResponse = combinedFailureResult.generateErrorHttpResponse(httpRequest)
+
+                NotStubbed(HttpStubResponse(httpFailureResponse))
+            }
         }
 
         else -> FoundStubbedResponse(
@@ -877,6 +889,69 @@ private fun fakeHttpResponse(features: List<Feature>, httpRequest: HttpRequest):
             )
         )
     }
+}
+
+fun dumpIntoFirstAvailableStringField(httpResponse: HttpResponse, stringValue: String): HttpResponse {
+    val responseBody = httpResponse.body
+
+    if(responseBody !is JSONObjectValue)
+        return httpResponse
+
+    val newBody = dumpIntoFirstAvailableStringField(responseBody, stringValue)
+
+    return httpResponse.copy(body = newBody)
+}
+
+fun dumpIntoFirstAvailableStringField(jsonObjectValue: JSONObjectValue, stringValue: String): JSONObjectValue {
+    val key = jsonObjectValue.jsonObject.keys.find { key ->
+        key == "message" && jsonObjectValue.jsonObject[key] is StringValue
+    } ?: jsonObjectValue.jsonObject.keys.find { key ->
+        jsonObjectValue.jsonObject[key] is StringValue
+    }
+
+    if(key != null)
+        return jsonObjectValue.copy(
+            jsonObject = jsonObjectValue.jsonObject.plus(
+                key to StringValue(stringValue)
+            )
+        )
+
+    val newMap = jsonObjectValue.jsonObject.mapValues { (key, value) ->
+        if(value is JSONObjectValue) {
+            dumpIntoFirstAvailableStringField(value, stringValue)
+        } else if(value is JSONArrayValue) {
+            dumpIntoFirstAvailableStringField(value, stringValue)
+        } else {
+            value
+        }
+    }
+
+    return jsonObjectValue.copy(newMap)
+}
+
+fun dumpIntoFirstAvailableStringField(jsonArrayValue: JSONArrayValue, stringValue: String): JSONArrayValue {
+    val indexOfFirstStringValue = jsonArrayValue.list.indexOfFirst { it is StringValue }
+
+    if(indexOfFirstStringValue >= 0) {
+        val mutableList = jsonArrayValue.list.toMutableList()
+        mutableList.add(indexOfFirstStringValue, StringValue(stringValue))
+
+        return jsonArrayValue.copy(
+            list = mutableList
+        )
+    }
+
+    val newList = jsonArrayValue.list.map { value ->
+        if(value is JSONObjectValue) {
+            dumpIntoFirstAvailableStringField(value, stringValue)
+        } else if(value is JSONArrayValue) {
+            dumpIntoFirstAvailableStringField(value, stringValue)
+        } else {
+            value
+        }
+    }
+
+    return jsonArrayValue.copy(list = newList)
 }
 
 private fun strictModeHttp400Response(

--- a/core/src/main/kotlin/io/specmatic/stub/RequestContext.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/RequestContext.kt
@@ -1,0 +1,6 @@
+package io.specmatic.stub
+
+import io.specmatic.core.Context
+import io.specmatic.core.HttpRequest
+
+data class RequestContext(val httpRequest: HttpRequest) : Context

--- a/core/src/main/kotlin/io/specmatic/stub/RequestInterceptor.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/RequestInterceptor.kt
@@ -1,0 +1,7 @@
+package io.specmatic.stub
+
+import io.specmatic.core.HttpRequest
+
+interface RequestInterceptor {
+    fun interceptRequest(httpRequest: HttpRequest): HttpRequest?
+}

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
@@ -1623,6 +1623,73 @@ components:
     }
 
     @Test
+    fun `a generative stub should respond to an invalid request with a 422 with the error in the message key 2 levels deep`() {
+        val spec = """
+            openapi: 3.0.0
+            info:
+              title: Sample API
+              description: Optional multiline or single-line description in [CommonMark](http://commonmark.org/help/) or HTML.
+              version: 0.1.9
+            servers:
+              - url: http://api.example.com/v1
+                description: Optional server description, e.g. Main (production) server
+              - url: http://staging-api.example.com
+                description: Optional server description, e.g. Internal staging server for testing
+            paths:
+              /hello:
+                post:
+                  summary: hello world
+                  description: Optional extended description in CommonMark or HTML.
+                  requestBody:
+                    content:
+                      application/json:
+                        schema:
+                          type: object
+                          required:
+                            - data
+                          properties:
+                            data:
+                              type: string
+                  responses:
+                    '200':
+                      description: Says hello
+                      content:
+                        text/plain:
+                          schema:
+                            type: string
+                    '422':
+                      description: Bad request
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                            required:
+                              - error_info
+                            properties:
+                              error_info:
+                                type: object
+                                required:
+                                  - message
+                                properties:
+                                  message:
+                                    type: string
+        """.trimIndent()
+
+        val feature = OpenApiSpecification.fromYAML(spec, "").toFeature()
+
+        HttpStub(listOf(feature), specmaticConfigPath = "src/test/resources/specmatic_config_wtih_generate_stub.yaml").use { stub ->
+            val request = HttpRequest("POST", path = "/hello", body = parsedJSONObject("""{"data": 10}"""))
+            val response = stub.client.execute(request)
+
+            assertThat(response.status).isEqualTo(422)
+            assertThat(response.body).isInstanceOf(JSONObjectValue::class.java)
+
+            val responseBody = response.body as JSONObjectValue
+            assertThat(responseBody.findFirstChildByPath("error_info.message")?.toStringLiteral()).contains("REQUEST.BODY.data")
+        }
+    }
+
+    @Test
     fun `a generative stub should return the error in any available string key in the 4xx response if message is not found`() {
         val spec = """
             openapi: 3.0.0

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
@@ -1667,7 +1667,7 @@ components:
                               - error_info
                             properties:
                               error_info:
-                                type: id
+                                type: string
         """.trimIndent()
 
         val feature = OpenApiSpecification.fromYAML(spec, "").toFeature()

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
@@ -14,6 +14,7 @@ import io.specmatic.test.HttpClient
 import io.specmatic.test.TestExecutor
 import io.mockk.every
 import io.mockk.mockk
+import io.specmatic.stub
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.RepeatedTest
@@ -1547,21 +1548,15 @@ components:
 
         val feature = OpenApiSpecification.fromYAML(spec, "").toFeature()
 
-        System.setProperty("SPECMATIC_GENERATIVE_STUB", "true")
+        HttpStub(listOf(feature), specmaticConfigPath = "src/test/resources/specmatic_config_wtih_generate_stub.yaml").use { stub ->
+            val request = HttpRequest("POST", path = "/hello", body = parsedJSONObject("""{"data": 10}"""))
+            val response = stub.client.execute(request)
 
-        try {
-            HttpStub(feature).use { stub ->
-                val request = HttpRequest("POST", path = "/hello", body = parsedJSONObject("""{"data": 10}"""))
-                val response = stub.client.execute(request)
+            assertThat(response.status).isEqualTo(400)
+            assertThat(response.body).isInstanceOf(JSONObjectValue::class.java)
 
-                assertThat(response.status).isEqualTo(400)
-                assertThat(response.body).isInstanceOf(JSONObjectValue::class.java)
-
-                val responseBody = response.body as JSONObjectValue
-                assertThat(responseBody.jsonObject["message"]?.toStringLiteral()).contains("REQUEST.BODY.data")
-            }
-        } finally {
-            System.clearProperty("SPECMATIC_GENERATIVE_STUB")
+            val responseBody = response.body as JSONObjectValue
+            assertThat(responseBody.jsonObject["message"]?.toStringLiteral()).contains("REQUEST.BODY.data")
         }
     }
 
@@ -1615,21 +1610,15 @@ components:
 
         val feature = OpenApiSpecification.fromYAML(spec, "").toFeature()
 
-        System.setProperty("SPECMATIC_GENERATIVE_STUB", "true")
+        HttpStub(listOf(feature), specmaticConfigPath = "src/test/resources/specmatic_config_wtih_generate_stub.yaml").use { stub ->
+            val request = HttpRequest("POST", path = "/hello", body = parsedJSONObject("""{"data": 10}"""))
+            val response = stub.client.execute(request)
 
-        try {
-            HttpStub(feature).use { stub ->
-                val request = HttpRequest("POST", path = "/hello", body = parsedJSONObject("""{"data": 10}"""))
-                val response = stub.client.execute(request)
+            assertThat(response.status).isEqualTo(422)
+            assertThat(response.body).isInstanceOf(JSONObjectValue::class.java)
 
-                assertThat(response.status).isEqualTo(422)
-                assertThat(response.body).isInstanceOf(JSONObjectValue::class.java)
-
-                val responseBody = response.body as JSONObjectValue
-                assertThat(responseBody.jsonObject["message"]?.toStringLiteral()).contains("REQUEST.BODY.data")
-            }
-        } finally {
-            System.clearProperty("SPECMATIC_GENERATIVE_STUB")
+            val responseBody = response.body as JSONObjectValue
+            assertThat(responseBody.jsonObject["message"]?.toStringLiteral()).contains("REQUEST.BODY.data")
         }
     }
 
@@ -1683,21 +1672,15 @@ components:
 
         val feature = OpenApiSpecification.fromYAML(spec, "").toFeature()
 
-        System.setProperty("SPECMATIC_GENERATIVE_STUB", "true")
+        HttpStub(listOf(feature), specmaticConfigPath = "src/test/resources/specmatic_config_wtih_generate_stub.yaml").use { stub ->
+            val request = HttpRequest("POST", path = "/hello", body = parsedJSONObject("""{"data": 10}"""))
+            val response = stub.client.execute(request)
 
-        try {
-            HttpStub(feature).use { stub ->
-                val request = HttpRequest("POST", path = "/hello", body = parsedJSONObject("""{"data": 10}"""))
-                val response = stub.client.execute(request)
+            assertThat(response.status).isEqualTo(422)
+            assertThat(response.body).isInstanceOf(JSONObjectValue::class.java)
 
-                assertThat(response.status).isEqualTo(422)
-                assertThat(response.body).isInstanceOf(JSONObjectValue::class.java)
-
-                val responseBody = response.body as JSONObjectValue
-                assertThat(responseBody.jsonObject["error_info"]?.toStringLiteral()).contains("REQUEST.BODY.data")
-            }
-        } finally {
-            System.clearProperty("SPECMATIC_GENERATIVE_STUB")
+            val responseBody = response.body as JSONObjectValue
+            assertThat(responseBody.jsonObject["error_info"]?.toStringLiteral()).contains("REQUEST.BODY.data")
         }
     }
 
@@ -1751,21 +1734,15 @@ components:
 
         val feature = OpenApiSpecification.fromYAML(spec, "").toFeature()
 
-        System.setProperty("SPECMATIC_GENERATIVE_STUB", "true")
+        HttpStub(listOf(feature), specmaticConfigPath = "src/test/resources/specmatic_config_wtih_generate_stub.yaml").use { stub ->
+            val request = HttpRequest("POST", path = "/hello", body = parsedJSONObject("""{"data": 10}"""))
+            val response = stub.client.execute(request)
 
-        try {
-            HttpStub(feature).use { stub ->
-                val request = HttpRequest("POST", path = "/hello", body = parsedJSONObject("""{"data": 10}"""))
-                val response = stub.client.execute(request)
+            assertThat(response.status).isEqualTo(422)
+            assertThat(response.body).isInstanceOf(JSONObjectValue::class.java)
 
-                assertThat(response.status).isEqualTo(422)
-                assertThat(response.body).isInstanceOf(JSONObjectValue::class.java)
-
-                val responseBody = response.body as JSONObjectValue
-                assertThat(responseBody.jsonObject["message"]).isInstanceOf(NumberValue::class.java)
-            }
-        } finally {
-            System.clearProperty("SPECMATIC_GENERATIVE_STUB")
+            val responseBody = response.body as JSONObjectValue
+            assertThat(responseBody.jsonObject["message"]).isInstanceOf(NumberValue::class.java)
         }
     }
 }

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
@@ -1496,4 +1496,276 @@ components:
             assertThat(response.body.toStringLiteral()).isEqualTo("Hello, World!")
         }
     }
+
+    @Test
+    fun `a generative stub should respond to an invalid request with a 400 per the spec with the error in the message key`() {
+        val spec = """
+            openapi: 3.0.0
+            info:
+              title: Sample API
+              description: Optional multiline or single-line description in [CommonMark](http://commonmark.org/help/) or HTML.
+              version: 0.1.9
+            servers:
+              - url: http://api.example.com/v1
+                description: Optional server description, e.g. Main (production) server
+              - url: http://staging-api.example.com
+                description: Optional server description, e.g. Internal staging server for testing
+            paths:
+              /hello:
+                post:
+                  summary: hello world
+                  description: Optional extended description in CommonMark or HTML.
+                  requestBody:
+                    content:
+                      application/json:
+                        schema:
+                          type: object
+                          required:
+                            - data
+                          properties:
+                            data:
+                              type: string
+                  responses:
+                    '200':
+                      description: Says hello
+                      content:
+                        text/plain:
+                          schema:
+                            type: string
+                    '400':
+                      description: Bad request
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                            required:
+                              - message
+                            properties:
+                              message:
+                                type: string
+        """.trimIndent()
+
+        val feature = OpenApiSpecification.fromYAML(spec, "").toFeature()
+
+        System.setProperty("SPECMATIC_GENERATIVE_STUB", "true")
+
+        try {
+            HttpStub(feature).use { stub ->
+                val request = HttpRequest("POST", path = "/hello", body = parsedJSONObject("""{"data": 10}"""))
+                val response = stub.client.execute(request)
+
+                assertThat(response.status).isEqualTo(400)
+                assertThat(response.body).isInstanceOf(JSONObjectValue::class.java)
+
+                val responseBody = response.body as JSONObjectValue
+                assertThat(responseBody.jsonObject["message"]?.toStringLiteral()).contains("REQUEST.BODY.data")
+            }
+        } finally {
+            System.clearProperty("SPECMATIC_GENERATIVE_STUB")
+        }
+    }
+
+    @Test
+    fun `a generative stub should respond to an invalid request with a 422 with the error in the message key`() {
+        val spec = """
+            openapi: 3.0.0
+            info:
+              title: Sample API
+              description: Optional multiline or single-line description in [CommonMark](http://commonmark.org/help/) or HTML.
+              version: 0.1.9
+            servers:
+              - url: http://api.example.com/v1
+                description: Optional server description, e.g. Main (production) server
+              - url: http://staging-api.example.com
+                description: Optional server description, e.g. Internal staging server for testing
+            paths:
+              /hello:
+                post:
+                  summary: hello world
+                  description: Optional extended description in CommonMark or HTML.
+                  requestBody:
+                    content:
+                      application/json:
+                        schema:
+                          type: object
+                          required:
+                            - data
+                          properties:
+                            data:
+                              type: string
+                  responses:
+                    '200':
+                      description: Says hello
+                      content:
+                        text/plain:
+                          schema:
+                            type: string
+                    '422':
+                      description: Bad request
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                            required:
+                              - message
+                            properties:
+                              message:
+                                type: string
+        """.trimIndent()
+
+        val feature = OpenApiSpecification.fromYAML(spec, "").toFeature()
+
+        System.setProperty("SPECMATIC_GENERATIVE_STUB", "true")
+
+        try {
+            HttpStub(feature).use { stub ->
+                val request = HttpRequest("POST", path = "/hello", body = parsedJSONObject("""{"data": 10}"""))
+                val response = stub.client.execute(request)
+
+                assertThat(response.status).isEqualTo(422)
+                assertThat(response.body).isInstanceOf(JSONObjectValue::class.java)
+
+                val responseBody = response.body as JSONObjectValue
+                assertThat(responseBody.jsonObject["message"]?.toStringLiteral()).contains("REQUEST.BODY.data")
+            }
+        } finally {
+            System.clearProperty("SPECMATIC_GENERATIVE_STUB")
+        }
+    }
+
+    @Test
+    fun `a generative stub should return the error in any available string key in the 4xx response if message is not found`() {
+        val spec = """
+            openapi: 3.0.0
+            info:
+              title: Sample API
+              description: Optional multiline or single-line description in [CommonMark](http://commonmark.org/help/) or HTML.
+              version: 0.1.9
+            servers:
+              - url: http://api.example.com/v1
+                description: Optional server description, e.g. Main (production) server
+              - url: http://staging-api.example.com
+                description: Optional server description, e.g. Internal staging server for testing
+            paths:
+              /hello:
+                post:
+                  summary: hello world
+                  description: Optional extended description in CommonMark or HTML.
+                  requestBody:
+                    content:
+                      application/json:
+                        schema:
+                          type: object
+                          required:
+                            - data
+                          properties:
+                            data:
+                              type: string
+                  responses:
+                    '200':
+                      description: Says hello
+                      content:
+                        text/plain:
+                          schema:
+                            type: string
+                    '422':
+                      description: Bad request
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                            required:
+                              - error_info
+                            properties:
+                              error_info:
+                                type: id
+        """.trimIndent()
+
+        val feature = OpenApiSpecification.fromYAML(spec, "").toFeature()
+
+        System.setProperty("SPECMATIC_GENERATIVE_STUB", "true")
+
+        try {
+            HttpStub(feature).use { stub ->
+                val request = HttpRequest("POST", path = "/hello", body = parsedJSONObject("""{"data": 10}"""))
+                val response = stub.client.execute(request)
+
+                assertThat(response.status).isEqualTo(422)
+                assertThat(response.body).isInstanceOf(JSONObjectValue::class.java)
+
+                val responseBody = response.body as JSONObjectValue
+                assertThat(responseBody.jsonObject["error_info"]?.toStringLiteral()).contains("REQUEST.BODY.data")
+            }
+        } finally {
+            System.clearProperty("SPECMATIC_GENERATIVE_STUB")
+        }
+    }
+
+    @Test
+    fun `a generative stub should return a randomized 4xx response when it cannot find a string key`() {
+        val spec = """
+            openapi: 3.0.0
+            info:
+              title: Sample API
+              description: Optional multiline or single-line description in [CommonMark](http://commonmark.org/help/) or HTML.
+              version: 0.1.9
+            servers:
+              - url: http://api.example.com/v1
+                description: Optional server description, e.g. Main (production) server
+              - url: http://staging-api.example.com
+                description: Optional server description, e.g. Internal staging server for testing
+            paths:
+              /hello:
+                post:
+                  summary: hello world
+                  description: Optional extended description in CommonMark or HTML.
+                  requestBody:
+                    content:
+                      application/json:
+                        schema:
+                          type: object
+                          required:
+                            - data
+                          properties:
+                            data:
+                              type: string
+                  responses:
+                    '200':
+                      description: Says hello
+                      content:
+                        text/plain:
+                          schema:
+                            type: string
+                    '422':
+                      description: Bad request
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                            required:
+                              - message
+                            properties:
+                              message:
+                                type: integer
+        """.trimIndent()
+
+        val feature = OpenApiSpecification.fromYAML(spec, "").toFeature()
+
+        System.setProperty("SPECMATIC_GENERATIVE_STUB", "true")
+
+        try {
+            HttpStub(feature).use { stub ->
+                val request = HttpRequest("POST", path = "/hello", body = parsedJSONObject("""{"data": 10}"""))
+                val response = stub.client.execute(request)
+
+                assertThat(response.status).isEqualTo(422)
+                assertThat(response.body).isInstanceOf(JSONObjectValue::class.java)
+
+                val responseBody = response.body as JSONObjectValue
+                assertThat(responseBody.jsonObject["message"]).isInstanceOf(NumberValue::class.java)
+            }
+        } finally {
+            System.clearProperty("SPECMATIC_GENERATIVE_STUB")
+        }
+    }
 }

--- a/core/src/test/resources/specmatic_config_wtih_generate_stub.yaml
+++ b/core/src/test/resources/specmatic_config_wtih_generate_stub.yaml
@@ -1,0 +1,2 @@
+stub:
+  generative: true


### PR DESCRIPTION
**What**:

With this feature switched on, 4xx responses coming from Specmatic stub in response to bad requests will take the form of an actual 4xx in the spec, if one is found. If this response contains a string value, the message will be stored in the string.

For example, consider the following spec:

```yaml
openapi: 3.0.0
info:
  title: Sample API
  description: Optional multiline or single-line description in [CommonMark](http://commonmark.org/help/) or HTML.
  version: 0.1.9
servers:
  - url: http://api.example.com/v1
    description: Optional server description, e.g. Main (production) server
  - url: http://staging-api.example.com
    description: Optional server description, e.g. Internal staging server for testing
paths:
  /hello:
    post:
      summary: hello world
      description: Optional extended description in CommonMark or HTML.
      requestBody:
        content:
          application/json:
            schema:
              type: object
              required:
                - data
              properties:
                data:
                  type: string
      responses:
        '200':
          description: Says hello
          content:
            text/plain:
              schema:
                type: string
        '422':
          description: Bad request
          content:
            application/json:
              schema:
                type: object
                required:
                  - message
                properties:
                  message:
                    type: string
```

If a Specmatic stub is run against this spec, and the following request is sent to it:

```json
{
  "data": 10
}
```

...the response generated may look like this:

```json
    {
        "message": "In scenario \"hello world. Response: Says hello\"\nAPI: POST /hello -> 200\n\n  >> REQUEST.BODY.data\n  \n     Contract expected string but request contained 10 (number)\n\nIn scenario \"hello world. Response: Bad request\"\nAPI: POST /hello -> 422\n\n  >> REQUEST.BODY.data\n  \n     Contract expected string but request contained 10 (number)"
    }
```

To switch on the feature, add the following to `specmatic.yaml`:

```yaml
stub:
  generative: true
```

**Why**:

It may be useful to see what an actual spec-valid 4xx looks like in response to an invalid request. Until now, Specmatic responded with an error message of its own, even if the specification has its own 4xx. This feature now let's Specmatic use the provided 4xx schema to return it's error message.

**How**:

* HttpStub has been modified to check for this flag, and respond with the appropriate 4xx.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate
