### PR TITLE
Unify BackwardCompatibilityCommand

### DIFF
--- a/application/src/main/kotlin/application/Seperator.kt
+++ b/application/src/main/kotlin/application/Seperator.kt
@@ -1,0 +1,12 @@
+package application;
+
+import picocli.CommandLine.Command
+import java.util.concurrent.Callable
+
+@Command(
+    name = " ",
+    description = [" "]
+)
+class Separator : Callable<Int> {
+    override fun call(): Int = 0
+}

--- a/application/src/main/kotlin/application/SpecmaticApplicationRunner.kt
+++ b/application/src/main/kotlin/application/SpecmaticApplicationRunner.kt
@@ -14,6 +14,10 @@ class SpecmaticApplicationRunner(specmaticCommand: SpecmaticCommand, private val
     override fun run(vararg args: String) {
         val cmd = CommandLine(myCommand, factory)
         cmd.subcommands.getValue("generate-completion").commandSpec.usageMessage().hidden(true)
+        
+        // Get console width or default to 80
+        val width = System.getenv("COLUMNS")?.toIntOrNull() ?: 150
+        cmd.usageHelpWidth = width
 
         exitCode = cmd.execute(*args)
     }

--- a/application/src/main/kotlin/application/SpecmaticCommand.kt
+++ b/application/src/main/kotlin/application/SpecmaticCommand.kt
@@ -8,9 +8,14 @@ import java.util.concurrent.Callable
 @Component
 @Command(
         name = "specmatic",
+        description = ["Specmatic CLI tool"],
         mixinStandardHelpOptions = true,
         versionProvider = VersionProvider::class,
-        subcommands = [BackwardCompatibilityCheckCommand::class, BundleCommand::class, CompareCommand::class, CompatibleCommand::class, DifferenceCommand::class, GenerateCompletion::class, GraphCommand::class, MergeCommand::class, ToOpenAPICommand::class, ImportCommand::class, InstallCommand::class, ProxyCommand::class, PushCommand::class, ReDeclaredAPICommand::class, ExamplesCommand::class, SamplesCommand::class, StubCommand::class, SubscribeCommand::class, TestCommand::class, ValidateViaLogs::class, CentralContractRepoReportCommand::class]
+        subcommands = [BackwardCompatibilityCheckCommand::class, StubCommand::class, TestCommand::class, Separator::class, BundleCommand::class, GenerateCompletion::class, GraphCommand::class, MergeCommand::class, ToOpenAPICommand::class, ImportCommand::class, InstallCommand::class, ProxyCommand::class, ReDeclaredAPICommand::class, ExamplesCommand::class, SamplesCommand::class,  SubscribeCommand::class, ValidateViaLogs::class, CentralContractRepoReportCommand::class],
+        synopsisHeading = "%nUsage: ",
+        commandListHeading = "%nCommands:%n",
+        optionListHeading = "%nOptions:%n",
+        footer = ["%nRun 'specmatic COMMAND --help' for more information on a command."],
 )
 class SpecmaticCommand : Callable<Int> {
     override fun call(): Int {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: 
1. Moved push, compare, compatibility, and difference commands under backwardCompatibilityCommand
2. Improved formatting of the help output.

<!-- Why are these changes necessary? -->

**Why**:
To streamline backwardCompatibilityCheck command across specifications.

<!-- How were these changes implemented? -->

**How**:
By merging all commands related to backward compatibility as sub commands under backwardCompatibilityCommand.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation. N/A
- [ x] Tests
- [ ] Sonar Quality Gate. N/A

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #123

<!-- feel free to add additional comments -->
