### PR TITLE
If a test file is not loaded, give the reason before running the tests

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -16,6 +16,7 @@ import io.cucumber.messages.IdGenerator.Incrementing
 import io.cucumber.messages.types.*
 import io.cucumber.messages.types.Examples
 import io.specmatic.core.utilities.*
+import io.specmatic.stub.stringToMockScenario
 import io.swagger.v3.oas.models.*
 import io.swagger.v3.oas.models.headers.Header
 import io.swagger.v3.oas.models.info.Info
@@ -1443,8 +1444,19 @@ data class Feature(
             println()
             logger.log("The following externalized examples were not used:")
 
-            unusedExternalizedExamples.sorted().forEach {
-                logger.log("  $it")
+            unusedExternalizedExamples.sorted().forEach { externalizedExamplePath: String ->
+                logger.log("  $externalizedExamplePath")
+
+                try {
+                    val example = ScenarioStub.parse(File(externalizedExamplePath).readText())
+
+                    val method = example.request.method
+                    val path = example.request.path
+                    val responseCode = example.response.status
+                    logger.log("    $method $path -> $responseCode not found in the specification")
+                } catch(e: Throwable) {
+                    logger.log("    Could not parse the example: ${exceptionCauseMessage(e)}")
+                }
             }
 
             logger.newLine()

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -1453,7 +1453,7 @@ data class Feature(
                     val method = example.request.method
                     val path = example.request.path
                     val responseCode = example.response.status
-                    logger.log("    $method $path -> $responseCode not found in the specification")
+                    logger.log("    $method $path -> $responseCode does not match any operation in the specification")
                 } catch(e: Throwable) {
                     logger.log("    Could not parse the example: ${exceptionCauseMessage(e)}")
                 }

--- a/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
@@ -5,6 +5,7 @@ import io.specmatic.core.pattern.NumberPattern
 import io.specmatic.core.pattern.StringPattern
 import io.specmatic.core.utilities.exceptionCauseMessage
 import io.specmatic.core.value.*
+import io.specmatic.stub.captureStandardOutput
 import io.specmatic.test.ScenarioTestGenerationException
 import io.specmatic.test.ScenarioTestGenerationFailure
 import io.specmatic.test.TestExecutor
@@ -2337,6 +2338,18 @@ paths:
         assertThatThrownBy { feature.validateExamplesOrException() }.satisfies(Consumer { exception ->
             assertThat(exceptionCauseMessage(exception)).contains("200_OK")
         })
+    }
+
+    @Test
+    fun `show the reason why an example was ignored when loading it for test`() {
+        val feature = OpenApiSpecification.fromFile("src/test/resources/openapi/has_irrelevant_externalized_test.yaml").toFeature()
+
+        val (output, _) = captureStandardOutput {
+            feature.loadExternalisedExamples()
+        }
+
+        assertThat(output)
+            .contains("POST /order_action_figure -> 200 not found in the specification")
     }
 
     companion object {

--- a/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
@@ -2349,7 +2349,7 @@ paths:
         }
 
         assertThat(output)
-            .contains("POST /order_action_figure -> 200 not found in the specification")
+            .contains("POST /order_action_figure -> 200 does not match any operation in the specification")
     }
 
     companion object {


### PR DESCRIPTION
**What**:

When an externalised example is not loaded when running tests, show the reason why this happened.

**Why**:

Externalised examples are not loaded when either the method, path or status code are not found in the spec. Such files are listed as well before the tests run. But the reason for skipping them is not explicitly mentioned, and this can be confusing for newcomers.

We now display the API (e.g. POST /orders -> 201) and state that this was not found in the spec.

**How**:

This required a small modification to `Feature.loadExternalisedExamples`.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate
