### PR TITLE
Add export command in ExamplesCommand that exports the inline example

### DIFF
--- a/application/src/main/kotlin/application/ExamplesCommand.kt
+++ b/application/src/main/kotlin/application/ExamplesCommand.kt
@@ -5,6 +5,7 @@ import io.specmatic.core.Result
 import io.specmatic.core.Results
 import io.specmatic.core.SPECMATIC_STUB_DICTIONARY
 import io.specmatic.core.examples.server.ExamplesInteractiveServer
+import io.specmatic.core.examples.server.ExamplesInteractiveServer.Companion.externaliseInlineExamples
 import io.specmatic.core.examples.server.ExamplesInteractiveServer.Companion.validateSingleExample
 import io.specmatic.core.examples.server.defaultExternalExampleDirFrom
 import io.specmatic.core.examples.server.loadExternalExamples
@@ -29,7 +30,8 @@ private const val FAILURE_EXIT_CODE = 1
     subcommands = [
         ExamplesCommand.Validate::class,
         ExamplesCommand.Interactive::class,
-        ExamplesCommand.Transform::class
+        ExamplesCommand.Transform::class,
+        ExamplesCommand.Export::class
     ]
 )
 class ExamplesCommand : Callable<Int> {
@@ -571,6 +573,26 @@ For example:
                 )
             } else {
                 logger.log("Please choose one of the transformations from the available command-line parameters.")
+            }
+        }
+    }
+
+    @Command(
+        name = "export",
+        mixinStandardHelpOptions = true,
+        description = ["Export the inline examples from the contract file"]
+    )
+    class Export: Callable<Unit> {
+        @Option(names = ["--contract-file"], description = ["Contract file path"], required = true)
+        lateinit var contractFile: File
+
+        override fun call() {
+            try {
+                val examplesDir = externaliseInlineExamples(contractFile)
+                consoleLog("${System.lineSeparator()}The inline examples were successfully exported to $examplesDir")
+                exitProcess(0)
+            } catch(e: Exception) {
+                exitWithMessage("Failed while exporting the inline examples from ${contractFile.nameWithoutExtension}:\n${e.message}")
             }
         }
     }

--- a/core/src/test/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServerTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServerTest.kt
@@ -1,0 +1,68 @@
+package io.specmatic.core.examples.server
+
+import io.specmatic.conversions.ExampleFromFile
+import io.specmatic.core.HttpRequest
+import io.specmatic.core.HttpResponse
+import io.specmatic.core.value.JSONObjectValue
+import io.specmatic.core.value.NumberValue
+import io.specmatic.core.value.StringValue
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class ExamplesInteractiveServerTest {
+    @Nested
+    inner class ExternaliseInlineExamplesTests {
+
+        @Test
+        fun `should externalise the inline examples into an examples folder`() {
+            var examplesDir: File? = null
+            try {
+                val contractFile = File("src/test/resources/openapi/has_multiple_inline_examples.yaml")
+                examplesDir = ExamplesInteractiveServer.externaliseInlineExamples(contractFile)
+
+                val externalisedExampleFiles = examplesDir.listFiles()?.map { it.name }
+                assertThat(externalisedExampleFiles).containsExactlyInAnyOrder(
+                    "products_POST_201_1.json",
+                    "findAvailableProducts_GET_200_2.json",
+                    "findAvailableProducts_GET_503_3.json",
+                    "orders_GET_200_4.json"
+                )
+                val postProductsExample = examplesDir.listFiles()?.first {
+                    val exampleFromFile = ExampleFromFile(it)
+                    exampleFromFile.request.path == "/products" && exampleFromFile.requestMethod == "POST"
+                }
+
+                val postProductsExampleFromFile = ExampleFromFile(postProductsExample!!)
+                assertThat(postProductsExampleFromFile.request).isEqualTo(
+                    HttpRequest(
+                        method = "POST",
+                        path = "/products",
+                        headers = mapOf("Content-Type" to "application/json"),
+                        body = JSONObjectValue(
+                            mapOf(
+                                "name" to StringValue("iPhone"),
+                                "type" to StringValue("gadget"),
+                                "inventory" to NumberValue(100)
+                            )
+                        )
+                    )
+                )
+                assertThat(postProductsExampleFromFile.response).isEqualTo(
+                    HttpResponse(
+                        status = 201,
+                        body = JSONObjectValue(
+                            mapOf(
+                                "id" to NumberValue(1)
+                            )
+                        ),
+                        headers = emptyMap()
+                    )
+                )
+            } finally {
+                examplesDir?.deleteRecursively()
+            }
+        }
+    }
+}

--- a/core/src/test/resources/openapi/has_multiple_inline_examples.yaml
+++ b/core/src/test/resources/openapi/has_multiple_inline_examples.yaml
@@ -1,0 +1,174 @@
+openapi: 3.0.0
+info:
+  title: Order API
+  version: '1.0'
+servers:
+  - url: http://localhost:8080
+paths:
+  /products:
+    post:
+      summary: Create a new product
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+                - type
+                - inventory
+              properties:
+                name:
+                  type: string
+                type:
+                  type: string
+                inventory:
+                  type: integer
+            examples:
+              POST_PRODUCTS_SUCCESS:
+                value:
+                  name: iPhone
+                  type: gadget
+                  inventory: 100
+      responses:
+        '201':
+          description: Product created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+              examples:
+                POST_PRODUCTS_SUCCESS:
+                  value:
+                    id: 1
+
+  /findAvailableProducts:
+    get:
+      summary: Fetch product details
+      parameters:
+        - name: type
+          in: query
+          schema:
+            type: string
+          examples:
+            FIND_SUCCESS:
+              value: gadget
+            FIND_TIMEOUT:
+              value: other
+        - name: pageSize
+          in: header
+          schema:
+            type: integer
+          examples:
+            FIND_SUCCESS:
+              value: 10
+            FIND_TIMEOUT:
+              value: 20
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Product'
+              examples:
+                FIND_SUCCESS:
+                  value:
+                    - name: iPhone
+                      id: 1
+                      type: gadget
+                      inventory: 100
+        '503':
+          description: Timeout
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequest'
+              examples:
+                FIND_TIMEOUT:
+                  value:
+                    timestamp: '2020-06-02T12:00:00.000+00:00'
+                    status: 503
+                    error: Service Unavailable
+                    message: Timeout
+
+  /orders:
+    get:
+      summary: Retrieve order information
+      parameters:
+        - in: query
+          name: orderId
+          schema:
+            type: integer
+          examples:
+            GET_ORDER_SUCCESS:
+              value: 100
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Order'
+              examples:
+                GET_ORDER_SUCCESS:
+                  value:
+                    - id: 1
+                      productid: 1
+                      count: 2
+                      status: "completed"
+
+components:
+  schemas:
+    Product:
+      type: object
+      properties:
+        name:
+          type: string
+        id:
+          type: integer
+        type:
+          type: string
+        inventory:
+          type: integer
+      required:
+        - name
+        - id
+        - type
+        - inventory
+
+    Order:
+      type: object
+      properties:
+        id:
+          type: integer
+        productid:
+          type: integer
+        count:
+          type: integer
+        status:
+          type: string
+      required:
+        - id
+        - productid
+        - count
+        - status
+
+    BadRequest:
+      type: object
+      properties:
+        timestamp:
+          type: string
+        status:
+          type: number
+        error:
+          type: string
+        message:
+          type: string


### PR DESCRIPTION
Add ability to export inline examples into external examples with `examples export` command

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->


<!-- feel free to add additional comments -->
