### PR TITLE
Html report changes

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -184,7 +184,7 @@ data class ReportFormatter(
     val layout: ReportFormatterLayout = ReportFormatterLayout.TABLE,
     val title: String? = "Specmatic Report",
     val heading: String? = "Contract Test Results",
-    val outputDirectory: String? = "reports/specmatic/html"
+    val outputDirectory: String? = "build/reports/specmatic/html"
 )
 
 enum class ReportFormatterType {

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -184,7 +184,7 @@ data class ReportFormatter(
     val layout: ReportFormatterLayout = ReportFormatterLayout.TABLE,
     val title: String? = "Specmatic Report",
     val heading: String? = "Contract Test Results",
-    val outputDirectory: String? = "build/reports/specmatic/html"
+    val outputDirectory: String? = "./build/reports/specmatic/html"
 )
 
 enum class ReportFormatterType {

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/OpenApiCoverageReportProcessor.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/OpenApiCoverageReportProcessor.kt
@@ -51,12 +51,7 @@ class OpenApiCoverageReportProcessor(private val openApiCoverageReportInput: Ope
     }
 
     private fun configureOpenApiCoverageReportRenderers(reportConfiguration: ReportConfiguration): List<ReportRenderer<OpenAPICoverageConsoleReport>> {
-        return reportConfiguration.formatters!!.map {
-            when (it.type) {
-                ReportFormatterType.TEXT -> CoverageReportTextRenderer()
-                else -> throw Exception("Report formatter type: ${it.type} is not supported")
-            }
-        }
+        return listOf(CoverageReportTextRenderer())
     }
 
     private fun assertSuccessCriteria(


### PR DESCRIPTION
**What**:

1. Fixing default report dir
2. Removing faulty error message

**Why**:

1. Reports getting generated in `reports` instead of `build/reports`
2. Error says HTML is not a valid report type even though report is created

**How**:

1. Updated default report path
2. Removed incorrect report type check temporarily

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [ ] Tests
- [ ] Sonar Quality Gate

