### PR TITLE
Fixes for HTTP path with more than two segments

### DIFF
--- a/core/src/test/kotlin/io/specmatic/core/HttpPathPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpPathPatternTest.kt
@@ -166,18 +166,58 @@ internal class HttpPathPatternTest {
         val pattern = buildHttpPathPattern("/products/(id:number)/image")
         val negativePatterns = pattern.negativeBasedOn(Row(), Resolver()).toList()
         assertThat(negativePatterns).hasSize(2)
-        assertThat(negativePatterns[0].value).isEqualTo(
+        assertThat(negativePatterns[0].value).containsExactlyElementsOf(
             listOf(
                 URLPathSegmentPattern(ExactValuePattern(StringValue("products"))),
                 URLPathSegmentPattern(BooleanPattern(), "id"),
                 URLPathSegmentPattern(ExactValuePattern(StringValue("image"))),
             )
         )
-        assertThat(negativePatterns[1].value).isEqualTo(
+        assertThat(negativePatterns[1].value).containsExactlyElementsOf(
             listOf(
                 URLPathSegmentPattern(ExactValuePattern(StringValue("products"))),
                 URLPathSegmentPattern(StringPattern(), "id"),
                 URLPathSegmentPattern(ExactValuePattern(StringValue("image"))),
+            )
+        )
+    }
+
+    @Test
+    fun `should generate negative patterns for path containing alternating fixed segments and params`() {
+        assertThat(listOf(URLPathSegmentPattern(NumberPattern(), "orgId"))).isEqualTo(listOf(URLPathSegmentPattern(NumberPattern(), "orgId")))
+        val pattern = buildHttpPathPattern("/organizations/(orgId:number)/employees/(empId:number)")
+        val negativePatterns = pattern.negativeBasedOn(Row(), Resolver()).toList()
+        assertThat(negativePatterns).hasSize(4)
+        assertThat(negativePatterns[0].value).containsExactlyElementsOf(
+            listOf(
+                URLPathSegmentPattern(ExactValuePattern(StringValue("organizations"))),
+                URLPathSegmentPattern(BooleanPattern(), "orgId"),
+                URLPathSegmentPattern(ExactValuePattern(StringValue("employees"))),
+                URLPathSegmentPattern(DeferredPattern("(number)"), "empId"),
+            )
+        )
+        assertThat(negativePatterns[1].value).containsExactlyElementsOf(
+            listOf(
+                URLPathSegmentPattern(ExactValuePattern(StringValue("organizations"))),
+                URLPathSegmentPattern(StringPattern(), "orgId"),
+                URLPathSegmentPattern(ExactValuePattern(StringValue("employees"))),
+                URLPathSegmentPattern(DeferredPattern("(number)"), "empId"),
+            )
+        )
+        assertThat(negativePatterns[2].value).containsExactlyElementsOf(
+            listOf(
+                URLPathSegmentPattern(ExactValuePattern(StringValue("organizations"))),
+                URLPathSegmentPattern(DeferredPattern("(number)"), "orgId"),
+                URLPathSegmentPattern(ExactValuePattern(StringValue("employees"))),
+                URLPathSegmentPattern(BooleanPattern(), "empId"),
+            )
+        )
+        assertThat(negativePatterns[3].value).containsExactlyElementsOf(
+            listOf(
+                URLPathSegmentPattern(ExactValuePattern(StringValue("organizations"))),
+                URLPathSegmentPattern(DeferredPattern("(number)"), "orgId"),
+                URLPathSegmentPattern(ExactValuePattern(StringValue("employees"))),
+                URLPathSegmentPattern(StringPattern(), "empId"),
             )
         )
     }

--- a/core/src/test/kotlin/io/specmatic/core/HttpPathPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpPathPatternTest.kt
@@ -169,14 +169,14 @@ internal class HttpPathPatternTest {
         assertThat(negativePatterns[0].value).isEqualTo(
             listOf(
                 URLPathSegmentPattern(ExactValuePattern(StringValue("products"))),
-                URLPathSegmentPattern(StringPattern(), "id"),
+                URLPathSegmentPattern(BooleanPattern(), "id"),
                 URLPathSegmentPattern(ExactValuePattern(StringValue("image"))),
             )
         )
         assertThat(negativePatterns[1].value).isEqualTo(
             listOf(
                 URLPathSegmentPattern(ExactValuePattern(StringValue("products"))),
-                URLPathSegmentPattern(BooleanPattern(), "id"),
+                URLPathSegmentPattern(StringPattern(), "id"),
                 URLPathSegmentPattern(ExactValuePattern(StringValue("image"))),
             )
         )

--- a/core/src/test/kotlin/io/specmatic/core/HttpPathPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpPathPatternTest.kt
@@ -162,6 +162,27 @@ internal class HttpPathPatternTest {
     }
 
     @Test
+    fun `should generate negative patterns for path containing params between fixed segments`() {
+        val pattern = buildHttpPathPattern("/products/(id:number)/image")
+        val negativePatterns = pattern.negativeBasedOn(Row(), Resolver()).toList()
+        assertThat(negativePatterns).hasSize(2)
+        assertThat(negativePatterns[0].value).isEqualTo(
+            listOf(
+                URLPathSegmentPattern(ExactValuePattern(StringValue("products"))),
+                URLPathSegmentPattern(StringPattern(), "id"),
+                URLPathSegmentPattern(ExactValuePattern(StringValue("image"))),
+            )
+        )
+        assertThat(negativePatterns[1].value).isEqualTo(
+            listOf(
+                URLPathSegmentPattern(ExactValuePattern(StringValue("products"))),
+                URLPathSegmentPattern(BooleanPattern(), "id"),
+                URLPathSegmentPattern(ExactValuePattern(StringValue("image"))),
+            )
+        )
+    }
+
+    @Test
     fun `should return all path param errors together`() {
         val pattern = buildHttpPathPattern("/pets/(petid:number)/file/(fileid:number)")
         val mismatchResult = pattern.matches(URI("/pets/abc/file/def")) as Result.Failure

--- a/version.properties
+++ b/version.properties
@@ -1,2 +1,2 @@
-version=2.0.12
+version=2.0.13
 


### PR DESCRIPTION
**What**:

Fixes for HTTP path with more than two segments

**Why**:

When HTTP path has multiple params (Ex: `/organizations/{orgId}/employess/{empId}`), negative test generation is chopping of all path segments after the second segement

**How**:

Temporarily removed the recursive approach in negative test generation for path HTTP path params

**Checklist**:


- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

