### PR TITLE
Loading config file from classpath Also in case of env property or classpath checking if the file exists before returning

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -27,12 +27,14 @@ import java.io.File
 
 const val APPLICATION_NAME = "Specmatic"
 const val APPLICATION_NAME_LOWER_CASE = "specmatic"
+const val CONFIG_FILE_NAME_WITHOUT_EXT = "specmatic"
 const val DEFAULT_TIMEOUT_IN_MILLISECONDS: Long = 6000L
 const val CONTRACT_EXTENSION = "spec"
 const val YAML = "yaml"
 const val WSDL = "wsdl"
 const val YML = "yml"
 const val JSON = "json"
+val CONFIG_EXTENSIONS = listOf(YAML, YML, JSON)
 val OPENAPI_FILE_EXTENSIONS = listOf(YAML, YML, JSON)
 val CONTRACT_EXTENSIONS = listOf(CONTRACT_EXTENSION, WSDL) + OPENAPI_FILE_EXTENSIONS
 const val DATA_DIR_SUFFIX = "_data"

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -7,7 +7,8 @@ import io.specmatic.core.log.ignoreLog
 import io.specmatic.core.log.logger
 import io.specmatic.core.pattern.*
 import io.specmatic.core.utilities.*
-import io.specmatic.core.utilities.Flags.Companion.CONFIG_FILE_PATH
+import io.specmatic.core.utilities.Flags.Companion.SPECMATIC_TEST_TIMEOUT
+import io.specmatic.core.utilities.Flags.Companion.getLongValue
 import io.specmatic.core.value.JSONArrayValue
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.Value
@@ -160,7 +161,7 @@ open class SpecmaticJUnitSupport {
             }
         }
 
-        val configFile get() = Flags.getStringValue(CONFIG_FILE_PATH) ?: getConfigFilePath()
+        val configFile get() = getConfigFilePath()
 
         private fun getConfigFileWithAbsolutePath() = File(configFile).canonicalPath
     }
@@ -207,7 +208,11 @@ open class SpecmaticJUnitSupport {
 
         specmaticConfig = getSpecmaticConfig()
 
-        val timeoutInMilliseconds = specmaticConfig?.test?.timeoutInMilliseconds ?: try { Flags.getLongValue(Flags.SPECMATIC_TEST_TIMEOUT) } catch(e: NumberFormatException) { throw ContractException("${Flags.SPECMATIC_TEST_TIMEOUT} should be a value of type long") } ?:  DEFAULT_TIMEOUT_IN_MILLISECONDS
+        val timeoutInMilliseconds = specmaticConfig?.test?.timeoutInMilliseconds ?: try {
+            getLongValue(SPECMATIC_TEST_TIMEOUT)
+        } catch (e: NumberFormatException) {
+            throw ContractException("$SPECMATIC_TEST_TIMEOUT should be a value of type long")
+        } ?: DEFAULT_TIMEOUT_IN_MILLISECONDS
 
         val suggestionsData = System.getProperty(INLINE_SUGGESTIONS) ?: ""
         val suggestionsPath = System.getProperty(SUGGESTIONS_PATH) ?: ""

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=2.0.28
+version=2.0.29


### PR DESCRIPTION

**What**:

If the config file is available as part of the classpath then use it instead of always expecting it to be at the top level of the project.

**Why**:

Some developers prefer to keep specmatic.yaml config file inside their src/test/resources folder.

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [ ] Tests
- [ ] Sonar Quality Gate