### PR TITLE
Stub strict mode example loading fixes

### DIFF
--- a/application/src/main/kotlin/application/StubCommand.kt
+++ b/application/src/main/kotlin/application/StubCommand.kt
@@ -7,7 +7,7 @@ import io.specmatic.core.log.*
 import io.specmatic.core.utilities.ContractPathData
 import io.specmatic.core.utilities.Flags.Companion.SPECMATIC_STUB_DELAY
 import io.specmatic.core.utilities.exitIfAnyDoNotExist
-import io.specmatic.core.utilities.exitIfInvalidExamplesDirExists
+import io.specmatic.core.utilities.exitIfDirectoriesAreInvalid
 import io.specmatic.core.utilities.exitWithMessage
 import io.specmatic.stub.ContractStub
 import io.specmatic.stub.HttpClientFactory
@@ -180,7 +180,7 @@ class StubCommand : Callable<Unit> {
 
     private fun startServer() {
         val workingDirectory = WorkingDirectory()
-        if(strictMode) exitIfInvalidExamplesDirExists(exampleDirs)
+        if(strictMode) exitIfDirectoriesAreInvalid(exampleDirs, "example directories")
         val stubData = stubLoaderEngine.loadStubs(contractSources, exampleDirs, specmaticConfigPath, strictMode)
 
         val certInfo = CertInfo(keyStoreFile, keyStoreDir, keyStorePassword, keyStoreAlias, keyPassword)

--- a/application/src/main/kotlin/application/StubCommand.kt
+++ b/application/src/main/kotlin/application/StubCommand.kt
@@ -181,7 +181,7 @@ class StubCommand : Callable<Unit> {
     private fun startServer() {
         val workingDirectory = WorkingDirectory()
         if(strictMode) exitIfInvalidExamplesDirExists(exampleDirs)
-        val stubData = stubLoaderEngine.loadStubs(contractSources, exampleDirs, specmaticConfigPath)
+        val stubData = stubLoaderEngine.loadStubs(contractSources, exampleDirs, specmaticConfigPath, strictMode)
 
         val certInfo = CertInfo(keyStoreFile, keyStoreDir, keyStorePassword, keyStoreAlias, keyPassword)
 

--- a/application/src/main/kotlin/application/StubCommand.kt
+++ b/application/src/main/kotlin/application/StubCommand.kt
@@ -10,6 +10,7 @@ import io.specmatic.core.utilities.exitIfAnyDoNotExist
 import io.specmatic.core.utilities.exitWithMessage
 import io.specmatic.stub.ContractStub
 import io.specmatic.stub.HttpClientFactory
+import io.specmatic.stub.exitIfInvalidExamplesDirExists
 import org.springframework.beans.factory.annotation.Autowired
 import picocli.CommandLine.*
 import java.io.File
@@ -179,6 +180,7 @@ class StubCommand : Callable<Unit> {
 
     private fun startServer() {
         val workingDirectory = WorkingDirectory()
+        if(strictMode) exitIfInvalidExamplesDirExists(exampleDirs)
         val stubData = stubLoaderEngine.loadStubs(contractSources, exampleDirs, specmaticConfigPath)
 
         val certInfo = CertInfo(keyStoreFile, keyStoreDir, keyStorePassword, keyStoreAlias, keyPassword)

--- a/application/src/main/kotlin/application/StubCommand.kt
+++ b/application/src/main/kotlin/application/StubCommand.kt
@@ -1,14 +1,30 @@
 package application
 
-import io.specmatic.core.*
+import io.specmatic.core.APPLICATION_NAME_LOWER_CASE
+import io.specmatic.core.CONTRACT_EXTENSIONS
+import io.specmatic.core.Configuration
 import io.specmatic.core.Configuration.Companion.DEFAULT_HTTP_STUB_HOST
 import io.specmatic.core.Configuration.Companion.DEFAULT_HTTP_STUB_PORT
-import io.specmatic.core.log.*
+import io.specmatic.core.WorkingDirectory
+import io.specmatic.core.getConfigFileName
+import io.specmatic.core.log.CompositePrinter
+import io.specmatic.core.log.ConsolePrinter
+import io.specmatic.core.log.JSONConsoleLogPrinter
+import io.specmatic.core.log.JSONFilePrinter
+import io.specmatic.core.log.LogDirectory
+import io.specmatic.core.log.LogPrinter
+import io.specmatic.core.log.LogTail
+import io.specmatic.core.log.NonVerbose
+import io.specmatic.core.log.StringLog
+import io.specmatic.core.log.TextFilePrinter
+import io.specmatic.core.log.Verbose
+import io.specmatic.core.log.consoleLog
+import io.specmatic.core.log.logger
 import io.specmatic.core.utilities.ContractPathData
 import io.specmatic.core.utilities.Flags.Companion.SPECMATIC_STUB_DELAY
 import io.specmatic.core.utilities.exitIfAnyDoNotExist
-import io.specmatic.core.utilities.throwExceptionIfDirectoriesAreInvalid
 import io.specmatic.core.utilities.exitWithMessage
+import io.specmatic.core.utilities.throwExceptionIfDirectoriesAreInvalid
 import io.specmatic.stub.ContractStub
 import io.specmatic.stub.HttpClientFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -147,7 +163,7 @@ class StubCommand : Callable<Unit> {
                 }
             }
         } catch (e: Throwable) {
-            consoleLog(e)
+            exitWithMessage(e.message.orEmpty())
         }
     }
 

--- a/application/src/main/kotlin/application/StubCommand.kt
+++ b/application/src/main/kotlin/application/StubCommand.kt
@@ -7,10 +7,10 @@ import io.specmatic.core.log.*
 import io.specmatic.core.utilities.ContractPathData
 import io.specmatic.core.utilities.Flags.Companion.SPECMATIC_STUB_DELAY
 import io.specmatic.core.utilities.exitIfAnyDoNotExist
+import io.specmatic.core.utilities.exitIfInvalidExamplesDirExists
 import io.specmatic.core.utilities.exitWithMessage
 import io.specmatic.stub.ContractStub
 import io.specmatic.stub.HttpClientFactory
-import io.specmatic.stub.exitIfInvalidExamplesDirExists
 import org.springframework.beans.factory.annotation.Autowired
 import picocli.CommandLine.*
 import java.io.File

--- a/application/src/main/kotlin/application/StubCommand.kt
+++ b/application/src/main/kotlin/application/StubCommand.kt
@@ -1,30 +1,14 @@
 package application
 
-import io.specmatic.core.APPLICATION_NAME_LOWER_CASE
-import io.specmatic.core.CONTRACT_EXTENSIONS
-import io.specmatic.core.Configuration
+import io.specmatic.core.*
 import io.specmatic.core.Configuration.Companion.DEFAULT_HTTP_STUB_HOST
 import io.specmatic.core.Configuration.Companion.DEFAULT_HTTP_STUB_PORT
-import io.specmatic.core.WorkingDirectory
-import io.specmatic.core.getConfigFileName
-import io.specmatic.core.log.CompositePrinter
-import io.specmatic.core.log.ConsolePrinter
-import io.specmatic.core.log.JSONConsoleLogPrinter
-import io.specmatic.core.log.JSONFilePrinter
-import io.specmatic.core.log.LogDirectory
-import io.specmatic.core.log.LogPrinter
-import io.specmatic.core.log.LogTail
-import io.specmatic.core.log.NonVerbose
-import io.specmatic.core.log.StringLog
-import io.specmatic.core.log.TextFilePrinter
-import io.specmatic.core.log.Verbose
-import io.specmatic.core.log.consoleLog
-import io.specmatic.core.log.logger
+import io.specmatic.core.log.*
 import io.specmatic.core.utilities.ContractPathData
 import io.specmatic.core.utilities.Flags.Companion.SPECMATIC_STUB_DELAY
 import io.specmatic.core.utilities.exitIfAnyDoNotExist
-import io.specmatic.core.utilities.exitWithMessage
 import io.specmatic.core.utilities.throwExceptionIfDirectoriesAreInvalid
+import io.specmatic.core.utilities.exitWithMessage
 import io.specmatic.stub.ContractStub
 import io.specmatic.stub.HttpClientFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -163,7 +147,7 @@ class StubCommand : Callable<Unit> {
                 }
             }
         } catch (e: Throwable) {
-            exitWithMessage(e.message.orEmpty())
+            consoleLog(e)
         }
     }
 

--- a/application/src/main/kotlin/application/StubCommand.kt
+++ b/application/src/main/kotlin/application/StubCommand.kt
@@ -7,7 +7,7 @@ import io.specmatic.core.log.*
 import io.specmatic.core.utilities.ContractPathData
 import io.specmatic.core.utilities.Flags.Companion.SPECMATIC_STUB_DELAY
 import io.specmatic.core.utilities.exitIfAnyDoNotExist
-import io.specmatic.core.utilities.exitIfDirectoriesAreInvalid
+import io.specmatic.core.utilities.throwExceptionIfDirectoriesAreInvalid
 import io.specmatic.core.utilities.exitWithMessage
 import io.specmatic.stub.ContractStub
 import io.specmatic.stub.HttpClientFactory
@@ -180,7 +180,7 @@ class StubCommand : Callable<Unit> {
 
     private fun startServer() {
         val workingDirectory = WorkingDirectory()
-        if(strictMode) exitIfDirectoriesAreInvalid(exampleDirs, "example directories")
+        if(strictMode) throwExceptionIfDirectoriesAreInvalid(exampleDirs, "example directories")
         val stubData = stubLoaderEngine.loadStubs(contractSources, exampleDirs, specmaticConfigPath, strictMode)
 
         val certInfo = CertInfo(keyStoreFile, keyStoreDir, keyStorePassword, keyStoreAlias, keyPassword)

--- a/application/src/main/kotlin/application/StubLoaderEngine.kt
+++ b/application/src/main/kotlin/application/StubLoaderEngine.kt
@@ -13,7 +13,12 @@ import java.io.File
 
 @Component
 class StubLoaderEngine {
-    fun loadStubs(contractPathDataList: List<ContractPathData>, dataDirs: List<String>, specmaticConfigPath: String? = null): List<Pair<Feature, List<ScenarioStub>>> {
+    fun loadStubs(
+        contractPathDataList: List<ContractPathData>,
+        dataDirs: List<String>,
+        specmaticConfigPath: String? = null,
+        strictMode: Boolean
+    ): List<Pair<Feature, List<ScenarioStub>>> {
         contractPathDataList.forEach { contractPath ->
             if(!File(contractPath.path).exists()) {
                 logger.log("$contractPath does not exist.")
@@ -24,7 +29,7 @@ class StubLoaderEngine {
 
         return when {
             dataDirs.isNotEmpty() -> {
-                loadContractStubsFromFiles(contractPathDataList, dataDirs, specmaticConfig)
+                loadContractStubsFromFiles(contractPathDataList, dataDirs, specmaticConfig, strictMode)
             }
             else -> loadContractStubsFromImplicitPaths(contractPathDataList, specmaticConfig)
         }

--- a/application/src/test/kotlin/application/StubCommandTest.kt
+++ b/application/src/test/kotlin/application/StubCommandTest.kt
@@ -97,7 +97,8 @@ internal class StubCommandTest {
                 stubLoaderEngine.loadStubs(
                     listOf(contractPath).map { ContractPathData("", it) },
                     emptyList(),
-                    any()
+                    any(),
+                    false
                 )
             }.returns(stubInfo)
 
@@ -203,7 +204,8 @@ internal class StubCommandTest {
                 stubLoaderEngine.loadStubs(
                     listOf(contractPath).map { ContractPathData("", it) },
                     emptyList(),
-                    any()
+                    any(),
+                    false
                 )
             }.returns(stubInfo)
 

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -42,7 +42,7 @@ const val DEFAULT_WORKING_DIRECTORY = ".$APPLICATION_NAME_LOWER_CASE"
 
 const val SPECMATIC_STUB_DICTIONARY = "SPECMATIC_STUB_DICTIONARY"
 
-const val missingConfigurationFileMessage = "config file does not exist. (Could not find file ./specmatic.json OR ./specmatic.yaml OR ./specmatic.yml)"
+const val MISSING_CONFIG_FILE_MESSAGE = "Config file does not exist. (Could not find file ./specmatic.json OR ./specmatic.yaml OR ./specmatic.yml)"
 
 class WorkingDirectory(private val filePath: File) {
     constructor(path: String = DEFAULT_WORKING_DIRECTORY): this(File(path))

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -42,6 +42,8 @@ const val DEFAULT_WORKING_DIRECTORY = ".$APPLICATION_NAME_LOWER_CASE"
 
 const val SPECMATIC_STUB_DICTIONARY = "SPECMATIC_STUB_DICTIONARY"
 
+const val missingConfigurationFileMessage = "config file does not exist. (Could not find file ./specmatic.json OR ./specmatic.yaml OR ./specmatic.yml)"
+
 class WorkingDirectory(private val filePath: File) {
     constructor(path: String = DEFAULT_WORKING_DIRECTORY): this(File(path))
 

--- a/core/src/main/kotlin/io/specmatic/core/utilities/Utilities.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/Utilities.kt
@@ -244,9 +244,11 @@ fun createIfDoesNotExist(workingDirectoryPath: String) {
     }
 }
 
-fun exitIfDoesNotExist(label: String, filePath: String) {
-    if(!File(filePath).exists())
-        exitWithMessage("${label.capitalizeFirstChar()} does not exist. (Could not find file ./specmatic.json OR ./specmatic.yaml OR ./specmatic.yml)")
+fun exitIfInvalidExamplesDirExists(exampleDirPaths: List<String>) {
+    val invalidDataDirs = exampleDirPaths.filter { File(it).exists().not() || File(it).isDirectory.not() }
+    if (invalidDataDirs.isNotEmpty()) {
+        exitWithMessage("The following example directories are invalid: ${invalidDataDirs.joinToString(", ")}. Please provide the valid example directories.")
+    }
 }
 
 fun exitIfAnyDoNotExist(label: String, filePaths: List<String>) {

--- a/core/src/main/kotlin/io/specmatic/core/utilities/Utilities.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/Utilities.kt
@@ -244,10 +244,10 @@ fun createIfDoesNotExist(workingDirectoryPath: String) {
     }
 }
 
-fun exitIfDirectoriesAreInvalid(directoryPathsToVerify: List<String>, natureOfDirectoryPaths: String) {
+fun throwExceptionIfDirectoriesAreInvalid(directoryPathsToVerify: List<String>, natureOfDirectoryPaths: String) {
     val invalidDataDirs = directoryPathsToVerify.filter { File(it).exists().not() || File(it).isDirectory.not() }
     if (invalidDataDirs.isNotEmpty()) {
-        exitWithMessage("The following $natureOfDirectoryPaths are invalid: ${invalidDataDirs.joinToString(", ")}. Please provide the valid $natureOfDirectoryPaths.")
+        throw Exception("The following $natureOfDirectoryPaths are invalid: ${invalidDataDirs.joinToString(", ")}. Please provide the valid $natureOfDirectoryPaths.")
     }
 }
 

--- a/core/src/main/kotlin/io/specmatic/core/utilities/Utilities.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/Utilities.kt
@@ -244,10 +244,10 @@ fun createIfDoesNotExist(workingDirectoryPath: String) {
     }
 }
 
-fun exitIfInvalidExamplesDirExists(exampleDirPaths: List<String>) {
-    val invalidDataDirs = exampleDirPaths.filter { File(it).exists().not() || File(it).isDirectory.not() }
+fun exitIfDirectoriesAreInvalid(directoryPathsToVerify: List<String>, natureOfDirectoryPaths: String) {
+    val invalidDataDirs = directoryPathsToVerify.filter { File(it).exists().not() || File(it).isDirectory.not() }
     if (invalidDataDirs.isNotEmpty()) {
-        exitWithMessage("The following example directories are invalid: ${invalidDataDirs.joinToString(", ")}. Please provide the valid example directories.")
+        exitWithMessage("The following $natureOfDirectoryPaths are invalid: ${invalidDataDirs.joinToString(", ")}. Please provide the valid $natureOfDirectoryPaths.")
     }
 }
 

--- a/core/src/main/kotlin/io/specmatic/stub/api.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/api.kt
@@ -9,7 +9,7 @@ import io.specmatic.core.log.logger
 import io.specmatic.core.utilities.ContractPathData
 import io.specmatic.core.utilities.contractStubPaths
 import io.specmatic.core.utilities.examplesDirFor
-import io.specmatic.core.utilities.exitIfDirectoriesAreInvalid
+import io.specmatic.core.utilities.throwExceptionIfDirectoriesAreInvalid
 import io.specmatic.core.utilities.exitWithMessage
 import io.specmatic.mock.NoMatchingScenario
 import io.specmatic.mock.ScenarioStub
@@ -100,7 +100,7 @@ internal fun createStub(
     if(File(configFileName).exists().not()) exitWithMessage(MISSING_CONFIG_FILE_MESSAGE)
     val contractPathData = contractStubPaths(configFileName)
 
-    if(strict) exitIfDirectoriesAreInvalid(dataDirPaths, "example directories")
+    if(strict) throwExceptionIfDirectoriesAreInvalid(dataDirPaths, "example directories")
 
     val specmaticConfig = loadSpecmaticConfigOrDefault(configFileName)
     val contractInfo = loadContractStubsFromFiles(contractPathData, dataDirPaths, specmaticConfig, strict)
@@ -402,7 +402,7 @@ fun loadContractStubs(
         when (val feature = matchResults.firstNotNullOfOrNull { it.feature }) {
             null -> {
                 val errorMessage = stubMatchErrorMessage(matchResults, stubFile).prependIndent("  ")
-                if(strictMode) exitWithMessage(errorMessage)
+                if(strictMode) throw Exception(errorMessage)
                 else consoleLog(StringLog(errorMessage))
                 null
             }

--- a/core/src/main/kotlin/io/specmatic/stub/api.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/api.kt
@@ -10,6 +10,7 @@ import io.specmatic.core.utilities.ContractPathData
 import io.specmatic.core.utilities.contractStubPaths
 import io.specmatic.core.utilities.examplesDirFor
 import io.specmatic.core.utilities.exitIfDoesNotExist
+import io.specmatic.core.utilities.exitWithMessage
 import io.specmatic.mock.NoMatchingScenario
 import io.specmatic.mock.ScenarioStub
 import org.yaml.snakeyaml.Yaml
@@ -99,6 +100,8 @@ internal fun createStub(
     val configFileName = getConfigFileName()
     exitIfDoesNotExist("config file", configFileName)
     val contractPathData = contractStubPaths(configFileName)
+
+    if(strict) exitIfInvalidExamplesDirExists(dataDirPaths)
 
     val specmaticConfig = loadSpecmaticConfigOrDefault(configFileName)
     val contractInfo = loadContractStubsFromFiles(contractPathData, dataDirPaths, specmaticConfig)
@@ -477,3 +480,9 @@ fun isOpenAPI(path: String): Boolean =
         false
     }
 
+fun exitIfInvalidExamplesDirExists(exampleDirPaths: List<String>) {
+    val invalidDataDirs = exampleDirPaths.filter { File(it).exists().not() || File(it).isDirectory.not() }
+    if (invalidDataDirs.isNotEmpty()) {
+        exitWithMessage("The following example directories are invalid: ${invalidDataDirs.joinToString(", ")}. Please provide the valid example directories.")
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/stub/api.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/api.kt
@@ -9,7 +9,7 @@ import io.specmatic.core.log.logger
 import io.specmatic.core.utilities.ContractPathData
 import io.specmatic.core.utilities.contractStubPaths
 import io.specmatic.core.utilities.examplesDirFor
-import io.specmatic.core.utilities.exitIfDoesNotExist
+import io.specmatic.core.utilities.exitIfInvalidExamplesDirExists
 import io.specmatic.core.utilities.exitWithMessage
 import io.specmatic.mock.NoMatchingScenario
 import io.specmatic.mock.ScenarioStub
@@ -96,9 +96,8 @@ internal fun createStub(
     timeoutMillis: Long,
     strict: Boolean = false
 ): ContractStub {
-    // TODO - see if these two can be extracted out.
     val configFileName = getConfigFileName()
-    exitIfDoesNotExist("config file", configFileName)
+    if(File(configFileName).exists().not()) exitWithMessage(missingConfigurationFileMessage)
     val contractPathData = contractStubPaths(configFileName)
 
     if(strict) exitIfInvalidExamplesDirExists(dataDirPaths)
@@ -122,9 +121,8 @@ internal fun createStub(
 
 internal fun createStub(host: String = "localhost", port: Int = 9000, timeoutMillis: Long, strict: Boolean = false, givenConfigFileName: String? = null): ContractStub {
     val workingDirectory = WorkingDirectory()
-    // TODO - see if these two can be extracted out.
     val configFileName = givenConfigFileName ?: getConfigFileName()
-    exitIfDoesNotExist("config file", configFileName)
+    if(File(configFileName).exists().not()) exitWithMessage(missingConfigurationFileMessage)
 
     val specmaticConfig = loadSpecmaticConfigOrDefault(configFileName)
     val stubs = loadContractStubsFromImplicitPaths(contractStubPaths(configFileName), specmaticConfig)
@@ -494,10 +492,3 @@ fun isOpenAPI(path: String): Boolean =
         logger.log(e, "Could not parse $path")
         false
     }
-
-fun exitIfInvalidExamplesDirExists(exampleDirPaths: List<String>) {
-    val invalidDataDirs = exampleDirPaths.filter { File(it).exists().not() || File(it).isDirectory.not() }
-    if (invalidDataDirs.isNotEmpty()) {
-        exitWithMessage("The following example directories are invalid: ${invalidDataDirs.joinToString(", ")}. Please provide the valid example directories.")
-    }
-}

--- a/core/src/main/kotlin/io/specmatic/stub/api.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/api.kt
@@ -284,6 +284,12 @@ fun loadContractStubsFromFiles(
     consoleLog(StringLog("Loading the following contracts:${System.lineSeparator()}$contactPathsString"))
     consoleLog(StringLog(""))
 
+    val invalidContractPaths = contractPathDataList.filter { File(it.path).exists().not() }.map { it.path }
+    if(invalidContractPaths.isNotEmpty() && strictMode) {
+        val exitMessage = "Error loading the following contracts since they do not exist:${System.lineSeparator()}${invalidContractPaths.joinToString(System.lineSeparator())}"
+        throw Exception(exitMessage)
+    }
+
     val features = contractPathDataList.mapNotNull { contractPathData ->
         loadIfOpenAPISpecification(contractPathData, specmaticConfig)
     }

--- a/core/src/main/kotlin/io/specmatic/stub/api.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/api.kt
@@ -9,7 +9,7 @@ import io.specmatic.core.log.logger
 import io.specmatic.core.utilities.ContractPathData
 import io.specmatic.core.utilities.contractStubPaths
 import io.specmatic.core.utilities.examplesDirFor
-import io.specmatic.core.utilities.exitIfInvalidExamplesDirExists
+import io.specmatic.core.utilities.exitIfDirectoriesAreInvalid
 import io.specmatic.core.utilities.exitWithMessage
 import io.specmatic.mock.NoMatchingScenario
 import io.specmatic.mock.ScenarioStub
@@ -97,10 +97,10 @@ internal fun createStub(
     strict: Boolean = false
 ): ContractStub {
     val configFileName = getConfigFileName()
-    if(File(configFileName).exists().not()) exitWithMessage(missingConfigurationFileMessage)
+    if(File(configFileName).exists().not()) exitWithMessage(MISSING_CONFIG_FILE_MESSAGE)
     val contractPathData = contractStubPaths(configFileName)
 
-    if(strict) exitIfInvalidExamplesDirExists(dataDirPaths)
+    if(strict) exitIfDirectoriesAreInvalid(dataDirPaths, "example directories")
 
     val specmaticConfig = loadSpecmaticConfigOrDefault(configFileName)
     val contractInfo = loadContractStubsFromFiles(contractPathData, dataDirPaths, specmaticConfig, strict)
@@ -122,7 +122,7 @@ internal fun createStub(
 internal fun createStub(host: String = "localhost", port: Int = 9000, timeoutMillis: Long, strict: Boolean = false, givenConfigFileName: String? = null): ContractStub {
     val workingDirectory = WorkingDirectory()
     val configFileName = givenConfigFileName ?: getConfigFileName()
-    if(File(configFileName).exists().not()) exitWithMessage(missingConfigurationFileMessage)
+    if(File(configFileName).exists().not()) exitWithMessage(MISSING_CONFIG_FILE_MESSAGE)
 
     val specmaticConfig = loadSpecmaticConfigOrDefault(configFileName)
     val stubs = loadContractStubsFromImplicitPaths(contractStubPaths(configFileName), specmaticConfig)

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -243,7 +243,7 @@ open class SpecmaticJUnitSupport {
                 }
                 else -> {
                     val configFile = configFile
-                    if(File(configFile).exists().not()) exitWithMessage(missingConfigurationFileMessage)
+                    if(File(configFile).exists().not()) exitWithMessage(MISSING_CONFIG_FILE_MESSAGE)
 
                     createIfDoesNotExist(workingDirectory.path)
 

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -243,8 +243,7 @@ open class SpecmaticJUnitSupport {
                 }
                 else -> {
                     val configFile = configFile
-
-                    exitIfDoesNotExist("config file", configFile)
+                    if(File(configFile).exists().not()) exitWithMessage(missingConfigurationFileMessage)
 
                     createIfDoesNotExist(workingDirectory.path)
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
In strict mode, the stub shouldn't start if the examples directory is invalid in some way.

<!-- Why are these changes necessary? -->

**Why**:
To get early feedback on the invalid examples.

<!-- How were these changes implemented? -->

**How**:
By exiting if -
1. The provided examples directory is invalid.
2. One of the examples in the examples directory is invalid.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->


<!-- feel free to add additional comments -->
