### PR TITLE
The examples generate CLI should skip overwrite of the existing examples

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServer.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServer.kt
@@ -25,10 +25,6 @@ import io.specmatic.mock.NoMatchingScenario
 import io.specmatic.mock.ScenarioStub
 import io.specmatic.stub.HttpStub
 import io.specmatic.stub.HttpStubData
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.runBlocking
 import java.io.Closeable
 import java.io.File
 import java.io.FileNotFoundException
@@ -275,20 +271,16 @@ class ExamplesInteractiveServer(
                 val examplesDir =
                     getExamplesDirPath(contractFile)
 
-                if(examplesDir.exists() && overwriteByDefault == false) {
+                if(examplesDir.exists() && overwriteByDefault.not()) {
                     val response: String = Scanner(System.`in`).use { scanner ->
-                        print("Do you want to continue? (y/n): ")
+                        print("Do you want to overwrite all the existing examples in ${examplesDir.name}? (y/n): ")
                         scanner.nextLine().trim().lowercase()
                     }
-
-                    if(response != "y") {
+                    if(response == "y") {
+                        println("Overwriting all the examples in ${examplesDir.name}")
                         println()
-                        println("You chose $response, terminating example generation.")
-                        println()
-                        return emptyList()
+                        examplesDir.deleteRecursively()
                     }
-
-                    examplesDir.deleteRecursively()
                 }
 
                 examplesDir.mkdirs()
@@ -298,7 +290,15 @@ class ExamplesInteractiveServer(
                     return emptyList()
                 }
 
+                val existingExamples = examplesDir.getExamplesFromDir()
                 return feature.scenarios.map { scenario ->
+                    val existingExample = getExistingExampleFile(scenario, existingExamples)
+                    if(existingExample?.second?.isNotBlank() == true) existingExample.first.delete()
+                    if(existingExample != null && existingExample.second.isBlank()) {
+                        println("Example already exists for ${scenario.testDescription()} within the file ${existingExample.first.name}, skipping generation.\n")
+                        return@map existingExample.first.path
+                    }
+
                     println("Generating for ${scenario.testDescription()}")
                     val generatedScenario = scenario.generateTestScenarios(DefaultStrategies).first().value
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Enables generate CLI in examples to skip the overwrite operation of existing examples.
<!-- Why are these changes necessary? -->


<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->


<!-- feel free to add additional comments -->
