### PR TITLE
Default value fixes

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -16,6 +16,7 @@ import io.cucumber.messages.IdGenerator.Incrementing
 import io.cucumber.messages.types.*
 import io.cucumber.messages.types.Examples
 import io.specmatic.core.utilities.*
+import io.specmatic.mock.loadDictionary
 import io.swagger.v3.oas.models.*
 import io.swagger.v3.oas.models.headers.Header
 import io.swagger.v3.oas.models.info.Info
@@ -453,7 +454,7 @@ data class Feature(
         scenarioStub: ScenarioStub,
         mismatchMessages: MismatchMessages = DefaultMismatchMessages
     ): HttpStubData {
-        val dictionary = specmaticConfig.stub.dictionary?.let { parsedJSONObject(File(it).readText()).jsonObject } ?: emptyMap()
+        val dictionary = specmaticConfig.stub.dictionary?.let { loadDictionary(it) } ?: emptyMap()
 
         val scenarioStub = scenarioStub.copy(dictionary = dictionary)
 

--- a/core/src/main/kotlin/io/specmatic/core/HttpResponse.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpResponse.kt
@@ -181,7 +181,7 @@ data class HttpResponse(
         val newMap = value.jsonObject.mapValues { (key, value) ->
             if(value is StringValue && isVanillaPatternToken(value.string) && key in dictionary) {
                 dictionary.getValue(key)
-            } else value
+            } else substituteDictionaryValues(value, dictionary)
         }
 
         return value.copy(newMap)

--- a/core/src/main/kotlin/io/specmatic/mock/ScenarioStub.kt
+++ b/core/src/main/kotlin/io/specmatic/mock/ScenarioStub.kt
@@ -1,20 +1,22 @@
 package io.specmatic.mock
 
 import io.specmatic.core.*
+import io.specmatic.core.log.logger
 import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.pattern.Pattern
 import io.specmatic.core.pattern.parsedJSONObject
 import io.specmatic.core.utilities.Flags
+import io.specmatic.core.utilities.exceptionCauseMessage
 import io.specmatic.core.value.*
 import io.specmatic.stub.stringToMockScenario
 import java.io.File
 
-fun loadDictionary(): Map<String,Value> {
-    val configFileName = getConfigFileName()
-    val configuredDictionary = if(File(configFileName).exists()) loadSpecmaticConfig(configFileName).stub.dictionary else null
-
-    val fileName = Flags.getStringValue(SPECMATIC_STUB_DICTIONARY) ?: configuredDictionary ?: return emptyMap()
-    return parsedJSONObject(File(fileName).readText()).jsonObject
+fun loadDictionary(fileName: String): Map<String,Value> {
+    return try {
+        parsedJSONObject(File(fileName).readText()).jsonObject
+    } catch(e: Throwable) {
+        throw ContractException("Error loading default value dictionary $fileName: ${exceptionCauseMessage(e)}")
+    }
 }
 
 data class ScenarioStub(

--- a/core/src/test/kotlin/integration_tests/PartialExampleTest.kt
+++ b/core/src/test/kotlin/integration_tests/PartialExampleTest.kt
@@ -503,4 +503,26 @@ class PartialExampleTest {
             System.clearProperty(SPECMATIC_STUB_DICTIONARY)
         }
     }
+
+    @Test
+    fun `data substitution in response body at second level within array using dictionary`() {
+        val specWithSubstitution = osAgnosticPath("src/test/resources/openapi/substitutions/dictionary_value_at_second_level_with_array.yaml")
+
+        try {
+            System.setProperty(SPECMATIC_STUB_DICTIONARY, "src/test/resources/openapi/substitutions/dictionary.json")
+
+            createStubFromContracts(listOf(specWithSubstitution), timeoutMillis = 0).use { stub ->
+                val request = HttpRequest("POST", "/person", body = parsedJSONObject("""{"name": "Janet"}"""))
+                val response = stub.client.execute(request)
+
+                assertThat(response.status).isEqualTo(200)
+                val responseBody = response.body as JSONObjectValue
+
+                assertThat(responseBody.findFirstChildByPath("id")).isEqualTo(NumberValue(10))
+                assertThat(responseBody.findFirstChildByPath("addresses.[0].street")).isEqualTo(StringValue("Baker Street"))
+            }
+        } finally {
+            System.clearProperty(SPECMATIC_STUB_DICTIONARY)
+        }
+    }
 }

--- a/core/src/test/kotlin/integration_tests/StubSubstitutionTest.kt
+++ b/core/src/test/kotlin/integration_tests/StubSubstitutionTest.kt
@@ -701,4 +701,28 @@ class StubSubstitutionTest {
             System.clearProperty(SPECMATIC_STUB_DICTIONARY)
         }
     }
+
+    @Test
+    fun `broken dictionary should be mentioned in an error message at stub load time`() {
+        try {
+            val specWithSubstitution = osAgnosticPath("src/test/resources/openapi/substitutions/dictionary_value_at_second_level.yaml")
+            val brokenDictionaryPath = "src/test/resources/openapi/substitutions/broken-dictionary.json"
+            System.setProperty(SPECMATIC_STUB_DICTIONARY, brokenDictionaryPath)
+
+            val (output, _) = captureStandardOutput {
+                try {
+                    val stub = createStubFromContracts(listOf(specWithSubstitution), timeoutMillis = 0)
+                    stub.close()
+                } catch(e: Throwable) {
+                    println(e)
+                }
+            }
+
+            println(output)
+
+            assertThat(output).contains(brokenDictionaryPath)
+        } finally {
+            System.clearProperty(SPECMATIC_STUB_DICTIONARY)
+        }
+    }
 }

--- a/core/src/test/kotlin/integration_tests/StubSubstitutionTest.kt
+++ b/core/src/test/kotlin/integration_tests/StubSubstitutionTest.kt
@@ -679,4 +679,26 @@ class StubSubstitutionTest {
             System.clearProperty(SPECMATIC_STUB_DICTIONARY)
         }
     }
+
+    @Test
+    fun `data substitution in response body at second level using dictionary`() {
+        val specWithSubstitution = osAgnosticPath("src/test/resources/openapi/substitutions/dictionary_value_at_second_level.yaml")
+
+        try {
+            System.setProperty(SPECMATIC_STUB_DICTIONARY, "src/test/resources/openapi/substitutions/dictionary.json")
+
+            createStubFromContracts(listOf(specWithSubstitution), timeoutMillis = 0).use { stub ->
+                val request = HttpRequest("POST", "/person", body = parsedJSONObject("""{"name": "Charles"}"""))
+                val response = stub.client.execute(request)
+
+                assertThat(response.status).isEqualTo(200)
+                val responseBody = response.body as JSONObjectValue
+
+                assertThat(responseBody.findFirstChildByPath("id")).isEqualTo(NumberValue(100))
+                assertThat(responseBody.findFirstChildByPath("address.street")).isEqualTo(StringValue("Baker Street"))
+            }
+        } finally {
+            System.clearProperty(SPECMATIC_STUB_DICTIONARY)
+        }
+    }
 }

--- a/core/src/test/kotlin/integration_tests/StubSubstitutionTest.kt
+++ b/core/src/test/kotlin/integration_tests/StubSubstitutionTest.kt
@@ -703,6 +703,28 @@ class StubSubstitutionTest {
     }
 
     @Test
+    fun `data substitution in response body at second level within array using dictionary`() {
+        val specWithSubstitution = osAgnosticPath("src/test/resources/openapi/substitutions/dictionary_value_at_second_level_with_array.yaml")
+
+        try {
+            System.setProperty(SPECMATIC_STUB_DICTIONARY, "src/test/resources/openapi/substitutions/dictionary.json")
+
+            createStubFromContracts(listOf(specWithSubstitution), timeoutMillis = 0).use { stub ->
+                val request = HttpRequest("POST", "/person", body = parsedJSONObject("""{"name": "Charles"}"""))
+                val response = stub.client.execute(request)
+
+                assertThat(response.status).isEqualTo(200)
+                val responseBody = response.body as JSONObjectValue
+
+                assertThat(responseBody.findFirstChildByPath("id")).isEqualTo(NumberValue(100))
+                assertThat(responseBody.findFirstChildByPath("addresses.[0].street")).isEqualTo(StringValue("Baker Street"))
+            }
+        } finally {
+            System.clearProperty(SPECMATIC_STUB_DICTIONARY)
+        }
+    }
+
+    @Test
     fun `broken dictionary should be mentioned in an error message at stub load time`() {
         try {
             val specWithSubstitution = osAgnosticPath("src/test/resources/openapi/substitutions/dictionary_value_at_second_level.yaml")

--- a/core/src/test/resources/openapi/substitutions/broken-dictionary.json
+++ b/core/src/test/resources/openapi/substitutions/broken-dictionary.json
@@ -1,0 +1,7 @@
+{
+  "id": 10,
+  "X-Region": "Asia",sdfdsfs
+  "name": "George",
+  "X-Data-Token": "pqr",
+  "street": "Baker Street"
+}

--- a/core/src/test/resources/openapi/substitutions/dictionary.json
+++ b/core/src/test/resources/openapi/substitutions/dictionary.json
@@ -2,5 +2,6 @@
   "id": 10,
   "X-Region": "Asia",
   "name": "George",
-  "X-Data-Token": "pqr"
+  "X-Data-Token": "pqr",
+  "street": "Baker Street"
 }

--- a/core/src/test/resources/openapi/substitutions/dictionary_value_at_second_level.yaml
+++ b/core/src/test/resources/openapi/substitutions/dictionary_value_at_second_level.yaml
@@ -1,0 +1,41 @@
+openapi: 3.0.0
+info:
+  title: Sample API
+  version: 0.1.9
+paths:
+  /person:
+    post:
+      summary: Add person
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                  - address
+                properties:
+                  id:
+                    type: integer
+                  address:
+                    type: object
+                    required:
+                      - street
+                    properties:
+                      building:
+                        type: string
+                      street:
+                        type: string

--- a/core/src/test/resources/openapi/substitutions/dictionary_value_at_second_level_examples/example-partial.json
+++ b/core/src/test/resources/openapi/substitutions/dictionary_value_at_second_level_examples/example-partial.json
@@ -1,0 +1,19 @@
+{
+  "partial": {
+    "http-request": {
+      "method": "POST",
+      "path": "/person",
+      "body": {
+        "name": "Janet"
+      }
+    },
+    "http-response": {
+      "status": 200,
+      "body": {
+        "address": {
+          "street": "(string)"
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/resources/openapi/substitutions/dictionary_value_at_second_level_examples/example.json
+++ b/core/src/test/resources/openapi/substitutions/dictionary_value_at_second_level_examples/example.json
@@ -1,0 +1,18 @@
+{
+  "http-request": {
+    "method": "POST",
+    "path": "/person",
+    "body": {
+      "name": "Charles"
+    }
+  },
+  "http-response": {
+    "status": 200,
+    "body": {
+      "id": 100,
+      "address": {
+        "street": "(string)"
+      }
+    }
+  }
+}

--- a/core/src/test/resources/openapi/substitutions/dictionary_value_at_second_level_with_array.yaml
+++ b/core/src/test/resources/openapi/substitutions/dictionary_value_at_second_level_with_array.yaml
@@ -1,0 +1,43 @@
+openapi: 3.0.0
+info:
+  title: Sample API
+  version: 0.1.9
+paths:
+  /person:
+    post:
+      summary: Add person
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                  - address
+                properties:
+                  id:
+                    type: integer
+                  addresses:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - street
+                      properties:
+                        building:
+                          type: string
+                        street:
+                          type: string

--- a/core/src/test/resources/openapi/substitutions/dictionary_value_at_second_level_with_array_examples/example-partial.json
+++ b/core/src/test/resources/openapi/substitutions/dictionary_value_at_second_level_with_array_examples/example-partial.json
@@ -1,0 +1,21 @@
+{
+  "partial": {
+    "http-request": {
+      "method": "POST",
+      "path": "/person",
+      "body": {
+        "name": "Janet"
+      }
+    },
+    "http-response": {
+      "status": 200,
+      "body": {
+        "addresses": [
+          {
+            "street": "(string)"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/core/src/test/resources/openapi/substitutions/dictionary_value_at_second_level_with_array_examples/example.json
+++ b/core/src/test/resources/openapi/substitutions/dictionary_value_at_second_level_with_array_examples/example.json
@@ -1,0 +1,20 @@
+{
+  "http-request": {
+    "method": "POST",
+    "path": "/person",
+    "body": {
+      "name": "Charles"
+    }
+  },
+  "http-response": {
+    "status": 200,
+    "body": {
+      "id": 100,
+      "addresses": [
+        {
+          "street": "(string)"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
**What**:

- When a dictionary file has invalid JSON, the parse error will now print the path of the file and state that it was a dictionary parse error
- Default values are looked up in the dictionary at n-depth (bug fix)

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate
