### PR TITLE
Extensible query params

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
@@ -8,6 +8,7 @@ import io.specmatic.core.pattern.*
 import io.specmatic.core.value.StringValue
 import io.ktor.util.*
 import io.specmatic.core.utilities.Flags
+import io.specmatic.core.utilities.Flags.Companion.EXTENSIBLE_QUERY_PARAMS
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.Value
 
@@ -18,8 +19,6 @@ const val CONTENT_TYPE = "Content-Type"
 private val invalidRequestStatuses = listOf(400, 422)
 
 data class HeaderMatchParams(val request: HttpRequest, val headersResolver: Resolver?, val defaultResolver: Resolver, val failures: List<Failure>)
-
-private const val EXTENSIBLE_QUERY_PARAMS = "EXTENSIBLE_QUERY_PARAMS"
 
 data class HttpRequestPattern(
     val headersPattern: HttpHeadersPattern = HttpHeadersPattern(),

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
@@ -7,6 +7,7 @@ import io.specmatic.core.Result.Success
 import io.specmatic.core.pattern.*
 import io.specmatic.core.value.StringValue
 import io.ktor.util.*
+import io.specmatic.core.utilities.Flags
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.Value
 
@@ -17,6 +18,8 @@ const val CONTENT_TYPE = "Content-Type"
 private val invalidRequestStatuses = listOf(400, 422)
 
 data class HeaderMatchParams(val request: HttpRequest, val headersResolver: Resolver?, val defaultResolver: Resolver, val failures: List<Failure>)
+
+private const val EXTENSIBLE_QUERY_PARAMS = "EXTENSIBLE_QUERY_PARAMS"
 
 data class HttpRequestPattern(
     val headersPattern: HttpHeadersPattern = HttpHeadersPattern(),
@@ -223,7 +226,17 @@ data class HttpRequestPattern(
     private fun matchQuery(parameters: Triple<HttpRequest, Resolver, List<Failure>>): MatchingResult<Triple<HttpRequest, Resolver, List<Failure>>> {
         val (httpRequest, resolver, failures) = parameters
 
-        val result = httpQueryParamPattern.matches(httpRequest, resolver)
+        val updatedResolver =
+            if(Flags.getBooleanValue(EXTENSIBLE_QUERY_PARAMS))
+                resolver.copy(
+                    findKeyErrorCheck = resolver.findKeyErrorCheck.copy(
+                        unexpectedKeyCheck = IgnoreUnexpectedKeys
+                    )
+                )
+            else
+                resolver
+
+        val result = httpQueryParamPattern.matches(httpRequest, updatedResolver)
 
         return if (result is Failure)
             MatchSuccess(Triple(httpRequest, resolver, failures.plus(result)))
@@ -364,24 +377,29 @@ data class HttpRequestPattern(
 
             val matchResult = Result.fromResults(results)
 
-            if(matchResult is Failure)
+            if (matchResult is Failure)
                 throw ContractException(matchResult.toFailureReport())
 
-            paramsUnaccountedFor.map { (name, values) ->
-                val pattern = if (values.size > 1) {
-                    QueryParameterArrayPattern(values.map { ExactValuePattern(StringValue(it.second)) }, name)
-                } else {
-                    QueryParameterScalarPattern(ExactValuePattern(StringValue(values.single().second)))
-                }
-
-                name to pattern
-            }.toMap()
+            unaccountedQueryParamsToMap(paramsUnaccountedFor)
+        } else if(Flags.getBooleanValue(EXTENSIBLE_QUERY_PARAMS)) {
+            unaccountedQueryParamsToMap(paramsUnaccountedFor)
         } else {
             emptyMap()
         }
 
         return paramsWithinPattern + paramsOutsidePattern
     }
+
+    private fun unaccountedQueryParamsToMap(paramsUnaccountedFor: Map<String, List<Pair<String, String>>>) =
+        paramsUnaccountedFor.map { (name, values) ->
+            val pattern = if (values.size > 1) {
+                QueryParameterArrayPattern(values.map { ExactValuePattern(StringValue(it.second)) }, name)
+            } else {
+                QueryParameterScalarPattern(ExactValuePattern(StringValue(values.single().second)))
+            }
+
+            name to pattern
+        }.toMap()
 
     private fun encompassedType(valueString: String, key: String?, type: Pattern, resolver: Resolver): Pattern {
         return when {

--- a/core/src/main/kotlin/io/specmatic/core/utilities/Flags.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/Flags.kt
@@ -15,6 +15,8 @@ class Flags {
         const val SPECMATIC_PRETTY_PRINT = "SPECMATIC_PRETTY_PRINT"
         const val EXAMPLE_DIRECTORIES = "EXAMPLE_DIRECTORIES"
 
+        const val EXTENSIBLE_QUERY_PARAMS = "EXTENSIBLE_QUERY_PARAMS"
+
         fun getStringValue(flagName: String): String? = System.getenv(flagName) ?: System.getProperty(flagName)
 
         fun getBooleanValue(flagName: String, default: Boolean = false) = getStringValue(flagName)?.toBoolean() ?: default


### PR DESCRIPTION
**What**:

Implemented `EXTENSIBLE_QUERY_PARAMS` along the same lines as `EXTENSIBLE_SCHEMA`, for stubbing.

When this flag is set to `true`, an example with query parameters outside the spec will be accepted. Requests will not match the example unless all query params in the example including the ones outside the spec are present in the request.

It is experimental for now, so it has been implemented as an environment variable only.

**How**:

`EXTENSIBLE_QUERY_PARAMS` is read in HttpRequestPattern in the `matchQuery` method, so that examples with extra query params match, and in `toTypeMapForQueryParameters`, so that the pattern generated from the example for the stub includes the extra query parameters.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [ ] Tests
- [ ] Sonar Quality Gate
