### PR TITLE
Ignore inline examples

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -93,7 +93,8 @@ data class SpecmaticConfig(
     val test: TestConfiguration? = TestConfiguration(),
     val stub: StubConfiguration = StubConfiguration(),
     val examples: List<String> = getStringValue(EXAMPLE_DIRECTORIES)?.split(",") ?: emptyList(),
-    val workflow: WorkflowConfiguration? = null
+    val workflow: WorkflowConfiguration? = null,
+    val ignoreInlineExamples: Boolean = false
 ) {
     fun isExtensibleSchemaEnabled(): Boolean {
         return (test?.allowExtensibleSchema == true)

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -338,6 +338,7 @@ Pet:
         val openApiFile = "src/test/resources/openapi/response_schema_validation_including_optional_spec.yaml"
         val specmaticConfig = mockk<SpecmaticConfig> {
             every { isResponseValueValidationEnabled() } returns true
+            every { ignoreInlineExamples } returns false
         }
         val openApiSpecification = OpenApiSpecification(
             openApiFilePath = openApiFile,

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -8392,6 +8392,61 @@ components:
 
     }
 
+    @Test
+    fun `should ignore inline examples when ignoreInlineExamples flag is set in specmatic config`() {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+                ---
+                openapi: "3.0.1"
+                info:
+                  title: "Person API"
+                  version: "1"
+                paths:
+                  /person:
+                    post:
+                      summary: "Get person by id"
+                      requestBody:
+                        content:
+                          application/json:
+                            schema:
+                              required:
+                              - age
+                              properties:
+                                age:
+                                  description: age of the person
+                                  type: number
+                            examples:
+                              SUCCESSFUL_API_CALL:
+                                value:
+                                  age: 10
+                      responses:
+                        200:
+                          description: "Get person by id"
+                          content:
+                            text/plain:
+                              schema:
+                                type: string
+                              examples:
+                                SUCCESSFUL_API_CALL:
+                                  value:
+                                    age: "person data"
+                """.trimIndent(), "",
+            specmaticConfig = SpecmaticConfig(ignoreInlineExamples = true)
+        ).toFeature()
+
+        val results = feature.executeTests(object : TestExecutor {
+            override fun execute(request: HttpRequest): HttpResponse {
+                val jsonRequestBody = request.body as JSONObjectValue
+
+                assertThat(jsonRequestBody.findFirstChildByPath("age")?.toStringLiteral()).isNotEqualTo("10")
+                return HttpResponse(200, "person data")
+            }
+        })
+
+        assertThat(results.testCount).isPositive()
+        assertThat(results.success()).isTrue()
+    }
+
     private fun ignoreButLogException(function: () -> OpenApiSpecification) {
         try {
             function()

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -233,7 +233,8 @@ open class SpecmaticJUnitSupport {
                             testConfig,
                             specificationPath = it,
                             filterName = filterName,
-                            filterNotName = filterNotName
+                            filterNotName = filterNotName,
+                            specmaticConfig = specmaticConfig
                         )
                     }
                     val tests: Sequence<ContractTest> = testScenariosAndEndpointsPairList.asSequence().flatMap { it.first }

--- a/version.properties
+++ b/version.properties
@@ -1,2 +1,2 @@
-version=2.0.18
+version=2.0.19
 


### PR DESCRIPTION
**What**:

Ability to ignore inline examples using the `ignoreInlineExamples` flag in specmatic.yaml 

**Why**:

Useful when the examples in a spec are broken and need to be fixed, and we do not want to block on that when running contract tests from external examples.

**How**:

The flag is read at parse time, and inline examples are ignored if the flag is true.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate
