### PR TITLE
Log the example file that matched the request

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -491,7 +491,8 @@ data class Feature(
                     scenario = matchingScenario,
                     partial = scenarioStub.partial.copy(response = scenarioStub.partial.response.substituteDictionaryValues(scenarioStub.dictionary)),
                     data = scenarioStub.data,
-                    dictionary = scenarioStub.dictionary
+                    dictionary = scenarioStub.dictionary,
+                    examplePath = scenarioStub.filePath
                 )
             }
             else {
@@ -510,7 +511,8 @@ data class Feature(
                 requestBodyRegex = scenarioStub.requestBodyRegex?.let { Regex(it) },
                 stubToken = scenarioStub.stubToken,
                 data = scenarioStub.data,
-                dictionary = scenarioStub.dictionary
+                dictionary = scenarioStub.dictionary,
+                examplePath = scenarioStub.filePath
             )
         }
     }

--- a/core/src/main/kotlin/io/specmatic/core/log/HttpLogMessage.kt
+++ b/core/src/main/kotlin/io/specmatic/core/log/HttpLogMessage.kt
@@ -14,6 +14,7 @@ data class HttpLogMessage(
     var responseTime: CurrentDate? = null,
     var response: HttpResponse? = null,
     var contractPath: String = "",
+    var examplePath: String? = null,
     val targetServer: String = "",
     val comment: String? = null,
     var scenario: Scenario? = null,
@@ -60,10 +61,13 @@ data class HttpLogMessage(
         }
 
         val contractPathLines = if(contractPath.isNotBlank()) {
+            val exampleLine = examplePath?.let { "${linePrefix}Example matched: $examplePath" }
+
             listOf(
                 "${linePrefix}Contract matched: $contractPath",
+                exampleLine,
                 ""
-            )
+            ).filterNotNull()
         } else {
             emptyList()
         }
@@ -95,6 +99,7 @@ data class HttpLogMessage(
     fun addResponse(stubResponse: HttpStubResponse) {
         addResponse(stubResponse.response)
         contractPath = stubResponse.contractPath
+        examplePath = stubResponse.examplePath
     }
 
     fun logStartRequestTime() {

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -800,7 +800,8 @@ private fun stubbedResponse(
             it.delayInMilliseconds,
             it.contractPath,
             scenario = mock.scenario,
-            feature = mock.feature
+            feature = mock.feature,
+            examplePath = it.examplePath
         ) to it
     }
 

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStubResponse.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStubResponse.kt
@@ -11,6 +11,7 @@ data class HttpStubResponse(
     val response: HttpResponse,
     val delayInMilliSeconds: Long? = null,
     val contractPath: String = "",
+    val examplePath: String? = null,
     val feature: Feature? = null,
     val scenario: Scenario? = null,
     val dictionary: Map<String, Value> = emptyMap()

--- a/core/src/main/kotlin/io/specmatic/stub/StubData.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/StubData.kt
@@ -17,6 +17,7 @@ data class HttpStubData(
     val delayInMilliseconds: Long? = null,
     val responsePattern: HttpResponsePattern,
     val contractPath: String = "",
+    val examplePath: String? = null,
     val stubToken: String? = null,
     val requestBodyRegex: Regex? = null,
     val feature:Feature? = null,


### PR DESCRIPTION
**What**:

When Specmatic stub finds a match for an incoming request, the specification is logged, but the example file name is not. This PR now logs the example file.

**Why**:

This is a first step as an aid to debugging matching and mismatching issues.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate
