### PR TITLE
Stop auto-generation of mandatory query params and headers missing in example

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
@@ -296,9 +296,12 @@ data class HttpHeadersPattern(
         return matches(this.pattern, row, resolver, "header")
     }
 
-    fun readFrom(row: Row, resolver: Resolver): Sequence<ReturnValue<HttpHeadersPattern>> {
+    fun readFrom(
+        row: Row,
+        resolver: Resolver,
+    ): Sequence<ReturnValue<HttpHeadersPattern>> {
         return attempt(breadCrumb = HEADERS_BREADCRUMB) {
-            readFrom(this.pattern, row, resolver)
+            readFrom(this.pattern, row, resolver, resolver.isNegative)
         }.map {
             HasValue(HttpHeadersPattern(it, contentType = contentType))
         }

--- a/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
@@ -299,9 +299,10 @@ data class HttpHeadersPattern(
     fun readFrom(
         row: Row,
         resolver: Resolver,
+        generateMandatoryEntryIfMissing: Boolean,
     ): Sequence<ReturnValue<HttpHeadersPattern>> {
         return attempt(breadCrumb = HEADERS_BREADCRUMB) {
-            readFrom(this.pattern, row, resolver, resolver.isNegative)
+            readFrom(this.pattern, row, resolver, generateMandatoryEntryIfMissing)
         }.map {
             HasValue(HttpHeadersPattern(it, contentType = contentType))
         }

--- a/core/src/main/kotlin/io/specmatic/core/HttpQueryParamPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpQueryParamPattern.kt
@@ -282,7 +282,10 @@ fun readFrom(
             )
             return@fold acc.plus(withoutOptionality to patternValue.exactMatchElseType())
         }
-        if (isOptional(key) || generateMandatoryEntryIfMissing.not()) return@fold acc
+
+        if (isOptional(key) || generateMandatoryEntryIfMissing.not())
+            return@fold acc
+
         acc.plus(withoutOptionality to pattern.generate(resolver).exactMatchElseType())
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/HttpQueryParamPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpQueryParamPattern.kt
@@ -193,10 +193,11 @@ data class HttpQueryParamPattern(val queryPatterns: Map<String, Pattern>, val ad
 
     fun readFrom(
         row: Row,
-        resolver: Resolver
+        resolver: Resolver,
+        generateMandatoryEntryIfMissing: Boolean
     ): Sequence<ReturnValue<Map<String, Pattern>>> {
         return attempt(breadCrumb = QUERY_PARAMS_BREADCRUMB) {
-            readFrom(queryPatterns, row, resolver, resolver.isNegative).map { HasValue(it) }
+            readFrom(queryPatterns, row, resolver, generateMandatoryEntryIfMissing).map { HasValue(it) }
         }
     }
     fun matches(row: Row, resolver: Resolver): Result {

--- a/core/src/main/kotlin/io/specmatic/core/HttpQueryParamPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpQueryParamPattern.kt
@@ -191,9 +191,12 @@ data class HttpQueryParamPattern(val queryPatterns: Map<String, Pattern>, val ad
         return matches(HttpRequest(path = uri.path, queryParametersMap =  queryParams), resolver)
     }
 
-    fun readFrom(row: Row, resolver: Resolver): Sequence<ReturnValue<Map<String, Pattern>>> {
+    fun readFrom(
+        row: Row,
+        resolver: Resolver
+    ): Sequence<ReturnValue<Map<String, Pattern>>> {
         return attempt(breadCrumb = QUERY_PARAMS_BREADCRUMB) {
-            readFrom(queryPatterns, row, resolver).map { HasValue(it) }
+            readFrom(queryPatterns, row, resolver, resolver.isNegative).map { HasValue(it) }
         }
     }
     fun matches(row: Row, resolver: Resolver): Result {
@@ -263,20 +266,24 @@ fun matches(patterns: Map<String, Pattern>, row: Row, resolver: Resolver, paramT
     return Result.fromResults(results)
 }
 
-fun readFrom(patterns: Map<String, Pattern>, row: Row, resolver: Resolver): Sequence<Map<String, Pattern>> {
+fun readFrom(
+    patterns: Map<String, Pattern>,
+    row: Row,
+    resolver: Resolver,
+    generateMandatoryEntryIfMissing: Boolean
+): Sequence<Map<String, Pattern>> {
     val rowAsPattern = patterns.entries.fold(emptyMap<String, Pattern>()) { acc, (key, pattern) ->
         val withoutOptionality = withoutOptionality(key)
 
         if (row.containsField(withoutOptionality)) {
-            val value = row.getField(withoutOptionality)
-            val patternValue = resolver.parse(pattern, value)
-
-            acc.plus(withoutOptionality to patternValue.exactMatchElseType())
-        } else if (isOptional(key)) {
-            acc
-        } else {
-            acc.plus(withoutOptionality to pattern.generate(resolver).exactMatchElseType())
+            val patternValue = resolver.parse(
+                pattern,
+                row.getField(withoutOptionality)
+            )
+            return@fold acc.plus(withoutOptionality to patternValue.exactMatchElseType())
         }
+        if (isOptional(key) || generateMandatoryEntryIfMissing.not()) return@fold acc
+        acc.plus(withoutOptionality to pattern.generate(resolver).exactMatchElseType())
     }
 
     return sequenceOf(rowAsPattern)

--- a/core/src/test/kotlin/integration_tests/OmittedParameterExamples.kt
+++ b/core/src/test/kotlin/integration_tests/OmittedParameterExamples.kt
@@ -306,7 +306,7 @@ components:
     }
 
     @Test
-    fun `mandatory header without example having a 400 response should be generated`() {
+    fun `mandatory header without example having a 400 response should NOT be generated`() {
         val productSpec = OpenApiSpecification.fromYAML("""
 openapi: 3.0.3
 info:
@@ -377,7 +377,11 @@ components:
             var response: HttpResponse = HttpResponse.OK
 
             override fun execute(request: HttpRequest): HttpResponse {
-                assertThat(request.headers.keys).contains("productCategory")
+                if(response.status == 400) {
+                    assertThat(request.headers.keys).doesNotContain("productCategory")
+                } else {
+                    assertThat(request.headers.keys).contains("productCategory")
+                }
                 return response
             }
 
@@ -398,7 +402,7 @@ components:
     }
 
     @Test
-    fun `mandatory header without example having a 500 response should be generated`() {
+    fun `mandatory header without example having a 500 response should NOT be generated`() {
         val productSpec = OpenApiSpecification.fromYAML("""
 openapi: 3.0.3
 info:
@@ -469,7 +473,11 @@ components:
             var response: HttpResponse = HttpResponse.OK
 
             override fun execute(request: HttpRequest): HttpResponse {
-                assertThat(request.headers.keys).contains("productCategory")
+                if(response.status == 500) {
+                    assertThat(request.headers.keys).doesNotContain("productCategory")
+                } else {
+                    assertThat(request.headers.keys).contains("productCategory")
+                }
                 return response
             }
 
@@ -561,7 +569,11 @@ components:
             var response: HttpResponse = HttpResponse.OK
 
             override fun execute(request: HttpRequest): HttpResponse {
-                assertThat(request.queryParams.keys).contains("productCategory")
+                if(response.status == 400) {
+                    assertThat(request.queryParams.keys).doesNotContain("productCategory")
+                } else {
+                    assertThat(request.queryParams.keys).contains("productCategory")
+                }
                 return response
             }
 
@@ -653,7 +665,11 @@ components:
             var response: HttpResponse = HttpResponse.OK
 
             override fun execute(request: HttpRequest): HttpResponse {
-                assertThat(request.queryParams.keys).contains("productCategory")
+                if(response.status == 500) {
+                    assertThat(request.queryParams.keys).doesNotContain("productCategory")
+                } else {
+                    assertThat(request.queryParams.keys).contains("productCategory")
+                }
                 return response
             }
 

--- a/core/src/test/kotlin/integration_tests/OmittedParameterExamples.kt
+++ b/core/src/test/kotlin/integration_tests/OmittedParameterExamples.kt
@@ -398,7 +398,7 @@ components:
         })
 
         assertThat(results.success()).withFailMessage(results.report()).isTrue()
-        assertThat(results.successCount).isEqualTo(2)
+        assertThat(results.testCount).isEqualTo(2)
     }
 
     @Test


### PR DESCRIPTION

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Disable auto-generation of mandatory query param/header which is intentionally not specified in an example to emulate a negative scenario
<!-- Why are these changes necessary? -->

**Why**:
If a user wants to specify an example where a mandatory query param is missing, currently specmatic auto-generates that mandatory query param even though it is not present in the example.
To fix this behaviour, this PR has been raised.
<!-- How were these changes implemented? -->



<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->


<!-- feel free to add additional comments -->
