### PR TITLE
Externalised examples for 400 status code should load for stubs

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
@@ -59,6 +59,23 @@ data class HttpRequestPattern(
         }
     }
 
+    fun matchesPathAndMethod(
+        incomingHttpRequest: HttpRequest,
+        resolver: Resolver
+    ): Result {
+        val result = incomingHttpRequest to resolver to
+                ::matchPath then
+                ::matchMethod then
+                ::summarize otherwise
+                ::handleError toResult
+                ::returnResult
+
+        return when (result) {
+            is Failure -> result.breadCrumb("REQUEST")
+            else -> result
+        }
+    }
+
     private fun matchSecurityScheme(parameters: Triple<HttpRequest, Resolver, List<Failure>>): MatchingResult<Triple<HttpRequest, Resolver, List<Failure>>> {
         val (httpRequest, resolver, failures) = parameters
 

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -486,7 +486,10 @@ data class Scenario(
                 mismatchMessages = mismatchMessages
             )
 
-            val requestMatchResult = attempt(breadCrumb = "REQUEST") { httpRequestPattern.matches(request, resolver) }
+            val requestMatchResult = attempt(breadCrumb = "REQUEST") {
+                if(response.status == 400) httpRequestPattern.matchesPathAndMethod(request, resolver)
+                else httpRequestPattern.matches(request, resolver)
+            }
 
             if (requestMatchResult is Result.Failure)
                 requestMatchResult.updateScenario(this)

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
@@ -1940,6 +1940,25 @@ components:
         }
     }
 
+    @Test
+    fun `should use the 400 response code based externalised example and respond accordingly`() {
+        createStubFromContracts(
+            contractPaths = listOf("src/test/resources/openapi/has_400_example_for_stub.yaml"),
+            dataDirPaths = listOf("src/test/resources/openapi/has_400_example_for_stub_examples")
+        ).use { stub ->
+            val request = HttpRequest(
+                "GET",
+                "/items",
+                queryParametersMap = mapOf(
+                    "optional-param" to "optional"
+                )
+            )
+            val response = (stub.client.execute(request).body as JSONObjectValue).jsonObject
+
+            assertThat(response["message"]?.toStringLiteral()).isEqualTo("required-param is missing. Please provide.")
+        }
+    }
+
     @ParameterizedTest
     @CsvSource(
         "Expected, Actual, Status",

--- a/core/src/test/resources/openapi/has_400_example_for_stub.yaml
+++ b/core/src/test/resources/openapi/has_400_example_for_stub.yaml
@@ -1,0 +1,34 @@
+openapi: 3.0.3
+info:
+  title: Simple API
+  version: 1.0.0
+paths:
+  /items:
+    get:
+      parameters:
+        - name: required-param
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: optional-param
+          in: query
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string

--- a/core/src/test/resources/openapi/has_400_example_for_stub_examples/400_response_example.json
+++ b/core/src/test/resources/openapi/has_400_example_for_stub_examples/400_response_example.json
@@ -1,0 +1,15 @@
+{
+  "http-request": {
+    "path": "/items",
+    "method": "GET",
+    "query": {
+      "optional-param": "optional"
+    }
+  },
+  "http-response": {
+    "status": 400,
+    "body": {
+      "message": "required-param is missing. Please provide."
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

<!-- Why are these changes necessary? -->

**Why**:
Recently, a functionality was built for tests where the externalized examples for 400 status code were used as-is while running the tests. To maintain symmetry with that, support for externalized examples with a 400 status code has also been built for stubs.

<!-- How were these changes implemented? -->

**How**:
By matching only path and method in case the response status code in externalised example is 400.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->


<!-- feel free to add additional comments -->
