### PR TITLE
Added check for slf4j log

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -34,6 +34,7 @@ jobs:
     - name: Fail if slf4j is found in the log
       if: matrix.os == 'ubuntu-latest'
       run: |
+        set +e
         java -jar application/build/libs/specmatic.jar --version 2>&1 | grep slf4j
         
         if [ $? -eq 0 ]

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -35,7 +35,11 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: |
         java -jar application/build/libs/specmatic.jar --version 2>&1 | grep slf4j
-        if [ $? -eq 0 ]; then exit 1; fi
+        
+        if [ $? -eq 0 ]
+        then
+          exit 1
+        fi
 
     - name: Upload core Gradle Log
       if: always()

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -30,6 +30,8 @@ jobs:
         ./gradlew clean
         git clean -fd
         ./gradlew build
+        java -jar application/build/libs/specmatic.jar --version 2>&1 | grep slf4j
+        if [ $? = 0 ]; then exit 1; fi
 
     - name: Upload core Gradle Log
       if: always()

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -35,7 +35,7 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: |
         java -jar application/build/libs/specmatic.jar --version 2>&1 | grep slf4j
-        if [ $? = 0 ]; then exit 1; fi
+        if [ $? -eq 0 ]; then exit 1; fi
 
     - name: Upload core Gradle Log
       if: always()

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -38,6 +38,8 @@ jobs:
         
         if [ $? -eq 0 ]
         then
+          java -jar application/build/libs/specmatic.jar --version
+        
           exit 1
         fi
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -30,6 +30,10 @@ jobs:
         ./gradlew clean
         git clean -fd
         ./gradlew build
+
+    - name: Fail if slf4j is found in the log
+      if: matrix.os == 'ubuntu-latest'
+      run: |
         java -jar application/build/libs/specmatic.jar --version 2>&1 | grep slf4j
         if [ $? = 0 ]; then exit 1; fi
 

--- a/application/build.gradle
+++ b/application/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     implementation "org.eclipse.jgit:org.eclipse.jgit:$jgit_version"
     implementation "org.eclipse.jgit:org.eclipse.jgit.ssh.apache:$jgit_version"
 
-    implementation 'org.slf4j:slf4j-nop:2.0.14'
+    implementation 'org.slf4j:slf4j-nop:2.0.13'
 
     implementation 'org.apache.ant:ant-junit:1.10.14'
 


### PR DESCRIPTION

**What**:

Added an extra section to the `gradle.yml` Github workflow to check for the existence of slf4j when running the version command.

**Why**:

This log keeps popping up unexpectedly and breaks the python build.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate
