### PR TITLE
json-path-like syntax in dictionary lookup

### DIFF
--- a/core/src/test/kotlin/integration_tests/PartialExampleTest.kt
+++ b/core/src/test/kotlin/integration_tests/PartialExampleTest.kt
@@ -527,7 +527,7 @@ class PartialExampleTest {
     }
 
     @Test
-    fun `more complicated data substitutions in response body`() {
+    fun `more complicated data substitutions in response body with 3 level deep partial generation`() {
         val specWithSubstitution = osAgnosticPath("src/test/resources/openapi/substitutions/complicated_spec_with_dictionary_substitutions.yaml")
 
         try {

--- a/core/src/test/kotlin/integration_tests/PartialExampleTest.kt
+++ b/core/src/test/kotlin/integration_tests/PartialExampleTest.kt
@@ -525,4 +525,31 @@ class PartialExampleTest {
             System.clearProperty(SPECMATIC_STUB_DICTIONARY)
         }
     }
+
+    @Test
+    fun `more complicated data substitutions in response body`() {
+        val specWithSubstitution = osAgnosticPath("src/test/resources/openapi/substitutions/complicated_spec_with_dictionary_substitutions.yaml")
+
+        try {
+            System.setProperty(SPECMATIC_STUB_DICTIONARY, "src/test/resources/openapi/substitutions/complicated_dictionary.json")
+
+            createStubFromContracts(listOf(specWithSubstitution), timeoutMillis = 0).use { stub ->
+                stub.client.execute(
+                    HttpRequest("POST", "/person", body = parsedJSONObject("""{"name": "Charles"}"""))).let { response ->
+
+                    assertThat(response.status).isEqualTo(200)
+                    val responseBody = response.body as JSONObjectValue
+
+                    assertThat(responseBody.findFirstChildByPath("person.name")).isEqualTo(StringValue("Jackie"))
+                    assertThat(responseBody.findFirstChildByPath("person.addresses.[0].street")).isEqualTo(StringValue("Baker Street"))
+                    assertThat(responseBody.findFirstChildByPath("person.addresses.[1].street")).isEqualTo(StringValue("Baker Street"))
+                    assertThat(responseBody.findFirstChildByPath("person.past_companies.[0].name")).isEqualTo(StringValue("Acme Inc"))
+                    assertThat(responseBody.findFirstChildByPath("person.past_companies.[1].name")).isEqualTo(StringValue("Paint Inc"))
+                }
+
+            }
+        } finally {
+            System.clearProperty(SPECMATIC_STUB_DICTIONARY)
+        }
+    }
 }

--- a/core/src/test/resources/openapi/substitutions/complicated_dictionary.json
+++ b/core/src/test/resources/openapi/substitutions/complicated_dictionary.json
@@ -1,0 +1,6 @@
+{
+  "person.addresses[*].street": "Baker Street",
+  "person.past_companies[0].name": "Acme Inc",
+  "person.past_companies[1].name": "Paint Inc",
+  "person.name": "Jackie"
+}

--- a/core/src/test/resources/openapi/substitutions/complicated_spec_with_dictionary_substitutions.yaml
+++ b/core/src/test/resources/openapi/substitutions/complicated_spec_with_dictionary_substitutions.yaml
@@ -43,6 +43,7 @@ paths:
                           type: object
                           required:
                             - street
+                            - building
                           properties:
                             building:
                               type: string
@@ -54,6 +55,7 @@ paths:
                           type: object
                           required:
                             - name
+                            - year
                           properties:
                             name:
                               type: string

--- a/core/src/test/resources/openapi/substitutions/complicated_spec_with_dictionary_substitutions.yaml
+++ b/core/src/test/resources/openapi/substitutions/complicated_spec_with_dictionary_substitutions.yaml
@@ -60,6 +60,6 @@ paths:
                             name:
                               type: string
                             year:
-                              type: string
+                              type: integer
                             duration:
                               type: string

--- a/core/src/test/resources/openapi/substitutions/complicated_spec_with_dictionary_substitutions.yaml
+++ b/core/src/test/resources/openapi/substitutions/complicated_spec_with_dictionary_substitutions.yaml
@@ -1,0 +1,63 @@
+openapi: 3.0.0
+info:
+  title: Sample API
+  version: 0.1.9
+paths:
+  /person:
+    post:
+      summary: Add person
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                  - person
+                properties:
+                  id:
+                    type: integer
+                  person:
+                    type: object
+                    required:
+                      - name
+                    properties:
+                      name:
+                        type: string
+                      addresses:
+                        type: array
+                        items:
+                          type: object
+                          required:
+                            - street
+                          properties:
+                            building:
+                              type: string
+                            street:
+                              type: string
+                      past_companies:
+                        type: array
+                        items:
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            name:
+                              type: string
+                            year:
+                              type: string
+                            duration:
+                              type: string

--- a/core/src/test/resources/openapi/substitutions/complicated_spec_with_dictionary_substitutions_examples/example.json
+++ b/core/src/test/resources/openapi/substitutions/complicated_spec_with_dictionary_substitutions_examples/example.json
@@ -1,0 +1,33 @@
+{
+  "partial": {
+    "http-request": {
+      "method": "POST",
+      "path": "/person",
+      "body": {}
+    },
+    "http-response": {
+      "status": 200,
+      "body": {
+        "person": {
+          "name": "(string)",
+          "addresses": [
+            {
+              "street": "(string)"
+            },
+            {
+              "street": "(string)"
+            }
+          ],
+          "past_companies": [
+            {
+              "name": "(string)"
+            },
+            {
+              "name": "(string)"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/resources/openapi/substitutions/dictionary.json
+++ b/core/src/test/resources/openapi/substitutions/dictionary.json
@@ -3,5 +3,7 @@
   "X-Region": "Asia",
   "name": "George",
   "X-Data-Token": "pqr",
-  "street": "Baker Street"
+  "street": "Baker Street",
+  "addresses[0].street": "Baker Street",
+  "address.street": "Baker Street"
 }


### PR DESCRIPTION
**What**:

Dictionaries can now contain the following:

```json
{
  "person.addresses[*].street": "Baker Street",
  "person.past_companies[0].name": "Acme Inc",
  "person.past_companies[1].name": "Paint Inc",
  "person.name": "Jackie"
}
```

**Why**:

This syntax allows dictionaries to unambiguously declare which values should be substituted. For example, the same key may appear under different areas of the JSON response (see the person and company name keys in the above example).

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate
