### PR TITLE
Hooks for contract test requests

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/GenerationStrategies.kt
+++ b/core/src/main/kotlin/io/specmatic/core/GenerationStrategies.kt
@@ -12,8 +12,6 @@ interface GenerationStrategies {
     fun generateHttpRequestBodies(resolver: Resolver, body: Pattern, row: Row): Sequence<ReturnValue<Pattern>>
     fun resolveRow(row: Row): Row
     fun generateKeySubLists(key: String, subList: List<String>): Sequence<List<String>>
-    fun positiveTestScenarios(feature: Feature, suggestions: List<Scenario>): Sequence<Pair<Scenario, ReturnValue<Scenario>>>
-    fun negativeTestScenarios(feature: Feature): Sequence<Pair<Scenario, ReturnValue<Scenario>>>
     fun fillInTheMissingMapPatterns(
         newQueryParamsList: Sequence<Map<String, Pattern>>,
         queryPatterns: Map<String, Pattern>,

--- a/core/src/main/kotlin/io/specmatic/core/GenerativeTestsEnabled.kt
+++ b/core/src/main/kotlin/io/specmatic/core/GenerativeTestsEnabled.kt
@@ -93,17 +93,6 @@ data class GenerativeTestsEnabled(private val positiveOnly: Boolean) : Generatio
             sequenceOf(subList + key)
     }
 
-    override fun positiveTestScenarios(feature: Feature, suggestions: List<Scenario>): Sequence<Pair<Scenario, ReturnValue<Scenario>>> {
-        return feature.positiveTestScenarios(suggestions)
-    }
-
-    override fun negativeTestScenarios(feature: Feature): Sequence<Pair<Scenario, ReturnValue<Scenario>>> {
-        return if(positiveOnly)
-            emptySequence()
-        else
-            feature.negativeTestScenarios()
-    }
-
     override fun fillInTheMissingMapPatterns(
         newQueryParamsList: Sequence<Map<String, Pattern>>,
         queryPatterns: Map<String, Pattern>,

--- a/core/src/main/kotlin/io/specmatic/core/NonGenerativeTests.kt
+++ b/core/src/main/kotlin/io/specmatic/core/NonGenerativeTests.kt
@@ -41,14 +41,6 @@ object NonGenerativeTests : GenerationStrategies {
         return sequenceOf(subList + key)
     }
 
-    override fun positiveTestScenarios(feature: Feature, suggestions: List<Scenario>): Sequence<Pair<Scenario, ReturnValue<Scenario>>> {
-        return feature.positiveTestScenarios(suggestions)
-    }
-
-    override fun negativeTestScenarios(feature: Feature): Sequence<Pair<Scenario, ReturnValue<Scenario>>> {
-        return sequenceOf()
-    }
-
     override fun fillInTheMissingMapPatterns(
         newQueryParamsList: Sequence<Map<String, Pattern>>,
         queryPatterns: Map<String, Pattern>,

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -422,6 +422,7 @@ data class Scenario(
         flagsBased: FlagsBased,
         variables: Map<String, String> = emptyMap(),
         testBaseURLs: Map<String, String> = emptyMap(),
+        fn: (Scenario, Row) -> Scenario = { s, _ -> s }
     ): Sequence<ReturnValue<Scenario>> {
         val referencesWithBaseURLs = references.mapValues { (_, reference) ->
             reference.copy(variables = variables, baseURLs = testBaseURLs)
@@ -436,7 +437,11 @@ data class Scenario(
                     }
                 }
             }.flatMap { row ->
-                newBasedOn(row, flagsBased)
+                newBasedOn(row, flagsBased).map { scenarioR ->
+                    scenarioR.ifValue { scenario ->
+                        fn(scenario, row)
+                    }
+                }
             }
         }
     }

--- a/core/src/test/kotlin/integration_tests/ExtensibleSchemaTest.kt
+++ b/core/src/test/kotlin/integration_tests/ExtensibleSchemaTest.kt
@@ -4,10 +4,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.unmockkAll
 import io.specmatic.conversions.OpenApiSpecification
-import io.specmatic.core.HttpRequest
-import io.specmatic.core.HttpResponse
-import io.specmatic.core.Scenario
-import io.specmatic.core.SpecmaticConfig
+import io.specmatic.core.*
 import io.specmatic.core.pattern.parsedJSONObject
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.test.TestExecutor
@@ -140,9 +137,7 @@ paths:
 
     @Test
     fun `with extensible schema and generative tests enabled both positive and negative generated tests should appear`() {
-        val specmaticConfig = mockk<SpecmaticConfig>(relaxed = true) {
-            every { isExtensibleSchemaEnabled() } returns true
-        }
+        val specmaticConfig = SpecmaticConfig(test = TestConfiguration(allowExtensibleSchema = true))
         val feature =
             OpenApiSpecification.fromYAML(
                 """

--- a/core/src/test/kotlin/io/specmatic/core/RunContractTestsUsingScenario.kt
+++ b/core/src/test/kotlin/io/specmatic/core/RunContractTestsUsingScenario.kt
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test
 import java.util.*
 import java.util.function.Consumer
 
-internal class ScenarioAsTest {
+internal class RunContractTestsUsingScenario {
     @Test
     fun `should generate one test scenario when there are no examples`() {
         val scenario = Scenario(

--- a/version.properties
+++ b/version.properties
@@ -1,2 +1,2 @@
-version=2.0.15
+version=2.0.16
 


### PR DESCRIPTION
**What**:

Added a hook in for handling contract test requests modifications not supported by a specification may need to be made to the request.

**Why**:

Useful for protocols that tunnel over HTTP, and utilise HTTP features out-of-band of their specification.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

