### PR TITLE
Fix for query params in external example url

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -1397,7 +1397,7 @@ data class Feature(
                 with(exampleFromFile) {
                     OpenApiSpecification.OperationIdentifier(
                         requestMethod,
-                        pathOnly(requestPath),
+                        requestPath,
                         responseStatus
                     ) to exampleFromFile.toRow(specmaticConfig)
                 }
@@ -1408,10 +1408,6 @@ data class Feature(
         }
             .groupBy { (operationIdentifier, _) -> operationIdentifier }
             .mapValues { (_, value) -> value.map { it.second } }
-    }
-
-    private fun pathOnly(requestPath: String): String {
-        return URI(requestPath).path ?: ""
     }
 
     fun loadExternalisedExamplesAndListUnloadableExamples(): Pair<Feature, Set<String>> {

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -1397,7 +1397,7 @@ data class Feature(
                 with(exampleFromFile) {
                     OpenApiSpecification.OperationIdentifier(
                         requestMethod,
-                        requestPath,
+                        pathOnly(requestPath),
                         responseStatus
                     ) to exampleFromFile.toRow(specmaticConfig)
                 }
@@ -1408,6 +1408,10 @@ data class Feature(
         }
             .groupBy { (operationIdentifier, _) -> operationIdentifier }
             .mapValues { (_, value) -> value.map { it.second } }
+    }
+
+    private fun pathOnly(requestPath: String): String {
+        return URI(requestPath).path ?: ""
     }
 
     fun loadExternalisedExamplesAndListUnloadableExamples(): Pair<Feature, Set<String>> {

--- a/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
@@ -2352,6 +2352,15 @@ paths:
             .contains("POST /order_action_figure -> 200 does not match any operation in the specification")
     }
 
+    @Test
+    fun `validate an invalid query param in the path of an externalised example`() {
+        val feature = OpenApiSpecification.fromFile("src/test/resources/openapi/spec_with_invalid_external_query_in_url.yaml").toFeature().loadExternalisedExamples()
+
+        assertThatThrownBy {
+            feature.validateExamplesOrException()
+        }.hasMessageContaining("REQUEST.QUERY-PARAMS.enabled")
+    }
+
     companion object {
         @JvmStatic
         fun singleFeatureContractSource(): Stream<Arguments> {

--- a/core/src/test/resources/openapi/spec_with_invalid_external_query_in_url.yaml
+++ b/core/src/test/resources/openapi/spec_with_invalid_external_query_in_url.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.1
+info:
+  title: Random
+  version: "1"
+paths:
+  /data:
+    get:
+      summary: Random
+      parameters:
+        - name: enabled
+          in: query
+          schema:
+            type: boolean
+      responses:
+        "200":
+          description: Random
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer

--- a/core/src/test/resources/openapi/spec_with_invalid_external_query_in_url_examples/example.json
+++ b/core/src/test/resources/openapi/spec_with_invalid_external_query_in_url_examples/example.json
@@ -1,0 +1,12 @@
+{
+  "http-request": {
+    "method": "GET",
+    "path": "/data?enabled=not-a-boolean"
+  },
+  "http-response": {
+    "status": 200,
+    "body": {
+      "id": 10
+    }
+  }
+}

--- a/core/src/test/resources/openapi/spec_with_valid_external_query_in_url.yaml
+++ b/core/src/test/resources/openapi/spec_with_valid_external_query_in_url.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.1
+info:
+  title: Random
+  version: "1"
+paths:
+  /data:
+    get:
+      summary: Random
+      parameters:
+        - name: enabled
+          in: query
+          schema:
+            type: boolean
+      responses:
+        "200":
+          description: Random
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer

--- a/core/src/test/resources/openapi/spec_with_valid_external_query_in_url_examples/example.json
+++ b/core/src/test/resources/openapi/spec_with_valid_external_query_in_url_examples/example.json
@@ -1,0 +1,12 @@
+{
+  "http-request": {
+    "method": "GET",
+    "path": "/data?enabled=true"
+  },
+  "http-response": {
+    "status": 200,
+    "body": {
+      "id": 10
+    }
+  }
+}


### PR DESCRIPTION
**What**:

Added a fix for the code handling query params in external example, such as this:

```json
{
  "http-request": {
    "method": "GET",
    "path": "/data?enabled=true"
  },
  "http-responses": {
    "status": 200,
    "body": []
  }
}
```

The query param is in the URL, and the fix ensures that example is loaded.

**Why**:

Query params were mistakenly treated as part of the URL, resulting in the example not being loaded.

**How**:

Added better path handling to the `ExampleFromFile` class.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate
