### PR TITLE
Add support for "null" type in oneOf

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -1428,7 +1428,7 @@ class OpenApiSpecification(
 
                     pattern
                 } else if (schema.oneOf != null) {
-                    val candidatePatterns = schema.oneOf.filterNot { nullableEmptyObject(it) }.map { componentSchema ->
+                    val candidatePatterns = schema.oneOf.filterNot { isNullable(it) }.map { componentSchema ->
                         val (componentName, schemaToProcess) =
                             if (componentSchema.`$ref` != null)
                                 resolveReferenceToSchema(componentSchema.`$ref`)
@@ -1439,7 +1439,7 @@ class OpenApiSpecification(
                     }
 
                     val nullable =
-                        if (schema.oneOf.any { nullableEmptyObject(it) }) listOf(NullPattern) else emptyList()
+                        if (schema.oneOf.any { isNullable(it) }) listOf(NullPattern) else emptyList()
 
                     AnyPattern(candidatePatterns.plus(nullable), discriminatorProperty =  schema.discriminator?.propertyName, discriminatorValues = schema.discriminator?.let { it.mapping.keys.toSet() }.orEmpty())
                 } else if (schema.anyOf != null) {
@@ -1561,7 +1561,8 @@ class OpenApiSpecification(
         return pattern
     }
 
-    private fun nullableEmptyObject(schema: Schema<*>): Boolean {
+    private fun isNullable(schema: Schema<*>): Boolean {
+         if(schema.type == "null") return true
         return schema is ObjectSchema && schema.nullable == true
     }
 


### PR DESCRIPTION
If I run the spec containing the following schema as a stub -
```
schema:
  type: object
  properties:
    id:
      type: number
    type:
      oneOf:
        - type: string
          enum:
            - BASIC
            - PREMIUM
        - type: "null"
```
And, I try to hit this endpoint by passing the value for type as null i.e. `"type": null`, I get the following error -
```
Contract expected ("BASIC" or "PREMIUM") but request contained null
```

This PR fixes this issue and supports null values if `oneOf` the types is "null"

