### PR TITLE
Externalised example should override inline example for stub

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -553,6 +553,14 @@ data class Feature(
         serverState = emptyMap()
     }
 
+    fun overrideInlineExamples(externalExampleNames: Set<String>): Feature {
+        return this.copy(
+            stubsFromExamples = this.stubsFromExamples.filterKeys { inlineExampleName ->
+                inlineExampleName !in externalExampleNames
+            }
+        )
+    }
+
     private fun getScenarioWithDescription(scenarioResult: ReturnValue<Scenario>): ReturnValue<Scenario> {
         return scenarioResult.ifHasValue { result: HasValue<Scenario> ->
             val apiDescription = result.value.descriptionFromPlugin ?: result.value.apiDescription

--- a/core/src/main/kotlin/io/specmatic/stub/api.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/api.kt
@@ -119,13 +119,24 @@ internal fun createStub(
     )
 }
 
-internal fun createStub(host: String = "localhost", port: Int = 9000, timeoutMillis: Long, strict: Boolean = false, givenConfigFileName: String? = null): ContractStub {
+internal fun createStub(
+    host: String = "localhost",
+    port: Int = 9000,
+    timeoutMillis: Long,
+    strict: Boolean = false,
+    givenConfigFileName: String? = null,
+    dataDirPaths: List<String> = emptyList()
+): ContractStub {
     val workingDirectory = WorkingDirectory()
     val configFileName = givenConfigFileName ?: getConfigFileName()
     if(File(configFileName).exists().not()) exitWithMessage(MISSING_CONFIG_FILE_MESSAGE)
 
     val specmaticConfig = loadSpecmaticConfigOrDefault(configFileName)
-    val stubs = loadContractStubsFromImplicitPaths(contractStubPaths(configFileName), specmaticConfig)
+    val stubs = if(dataDirPaths.isEmpty()) {
+        loadContractStubsFromImplicitPaths(contractStubPaths(configFileName), specmaticConfig)
+    } else {
+        loadContractStubsFromFiles(contractStubPaths(configFileName), dataDirPaths, specmaticConfig, strict)
+    }
     val features = stubs.map { it.first }
     val expectations = contractInfoToHttpExpectations(stubs)
 
@@ -318,7 +329,19 @@ fun loadExpectationsForFeatures(
         }
     }
 
-    return loadContractStubs(features, mockData, strictMode)
+    val externalExampleNames = dataFiles.map { it.nameWithoutExtension }.toSet()
+
+    return loadContractStubs(features, mockData, strictMode).map {
+        it.copy(first = it.first.overrideInlineExamples(externalExampleNames))
+    }
+}
+
+private fun Feature.overrideInlineExamples(externalExampleNames: Set<String>): Feature {
+    return this.copy(
+        stubsFromExamples = this.stubsFromExamples.filterKeys { inlineExampleName ->
+            inlineExampleName !in externalExampleNames
+        }
+    )
 }
 
 private fun printDataFiles(dataFiles: List<File>) {

--- a/core/src/main/kotlin/io/specmatic/stub/api.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/api.kt
@@ -336,14 +336,6 @@ fun loadExpectationsForFeatures(
     }
 }
 
-private fun Feature.overrideInlineExamples(externalExampleNames: Set<String>): Feature {
-    return this.copy(
-        stubsFromExamples = this.stubsFromExamples.filterKeys { inlineExampleName ->
-            inlineExampleName !in externalExampleNames
-        }
-    )
-}
-
 private fun printDataFiles(dataFiles: List<File>) {
     if (dataFiles.isNotEmpty()) {
         val dataFilesString = dataFiles.joinToString(System.lineSeparator()) { it.path.prependIndent("  ") }

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -8070,6 +8070,44 @@ paths:
     }
 
     @Test
+    fun `inline example should not be loaded as stub if there exists an externalised example with the same name`() {
+        val defaultSpecmaticConfig = Configuration.globalConfigFileName
+
+        try {
+            Configuration.globalConfigFileName = "src/test/resources/overriding_external_example_specmatic.yaml"
+
+            createStub(
+                host = "localhost",
+                port = 9000,
+                timeoutMillis = 1000,
+                strict = false,
+                givenConfigFileName = "src/test/resources/overriding_external_example_specmatic.yaml",
+                dataDirPaths = listOf("src/test/resources/openapi/has_overriding_external_examples_examples")
+            ).use { stub ->
+                // externalised stub data loads as expected
+                stub.client.execute(
+                    HttpRequest("GET", "/person/overriding_external_id")
+                ).also {
+                    val responseBody = (it.body as JSONObjectValue).jsonObject
+                    assertThat(responseBody["id"]).isEqualTo(NumberValue(789))
+                    assertThat(responseBody["name"]).isEqualTo(StringValue("John External Doe"))
+                }
+
+                // inline stub data does not load as expected
+                stub.client.execute(
+                    HttpRequest("GET", "/person/overridden_inline_id")
+                ).also {
+                    val responseBody = (it.body as JSONObjectValue).jsonObject
+                    assertThat(responseBody["id"]).isNotEqualTo(NumberValue(1000))
+                    assertThat(responseBody["name"]).isNotEqualTo(StringValue("Unknown"))
+                }
+            }
+        } finally {
+            Configuration.globalConfigFileName = defaultSpecmaticConfig
+        }
+    }
+
+    @Test
     fun `when a workflow exists id of a created entity should be passed on to subsequent API calls`() {
         val spec = """
 openapi: 3.0.0

--- a/core/src/test/resources/overriding_external_example_specmatic.yaml
+++ b/core/src/test/resources/overriding_external_example_specmatic.yaml
@@ -1,0 +1,4 @@
+sources:
+  - provider: filesystem
+    stub:
+      - src/test/resources/openapi/has_overriding_external_examples.yaml


### PR DESCRIPTION
Externalised example with the same name as that of an inline example should override the inline example while loading the stub data

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->



<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->


<!-- feel free to add additional comments -->
