### PR TITLE
Fixed issue with loading an example with a path param pattern in test mode

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/HttpPathPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpPathPattern.kt
@@ -54,6 +54,7 @@ data class HttpPathPattern(
 
         val results = pathSegmentPatterns.zip(pathSegments).map { (urlPathPattern, token) ->
             try {
+
                 val parsedValue = urlPathPattern.tryParse(token, resolver)
                 val result = resolver.matchesPattern(urlPathPattern.key, urlPathPattern.pattern, parsedValue)
                 if (result is Failure) {

--- a/core/src/main/kotlin/io/specmatic/core/HttpPathPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpPathPattern.kt
@@ -115,7 +115,12 @@ data class HttpPathPattern(
                     val rowValue = row.getField(key)
                     when {
                         isPatternToken(rowValue) -> attempt("Pattern mismatch in example of path param \"${urlPathParamPattern.key}\"") {
-                            val rowPattern = resolver.getPattern(rowValue)
+                            val rowValueWithoutWithoutIdentifier = withoutPatternDelimiters(rowValue).split(':').let {
+                                it.getOrNull(1) ?: it.getOrNull(0) ?: throw ContractException("Invalid pattern token $rowValue in example")
+                            }.let {
+                                withPatternDelimiters(it)
+                            }
+                            val rowPattern = resolver.getPattern(rowValueWithoutWithoutIdentifier)
                             when (val result = urlPathParamPattern.encompasses(rowPattern, resolver, resolver)) {
                                 is Success -> urlPathParamPattern.copy(pattern = rowPattern)
                                 is Failure -> throw ContractException(result.toFailureReport())

--- a/core/src/main/kotlin/io/specmatic/core/HttpPathPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpPathPattern.kt
@@ -120,10 +120,16 @@ data class HttpPathPattern(
                             }.let {
                                 withPatternDelimiters(it)
                             }
-                            val rowPattern = resolver.getPattern(rowValueWithoutWithoutIdentifier)
-                            when (val result = urlPathParamPattern.encompasses(rowPattern, resolver, resolver)) {
-                                is Success -> urlPathParamPattern.copy(pattern = rowPattern)
-                                is Failure -> throw ContractException(result.toFailureReport())
+                            val rowPattern = resolvedHop(resolver.getPattern(rowValueWithoutWithoutIdentifier), resolver)
+                            val pathSegmentPattern = resolvedHop(urlPathParamPattern.pattern, resolver)
+
+                            if(pathSegmentPattern.javaClass == rowPattern.javaClass) {
+                                urlPathParamPattern
+                            } else {
+                                when (val result = urlPathParamPattern.encompasses(rowPattern, resolver, resolver)) {
+                                    is Success -> urlPathParamPattern.copy(pattern = rowPattern)
+                                    is Failure -> throw ContractException(result.toFailureReport())
+                                }
                             }
                         }
 

--- a/core/src/main/kotlin/io/specmatic/core/URLPathSegmentPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/URLPathSegmentPattern.kt
@@ -54,7 +54,7 @@ data class URLPathSegmentPattern(override val pattern: Pattern, override val key
 
     override fun encompasses(otherPattern: Pattern, thisResolver: Resolver, otherResolver: Resolver, typeStack: TypeStack): Result {
         if(otherPattern !is URLPathSegmentPattern)
-            return Result.Failure("Expected url type, got ${otherPattern.typeName}")
+            return this.pattern.encompasses(otherPattern, thisResolver, otherResolver, typeStack)
 
         return otherPattern.pattern.fitsWithin(patternSet(thisResolver), otherResolver, thisResolver, typeStack)
     }

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
@@ -2304,4 +2304,16 @@ components:
         assertThat(output)
             .contains("@department")
     }
+
+    @Test
+    fun `stub should load an example for a spec with pattern as a path param`() {
+        createStubFromContracts(listOf(("src/test/resources/openapi/spec_with_path_param.yaml")), timeoutMillis = 0).use { stub ->
+            val request = HttpRequest("GET", "/users/abc123", queryParametersMap = mapOf("item" to "10"))
+            val response = stub.client.execute(request)
+
+            assertThat(response.status).isEqualTo(200)
+            val responseBody = response.body as JSONObjectValue
+            assertThat(responseBody.findFirstChildByPath("id")).isEqualTo(NumberValue(10))
+        }
+    }
 }

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
@@ -2317,7 +2317,6 @@ components:
         }
     }
 
-
     @Test
     fun `stub should flag an error when a path param in an external example has an invalid type`() {
         val (output, _) = captureStandardOutput {
@@ -2326,5 +2325,17 @@ components:
         }
 
         assertThat(output).contains(">> REQUEST.PATH.userId")
+    }
+
+    @Test
+    fun `stub should load an example for a spec with constrained path param`() {
+        createStubFromContracts(listOf(("src/test/resources/openapi/spec_with_path_param_with_constraint.yaml")), timeoutMillis = 0).use { stub ->
+            val request = HttpRequest("GET", "/users/100")
+            val response = stub.client.execute(request)
+
+            assertThat(response.status).isEqualTo(200)
+            val responseBody = response.body as JSONObjectValue
+            assertThat(responseBody.findFirstChildByPath("id")).isEqualTo(NumberValue(10))
+        }
     }
 }

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
@@ -2316,4 +2316,15 @@ components:
             assertThat(responseBody.findFirstChildByPath("id")).isEqualTo(NumberValue(10))
         }
     }
+
+
+    @Test
+    fun `stub should flag an error when a path param in an external example has an invalid type`() {
+        val (output, _) = captureStandardOutput {
+            val stub = createStubFromContracts(listOf(("src/test/resources/openapi/spec_with_invalid_path_param_example.yaml")), timeoutMillis = 0)
+            stub.close()
+        }
+
+        assertThat(output).contains(">> REQUEST.PATH.userId")
+    }
 }

--- a/core/src/test/resources/openapi/spec_with_invalid_path_param_example.yaml
+++ b/core/src/test/resources/openapi/spec_with_invalid_path_param_example.yaml
@@ -11,12 +11,7 @@ paths:
           in: path
           required: true
           schema:
-            type: string
-        - name: item
-          in: query
-          required: true
-          schema:
-            type: string
+            type: integer
       responses:
         '200':
           description: User created successfully

--- a/core/src/test/resources/openapi/spec_with_invalid_path_param_example_examples/example.json
+++ b/core/src/test/resources/openapi/spec_with_invalid_path_param_example_examples/example.json
@@ -1,0 +1,12 @@
+{
+  "http-request": {
+    "method": "GET",
+    "path": "/users/(userId:string)"
+  },
+  "http-response": {
+    "status": 200,
+    "body": {
+      "id": 10
+    }
+  }
+}

--- a/core/src/test/resources/openapi/spec_with_path_param.yaml
+++ b/core/src/test/resources/openapi/spec_with_path_param.yaml
@@ -1,0 +1,42 @@
+openapi: 3.0.0
+info:
+  title: Simple API
+  version: 1.0.0
+paths:
+  /users/{userId}:
+    get:
+      summary: Create a user profile
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: item
+          in: query
+          required: true
+          schema:
+            type: string
+#      requestBody:
+#        required: true
+#        content:
+#          application/json:
+#            schema:
+#              type: object
+#              required:
+#                - name
+#              properties:
+#                name:
+#                  type: string
+      responses:
+        '200':
+          description: User created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                properties:
+                  id:
+                    type: integer

--- a/core/src/test/resources/openapi/spec_with_path_param_examples/example.json
+++ b/core/src/test/resources/openapi/spec_with_path_param_examples/example.json
@@ -1,0 +1,12 @@
+{
+  "http-request": {
+    "method": "GET",
+    "path": "/users/(userId:string)?item=10"
+  },
+  "http-response": {
+    "status": 200,
+    "body": {
+      "id": 10
+    }
+  }
+}

--- a/core/src/test/resources/openapi/spec_with_path_param_with_constraint.yaml
+++ b/core/src/test/resources/openapi/spec_with_path_param_with_constraint.yaml
@@ -1,0 +1,27 @@
+openapi: 3.0.0
+info:
+  title: Simple API
+  version: 1.0.0
+paths:
+  /users/{userId}:
+    get:
+      summary: Create a user profile
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: integer
+            minimum: 10
+      responses:
+        '200':
+          description: User created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                properties:
+                  id:
+                    type: integer

--- a/core/src/test/resources/openapi/spec_with_path_param_with_constraint_examples/example.json
+++ b/core/src/test/resources/openapi/spec_with_path_param_with_constraint_examples/example.json
@@ -1,0 +1,12 @@
+{
+  "http-request": {
+    "method": "GET",
+    "path": "/users/(userId:number)"
+  },
+  "http-response": {
+    "status": 200,
+    "body": {
+      "id": 10
+    }
+  }
+}


### PR DESCRIPTION
**What**:

There was a bug in which the following example would not be loaded in test mode.

```json
{
  "http-request": {
    "method": "GET",
    "path": "/users/(userId:string)?item=10"
  },
  "http-response": {
    "status": 200,
    "body": {
      "id": 10
    }
  }
}
```

This has been fixed.

**How**:


**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

