### PR TITLE
Error messages cleanup

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -1007,6 +1007,18 @@ class OpenApiSpecification(
     }
 
     data class Discriminator(private val discriminatorDetails: Map<String, Map<String, Pair<String, List<Schema<Any>>>>> = emptyMap()) {
+        val values: List<String>
+            get() {
+                return discriminatorDetails.entries.firstOrNull()?.let {
+                    it.value.keys.toList()
+                } ?: emptyList()
+            }
+
+        val key: String?
+            get() {
+                return discriminatorDetails.entries.firstOrNull()?.key
+            }
+
         val schemas: List<Schema<Any>>
             get() {
                 return discriminatorDetails.entries.flatMap {
@@ -1248,7 +1260,7 @@ class OpenApiSpecification(
                     else if (oneOfs.size > 1)
                         AnyPattern(oneOfs)
                     else if(schemaProperties.size > 1)
-                        AnyPattern(schemaProperties.map { toJSONObjectPattern(it, "(${patternName})") })
+                        AnyPattern(schemaProperties.map { toJSONObjectPattern(it, "(${patternName})") }, discriminatorProperty = allDiscriminators.key, discriminatorValues = allDiscriminators.values)
                     else
                         toJSONObjectPattern(schemaProperties.single(), "(${patternName})")
                 } else if (schema.oneOf != null) {

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
@@ -163,7 +163,8 @@ data class HttpRequestPattern(
                 else
                     MatchSuccess(Triple(httpRequest, defaultResolver, failures.plus(result)))
             }
-            else -> MatchSuccess(Triple(httpRequest, defaultResolver, failures))
+            else ->
+                MatchSuccess(Triple(httpRequest, defaultResolver, failures))
         }
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/Result.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Result.kt
@@ -39,6 +39,8 @@ sealed class Result {
         }
     }
 
+    abstract fun isAnyFluffy(acceptableFluffLevel: Int): Boolean
+
     fun updateScenario(scenario: ScenarioDetailsForResult): Result {
         this.scenario = scenario
         return this
@@ -166,6 +168,10 @@ sealed class Result {
             }
         }
 
+        override fun isAnyFluffy(acceptableFluffLevel: Int): Boolean {
+            return failureReason?.let { it.fluffLevel > acceptableFluffLevel } == true || causes.any { it.cause?.isAnyFluffy(acceptableFluffLevel) == true }
+        }
+
         override fun isSuccess() = false
 
         fun traverseFailureReason(): FailureReason? {
@@ -176,6 +182,10 @@ sealed class Result {
     }
 
     data class Success(val variables: Map<String, String> = emptyMap(), val partialSuccessMessage: String? = null) : Result() {
+        override fun isAnyFluffy(acceptableFluffLevel: Int): Boolean {
+            return false
+        }
+
         override fun isSuccess() = true
         override fun ifSuccess(function: () -> Result) = function()
         override fun withBindings(bindings: Map<String, String>, response: HttpResponse): Result {
@@ -231,7 +241,8 @@ enum class FailureReason(val fluffLevel: Int) {
     ContentTypeMismatch(1),
     RequestMismatchButStatusAlsoWrong(1),
     URLPathMisMatch(2),
-    SOAPActionMismatch(2)
+    SOAPActionMismatch(2),
+    DiscriminatorMismatch(2)
 }
 
 data class MatchFailureDetails(val breadCrumbs: List<String> = emptyList(), val errorMessages: List<String> = emptyList(), val path: String? = null)

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -498,6 +498,9 @@ data class Scenario(
                     failureReason = FailureReason.RequestMismatchButStatusAlsoWrong
                 )
 
+            if(requestMatchResult is Result.Failure && requestMatchResult.isAnyFluffy(0))
+                return requestMatchResult
+
             val responseMatchResult =
                 attempt(breadCrumb = "RESPONSE") { httpResponsePattern.matchesMock(response, resolver) }
 

--- a/core/src/main/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServer.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServer.kt
@@ -16,6 +16,7 @@ import io.specmatic.core.examples.server.ExamplesView.Companion.toTableRows
 import io.specmatic.core.log.logger
 import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.route.modules.HealthCheckModule.Companion.configureHealthCheckModule
+import io.specmatic.core.utilities.capitalizeFirstChar
 import io.specmatic.core.utilities.uniqueNameForApiOperation
 import io.specmatic.core.value.Value
 import io.specmatic.mock.NoMatchingScenario
@@ -352,11 +353,11 @@ object InteractiveExamplesMismatchMessages : MismatchMessages {
     }
 
     override fun unexpectedKey(keyLabel: String, keyName: String): String {
-        return "$keyLabel $keyName in the example is not in the specification"
+        return "${keyLabel.capitalizeFirstChar()} $keyName in the example is not in the specification"
     }
 
     override fun expectedKeyWasMissing(keyLabel: String, keyName: String): String {
-        return "$keyLabel $keyName in the specification is missing from the example"
+        return "${keyLabel.capitalizeFirstChar()} $keyName in the specification is missing from the example"
     }
 }
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
@@ -1,6 +1,7 @@
 package io.specmatic.core.pattern
 
 import io.specmatic.core.*
+import io.specmatic.core.Result.Failure
 import io.specmatic.core.pattern.config.NegativePatternConfiguration
 import io.specmatic.core.value.EmptyString
 import io.specmatic.core.value.NullValue
@@ -11,7 +12,9 @@ data class AnyPattern(
     override val pattern: List<Pattern>,
     val key: String? = null,
     override val typeAlias: String? = null,
-    override val example: String? = null
+    override val example: String? = null,
+    private val discriminatorProperty: String? = null,
+    private val discriminatorValues: List<String> = emptyList()
 ) : Pattern, HasDefaultExample {
     override fun equals(other: Any?): Boolean = other is AnyPattern && other.pattern == this.pattern
 
@@ -29,7 +32,7 @@ data class AnyPattern(
         if(successfulGeneration != null)
             return successfulGeneration
 
-        val failures = results.toList().filterIsInstance<Result.Failure>()
+        val failures = results.toList().filterIsInstance<Failure>()
 
         return HasFailure(Result.Failure.fromFailures(failures))
     }
@@ -85,18 +88,27 @@ data class AnyPattern(
         if(matchResult != null)
             return matchResult.result
 
+        if(discriminatorProperty != null) {
+            val deepMatchResults = matchResults.map { it.result }.filterIsInstance<Failure>().filterNot { it.isAnyFluffy(0) }
+
+            if(deepMatchResults.isEmpty())
+                return Failure("Expected key $discriminatorProperty to contain one of ${discriminatorValues.joinToString(", ")}")
+
+            return Failure.fromFailures(deepMatchResults)
+        }
+
         val resolvedPatterns = pattern.map { resolvedHop(it, resolver) }
 
         if(resolvedPatterns.any { it is NullPattern } || resolvedPatterns.all { it is ExactValuePattern })
             return failedToFindAny(
                     typeName,
                     sampleData,
-                    getResult(matchResults.map { it.result as Result.Failure }),
+                    getResult(matchResults.map { it.result as Failure }),
                     resolver.mismatchMessages
                 )
 
         val failuresWithUpdatedBreadcrumbs = matchResults.map {
-            Pair(it.pattern, it.result as Result.Failure)
+            Pair(it.pattern, it.result as Failure)
         }.mapIndexed { index, (pattern, failure) ->
             val ordinal = index + 1
 
@@ -112,7 +124,7 @@ data class AnyPattern(
         return Result.fromFailures(failuresWithUpdatedBreadcrumbs)
     }
 
-    private fun getResult(failures: List<Result.Failure>): List<Result.Failure> = when {
+    private fun getResult(failures: List<Failure>): List<Failure> = when {
         isNullablePattern() -> {
             val index = pattern.indexOfFirst { !isEmpty(it) }
             listOf(failures[index])
@@ -259,7 +271,7 @@ data class AnyPattern(
     ): Result {
         val compatibleResult = otherPattern.fitsWithin(patternSet(thisResolver), otherResolver, thisResolver, typeStack)
 
-        return if(compatibleResult is Result.Failure && allValuesAreScalar())
+        return if(compatibleResult is Failure && allValuesAreScalar())
             mismatchResult(this, otherPattern, thisResolver.mismatchMessages)
         else
             compatibleResult
@@ -290,7 +302,7 @@ data class AnyPattern(
     }
 }
 
-private fun failedToFindAny(expected: String, actual: Value?, results: List<Result.Failure>, mismatchMessages: MismatchMessages): Result.Failure =
+private fun failedToFindAny(expected: String, actual: Value?, results: List<Failure>, mismatchMessages: MismatchMessages): Failure =
     when (results.size) {
         1 -> results[0]
         else -> {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ExactValuePattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ExactValuePattern.kt
@@ -1,16 +1,22 @@
 package io.specmatic.core.pattern
 
+import io.specmatic.core.FailureReason
 import io.specmatic.core.Resolver
 import io.specmatic.core.Result
 import io.specmatic.core.mismatchResult
 import io.specmatic.core.pattern.config.NegativePatternConfiguration
 import io.specmatic.core.value.Value
 
-data class ExactValuePattern(override val pattern: Value, override val typeAlias: String? = null) : Pattern {
+data class ExactValuePattern(override val pattern: Value, override val typeAlias: String? = null, private val discriminator: Boolean = false) : Pattern {
     override fun matches(sampleData: Value?, resolver: Resolver): Result {
         return when (pattern == sampleData) {
             true -> Result.Success()
-            else -> mismatchResult(pattern, sampleData, resolver.mismatchMessages)
+            else -> mismatchResult(pattern, sampleData, resolver.mismatchMessages).let {
+                if(discriminator)
+                    it.copy(failureReason = FailureReason.DiscriminatorMismatch)
+                else
+                    it
+            }
         }
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ExactValuePattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ExactValuePattern.kt
@@ -7,7 +7,7 @@ import io.specmatic.core.mismatchResult
 import io.specmatic.core.pattern.config.NegativePatternConfiguration
 import io.specmatic.core.value.Value
 
-data class ExactValuePattern(override val pattern: Value, override val typeAlias: String? = null, private val discriminator: Boolean = false) : Pattern {
+data class ExactValuePattern(override val pattern: Value, override val typeAlias: String? = null, val discriminator: Boolean = false) : Pattern {
     override fun matches(sampleData: Value?, resolver: Resolver): Result {
         return when (pattern == sampleData) {
             true -> Result.Success()

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -8655,6 +8655,11 @@ components:
         assertThat(results.success()).isTrue()
     }
 
+    @Test
+    fun `discriminator error when the discriminator key doesnt match`() {
+
+    }
+
     private fun ignoreButLogException(function: () -> OpenApiSpecification) {
         try {
             function()

--- a/core/src/test/kotlin/io/specmatic/stub/ApiKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/ApiKtTest.kt
@@ -511,7 +511,7 @@ sample.json didn't match math.$CONTRACT_EXTENSION
 
     @Test
     fun `should show level 1 fluffy errors and eliminate level 2 fluffy errors if no deep errors are found`() {
-        val results1 = Results(listOf(Result.Failure("failed", null, "", FailureReason.MethodMismatch)))
+        val results1 = Results(listOf(Result.Failure("failed", null, "", FailureReason.ContentTypeMismatch)))
         val results2 = Results(listOf(Result.Failure("fluffy", null, "", FailureReason.SOAPActionMismatch)))
 
         val errorMessage = stubMatchErrorMessage(listOf(makeStubMatchResults(results1), makeStubMatchResults(results2)), "stubfile.json")


### PR DESCRIPTION
**What**:

Cleaned up the error message when the value of a discriminator property in a JSON object does not match the discriminator options, or when it does and the schema used as per the discriminator mapping does not match the JSON object.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate
