### PR TITLE
Declare a dictionary in config

### DIFF
--- a/application/src/main/kotlin/application/StubCommand.kt
+++ b/application/src/main/kotlin/application/StubCommand.kt
@@ -179,7 +179,7 @@ class StubCommand : Callable<Unit> {
 
     private fun startServer() {
         val workingDirectory = WorkingDirectory()
-        val stubData = stubLoaderEngine.loadStubs(contractSources, exampleDirs)
+        val stubData = stubLoaderEngine.loadStubs(contractSources, exampleDirs, specmaticConfigPath)
 
         val certInfo = CertInfo(keyStoreFile, keyStoreDir, keyStorePassword, keyStoreAlias, keyPassword)
 

--- a/application/src/main/kotlin/application/StubLoaderEngine.kt
+++ b/application/src/main/kotlin/application/StubLoaderEngine.kt
@@ -1,6 +1,8 @@
 package application
 
 import io.specmatic.core.Feature
+import io.specmatic.core.getConfigFileName
+import io.specmatic.core.loadSpecmaticConfigOrDefault
 import io.specmatic.core.log.logger
 import io.specmatic.core.utilities.ContractPathData
 import io.specmatic.mock.ScenarioStub
@@ -11,15 +13,20 @@ import java.io.File
 
 @Component
 class StubLoaderEngine {
-    fun loadStubs(contractPathDataList: List<ContractPathData>, dataDirs: List<String>): List<Pair<Feature, List<ScenarioStub>>> {
+    fun loadStubs(contractPathDataList: List<ContractPathData>, dataDirs: List<String>, specmaticConfigPath: String? = null): List<Pair<Feature, List<ScenarioStub>>> {
         contractPathDataList.forEach { contractPath ->
             if(!File(contractPath.path).exists()) {
                 logger.log("$contractPath does not exist.")
             }
         }
+
+        val specmaticConfig = loadSpecmaticConfigOrDefault(specmaticConfigPath ?: getConfigFileName())
+
         return when {
-            dataDirs.isNotEmpty() -> loadContractStubsFromFiles(contractPathDataList, dataDirs)
-            else -> loadContractStubsFromImplicitPaths(contractPathDataList)
+            dataDirs.isNotEmpty() -> {
+                loadContractStubsFromFiles(contractPathDataList, dataDirs, specmaticConfig)
+            }
+            else -> loadContractStubsFromImplicitPaths(contractPathDataList, specmaticConfig)
         }
     }
 }

--- a/application/src/test/kotlin/application/StubCommandTest.kt
+++ b/application/src/test/kotlin/application/StubCommandTest.kt
@@ -96,7 +96,8 @@ internal class StubCommandTest {
             every {
                 stubLoaderEngine.loadStubs(
                     listOf(contractPath).map { ContractPathData("", it) },
-                    emptyList()
+                    emptyList(),
+                    any()
                 )
             }.returns(stubInfo)
 
@@ -201,7 +202,8 @@ internal class StubCommandTest {
             every {
                 stubLoaderEngine.loadStubs(
                     listOf(contractPath).map { ContractPathData("", it) },
-                    emptyList()
+                    emptyList(),
+                    any()
                 )
             }.returns(stubInfo)
 

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -440,6 +440,10 @@ data class Feature(
         scenarioStub: ScenarioStub,
         mismatchMessages: MismatchMessages = DefaultMismatchMessages
     ): HttpStubData {
+        val dictionary = specmaticConfig.stub.dictionary?.let { parsedJSONObject(File(it).readText()).jsonObject } ?: emptyMap()
+
+        val scenarioStub = scenarioStub.copy(dictionary = dictionary)
+
         if(scenarios.isEmpty())
             throw ContractException("No scenarios found in feature $name ($path)")
 

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -20,6 +20,7 @@ import io.specmatic.core.utilities.Flags.Companion.VALIDATE_RESPONSE_VALUE
 import io.specmatic.core.utilities.Flags.Companion.getBooleanValue
 import io.specmatic.core.utilities.Flags.Companion.getLongValue
 import io.specmatic.core.utilities.Flags.Companion.getStringValue
+import io.specmatic.core.utilities.exceptionCauseMessage
 import java.io.File
 
 const val APPLICATION_NAME = "Specmatic"
@@ -273,6 +274,18 @@ data class APIKeySecuritySchemeConfiguration(
     override val type: String = "apiKey",
     val value: String = ""
 ) : SecuritySchemeConfiguration()
+
+fun loadSpecmaticConfigOrDefault(configFileName: String? = null): SpecmaticConfig {
+    return if(configFileName == null)
+        SpecmaticConfig()
+    else try {
+        loadSpecmaticConfig(configFileName)
+    }
+    catch (e: ContractException) {
+        logger.log(exceptionCauseMessage(e))
+        SpecmaticConfig()
+    }
+}
 
 fun loadSpecmaticConfig(configFileName: String? = null): SpecmaticConfig {
     val configFile = File(configFileName ?: globalConfigFileName)

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -38,6 +38,8 @@ const val EXAMPLES_DIR_SUFFIX = "_examples"
 const val SPECMATIC_GITHUB_ISSUES = "https://github.com/znsio/specmatic/issues"
 const val DEFAULT_WORKING_DIRECTORY = ".$APPLICATION_NAME_LOWER_CASE"
 
+const val SPECMATIC_STUB_DICTIONARY = "SPECMATIC_STUB_DICTIONARY"
+
 class WorkingDirectory(private val filePath: File) {
     constructor(path: String = DEFAULT_WORKING_DIRECTORY): this(File(path))
 
@@ -64,7 +66,8 @@ fun String.loadContract(): Feature {
 
 data class StubConfiguration(
     val generative: Boolean? = false,
-    val delayInMilliseconds: Long? = getLongValue(SPECMATIC_STUB_DELAY)
+    val delayInMilliseconds: Long? = getLongValue(SPECMATIC_STUB_DELAY),
+    val dictionary: String? = getStringValue(SPECMATIC_STUB_DICTIONARY)
 )
 
 data class WorkflowIDOperation(

--- a/core/src/main/kotlin/io/specmatic/core/utilities/Flags.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/Flags.kt
@@ -16,7 +16,7 @@ class Flags {
 
         fun getStringValue(flagName: String): String? = System.getenv(flagName) ?: System.getProperty(flagName)
 
-        fun getBooleanValue(flagName: String) = ( getStringValue(flagName) ?: "false").toBoolean()
+        fun getBooleanValue(flagName: String, default: Boolean = false) = getStringValue(flagName)?.toBoolean() ?: default
 
         fun getLongValue(flagName: String): Long? = ( getStringValue(flagName))?.toLong()
     }

--- a/core/src/main/kotlin/io/specmatic/core/utilities/Flags.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/Flags.kt
@@ -12,6 +12,7 @@ class Flags {
         const val SPECMATIC_STUB_DELAY = "SPECMATIC_STUB_DELAY"
         const val SPECMATIC_TEST_TIMEOUT = "SPECMATIC_TEST_TIMEOUT"
 
+        const val SPECMATIC_PRETTY_PRINT = "SPECMATIC_PRETTY_PRINT"
         const val EXAMPLE_DIRECTORIES = "EXAMPLE_DIRECTORIES"
 
         fun getStringValue(flagName: String): String? = System.getenv(flagName) ?: System.getProperty(flagName)

--- a/core/src/main/kotlin/io/specmatic/mock/ScenarioStub.kt
+++ b/core/src/main/kotlin/io/specmatic/mock/ScenarioStub.kt
@@ -9,10 +9,9 @@ import io.specmatic.core.value.*
 import io.specmatic.stub.stringToMockScenario
 import java.io.File
 
-const val SPECMATIC_STUB_DICTIONARY = "SPECMATIC_STUB_DICTIONARY"
-
 fun loadDictionary(): Map<String,Value> {
-    val fileName = Flags.getStringValue(SPECMATIC_STUB_DICTIONARY) ?: return emptyMap()
+    val specmaticConfig = loadSpecmaticConfig(getConfigFileName())
+    val fileName = specmaticConfig.stub.dictionary ?: return emptyMap()
     return parsedJSONObject(File(fileName).readText()).jsonObject
 }
 

--- a/core/src/main/kotlin/io/specmatic/mock/ScenarioStub.kt
+++ b/core/src/main/kotlin/io/specmatic/mock/ScenarioStub.kt
@@ -10,8 +10,10 @@ import io.specmatic.stub.stringToMockScenario
 import java.io.File
 
 fun loadDictionary(): Map<String,Value> {
-    val specmaticConfig = loadSpecmaticConfig(getConfigFileName())
-    val fileName = specmaticConfig.stub.dictionary ?: return emptyMap()
+    val configFileName = getConfigFileName()
+    val configuredDictionary = if(File(configFileName).exists()) loadSpecmaticConfig(configFileName).stub.dictionary else null
+
+    val fileName = Flags.getStringValue(SPECMATIC_STUB_DICTIONARY) ?: configuredDictionary ?: return emptyMap()
     return parsedJSONObject(File(fileName).readText()).jsonObject
 }
 
@@ -312,7 +314,7 @@ fun mockFromJSON(mockSpec: Map<String, Value>): ScenarioStub {
     if(PARTIAL in mockSpec) {
         val template = mockSpec.getValue(PARTIAL) as? JSONObjectValue ?: throw ContractException("template key must be an object")
 
-        return ScenarioStub(partial = mockFromJSON(template.jsonObject), data = data, dictionary = loadDictionary())
+        return ScenarioStub(partial = mockFromJSON(template.jsonObject), data = data)
     }
 
     val mockRequest: HttpRequest = requestFromJSON(getJSONObjectValue(MOCK_HTTP_REQUEST_ALL_KEYS, mockSpec))
@@ -331,8 +333,7 @@ fun mockFromJSON(mockSpec: Map<String, Value>): ScenarioStub {
         delayInMilliseconds = delayInMs,
         stubToken = stubToken,
         requestBodyRegex = requestBodyRegex,
-        data = data,
-        dictionary = loadDictionary()
+        data = data
     )
 }
 

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -89,8 +89,6 @@ class HttpStub(
     private fun staticHttpStubData(rawHttpStubs: List<HttpStubData>): MutableList<HttpStubData> {
         val staticStubs = rawHttpStubs.filter { it.stubToken == null }
 
-        val dictionary = loadDictionary()
-
         val stubsFromSpecificationExamples: List<HttpStubData> = features.map { feature ->
             feature.stubsFromExamples.entries.map { (exampleName, examples) ->
                 examples.mapNotNull { (request, response) ->

--- a/core/src/main/kotlin/io/specmatic/stub/api.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/api.kt
@@ -10,7 +10,6 @@ import io.specmatic.core.utilities.ContractPathData
 import io.specmatic.core.utilities.contractStubPaths
 import io.specmatic.core.utilities.examplesDirFor
 import io.specmatic.core.utilities.exitIfDoesNotExist
-import io.specmatic.core.value.StringValue
 import io.specmatic.mock.NoMatchingScenario
 import io.specmatic.mock.ScenarioStub
 import org.yaml.snakeyaml.Yaml
@@ -100,7 +99,9 @@ internal fun createStub(
     val configFileName = getConfigFileName()
     exitIfDoesNotExist("config file", configFileName)
     val contractPathData = contractStubPaths(configFileName)
-    val contractInfo = loadContractStubsFromFiles(contractPathData, dataDirPaths)
+
+    val specmaticConfig = loadSpecmaticConfigOrDefault(configFileName)
+    val contractInfo = loadContractStubsFromFiles(contractPathData, dataDirPaths, specmaticConfig)
     val features = contractInfo.map { it.first }
     val httpExpectations = contractInfoToHttpExpectations(contractInfo)
 
@@ -122,7 +123,8 @@ internal fun createStub(host: String = "localhost", port: Int = 9000, timeoutMil
     val configFileName = givenConfigFileName ?: getConfigFileName()
     exitIfDoesNotExist("config file", configFileName)
 
-    val stubs = loadContractStubsFromImplicitPaths(contractStubPaths(configFileName))
+    val specmaticConfig = loadSpecmaticConfigOrDefault(configFileName)
+    val stubs = loadContractStubsFromImplicitPaths(contractStubPaths(configFileName), specmaticConfig)
     val features = stubs.map { it.first }
     val expectations = contractInfoToHttpExpectations(stubs)
 
@@ -144,9 +146,29 @@ internal fun createStubFromContracts(
     dataDirPaths: List<String>,
     host: String = "localhost",
     port: Int = 9000,
-    timeoutMillis: Long
+    timeoutMillis: Long,
+    specmaticConfigPath: String? = null
 ): HttpStub {
-    val contractInfo = loadContractStubsFromFiles(contractPaths.map { ContractPathData("", it) }, dataDirPaths)
+
+    return createStubFromContracts(
+        contractPaths,
+        dataDirPaths,
+        host,
+        port,
+        timeoutMillis,
+        loadSpecmaticConfigOrDefault(specmaticConfigPath)
+    )
+}
+
+internal fun createStubFromContracts(
+    contractPaths: List<String>,
+    dataDirPaths: List<String>,
+    host: String = "localhost",
+    port: Int = 9000,
+    timeoutMillis: Long,
+    specmaticConfig: SpecmaticConfig
+): HttpStub {
+    val contractInfo = loadContractStubsFromFiles(contractPaths.map { ContractPathData("", it) }, dataDirPaths, specmaticConfig)
     val features = contractInfo.map { it.first }
     val httpExpectations = contractInfoToHttpExpectations(contractInfo)
 
@@ -177,7 +199,7 @@ internal fun createStubFromContracts(
     return createStubFromContracts(contractPaths, completeList, host, port, timeoutMillis)
 }
 
-fun loadContractStubsFromImplicitPaths(contractPathDataList: List<ContractPathData>): List<Pair<Feature, List<ScenarioStub>>> {
+fun loadContractStubsFromImplicitPaths(contractPathDataList: List<ContractPathData>, specmaticConfig: SpecmaticConfig = SpecmaticConfig()): List<Pair<Feature, List<ScenarioStub>>> {
     return contractPathDataList.map { Pair(File(it.path), it) }.flatMap { (contractPath, contractSource) ->
         when {
             contractPath.isFile && contractPath.extension in CONTRACT_EXTENSIONS -> {
@@ -188,7 +210,7 @@ fun loadContractStubsFromImplicitPaths(contractPathDataList: List<ContractPathDa
                     emptyList()
                 }
                 else try {
-                    val feature = parseContractFileToFeature(contractPath, CommandHook(HookName.stub_load_contract), contractSource.provider, contractSource.repository, contractSource.branch, contractSource.specificationPath)
+                    val feature = parseContractFileToFeature(contractPath, CommandHook(HookName.stub_load_contract), contractSource.provider, contractSource.repository, contractSource.branch, contractSource.specificationPath).copy(specmaticConfig = specmaticConfig)
 
                     val implicitDataDirs = implicitDirsForSpecifications(contractPath)
 
@@ -249,13 +271,13 @@ private fun logIgnoredFiles(implicitDataDir: File) {
     }
 }
 
-fun loadContractStubsFromFiles(contractPathDataList: List<ContractPathData>, dataDirPaths: List<String>): List<Pair<Feature, List<ScenarioStub>>> {
+fun loadContractStubsFromFiles(contractPathDataList: List<ContractPathData>, dataDirPaths: List<String>, specmaticConfig: SpecmaticConfig): List<Pair<Feature, List<ScenarioStub>>> {
     val contactPathsString = contractPathDataList.joinToString(System.lineSeparator()) { it.path }
     consoleLog(StringLog("Loading the following contracts:${System.lineSeparator()}$contactPathsString"))
     consoleLog(StringLog(""))
 
     val features = contractPathDataList.mapNotNull { contractPathData ->
-        loadIfOpenAPISpecification(contractPathData)
+        loadIfOpenAPISpecification(contractPathData, specmaticConfig)
     }
 
     return loadExpectationsForFeatures(features, dataDirPaths)
@@ -436,9 +458,9 @@ fun implicitContractDataDir(contractPath: String, customBase: String? = null): F
     }
 }
 
-fun loadIfOpenAPISpecification(contractPathData: ContractPathData): Pair<String, Feature>? {
+fun loadIfOpenAPISpecification(contractPathData: ContractPathData, specmaticConfig: SpecmaticConfig): Pair<String, Feature>? {
     if (recognizedExtensionButNotOpenAPI(contractPathData) || isOpenAPI(contractPathData.path))
-        return Pair(contractPathData.path, parseContractFileToFeature(contractPathData.path, CommandHook(HookName.stub_load_contract), contractPathData.provider, contractPathData.repository, contractPathData.branch, contractPathData.specificationPath))
+        return Pair(contractPathData.path, parseContractFileToFeature(contractPathData.path, CommandHook(HookName.stub_load_contract), contractPathData.provider, contractPathData.repository, contractPathData.branch, contractPathData.specificationPath).copy(specmaticConfig = specmaticConfig))
 
     logger.log("Ignoring ${contractPathData.path} as it does not have a recognized specification extension")
     return null

--- a/core/src/test/kotlin/integration_tests/PartialExampleTest.kt
+++ b/core/src/test/kotlin/integration_tests/PartialExampleTest.kt
@@ -2,11 +2,11 @@ package integration_tests
 
 import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.core.HttpRequest
+import io.specmatic.core.SPECMATIC_STUB_DICTIONARY
 import io.specmatic.core.pattern.parsedJSONObject
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.NumberValue
 import io.specmatic.core.value.StringValue
-import io.specmatic.mock.SPECMATIC_STUB_DICTIONARY
 import io.specmatic.stub.HttpStub
 import io.specmatic.stub.captureStandardOutput
 import io.specmatic.stub.createStubFromContracts

--- a/core/src/test/kotlin/integration_tests/StubSubstitutionTest.kt
+++ b/core/src/test/kotlin/integration_tests/StubSubstitutionTest.kt
@@ -3,11 +3,11 @@ package integration_tests
 import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpResponse
+import io.specmatic.core.SPECMATIC_STUB_DICTIONARY
 import io.specmatic.core.pattern.parsedJSONObject
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.NumberValue
 import io.specmatic.core.value.StringValue
-import io.specmatic.mock.SPECMATIC_STUB_DICTIONARY
 import io.specmatic.mock.ScenarioStub
 import io.specmatic.osAgnosticPath
 import io.specmatic.stub.HttpStub

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
@@ -14,7 +14,6 @@ import io.specmatic.test.HttpClient
 import io.specmatic.test.TestExecutor
 import io.mockk.every
 import io.mockk.mockk
-import io.specmatic.mock.SPECMATIC_STUB_DICTIONARY
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.RepeatedTest

--- a/version.properties
+++ b/version.properties
@@ -1,2 +1,2 @@
-version=2.0.14
+version=2.0.15
 


### PR DESCRIPTION
**What**:

* Ability to declare a dictionary in configuration

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate
