### PR TITLE
Generate negative scenarios where mandatory headers are removed

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
@@ -233,20 +233,12 @@ data class HttpHeadersPattern(
     private fun patternsWithNoRequiredHeaders(
         patternMap: Map<String, Pattern>
     ): Sequence<ReturnValue<HttpHeadersPattern>> = sequence {
-        patternMap.forEach { (keyToOmit, _) ->
-            if(keyToOmit.endsWith("?").not()) {
-                yield(
-                    HasValue(
-                        HttpHeadersPattern(
-                            patternMap.filterKeys {
-                                key -> key != keyToOmit
-                            }.mapKeys { withoutOptionality(it.key) },
-                            contentType = contentType
-                        ),
-                        "mandatory header not sent"
-                    ).breadCrumb(keyToOmit)
-                )
-            }
+        patternsWithNoRequiredKeys(patternMap, "mandatory header not sent").forEach {
+            yield(
+                it.ifValue { pattern ->
+                    HttpHeadersPattern(pattern, contentType = contentType)
+                }
+            )
         }
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
@@ -232,15 +232,12 @@ data class HttpHeadersPattern(
 
     private fun patternsWithNoRequiredHeaders(
         patternMap: Map<String, Pattern>
-    ): Sequence<ReturnValue<HttpHeadersPattern>> = sequence {
-        patternsWithNoRequiredKeys(patternMap, "mandatory header not sent").forEach {
-            yield(
-                it.ifValue { pattern ->
-                    HttpHeadersPattern(pattern, contentType = contentType)
-                }
-            )
+    ): Sequence<ReturnValue<HttpHeadersPattern>> =
+        patternsWithNoRequiredKeys(patternMap, "mandatory header not sent").map {
+            it.ifValue { pattern ->
+                HttpHeadersPattern(pattern, contentType = contentType)
+            }
         }
-    }
 
     fun newBasedOn(resolver: Resolver): Sequence<HttpHeadersPattern> =
         allOrNothingCombinationIn<Pattern>(

--- a/core/src/main/kotlin/io/specmatic/core/HttpQueryParamPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpQueryParamPattern.kt
@@ -165,27 +165,11 @@ data class HttpQueryParamPattern(val queryPatterns: Map<String, Pattern>, val ad
                     resolver
                 )
             }.plus(
-                patternsWithNoRequiredQueryParams(patternMap)
+                patternsWithNoRequiredKeys(patternMap, "mandatory query param not sent")
             )
         }
     }
 
-    private fun patternsWithNoRequiredQueryParams(
-        params: Map<String, Pattern>
-    ): Sequence<ReturnValue<Map<String, Pattern>>> = sequence {
-        params.forEach { (keyToOmit, _) ->
-            if (keyToOmit.endsWith("?").not()) {
-                yield(
-                    HasValue(
-                        params.filterKeys { key -> key != keyToOmit }.mapKeys {
-                            withoutOptionality(it.key)
-                        },
-                        "mandatory query param not sent"
-                    ).breadCrumb(keyToOmit)
-                )
-            }
-        }
-    }
 
     fun matches(uri: URI, queryParams: Map<String, String>, resolver: Resolver = Resolver()): Result {
         return matches(HttpRequest(path = uri.path, queryParametersMap =  queryParams), resolver)
@@ -280,4 +264,22 @@ fun readFrom(patterns: Map<String, Pattern>, row: Row, resolver: Resolver): Sequ
     }
 
     return sequenceOf(rowAsPattern)
+}
+
+fun patternsWithNoRequiredKeys(
+    params: Map<String, Pattern>,
+    omitMessage: String
+): Sequence<ReturnValue<Map<String, Pattern>>> = sequence {
+    params.forEach { (keyToOmit, _) ->
+        if (keyToOmit.endsWith("?").not()) {
+            yield(
+                HasValue(
+                    params.filterKeys { key -> key != keyToOmit }.mapKeys {
+                        withoutOptionality(it.key)
+                    },
+                    omitMessage
+                ).breadCrumb(keyToOmit)
+            )
+        }
+    }
 }

--- a/core/src/test/kotlin/integration_tests/ResiliencyTests.kt
+++ b/core/src/test/kotlin/integration_tests/ResiliencyTests.kt
@@ -248,7 +248,7 @@ class GenerativeTests {
 
         try {
             val results = runGenerativeTests(feature)
-            assertThat(results.results).hasSize(6)
+            assertThat(results.results).hasSize(7)
         } catch (e: ContractException) {
             println(e.report())
             throw e
@@ -703,7 +703,7 @@ class GenerativeTests {
 
         try {
             val results = runGenerativeTests(feature)
-            assertThat(results.results).hasSize(8)
+            assertThat(results.results).hasSize(9)
         } catch (e: ContractException) {
             println(e.report())
             throw e
@@ -2023,7 +2023,7 @@ class GenerativeTests {
 
         assertThat(testsSeen).doesNotContain("-ve" to "BAD_REQUEST")
         assertThat(testsSeen).doesNotContain("-ve" to "SERVER_ERROR")
-        assertThat(results.testCount).isEqualTo(6)
+        assertThat(results.testCount).isEqualTo(7)
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -8905,8 +8905,12 @@ paths:
             assertThat(tests.size).isEqualTo(2)
             val firstScenarioHeaders = tests.first().second.value.httpRequestPattern.headersPattern.pattern
             val secondScenarioHeaders = tests.last().second.value.httpRequestPattern.headersPattern.pattern
-            assertThat(firstScenarioHeaders.keys).doesNotContain("X-Required-Header")
-            assertThat(secondScenarioHeaders.keys).doesNotContain("X-Another-Required-Header")
+            assertThat(firstScenarioHeaders.keys.toList())
+                .doesNotContain("X-Required-Header")
+                .contains("X-Another-Required-Header")
+            assertThat(secondScenarioHeaders.keys.toList())
+                .contains("X-Required-Header")
+                .doesNotContain("X-Another-Required-Header")
             assertThat(tests.first().second.value.testDescription()).isEqualTo(" Scenario: GET /persons -> 4xx [REQUEST.HEADER.X-Required-Header mandatory header not sent]")
             assertThat(tests.last().second.value.testDescription()).isEqualTo(" Scenario: GET /persons -> 4xx [REQUEST.HEADER.X-Another-Required-Header mandatory header not sent]")
         }

--- a/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
@@ -1424,7 +1424,7 @@ paths:
             contract.enableGenerativeTesting().generateContractTestScenarios(emptyList()).toList()
                 .map { it.second.value }
         val negativeTestScenarios = scenarios.filter { it.testDescription().contains("-ve") }
-        assertThat(negativeTestScenarios.count()).isEqualTo(10)
+        assertThat(negativeTestScenarios.count()).isEqualTo(12)
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/core/HttpHeadersPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpHeadersPatternTest.kt
@@ -224,7 +224,9 @@ internal class HttpHeadersPatternTest {
         val headers = HttpHeadersPattern(mapOf("X-TraceID" to StringPattern()))
         val newHeaders = headers.negativeBasedOn(Row(), Resolver()).map { it.value }.toList()
 
-        assertThat(newHeaders).isEmpty()
+        assertThat(newHeaders).containsExactlyInAnyOrder(
+            HttpHeadersPattern(mapOf())
+        )
     }
 
     @Tag(GENERATION)
@@ -236,6 +238,7 @@ internal class HttpHeadersPatternTest {
         assertThat(newHeaders).containsExactlyInAnyOrder(
             HttpHeadersPattern(mapOf("X-TraceID" to StringPattern())),
             HttpHeadersPattern(mapOf("X-TraceID" to BooleanPattern())),
+            HttpHeadersPattern(mapOf())
         )
     }
 

--- a/core/src/test/kotlin/io/specmatic/core/HttpPathPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpPathPatternTest.kt
@@ -263,6 +263,7 @@ internal class HttpPathPatternTest {
         assertThat(newHeaders).containsExactlyInAnyOrder(
             HttpHeadersPattern(mapOf("X-TraceID" to StringPattern())),
             HttpHeadersPattern(mapOf("X-TraceID" to BooleanPattern())),
+            HttpHeadersPattern(mapOf())
         )
     }
 }

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=2.0.27
+version=2.0.28


### PR DESCRIPTION
Add support for generation of negative test scenarios where mandatory headers are removed from the request.