### PR TITLE
Example generations using dictionary in both interactive and command-line modes.

### DIFF
--- a/application/src/main/kotlin/application/ExamplesCommand.kt
+++ b/application/src/main/kotlin/application/ExamplesCommand.kt
@@ -157,7 +157,7 @@ class ExamplesCommand : Callable<Unit> {
                     ExamplesInteractiveServer.validate(feature, examples = externalExamples, scenarioFilter = scenarioFilter)
                 } else emptyMap()
 
-                val hasFailures = inlineExampleValidationResults.isNotEmpty() || externalExampleValidationResults.isNotEmpty()
+                val hasFailures = inlineExampleValidationResults.any { it.value is Result.Failure } || externalExampleValidationResults.any { it.value is Result.Failure }
 
                 if(hasFailures) {
                     println()

--- a/application/src/main/kotlin/application/ExamplesCommand.kt
+++ b/application/src/main/kotlin/application/ExamplesCommand.kt
@@ -3,7 +3,7 @@ package application
 import io.specmatic.core.Result
 import io.specmatic.core.Results
 import io.specmatic.core.examples.server.ExamplesInteractiveServer
-import io.specmatic.core.examples.server.ExamplesInteractiveServer.Companion.validate2
+import io.specmatic.core.examples.server.ExamplesInteractiveServer.Companion.validate
 import io.specmatic.core.log.*
 import io.specmatic.core.parseContractFileToFeature
 import io.specmatic.core.pattern.ContractException
@@ -111,7 +111,7 @@ class ExamplesCommand : Callable<Unit> {
 
             if (exampleFile != null) {
                 try {
-                    Result.fromResults(validate2(contractFile, exampleFile).values.filterIsInstance<Result.Failure>()).throwOnFailure()
+                    Result.fromResults(validate(contractFile, exampleFile).values.filterIsInstance<Result.Failure>()).throwOnFailure()
 
                     logger.log("The provided example ${exampleFile.name} is valid.")
                 } catch (e: ContractException) {
@@ -137,7 +137,7 @@ class ExamplesCommand : Callable<Unit> {
                         }
                     }
 
-                    ExamplesInteractiveServer.validate2(feature, examples = inlineExamples, scenarioFilter = scenarioFilter)
+                    ExamplesInteractiveServer.validate(feature, examples = inlineExamples, scenarioFilter = scenarioFilter)
                 } else emptyMap()
 
                 val externalExampleValidationResults = if(validateExternal) {
@@ -157,7 +157,7 @@ class ExamplesCommand : Callable<Unit> {
                         listOf(ScenarioStub.readFromFile(it.value))
                     }
 
-                    ExamplesInteractiveServer.validate2(feature, examples = externalExamples, scenarioFilter = scenarioFilter)
+                    ExamplesInteractiveServer.validate(feature, examples = externalExamples, scenarioFilter = scenarioFilter)
                 } else emptyMap()
 
                 val hasFailures = inlineExampleValidationResults.isNotEmpty() || externalExampleValidationResults.isNotEmpty()

--- a/application/src/main/kotlin/application/ExamplesCommand.kt
+++ b/application/src/main/kotlin/application/ExamplesCommand.kt
@@ -177,7 +177,7 @@ class ExamplesCommand : Callable<Unit> {
 
             validationResults.forEach { (exampleFileName, result) ->
                 if (!result.isSuccess()) {
-                    logger.log(System.lineSeparator() + "$tag $exampleFileName has following validation error(s):")
+                    logger.log(System.lineSeparator() + "$tag $exampleFileName has the following validation error(s):")
                     logger.log(result.reportString())
                 }
             }
@@ -185,7 +185,7 @@ class ExamplesCommand : Callable<Unit> {
             println()
             logger.log("=============== Validation Summary ===============")
             logger.log(Results(validationResults.values.toList()).summary())
-            logger.log("==================================================")
+            logger.log("""==================================================""")
         }
     }
 

--- a/application/src/main/kotlin/application/ExamplesCommand.kt
+++ b/application/src/main/kotlin/application/ExamplesCommand.kt
@@ -19,7 +19,6 @@ import picocli.CommandLine.*
 import java.io.File
 import java.lang.Thread.sleep
 import java.util.concurrent.Callable
-import kotlin.system.exitProcess
 
 @Command(
     name = "examples",
@@ -27,7 +26,7 @@ import kotlin.system.exitProcess
     description = ["Generate externalised JSON example files with API requests and responses"],
     subcommands = [ExamplesCommand.Validate::class, ExamplesCommand.Interactive::class]
 )
-class ExamplesCommand : Callable<Unit> {
+class ExamplesCommand : Callable<Int> {
     @Option(
         names = ["--filter-name"],
         description = ["Use only APIs with this value in their name"],
@@ -58,13 +57,15 @@ class ExamplesCommand : Callable<Unit> {
     @Option(names = ["--dictionary"], description = ["External Dictionary File Path, defaults to dictionary.json"])
     var dictFile: File? = null
 
-    override fun call() {
+    override fun call(): Int {
         if (contractFile == null) {
             println("No contract file provided. Use a subcommand or provide a contract file. Use --help for more details.")
-            return
+            return 1
         }
-        if (!contractFile!!.exists())
-            exitWithMessage("Could not find file ${contractFile!!.path}")
+        if (!contractFile!!.exists()) {
+            logger.log("Could not find file ${contractFile!!.path}")
+            return 1
+        }
 
         configureLogger(this.verbose)
 
@@ -81,8 +82,10 @@ class ExamplesCommand : Callable<Unit> {
             )
         } catch (e: Throwable) {
             logger.log(e)
-            exitProcess(1)
+            return 1
         }
+
+        return 0
     }
 
     @Command(
@@ -115,8 +118,10 @@ class ExamplesCommand : Callable<Unit> {
         var filterNotName: String = ""
 
         override fun call(): Int {
-            if (!contractFile.exists())
-                exitWithMessage("Could not find file ${contractFile.path}")
+            if (!contractFile.exists()) {
+                logger.log("Could not find file ${contractFile.path}")
+                return 1
+            }
 
             configureLogger(this.verbose)
 

--- a/application/src/main/kotlin/application/ExamplesCommand.kt
+++ b/application/src/main/kotlin/application/ExamplesCommand.kt
@@ -166,31 +166,29 @@ class ExamplesCommand : Callable<Unit> {
                     println()
                     logger.log("=============== Validation Results ===============")
 
-                    if(inlineExampleValidationResults.isNotEmpty()) {
-                        printValidationResult(inlineExampleValidationResults)
-                    }
-
-                    if(externalExampleValidationResults.isNotEmpty()) {
-                        printValidationResult(externalExampleValidationResults)
-                    }
+                    printValidationResult(inlineExampleValidationResults, "Inline example")
+                    printValidationResult(externalExampleValidationResults, "Example file")
 
                     exitProcess(1)
                 }
             }
         }
 
-        private fun printValidationResult(inlineExampleValidationResults: Map<String, Result>) {
-            inlineExampleValidationResults.forEach { (exampleFileName, result) ->
+        private fun printValidationResult(validationResults: Map<String, Result>, tag: String) {
+            if(validationResults.isEmpty())
+                return
+
+            validationResults.forEach { (exampleFileName, result) ->
                 if (!result.isSuccess()) {
-                    logger.log(System.lineSeparator() + "Example File $exampleFileName has following validation error(s):")
+                    logger.log(System.lineSeparator() + "$tag $exampleFileName has following validation error(s):")
                     logger.log(result.reportString())
                 }
             }
 
             println()
             logger.log("=============== Validation Summary ===============")
-            logger.log(Results(inlineExampleValidationResults.values.toList()).summary())
-            logger.log("=======================================")
+            logger.log(Results(validationResults.values.toList()).summary())
+            logger.log("==================================================")
         }
     }
 

--- a/application/src/main/kotlin/application/ExamplesCommand.kt
+++ b/application/src/main/kotlin/application/ExamplesCommand.kt
@@ -80,7 +80,7 @@ class ExamplesCommand : Callable<Unit> {
         mixinStandardHelpOptions = true,
         description = ["Validate the examples"]
     )
-    class Validate : Callable<Unit> {
+    class Validate : Callable<Int> {
         @Option(names = ["--contract-file"], description = ["Contract file path"], required = true)
         lateinit var contractFile: File
 
@@ -104,7 +104,7 @@ class ExamplesCommand : Callable<Unit> {
         )
         var filterNotName: String = ""
 
-        override fun call() {
+        override fun call(): Int {
             if (!contractFile.exists())
                 exitWithMessage("Could not find file ${contractFile.path}")
 
@@ -118,7 +118,7 @@ class ExamplesCommand : Callable<Unit> {
                 } catch (e: ContractException) {
                     logger.log("The provided example ${exampleFile.name} is invalid. Reason:\n")
                     logger.log(exceptionCauseMessage(e))
-                    exitProcess(1)
+                    return 1
                 }
             } else {
                 val scenarioFilter = ExamplesInteractiveServer.ScenarioFilter(filterName, filterNotName)
@@ -146,12 +146,12 @@ class ExamplesCommand : Callable<Unit> {
 
                     if(!externalExampleDir.exists()) {
                         logger.log("$externalExampleDir does not exist, did not find any files to validate")
-                        exitProcess(1)
+                        return 1
                     }
 
                     if(externalExamples.none()) {
                         logger.log("No example files found in $externalExampleDir")
-                        exitProcess(1)
+                        return 1
                     }
 
                     ExamplesInteractiveServer.validate(feature, examples = externalExamples, scenarioFilter = scenarioFilter)
@@ -166,9 +166,11 @@ class ExamplesCommand : Callable<Unit> {
                     printValidationResult(inlineExampleValidationResults, "Inline example")
                     printValidationResult(externalExampleValidationResults, "Example file")
 
-                    exitProcess(1)
+                    return 1
                 }
             }
+
+            return 0
         }
 
         private fun printValidationResult(validationResults: Map<String, Result>, tag: String) {

--- a/application/src/main/kotlin/application/ExamplesCommand.kt
+++ b/application/src/main/kotlin/application/ExamplesCommand.kt
@@ -138,7 +138,7 @@ class ExamplesCommand : Callable<Unit> {
                         }
                     }
 
-                    ExamplesInteractiveServer.validate(feature, examples = inlineExamples, scenarioFilter = scenarioFilter)
+                    ExamplesInteractiveServer.validate(feature, examples = inlineExamples, inline = true, scenarioFilter = scenarioFilter)
                 } else emptyMap()
 
                 val externalExampleValidationResults = if(validateExternal) {

--- a/application/src/test/kotlin/application/ExamplesCommandTest.kt
+++ b/application/src/test/kotlin/application/ExamplesCommandTest.kt
@@ -1,0 +1,86 @@
+package application
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class ExamplesCommandTest {
+    @Test
+    fun `examples validate command should not write an empty error`(@TempDir tempDir: File) {
+        val specFile = tempDir.resolve("spec.yaml")
+        val examplesDir = tempDir.resolve("spec_examples")
+
+        specFile.createNewFile()
+        val spec = """
+openapi: 3.0.0
+info:
+  title: Product API
+  version: 1.0.0
+paths:
+  /product/{id}:
+    get:
+      summary: Get product details
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Product details
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  name:
+                    type: string
+                  price:
+                    type: number
+                    format: float
+        """.trimIndent()
+        specFile.writeText(spec)
+
+        examplesDir.mkdirs()
+        val example = """
+{
+  "http-request": {
+    "method": "GET",
+    "path": "/products/1"
+  },
+  "http-response": {
+    "status": 200,
+    "body": {
+      "id": 1,
+      "name": "Laptop",
+      "price": 1000.99
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}
+        """.trimIndent()
+
+        val exampleFile = examplesDir.resolve("example.json")
+        exampleFile.writeText(example)
+
+        val command = ExamplesCommand.Validate().also {
+            it.contractFile = specFile
+        }
+
+        val (output, returnValue: Int) = captureStandardOutput {
+            command.call()
+        }
+
+        println(output)
+
+        assertThat(returnValue).isNotEqualTo(0)
+        assertThat(output).contains("No matching REST stub or contract found")
+    }
+}

--- a/application/src/test/kotlin/application/ExamplesCommandTest.kt
+++ b/application/src/test/kotlin/application/ExamplesCommandTest.kt
@@ -1,14 +1,13 @@
 package application
 
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
 
 class ExamplesCommandTest {
     @Test
-    fun `examples validate command should not write an empty error`(@TempDir tempDir: File) {
+    fun `examples validate command should not print an empty error when it sees an inline example for a filtered-out scenario`(@TempDir tempDir: File) {
         val specFile = tempDir.resolve("spec.yaml")
         val examplesDir = tempDir.resolve("spec_examples")
 
@@ -82,5 +81,320 @@ paths:
 
         assertThat(returnValue).isNotEqualTo(0)
         assertThat(output).contains("No matching REST stub or contract found")
+    }
+
+    @Test
+    fun `should display an error message for an invalid example`(@TempDir tempDir: File) {
+        val specFile = tempDir.resolve("spec.yaml")
+        val examplesDir = tempDir.resolve("spec_examples")
+
+        specFile.createNewFile()
+        val spec = """
+openapi: 3.0.0
+info:
+  title: Product API
+  version: 1.0.0
+paths:
+  /product/{id}:
+    get:
+      summary: Get product details
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Product details
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  name:
+                    type: string
+                  price:
+                    type: number
+                    format: float
+        """.trimIndent()
+        specFile.writeText(spec)
+
+        examplesDir.mkdirs()
+        val example = """
+{
+  "http-request": {
+    "method": "GET",
+    "path": "/product/abc123"
+  },
+  "http-response": {
+    "status": 200,
+    "body": {
+      "id": 1,
+      "name": "Laptop",
+      "price": 1000.99
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}
+        """.trimIndent()
+
+        val exampleFile = examplesDir.resolve("example.json")
+        exampleFile.writeText(example)
+
+        val command = ExamplesCommand.Validate().also {
+            it.contractFile = specFile
+        }
+
+        val (output, returnValue: Int) = captureStandardOutput {
+            command.call()
+        }
+
+        println(output)
+
+        assertThat(returnValue).isNotEqualTo(0)
+        assertThat(output).contains("""expected number but example contained""")
+    }
+
+    @Test
+    fun `should display a success message when all examples are valid`(@TempDir tempDir: File) {
+        val specFile = tempDir.resolve("spec.yaml")
+        val examplesDir = tempDir.resolve("spec_examples")
+
+        specFile.createNewFile()
+        val spec = """
+openapi: 3.0.0
+info:
+  title: Product API
+  version: 1.0.0
+paths:
+  /product/{id}:
+    get:
+      summary: Get product details
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Product details
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  name:
+                    type: string
+                  price:
+                    type: number
+                    format: float
+        """.trimIndent()
+        specFile.writeText(spec)
+
+        examplesDir.mkdirs()
+        val example = """
+{
+  "http-request": {
+    "method": "GET",
+    "path": "/product/1"
+  },
+  "http-response": {
+    "status": 200,
+    "body": {
+      "id": 1,
+      "name": "Laptop",
+      "price": 1000.99
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}
+        """.trimIndent()
+
+        val exampleFile = examplesDir.resolve("example.json")
+        exampleFile.writeText(example)
+
+        val command = ExamplesCommand.Validate().also {
+            it.contractFile = specFile
+        }
+
+        val (output, returnValue: Int) = captureStandardOutput {
+            command.call()
+        }
+
+        println(output)
+
+        assertThat(returnValue).isEqualTo(0)
+        assertThat(output.lines().last()).matches("Validating.*example.json")
+    }
+
+    @Test
+    fun `should generate an example if missing`(@TempDir tempDir: File) {
+        val specFile = tempDir.resolve("spec.yaml")
+        val examplesDir = tempDir.resolve("spec_examples")
+
+        specFile.createNewFile()
+        val spec = """
+openapi: 3.0.0
+info:
+  title: Product API
+  version: 1.0.0
+paths:
+  /product/{id}:
+    get:
+      summary: Get product details
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Product details
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  name:
+                    type: string
+                  price:
+                    type: number
+                    format: float
+        """.trimIndent()
+        specFile.writeText(spec)
+
+        examplesDir.deleteRecursively()
+        examplesDir.mkdirs()
+
+        ExamplesCommand().also {
+            it.contractFile = specFile
+        }.call()
+
+        val examplesCreated = examplesDir.walk().filter { it.isFile }.toList()
+
+        assertThat(examplesCreated).hasSize(1)
+        assertThat(examplesCreated.single().name).matches("product_[0-9]*_GET_200.json")
+
+    }
+
+    @Test
+    fun `should generate only the missing examples and leave the existing examples as is`(@TempDir tempDir: File) {
+        val specFile = tempDir.resolve("spec.yaml")
+        val examplesDir = tempDir.resolve("spec_examples")
+
+        specFile.createNewFile()
+        val spec = """
+openapi: 3.0.0
+info:
+  title: Product API
+  version: 1.0.0
+paths:
+  /product:
+    get:
+      summary: Get product details
+      responses:
+        '200':
+          description: Product details
+          content:
+            application/json:
+              schema:
+                schema:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                      name:
+                        type: string
+                      price:
+                        type: number
+                        format: float
+  /product/{id}:
+    get:
+      summary: Get product details
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Product details
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  name:
+                    type: string
+                  price:
+                    type: number
+                    format: float
+        """.trimIndent()
+        specFile.writeText(spec)
+
+        examplesDir.deleteRecursively()
+        examplesDir.mkdirs()
+
+        examplesDir.mkdirs()
+        val example = """
+{
+  "http-request": {
+    "method": "GET",
+    "path": "/product/1"
+  },
+  "http-response": {
+    "status": 200,
+    "body": {
+      "id": 1,
+      "name": "Laptop",
+      "price": 1000.99
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}
+        """.trimIndent()
+
+        val exampleFile = examplesDir.resolve("example.json")
+        exampleFile.writeText(example)
+
+        ExamplesCommand().also {
+            it.contractFile = specFile
+        }.call()
+
+        val examplesCreated = examplesDir.walk().filter { it.isFile }.toList()
+
+        assertThat(examplesCreated).hasSize(2)
+        println(examplesCreated.map { it.name })
+        assertThat(examplesCreated.filter { it.name == "example.json" }).hasSize(1)
+        assertThat(examplesCreated.filter { it.name == "product_GET_200.json" }).hasSize(1)
+
+        assertThat(examplesCreated.find { it.name == "example.json" }?.readText() ?: "")
+            .contains(""""name": "Laptop"""")
+            .contains(""""price": 1000.99""")
+
+        val generatedExample = examplesCreated.first { it.name == "product_GET_200.json" }
+        assertThat(generatedExample.readText()).contains(""""path": "/product"""")
+
+
     }
 }

--- a/application/src/test/kotlin/application/ExamplesCommandTest.kt
+++ b/application/src/test/kotlin/application/ExamplesCommandTest.kt
@@ -161,7 +161,7 @@ paths:
     }
 
     @Test
-    fun `should display a success message when all examples are valid`(@TempDir tempDir: File) {
+    fun `should not display an error message when all examples are valid`(@TempDir tempDir: File) {
         val specFile = tempDir.resolve("spec.yaml")
         val examplesDir = tempDir.resolve("spec_examples")
 
@@ -394,7 +394,5 @@ paths:
 
         val generatedExample = examplesCreated.first { it.name == "product_GET_200.json" }
         assertThat(generatedExample.readText()).contains(""""path": "/product"""")
-
-
     }
 }

--- a/application/src/test/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServerTest.kt
+++ b/application/src/test/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServerTest.kt
@@ -1,0 +1,151 @@
+package io.specmatic.core.examples.server
+
+import io.specmatic.conversions.ExampleFromFile
+import io.specmatic.core.Dictionary
+import io.specmatic.core.pattern.parsedJSONObject
+import io.specmatic.core.value.JSONArrayValue
+import io.specmatic.core.value.JSONObjectValue
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class ExamplesInteractiveServerTest {
+    companion object {
+        private val externalDictionary = Dictionary(
+            parsedJSONObject("""
+                {
+                    "Authentication": "Bearer 123",
+                    "name": "John Doe",
+                    "address": "123 Main Street",
+                    "[0].name": "John Doe",
+                    "[0].address": "123 Main Street",
+                    "[*].name": "Jane Doe",
+                    "[*].address": "456 Main Street"
+                }
+                """.trimIndent()).jsonObject
+        )
+        private val partialDictionary = Dictionary(
+            parsedJSONObject("""
+                {
+                    "name": "John Doe",
+                    "address": "123 Main Street"
+                }
+                """.trimIndent()).jsonObject
+        )
+
+        @JvmStatic
+        @AfterAll
+        fun cleanUp() {
+            val examplesFolder = File("src/test/resources/specifications/tracker_examples")
+            if (examplesFolder.exists()) examplesFolder.delete()
+        }
+    }
+
+    @Test
+    fun `should generate all random values when no dictionary is provided`() {
+        val examples = ExamplesInteractiveServer.generate(
+            contractFile = File("src/test/resources/specifications/tracker.yaml"),
+            scenarioFilter = ExamplesInteractiveServer.ScenarioFilter("", ""), extensive = false,
+            externalDictionary = Dictionary()
+        ).map { File(it) }
+
+        try {
+            examples.forEach {
+                val example = ExampleFromFile(it)
+
+                val request = example.request
+                val requestBody = request.body as JSONObjectValue
+                assertThat(request.headers).containsKeys("Authentication")
+                assertThat(requestBody.findFirstChildByPath("name")?.toStringLiteral()).isNotNull()
+                assertThat(requestBody.findFirstChildByPath("address")?.toStringLiteral()).isNotNull()
+
+                val response = example.response
+                val responseBody = (response.body as JSONArrayValue).list
+                responseBody.forEach { value ->
+                    value as JSONObjectValue
+                    assertThat(value.findFirstChildByPath("name")?.toStringLiteral()).isNotNull()
+                    assertThat(value.findFirstChildByPath("address")?.toStringLiteral()).isNotNull()
+                }
+            }
+        } finally {
+            examples.forEach { it.delete() }
+        }
+    }
+
+    @Test
+    fun `should use values from dictionary when provided`() {
+        val examples = ExamplesInteractiveServer.generate(
+            contractFile = File("src/test/resources/specifications/tracker.yaml"),
+            scenarioFilter = ExamplesInteractiveServer.ScenarioFilter("", ""), extensive = false,
+            externalDictionary = externalDictionary
+        ).map { File(it) }
+
+        try {
+            examples.forEach {
+                val example = ExampleFromFile(it)
+
+                val request = example.request
+                val requestBody = request.body as JSONObjectValue
+
+                assertThat(request.headers).containsKeys("Authentication")
+                assertThat(request.headers.getValue("Authentication")).isEqualTo("Bearer 123")
+                assertThat(requestBody.findFirstChildByPath("name")?.toStringLiteral()).isEqualTo("John Doe")
+                assertThat(requestBody.findFirstChildByPath("address")?.toStringLiteral()).isEqualTo("123 Main Street")
+
+                val response = example.response
+                val responseBody = (response.body as JSONArrayValue).list
+                responseBody.forEachIndexed { index, value ->
+                    value as JSONObjectValue
+                    val (name, address) = when (index) {
+                        0 -> "John Doe" to "123 Main Street"
+                        else -> "Jane Doe" to "456 Main Street"
+                    }
+
+                    assertThat(value.findFirstChildByPath("name")?.toStringLiteral()).isEqualTo(name)
+                    assertThat(value.findFirstChildByPath("address")?.toStringLiteral()).isEqualTo(address)
+                }
+            }
+        } finally {
+            examples.forEach { it.delete() }
+        }
+    }
+
+    @Test
+    fun `should only replace values if key is in dictionary`() {
+        val examples = ExamplesInteractiveServer.generate(
+            contractFile = File("src/test/resources/specifications/tracker.yaml"),
+            scenarioFilter = ExamplesInteractiveServer.ScenarioFilter("", ""), extensive = false,
+            externalDictionary = partialDictionary
+        ).map { File(it) }
+
+        try {
+            examples.forEach {
+                val example = ExampleFromFile(it)
+
+                val request = example.request
+                val requestBody = request.body as JSONObjectValue
+
+                assertThat(request.headers).containsKeys("Authentication")
+                assertThat(request.headers.getValue("Authentication")).isNotEqualTo("Bearer 123")
+                assertThat(requestBody.findFirstChildByPath("name")?.toStringLiteral()).isEqualTo("John Doe")
+                assertThat(requestBody.findFirstChildByPath("address")?.toStringLiteral()).isEqualTo("123 Main Street")
+
+                val response = example.response
+                val responseBody = (response.body as JSONArrayValue).list
+                responseBody.forEachIndexed { index, value ->
+                    value as JSONObjectValue
+                    val (name, address) = when (index) {
+                        0 -> "John Doe" to "123 Main Street"
+                        else -> "Jane Doe" to "456 Main Street"
+                    }
+
+                    assertThat(value.findFirstChildByPath("name")?.toStringLiteral()).isNotEqualTo(name)
+                    assertThat(value.findFirstChildByPath("address")?.toStringLiteral()).isNotEqualTo(address)
+                }
+            }
+        } finally {
+            examples.forEach { it.delete() }
+        }
+    }
+}

--- a/application/src/test/resources/specifications/tracker.yaml
+++ b/application/src/test/resources/specifications/tracker.yaml
@@ -1,0 +1,57 @@
+openapi: 3.0.3
+info:
+  title: Generate API
+  description: API for generating a response with name, address, and tracker ID.
+  version: 1.0.0
+paths:
+  /generate:
+    post:
+      summary: Generate a response with name, address, and tracker ID
+      description: Accepts a JSON object with `name` and `address` and returns an object with `name`, `trackerId`, and `address`.\
+      security:
+        - apiKey: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  example: "John Doe"
+                address:
+                  type: string
+                  example: "123 Main St, Anytown, USA"
+              required:
+                - name
+                - address
+      responses:
+        '200':
+          description: Successful response with name, tracker ID, and address
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                      example: "John Doe"
+                    trackerId:
+                      type: integer
+                      example: 123456
+                    address:
+                      type: string
+                      example: "123 Main St, Anytown, USA"
+                  required:
+                    - name
+                    - trackerId
+                    - address
+components:
+  securitySchemes:
+    apiKey:
+      type: apiKey
+      in: header
+      name: Authentication

--- a/core/src/main/kotlin/io/specmatic/core/Dictionary.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Dictionary.kt
@@ -1,0 +1,78 @@
+package io.specmatic.core
+
+import io.specmatic.core.value.JSONArrayValue
+import io.specmatic.core.value.JSONObjectValue
+import io.specmatic.core.value.StringValue
+import io.specmatic.core.value.Value
+
+class Dictionary(val map: Map<String, Value> = emptyMap()) {
+    private fun substituteDictionaryValues(value: JSONArrayValue, paths: List<String> = emptyList(), forceSubstitution: Boolean = false): Value {
+        val newList = value.list.mapIndexed { index, valueInArray ->
+            val indexesToAdd = listOf("[$index]", "[*]")
+
+            val updatedPaths = paths.flatMap { path ->
+                indexesToAdd.map { indexToAdd ->
+                    path + indexToAdd
+                }
+            }.ifEmpty {
+                indexesToAdd
+            }
+
+            substituteDictionaryValues(valueInArray, updatedPaths, forceSubstitution)
+        }
+
+        return value.copy(list = newList)
+    }
+
+    private fun substituteDictionaryValues(value: JSONObjectValue, paths: List<String> = emptyList(), forceSubstitution: Boolean = false): Value {
+        val newMap = value.jsonObject.mapValues { (key, value) ->
+
+            val updatedPaths = paths.map { path ->
+                path + ".$key"
+            }.ifEmpty { listOf(key) }
+
+            val pathFoundInDictionary = updatedPaths.firstOrNull { it in map }
+            if(value is StringValue && (isVanillaPatternToken(value.string) || forceSubstitution) && pathFoundInDictionary != null) {
+                map.getValue(pathFoundInDictionary)
+            } else {
+                substituteDictionaryValues(value, updatedPaths, forceSubstitution)
+            }
+        }
+
+        return value.copy(jsonObject = newMap)
+    }
+
+    private fun substituteDictionaryValues(value: Value, paths: List<String> = emptyList(), forceSubstitution: Boolean = false): Value {
+        return when (value) {
+            is JSONObjectValue -> {
+                substituteDictionaryValues(value, paths, forceSubstitution)
+            }
+            is JSONArrayValue -> {
+                substituteDictionaryValues(value, paths, forceSubstitution)
+            }
+            else -> value
+        }
+    }
+
+    fun substituteDictionaryValues(httpResponse: HttpResponse, forceSubstitution: Boolean = false): HttpResponse {
+        val updatedHeaders = httpResponse.headers.mapValues { (headerName, headerValue) ->
+            if((isVanillaPatternToken(headerValue) || forceSubstitution) && headerName in map) {
+                map.getValue(headerName).toStringLiteral()
+            } else headerValue
+        }
+        val updatedBody = substituteDictionaryValues(httpResponse.body, forceSubstitution = forceSubstitution)
+
+        return httpResponse.copy(headers = updatedHeaders, body= updatedBody)
+    }
+
+    fun substituteDictionaryValues(httpRequest: HttpRequest, forceSubstitution: Boolean = false): HttpRequest {
+        val updatedHeaders = httpRequest.headers.mapValues { (headerName, headerValue) ->
+            if((isVanillaPatternToken(headerValue) || forceSubstitution) && headerName in map) {
+                map.getValue(headerName).toStringLiteral()
+            } else headerValue
+        }
+        val updatedBody = substituteDictionaryValues(httpRequest.body, forceSubstitution = forceSubstitution)
+
+        return httpRequest.copy(headers = updatedHeaders, body= updatedBody)
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -472,14 +472,14 @@ data class Feature(
     ): HttpStubData {
         val dictionary = specmaticConfig.stub.dictionary?.let { loadDictionary(it) } ?: emptyMap()
 
-        val scenarioStub = scenarioStub.copy(dictionary = dictionary)
+        val scenarioStubWithDictionary = scenarioStub.copy(dictionary = dictionary)
 
         if(scenarios.isEmpty())
             throw ContractException("No scenarios found in feature $name ($path)")
 
-        return if(scenarioStub.partial != null) {
+        return if(scenarioStubWithDictionary.partial != null) {
             val results = scenarios.asSequence().map { scenario ->
-                scenario.matchesTemplate(scenarioStub.partial) to scenario
+                scenario.matchesPartial(scenarioStubWithDictionary.partial) to scenario
             }
 
             val matchingScenario = results.filter { it.first is Result.Success }.map { it.second }.firstOrNull()
@@ -505,30 +505,30 @@ data class Feature(
                     matchingScenario.resolver,
                     responsePattern = responseTypeWithAncestors,
                     scenario = matchingScenario,
-                    partial = scenarioStub.partial.copy(response = scenarioStub.partial.response.substituteDictionaryValues(scenarioStub.dictionary)),
-                    data = scenarioStub.data,
-                    dictionary = scenarioStub.dictionary,
-                    examplePath = scenarioStub.filePath
+                    partial = scenarioStubWithDictionary.partial.copy(response = scenarioStubWithDictionary.partial.response.substituteDictionaryValues(scenarioStubWithDictionary.dictionary)),
+                    data = scenarioStubWithDictionary.data,
+                    dictionary = scenarioStubWithDictionary.dictionary,
+                    examplePath = scenarioStubWithDictionary.filePath
                 )
             }
             else {
                 val failures = Results(results.map { it.first }.filterIsInstance<Result.Failure>().toList()).withoutFluff()
 
-                throw NoMatchingScenario(failures, msg = "Could not load partial example ${scenarioStub.filePath}")
+                throw NoMatchingScenario(failures, msg = "Could not load partial example ${scenarioStubWithDictionary.filePath}")
             }
         } else {
             matchingStub(
-                scenarioStub.request,
-                scenarioStub.response,
+                scenarioStubWithDictionary.request,
+                scenarioStubWithDictionary.response,
                 mismatchMessages,
-                scenarioStub.dictionary
+                scenarioStubWithDictionary.dictionary
             ).copy(
-                delayInMilliseconds = scenarioStub.delayInMilliseconds,
-                requestBodyRegex = scenarioStub.requestBodyRegex?.let { Regex(it) },
-                stubToken = scenarioStub.stubToken,
-                data = scenarioStub.data,
-                dictionary = scenarioStub.dictionary,
-                examplePath = scenarioStub.filePath
+                delayInMilliseconds = scenarioStubWithDictionary.delayInMilliseconds,
+                requestBodyRegex = scenarioStubWithDictionary.requestBodyRegex?.let { Regex(it) },
+                stubToken = scenarioStubWithDictionary.stubToken,
+                data = scenarioStubWithDictionary.data,
+                dictionary = scenarioStubWithDictionary.dictionary,
+                examplePath = scenarioStubWithDictionary.filePath
             )
         }
     }

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -297,7 +297,7 @@ data class Feature(
         dictionary: Dictionary = Dictionary()
     ): HttpStubData {
         try {
-            val results = stubMatchResult(request, dictionary.substituteDictionaryValues(response), mismatchMessages)
+            val results = stubMatchResult(request, response.substituteDictionaryValues(dictionary), mismatchMessages)
 
             return results.find {
                 it.first != null
@@ -506,7 +506,7 @@ data class Feature(
                     matchingScenario.resolver,
                     responsePattern = responseTypeWithAncestors,
                     scenario = matchingScenario,
-                    partial = scenarioStub.partial.copy(response = dictionary.substituteDictionaryValues(scenarioStub.partial.response)),
+                    partial = scenarioStub.partial.copy(response = scenarioStub.partial.response.substituteDictionaryValues(dictionary)),
                     data = scenarioStub.data,
                     dictionary = scenarioStub.dictionary,
                     examplePath = scenarioStub.filePath

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -294,10 +294,10 @@ data class Feature(
         request: HttpRequest,
         response: HttpResponse,
         mismatchMessages: MismatchMessages = DefaultMismatchMessages,
-        dictionary: Map<String, Value> = emptyMap()
+        dictionary: Dictionary = Dictionary()
     ): HttpStubData {
         try {
-            val results = stubMatchResult(request, response.substituteDictionaryValues(dictionary), mismatchMessages)
+            val results = stubMatchResult(request, dictionary.substituteDictionaryValues(response), mismatchMessages)
 
             return results.find {
                 it.first != null
@@ -470,7 +470,8 @@ data class Feature(
         scenarioStub: ScenarioStub,
         mismatchMessages: MismatchMessages = DefaultMismatchMessages
     ): HttpStubData {
-        val dictionary = specmaticConfig.stub.dictionary?.let { loadDictionary(it) } ?: emptyMap()
+        val dictionaryMap = specmaticConfig.stub.dictionary?.let { loadDictionary(it) } ?: emptyMap()
+        val dictionary = Dictionary(dictionaryMap)
 
         val scenarioStub = scenarioStub.copy(dictionary = dictionary)
 
@@ -505,7 +506,7 @@ data class Feature(
                     matchingScenario.resolver,
                     responsePattern = responseTypeWithAncestors,
                     scenario = matchingScenario,
-                    partial = scenarioStub.partial.copy(response = scenarioStub.partial.response.substituteDictionaryValues(scenarioStub.dictionary)),
+                    partial = scenarioStub.partial.copy(response = dictionary.substituteDictionaryValues(scenarioStub.partial.response)),
                     data = scenarioStub.data,
                     dictionary = scenarioStub.dictionary,
                     examplePath = scenarioStub.filePath

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
@@ -363,21 +363,6 @@ data class HttpRequest(
     }
 
     fun withoutDynamicHeaders(): HttpRequest = copy(headers = headers.withoutDynamicHeaders())
-
-    /**
-     * @param forceSubstitution Forces substitution even in case of a concrete values (eg: "BYFJA").
-     */
-    fun substituteDictionaryValues(dictionary: Map<String, Value>, forceSubstitution: Boolean = false): HttpRequest {
-        val updatedHeaders = headers.mapValues { (headerName, headerValue) ->
-            if((isVanillaPatternToken(headerValue) || forceSubstitution) && headerName in dictionary) {
-                dictionary.getValue(headerName).toStringLiteral()
-            } else headerValue
-        }
-
-        val updatedBody = substituteDictionaryValues(body, dictionary, forceSubstitution = forceSubstitution)
-
-        return this.copy(headers = updatedHeaders, body= updatedBody)
-    }
 }
 
 private fun setIfNotEmpty(dest: MutableMap<String, Value>, key: String, data: Map<String, String>) {

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
@@ -363,6 +363,13 @@ data class HttpRequest(
     }
 
     fun withoutDynamicHeaders(): HttpRequest = copy(headers = headers.withoutDynamicHeaders())
+
+    fun substituteDictionaryValues(dictionary: Dictionary, forceSubstitution: Boolean = false): HttpRequest {
+        val updatedHeaders = dictionary.substituteDictionaryValues(this.headers, forceSubstitution = forceSubstitution)
+        val updatedBody = dictionary.substituteDictionaryValues(this.body, forceSubstitution = forceSubstitution)
+
+        return this.copy(headers = updatedHeaders, body= updatedBody)
+    }
 }
 
 private fun setIfNotEmpty(dest: MutableMap<String, Value>, key: String, data: Map<String, String>) {

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
@@ -363,6 +363,21 @@ data class HttpRequest(
     }
 
     fun withoutDynamicHeaders(): HttpRequest = copy(headers = headers.withoutDynamicHeaders())
+
+    /**
+     * @param forceSubstitution Forces substitution even in case of a concrete values (eg: "BYFJA").
+     */
+    fun substituteDictionaryValues(dictionary: Map<String, Value>, forceSubstitution: Boolean = false): HttpRequest {
+        val updatedHeaders = headers.mapValues { (headerName, headerValue) ->
+            if((isVanillaPatternToken(headerValue) || forceSubstitution) && headerName in dictionary) {
+                dictionary.getValue(headerName).toStringLiteral()
+            } else headerValue
+        }
+
+        val updatedBody = substituteDictionaryValues(body, dictionary, forceSubstitution = forceSubstitution)
+
+        return this.copy(headers = updatedHeaders, body= updatedBody)
+    }
 }
 
 private fun setIfNotEmpty(dest: MutableMap<String, Value>, key: String, data: Map<String, String>) {

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
@@ -768,7 +768,7 @@ data class HttpRequestPattern(
         originalRequest: HttpRequest,
         resolver: Resolver,
         data: JSONObjectValue,
-        dictionary: Map<String, Value>
+        dictionary: Dictionary
     ): Substitution {
         return Substitution(runningRequest, originalRequest, httpPathPattern ?: HttpPathPattern(emptyList(), ""), headersPattern, httpQueryParamPattern, body, resolver, data, dictionary)
     }

--- a/core/src/main/kotlin/io/specmatic/core/HttpResponse.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpResponse.kt
@@ -167,6 +167,13 @@ data class HttpResponse(
     }
 
     private fun headersHasOnlyTextPlainContentTypeHeader() = headers.size == 1 && headers[CONTENT_TYPE] == "text/plain"
+
+    fun substituteDictionaryValues(dictionary: Dictionary, forceSubstitution: Boolean = false): HttpResponse {
+        val updatedHeaders = dictionary.substituteDictionaryValues(this.headers, forceSubstitution = forceSubstitution)
+        val updatedBody = dictionary.substituteDictionaryValues(this.body, forceSubstitution = forceSubstitution)
+
+        return this.copy(headers = updatedHeaders, body= updatedBody)
+    }
 }
 
 fun isVanillaPatternToken(token: String) = isPatternToken(token) && token.indexOf(':') < 0

--- a/core/src/main/kotlin/io/specmatic/core/HttpResponse.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpResponse.kt
@@ -168,62 +168,17 @@ data class HttpResponse(
 
     private fun headersHasOnlyTextPlainContentTypeHeader() = headers.size == 1 && headers[CONTENT_TYPE] == "text/plain"
 
-    fun substituteDictionaryValues(value: JSONArrayValue, dictionary: Map<String, Value>, paths: List<String> = emptyList()): Value {
-        val newList = value.list.mapIndexed { index, valueInArray ->
-            val indexesToAdd = listOf("[$index]", "[*]")
-
-            val updatedPaths = paths.flatMap { path ->
-                indexesToAdd.map { indexToAdd ->
-                    path + indexToAdd
-                }
-            }.ifEmpty {
-                indexesToAdd
-            }
-
-            substituteDictionaryValues(valueInArray, dictionary, updatedPaths)
-        }
-
-        return value.copy(newList)
-    }
-
-    fun substituteDictionaryValues(value: JSONObjectValue, dictionary: Map<String, Value>, paths: List<String> = emptyList()): Value {
-        val newMap = value.jsonObject.mapValues { (key, value) ->
-
-            val updatedPaths = paths.map { path ->
-                path + ".$key"
-            }.ifEmpty { listOf(key) }
-
-            val pathFoundInDictionary = updatedPaths.firstOrNull { it in dictionary }
-            if(value is StringValue && isVanillaPatternToken(value.string) && pathFoundInDictionary != null) {
-                dictionary.getValue(pathFoundInDictionary)
-            } else {
-                substituteDictionaryValues(value, dictionary, updatedPaths)
-            }
-        }
-
-        return value.copy(newMap)
-    }
-
-    fun substituteDictionaryValues(value: Value, dictionary: Map<String, Value>, paths: List<String> = emptyList()): Value {
-        return when (value) {
-            is JSONObjectValue -> {
-                substituteDictionaryValues(value, dictionary, paths)
-            }
-            is JSONArrayValue -> {
-                substituteDictionaryValues(value, dictionary, paths)
-            }
-            else -> value
-        }
-    }
-
-    fun substituteDictionaryValues(dictionary: Map<String, Value>): HttpResponse {
+    /**
+     * @param forceSubstitution Forces substitution even in case of a concrete values (eg: "BYFJA").
+     */
+    fun substituteDictionaryValues(dictionary: Map<String, Value>, forceSubstitution: Boolean = false): HttpResponse {
         val updatedHeaders = headers.mapValues { (headerName, headerValue) ->
-            if(isVanillaPatternToken(headerValue) && headerName in dictionary) {
+            if((isVanillaPatternToken(headerValue) || forceSubstitution) && headerName in dictionary) {
                 dictionary.getValue(headerName).toStringLiteral()
             } else headerValue
         }
 
-        val updatedBody = substituteDictionaryValues(body, dictionary)
+        val updatedBody = substituteDictionaryValues(body, dictionary, forceSubstitution = forceSubstitution)
 
         return this.copy(headers = updatedHeaders, body= updatedBody)
     }
@@ -307,3 +262,51 @@ fun dropContentAndCORSResponseHeaders(response: HttpResponse) =
     response.copy(headers = response.headers.filterNot {
         it.key in responseHeadersToExcludeFromConversion || it.key.lowercase() in listOf("content-type", "content-encoding", "content-length", "content-disposition") || it.key.startsWith("Access-Control-")
     })
+
+fun substituteDictionaryValues(value: JSONArrayValue, dictionary: Map<String, Value>, paths: List<String> = emptyList(), forceSubstitution: Boolean = false): Value {
+    val newList = value.list.mapIndexed { index, valueInArray ->
+        val indexesToAdd = listOf("[$index]", "[*]")
+
+        val updatedPaths = paths.flatMap { path ->
+            indexesToAdd.map { indexToAdd ->
+                path + indexToAdd
+            }
+        }.ifEmpty {
+            indexesToAdd
+        }
+
+        substituteDictionaryValues(valueInArray, dictionary, updatedPaths, forceSubstitution)
+    }
+
+    return value.copy(newList)
+}
+
+fun substituteDictionaryValues(value: JSONObjectValue, dictionary: Map<String, Value>, paths: List<String> = emptyList(), forceSubstitution: Boolean = false): Value {
+    val newMap = value.jsonObject.mapValues { (key, value) ->
+
+        val updatedPaths = paths.map { path ->
+            path + ".$key"
+        }.ifEmpty { listOf(key) }
+
+        val pathFoundInDictionary = updatedPaths.firstOrNull { it in dictionary }
+        if(value is StringValue && (isVanillaPatternToken(value.string) || forceSubstitution) && pathFoundInDictionary != null) {
+            dictionary.getValue(pathFoundInDictionary)
+        } else {
+            substituteDictionaryValues(value, dictionary, updatedPaths, forceSubstitution)
+        }
+    }
+
+    return value.copy(newMap)
+}
+
+fun substituteDictionaryValues(value: Value, dictionary: Map<String, Value>, paths: List<String> = emptyList(), forceSubstitution: Boolean = false): Value {
+    return when (value) {
+        is JSONObjectValue -> {
+            substituteDictionaryValues(value, dictionary, paths, forceSubstitution)
+        }
+        is JSONArrayValue -> {
+            substituteDictionaryValues(value, dictionary, paths, forceSubstitution)
+        }
+        else -> value
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/core/HttpResponsePattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpResponsePattern.kt
@@ -168,9 +168,9 @@ data class HttpResponsePattern(
         )
     }
 
-    fun generateResponse(partial: HttpResponse, dictionary: Map<String, Value>, resolver: Resolver): HttpResponse {
-        val headers = headersPattern.fillInTheBlanks(partial.headers, dictionary, resolver).breadCrumb("HEADERS")
-        val body: ReturnValue<Value> = body.fillInTheBlanks(partial.body, dictionary, resolver).breadCrumb("BODY")
+    fun generateResponse(partial: HttpResponse, dictionary: Dictionary, resolver: Resolver): HttpResponse {
+        val headers = headersPattern.fillInTheBlanks(partial.headers, dictionary.map, resolver).breadCrumb("HEADERS")
+        val body: ReturnValue<Value> = body.fillInTheBlanks(partial.body, dictionary.map, resolver).breadCrumb("BODY")
 
         return headers.combine(body) { fullHeaders, fullBody ->
             partial.copy(

--- a/core/src/main/kotlin/io/specmatic/core/HttpResponsePattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpResponsePattern.kt
@@ -169,8 +169,8 @@ data class HttpResponsePattern(
     }
 
     fun generateResponse(partial: HttpResponse, dictionary: Dictionary, resolver: Resolver): HttpResponse {
-        val headers = headersPattern.fillInTheBlanks(partial.headers, dictionary.map, resolver).breadCrumb("HEADERS")
-        val body: ReturnValue<Value> = body.fillInTheBlanks(partial.body, dictionary.map, resolver).breadCrumb("BODY")
+        val headers = headersPattern.fillInTheBlanks(partial.headers, dictionary, resolver).breadCrumb("HEADERS")
+        val body: ReturnValue<Value> = body.fillInTheBlanks(partial.body, dictionary, resolver).breadCrumb("BODY")
 
         return headers.combine(body) { fullHeaders, fullBody ->
             partial.copy(

--- a/core/src/main/kotlin/io/specmatic/core/Result.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Result.kt
@@ -323,7 +323,8 @@ enum class FailureReason(val fluffLevel: Int, val objectMatchOccurred: Boolean) 
     SOAPActionMismatch(2, false),
     DiscriminatorMismatch(0, true),
     FailedButDiscriminatorMatched(0, true),
-    FailedButObjectTypeMatched(0, true)
+    FailedButObjectTypeMatched(0, true),
+    ScenarioMismatch(2, false)
 }
 
 data class MatchFailureDetails(val breadCrumbs: List<String> = emptyList(), val errorMessages: List<String> = emptyList(), val path: String? = null)

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -627,7 +627,7 @@ data class Scenario(
         return httpResponsePattern.resolveSubstitutions(substitution, response)
     }
 
-    fun matchesTemplate(template: ScenarioStub): Result {
+    fun matchesPartial(template: ScenarioStub): Result {
         val updatedResolver = resolver.copy(findKeyErrorCheck = PARTIAL_KEYCHECK, mockMode = true)
 
         val requestMatch = httpRequestPattern.matches(template.request, updatedResolver, updatedResolver)

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -621,7 +621,7 @@ data class Scenario(
         originalRequest: HttpRequest,
         response: HttpResponse,
         data: JSONObjectValue,
-        dictionary: Map<String, Value>
+        dictionary: Dictionary
     ): HttpResponse {
         val substitution = httpRequestPattern.getSubstitution(request, originalRequest, resolver, data, dictionary)
         return httpResponsePattern.resolveSubstitutions(substitution, response)

--- a/core/src/main/kotlin/io/specmatic/core/Substitution.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Substitution.kt
@@ -15,7 +15,7 @@ class Substitution(
     val body: Pattern,
     val resolver: Resolver,
     val data: JSONObjectValue,
-    val dictionary: Map<String, Value>
+    val dictionary: Dictionary
 ) {
     val variableValues: Map<String, String>
 
@@ -106,7 +106,7 @@ class Substitution(
     fun substituteSimpleVariableLookup(string: String, key: String? = null): String {
         val name = string.trim().removeSurrounding("$(", ")")
         return variableValues[name]
-                ?: key?.let { dictionary[key]?.toStringLiteral() }
+                ?: key?.let { dictionary.map[key]?.toStringLiteral() }
                 ?: throw ContractException("Could not resolve expression $string as no variable by the name $name was found")
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/Substitution.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Substitution.kt
@@ -106,7 +106,7 @@ class Substitution(
     fun substituteSimpleVariableLookup(string: String, key: String? = null): String {
         val name = string.trim().removeSurrounding("$(", ")")
         return variableValues[name]
-                ?: key?.let { dictionary.map[key]?.toStringLiteral() }
+                ?: key?.let { dictionary.lookup(key)?.toStringLiteral() }
                 ?: throw ContractException("Could not resolve expression $string as no variable by the name $name was found")
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServer.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServer.kt
@@ -415,6 +415,18 @@ class ExamplesInteractiveServer(
             return results
         }
 
+        private fun getCleanedUpFailure(
+            failureResults: Results,
+            noMatchingScenario: NoMatchingScenario?
+        ): Results {
+            return failureResults.toResultIfAny().let {
+                if (it.reportString().isBlank())
+                    Results(listOf(Result.Failure(noMatchingScenario?.message ?: "")))
+                else
+                    failureResults
+            }
+        }
+
         private fun validateExample(
             feature: Feature,
             scenarioStub: ScenarioStub
@@ -427,7 +439,9 @@ class ExamplesInteractiveServer(
             if (validationResult == null) {
                 val failures = noMatchingScenario?.results?.withoutFluff()?.results ?: emptyList()
 
-                val failureResults = Results(failures).withoutFluff()
+                val failureResults = Results(failures).withoutFluff().let {
+                    getCleanedUpFailure(it, noMatchingScenario)
+                }
                 throw NoMatchingScenario(
                     failureResults,
                     cachedMessage = failureResults.report(scenarioStub.request),

--- a/core/src/main/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServer.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServer.kt
@@ -34,7 +34,7 @@ class ExamplesInteractiveServer(
     private val inputContractFile: File? = null,
     private val filterName: String,
     private val filterNotName: String,
-    private val externalDictionary: Map<String, Value>
+    private val externalDictionary: Dictionary
 ) : Closeable {
     private var contractFileFromRequest: File? = null
 
@@ -249,7 +249,7 @@ class ExamplesInteractiveServer(
     }
 
     companion object {
-        fun generate(contractFile: File, scenarioFilter: ScenarioFilter, extensive: Boolean, externalDictionary: Map<String, Value>): List<String> {
+        fun generate(contractFile: File, scenarioFilter: ScenarioFilter, extensive: Boolean, externalDictionary: Dictionary): List<String> {
             try {
                 val feature: Feature = parseContractFileToFeature(contractFile).let { feature ->
                     val filteredScenarios = if (!extensive) {
@@ -287,10 +287,10 @@ class ExamplesInteractiveServer(
                     val generatedScenario = scenario.generateTestScenarios(DefaultStrategies).first().value
 
                     val request = generatedScenario.httpRequestPattern.generate(generatedScenario.resolver)
-                    val updatedRequest = request.substituteDictionaryValues(externalDictionary, forceSubstitution = true)
+                    val updatedRequest = externalDictionary.substituteDictionaryValues(request, forceSubstitution = true)
 
                     val response = generatedScenario.httpResponsePattern.generateResponse(generatedScenario.resolver).cleanup()
-                    val updatedResponse = response.substituteDictionaryValues(externalDictionary, forceSubstitution = true)
+                    val updatedResponse = externalDictionary.substituteDictionaryValues(response, forceSubstitution = true)
 
                     val scenarioStub = ScenarioStub(updatedRequest, updatedResponse)
                     val stubJSON = scenarioStub.toJSON()
@@ -319,7 +319,7 @@ class ExamplesInteractiveServer(
             path: String,
             responseStatusCode: Int,
             contentType: String? = null,
-            externalDictionary: Map<String, Value>
+            externalDictionary: Dictionary
         ): String? {
             val feature = parseContractFileToFeature(contractFile)
             val scenario = feature.scenarios.firstOrNull {
@@ -334,10 +334,10 @@ class ExamplesInteractiveServer(
             else examplesDir.mkdirs()
 
             val request = scenario.generateHttpRequest()
-            val updatedRequest = request.substituteDictionaryValues(externalDictionary, forceSubstitution = true)
+            val updatedRequest = externalDictionary.substituteDictionaryValues(request, forceSubstitution = true)
 
             val response = feature.lookupResponse(scenario).cleanup()
-            val updatedResponse = response.substituteDictionaryValues(externalDictionary, forceSubstitution = true)
+            val updatedResponse = externalDictionary.substituteDictionaryValues(response, forceSubstitution = true)
 
             val scenarioStub = ScenarioStub(updatedRequest, updatedResponse)
             val stubJSON = scenarioStub.toJSON()

--- a/core/src/main/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServer.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServer.kt
@@ -287,10 +287,10 @@ class ExamplesInteractiveServer(
                     val generatedScenario = scenario.generateTestScenarios(DefaultStrategies).first().value
 
                     val request = generatedScenario.httpRequestPattern.generate(generatedScenario.resolver)
-                    val updatedRequest = externalDictionary.substituteDictionaryValues(request, forceSubstitution = true)
+                    val updatedRequest = request.substituteDictionaryValues(externalDictionary, forceSubstitution = true)
 
                     val response = generatedScenario.httpResponsePattern.generateResponse(generatedScenario.resolver).cleanup()
-                    val updatedResponse = externalDictionary.substituteDictionaryValues(response, forceSubstitution = true)
+                    val updatedResponse = response.substituteDictionaryValues(externalDictionary, forceSubstitution = true)
 
                     val scenarioStub = ScenarioStub(updatedRequest, updatedResponse)
                     val stubJSON = scenarioStub.toJSON()
@@ -334,10 +334,10 @@ class ExamplesInteractiveServer(
             else examplesDir.mkdirs()
 
             val request = scenario.generateHttpRequest()
-            val updatedRequest = externalDictionary.substituteDictionaryValues(request, forceSubstitution = true)
+            val updatedRequest = request.substituteDictionaryValues(externalDictionary, forceSubstitution = true)
 
             val response = feature.lookupResponse(scenario).cleanup()
-            val updatedResponse = externalDictionary.substituteDictionaryValues(response, forceSubstitution = true)
+            val updatedResponse = response.substituteDictionaryValues(externalDictionary, forceSubstitution = true)
 
             val scenarioStub = ScenarioStub(updatedRequest, updatedResponse)
             val stubJSON = scenarioStub.toJSON()

--- a/core/src/main/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServer.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServer.kt
@@ -308,7 +308,7 @@ class ExamplesInteractiveServer(
                             val trimmedScenarioDescription = scenario.testDescription().trim()
 
                             if (!it.created) {
-                                println("Example for $trimmedScenarioDescription exists: $loggablePath")
+                                println("Example exists for $trimmedScenarioDescription: $loggablePath")
                             } else {
                                 println("Created example for $trimmedScenarioDescription: $loggablePath")
                             }
@@ -327,8 +327,10 @@ class ExamplesInteractiveServer(
 
                     logger.log(System.lineSeparator() + "NOTE: All examples may be found in ${getExamplesDirPath(contractFile).canonicalFile}" + System.lineSeparator())
 
+                    val errorsClause = if(errorCount > 0) ", $errorCount examples could not be generated due to errors" else ""
+
                     logger.log("=============== Example Generation Summary ===============")
-                    logger.log("Created: $createdFileCount, Already existed: $existingFileCount, Errors: $errorCount")
+                    logger.log("$createdFileCount example(s) created, $existingFileCount examples already existed$errorsClause")
                     logger.log("==========================================================")
                 }.mapNotNull { it.path }
             } catch (e: StackOverflowError) {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
@@ -19,7 +19,7 @@ data class AnyPattern(
 
     data class AnyPatternMatch(val pattern: Pattern, val result: Result)
 
-    override fun fillInTheBlanks(value: Value, dictionary: Map<String, Value>, resolver: Resolver): ReturnValue<Value> {
+    override fun fillInTheBlanks(value: Value, dictionary: Dictionary, resolver: Resolver): ReturnValue<Value> {
         val results = pattern.asSequence().map {
             it.fillInTheBlanks(value, dictionary, resolver)
         }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/DeferredPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/DeferredPattern.kt
@@ -1,5 +1,6 @@
 package io.specmatic.core.pattern
 
+import io.specmatic.core.Dictionary
 import io.specmatic.core.Resolver
 import io.specmatic.core.Result
 import io.specmatic.core.Substitution
@@ -8,7 +9,7 @@ import io.specmatic.core.value.EmptyString
 import io.specmatic.core.value.Value
 
 data class DeferredPattern(override val pattern: String, val key: String? = null) : Pattern {
-    override fun fillInTheBlanks(value: Value, dictionary: Map<String, Value>, resolver: Resolver): ReturnValue<Value> {
+    override fun fillInTheBlanks(value: Value, dictionary: Dictionary, resolver: Resolver): ReturnValue<Value> {
         return resolvePattern(resolver).fillInTheBlanks(value, dictionary, resolver)
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/DictionaryPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/DictionaryPattern.kt
@@ -1,9 +1,6 @@
 package io.specmatic.core.pattern
 
-import io.specmatic.core.Resolver
-import io.specmatic.core.Result
-import io.specmatic.core.Substitution
-import io.specmatic.core.mismatchResult
+import io.specmatic.core.*
 import io.specmatic.core.pattern.config.NegativePatternConfiguration
 import io.specmatic.core.value.JSONArrayValue
 import io.specmatic.core.value.JSONObjectValue
@@ -11,7 +8,7 @@ import io.specmatic.core.value.StringValue
 import io.specmatic.core.value.Value
 
 data class DictionaryPattern(val keyPattern: Pattern, val valuePattern: Pattern, override val typeAlias: String? = null) : Pattern {
-    override fun fillInTheBlanks(value: Value, dictionary: Map<String, Value>, resolver: Resolver): ReturnValue<Value> {
+    override fun fillInTheBlanks(value: Value, dictionary: Dictionary, resolver: Resolver): ReturnValue<Value> {
         val jsonObject = value as? JSONObjectValue ?: return HasFailure("Can't generate object value from partial of type ${value.displayableType()}")
 
         val returnValue = jsonObject.jsonObject.mapValues { (key, value) ->

--- a/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
@@ -27,7 +27,7 @@ data class JSONObjectPattern(
     val minProperties: Int? = null,
     val maxProperties: Int? = null
 ) : Pattern {
-    override fun fillInTheBlanks(value: Value, dictionary: Map<String, Value>, resolver: Resolver): ReturnValue<Value> {
+    override fun fillInTheBlanks(value: Value, dictionary: Dictionary, resolver: Resolver): ReturnValue<Value> {
         val jsonObject = value as? JSONObjectValue ?: return HasFailure("Can't generate object value from partial of type ${value.displayableType()}")
 
         val mapWithKeysInPartial = jsonObject.jsonObject.mapValues { (name, value) ->
@@ -54,7 +54,7 @@ data class JSONObjectPattern(
         val mapWithMissingKeysGenerated = pattern.filterKeys {
             !it.endsWith("?") && it !in jsonObject.jsonObject
         }.mapValues { (name, valuePattern) ->
-            val generatedValue = dictionary[name]?.let { dictionaryValue ->
+            val generatedValue = dictionary.lookup(name)?.let { dictionaryValue ->
                 val matchResult = valuePattern.matches(dictionaryValue, resolver)
                 if(matchResult is Result.Failure)
                     HasFailure(matchResult)

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
@@ -1,9 +1,6 @@
 package io.specmatic.core.pattern
 
-import io.specmatic.core.Resolver
-import io.specmatic.core.Result
-import io.specmatic.core.Substitution
-import io.specmatic.core.mismatchResult
+import io.specmatic.core.*
 import io.specmatic.core.pattern.config.NegativePatternConfiguration
 import io.specmatic.core.value.JSONArrayValue
 import io.specmatic.core.value.ListValue
@@ -14,7 +11,7 @@ data class ListPattern(override val pattern: Pattern, override val typeAlias: St
     override val memberList: MemberList
         get() = MemberList(emptyList(), pattern)
 
-    override fun fillInTheBlanks(value: Value, dictionary: Map<String, Value>, resolver: Resolver): ReturnValue<Value> {
+    override fun fillInTheBlanks(value: Value, dictionary: Dictionary, resolver: Resolver): ReturnValue<Value> {
         val listValue = value as? JSONArrayValue ?: return HasFailure("Cannot generate a list from partial of type ${value.displayableType()}")
         val newList = listValue.list.map { pattern.fillInTheBlanks(it, dictionary, resolver) }.listFold()
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/Pattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/Pattern.kt
@@ -1,5 +1,6 @@
 package io.specmatic.core.pattern
 
+import io.specmatic.core.Dictionary
 import io.specmatic.core.Resolver
 import io.specmatic.core.Result
 import io.specmatic.core.Substitution
@@ -78,7 +79,7 @@ interface Pattern {
             HasValue(emptyMap())
     }
 
-    fun fillInTheBlanks(value: Value, dictionary: Map<String, Value>, resolver: Resolver): ReturnValue<Value> {
+    fun fillInTheBlanks(value: Value, dictionary: Dictionary, resolver: Resolver): ReturnValue<Value> {
         exception { parse(value.toStringLiteral(), resolver) }?.let { return HasException(it) }
 
         return HasValue(value)

--- a/core/src/main/kotlin/io/specmatic/mock/ScenarioStub.kt
+++ b/core/src/main/kotlin/io/specmatic/mock/ScenarioStub.kt
@@ -28,7 +28,7 @@ data class ScenarioStub(
     val data: JSONObjectValue = JSONObjectValue(),
     val filePath: String? = null,
     val partial: ScenarioStub? = null,
-    val dictionary: Map<String, Value> = emptyMap()
+    val dictionary: Dictionary = Dictionary()
 ) {
     fun toJSON(): JSONObjectValue {
         val mockInteraction = mutableMapOf<String, Value>()

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStubResponse.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStubResponse.kt
@@ -1,11 +1,7 @@
 package io.specmatic.stub
 
-import io.specmatic.core.Feature
-import io.specmatic.core.HttpRequest
-import io.specmatic.core.HttpResponse
-import io.specmatic.core.Scenario
+import io.specmatic.core.*
 import io.specmatic.core.value.JSONObjectValue
-import io.specmatic.core.value.Value
 
 data class HttpStubResponse(
     val response: HttpResponse,
@@ -14,7 +10,7 @@ data class HttpStubResponse(
     val examplePath: String? = null,
     val feature: Feature? = null,
     val scenario: Scenario? = null,
-    val dictionary: Map<String, Value> = emptyMap()
+    val dictionary: Dictionary = Dictionary()
 ) {
     fun resolveSubstitutions(
         request: HttpRequest,

--- a/core/src/main/kotlin/io/specmatic/stub/StubData.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/StubData.kt
@@ -25,7 +25,7 @@ data class HttpStubData(
     val originalRequest: HttpRequest? = null,
     val data: JSONObjectValue = JSONObjectValue(),
     val partial: ScenarioStub? = null,
-    val dictionary: Map<String, Value> = emptyMap()
+    val dictionary: Dictionary = Dictionary()
 ) {
     val matchFailure: Boolean
         get() = response.headers[SPECMATIC_RESULT_HEADER] == "failure"

--- a/core/src/main/resources/templates/examples/index.html
+++ b/core/src/main/resources/templates/examples/index.html
@@ -1449,7 +1449,8 @@
     }
 
     function getHostPort() {
-        return table.getAttribute("data-hostPort");
+        let hostPort = table.getAttribute("data-hostPort");
+        return hostPort ? hostPort.replace(/\/$/, '') : hostPort;
     }
 
     function enableValidateBtn(tableRow) {

--- a/core/src/test/kotlin/io/specmatic/TestUtilities.kt
+++ b/core/src/test/kotlin/io/specmatic/TestUtilities.kt
@@ -157,3 +157,16 @@ fun runningOnWindows(): Boolean {
 
     return "windows" in osName.lowercase()
 }
+
+class Waiter(val delayInMilliSeconds: Long, val maximumWaitTime: Long) {
+    private var totalWaitTime = 0L
+
+    fun waitForMoreTime() {
+        Thread.sleep(delayInMilliSeconds)
+        totalWaitTime += delayInMilliSeconds
+    }
+
+    fun canWaitForMoreTime(): Boolean {
+        return totalWaitTime < maximumWaitTime
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/DictionaryTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/DictionaryTest.kt
@@ -16,12 +16,12 @@ class DictionaryTest {
     }
 
     @Test
-    fun `should substitute for concrete and non-concrete values from dictionary when forceSubstitution is true`() {
+    fun `should substitute concrete and non-concrete values when forceSubstitution is enabled`() {
         val httpResponse = HttpResponse(
             headers = mapOf("Authentication" to "RANDOM_STRING"),
             body = parsedJSONObject("""{"name": "RANDOM_STRING", "address": "RANDOM_STRING"}""")
         )
-        val updatedResponse = dictionary.substituteDictionaryValues(httpResponse, forceSubstitution = true)
+        val updatedResponse = httpResponse.substituteDictionaryValues(dictionary, forceSubstitution = true)
         val jsonResponse = updatedResponse.body as JSONObjectValue
 
         assertThat(updatedResponse.headers["Authentication"]).isEqualTo("Bearer 123")
@@ -30,13 +30,13 @@ class DictionaryTest {
     }
 
     @Test
-    fun `should substitute for non-concrete values values from dictionary when forceSubstitution is false`() {
+    fun `should substitute only non-concrete values and retain concrete values when forceSubstitution is disabled`() {
         val httpRequest = HttpRequest(
             path = "/foo", method = "GET",
             headers = mapOf("Authentication" to "(string)"),
             body = parsedJSONObject("""{"name": "(string)", "address": "RANDOM_STRING"}""")
         )
-        val updatedHttpRequest = dictionary.substituteDictionaryValues(httpRequest)
+        val updatedHttpRequest = httpRequest.substituteDictionaryValues(dictionary)
         val jsonResponse = updatedHttpRequest.body as JSONObjectValue
 
         assertThat(updatedHttpRequest.headers["Authentication"]).isEqualTo("Bearer 123")

--- a/core/src/test/kotlin/io/specmatic/core/DictionaryTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/DictionaryTest.kt
@@ -1,0 +1,46 @@
+package io.specmatic.core
+
+import io.specmatic.core.pattern.parsedJSONObject
+import io.specmatic.core.value.JSONObjectValue
+import org.assertj.core.api.Assertions.assertThat
+
+import org.junit.jupiter.api.Test
+
+// NOTE: Concrete values are actual values, not placeholders like (string) or (number).
+// For example, "ATYGHA" is a concrete value, not a placeholder.
+class DictionaryTest {
+    companion object {
+        val dictionary = Dictionary(
+            parsedJSONObject("""{"name": "John Doe", "address": "123 Main Street", "Authentication": "Bearer 123"}""").jsonObject
+        )
+    }
+
+    @Test
+    fun `should substitute for concrete and non-concrete values from dictionary when forceSubstitution is true`() {
+        val httpResponse = HttpResponse(
+            headers = mapOf("Authentication" to "RANDOM_STRING"),
+            body = parsedJSONObject("""{"name": "RANDOM_STRING", "address": "RANDOM_STRING"}""")
+        )
+        val updatedResponse = dictionary.substituteDictionaryValues(httpResponse, forceSubstitution = true)
+        val jsonResponse = updatedResponse.body as JSONObjectValue
+
+        assertThat(updatedResponse.headers["Authentication"]).isEqualTo("Bearer 123")
+        assertThat(jsonResponse.findFirstChildByPath("name")?.toStringLiteral()).isEqualTo("John Doe")
+        assertThat(jsonResponse.findFirstChildByPath("address")?.toStringLiteral()).isEqualTo("123 Main Street")
+    }
+
+    @Test
+    fun `should substitute for non-concrete values values from dictionary when forceSubstitution is false`() {
+        val httpRequest = HttpRequest(
+            path = "/foo", method = "GET",
+            headers = mapOf("Authentication" to "(string)"),
+            body = parsedJSONObject("""{"name": "(string)", "address": "RANDOM_STRING"}""")
+        )
+        val updatedHttpRequest = dictionary.substituteDictionaryValues(httpRequest)
+        val jsonResponse = updatedHttpRequest.body as JSONObjectValue
+
+        assertThat(updatedHttpRequest.headers["Authentication"]).isEqualTo("Bearer 123")
+        assertThat(jsonResponse.findFirstChildByPath("name")?.toStringLiteral()).isEqualTo("John Doe")
+        assertThat(jsonResponse.findFirstChildByPath("address")?.toStringLiteral()).isEqualTo("RANDOM_STRING")
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/proxy/ProxyTest.kt
+++ b/core/src/test/kotlin/io/specmatic/proxy/ProxyTest.kt
@@ -8,6 +8,7 @@ import io.specmatic.core.pattern.parsedJSONObject
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.stub.HttpStub
 import io.ktor.http.*
+import io.specmatic.Waiter
 import io.specmatic.mock.DELAY_IN_MILLISECONDS
 import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
@@ -275,7 +276,15 @@ internal class ProxyTest {
                 assertThat(response.statusCodeValue).isEqualTo(202)
                 assertThat(response.body).isEqualTo("Dump process of spec and examples has started in the background")
 
-                Thread.sleep(3000)
+                val waiter = Waiter(1000L, 5000L)
+
+                while(waiter.canWaitForMoreTime()) {
+                    if(fakeFileWriter.receivedContract != null)
+                        break
+
+                    waiter.waitForMoreTime()
+                }
+
                 assertThat(fakeFileWriter.receivedContract?.trim()).startsWith("openapi:")
                 assertThatCode {
                     OpenApiSpecification.fromYAML(

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=2.0.24
+version=2.0.25


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Better Example generations by utilizing dictionary in both interactive and command-line modes.

<!-- Why are these changes necessary? -->

**Why**:  
Currently, examples are generated using random values, but now users can specify a dictionary for value substitution when generating examples.

<!-- How were these changes implemented? -->

**How**:
By leveraging the `substituteDictionaryValues` method in a Dictionary class, we can enable `forceSubstitution`, which replaces placeholder values with actual values from a user-provided dictionary.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->

<!-- feel free to add additional comments -->
