### PR TITLE
Added support for running a test with no body in the response

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -381,7 +381,7 @@ class OpenApiSpecification(
 
                     val (additionalExamples, updatedScenarios) = if(responseThatReturnsNoValues != null && unusedRequestExampleNames.isNotEmpty()) {
                         val empty204Response = HttpResponse(204)
-                        val examplesOfResponseThatReturnsNoValues: Map<String, List<Pair<HttpRequest, HttpResponse>>> = requestExamples.mapValues { (key, examples) ->
+                        val examplesOfResponseThatReturnsNoValues: Map<String, List<Pair<HttpRequest, HttpResponse>>> = requestExamples.filterKeys { it in unusedRequestExampleNames }.mapValues { (key, examples) ->
                             examples.map { it to empty204Response }
                         }
 
@@ -418,15 +418,6 @@ class OpenApiSpecification(
                         examplesOfResponseThatReturnsNoValues to updatedScenarioInfos
                     } else
                         emptyMap<String, List<Pair<HttpRequest, HttpResponse>>>() to scenarioInfos
-
-//                    val examplesOfResponseThatReturnsNoValues =
-//                        if(responseThatReturnsNoValues != null && unusedRequestExampleNames.isNotEmpty()) {
-//                            val empty204Response = HttpResponse(204)
-//                            requestExamples.mapValues { (key, examples) ->
-//                                examples.map { it to empty204Response }
-//                            }
-//                        } else
-//                            emptyMap()
 
                     Triple(updatedScenarios, examples + additionalExamples, requestExampleNames)
                 }

--- a/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
@@ -20,6 +20,10 @@ data class HttpHeadersPattern(
         }
     }
 
+    fun isEmpty(): Boolean {
+        return pattern.isEmpty()
+    }
+
     fun matches(headers: Map<String, String>, resolver: Resolver): Result {
         val result = headers to resolver to
                 ::matchEach otherwise

--- a/core/src/test/kotlin/io/specmatic/core/ContractTests.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ContractTests.kt
@@ -17,6 +17,7 @@ import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.util.*
+import io.specmatic.core.log.logger
 import io.specmatic.test.ScenarioAsTest
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.fail
@@ -1183,7 +1184,109 @@ Examples:
         }
 
         assertThat(scenarioNames.single()).isEqualTo("Name added in hook")
+    }
 
+    @Test
+    fun `should be able to run a test for a 204 with no headers`() {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+            openapi: 3.0.3
+            info:
+              title: Simple API
+              version: 1.0.0
+            paths:
+              /:
+                post:
+                  summary: Simple POST endpoint
+                  requestBody:
+                    content:
+                      application/json:
+                        schema:
+                          type: object
+                          required:
+                            - field
+                          properties:
+                            field:
+                              type: string
+                        examples:
+                          SUCCESS:
+                            value:
+                              field: "abc123"
+                  responses:
+                    '204':
+                      description: A simple string response
+            """.trimIndent(), ""
+        ).toFeature()
+
+        val results = feature.executeTests(object : TestExecutor {
+            override fun execute(request: HttpRequest): HttpResponse {
+                val jsonRequestBody = request.body as JSONObjectValue
+
+                assertThat(jsonRequestBody.findFirstChildByPath("field")?.toStringLiteral()).isEqualTo("abc123")
+
+                return HttpResponse(204).also { response ->
+                    println(request.toLogString())
+                    println()
+                    println(response.toLogString())
+                }
+            }
+        })
+
+        assertThat(results.success()).withFailMessage(results.report()).isTrue()
+    }
+
+    @Test
+    fun `an orphan request example for a 204 that has headers should not run as a test`() {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+            openapi: 3.0.3
+            info:
+              title: Simple API
+              version: 1.0.0
+            paths:
+              /:
+                post:
+                  summary: Simple POST endpoint
+                  requestBody:
+                    content:
+                      application/json:
+                        schema:
+                          type: object
+                          required:
+                            - field
+                          properties:
+                            field:
+                              type: string
+                        examples:
+                          SUCCESS:
+                            value:
+                              field: "abc123"
+                  responses:
+                    '204':
+                      description: A simple string response
+                      headers:
+                        X-Header-Value:
+                          description: A header for the 204 response
+                          schema:
+                            type: string
+            """.trimIndent(), ""
+        ).toFeature()
+
+        val results = feature.executeTests(object : TestExecutor {
+            override fun execute(request: HttpRequest): HttpResponse {
+                val jsonRequestBody = request.body as JSONObjectValue
+
+                assertThat(jsonRequestBody.findFirstChildByPath("field")?.toStringLiteral()).isNotEqualTo("abc123")
+
+                return HttpResponse(204).also { response ->
+                    println(request.toLogString())
+                    println()
+                    println(response.toLogString())
+                }
+            }
+        })
+
+        assertThat(results.success()).withFailMessage(results.report()).isTrue()
     }
 }
 


### PR DESCRIPTION
**What**:

When a 204 response has no headers, we should consider any request example that did not match examples in the non-204 status codes as pertaining to 204, and use them for contract test and stub.

**Why**:

A 204 that does not specify headers has no way to provide an example, and thereby there is nothing on which to anchor a request example to, and as a result there's no way currently to run a test for a 204 with specific examples. This PR fixes the issue.

**How**:

OpenAPISpecification has been modified to look explicitly for request examples that had no corresponding response examples, and add them as examples for the 204 if the 204 exists. If a 204 does not exist, those examples do not get used.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

**Closes**: #1063 