### PR TITLE
Exit with status code 0 if there are no specs changed in BCC command

### DIFF
--- a/application/src/main/kotlin/application/BackwardCompatibilityCheckCommand.kt
+++ b/application/src/main/kotlin/application/BackwardCompatibilityCheckCommand.kt
@@ -43,7 +43,10 @@ class BackwardCompatibilityCheckCommand(
     override fun call() {
         val filesChangedInCurrentBranch: Set<String> = getOpenAPISpecFilesChangedInCurrentBranch()
 
-        if (filesChangedInCurrentBranch.isEmpty()) exitWithMessage("${newLine}No OpenAPI spec files were changed, skipping the check.$newLine")
+        if (filesChangedInCurrentBranch.isEmpty()) {
+            logger.log("${newLine}No OpenAPI spec files were changed, skipping the check.$newLine")
+            exitProcess(0)
+        }
 
         val filesReferringToChangedSchemaFiles = filesReferringToChangedSchemaFiles(filesChangedInCurrentBranch)
 

--- a/version.properties
+++ b/version.properties
@@ -1,2 +1,2 @@
-version=2.0.16
+version=2.0.17
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Fix a bug in backwardCompatibilityCheckCommand where we are exiting with status code 1 when no specs are changed.
<!-- Why are these changes necessary? -->

**Why**:
We should exit with status code 0 since this is not a error scenario.

<!-- How were these changes implemented? -->

**How**:
By exiting with status code 0 when no specs are changed.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->


<!-- feel free to add additional comments -->
