### PR TITLE
Implement a workflow where the id of an entity created via a POST API can be passed to a GET request

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -328,6 +328,8 @@ data class Feature(
         Results(results.map { it.second }.filterIsInstance<Result.Failure>().toMutableList())
 
     fun generateContractTests(suggestions: List<Scenario>): Sequence<ContractTest> {
+        val workflow = Workflow(specmaticConfig.workflow ?: WorkflowConfiguration())
+
         return generateContractTestScenarios(suggestions).map { (originalScenario, returnValue) ->
             returnValue.realise(
                 hasValue = { concreteTestScenario, comment ->
@@ -339,7 +341,9 @@ data class Feature(
                         concreteTestScenario.sourceRepositoryBranch,
                         concreteTestScenario.specification,
                         concreteTestScenario.serviceType,
-                        comment
+                        comment,
+                        workflow = workflow,
+                        originalScenario = originalScenario
                     )
                 },
                 orFailure = {

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -59,6 +59,15 @@ fun String.loadContract(): Feature {
     return parseContractFileToFeature(File(this))
 }
 
+data class WorkflowIDOperation(
+    val extract: String? = null,
+    val use: String? = null
+)
+
+data class WorkflowConfiguration(
+    val ids: Map<String, WorkflowIDOperation> = emptyMap()
+)
+
 data class SpecmaticConfig(
     val sources: List<Source> = emptyList(),
     val auth: Auth? = null,
@@ -69,7 +78,8 @@ data class SpecmaticConfig(
     val report: ReportConfiguration? = null,
     val security: SecurityConfiguration? = null,
     val test: TestConfiguration? = TestConfiguration(),
-    val examples: List<String> = getStringValue(EXAMPLE_DIRECTORIES)?.split(",") ?: emptyList()
+    val examples: List<String> = getStringValue(EXAMPLE_DIRECTORIES)?.split(",") ?: emptyList(),
+    val workflow: WorkflowConfiguration? = null
 ) {
     fun isExtensibleSchemaEnabled(): Boolean {
         return (test?.allowExtensibleSchema == true)

--- a/core/src/main/kotlin/io/specmatic/core/Workflow.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Workflow.kt
@@ -89,6 +89,10 @@ class Workflow(
                         updatedPath.set(indexToUpdate, it.toStringLiteral())
                     }
 
+                    val result = originalScenario.httpRequestPattern.httpPathPattern?.matches(updatedPath.joinToString("/"), originalScenario.resolver)
+
+                    result?.throwOnFailure()
+
                     request.copy(path = updatedPath.joinToString("/"))
                 }
             }

--- a/core/src/main/kotlin/io/specmatic/core/Workflow.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Workflow.kt
@@ -1,0 +1,100 @@
+package io.specmatic.core
+
+import io.specmatic.core.pattern.ContractException
+import io.specmatic.core.value.JSONObjectValue
+import io.specmatic.core.value.Value
+
+class Workflow(
+    val workflow: WorkflowConfiguration = WorkflowConfiguration(),
+) {
+    var id: Value? = null
+
+    fun extractDataFrom(request: HttpRequest, response: HttpResponse, originalScenario: Scenario) {
+        val operation = workflow.ids.get(originalScenario.apiDescription)
+
+        if(operation == null)
+            return
+
+        val extractLocation = operation.extract
+
+        if(extractLocation != null) {
+            val locationPath = extractLocation.split(".")
+            if(locationPath.size == 0)
+                return
+
+            val area = locationPath[0]
+
+            val path = locationPath.drop(1)
+
+            when(area.uppercase()) {
+                "BODY" -> {
+                    val responseBody = response.body
+
+                    if(path.size == 0) {
+                        id = responseBody
+                    } else if(responseBody is JSONObjectValue) {
+                        val data = responseBody.findFirstChildByPath(path.joinToString("."))
+                        if(data != null)
+                            id = data
+                    }
+                }
+                else -> {
+                    throw ContractException("Cannot extract data from $area yet")
+                }
+            }
+
+        }
+    }
+
+    fun updateRequest(request: HttpRequest, originalScenario: Scenario): HttpRequest {
+        val operation = workflow.ids.get(originalScenario.apiDescription) ?: workflow.ids.get("*")
+
+        if(operation == null)
+            return request
+
+        val useLocation = operation.use
+
+        if(useLocation == null)
+            return request
+
+        val locationPath = useLocation.split(".")
+        if(locationPath.size == 0)
+            return request
+
+        val area = locationPath[0]
+
+        val path = locationPath.drop(1)
+
+        return when(area.uppercase()) {
+            "PATH" -> {
+                if(path.size == 0)
+                    throw ContractException("Cannot use id $useLocation")
+
+                if(path.size > 1)
+                    throw ContractException("PATH.<name> must refer to the name of a path parameter")
+
+                val pathParamName = path.get(0)
+
+                val pathParamIndex = originalScenario.httpRequestPattern.httpPathPattern?.pathSegmentPatterns?.indexOfFirst { it.key == pathParamName } ?: -1
+
+                if(pathParamIndex < 0) {
+                    request
+                }
+                else {
+                    val updatedPath = request.path!!.split("/").toMutableList()
+
+                    val indexToUpdate = if(updatedPath.getOrNull(0) == "") pathParamIndex + 1 else pathParamIndex
+
+                    id?.let {
+                        updatedPath.set(indexToUpdate, it.toStringLiteral())
+                    }
+
+                    request.copy(path = updatedPath.joinToString("/"))
+                }
+            }
+            else -> {
+                throw ContractException("Cannot extract data from $area yet")
+            }
+        }
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/core/Workflow.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Workflow.kt
@@ -9,7 +9,7 @@ class Workflow(
 ) {
     var id: Value? = null
 
-    fun extractDataFrom(request: HttpRequest, response: HttpResponse, originalScenario: Scenario) {
+    fun extractDataFrom(response: HttpResponse, originalScenario: Scenario) {
         val operation = workflow.ids.get(originalScenario.apiDescription)
 
         if(operation == null)

--- a/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
@@ -93,7 +93,7 @@ data class ScenarioAsTest(
 
             val response = testExecutor.execute(request)
 
-            workflow.extractDataFrom(request, response, originalScenario)
+            workflow.extractDataFrom(response, originalScenario)
 
             val validatorResult = validators.asSequence().map { it.validate(scenario, response) }.filterNotNull().firstOrNull()
             val result = validatorResult ?: testResult(request, response, testScenario, flagsBased)

--- a/core/src/test/kotlin/integration_tests/WorkflowTest.kt
+++ b/core/src/test/kotlin/integration_tests/WorkflowTest.kt
@@ -1,0 +1,46 @@
+package integration_tests
+
+import io.specmatic.conversions.OpenApiSpecification
+import io.specmatic.core.*
+import io.specmatic.core.pattern.parsedJSONObject
+import io.specmatic.test.TestExecutor
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class WorkflowTest {
+    @Test
+    fun `a spec should be able to use the id of a newly created entity in another request for the same entity`() {
+        val specmaticConfig =
+            SpecmaticConfig(
+                workflow = WorkflowConfiguration(
+                    ids = mapOf(
+                        "POST /orders -> 201" to WorkflowIDOperation(extract = "BODY.id"),
+                        "*" to WorkflowIDOperation(use = "PATH.orderId")
+                    )
+                )
+            )
+
+        val feature = OpenApiSpecification
+            .fromFile(
+                "src/test/resources/openapi/spec_for_workflow_test.yaml",
+                specmaticConfig = specmaticConfig
+            )
+            .toFeature()
+
+        var idInRequest: String = ""
+
+        feature.executeTests(object : TestExecutor {
+            override fun execute(request: HttpRequest): HttpResponse {
+                if(request.method == "POST")
+                    return HttpResponse(201, parsedJSONObject("""{id: "new-order-id"}"""))
+
+                idInRequest = request.path!!.split("/").last()
+
+                return HttpResponse(200, parsedJSONObject("""{productid: 20, quantity: 1}"""))
+            }
+        })
+
+        assertThat(idInRequest).isEqualTo("new-order-id")
+
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiKtTest.kt
@@ -1670,7 +1670,7 @@ Scenario: zero should return not found
 
         var executed = false
 
-        val result = io.specmatic.test.ScenarioAsTest(feature.scenarios.first(), DefaultStrategies)
+        val result = io.specmatic.test.ScenarioAsTest(feature.scenarios.first(), DefaultStrategies, originalScenario = feature.scenarios.first())
             .runTest(object : TestExecutor {
                     override fun execute(request: HttpRequest): HttpResponse {
                         executed = true

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -8112,8 +8112,8 @@ components:
         val specmaticConfig = SpecmaticConfig(
             workflow = WorkflowConfiguration(
                 mapOf(
-                    "POST /order -> 201" to WorkflowIDOperation(extract = "BODY.id"),
-                    "GET /order/{id} -> 201" to WorkflowIDOperation(use = "PATH.id")
+                    "POST /orders -> 201" to WorkflowIDOperation(extract = "BODY.id"),
+                    "GET /orders/(orderId:string) -> 200" to WorkflowIDOperation(use = "PATH.orderId")
                 )
             )
         )

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -8030,6 +8030,112 @@ paths:
         }
     }
 
+    @Test
+    fun `when a workflow exists id of a created entity should be passed on to subsequent API calls`() {
+        val spec = """
+openapi: 3.0.0
+info:
+  title: Simple Order API
+  version: 1.0.0
+  description: A simple API for creating and fetching orders
+paths:
+  /orders:
+    post:
+      summary: Create a new order
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              ${"$"}ref: '#/components/schemas/Order'
+            examples:
+              SUCCESSFUL_ORDER:
+                value:
+                  productid: "abc123"
+                  quantity: 10
+      responses:
+        '201':
+          description: Order created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                properties:
+                  id:
+                    type: string
+              examples:
+                SUCCESSFUL_ORDER:
+                  value:
+                    id: "pqr123"
+  /orders/{orderId}:
+    get:
+      summary: Get order details
+      parameters:
+        - in: path
+          name: orderId
+          required: true
+          schema:
+            type: string
+          examples:
+            GET_ORDER:
+              value: "pqr123"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                ${"$"}ref: '#/components/schemas/Order'
+              examples:
+                GET_ORDER:
+                  value:
+                    productid: "abc123"
+                    quantity: 10
+
+components:
+  schemas:
+    Order:
+      type: object
+      required:
+        - productId
+        - quantity
+      properties:
+        productid:
+          type: string
+        quantity:
+          type: integer
+          minimum: 1
+        """.trimIndent()
+
+        val specmaticConfig = SpecmaticConfig(
+            workflow = WorkflowConfiguration(
+                mapOf(
+                    "POST /order -> 201" to WorkflowIDOperation(extract = "BODY.id"),
+                    "GET /order/{id} -> 201" to WorkflowIDOperation(use = "PATH.id")
+                )
+            )
+        )
+        val feature = OpenApiSpecification.fromYAML(spec, "", specmaticConfig = specmaticConfig).toFeature()
+
+        lateinit var path: String
+
+        val results = feature.executeTests(object : TestExecutor {
+            override fun execute(request: HttpRequest): HttpResponse {
+                if(request.method == "POST")
+                    return HttpResponse(201, body = parsedJSONObject("""{"id": "xyzabc"}"""))
+                else {
+                    path = request.path!!
+                    return HttpResponse(200, parsedJSONObject("""{"productid": "pqr123", "quantity": 10}"""))
+                }
+            }
+        })
+
+        assertThat(path).endsWith("/xyzabc")
+        assertThat(results.success()).isTrue()
+    }
+
     private fun ignoreButLogException(function: () -> OpenApiSpecification) {
         try {
             function()

--- a/core/src/test/kotlin/io/specmatic/core/WorkflowTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/WorkflowTest.kt
@@ -1,15 +1,12 @@
 package io.specmatic.core
 
 import io.specmatic.core.pattern.*
-import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.StringValue
-import io.specmatic.core.value.Value
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions.*
+import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.Test
 
 class WorkflowTest {
-    val postScenario = Scenario(
+    val postScenarioReturningNumber = Scenario(
         "Add data",
         HttpRequestPattern(
             method = "POST",
@@ -30,7 +27,28 @@ class WorkflowTest {
         emptyMap(),
     )
 
-    val getScenario = Scenario(
+    val postScenarioReturningString = Scenario(
+        "Add data",
+        HttpRequestPattern(
+            method = "POST",
+            httpPathPattern = buildHttpPathPattern("/data"),
+            body = StringPattern()
+        ),
+        HttpResponsePattern(
+            status = 201,
+            body = JSONObjectPattern(
+                mapOf(
+                    "id" to StringPattern()
+                )
+            )
+        ),
+        emptyMap(),
+        emptyList(),
+        emptyMap(),
+        emptyMap(),
+    )
+
+    val getScenarioAcceptingNumberInPath = Scenario(
         "Get data",
         HttpRequestPattern(
             method = "GET",
@@ -65,8 +83,8 @@ class WorkflowTest {
             )
         )
 
-        workflow.extractDataFrom(response, postScenario)
-        val updatedRequest = workflow.updateRequest(request, getScenario)
+        workflow.extractDataFrom(response, postScenarioReturningNumber)
+        val updatedRequest = workflow.updateRequest(request, getScenarioAcceptingNumberInPath)
 
         assertThat(updatedRequest.path).isEqualTo("/data/1000")
 
@@ -86,10 +104,31 @@ class WorkflowTest {
             )
         )
 
-        workflow.extractDataFrom(response, postScenario)
-        val updatedRequest = workflow.updateRequest(request, getScenario)
+        workflow.extractDataFrom(response, postScenarioReturningNumber)
+        val updatedRequest = workflow.updateRequest(request, getScenarioAcceptingNumberInPath)
 
         assertThat(updatedRequest.path).isEqualTo("/data/1000")
 
+    }
+
+    @Test
+    fun `should complain if the returned id is of the wrong type`() {
+        val request = HttpRequest("POST", "/data/1", body = StringValue("data"))
+        val response = HttpResponse(201, body = parsedJSONObject("""{"id": "abc"}"""))
+
+        val workflow = Workflow(
+            workflow = WorkflowConfiguration(
+                ids = mapOf(
+                    "*" to WorkflowIDOperation(use = "PATH.id"),
+                    "POST /data -> 201" to WorkflowIDOperation(extract = "BODY.id")
+                )
+            )
+        )
+
+        workflow.extractDataFrom(response, postScenarioReturningNumber)
+
+        assertThatThrownBy {
+            workflow.updateRequest(request, getScenarioAcceptingNumberInPath)
+        }.hasMessageContaining("Expected number")
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/WorkflowTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/WorkflowTest.kt
@@ -1,0 +1,95 @@
+package io.specmatic.core
+
+import io.specmatic.core.pattern.*
+import io.specmatic.core.value.JSONObjectValue
+import io.specmatic.core.value.StringValue
+import io.specmatic.core.value.Value
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class WorkflowTest {
+    val postScenario = Scenario(
+        "Add data",
+        HttpRequestPattern(
+            method = "POST",
+            httpPathPattern = buildHttpPathPattern("/data"),
+            body = StringPattern()
+        ),
+        HttpResponsePattern(
+            status = 201,
+            body = JSONObjectPattern(
+                mapOf(
+                    "id" to StringPattern()
+                )
+            )
+        ),
+        emptyMap(),
+        emptyList(),
+        emptyMap(),
+        emptyMap(),
+    )
+
+    val getScenario = Scenario(
+        "Get data",
+        HttpRequestPattern(
+            method = "GET",
+            httpPathPattern = buildHttpPathPattern("/data/(id:string)"),
+            body = StringPattern()
+        ),
+        HttpResponsePattern(
+            status = 200,
+            body = JSONObjectPattern(
+                mapOf(
+                    "id" to StringPattern()
+                )
+            )
+        ),
+        emptyMap(),
+        emptyList(),
+        emptyMap(),
+        emptyMap(),
+    )
+
+    @Test
+    fun `should fetch the specified id out a response and add it to a request`() {
+        val request = HttpRequest("POST", "/data/id-from-test-data", body = StringValue("data"))
+        val response = HttpResponse(201, body = parsedJSONObject("""{"id": "id-from-response"}"""))
+
+        val workflow = Workflow(
+            workflow = WorkflowConfiguration(
+                ids = mapOf(
+                    "GET /data/(id:string) -> 200" to WorkflowIDOperation(use = "PATH.id"),
+                    "POST /data -> 201" to WorkflowIDOperation(extract = "BODY.id")
+                )
+            )
+        )
+
+        workflow.extractDataFrom(response, postScenario)
+        val updatedRequest = workflow.updateRequest(request, getScenario)
+
+        assertThat(updatedRequest.path).isEqualTo("/data/id-from-response")
+
+    }
+
+    @Test
+    fun `should fetch the specified id out a response and add it to a request when configured for all requests`() {
+        val request = HttpRequest("POST", "/data/id-from-test-data", body = StringValue("data"))
+        val response = HttpResponse(201, body = parsedJSONObject("""{"id": "id-from-response"}"""))
+
+        val workflow = Workflow(
+            workflow = WorkflowConfiguration(
+                ids = mapOf(
+                    "*" to WorkflowIDOperation(use = "PATH.id"),
+                    "POST /data -> 201" to WorkflowIDOperation(extract = "BODY.id")
+                )
+            )
+        )
+
+        workflow.extractDataFrom(response, postScenario)
+        val updatedRequest = workflow.updateRequest(request, getScenario)
+
+        assertThat(updatedRequest.path).isEqualTo("/data/id-from-response")
+
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/WorkflowTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/WorkflowTest.kt
@@ -20,7 +20,7 @@ class WorkflowTest {
             status = 201,
             body = JSONObjectPattern(
                 mapOf(
-                    "id" to StringPattern()
+                    "id" to NumberPattern()
                 )
             )
         ),
@@ -34,14 +34,14 @@ class WorkflowTest {
         "Get data",
         HttpRequestPattern(
             method = "GET",
-            httpPathPattern = buildHttpPathPattern("/data/(id:string)"),
+            httpPathPattern = buildHttpPathPattern("/data/(id:number)"),
             body = StringPattern()
         ),
         HttpResponsePattern(
             status = 200,
             body = JSONObjectPattern(
                 mapOf(
-                    "id" to StringPattern()
+                    "id" to NumberPattern()
                 )
             )
         ),
@@ -53,13 +53,13 @@ class WorkflowTest {
 
     @Test
     fun `should fetch the specified id out a response and add it to a request`() {
-        val request = HttpRequest("POST", "/data/id-from-test-data", body = StringValue("data"))
-        val response = HttpResponse(201, body = parsedJSONObject("""{"id": "id-from-response"}"""))
+        val request = HttpRequest("POST", "/data/1", body = StringValue("data"))
+        val response = HttpResponse(201, body = parsedJSONObject("""{"id": "1000"}"""))
 
         val workflow = Workflow(
             workflow = WorkflowConfiguration(
                 ids = mapOf(
-                    "GET /data/(id:string) -> 200" to WorkflowIDOperation(use = "PATH.id"),
+                    "GET /data/(id:number) -> 200" to WorkflowIDOperation(use = "PATH.id"),
                     "POST /data -> 201" to WorkflowIDOperation(extract = "BODY.id")
                 )
             )
@@ -68,14 +68,14 @@ class WorkflowTest {
         workflow.extractDataFrom(response, postScenario)
         val updatedRequest = workflow.updateRequest(request, getScenario)
 
-        assertThat(updatedRequest.path).isEqualTo("/data/id-from-response")
+        assertThat(updatedRequest.path).isEqualTo("/data/1000")
 
     }
 
     @Test
     fun `should fetch the specified id out a response and add it to a request when configured for all requests`() {
-        val request = HttpRequest("POST", "/data/id-from-test-data", body = StringValue("data"))
-        val response = HttpResponse(201, body = parsedJSONObject("""{"id": "id-from-response"}"""))
+        val request = HttpRequest("POST", "/data/1", body = StringValue("data"))
+        val response = HttpResponse(201, body = parsedJSONObject("""{"id": "1000"}"""))
 
         val workflow = Workflow(
             workflow = WorkflowConfiguration(
@@ -89,7 +89,7 @@ class WorkflowTest {
         workflow.extractDataFrom(response, postScenario)
         val updatedRequest = workflow.updateRequest(request, getScenario)
 
-        assertThat(updatedRequest.path).isEqualTo("/data/id-from-response")
+        assertThat(updatedRequest.path).isEqualTo("/data/1000")
 
     }
 }

--- a/core/src/test/resources/openapi/spec_for_workflow_test.yaml
+++ b/core/src/test/resources/openapi/spec_for_workflow_test.yaml
@@ -1,0 +1,81 @@
+openapi: 3.0.0
+info:
+  title: Simple Order API
+  version: 1.0.0
+  description: A simple API for creating and fetching orders
+  contact:
+    name: API Support
+    email: support@example.com
+    url: https://www.example.com/support
+
+servers:
+  - url: https://api.example.com/v1
+    description: Production server
+  - url: https://staging-api.example.com/v1
+    description: Staging server
+
+tags:
+  - name: orders
+    description: Operations about orders
+
+paths:
+  /orders:
+    post:
+      summary: Create a new order
+      operationId: createOrder
+      tags:
+        - orders
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Order'
+      responses:
+        '201':
+          description: Order created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Id'
+
+  /orders/{orderId}:
+    get:
+      summary: Get order details
+      operationId: getOrder
+      tags:
+        - orders
+      parameters:
+        - in: path
+          name: orderId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Order'
+
+components:
+  schemas:
+    Order:
+      type: object
+      required:
+        - productId
+        - quantity
+      properties:
+        productId:
+          type: string
+        quantity:
+          type: integer
+          minimum: 1
+    Id:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string

--- a/version.properties
+++ b/version.properties
@@ -1,2 +1,2 @@
-version=2.0.7
+version=2.0.8
 


### PR DESCRIPTION
**What**:

Say a contract test goes out for `POST /orders -> 201` to create an order. The id comes back in the response body as the value of the key `id`.

The next contract test that goes out for `GET /orders/{id} -> 200` should have this key, in place of any test data that already exists.

**Why**:

In the above example, the system-under-test would not know any order with the id hard-code in the examples in the specification, so the API call to `GET /orders/{id}` would fail.

If a workflow is setup, then Specamtic will store the id from the POST /orders response, and update the request in the GET /orders/{id} test url with the id that it had stored.

**How**:

- Added a new `Workflow` class to perform the storage and extraction of ids
- Updated `ScenarioAsTest` to execute workflow methods
- Update Feature to construct `ScenarioAsTest` objects with the shared workflow object

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate
