### PR TITLE
Resolve issue where the parent schema has multiple discriminator mappings and each child schema also declares its all discriminator mapping

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -1167,7 +1167,21 @@ class OpenApiSpecification(
         }
 
         fun plus(newDiscriminator: Discriminator): Discriminator {
-            return this.copy(discriminatorDetails + newDiscriminator.discriminatorDetails)
+            return this.copy(mergeMapOfMaps(discriminatorDetails, newDiscriminator.discriminatorDetails))
+        }
+
+        private fun <T> mergeMapOfMaps(
+            discriminatorDetails1: Map<String, Map<String, T>>,
+            discriminatorDetails2: Map<String, Map<String, T>>
+        ): Map<String, Map<String, T>> {
+            val keys = discriminatorDetails1.keys + discriminatorDetails2.keys
+
+            return keys.map { key ->
+                val detail1 = discriminatorDetails1[key] ?: emptyMap()
+                val detail2 = discriminatorDetails2[key] ?: emptyMap()
+
+                key to (detail1 + detail2)
+            }.toMap()
         }
 
         fun hasValueForKey(propertyName: String?): Boolean {
@@ -1228,7 +1242,7 @@ class OpenApiSpecification(
                     } else {
                         schemaName to (emptyList<Schema<Any>>() to Discriminator())
                     }
-                }
+                }.filterValues { it.second.first.isNotEmpty() }
 
                 val discriminatorsFromResolvedMappingSchemas = mappingWithSchemaListAndDiscriminator.values.map { (possiblePropertyValue, discriminator) ->
                     discriminator.second

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -1235,12 +1235,12 @@ class OpenApiSpecification(
                 val mapping = rawDiscriminator.mapping ?: emptyMap()
 
                 val mappingWithSchemaListAndDiscriminator = mapping.mapValues { (discriminatorValue, refPath) ->
-                    val (schemaName, schema) = resolveReferenceToSchema(refPath)
-                    val componentName = extractComponentName(refPath)
-                    if(componentName !in typeStack) {
-                        schemaName to resolveDeepAllOfs(schema, discriminator, typeStack + componentName)
+                    val (mappedSchemaName, mappedSchema) = resolveReferenceToSchema(refPath)
+                    val mappedComponentName = extractComponentName(refPath)
+                    if(mappedComponentName !in typeStack) {
+                        mappedSchemaName to resolveDeepAllOfs(mappedSchema, discriminator, typeStack + mappedComponentName)
                     } else {
-                        schemaName to (emptyList<Schema<Any>>() to Discriminator())
+                        mappedSchemaName to (emptyList<Schema<Any>>() to Discriminator())
                     }
                 }.filterValues { it.second.first.isNotEmpty() }
 

--- a/core/src/test/kotlin/integration_tests/AllOfDiscriminatorTest.kt
+++ b/core/src/test/kotlin/integration_tests/AllOfDiscriminatorTest.kt
@@ -640,6 +640,14 @@ class AllOfDiscriminatorTest {
             stub.client.execute(HttpRequest("POST", "/vehicle", body = parsedJSONObject("""{"type": "bike", "seatingCapacity": 2, "sidecarAvailable": true}"""))).let {
                 assertThat(it.status).isEqualTo(201)
             }
+
+            stub.client.execute(HttpRequest("POST", "/vehicle", body = parsedJSONObject("""{"type": "car", "seatingCapacity": 2, "sidecarAvailable": true}"""))).let {
+                assertThat(it.status).isEqualTo(400)
+            }
+
+            stub.client.execute(HttpRequest("POST", "/vehicle", body = parsedJSONObject("""{"type": "bike", "seatingCapacity": 4, "gearType": "MT"}"""))).let {
+                assertThat(it.status).isEqualTo(400)
+            }
         }
     }
 

--- a/core/src/test/kotlin/integration_tests/AllOfDiscriminatorTest.kt
+++ b/core/src/test/kotlin/integration_tests/AllOfDiscriminatorTest.kt
@@ -372,7 +372,7 @@ class AllOfDiscriminatorTest {
         }
 
         @Test
-        fun `error when discriminator key is missing`() {
+        fun `error when discriminator key is missing from a value`() {
             assertThatThrownBy {
                 feature.matchingStub(
                     HttpRequest(


### PR DESCRIPTION
**What**:

The following schema was not handled correctly:

```yaml
Vehicle:
  allOf:
    - ${'$'}ref: '#/components/schemas/VehicleType'
    - type: object
      properties:
        seatingCapacity:
          type: integer
  discriminator:
    propertyName: "type"
    mapping:
      "car": "#/components/schemas/Transmission"
      "bike": "#/components/schemas/SideCar"

Transmission:
  allOf:
    - ${'$'}ref: '#/components/schemas/Vehicle'
    - type: object
      requried:
        - gearType
      properties:
        gearType:
          type: string
  discriminator:
    propertyName: "type"
    mapping:
      "car": "#/components/schemas/Transmission"
```

Note that car is declared both in the parent `Vehicle` schema and the child `Transmission` schema.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate
