### PR TITLE
Fixed error message when the discriminator is missing in spec

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
@@ -100,15 +100,37 @@ data class AnyPattern(
                 val discriminatorCsv = discriminatorValues.joinToString(", ")
 
                 if(sampleData is JSONObjectValue) {
-                    val baseMessage = "Expected the value of discriminator property to be one of $discriminatorCsv"
+                    val actualDiscriminatorValue = sampleData.jsonObject[discriminatorProperty]?.toStringLiteral()
 
-                    val message = baseMessage + if(discriminatorProperty in sampleData.jsonObject) {
-                        " but it was ${sampleData.jsonObject.getValue(discriminatorProperty).displayableValue()}"
-                    } else {
-                        " but it was missing"
+                    if(actualDiscriminatorValue == null) {
+                        Failure(
+                            "Discriminator property ${discriminatorProperty} is missing from the object",
+                            breadCrumb = discriminatorProperty,
+                            failureReason = FailureReason.DiscriminatorMismatch
+                        )
+
+                    } else if (actualDiscriminatorValue !in discriminatorValues) {
+                        val baseMessage = "Expected the value of discriminator property to be one of $discriminatorCsv"
+
+                        val message = baseMessage + if (discriminatorProperty in sampleData.jsonObject) {
+                            " but it was ${sampleData.jsonObject.getValue(discriminatorProperty).displayableValue()}"
+                        } else {
+                            " but it was missing"
+                        }
+
+                        Failure(
+                            message,
+                            breadCrumb = discriminatorProperty,
+                            failureReason = FailureReason.DiscriminatorMismatch
+                        )
                     }
-
-                    Failure(message, breadCrumb = discriminatorProperty, failureReason = FailureReason.DiscriminatorMismatch)
+                    else {
+                        Failure(
+                            "Discriminator property ${discriminatorProperty} is missing from the spec",
+                            breadCrumb = discriminatorProperty,
+                            failureReason = FailureReason.DiscriminatorMismatch
+                        )
+                    }
                 } else {
                     resolver.mismatchMessages.valueMismatchFailure("json object", sampleData)
                 }

--- a/core/src/test/kotlin/integration_tests/DiscriminatorTest.kt
+++ b/core/src/test/kotlin/integration_tests/DiscriminatorTest.kt
@@ -1,0 +1,238 @@
+package integration_tests
+
+import io.specmatic.conversions.OpenApiSpecification
+import io.specmatic.core.HttpRequest
+import io.specmatic.core.HttpResponse
+import io.specmatic.core.pattern.parsedJSONObject
+import io.specmatic.core.value.StringValue
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class DiscriminatorTest {
+    @Test
+    fun `when the discriminator property is missing from the spec the issue should be mentioned explicitly`() {
+        val feature = OpenApiSpecification.fromYAML("""
+            ---
+            openapi: 3.0.3
+            info:
+              title: Vehicle API
+              version: 1.0.0
+            paths:
+              /vehicle:
+                post:
+                  summary: Add a new vehicle
+                  requestBody:
+                    required: true
+                    content:
+                      application/json:
+                        schema:
+                          ${'$'}ref: '#/components/schemas/Vehicle'
+                  responses:
+                    '201':
+                      description: Vehicle created successfully
+                      content:
+                        text/plain:
+                          schema:
+                            type: string
+
+            components:
+              schemas:
+                VehicleType:
+                  type: object
+
+                Vehicle:
+                  allOf:
+                    - ${'$'}ref: '#/components/schemas/VehicleType'
+                    - type: object
+                      properties:
+                        seatingCapacity:
+                          type: integer
+                  discriminator:
+                    propertyName: "type"
+                    mapping:
+                      "car": "#/components/schemas/Car"
+                      "bike": "#/components/schemas/Bike"
+
+                Car:
+                  allOf:
+                    - ${'$'}ref: '#/components/schemas/Vehicle'
+                    - type: object
+                      requried:
+                        - gearType
+                      properties:
+                        gearType:
+                          type: string
+                Bike:
+                  allOf:
+                    - ${'$'}ref: '#/components/schemas/Vehicle'
+                    - type: object
+                      requried:
+                        - headlampStyle
+                      properties:
+                        headlampStyle:
+                          type: string
+        """.trimIndent(), "").toFeature()
+
+        val result = feature.matchResult(
+            HttpRequest("POST", "/vehicle", body = parsedJSONObject("""{"type": "car", "seatingCapacity": 4, "gearType": "MT"}""")),
+            HttpResponse(201, body = StringValue("success"))
+        )
+
+        assertThat(result.reportString()).doesNotContain("car, bike")
+        assertThat(result.reportString()).contains("missing from the spec")
+    }
+
+    @Test
+    fun `when the discriminator property is missing from the object the issue should be mentioned explicitly`() {
+        val feature = OpenApiSpecification.fromYAML("""
+            ---
+            openapi: 3.0.3
+            info:
+              title: Vehicle API
+              version: 1.0.0
+            paths:
+              /vehicle:
+                post:
+                  summary: Add a new vehicle
+                  requestBody:
+                    required: true
+                    content:
+                      application/json:
+                        schema:
+                          ${'$'}ref: '#/components/schemas/Vehicle'
+                  responses:
+                    '201':
+                      description: Vehicle created successfully
+                      content:
+                        text/plain:
+                          schema:
+                            type: string
+
+            components:
+              schemas:
+                VehicleType:
+                  type: object
+                  required:
+                    - type
+                  properties:
+                    type:
+                      type: string
+                Vehicle:
+                  allOf:
+                    - ${'$'}ref: '#/components/schemas/VehicleType'
+                    - type: object
+                      properties:
+                        seatingCapacity:
+                          type: integer
+                  discriminator:
+                    propertyName: "type"
+                    mapping:
+                      "car": "#/components/schemas/Car"
+                      "bike": "#/components/schemas/Bike"
+
+                Car:
+                  allOf:
+                    - ${'$'}ref: '#/components/schemas/Vehicle'
+                    - type: object
+                      requried:
+                        - gearType
+                      properties:
+                        gearType:
+                          type: string
+                Bike:
+                  allOf:
+                    - ${'$'}ref: '#/components/schemas/Vehicle'
+                    - type: object
+                      requried:
+                        - headlampStyle
+                      properties:
+                        headlampStyle:
+                          type: string
+        """.trimIndent(), "").toFeature()
+
+        val result = feature.matchResult(
+            HttpRequest("POST", "/vehicle", body = parsedJSONObject("""{"seatingCapacity": 4, "gearType": "MT"}""")),
+            HttpResponse(201, body = StringValue("success"))
+        )
+
+        val discriminatorProperty = "type"
+        assertThat(result.reportString()).contains("Discriminator property ${discriminatorProperty} is missing from the object")
+    }
+
+    @Test
+    fun `discriminator property with incorrect value should be caught as an error`() {
+        val feature = OpenApiSpecification.fromYAML("""
+            ---
+            openapi: 3.0.3
+            info:
+              title: Vehicle API
+              version: 1.0.0
+            paths:
+              /vehicle:
+                post:
+                  summary: Add a new vehicle
+                  requestBody:
+                    required: true
+                    content:
+                      application/json:
+                        schema:
+                          ${'$'}ref: '#/components/schemas/Vehicle'
+                  responses:
+                    '201':
+                      description: Vehicle created successfully
+                      content:
+                        text/plain:
+                          schema:
+                            type: string
+
+            components:
+              schemas:
+                VehicleType:
+                  type: object
+                  required:
+                    - type
+                  properties:
+                    type:
+                      type: string
+                Vehicle:
+                  allOf:
+                    - ${'$'}ref: '#/components/schemas/VehicleType'
+                    - type: object
+                      properties:
+                        seatingCapacity:
+                          type: integer
+                  discriminator:
+                    propertyName: "type"
+                    mapping:
+                      "car": "#/components/schemas/Car"
+                      "bike": "#/components/schemas/Bike"
+
+                Car:
+                  allOf:
+                    - ${'$'}ref: '#/components/schemas/Vehicle'
+                    - type: object
+                      requried:
+                        - gearType
+                      properties:
+                        gearType:
+                          type: string
+                Bike:
+                  allOf:
+                    - ${'$'}ref: '#/components/schemas/Vehicle'
+                    - type: object
+                      requried:
+                        - headlampStyle
+                      properties:
+                        headlampStyle:
+                          type: string
+        """.trimIndent(), "").toFeature()
+
+        val result = feature.matchResult(
+            HttpRequest("POST", "/vehicle", body = parsedJSONObject("""{"type": "airplane", "seatingCapacity": 4, "gearType": "MT"}""")),
+            HttpResponse(201, body = StringValue("success"))
+        )
+
+        assertThat(result.reportString()).contains("car, bike")
+    }
+
+}


### PR DESCRIPTION
**What**:

Error messages have been added to handle cases where the discriminator is present in the example but missing in the spec, or missing in the example.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate
