### PR TITLE
Vulnerability Scan stage for docker should fail for HIGH/CRITICAL

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,10 +41,9 @@ jobs:
         uses: aquasecurity/trivy-action@0.24.0
         with:
           image-ref: znsio/specmatic:${{ steps.read_version.outputs.VERSION }}
-          severity: HIGH,CRITICAL,MEDIUM,LOW,UNKNOWN 
+          severity: HIGH,CRITICAL
           exit-code: '1'
           ignore-unfixed: true
-          severity-threshold: HIGH 
           format: table
           vulnerability-type: os,library
     

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,7 +41,12 @@ jobs:
         uses: aquasecurity/trivy-action@0.24.0
         with:
           image-ref: znsio/specmatic:${{ steps.read_version.outputs.VERSION }}
-        continue-on-error: true
+          severity: HIGH,CRITICAL,MEDIUM,LOW,UNKNOWN 
+          exit-code: '1'
+          ignore-unfixed: true
+          severity-threshold: HIGH 
+          format: table
+          vulnerability-type: os,library
     
       - name: Push Docker Image
         run: docker push znsio/specmatic:${{ steps.read_version.outputs.VERSION }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,8 @@
 name: Manual Release Build and Docker Image
 
 on:
+  repository_dispatch:
+    types: [specmatic-core-release]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Makes the docker scan for vulnerabilities stage fail if HIGH or CRITICAL vulnerability is found.
Configures auto-trigger of docker release once the jar release is through.

<!-- Why are these changes necessary? -->

**Why**:
Currently, even if a HIGH vulnerability is found, the stage does not fail.

<!-- How were these changes implemented? -->

**How**:
By modifying the docker workflow file.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->


<!-- feel free to add additional comments -->
