### PR TITLE
Optimise scenario generation when request and response media types match exactly

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -321,6 +321,8 @@ class OpenApiSpecification(
                             toHttpResponsePatterns(operation.responses)
                         }
 
+                    val httpResponsePatternsGrouped = httpResponsePatterns.groupBy { it.responsePattern.status }
+
                     val httpRequestPatterns: List<RequestPatternsData> =
                         attempt("In $httpMethod $openApiPath request") {
                             toHttpRequestPatterns(
@@ -328,7 +330,60 @@ class OpenApiSpecification(
                             )
                         }
 
-                    val scenarioInfos =
+                    val httpRequestPatternDataGroupedByContentType = httpRequestPatterns.groupBy {
+                        it.requestPattern.headersPattern.contentType
+                    }
+
+                    val requestMediaTypes = httpRequestPatternDataGroupedByContentType.keys
+
+                    val requestResponsePairs = httpResponsePatternsGrouped.flatMap { (status, responses) ->
+                        val responsesGrouped = responses.groupBy {
+                            it.responsePattern.headersPattern.contentType
+                        }
+
+                        if (responsesGrouped.keys.filterNotNull().toSet() == requestMediaTypes.filterNotNull().toSet()) {
+                            responsesGrouped.map { (contentType, responsesData) ->
+                                httpRequestPatternDataGroupedByContentType.getValue(contentType)
+                                    .single() to responsesData.single()
+                            }
+                        } else {
+                            responses.flatMap { responsePatternData ->
+                                httpRequestPatterns.map { requestPatternData ->
+                                    requestPatternData to responsePatternData
+                                }
+                            }
+                        }
+
+                    }
+
+                    val scenarioInfos = requestResponsePairs.map { (requestPatternData, responsePatternData) ->
+                        val (httpRequestPattern, requestExamples: Map<String, List<HttpRequest>>, openApiRequest) = requestPatternData
+                        val (response, responseMediaType: MediaType, httpResponsePattern, responseExamples: Map<String, HttpResponse>) = responsePatternData
+
+                        val specmaticExampleRows: List<Row> =
+                            testRowsFromExamples(responseExamples, requestExamples, operation, openApiRequest)
+                        val scenarioName = scenarioName(operation, response, httpRequestPattern)
+
+                        val ignoreFailure = operation.tags.orEmpty().map { it.trim() }.contains("WIP")
+
+                        val rowsToBeUsed: List<Row> = specmaticExampleRows
+
+                        ScenarioInfo(
+                            scenarioName = scenarioName,
+                            patterns = patterns.toMap(),
+                            httpRequestPattern = httpRequestPattern,
+                            httpResponsePattern = httpResponsePattern,
+                            ignoreFailure = ignoreFailure,
+                            examples = rowsToExamples(rowsToBeUsed),
+                            sourceProvider = sourceProvider,
+                            sourceRepository = sourceRepository,
+                            sourceRepositoryBranch = sourceRepositoryBranch,
+                            specification = specificationPath,
+                            serviceType = SERVICE_TYPE_HTTP
+                        )
+                    }
+
+                    val scenarioInfos2 =
                         httpResponsePatterns.map { (response, responseMediaType: MediaType, httpResponsePattern, responseExamples: Map<String, HttpResponse>) ->
 
                             httpRequestPatterns.map { (httpRequestPattern, requestExamples: Map<String, List<HttpRequest>>, openApiRequest) ->


### PR DESCRIPTION
**What**:

When request media type and response media types in any status code match exactly, match them one-to-one to create as many scenarios as media types. If not, create combinations.

**Why**:

Conventionally, when request and response media types are matched, each request is supposed to corresponding to the response with the same media type.

If they do not, then we will multiply as we do not know which request to match to which response.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate
