### PR TITLE
Implement Dictionary Substitution for Path and Query parameters

### DIFF
--- a/application/src/test/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServerTest.kt
+++ b/application/src/test/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServerTest.kt
@@ -7,6 +7,7 @@ import io.specmatic.core.value.JSONArrayValue
 import io.specmatic.core.value.JSONObjectValue
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import java.io.File
 
@@ -36,6 +37,7 @@ class ExamplesInteractiveServerTest {
 
         @JvmStatic
         @AfterAll
+        @BeforeAll
         fun cleanUp() {
             val examplesFolder = File("src/test/resources/specifications/tracker_examples")
             if (examplesFolder.exists()) examplesFolder.delete()

--- a/application/src/test/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServerTest.kt
+++ b/application/src/test/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServerTest.kt
@@ -19,8 +19,8 @@ class ExamplesInteractiveServerTest {
             parsedJSONObject("""
                 {
                     "Authentication": "Bearer 123",
-                    "name": "John Doe",
-                    "address": "123 Main Street",
+                    "name": "John-Doe",
+                    "address": "123-Main-Street",
                     "[0].name": "John Doe",
                     "[0].address": "123 Main Street",
                     "[*].name": "Jane Doe",
@@ -31,14 +31,18 @@ class ExamplesInteractiveServerTest {
         private val partialDictionary = Dictionary(
             parsedJSONObject("""
                 {
-                    "name": "John Doe",
-                    "address": "123 Main Street"
+                    "name": "John-Doe",
+                    "address": "123-Main-Street"
                 }
                 """.trimIndent()).jsonObject
         )
 
         fun assertHeaders(headers: Map<String, String>, apiKey: String) {
             assertThat(headers["Authentication"]).isEqualTo(apiKey)
+        }
+
+        fun assertPathParameters(path: String?, name: String, address: String) {
+            assertThat(path).isEqualTo("/generate/names/$name/address/$address")
         }
 
         fun assertQueryParameters(queryParameters: QueryParameters, name: String, address: String) {
@@ -92,8 +96,9 @@ class ExamplesInteractiveServerTest {
 
             assertThrows<AssertionError>("Request Body Values should be randomly generated") {
                 when(request.method) {
-                    "POST" -> assertRequestBody(request.body, "John Doe", "123 Main Street")
-                    "GET"  -> assertQueryParameters(request.queryParams, "John Doe", "123 Main Street")
+                    "POST" -> assertRequestBody(request.body, "John-Doe", "123-Main-Street")
+                    "GET"  -> assertQueryParameters(request.queryParams, "John-Doe", "123-Main-Street")
+                    "DELETE" -> assertPathParameters(request.path, "John-Doe", "123-Main-Street")
                 }
             }
 
@@ -124,8 +129,9 @@ class ExamplesInteractiveServerTest {
             assertHeaders(request.headers, "Bearer 123")
 
             when(request.method) {
-                "POST" -> assertRequestBody(request.body, "John Doe", "123 Main Street")
-                "GET"  -> assertQueryParameters(request.queryParams, "John Doe", "123 Main Street")
+                "POST" -> assertRequestBody(request.body, "John-Doe", "123-Main-Street")
+                "GET"  -> assertQueryParameters(request.queryParams, "John-Doe", "123-Main-Street")
+                "DELETE" -> assertPathParameters(request.path, "John-Doe", "123-Main-Street")
             }
 
             assertResponseBody(response.body) {
@@ -155,8 +161,9 @@ class ExamplesInteractiveServerTest {
             }
 
             when(request.method) {
-                "POST" -> assertRequestBody(request.body, "John Doe", "123 Main Street")
-                "GET"  -> assertQueryParameters(request.queryParams, "John Doe", "123 Main Street")
+                "POST" -> assertRequestBody(request.body, "John-Doe", "123-Main-Street")
+                "GET"  -> assertQueryParameters(request.queryParams, "John-Doe", "123-Main-Street")
+                "DELETE" -> assertPathParameters(request.path, "John-Doe", "123-Main-Street")
             }
 
             assertThrows<AssertionError>("Response Body Values should be randomly generated") {

--- a/application/src/test/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServerTest.kt
+++ b/application/src/test/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServerTest.kt
@@ -101,7 +101,7 @@ class ExamplesInteractiveServerTest {
                     assertThat(body.findFirstChildByPath("address")?.toStringLiteral()).isNotEqualTo("123-Main-Street")
 
                 }
-                "GETS" -> {
+                "GET" -> {
                     val queryParameters = request.queryParams
                     assertThat(queryParameters.getValues("name")).doesNotContain("John-Doe")
                     assertThat(queryParameters.getValues("address")).doesNotContain("123-Main-Street")
@@ -111,6 +111,7 @@ class ExamplesInteractiveServerTest {
                     assertThat(path).doesNotContain("/generate/names/John-Doe/address/123-Main-Street")
                     assertThat(path.trim('/').split('/').last()).isNotEqualTo("(string)")
                 }
+                else -> throw IllegalArgumentException("Unexpected method ${request.method}")
             }
 
             responseBody.list.forEachIndexed { index, value ->
@@ -148,6 +149,7 @@ class ExamplesInteractiveServerTest {
                     assertPathParameters(request.path, "John-Doe", "123-Main-Street")
                     assertThat(request.path!!.trim('/').split('/').last()).isNotEqualTo("(string)")
                 }
+                else -> throw IllegalArgumentException("Unexpected method ${request.method}")
             }
 
             assertResponseBody(response.body) {
@@ -184,6 +186,7 @@ class ExamplesInteractiveServerTest {
                     assertPathParameters(request.path, "John-Doe", "123-Main-Street")
                     assertThat(request.path!!.trim('/').split('/').last()).isNotEqualTo("(string)")
                 }
+                else -> throw IllegalArgumentException("Unexpected method ${request.method}")
             }
 
             responseBody.list.forEachIndexed { index, value ->

--- a/application/src/test/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServerTest.kt
+++ b/application/src/test/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServerTest.kt
@@ -42,7 +42,6 @@ class ExamplesInteractiveServerTest {
 
         fun assertPathParameters(path: String?, name: String, address: String) {
             assertThat(path).contains("/generate/names/$name/address/$address")
-            assertThat(path!!.trim('/').split('/').last()).isNotEqualTo("(string)")
         }
 
         fun assertQueryParameters(queryParameters: QueryParameters, name: String, address: String) {
@@ -145,7 +144,10 @@ class ExamplesInteractiveServerTest {
             when(request.method) {
                 "POST" -> assertRequestBody(request.body, "John-Doe", "123-Main-Street")
                 "GET"  -> assertQueryParameters(request.queryParams, "John-Doe", "123-Main-Street")
-                "DELETE" -> assertPathParameters(request.path, "John-Doe", "123-Main-Street")
+                "DELETE" -> {
+                    assertPathParameters(request.path, "John-Doe", "123-Main-Street")
+                    assertThat(request.path!!.trim('/').split('/').last()).isNotEqualTo("(string)")
+                }
             }
 
             assertResponseBody(response.body) {
@@ -178,7 +180,10 @@ class ExamplesInteractiveServerTest {
             when(request.method) {
                 "POST" -> assertRequestBody(request.body, "John-Doe", "123-Main-Street")
                 "GET"  -> assertQueryParameters(request.queryParams, "John-Doe", "123-Main-Street")
-                "DELETE" -> assertPathParameters(request.path, "John-Doe", "123-Main-Street")
+                "DELETE" -> {
+                    assertPathParameters(request.path, "John-Doe", "123-Main-Street")
+                    assertThat(request.path!!.trim('/').split('/').last()).isNotEqualTo("(string)")
+                }
             }
 
             responseBody.list.forEachIndexed { index, value ->

--- a/application/src/test/resources/specifications/tracker.yaml
+++ b/application/src/test/resources/specifications/tracker.yaml
@@ -91,6 +91,48 @@ paths:
                     - name
                     - trackerId
                     - address
+  /generate/names/{name}/address/{address}:
+    delete:
+      summary: Generate a response with name, address, and tracker ID using path parameters
+      description: Accepts `name` and `address` as path parameters and returns an object with `name`, `trackerId`, and `address`.
+      security:
+        - apiKey: []
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+            example: "John Doe"
+        - name: address
+          in: path
+          required: true
+          schema:
+            type: string
+            example: "123 Main St, Anytown, USA"
+      responses:
+        '200':
+          description: Successful response with name, tracker ID, and address
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                      example: "John Doe"
+                    trackerId:
+                      type: integer
+                      example: 123456
+                    address:
+                      type: string
+                      example: "123 Main St, Anytown, USA"
+                  required:
+                    - name
+                    - trackerId
+                    - address
 components:
   securitySchemes:
     apiKey:

--- a/application/src/test/resources/specifications/tracker.yaml
+++ b/application/src/test/resources/specifications/tracker.yaml
@@ -91,7 +91,7 @@ paths:
                     - name
                     - trackerId
                     - address
-  /generate/names/{name}/address/{address}:
+  /generate/names/{name}/address/{address}/trackerId/{trackerId}:
     delete:
       summary: Generate a response with name, address, and tracker ID using path parameters
       description: Accepts `name` and `address` as path parameters and returns an object with `name`, `trackerId`, and `address`.
@@ -110,6 +110,12 @@ paths:
           schema:
             type: string
             example: "123 Main St, Anytown, USA"
+        - name: trackerId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: "123"
       responses:
         '200':
           description: Successful response with name, tracker ID, and address

--- a/application/src/test/resources/specifications/tracker.yaml
+++ b/application/src/test/resources/specifications/tracker.yaml
@@ -7,7 +7,7 @@ paths:
   /generate:
     post:
       summary: Generate a response with name, address, and tracker ID
-      description: Accepts a JSON object with `name` and `address` and returns an object with `name`, `trackerId`, and `address`.\
+      description: Accepts a JSON object with `name` and `address` and returns an object with `name`, `trackerId`, and `address`.
       security:
         - apiKey: []
       requestBody:
@@ -26,6 +26,48 @@ paths:
               required:
                 - name
                 - address
+      responses:
+        '200':
+          description: Successful response with name, tracker ID, and address
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                      example: "John Doe"
+                    trackerId:
+                      type: integer
+                      example: 123456
+                    address:
+                      type: string
+                      example: "123 Main St, Anytown, USA"
+                  required:
+                    - name
+                    - trackerId
+                    - address
+
+    get:
+      summary: Generate a response with name, address, and tracker ID using query parameters
+      description: Accepts `name` and `address` as query parameters and returns an object with `name`, `trackerId`, and `address`.
+      security:
+        - apiKey: []
+      parameters:
+        - name: name
+          in: query
+          required: true
+          schema:
+            type: string
+            example: "John Doe"
+        - name: address
+          in: query
+          required: true
+          schema:
+            type: string
+            example: "123 Main St, Anytown, USA"
       responses:
         '200':
           description: Successful response with name, tracker ID, and address

--- a/core/src/main/kotlin/io/specmatic/core/Dictionary.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Dictionary.kt
@@ -55,11 +55,15 @@ class Dictionary(private val map: Map<String, Value> = emptyMap()) {
     }
 
     fun substituteDictionaryValues(value: Map<String, String>, forceSubstitution: Boolean = false): Map<String, String> {
-        return value.mapValues { (name, value) ->
-            if((isVanillaPatternToken(value) || forceSubstitution) && name in map) {
-                map.getValue(name).toStringLiteral()
-            } else value
+        return value.mapValues { (key, value) ->
+            substituteDictionaryValues(key, value, forceSubstitution)
         }
+    }
+
+    fun substituteDictionaryValues(name: String, value: String, forceSubstitution: Boolean = false): String {
+        return if((isVanillaPatternToken(value) || forceSubstitution) && name in map) {
+            map.getValue(name).toStringLiteral()
+        } else value
     }
 
     fun lookup(key: String): Value? {

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
@@ -377,13 +377,16 @@ data class HttpRequest(
     }
 
     private fun substituteDictionaryValuesInPath(dictionary: Dictionary, httpPathPattern: HttpPathPattern): String {
-        val prefix  = "/".takeIf { this.path!!.startsWith("/") }.orEmpty()
-        val postfix = "/".takeIf {  this.path!!.endsWith("/")  }.orEmpty()
+        this.path as String
+        val prefix = "/".takeIf { this.path.startsWith("/") }.orEmpty()
+        val postfix = "/".takeIf { this.path.endsWith("/") }.orEmpty()
+        val actualPathSegments = this.path.trim('/').split("/").filter { it.isNotEmpty() }
 
-        return httpPathPattern.pathSegmentPatterns.map {
-            when (it.key) {
-                null -> it.pattern
-                else -> dictionary.substituteDictionaryValues(it.key, it.pattern.toString())
+        return httpPathPattern.pathSegmentPatterns.zip(actualPathSegments).map { (segmentPattern, actual) ->
+            if (segmentPattern.key != null && dictionary.contains(segmentPattern.key)) {
+                dictionary.substituteDictionaryValues(segmentPattern.key, "(${segmentPattern.pattern.typeName})")
+            } else {
+                actual
             }
         }.joinToString("/", prefix = prefix, postfix = postfix)
     }

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
@@ -377,7 +377,9 @@ data class HttpRequest(
     }
 
     private fun substituteDictionaryValuesInPath(dictionary: Dictionary, httpPathPattern: HttpPathPattern): String {
-        this.path as String
+        if (this.path !is String)
+            throw ContractException("Expected path to be a string value")
+
         val prefix = "/".takeIf { this.path.startsWith("/") }.orEmpty()
         val postfix = "/".takeIf { this.path.endsWith("/") }.orEmpty()
         val actualPathSegments = this.path.trim('/').split("/").filter { it.isNotEmpty() }

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
@@ -367,8 +367,9 @@ data class HttpRequest(
     fun substituteDictionaryValues(dictionary: Dictionary, forceSubstitution: Boolean = false): HttpRequest {
         val updatedHeaders = dictionary.substituteDictionaryValues(this.headers, forceSubstitution = forceSubstitution)
         val updatedBody = dictionary.substituteDictionaryValues(this.body, forceSubstitution = forceSubstitution)
+        val queryParams = queryParams.substituteDictionaryValues(dictionary, forceSubstitution)
 
-        return this.copy(headers = updatedHeaders, body= updatedBody)
+        return this.copy(headers = updatedHeaders, body= updatedBody, queryParams = queryParams)
     }
 }
 

--- a/core/src/main/kotlin/io/specmatic/core/QueryParameters.kt
+++ b/core/src/main/kotlin/io/specmatic/core/QueryParameters.kt
@@ -90,6 +90,11 @@ data class QueryParameters(val paramPairs: List<Pair<String, String>> = emptyLis
 
         })
     }
+
+    fun substituteDictionaryValues(dictionary: Dictionary, forceSubstitution: Boolean = false): QueryParameters {
+        val updatedQueryParameters = dictionary.substituteDictionaryValues(listOfPairsToMap(this.paramPairs), forceSubstitution)
+        return this.copy(paramPairs = mapToListOfPairs(updatedQueryParameters))
+    }
 }
 
 fun paramPairsExpanded(inputList: List<Pair<String, String>>): List<Pair<String, String>> {
@@ -102,6 +107,10 @@ fun mapToListOfPairs(inputMap: Map<String, String>): List<Pair<String, String>> 
     return inputMap.flatMap { (key, value) ->
         toListOfPairs(value, key)
     }
+}
+
+fun listOfPairsToMap(inputList: List<Pair<String, String>>): Map<String, String> {
+    return inputList.toMap()
 }
 
 fun pairToListOfPairs(pair: Pair<String, String>): List<Pair<String, String>> {

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -37,6 +37,7 @@ val CONTRACT_EXTENSIONS = listOf(CONTRACT_EXTENSION, WSDL) + OPENAPI_FILE_EXTENS
 const val DATA_DIR_SUFFIX = "_data"
 const val TEST_DIR_SUFFIX = "_tests"
 const val EXAMPLES_DIR_SUFFIX = "_examples"
+const val DICTIONARY_FILE_SUFFIX = "_dictionary.json"
 const val SPECMATIC_GITHUB_ISSUES = "https://github.com/znsio/specmatic/issues"
 const val DEFAULT_WORKING_DIRECTORY = ".$APPLICATION_NAME_LOWER_CASE"
 

--- a/core/src/main/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServer.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServer.kt
@@ -77,6 +77,7 @@ class ExamplesInteractiveServer(
                 post("/_specmatic/examples") {
                     val request = call.receive<ExamplePageRequest>()
                     contractFileFromRequest = File(request.contractFile)
+                    dictionaryFileFromRequest = request.dictionaryFile?.let { dictPath -> File(dictPath) }
                     val contractFile = getContractFileOrBadRequest(call) ?: return@post
                     try {
                         respondWithExamplePageHtmlContent(contractFile, request.hostPort, call)
@@ -519,8 +520,9 @@ class ExamplesInteractiveServer(
             val dictFilePath = when {
                 dictFile != null -> dictFile.path
 
-                contractFile?.canonicalFile?.parentFile?.resolve("dictionary.json")?.exists() == true -> {
-                    contractFile.canonicalFile.parentFile.resolve("dictionary.json").path
+                contractFile != null -> {
+                    val dictFileName = "${contractFile.nameWithoutExtension}${DICTIONARY_FILE_SUFFIX}"
+                    contractFile.canonicalFile.parentFile.resolve(dictFileName).takeIf { it.exists() }?.path
                 }
 
                 else -> {

--- a/core/src/main/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServer.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServer.kt
@@ -373,7 +373,8 @@ class ExamplesInteractiveServer(
             else examplesDir.mkdirs()
 
             val request = scenario.generateHttpRequest()
-            val updatedRequest = request.substituteDictionaryValues(externalDictionary, forceSubstitution = true)
+            val httpPathPattern = scenario.httpRequestPattern.httpPathPattern
+            val updatedRequest = request.substituteDictionaryValues(externalDictionary, forceSubstitution = true, httpPathPattern)
 
             val response = feature.lookupResponse(scenario).cleanup()
             val updatedResponse = response.substituteDictionaryValues(externalDictionary, forceSubstitution = true)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Implement Dictionary Substitution for Path and Query parameters, other fixes.

<!-- Why are these changes necessary? -->

**Why**:
This allows for substituting randomly generated values with those specified in a dictionary

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #123

<!-- feel free to add additional comments -->
