### PR TITLE
Flag for validating inline examples

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServer.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServer.kt
@@ -18,6 +18,7 @@ import io.specmatic.core.examples.server.ExamplesView.Companion.toTableRows
 import io.specmatic.core.log.logger
 import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.route.modules.HealthCheckModule.Companion.configureHealthCheckModule
+import io.specmatic.core.utilities.Flags
 import io.specmatic.core.utilities.capitalizeFirstChar
 import io.specmatic.core.utilities.uniqueNameForApiOperation
 import io.specmatic.mock.NoMatchingScenario
@@ -359,7 +360,10 @@ class ExamplesInteractiveServer(
             if(!examplesDir.isDirectory)
                 return Result.Failure("$examplesDir does not exist, did not find any files to validate")
 
-            val feature = parseContractFileToFeature(contractFile)
+            val feature = parseContractFileToFeature(contractFile).also {
+                validateInlineExamples(it)
+            }
+
 
             logger.log("Validating examples in ${examplesDir.path}")
 
@@ -392,7 +396,9 @@ class ExamplesInteractiveServer(
 
         fun validate(contractFile: File, exampleFile: File): List<HttpStubData> {
             val scenarioStub = ScenarioStub.readFromFile(exampleFile)
-            val feature = parseContractFileToFeature(contractFile)
+            val feature = parseContractFileToFeature(contractFile).also {
+                validateInlineExamples(it)
+            }
 
             val result: Pair<Pair<Result.Success, List<HttpStubData>>?, NoMatchingScenario?> =
                 HttpStub.setExpectation(scenarioStub, feature, InteractiveExamplesMismatchMessages)
@@ -411,6 +417,15 @@ class ExamplesInteractiveServer(
             }
 
             return validationResult.second
+        }
+
+        private fun validateInlineExamples(it: Feature) {
+            if (Flags.getBooleanValue("VALIDATE_INLINE_EXAMPLES"))
+                try {
+                    it.validateExamplesOrException()
+                } catch (e: Exception) {
+                    logger.log(e)
+                }
         }
 
         private fun HttpResponse.cleanup(): HttpResponse {


### PR DESCRIPTION
**What**:

```shell
VALIDATE_INLINE_EXAMPLES=true specmatic examples validate --contract-file <path to spec>
```

This will validate inline examples in addition to external ones. Experimental for now.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [ ] Tests
- [ ] Sonar Quality Gate
