### PR TITLE
Config fix for pretty-printing JSON in logs

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
@@ -9,6 +9,7 @@ import io.ktor.client.request.*
 import io.ktor.client.request.forms.*
 import io.ktor.http.*
 import io.ktor.http.content.*
+import io.specmatic.core.utilities.Flags.Companion.SPECMATIC_PRETTY_PRINT
 import io.specmatic.core.utilities.Flags.Companion.getBooleanValue
 import org.apache.http.client.utils.URLEncodedUtils
 import org.apache.http.message.BasicNameValuePair
@@ -628,7 +629,7 @@ fun singleLineJson(json: String): String {
 }
 
 fun formatJson(json: String): String {
-    return if (getBooleanValue("SPECMATIC_PRETTY_PRINT", true))
+    return if (getBooleanValue(SPECMATIC_PRETTY_PRINT, true))
         json
     else
         singleLineJson(json)

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
@@ -9,7 +9,7 @@ import io.ktor.client.request.*
 import io.ktor.client.request.forms.*
 import io.ktor.http.*
 import io.ktor.http.content.*
-import io.specmatic.core.utilities.Flags
+import io.specmatic.core.utilities.Flags.Companion.getBooleanValue
 import org.apache.http.client.utils.URLEncodedUtils
 import org.apache.http.message.BasicNameValuePair
 import java.io.File
@@ -158,7 +158,7 @@ data class HttpRequest(
             }
 
             else -> body.toString()
-        }.let { singleLineJsonIfFlagSet(it) }
+        }.let { formatJson(it) }
 
         val firstPart = listOf(firstLine, headerString).joinToString("\n").trim()
         val requestString = listOf(firstPart, "", bodyString).joinToString("\n")
@@ -627,9 +627,9 @@ fun singleLineJson(json: String): String {
         .replace(Regex("\\s+"), " ") // Replace any remaining sequences of whitespace with a single space
 }
 
-fun singleLineJsonIfFlagSet(json: String): String {
-    return if(Flags.getBooleanValue("SPECMATIC_PRETTY_PRINT") == false)
-        singleLineJson(json)
-    else
+fun formatJson(json: String): String {
+    return if (getBooleanValue("SPECMATIC_PRETTY_PRINT", true))
         json
+    else
+        singleLineJson(json)
 }

--- a/core/src/main/kotlin/io/specmatic/core/HttpResponse.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpResponse.kt
@@ -59,7 +59,7 @@ data class HttpResponse(
 
         val firstPart = listOf(statusLine, headerString).joinToString("\n").trim()
 
-        val formattedBody = body.toStringLiteral().let { singleLineJsonIfFlagSet(it) }
+        val formattedBody = formatJson(body.toStringLiteral())
 
         val responseString = listOf(firstPart, "", formattedBody).joinToString("\n")
         return startLinesWith(responseString, prefix)

--- a/core/src/main/kotlin/io/specmatic/core/utilities/Flags.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/Flags.kt
@@ -16,7 +16,7 @@ class Flags {
 
         fun getStringValue(flagName: String): String? = System.getenv(flagName) ?: System.getProperty(flagName)
 
-        fun getBooleanValue(flagName: String) = ( getStringValue(flagName) ?: "false").toBoolean()
+        fun getBooleanValue(flagName: String, defaultValue: Boolean = false) = getStringValue(flagName)?.toBoolean() ?: defaultValue
 
         fun getLongValue(flagName: String): Long? = ( getStringValue(flagName))?.toLong()
     }

--- a/core/src/main/kotlin/io/specmatic/core/utilities/Flags.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/Flags.kt
@@ -12,6 +12,7 @@ class Flags {
         const val SPECMATIC_STUB_DELAY = "SPECMATIC_STUB_DELAY"
         const val SPECMATIC_TEST_TIMEOUT = "SPECMATIC_TEST_TIMEOUT"
 
+        const val SPECMATIC_PRETTY_PRINT = "SPECMATIC_PRETTY_PRINT"
         const val EXAMPLE_DIRECTORIES = "EXAMPLE_DIRECTORIES"
 
         fun getStringValue(flagName: String): String? = System.getenv(flagName) ?: System.getProperty(flagName)

--- a/core/src/test/kotlin/io/specmatic/core/HttpRequestTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpRequestTest.kt
@@ -20,6 +20,7 @@ import io.ktor.http.*
 import io.mockk.every
 import io.mockk.spyk
 import io.mockk.verify
+import io.specmatic.core.utilities.Flags
 import java.util.stream.Stream
 import org.junit.jupiter.api.Assertions.assertEquals
 
@@ -342,5 +343,25 @@ internal class HttpRequestTest {
     fun `should percent-encode spaces within path segments`() {
         val request = HttpRequest("GET", "/test path")
         assertThat(request.getURL("http://localhost")).isEqualTo("http://localhost/test%20path")
+    }
+
+    @Test
+    fun `should pretty-print request body by default`() {
+        val request = HttpRequest("POST", "/", body = parsedJSONObject("""{"id": 10}"""))
+        assertThat(request.toLogString())
+            .contains(""" "id": 10""")
+            .doesNotContain("""{"id":10}""")
+    }
+
+    @Test
+    fun `should print request body in one line when flag is set to false`() {
+        try {
+            System.setProperty(Flags.SPECMATIC_PRETTY_PRINT, "false")
+            val request = HttpRequest("POST", "/", body = parsedJSONObject("""{"id": 10}"""))
+            assertThat(request.toLogString())
+                .contains("""{"id":10}""")
+        } finally {
+            System.clearProperty(Flags.SPECMATIC_PRETTY_PRINT)
+        }
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/HttpResponseTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpResponseTest.kt
@@ -3,7 +3,9 @@ package io.specmatic.core
 import io.specmatic.core.GherkinSection.Then
 import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.pattern.parsedJSON
+import io.specmatic.core.pattern.parsedJSONObject
 import io.specmatic.core.pattern.parsedValue
+import io.specmatic.core.utilities.Flags
 import io.specmatic.core.value.EmptyString
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.NumberValue
@@ -189,6 +191,31 @@ internal class HttpResponseTest {
             )
 
             assertThat(httpResponse.isNotEmpty()).isEqualTo(true)
+        }
+
+        @Test
+        fun `should pretty print by default`() {
+
+        }
+    }
+
+    @Test
+    fun `should pretty-print response body by default`() {
+        val request = HttpResponse(200, body = parsedJSONObject("""{"id": 10}"""))
+        assertThat(request.toLogString())
+            .contains(""" "id": 10""")
+            .doesNotContain("""{"id":10}""")
+    }
+
+    @Test
+    fun `should print response body in one line when flag is set to false`() {
+        try {
+            System.setProperty(Flags.SPECMATIC_PRETTY_PRINT, "false")
+            val request = HttpResponse(200, body = parsedJSONObject("""{"id": 10}"""))
+            assertThat(request.toLogString())
+                .contains("""{"id":10}""")
+        } finally {
+            System.clearProperty(Flags.SPECMATIC_PRETTY_PRINT)
         }
     }
 }


### PR DESCRIPTION
**What**:

Bug: SPECMATIC_PRETTY_PRINT was defaulting to true

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate
