### PR TITLE
Add descriptionFromPlugin in negative scenarios

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -402,13 +402,16 @@ data class Feature(
             val negativeTestScenarios =
                 negativeScenario.generateTestScenarios(flagsBased, testVariables, testBaseURLs).map { negativeScenarioResult ->
                     negativeScenarioResult.ifHasValue { result: HasValue<Scenario> ->
+                        val descriptionFromPlugin = result.value.descriptionFromPlugin?.takeIf {
+                            it.isNotBlank()
+                        }?.plus(" ") ?: ""
                         val description = result.valueDetails.singleLineDescription()
 
                         val tag = if(description.isNotBlank())
                             " [${description}]"
                         else
                             ""
-                        HasValue(result.value.copy(descriptionFromPlugin = "${result.value.apiDescription}$tag"))
+                        HasValue(result.value.copy(descriptionFromPlugin = "$descriptionFromPlugin${result.value.apiDescription}$tag"))
                     }
                 }
 

--- a/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
@@ -1493,6 +1493,69 @@ paths:
     }
 
     @Test
+    fun `negative tests should show the descriptorFromPlugin in the title if it exists in the scenario`() {
+        val contract = OpenApiSpecification.fromYAML(
+            """
+openapi: 3.0.0
+info:
+  title: Sample Product API
+  description: Optional multiline or single-line description in [CommonMark](http://commonmark.org/help/) or HTML.
+  version: 0.1.9
+servers:
+  - url: http://localhost:8080
+    description: Local
+paths:
+  /products:
+    post:
+      summary: Add Product
+      description: Add Product
+      requestBody:
+        content:
+          application/json:
+            examples:
+              SUCCESS:
+                value:
+                  name: 'abc'
+            schema:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+      responses:
+        '200':
+          description: Returns Product With Id
+          content:
+            application/json:
+              examples:
+                SUCCESS:
+                  value:
+                    id: 10
+              schema:
+                type: object
+                required:
+                  - id
+                properties:
+                  id:
+                    type: integer
+""".trimIndent(), ""
+        ).toFeature()
+
+        val scenarios: List<Scenario> =
+            contract.enableGenerativeTesting().generateContractTestScenarios(emptyList()).toList()
+                .map {
+                    it.second.value
+                }.map {
+                    it.copy(descriptionFromPlugin = "scenario custom description")
+                }
+        val negativeTestScenarios = scenarios.filter { it.testDescription().contains("-ve") }
+        assertThat(negativeTestScenarios.map { it.testDescription() }).allSatisfy {
+            assertThat(it).contains("scenario custom description ")
+        }
+    }
+
+    @Test
     fun `positive examples of 4xx should be able to have non-string non-spec-conformant examples`() {
         val specification = OpenApiSpecification.fromYAML("""
 openapi: 3.0.0


### PR DESCRIPTION


<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
While generating negative scenarios, Specmatic was ignoring any existing descriptionFromPlugin within a scenario.
Thus, the test names were not having the descriptionFromPlugin text.
This fix makes sure that descriptionFromPlugin is not ignored while generating negative scenarios.

<!-- Why are these changes necessary? -->

**Why**:
To not lose the descriptionFromPlugin information in negative scenarios.
<!-- How were these changes implemented? -->

**How**:
By not ignoring descriptionFromPlugin while generating negative scenarios.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [x] Tested against sample project
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->


<!-- feel free to add additional comments -->
