### PR TITLE
Generate one example per 2xx API by default

### DIFF
--- a/application/src/main/kotlin/application/ExamplesCommand.kt
+++ b/application/src/main/kotlin/application/ExamplesCommand.kt
@@ -20,6 +20,18 @@ import kotlin.system.exitProcess
 )
 class ExamplesCommand : Callable<Unit> {
 
+    @Option(names = ["--filter-name"], description = ["Use only APIs with this value in their name"], defaultValue = "\${env:SPECMATIC_FILTER_NAME}")
+    var filterName: String = ""
+
+    @Option(names = ["--filter-not-name"], description = ["Use only APIs which do not have this value in their name"], defaultValue = "\${env:SPECMATIC_FILTER_NOT_NAME}")
+    var filterNotName: String = ""
+
+    @Option(names = ["--extensive"], description = ["Generate all examples (by default, generates one example per 2xx API)"], defaultValue = "false")
+    var extensive: Boolean = false
+
+    @Option(names = ["--overwrite"], description = ["Overwrite the examples directory if it exists"], defaultValue = "false")
+    var overwrite: Boolean = false
+
     @Parameters(index = "0", description = ["Contract file path"], arity = "0..1")
     var contractFile: File? = null
 
@@ -32,7 +44,7 @@ class ExamplesCommand : Callable<Unit> {
             exitWithMessage("Could not find file ${contractFile!!.path}")
 
         try {
-            ExamplesInteractiveServer.generate(contractFile!!)
+            ExamplesInteractiveServer.generate(contractFile!!, ExamplesInteractiveServer.ScenarioFilter(filterName, filterNotName), extensive, overwrite)
         } catch (e: Exception) {
             exitWithMessage("An unexpected error occurred while generating examples: ${e.message}")
         }


### PR DESCRIPTION
**What**:

The specmatic examples command will now generate one example per API by default, only for 2xx APIs.

If you want examples for the others, use the `--extensive` flag.

If the _examples directory already exists, use the `--ovewrite` flag to overwrite it.

**Why**:

This may make example generation easier.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [ ] Tests
- [ ] Sonar Quality Gate
