### PR TITLE
Add a health check endpoint for proxy and stub server

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/route/modules/HealthCheckModule.kt
+++ b/core/src/main/kotlin/io/specmatic/core/route/modules/HealthCheckModule.kt
@@ -1,0 +1,34 @@
+package io.specmatic.core.route.modules
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.ktor.server.application.*
+import io.ktor.server.routing.*
+import io.specmatic.core.HttpRequest
+import io.specmatic.core.HttpResponse
+import io.specmatic.stub.respondToKtorHttpResponse
+
+class HealthCheckModule {
+    companion object {
+        private const val HEALTH_ENDPOINT = "/actuator/health"
+
+        fun Application.configureHealthCheckModule() {
+            routing {
+                get(HEALTH_ENDPOINT) {
+                    val healthStatus = mapOf("status" to "UP")
+                    respondToKtorHttpResponse(
+                        call,
+                        HttpResponse(
+                            status = 200,
+                            body = ObjectMapper().writeValueAsString(healthStatus),
+                            headers = mapOf("Content-Type" to "application/json")
+                        )
+                    )
+                }
+            }
+        }
+
+        fun HttpRequest.isHealthCheckRequest(): Boolean {
+            return (this.path == HEALTH_ENDPOINT) && (this.method == "GET")
+        }
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/proxy/Proxy.kt
+++ b/core/src/main/kotlin/io/specmatic/proxy/Proxy.kt
@@ -1,11 +1,11 @@
 package io.specmatic.proxy
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
 import io.ktor.server.netty.*
-import io.ktor.server.routing.*
 import io.specmatic.core.*
+import io.specmatic.core.route.modules.HealthCheckModule.Companion.configureHealthCheckModule
+import io.specmatic.core.route.modules.HealthCheckModule.Companion.isHealthCheckRequest
 import io.specmatic.core.log.logger
 import io.specmatic.core.utilities.exceptionCauseMessage
 import io.specmatic.mock.ScenarioStub
@@ -86,7 +86,7 @@ class Proxy(host: String, port: Int, baseURL: String, private val outputDirector
                 }
             }
 
-            healthCheckModule()
+            configureHealthCheckModule()
         }
 
         when (keyData) {
@@ -99,26 +99,6 @@ class Proxy(host: String, port: Int, baseURL: String, private val outputDirector
                 this.port = port
             }
         }
-    }
-
-    private fun Application.healthCheckModule() {
-        routing {
-            get("/actuator/health") {
-                val healthStatus = mapOf("status" to "UP")
-                respondToKtorHttpResponse(
-                    call,
-                    HttpResponse(
-                        status = 200,
-                        body = ObjectMapper().writeValueAsString(healthStatus),
-                        headers = mapOf("Content-Type" to "application/json")
-                    )
-                )
-            }
-        }
-    }
-
-    private fun HttpRequest.isHealthCheckRequest(): Boolean {
-       return (this.path == "/actuator/health") && (this.method == "GET")
     }
 
     private fun withoutContentEncodingGzip(httpResponse: HttpResponse): HttpResponse {

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -12,6 +12,8 @@ import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.util.*
 import io.specmatic.core.*
+import io.specmatic.core.route.modules.HealthCheckModule.Companion.configureHealthCheckModule
+import io.specmatic.core.route.modules.HealthCheckModule.Companion.isHealthCheckRequest
 import io.specmatic.core.log.*
 import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.pattern.parsedValue
@@ -197,6 +199,8 @@ class HttpStub(
                     val rawHttpRequest = ktorHttpRequestToHttpRequest(call)
                     httpLogMessage.addRequest(rawHttpRequest)
 
+                    if(rawHttpRequest.isHealthCheckRequest()) return@intercept
+
                     val httpRequest = requestInterceptors.fold(rawHttpRequest) { request, requestInterceptor ->
                         requestInterceptor.interceptRequest(request) ?: request
                     }
@@ -271,6 +275,8 @@ class HttpStub(
 
                 log(httpLogMessage)
             }
+
+            configureHealthCheckModule()
         }
 
         when (keyData) {

--- a/core/src/test/kotlin/io/specmatic/proxy/ProxyTest.kt
+++ b/core/src/test/kotlin/io/specmatic/proxy/ProxyTest.kt
@@ -215,6 +215,19 @@ internal class ProxyTest {
 
         }
     }
+
+    @Test
+    fun `should return health status as UP if the actuator health endpoint is hit`() {
+        HttpStub(simpleFeature).use {
+            Proxy(host = "localhost", port = 9001, "http://localhost:9001", fakeFileWriter).use {
+                val client = RestTemplate()
+                val response = client.getForEntity("http://localhost:9001/actuator/health", Map::class.java)
+
+                assertThat(response.statusCodeValue).isEqualTo(200)
+                assertThat(response.body).isEqualTo(mapOf("status" to "UP"))
+            }
+        }
+    }
 }
 
 class FakeFileWriter : FileWriter {

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
@@ -1032,6 +1032,26 @@ paths:
     }
 
     @Test
+    fun `should return health status as UP if the actuator health endpoint is hit`() {
+        val specification =
+            OpenApiSpecification.fromFile("src/test/resources/openapi/spec_with_space_in_path.yaml").toFeature()
+
+        HttpStub(specification).use { stub ->
+            val request = HttpRequest("GET", "/actuator/health")
+
+            val response = stub.client.execute(request)
+
+            assertThat(response.status).isEqualTo(200)
+            response.body.let {
+                assertThat(it).isInstanceOf(JSONObjectValue::class.java)
+                it as JSONObjectValue
+
+                assertThat(it.jsonObject["status"]?.toStringLiteral()).isEqualTo("UP")
+            }
+        }
+    }
+
+    @Test
     fun `should load a stub with a space in the path and return the stubbed response`() {
         val pathWithSpace = "/da ta"
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Exposes a health check endpoint for proxy and stub server.
<!-- Why are these changes necessary? -->

**Why**:
Users can hit this endpoint to confirm where they can start interacting with the proxy or stub.
<!-- How were these changes implemented? -->

**How**:
Adding a health check endpoint for proxy and stub.

**P.S.** Currently we are just returning the "UP" status. I couldn't think of when we can send a "DOWN" status. Please let me know if you have any scenario in mind where we should return "DOWN" as status.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

<img width="912" alt="Screenshot 2024-08-09 at 12 47 24 PM" src="https://github.com/user-attachments/assets/4d3bc00a-e48d-4648-8606-0711ff8affd0">

<!-- Kindly link the issue that this PR will be addressing -->


<!-- feel free to add additional comments -->
