### PR TITLE
Got query params in test path working like stub

### DIFF
--- a/core/src/test/kotlin/io/specmatic/conversions/ExampleFromFileTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/ExampleFromFileTest.kt
@@ -1,0 +1,53 @@
+package io.specmatic.conversions
+
+import io.specmatic.core.pattern.parsedJSONObject
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class ExampleFromFileTest {
+    @Test
+    fun `it should query params from the url if present`() {
+        val example = """
+            {
+                "http-request": {
+                    "method": "GET",
+                    "path": "/hello?world=true"
+                },
+                "http-response": {
+                    "status": 200,
+                    "body": "ok"
+                }
+            }
+        """.trimIndent().let {
+
+            ExampleFromFile(parsedJSONObject(it), File("./data.json"))
+        }
+
+        assertThat(example.queryParams).containsExactlyEntriesOf(mapOf("world" to "true"))
+    }
+
+    @Test
+    fun `it should combine query params from the url if present with those from the block`() {
+        val example = """
+            {
+                "http-request": {
+                    "method": "GET",
+                    "path": "/query?hello=true",
+                    "query": {
+                        "world": "true"
+                    }
+                },
+                "http-response": {
+                    "status": 200,
+                    "body": "ok"
+                }
+            }
+        """.trimIndent().let {
+
+            ExampleFromFile(parsedJSONObject(it), File("./data.json"))
+        }
+
+        assertThat(example.queryParams).containsExactlyEntriesOf(mapOf("hello" to "true", "world" to "true"))
+    }
+}


### PR DESCRIPTION
**What**:

Query params found in the path in externalised examples were used by Spcematic stub, but not test. With this PR, they are used by Specmatic test as well.

**Why**:

This ensures symmetric behaviour between stub and test.

**How**:

`ExampleFromFile` has been modified to work the same way as `HttpRequest.updatePath`.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

