### PR TITLE
Metadata based filtering for test

### DIFF
--- a/application/src/main/kotlin/application/TestCommand.kt
+++ b/application/src/main/kotlin/application/TestCommand.kt
@@ -93,7 +93,7 @@ Filter tests matching the specified filtering criteria
 You can filter tests based on the following keys:
 - `METHOD`: HTTP methods (e.g., GET, POST)
 - `PATH`: Request paths (e.g., /users, /product)
-- `STATUS-CODE`: HTTP response status codes (e.g., 200, 400)
+- `STATUS`: HTTP response status codes (e.g., 200, 400)
 - `HEADERS`: Request headers (e.g., Accept, X-Request-ID)
 - `QUERY-PARAM`: Query parameters (e.g., status, productId)
 - `EXAMPLE-NAME`: Example name (e.g., create-product, active-status)
@@ -119,7 +119,7 @@ Filter tests not matching the specified criteria
 
 This option supports the same filtering keys and syntax as the --filter option.
 For example:
---filterNot="STATUS-CODE=400" --filterNot="METHOD=PATCH,PUT"
+--filterNot="STATUS=400" --filterNot="METHOD=PATCH,PUT"
            """
         ],
         required = false

--- a/application/src/main/kotlin/application/TestCommand.kt
+++ b/application/src/main/kotlin/application/TestCommand.kt
@@ -17,7 +17,9 @@ import io.specmatic.core.utilities.xmlToString
 import io.specmatic.test.SpecmaticJUnitSupport
 import io.specmatic.test.SpecmaticJUnitSupport.Companion.CONTRACT_PATHS
 import io.specmatic.test.SpecmaticJUnitSupport.Companion.ENV_NAME
+import io.specmatic.test.SpecmaticJUnitSupport.Companion.FILTER
 import io.specmatic.test.SpecmaticJUnitSupport.Companion.FILTER_NAME_PROPERTY
+import io.specmatic.test.SpecmaticJUnitSupport.Companion.FILTER_NOT
 import io.specmatic.test.SpecmaticJUnitSupport.Companion.FILTER_NOT_NAME_PROPERTY
 import io.specmatic.test.SpecmaticJUnitSupport.Companion.HOST
 import io.specmatic.test.SpecmaticJUnitSupport.Companion.INLINE_SUGGESTIONS
@@ -82,6 +84,47 @@ class TestCommand : Callable<Unit> {
     @Option(names = ["--filter-not-name"], description = ["Run only tests which do not have this value in their name"], defaultValue = "\${env:SPECMATIC_FILTER_NOT_NAME}")
     var filterNotName: String = ""
 
+    @Option(
+        names= ["--filter"],
+        description = [
+           """
+Filter tests matching the specified filtering criteria
+
+You can filter tests based on the following keys:
+- `method`: HTTP methods (e.g., GET, POST)
+- `path`: Request paths (e.g., /users, /product)
+- `status-code`: HTTP response status codes (e.g., 200, 400)
+- `query`: Query parameters (e.g., status, productId)
+- `header`: Request headers (e.g., Accept, X-Request-ID)
+
+To specify multiple values for the same filter, separate them with commas. 
+For example, to filter by HTTP methods: 
+--filter "method=GET,POST"
+
+You can combine multiple filters using a semicolon. 
+For example:
+--filter "method=GET,POST;path=/users;status-code=200,400;header=Accept"
+           """
+        ],
+        required = false
+    )
+    var filter: String = ""
+
+    @Option(
+        names= ["--filterNot"],
+        description = [
+           """
+Filter tests not matching the specified criteria
+
+This option supports the same filtering keys and syntax as the --filter option.
+For example:
+--filterNot "status-code=400;header.Content-Type=application/xml"
+           """
+        ],
+        required = false
+    )
+    var filterNot: String = ""
+
     @Option(names = ["--env"], description = ["Environment name"])
     var envName: String = ""
 
@@ -143,6 +186,8 @@ class TestCommand : Callable<Unit> {
         System.setProperty(INLINE_SUGGESTIONS, suggestions)
         System.setProperty(ENV_NAME, envName)
         System.setProperty("protocol", protocol)
+        System.setProperty(FILTER, filter)
+        System.setProperty(FILTER_NOT, filterNot)
 
         if(exampleDirs.isNotEmpty()) {
             System.setProperty(EXAMPLE_DIRECTORIES, exampleDirs.joinToString(","))

--- a/application/src/main/kotlin/application/TestCommand.kt
+++ b/application/src/main/kotlin/application/TestCommand.kt
@@ -112,7 +112,7 @@ For example:
     var filter: List<String> = emptyList()
 
     @Option(
-        names= ["--filterNot"],
+        names= ["--filter-not"],
         description = [
            """
 Filter tests not matching the specified criteria

--- a/application/src/main/kotlin/application/TestCommand.kt
+++ b/application/src/main/kotlin/application/TestCommand.kt
@@ -91,24 +91,25 @@ class TestCommand : Callable<Unit> {
 Filter tests matching the specified filtering criteria
 
 You can filter tests based on the following keys:
-- `method`: HTTP methods (e.g., GET, POST)
-- `path`: Request paths (e.g., /users, /product)
-- `status-code`: HTTP response status codes (e.g., 200, 400)
-- `query`: Query parameters (e.g., status, productId)
-- `header`: Request headers (e.g., Accept, X-Request-ID)
+- `METHOD`: HTTP methods (e.g., GET, POST)
+- `PATH`: Request paths (e.g., /users, /product)
+- `STATUS-CODE`: HTTP response status codes (e.g., 200, 400)
+- `HEADERS`: Request headers (e.g., Accept, X-Request-ID)
+- `QUERY-PARAM`: Query parameters (e.g., status, productId)
+- `EXAMPLE-NAME`: Example name (e.g., create-product, active-status)
 
 To specify multiple values for the same filter, separate them with commas. 
 For example, to filter by HTTP methods: 
---filter "method=GET,POST"
+--filter="METHOD=GET,POST"
 
-You can combine multiple filters using a semicolon. 
+You can supply multiple filters as well. 
 For example:
---filter "method=GET,POST;path=/users;status-code=200,400;header=Accept"
+--filter="METHOD=GET,POST" --filter="PATH=/users"
            """
         ],
         required = false
     )
-    var filter: String = ""
+    var filter: List<String> = emptyList()
 
     @Option(
         names= ["--filterNot"],
@@ -118,12 +119,12 @@ Filter tests not matching the specified criteria
 
 This option supports the same filtering keys and syntax as the --filter option.
 For example:
---filterNot "status-code=400;header.Content-Type=application/xml"
+--filterNot="STATUS-CODE=400" --filterNot="METHOD=PATCH,PUT"
            """
         ],
         required = false
     )
-    var filterNot: String = ""
+    var filterNot: List<String> = emptyList()
 
     @Option(names = ["--env"], description = ["Environment name"])
     var envName: String = ""
@@ -186,8 +187,8 @@ For example:
         System.setProperty(INLINE_SUGGESTIONS, suggestions)
         System.setProperty(ENV_NAME, envName)
         System.setProperty("protocol", protocol)
-        System.setProperty(FILTER, filter)
-        System.setProperty(FILTER_NOT, filterNot)
+        System.setProperty(FILTER, filter.joinToString(";"))
+        System.setProperty(FILTER_NOT, filterNot.joinToString(";"))
 
         if(exampleDirs.isNotEmpty()) {
             System.setProperty(EXAMPLE_DIRECTORIES, exampleDirs.joinToString(","))

--- a/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
@@ -20,6 +20,8 @@ data class HttpHeadersPattern(
         }
     }
 
+    val headerNames = pattern.keys
+
     fun isEmpty(): Boolean {
         return pattern.isEmpty()
     }

--- a/core/src/main/kotlin/io/specmatic/core/HttpQueryParamPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpQueryParamPattern.kt
@@ -10,6 +10,8 @@ const val QUERY_PARAMS_BREADCRUMB = "QUERY-PARAMS"
 
 data class HttpQueryParamPattern(val queryPatterns: Map<String, Pattern>, val additionalProperties: Pattern? = null) {
 
+    val queryKeyNames = queryPatterns.keys
+
     fun generate(resolver: Resolver): List<Pair<String, String>> {
         return attempt(breadCrumb = "QUERY-PARAMS") {
             queryPatterns.map { it.key.removeSuffix("?") to it.value }.flatMap { (parameterName, pattern) ->

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
@@ -30,9 +30,9 @@ data class HttpRequestPattern(
     val multiPartFormDataPattern: List<MultiPartFormDataPattern> = emptyList(),
     val securitySchemes: List<OpenAPISecurityScheme> = listOf(NoSecurityScheme())
 ) {
-    fun getHeaderKeys() = headersPattern.pattern.keys
+    fun getHeaderKeys() = headersPattern.headerNames
 
-    fun getQueryParamKeys() = httpQueryParamPattern.queryPatterns.keys
+    fun getQueryParamKeys() = httpQueryParamPattern.queryKeyNames
 
     fun matches(incomingHttpRequest: HttpRequest, resolver: Resolver, headersResolver: Resolver? = null, requestBodyReqex: Regex? = null): Result {
         val result = incomingHttpRequest to resolver to

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
@@ -30,6 +30,10 @@ data class HttpRequestPattern(
     val multiPartFormDataPattern: List<MultiPartFormDataPattern> = emptyList(),
     val securitySchemes: List<OpenAPISecurityScheme> = listOf(NoSecurityScheme())
 ) {
+    fun getHeaderKeys() = headersPattern.pattern.keys
+
+    fun getQueryParamKeys() = httpQueryParamPattern.queryPatterns.keys
+
     fun matches(incomingHttpRequest: HttpRequest, resolver: Resolver, headersResolver: Resolver? = null, requestBodyReqex: Regex? = null): Result {
         val result = incomingHttpRequest to resolver to
                 ::matchPath then

--- a/core/src/main/kotlin/io/specmatic/core/HttpResponsePattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpResponsePattern.kt
@@ -6,6 +6,7 @@ import io.specmatic.core.value.Value
 import io.specmatic.stub.softCastValueToXML
 
 const val DEFAULT_RESPONSE_CODE = 1000
+const val STATUS_BREAD_CRUMB = "STATUS"
 
 data class HttpResponsePattern(
     val headersPattern: HttpHeadersPattern = HttpHeadersPattern(),

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -637,7 +637,8 @@ data class Scenario(
             path = this.path,
             statusCode = this.status,
             header = this.httpRequestPattern.getHeaderKeys(),
-            query = this.httpRequestPattern.getQueryParamKeys()
+            query = this.httpRequestPattern.getQueryParamKeys(),
+            exampleName = this.exampleName.orEmpty()
         )
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -1,6 +1,7 @@
 package io.specmatic.core
 
 import io.specmatic.conversions.OpenApiSpecification
+import io.specmatic.core.filters.ScenarioMetadata
 import io.specmatic.core.log.logger
 import io.specmatic.core.pattern.*
 import io.specmatic.core.utilities.capitalizeFirstChar
@@ -628,6 +629,16 @@ data class Scenario(
             if(rowsThatAreNotOverridden.isEmpty()) return@mapNotNull null
             it.copy(rows = rowsThatAreNotOverridden)
         }
+    }
+
+    fun toScenarioMetadata(): ScenarioMetadata {
+        return ScenarioMetadata(
+            method = this.method,
+            path = this.path,
+            statusCode = this.status,
+            header = this.httpRequestPattern.getHeaderKeys(),
+            query = this.httpRequestPattern.getQueryParamKeys()
+        )
     }
 }
 

--- a/core/src/main/kotlin/io/specmatic/core/filters/ScenarioFilterTags.kt
+++ b/core/src/main/kotlin/io/specmatic/core/filters/ScenarioFilterTags.kt
@@ -4,11 +4,12 @@ import io.specmatic.core.HEADERS_BREADCRUMB
 import io.specmatic.core.METHOD_BREAD_CRUMB
 import io.specmatic.core.PATH_BREAD_CRUMB
 import io.specmatic.core.QUERY_PARAMS_BREADCRUMB
+import io.specmatic.core.STATUS_BREAD_CRUMB
 
 enum class ScenarioFilterTags(val key: String) {
     METHOD(METHOD_BREAD_CRUMB),
     PATH(PATH_BREAD_CRUMB),
-    STATUS_CODE("STATUS-CODE"),
+    STATUS_CODE(STATUS_BREAD_CRUMB),
     HEADER(HEADERS_BREADCRUMB),
     QUERY(QUERY_PARAMS_BREADCRUMB),
     EXAMPLE_NAME("EXAMPLE-NAME")

--- a/core/src/main/kotlin/io/specmatic/core/filters/ScenarioFilterTags.kt
+++ b/core/src/main/kotlin/io/specmatic/core/filters/ScenarioFilterTags.kt
@@ -1,10 +1,15 @@
 package io.specmatic.core.filters
 
+import io.specmatic.core.HEADERS_BREADCRUMB
+import io.specmatic.core.METHOD_BREAD_CRUMB
+import io.specmatic.core.PATH_BREAD_CRUMB
+import io.specmatic.core.QUERY_PARAMS_BREADCRUMB
+
 enum class ScenarioFilterTags(val key: String) {
-    METHOD("method"),
-    PATH("path"),
-    STATUS_CODE("status-code"),
-    HEADER("header"),
-    QUERY("query"),
-    EXAMPLE_NAME("example-name")
+    METHOD(METHOD_BREAD_CRUMB),
+    PATH(PATH_BREAD_CRUMB),
+    STATUS_CODE("STATUS-CODE"),
+    HEADER(HEADERS_BREADCRUMB),
+    QUERY(QUERY_PARAMS_BREADCRUMB),
+    EXAMPLE_NAME("EXAMPLE-NAME")
 }

--- a/core/src/main/kotlin/io/specmatic/core/filters/ScenarioFilterTags.kt
+++ b/core/src/main/kotlin/io/specmatic/core/filters/ScenarioFilterTags.kt
@@ -1,0 +1,9 @@
+package io.specmatic.core.filters
+
+enum class ScenarioFilterTags(val key: String) {
+    METHOD("method"),
+    PATH("path"),
+    STATUS_CODE("status-code"),
+    HEADER("header"),
+    QUERY("query")
+}

--- a/core/src/main/kotlin/io/specmatic/core/filters/ScenarioFilterTags.kt
+++ b/core/src/main/kotlin/io/specmatic/core/filters/ScenarioFilterTags.kt
@@ -5,5 +5,6 @@ enum class ScenarioFilterTags(val key: String) {
     PATH("path"),
     STATUS_CODE("status-code"),
     HEADER("header"),
-    QUERY("query")
+    QUERY("query"),
+    EXAMPLE_NAME("example-name")
 }

--- a/core/src/main/kotlin/io/specmatic/core/filters/ScenarioMetadata.kt
+++ b/core/src/main/kotlin/io/specmatic/core/filters/ScenarioMetadata.kt
@@ -1,0 +1,9 @@
+package io.specmatic.core.filters
+
+data class ScenarioMetadata(
+    val method: String,
+    val path: String,
+    val statusCode: Int,
+    val header: Set<String>,
+    val query: Set<String>
+)

--- a/core/src/main/kotlin/io/specmatic/core/filters/ScenarioMetadata.kt
+++ b/core/src/main/kotlin/io/specmatic/core/filters/ScenarioMetadata.kt
@@ -5,5 +5,6 @@ data class ScenarioMetadata(
     val path: String,
     val statusCode: Int,
     val header: Set<String>,
-    val query: Set<String>
+    val query: Set<String>,
+    val exampleName: String
 )

--- a/core/src/main/kotlin/io/specmatic/core/filters/ScenarioMetadataFilter.kt
+++ b/core/src/main/kotlin/io/specmatic/core/filters/ScenarioMetadataFilter.kt
@@ -66,14 +66,3 @@ data class ScenarioMetadataFilter(
         }
     }
 }
-
-
-
-
-
-
-
-
-
-
-

--- a/core/src/main/kotlin/io/specmatic/core/filters/ScenarioMetadataFilter.kt
+++ b/core/src/main/kotlin/io/specmatic/core/filters/ScenarioMetadataFilter.kt
@@ -1,5 +1,6 @@
 package io.specmatic.core.filters
 
+import io.specmatic.core.Scenario
 import io.specmatic.test.ContractTest
 
 data class ScenarioMetadataFilter(
@@ -60,6 +61,18 @@ data class ScenarioMetadataFilter(
                 scenarioMetadataFilter.isSatisfiedByAll(it.scenario.toScenarioMetadata())
             }.filterNot {
                 scenarioMetadataExclusionFilter.isSatisfiedByAtLeastOne(it.scenario.toScenarioMetadata())
+            }
+        }
+
+        fun filterScenariosUsing(
+            scenarios: Sequence<Scenario>,
+            scenarioMetadataFilter: ScenarioMetadataFilter,
+            scenarioMetadataExclusionFilter: ScenarioMetadataFilter
+        ): Sequence<Scenario> {
+            return scenarios.filter {
+                scenarioMetadataFilter.isSatisfiedByAll(it.toScenarioMetadata())
+            }.filterNot {
+                scenarioMetadataExclusionFilter.isSatisfiedByAtLeastOne(it.toScenarioMetadata())
             }
         }
 

--- a/core/src/main/kotlin/io/specmatic/core/filters/ScenarioMetadataFilter.kt
+++ b/core/src/main/kotlin/io/specmatic/core/filters/ScenarioMetadataFilter.kt
@@ -5,12 +5,15 @@ data class ScenarioMetadataFilter(
     val paths: Set<String> = emptySet(),
     val statusCodes: Set<String> = emptySet(),
     val headers: Set<String> = emptySet(),
-    val queryParams: Set<String> = emptySet()
+    val queryParams: Set<String> = emptySet(),
+    val exampleNames: Set<String> = emptySet()
 ) {
     fun isSatisfiedByAll(metadata: ScenarioMetadata): Boolean {
         return methods.contains(metadata.method, false) &&
                 paths.contains(metadata.path, false) &&
                 statusCodes.contains(metadata.statusCode.toString(), false) &&
+                (metadata.exampleName.isNotBlank()
+                        && exampleNames.contains(metadata.exampleName, false)) &&
                 (headers.isEmpty() || metadata.header.any { headers.contains(it, false) }) &&
                 (queryParams.isEmpty() || metadata.query.any { queryParams.contains(it, false) })
     }
@@ -19,6 +22,8 @@ data class ScenarioMetadataFilter(
         return methods.contains(metadata.method, true) ||
                 paths.contains(metadata.path, true) ||
                 statusCodes.contains(metadata.statusCode.toString(), true) ||
+                (metadata.exampleName.isNotBlank()
+                        && exampleNames.contains(metadata.exampleName, true)) ||
                 (headers.isNotEmpty() && metadata.header.any { headers.contains(it, true) }) ||
                 (queryParams.isNotEmpty() && metadata.query.any { queryParams.contains(it, true) })
     }
@@ -41,7 +46,8 @@ data class ScenarioMetadataFilter(
                 paths = filters.getFiltersWithTag(ScenarioFilterTags.PATH),
                 statusCodes = filters.getFiltersWithTag(ScenarioFilterTags.STATUS_CODE),
                 headers = filters.getFiltersWithTag(ScenarioFilterTags.HEADER),
-                queryParams = filters.getFiltersWithTag(ScenarioFilterTags.QUERY)
+                queryParams = filters.getFiltersWithTag(ScenarioFilterTags.QUERY),
+                exampleNames = filters.getFiltersWithTag(ScenarioFilterTags.EXAMPLE_NAME)
             )
         }
 

--- a/core/src/main/kotlin/io/specmatic/core/filters/ScenarioMetadataFilter.kt
+++ b/core/src/main/kotlin/io/specmatic/core/filters/ScenarioMetadataFilter.kt
@@ -11,7 +11,7 @@ data class ScenarioMetadataFilter(
     fun isSatisfiedByAll(metadata: ScenarioMetadata): Boolean {
         return methods.contains(metadata.method, false) &&
                 paths.contains(metadata.path, false) &&
-                isStatusCodeMatch(metadata.statusCode, false) &&
+                isStatusCodeFilterSatisfied(metadata.statusCode, false) &&
                 exampleNames.contains(metadata.exampleName, false) &&
                 (headers.isEmpty() || metadata.header.any { headers.contains(it, false) }) &&
                 (queryParams.isEmpty() || metadata.query.any { queryParams.contains(it, false) })
@@ -20,7 +20,7 @@ data class ScenarioMetadataFilter(
     fun isSatisfiedByAtLeastOne(metadata: ScenarioMetadata): Boolean {
         return methods.contains(metadata.method, true) ||
                 paths.contains(metadata.path, true) ||
-                isStatusCodeMatch(metadata.statusCode, true) ||
+                isStatusCodeFilterSatisfied(metadata.statusCode, true) ||
                 exampleNames.contains(metadata.exampleName, true) ||
                 (headers.isNotEmpty() && metadata.header.any { headers.contains(it, true) }) ||
                 (queryParams.isNotEmpty() && metadata.query.any { queryParams.contains(it, true) })
@@ -31,7 +31,7 @@ data class ScenarioMetadataFilter(
         return (this.isEmpty() || element in this)
     }
 
-    private fun isStatusCodeMatch(statusCode: Int, strict: Boolean): Boolean {
+    private fun isStatusCodeFilterSatisfied(statusCode: Int, strict: Boolean): Boolean {
         val hasMatchingStatusCode = statusCodes.any { statusCodePattern ->
             when {
                 statusCodePattern.length == 3 && statusCodePattern.endsWith("xx") ->

--- a/core/src/main/kotlin/io/specmatic/core/filters/ScenarioMetadataFilter.kt
+++ b/core/src/main/kotlin/io/specmatic/core/filters/ScenarioMetadataFilter.kt
@@ -1,0 +1,73 @@
+package io.specmatic.core.filters
+
+data class ScenarioMetadataFilter(
+    val methods: Set<String> = emptySet(),
+    val paths: Set<String> = emptySet(),
+    val statusCodes: Set<String> = emptySet(),
+    val headers: Set<String> = emptySet(),
+    val queryParams: Set<String> = emptySet()
+) {
+    fun isSatisfiedByAll(metadata: ScenarioMetadata): Boolean {
+        return methods.contains(metadata.method, false) &&
+                paths.contains(metadata.path, false) &&
+                statusCodes.contains(metadata.statusCode.toString(), false) &&
+                (headers.isEmpty() || metadata.header.any { headers.contains(it, false) }) &&
+                (queryParams.isEmpty() || metadata.query.any { queryParams.contains(it, false) })
+    }
+
+    fun isSatisfiedByAtLeastOne(metadata: ScenarioMetadata): Boolean {
+        return methods.contains(metadata.method, true) ||
+                paths.contains(metadata.path, true) ||
+                statusCodes.contains(metadata.statusCode.toString(), true) ||
+                (headers.isNotEmpty() && metadata.header.any { headers.contains(it, true) }) ||
+                (queryParams.isNotEmpty() && metadata.query.any { queryParams.contains(it, true) })
+    }
+
+    private fun Set<String>.contains(element: String, strict: Boolean): Boolean {
+        if(strict) return (this.isNotEmpty() && element in this)
+        return (this.isEmpty() || element in this)
+    }
+
+    companion object {
+        private const val FILTER_SEPARATOR = ";"
+
+        fun from(filter: String): ScenarioMetadataFilter {
+            if(filter.split(FILTER_SEPARATOR).isEmpty()) {
+                return ScenarioMetadataFilter()
+            }
+            val filters = filter.split(FILTER_SEPARATOR)
+            return ScenarioMetadataFilter(
+                methods = filters.getFiltersWithTag(ScenarioFilterTags.METHOD),
+                paths = filters.getFiltersWithTag(ScenarioFilterTags.PATH),
+                statusCodes = filters.getFiltersWithTag(ScenarioFilterTags.STATUS_CODE),
+                headers = filters.getFiltersWithTag(ScenarioFilterTags.HEADER),
+                queryParams = filters.getFiltersWithTag(ScenarioFilterTags.QUERY)
+            )
+        }
+
+        private fun List<String>.getFiltersWithTag(tag: ScenarioFilterTags): Set<String> {
+            return this.asSequence().map {
+                it.trim().split("=")
+            }.filter { it.size == 2 }.filter {
+                val key = it[0]
+                key == tag.key
+            }.flatMap {
+                val values = it[1]
+                values.trim().split(",").map { value ->
+                    value.trim()
+                }
+            }.toSet()
+        }
+    }
+}
+
+
+
+
+
+
+
+
+
+
+

--- a/core/src/main/kotlin/io/specmatic/core/filters/ScenarioMetadataFilter.kt
+++ b/core/src/main/kotlin/io/specmatic/core/filters/ScenarioMetadataFilter.kt
@@ -52,27 +52,16 @@ data class ScenarioMetadataFilter(
             )
         }
 
-        fun filterTestsUsing(
-            contractTests: Sequence<ContractTest>,
+        fun <T> filterUsing(
+            items: Sequence<T>,
             scenarioMetadataFilter: ScenarioMetadataFilter,
-            scenarioMetadataExclusionFilter: ScenarioMetadataFilter
-        ): Sequence<ContractTest> {
-            return contractTests.filter {
-                scenarioMetadataFilter.isSatisfiedByAll(it.scenario.toScenarioMetadata())
+            scenarioMetadataExclusionFilter: ScenarioMetadataFilter,
+            toScenarioMetadata: (T) -> ScenarioMetadata
+        ): Sequence<T> {
+            return items.filter {
+                scenarioMetadataFilter.isSatisfiedByAll(toScenarioMetadata(it))
             }.filterNot {
-                scenarioMetadataExclusionFilter.isSatisfiedByAtLeastOne(it.scenario.toScenarioMetadata())
-            }
-        }
-
-        fun filterScenariosUsing(
-            scenarios: Sequence<Scenario>,
-            scenarioMetadataFilter: ScenarioMetadataFilter,
-            scenarioMetadataExclusionFilter: ScenarioMetadataFilter
-        ): Sequence<Scenario> {
-            return scenarios.filter {
-                scenarioMetadataFilter.isSatisfiedByAll(it.toScenarioMetadata())
-            }.filterNot {
-                scenarioMetadataExclusionFilter.isSatisfiedByAtLeastOne(it.toScenarioMetadata())
+                scenarioMetadataExclusionFilter.isSatisfiedByAtLeastOne(toScenarioMetadata(it))
             }
         }
 

--- a/core/src/main/kotlin/io/specmatic/core/utilities/Utilities.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/Utilities.kt
@@ -334,7 +334,9 @@ fun saveJsonFile(jsonString: String, path: String, fileName: String) {
 }
 
 fun readEnvVarOrProperty(envVarName: String, propertyName: String): String? {
-    return System.getenv(envVarName) ?: System.getProperty(propertyName)
+    if(System.getenv(envVarName).isNullOrEmpty().not()) return System.getenv(envVarName)
+    if(System.getProperty(propertyName).isNullOrEmpty().not()) return System.getProperty(propertyName)
+    return null
 }
 
 fun examplesDirFor(openApiFilePath: String, alternateSuffix: String): File {

--- a/core/src/main/kotlin/io/specmatic/core/utilities/Utilities.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/Utilities.kt
@@ -334,9 +334,7 @@ fun saveJsonFile(jsonString: String, path: String, fileName: String) {
 }
 
 fun readEnvVarOrProperty(envVarName: String, propertyName: String): String? {
-    if(System.getenv(envVarName).isNullOrEmpty().not()) return System.getenv(envVarName)
-    if(System.getProperty(propertyName).isNullOrEmpty().not()) return System.getProperty(propertyName)
-    return null
+    return System.getenv(envVarName) ?: System.getProperty(propertyName)
 }
 
 fun examplesDirFor(openApiFilePath: String, alternateSuffix: String): File {

--- a/core/src/main/kotlin/io/specmatic/test/ContractTest.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ContractTest.kt
@@ -3,13 +3,14 @@ package io.specmatic.test
 import io.specmatic.core.HttpResponse
 import io.specmatic.core.Result
 import io.specmatic.core.Scenario
+import io.specmatic.core.filters.ScenarioMetadata
 
 interface ResponseValidator {
     fun validate(scenario: Scenario, httpResponse: HttpResponse): Result?
 }
 
 interface ContractTest {
-    val scenario: Scenario
+    fun toScenarioMetadata(): ScenarioMetadata
     fun testResultRecord(result: Result, response: HttpResponse?): TestResultRecord?
     fun testDescription(): String
     fun runTest(testBaseURL: String, timeoutInMilliseconds: Long): Pair<Result, HttpResponse?>

--- a/core/src/main/kotlin/io/specmatic/test/ContractTest.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ContractTest.kt
@@ -9,6 +9,7 @@ interface ResponseValidator {
 }
 
 interface ContractTest {
+    val scenario: Scenario
     fun testResultRecord(result: Result, response: HttpResponse?): TestResultRecord?
     fun testDescription(): String
     fun runTest(testBaseURL: String, timeoutInMilliseconds: Long): Pair<Result, HttpResponse?>

--- a/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
@@ -2,6 +2,7 @@ package io.specmatic.test
 
 import io.specmatic.conversions.convertPathParameterStyle
 import io.specmatic.core.*
+import io.specmatic.core.filters.ScenarioMetadata
 import io.specmatic.core.log.HttpLogMessage
 import io.specmatic.core.log.LogMessage
 import io.specmatic.core.log.logger
@@ -9,7 +10,7 @@ import io.specmatic.core.utilities.exceptionCauseMessage
 import io.specmatic.core.value.Value
 
 data class ScenarioAsTest(
-    override val scenario: Scenario,
+    val scenario: Scenario,
     private val flagsBased: FlagsBased,
     private val sourceProvider: String? = null,
     private val sourceRepository: String? = null,
@@ -25,6 +26,8 @@ data class ScenarioAsTest(
     companion object {
         private var id: Value? = null
     }
+
+    override fun toScenarioMetadata() = scenario.toScenarioMetadata()
 
     override fun testResultRecord(result: Result, response: HttpResponse?): TestResultRecord {
         val resultStatus = result.testResult()

--- a/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
@@ -9,7 +9,7 @@ import io.specmatic.core.utilities.exceptionCauseMessage
 import io.specmatic.core.value.Value
 
 data class ScenarioAsTest(
-    val scenario: Scenario,
+    override val scenario: Scenario,
     private val flagsBased: FlagsBased,
     private val sourceProvider: String? = null,
     private val sourceRepository: String? = null,

--- a/core/src/main/kotlin/io/specmatic/test/ScenarioTestGenerationException.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ScenarioTestGenerationException.kt
@@ -3,15 +3,19 @@ package io.specmatic.test
 import io.specmatic.core.HttpResponse
 import io.specmatic.core.Result
 import io.specmatic.core.Scenario
+import io.specmatic.core.filters.ScenarioMetadata
 import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.utilities.exceptionCauseMessage
 
 class ScenarioTestGenerationException(
-    override val scenario: Scenario,
+    val scenario: Scenario,
     val e: Throwable,
     val message: String,
     val breadCrumb: String?
 ) : ContractTest {
+
+    override fun toScenarioMetadata() = scenario.toScenarioMetadata()
+
     override fun testResultRecord(result: Result, response: HttpResponse?): TestResultRecord? {
         return null
     }

--- a/core/src/main/kotlin/io/specmatic/test/ScenarioTestGenerationException.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ScenarioTestGenerationException.kt
@@ -6,7 +6,12 @@ import io.specmatic.core.Scenario
 import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.utilities.exceptionCauseMessage
 
-class ScenarioTestGenerationException(val scenario: Scenario, val e: Throwable, val message: String, val breadCrumb: String?) : ContractTest {
+class ScenarioTestGenerationException(
+    override val scenario: Scenario,
+    val e: Throwable,
+    val message: String,
+    val breadCrumb: String?
+) : ContractTest {
     override fun testResultRecord(result: Result, response: HttpResponse?): TestResultRecord? {
         return null
     }

--- a/core/src/main/kotlin/io/specmatic/test/ScenarioTestGenerationFailure.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ScenarioTestGenerationFailure.kt
@@ -3,11 +3,14 @@ package io.specmatic.test
 import io.specmatic.core.HttpResponse
 import io.specmatic.core.Result
 import io.specmatic.core.Scenario
+import io.specmatic.core.filters.ScenarioMetadata
 
 class ScenarioTestGenerationFailure(
-    override val scenario: Scenario,
+    val scenario: Scenario,
     val failure: Result.Failure
 ): ContractTest {
+    override fun toScenarioMetadata() = scenario.toScenarioMetadata()
+
     override fun testResultRecord(result: Result, response: HttpResponse?): TestResultRecord? {
         return null
     }

--- a/core/src/main/kotlin/io/specmatic/test/ScenarioTestGenerationFailure.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ScenarioTestGenerationFailure.kt
@@ -4,7 +4,10 @@ import io.specmatic.core.HttpResponse
 import io.specmatic.core.Result
 import io.specmatic.core.Scenario
 
-class ScenarioTestGenerationFailure(val scenario: Scenario, val failure: Result.Failure): ContractTest {
+class ScenarioTestGenerationFailure(
+    override val scenario: Scenario,
+    val failure: Result.Failure
+): ContractTest {
     override fun testResultRecord(result: Result, response: HttpResponse?): TestResultRecord? {
         return null
     }

--- a/core/src/test/kotlin/io/specmatic/core/ScenarioTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ScenarioTest.kt
@@ -1,5 +1,7 @@
 package io.specmatic.core
 
+import io.mockk.every
+import io.mockk.mockk
 import io.specmatic.core.pattern.*
 import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.Test
@@ -254,5 +256,35 @@ class ScenarioTest {
                 .hasMessageContaining("string")
                 .hasMessageContaining("REQUEST.BODY.id")
         })
+    }
+
+    @Test
+    fun `should return scenarioMetadata from scenario`() {
+        val httpRequestPattern = mockk<HttpRequestPattern> {
+            every {
+                getHeaderKeys()
+            } returns setOf("Authorization", "X-Request-ID")
+
+            every {
+                getQueryParamKeys()
+            } returns setOf("productId", "orderId")
+
+            every { method } returns "POST"
+            every { httpPathPattern } returns HttpPathPattern(emptyList(), "/createProduct")
+        }
+
+        val scenarioMetadata = Scenario(
+            "",
+            httpRequestPattern,
+            HttpResponsePattern(status = 200),
+            exampleName = "example"
+        ).toScenarioMetadata()
+
+        assertThat(scenarioMetadata.method).isEqualTo("POST")
+        assertThat(scenarioMetadata.path).isEqualTo("/createProduct")
+        assertThat(scenarioMetadata.query).isEqualTo(setOf("productId", "orderId"))
+        assertThat(scenarioMetadata.header).isEqualTo(setOf("Authorization", "X-Request-ID"))
+        assertThat(scenarioMetadata.statusCode).isEqualTo(200)
+        assertThat(scenarioMetadata.exampleName).isEqualTo("example")
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/filters/ScenarioMetadataFilterTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/filters/ScenarioMetadataFilterTest.kt
@@ -1,6 +1,12 @@
 package io.specmatic.core.filters
 
+import io.mockk.every
+import io.mockk.mockk
+import io.specmatic.core.filters.ScenarioMetadataFilter.Companion.filterTestsUsing
+import io.specmatic.test.ContractTest
+import io.specmatic.test.ScenarioAsTest
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -159,6 +165,191 @@ class ScenarioMetadataFilterTest {
             assertThat(filter.headers).containsExactlyInAnyOrder("Authorization", "Content-Type")
             assertThat(filter.queryParams).containsExactlyInAnyOrder("productId", "orderId")
             assertThat(filter.exampleNames).containsExactlyInAnyOrder("create-product")
+        }
+    }
+
+    @Nested
+    inner class TestsForFilterTestsUsingFunction {
+
+        private fun getScenarioAsTestReturning(scenarioMetadata: ScenarioMetadata): ScenarioAsTest {
+            return mockk<ScenarioAsTest> {
+                every { scenario } returns mockk {
+                    every { toScenarioMetadata() } returns scenarioMetadata
+                }
+            }
+        }
+
+        @Test
+        fun `should return all tests if there is no filter involved`() {
+            val tests = sequenceOf(
+                getScenarioAsTestReturning(
+                    ScenarioMetadata(
+                        method = "POST",
+                        path = "/product",
+                        statusCode = 200,
+                        header = emptySet(),
+                        query = emptySet(),
+                        exampleName = ""
+                    )
+                )
+            )
+            val filter = ScenarioMetadataFilter()
+            val result = filterTestsUsing(tests, filter, filter)
+
+            assertEquals(tests.toList(), result.toList())
+        }
+
+        @Test
+        fun `should return the test which satisfies the inclusion filter`() {
+            val tests = sequenceOf(
+                getScenarioAsTestReturning(
+                    ScenarioMetadata(
+                        "GET",
+                        "/path1",
+                        200,
+                        setOf("Content-Type: application/json"),
+                        setOf("id=1"),
+                        "example1"
+                    )
+                ),
+                getScenarioAsTestReturning(
+                    ScenarioMetadata(
+                        "POST",
+                        "/path2",
+                        404,
+                        setOf("Content-Type: application/json"),
+                        setOf("id=2"),
+                        "example2"
+                    )
+                )
+            )
+            val includeFilter = ScenarioMetadataFilter(methods = setOf("GET"), paths = setOf("/path1"))
+            val excludeFilter = ScenarioMetadataFilter()  // No exclusion
+
+            val result = filterTestsUsing(tests, includeFilter, excludeFilter).toList()
+
+            assertEquals(result.size, 1)
+            assertThat(result.single()).isEqualTo(tests.first())
+        }
+
+        @Test
+        fun `should return the test which satisfies the exclusion filter`() {
+            val tests = sequenceOf(
+                getScenarioAsTestReturning(
+                    ScenarioMetadata(
+                        "GET",
+                        "/path1",
+                        200,
+                        setOf("Content-Type: application/json"),
+                        setOf("id=1"),
+                        "example1"
+                    )
+                ),
+                getScenarioAsTestReturning(
+                    ScenarioMetadata(
+                        "POST",
+                        "/path2",
+                        404,
+                        setOf("Content-Type: application/json"),
+                        setOf("id=2"),
+                        "example2"
+                    )
+                ),
+                getScenarioAsTestReturning(
+                    ScenarioMetadata(
+                        "GET",
+                        "/path3",
+                        500,
+                        setOf("Content-Type: application/json"),
+                        setOf("id=3"),
+                        "example3"
+                    )
+                )
+            )
+            val includeFilter = ScenarioMetadataFilter()
+            val excludeFilter = ScenarioMetadataFilter(statusCodes = setOf("200"))  // Exclude status code 200
+
+            val result = filterTestsUsing(tests, includeFilter, excludeFilter).toList()
+
+            assertEquals(
+                tests.filterIndexed { index, _ -> index > 0 }.toList(),
+                result.toList()
+            )
+        }
+
+        @Test
+        fun `should return the test which satisfies both the inclusion and exclusion filters`() {
+            val tests = sequenceOf(
+                getScenarioAsTestReturning(
+                    ScenarioMetadata(
+                        "GET",
+                        "/path1",
+                        200,
+                        setOf("Content-Type: application/json"),
+                        setOf("id=1"),
+                        "example1"
+                    )
+                ),
+                getScenarioAsTestReturning(
+                    ScenarioMetadata(
+                        "GET",
+                        "/path1",
+                        400,
+                        setOf("Content-Type: application/json"),
+                        setOf("id=1"),
+                        "example1"
+                    )
+                ),
+                getScenarioAsTestReturning(
+                    ScenarioMetadata(
+                        "POST",
+                        "/path2",
+                        404,
+                        setOf("Content-Type: application/json"),
+                        setOf("id=2"),
+                        "example2"
+                    )
+                )
+            )
+            val includeFilter = ScenarioMetadataFilter(methods = setOf("GET")) // Include GET methods
+            val excludeFilter = ScenarioMetadataFilter(statusCodes = setOf("400"))  // Exclude 400 status codes
+
+            val result = filterTestsUsing(tests, includeFilter, excludeFilter).toList()
+
+            assertEquals(result.size, 1)
+            assertThat(result.single()).isEqualTo(tests.first())
+        }
+
+        @Test
+        fun `should return no test if the no test satisfies both inclusion and exclusion filters`() {
+            val tests = sequenceOf(
+                getScenarioAsTestReturning(
+                    ScenarioMetadata(
+                        "GET",
+                        "/path1",
+                        200,
+                        setOf(),
+                        setOf(),
+                        "example1"
+                    )
+                ),
+                getScenarioAsTestReturning(
+                    ScenarioMetadata(
+                        "POST",
+                        "/path2",
+                        404,
+                        setOf(),
+                        setOf(),
+                        "example2"
+                    )
+                )
+            )
+            val includeFilter = ScenarioMetadataFilter(methods = setOf("PUT"))
+            val excludeFilter = ScenarioMetadataFilter(exampleNames = setOf("example3"))
+
+            val result = filterTestsUsing(tests, includeFilter, excludeFilter)
+
+            assertEquals(emptyList<ContractTest>(), result.toList())
         }
     }
 

--- a/core/src/test/kotlin/io/specmatic/core/filters/ScenarioMetadataFilterTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/filters/ScenarioMetadataFilterTest.kt
@@ -2,7 +2,7 @@ package io.specmatic.core.filters
 
 import io.mockk.every
 import io.mockk.mockk
-import io.specmatic.core.filters.ScenarioMetadataFilter.Companion.filterTestsUsing
+import io.specmatic.core.filters.ScenarioMetadataFilter.Companion.filterUsing
 import io.specmatic.test.ContractTest
 import io.specmatic.test.ScenarioAsTest
 import org.assertj.core.api.Assertions.assertThat
@@ -132,7 +132,7 @@ class ScenarioMetadataFilterTest {
     }
 
     @Nested
-    inner class CreateFilterUsingFromTests {
+    inner class FilterStringToScenarioMetadataTests {
         @Test
         fun `should create the scenario metadata filter from the filter string`() {
             val filterString = "METHOD=POST,GET;STATUS-CODE=200;PATH=/users,/products"
@@ -169,7 +169,7 @@ class ScenarioMetadataFilterTest {
     }
 
     @Nested
-    inner class TestsForFilterTestsUsingFunction {
+    inner class TestsForFilterUsingFunction {
 
         private fun getScenarioAsTestReturning(scenarioMetadata: ScenarioMetadata): ScenarioAsTest {
             return mockk<ScenarioAsTest> {
@@ -194,7 +194,7 @@ class ScenarioMetadataFilterTest {
                 )
             )
             val filter = ScenarioMetadataFilter()
-            val result = filterTestsUsing(tests, filter, filter)
+            val result = filterUsing(tests, filter, filter) { it.scenario.toScenarioMetadata() }
 
             assertEquals(tests.toList(), result.toList())
         }
@@ -226,7 +226,9 @@ class ScenarioMetadataFilterTest {
             val includeFilter = ScenarioMetadataFilter(methods = setOf("GET"), paths = setOf("/path1"))
             val excludeFilter = ScenarioMetadataFilter()  // No exclusion
 
-            val result = filterTestsUsing(tests, includeFilter, excludeFilter).toList()
+            val result = filterUsing(tests, includeFilter, excludeFilter) {
+                it.scenario.toScenarioMetadata()
+            }.toList()
 
             assertEquals(result.size, 1)
             assertThat(result.single()).isEqualTo(tests.first())
@@ -269,7 +271,9 @@ class ScenarioMetadataFilterTest {
             val includeFilter = ScenarioMetadataFilter()
             val excludeFilter = ScenarioMetadataFilter(statusCodes = setOf("200"))  // Exclude status code 200
 
-            val result = filterTestsUsing(tests, includeFilter, excludeFilter).toList()
+            val result = filterUsing(tests, includeFilter, excludeFilter) {
+                it.scenario.toScenarioMetadata()
+            }.toList()
 
             assertEquals(
                 tests.filterIndexed { index, _ -> index > 0 }.toList(),
@@ -314,7 +318,9 @@ class ScenarioMetadataFilterTest {
             val includeFilter = ScenarioMetadataFilter(methods = setOf("GET")) // Include GET methods
             val excludeFilter = ScenarioMetadataFilter(statusCodes = setOf("400"))  // Exclude 400 status codes
 
-            val result = filterTestsUsing(tests, includeFilter, excludeFilter).toList()
+            val result = filterUsing(tests, includeFilter, excludeFilter) {
+                it.scenario.toScenarioMetadata()
+            }.toList()
 
             assertEquals(result.size, 1)
             assertThat(result.single()).isEqualTo(tests.first())
@@ -347,7 +353,9 @@ class ScenarioMetadataFilterTest {
             val includeFilter = ScenarioMetadataFilter(methods = setOf("PUT"))
             val excludeFilter = ScenarioMetadataFilter(exampleNames = setOf("example3"))
 
-            val result = filterTestsUsing(tests, includeFilter, excludeFilter)
+            val result = filterUsing(tests, includeFilter, excludeFilter) {
+                it.scenario.toScenarioMetadata()
+            }.toList()
 
             assertEquals(emptyList<ContractTest>(), result.toList())
         }

--- a/core/src/test/kotlin/io/specmatic/core/filters/ScenarioMetadataFilterTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/filters/ScenarioMetadataFilterTest.kt
@@ -1,0 +1,379 @@
+package io.specmatic.core.filters
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
+
+class ScenarioMetadataFilterTest {
+
+    @Nested
+    inner class IsSatisfiedByAllTests {
+        @Test
+        fun `should satisfy all filters when all criteria match`() {
+            val filter = ScenarioMetadataFilter(
+                methods = setOf("GET"),
+                paths = setOf("/users"),
+                statusCodes = setOf("200"),
+                headers = setOf("Authorization"),
+                queryParams = setOf("userId"),
+                exampleNames = setOf("example1")
+            )
+            val metadata = ScenarioMetadata(
+                method = "GET",
+                path = "/users",
+                statusCode = 200,
+                header = setOf("Authorization"),
+                query = setOf("userId"),
+                exampleName = "example1"
+            )
+            assertThat(filter.isSatisfiedByAll(metadata)).isTrue()
+        }
+
+        @Test
+        fun `should satisfy all filters with multiple headers and query params in metadata`() {
+            val filter = ScenarioMetadataFilter(
+                methods = setOf("GET"),
+                paths = setOf("/users"),
+                statusCodes = setOf("200"),
+                headers = setOf("Authorization", "Content-Type"),
+                queryParams = setOf("userId", "role"),
+                exampleNames = setOf("example1")
+            )
+            val metadata = ScenarioMetadata(
+                method = "GET",
+                path = "/users",
+                statusCode = 200,
+                header = setOf("Authorization", "Content-Type", "Custom-Header"),
+                query = setOf("userId", "role", "additionalQueryParam"),
+                exampleName = "example1"
+            )
+            assertThat(filter.isSatisfiedByAll(metadata)).isTrue()
+        }
+
+        @Test
+        fun `should satisfy all filters if all the filters are empty`() {
+            val filter = ScenarioMetadataFilter()
+            val metadata = ScenarioMetadata(
+                method = "GET",
+                path = "/any",
+                statusCode = 200,
+                header = emptySet(),
+                query = emptySet(),
+                exampleName = "example"
+            )
+            assertThat(filter.isSatisfiedByAll(metadata)).isTrue()
+        }
+    }
+
+    @Nested
+    inner class IsSatisfiedByAtLeastOneTests {
+        @Test
+        fun `should not satisfy at least one filter when no criteria match`() {
+            val filter = ScenarioMetadataFilter(
+                methods = setOf("POST"),
+                paths = setOf("/products"),
+                statusCodes = setOf("201"),
+                headers = setOf("Authorization"),
+                queryParams = setOf("userId"),
+                exampleNames = setOf("example2")
+            )
+            val metadata = ScenarioMetadata(
+                method = "GET",
+                path = "/users",
+                statusCode = 404,
+                header = emptySet(),
+                query = emptySet(),
+                exampleName = "example3"
+            )
+            assertThat(filter.isSatisfiedByAtLeastOne(metadata)).isFalse()
+        }
+
+        @Test
+        fun `should satisfy at least one filter with matching header`() {
+            val filter = ScenarioMetadataFilter(
+                headers = setOf("Authorization")
+            )
+            val metadata = ScenarioMetadata(
+                method = "GET",
+                path = "/any",
+                statusCode = 200,
+                header = setOf("Authorization", "X-Request-ID"),
+                query = setOf("anyId"),
+                exampleName = ""
+            )
+            assertThat(filter.isSatisfiedByAtLeastOne(metadata)).isTrue()
+        }
+
+        @Test
+        fun `should satisfy at least one filter with matching query param`() {
+            val filter = ScenarioMetadataFilter(
+                queryParams = setOf("anyId", "productId")
+            )
+            val metadata = ScenarioMetadata(
+                method = "GET",
+                path = "/any",
+                statusCode = 200,
+                header = setOf("Authorization", "X-Request-ID"),
+                query = setOf("anyId"),
+                exampleName = "some-example"
+            )
+            assertThat(filter.isSatisfiedByAtLeastOne(metadata)).isTrue()
+        }
+    }
+
+    @Nested
+    inner class CreateFilterUsingFromTests {
+        @Test
+        fun `should create the scenario metadata filter from the filter string`() {
+            val filterString = "METHOD=POST,GET;STATUS-CODE=200;PATH=/users,/products"
+            val filter = ScenarioMetadataFilter.from(filterString)
+
+            assertThat(filter.methods).containsExactlyInAnyOrder("POST", "GET")
+            assertThat(filter.statusCodes).containsExactly("200")
+            assertThat(filter.paths).containsExactlyInAnyOrder("/users", "/products")
+        }
+
+        @Test
+        fun `should create empty scenario metadata filter when filter string is empty`() {
+            val filterString = ""
+            val filter = ScenarioMetadataFilter.from(filterString)
+
+            assertThat(filter.methods).isEmpty()
+            assertThat(filter.statusCodes).isEmpty()
+            assertThat(filter.paths).isEmpty()
+            assertThat(filter.headers).isEmpty()
+            assertThat(filter.queryParams).isEmpty()
+            assertThat(filter.exampleNames).isEmpty()
+        }
+
+        @Test
+        fun `should create the scenario metadata filter with multiple criteria for headers & query-params`() {
+            val filterString = "METHOD=GET;HEADERS=Authorization,Content-Type;QUERY-PARAMS=productId,orderId;EXAMPLE-NAME=create-product"
+            val filter = ScenarioMetadataFilter.from(filterString)
+
+            assertThat(filter.methods).containsExactly("GET")
+            assertThat(filter.headers).containsExactlyInAnyOrder("Authorization", "Content-Type")
+            assertThat(filter.queryParams).containsExactlyInAnyOrder("productId", "orderId")
+            assertThat(filter.exampleNames).containsExactlyInAnyOrder("create-product")
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideMissingCriteriaScenariosForIsSatisfiedByAll")
+    fun `should not satisfy all filters when any criteria is missing`(
+        filter: ScenarioMetadataFilter,
+        metadata: ScenarioMetadata,
+        description: String
+    ) {
+        assertThat(filter.isSatisfiedByAll(metadata))
+            .describedAs(description)
+            .isFalse()
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideMatchingCriteriaScenariosForIsSatisfiedByAtLeastOne")
+    fun `should satisfy at least one filter when any criteria matches`(
+        filter: ScenarioMetadataFilter,
+        metadata: ScenarioMetadata,
+        description: String
+    ) {
+        assertThat(filter.isSatisfiedByAtLeastOne(metadata))
+            .describedAs(description)
+            .isTrue()
+    }
+
+    companion object {
+        @JvmStatic
+        fun provideMissingCriteriaScenariosForIsSatisfiedByAll(): Stream<Arguments> {
+            return Stream.of(
+                Arguments.of(
+                    ScenarioMetadataFilter(
+                        methods = setOf("POST"),
+                        paths = setOf("/products"),
+                        statusCodes = setOf("200"),
+                        headers = setOf("Authorization"),
+                        queryParams = setOf("productId"),
+                        exampleNames = setOf("example2")
+                    ),
+                    ScenarioMetadata(
+                        method = "POST",
+                        path = "/products",
+                        statusCode = 200,
+                        header = setOf("X-Request-ID"), // Authorization header missing
+                        query = setOf("productId"),
+                        exampleName = "example2"
+                    ),
+                    "Missing Authorization header"
+                ),
+                Arguments.of(
+                    ScenarioMetadataFilter(
+                        methods = setOf("POST"),
+                        paths = setOf("/products"),
+                        statusCodes = setOf("200"),
+                        headers = setOf("Authorization"),
+                        queryParams = setOf("productId"),
+                        exampleNames = setOf("example2")
+                    ),
+                    ScenarioMetadata(
+                        method = "POST",
+                        path = "/products",
+                        statusCode = 200,
+                        header = setOf("Authorization"),
+                        query = setOf(), // Query parameter productId missing
+                        exampleName = "example2"
+                    ),
+                    "Missing required query parameter"
+                ),
+                Arguments.of(
+                    ScenarioMetadataFilter(
+                        methods = setOf("POST"),
+                        paths = setOf("/products"),
+                        statusCodes = setOf("200"),
+                        headers = setOf("Authorization"),
+                        queryParams = setOf("productId"),
+                        exampleNames = setOf("example2")
+                    ),
+                    ScenarioMetadata(
+                        method = "GET", // Method does not match
+                        path = "/products",
+                        statusCode = 200,
+                        header = setOf("Authorization"),
+                        query = setOf("productId"),
+                        exampleName = "example2"
+                    ),
+                    "Method does not match"
+                ),
+                Arguments.of(
+                    ScenarioMetadataFilter(
+                        methods = setOf("POST"),
+                        paths = setOf("/products"),
+                        statusCodes = setOf("200"),
+                        headers = setOf("Authorization"),
+                        queryParams = setOf("productId"),
+                        exampleNames = setOf("example2")
+                    ),
+                    ScenarioMetadata(
+                        method = "POST",
+                        path = "/products",
+                        statusCode = 404, // Status code does not match
+                        header = setOf("Authorization"),
+                        query = setOf("productId"),
+                        exampleName = "example2"
+                    ),
+                    "Status code does not match"
+                ),
+                Arguments.of(
+                    ScenarioMetadataFilter(
+                        methods = setOf("POST"),
+                        paths = setOf("/products"),
+                        statusCodes = setOf("200"),
+                        headers = setOf("Authorization"),
+                        queryParams = setOf("productId"),
+                        exampleNames = setOf("example2")
+                    ),
+                    ScenarioMetadata(
+                        method = "POST",
+                        path = "/products",
+                        statusCode = 200,
+                        header = setOf("Authorization"),
+                        query = setOf("productId"),
+                        exampleName = "" // Example name is missing
+                    ),
+                    "Example name is missing"
+                )
+            )
+        }
+
+        @JvmStatic
+        fun provideMatchingCriteriaScenariosForIsSatisfiedByAtLeastOne(): Stream<Arguments> {
+            return Stream.of(
+                Arguments.of(
+                    ScenarioMetadataFilter(
+                        methods = setOf("POST"),
+                        paths = setOf("/products"),
+                        statusCodes = setOf("201")
+                    ),
+                    ScenarioMetadata(
+                        method = "POST",
+                        path = "/non-matching-path",
+                        statusCode = 404,
+                        header = emptySet(),
+                        query = emptySet(),
+                        exampleName = "non-matching"
+                    ),
+                    "Matching method should satisfy"
+                ),
+                Arguments.of(
+                    ScenarioMetadataFilter(
+                        methods = setOf("POST"),
+                        paths = setOf("/products"),
+                        statusCodes = setOf("201")
+                    ),
+                    ScenarioMetadata(
+                        method = "GET",
+                        path = "/products",
+                        statusCode = 200,
+                        header = setOf("Authorization"),
+                        query = setOf("productId"),
+                        exampleName = "example1"
+                    ),
+                    "Matching path should satisfy"
+                ),
+                Arguments.of(
+                    ScenarioMetadataFilter(
+                        methods = setOf("POST"),
+                        paths = setOf("/products"),
+                        statusCodes = setOf("201")
+                    ),
+                    ScenarioMetadata(
+                        method = "PUT",
+                        path = "/products",
+                        statusCode = 201,
+                        header = setOf("Authorization", "Content-Type"),
+                        query = setOf("userId", "role"),
+                        exampleName = "example2"
+                    ),
+                    "Matching status code should satisfy"
+                ),
+                Arguments.of(
+                    ScenarioMetadataFilter(
+                        methods = setOf("POST"),
+                        paths = setOf("/products"),
+                        statusCodes = setOf("201"),
+                        headers = setOf("X-Request-ID")
+                    ),
+                    ScenarioMetadata(
+                        method = "PATCH",
+                        path = "/non-matching-path",
+                        statusCode = 400,
+                        header = setOf("Authorization", "X-Request-ID"),
+                        query = setOf("productId", "quantity"),
+                        exampleName = "example3"
+                    ),
+                    "Matching header should satisfy"
+                ),
+                Arguments.of(
+                    ScenarioMetadataFilter(
+                        methods = setOf("POST"),
+                        paths = setOf("/products"),
+                        statusCodes = setOf("201")
+                    ),
+                    ScenarioMetadata(
+                        method = "POST",
+                        path = "/products",
+                        statusCode = 201,
+                        header = setOf("Authorization", "Content-Type"),
+                        query = setOf("productId", "category"),
+                        exampleName = "example4"
+                    ),
+                    "All criteria match"
+                )
+            )
+        }
+    }
+
+}

--- a/core/src/test/kotlin/io/specmatic/core/filters/ScenarioMetadataFilterTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/filters/ScenarioMetadataFilterTest.kt
@@ -40,6 +40,22 @@ class ScenarioMetadataFilterTest {
         }
 
         @Test
+        fun `should satisfy the pattern based status code filter when all criteria match`() {
+            val filter = ScenarioMetadataFilter(
+                statusCodes = setOf("2xx"),
+            )
+            val metadata = ScenarioMetadata(
+                method = "GET",
+                path = "/users",
+                statusCode = 200,
+                header = setOf("Authorization"),
+                query = setOf("userId"),
+                exampleName = "example1"
+            )
+            assertThat(filter.isSatisfiedByAll(metadata)).isTrue()
+        }
+
+        @Test
         fun `should satisfy all filters with multiple headers and query params in metadata`() {
             val filter = ScenarioMetadataFilter(
                 methods = setOf("GET"),
@@ -86,6 +102,22 @@ class ScenarioMetadataFilterTest {
                 headers = setOf("Authorization"),
                 queryParams = setOf("userId"),
                 exampleNames = setOf("example2")
+            )
+            val metadata = ScenarioMetadata(
+                method = "GET",
+                path = "/users",
+                statusCode = 404,
+                header = emptySet(),
+                query = emptySet(),
+                exampleName = "example3"
+            )
+            assertThat(filter.isSatisfiedByAtLeastOne(metadata)).isFalse()
+        }
+
+        @Test
+        fun `should not satisfy at least one pattern based status code filter when no criteria match`() {
+            val filter = ScenarioMetadataFilter(
+                statusCodes = setOf("5xx")
             )
             val metadata = ScenarioMetadata(
                 method = "GET",

--- a/core/src/test/kotlin/io/specmatic/core/filters/ScenarioMetadataFilterTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/filters/ScenarioMetadataFilterTest.kt
@@ -135,7 +135,7 @@ class ScenarioMetadataFilterTest {
     inner class FilterStringToScenarioMetadataTests {
         @Test
         fun `should create the scenario metadata filter from the filter string`() {
-            val filterString = "METHOD=POST,GET;STATUS-CODE=200;PATH=/users,/products"
+            val filterString = "METHOD=POST,GET;STATUS=200;PATH=/users,/products"
             val filter = ScenarioMetadataFilter.from(filterString)
 
             assertThat(filter.methods).containsExactlyInAnyOrder("POST", "GET")

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -295,7 +295,7 @@ open class SpecmaticJUnitSupport {
             ) { it.testDescription() }
 
             filterUsing(filteredTestsBasedOnName, scenarioMetadataFilter, scenarioMetadataExclusionFilter) {
-                it.scenario.toScenarioMetadata()
+                it.toScenarioMetadata()
             }
         } catch(e: ContractException) {
             return loadExceptionAsTestError(e)

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -5,6 +5,7 @@ import io.specmatic.conversions.convertPathParameterStyle
 import io.specmatic.core.*
 import io.specmatic.core.filters.ScenarioMetadataFilter
 import io.specmatic.core.filters.ScenarioMetadataFilter.Companion.filterTestsUsing
+import io.specmatic.core.filters.ScenarioMetadataFilter.Companion.filterScenariosUsing
 import io.specmatic.core.log.ignoreLog
 import io.specmatic.core.log.logger
 import io.specmatic.core.pattern.*
@@ -73,6 +74,11 @@ open class SpecmaticJUnitSupport {
         val partialSuccesses: MutableList<Result.Success> = mutableListOf()
         private var specmaticConfig: SpecmaticConfig? = null
         val openApiCoverageReportInput = OpenApiCoverageReportInput(getConfigFileWithAbsolutePath())
+        private val scenarioMetadataFilter = ScenarioMetadataFilter.from(readEnvVarOrProperty(FILTER, FILTER).orEmpty())
+        private val scenarioMetadataExclusionFilter = ScenarioMetadataFilter.from(
+            readEnvVarOrProperty(FILTER_NOT, FILTER_NOT).orEmpty()
+        )
+
 
         private val threads: Vector<String> = Vector<String>()
 
@@ -283,14 +289,13 @@ open class SpecmaticJUnitSupport {
             }
             openApiCoverageReportInput.addEndpoints(allEndpoints)
 
-            val filteredTestsBasedOnMetadata = filterTestsUsing(
-                contractTests = testScenarios,
-                scenarioMetadataFilter = ScenarioMetadataFilter.from(readEnvVarOrProperty(FILTER, FILTER).orEmpty()),
-                scenarioMetadataExclusionFilter = ScenarioMetadataFilter.from(
-                    readEnvVarOrProperty(FILTER_NOT, FILTER_NOT).orEmpty()
-                )
-            )
-            selectTestsToRun(filteredTestsBasedOnMetadata, filterName, filterNotName) { it.testDescription() }
+            val filteredTestsBasedOnName = selectTestsToRun(
+                testScenarios,
+                filterName,
+                filterNotName
+            ) { it.testDescription() }
+
+            filterTestsUsing(filteredTestsBasedOnName, scenarioMetadataFilter, scenarioMetadataExclusionFilter)
         } catch(e: ContractException) {
             return loadExceptionAsTestError(e)
         } catch(e: Throwable) {
@@ -479,8 +484,18 @@ open class SpecmaticJUnitSupport {
             )
         }
 
+        val filteredScenariosBasedOnName = selectTestsToRun(
+            feature.scenarios.asSequence(),
+            filterName,
+            filterNotName
+        ) { it.testDescription() }
+        val filteredScenarios = filterScenariosUsing(
+            filteredScenariosBasedOnName,
+            scenarioMetadataFilter,
+            scenarioMetadataExclusionFilter
+        )
         val tests: Sequence<ContractTest> = feature
-            .copy(scenarios = selectTestsToRun(feature.scenarios.asSequence(), filterName, filterNotName) { it.testDescription() }.toList())
+            .copy(scenarios = filteredScenarios.toList())
             .also {
                 if (it.scenarios.isEmpty())
                     logger.log("All scenarios were filtered out.")

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -4,8 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import io.specmatic.conversions.convertPathParameterStyle
 import io.specmatic.core.*
 import io.specmatic.core.filters.ScenarioMetadataFilter
-import io.specmatic.core.filters.ScenarioMetadataFilter.Companion.filterTestsUsing
-import io.specmatic.core.filters.ScenarioMetadataFilter.Companion.filterScenariosUsing
+import io.specmatic.core.filters.ScenarioMetadataFilter.Companion.filterUsing
 import io.specmatic.core.log.ignoreLog
 import io.specmatic.core.log.logger
 import io.specmatic.core.pattern.*
@@ -295,7 +294,9 @@ open class SpecmaticJUnitSupport {
                 filterNotName
             ) { it.testDescription() }
 
-            filterTestsUsing(filteredTestsBasedOnName, scenarioMetadataFilter, scenarioMetadataExclusionFilter)
+            filterUsing(filteredTestsBasedOnName, scenarioMetadataFilter, scenarioMetadataExclusionFilter) {
+                it.scenario.toScenarioMetadata()
+            }
         } catch(e: ContractException) {
             return loadExceptionAsTestError(e)
         } catch(e: Throwable) {
@@ -489,11 +490,11 @@ open class SpecmaticJUnitSupport {
             filterName,
             filterNotName
         ) { it.testDescription() }
-        val filteredScenarios = filterScenariosUsing(
+        val filteredScenarios = filterUsing(
             filteredScenariosBasedOnName,
             scenarioMetadataFilter,
             scenarioMetadataExclusionFilter
-        )
+        ) { it.toScenarioMetadata() }
         val tests: Sequence<ContractTest> = feature
             .copy(scenarios = filteredScenarios.toList())
             .also {

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -3,6 +3,7 @@ package io.specmatic.test
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.specmatic.conversions.convertPathParameterStyle
 import io.specmatic.core.*
+import io.specmatic.core.filters.ScenarioMetadataFilter
 import io.specmatic.core.log.ignoreLog
 import io.specmatic.core.log.logger
 import io.specmatic.core.pattern.*
@@ -62,6 +63,8 @@ open class SpecmaticJUnitSupport {
         const val VARIABLES_FILE_NAME = "variablesFileName"
         const val FILTER_NAME_PROPERTY = "filterName"
         const val FILTER_NOT_NAME_PROPERTY = "filterNotName"
+        const val FILTER = "filter"
+        const val FILTER_NOT = "filterNot"
         const val FILTER_NAME_ENVIRONMENT_VARIABLE = "FILTER_NAME"
         const val FILTER_NOT_NAME_ENVIRONMENT_VARIABLE = "FILTER_NOT_NAME"
         private const val ENDPOINTS_API = "endpointsAPI"
@@ -278,7 +281,15 @@ open class SpecmaticJUnitSupport {
                 }
             }
             openApiCoverageReportInput.addEndpoints(allEndpoints)
-            selectTestsToRun(testScenarios, filterName, filterNotName) { it.testDescription() }
+
+            val filteredTestsBasedOnMetadata = selectTestsToRun(
+                contractTests = testScenarios,
+                scenarioMetadataFilter = ScenarioMetadataFilter.from(readEnvVarOrProperty(FILTER, FILTER).orEmpty()),
+                scenarioMetadataExclusionFilter = ScenarioMetadataFilter.from(
+                    readEnvVarOrProperty(FILTER_NOT, FILTER_NOT).orEmpty()
+                )
+            )
+            selectTestsToRun(filteredTestsBasedOnMetadata, filterName, filterNotName) { it.testDescription() }
         } catch(e: ContractException) {
             return loadExceptionAsTestError(e)
         } catch(e: Throwable) {
@@ -575,4 +586,16 @@ fun <T> selectTestsToRun(
         filteredByName
 
     return filteredByNotName
+}
+
+fun selectTestsToRun(
+    contractTests: Sequence<ContractTest>,
+    scenarioMetadataFilter: ScenarioMetadataFilter,
+    scenarioMetadataExclusionFilter: ScenarioMetadataFilter
+): Sequence<ContractTest> {
+    return contractTests.filter {
+        scenarioMetadataFilter.isSatisfiedByAll(it.scenario.toScenarioMetadata())
+    }.filterNot {
+        scenarioMetadataExclusionFilter.isSatisfiedByAtLeastOne(it.scenario.toScenarioMetadata())
+    }
 }

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import io.specmatic.conversions.convertPathParameterStyle
 import io.specmatic.core.*
 import io.specmatic.core.filters.ScenarioMetadataFilter
+import io.specmatic.core.filters.ScenarioMetadataFilter.Companion.filterTestsUsing
 import io.specmatic.core.log.ignoreLog
 import io.specmatic.core.log.logger
 import io.specmatic.core.pattern.*
@@ -282,7 +283,7 @@ open class SpecmaticJUnitSupport {
             }
             openApiCoverageReportInput.addEndpoints(allEndpoints)
 
-            val filteredTestsBasedOnMetadata = selectTestsToRun(
+            val filteredTestsBasedOnMetadata = filterTestsUsing(
                 contractTests = testScenarios,
                 scenarioMetadataFilter = ScenarioMetadataFilter.from(readEnvVarOrProperty(FILTER, FILTER).orEmpty()),
                 scenarioMetadataExclusionFilter = ScenarioMetadataFilter.from(
@@ -588,14 +589,3 @@ fun <T> selectTestsToRun(
     return filteredByNotName
 }
 
-fun selectTestsToRun(
-    contractTests: Sequence<ContractTest>,
-    scenarioMetadataFilter: ScenarioMetadataFilter,
-    scenarioMetadataExclusionFilter: ScenarioMetadataFilter
-): Sequence<ContractTest> {
-    return contractTests.filter {
-        scenarioMetadataFilter.isSatisfiedByAll(it.scenario.toScenarioMetadata())
-    }.filterNot {
-        scenarioMetadataExclusionFilter.isSatisfiedByAtLeastOne(it.scenario.toScenarioMetadata())
-    }
-}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Add ability to filter tests based on the metadata of a certain test.
Add --filter and --filterNot argument in TestCommand to use these filters.
The filters follow a specific syntax which can be understood using `specmatic  test --help` command.

<!-- Why are these changes necessary? -->

**Why**:
The existing --filterName and --filterNotName were serving the purpose of filtering tests to an extent but potentially that algorithm is not scalable when it comes to evolving the filtering mechanism and making it more scalable.
Hence, this metadata based filtering is introduced. This is a first cut of it.

<!-- How were these changes implemented? -->


<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation  (Pending, will do it in parallel)
- [x] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->

<!-- feel free to add additional comments -->
