### PR TITLE
Discriminator property error message fix

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/pattern/ExactValuePattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ExactValuePattern.kt
@@ -13,7 +13,7 @@ data class ExactValuePattern(override val pattern: Value, override val typeAlias
             true -> Result.Success()
             else -> {
                 if (discriminator) {
-                    val errorMessage = "Expected the value of discriminator property to be ${pattern.displayableValue()}"
+                    val errorMessage = "Expected the value of discriminator property to be ${pattern.displayableValue()} but it was ${sampleData?.displayableValue()}"
                     Result.Failure(errorMessage, failureReason = FailureReason.DiscriminatorMismatch)
                 } else
                     mismatchResult(pattern, sampleData, resolver.mismatchMessages)


### PR DESCRIPTION
**What**:

Updated the error message shown when a discriminator property has an unexpected value. Now it will show both the expected value (or values) and the actual value.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [ ] Tests
- [ ] Sonar Quality Gate
