### PR TITLE
Use openjdk 17-slim image instead of ubuntu as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM ubuntu:22.04
+FROM openjdk:17-slim
 
 WORKDIR /usr/src/app
 
-# Install OpenJDK 17, git, and curl in a single RUN command
+# Install git and curl, and clean up
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends openjdk-17-jre git curl && \
+    apt-get install -y --no-install-recommends git curl && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
@@ -13,5 +13,3 @@ COPY ./application/build/libs/specmatic.jar /usr/src/app/specmatic.jar
 
 # Set the entrypoint to run the Specmatic JAR
 ENTRYPOINT ["java", "-jar", "/usr/src/app/specmatic.jar"]
-
-CMD []


### PR DESCRIPTION


<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Use openjdk 17-slim image instead of ubuntu as base image. This reduced the size by 100mb.
Also, remove unnecessary installation of OpenJDK.

<!-- Why are these changes necessary? -->


<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tested locally
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->


<!-- feel free to add additional comments -->
