### PR TITLE
Allow examples with only mandatory keys to be generated based on a flag

### DIFF
--- a/application/src/main/kotlin/application/ExamplesCommand.kt
+++ b/application/src/main/kotlin/application/ExamplesCommand.kt
@@ -366,6 +366,14 @@ For example:
         @Option(names = ["--testBaseURL"], description = ["The baseURL of system to test"], required = false)
         var testBaseURL: String? = null
 
+        @Option(
+            names = ["--allow-only-mandatory-keys-in-json"],
+            description = ["Allow only mandatory keys in the json request and response objects"],
+            required = false
+        )
+        var allowOnlyMandatoryKeysInJSONObject: Boolean = false
+
+
         var server: ExamplesInteractiveServer? = null
 
         override fun call() {
@@ -375,7 +383,18 @@ For example:
                 if (contractFile != null && !contractFile!!.exists())
                     exitWithMessage("Could not find file ${contractFile!!.path}")
 
-                server = ExamplesInteractiveServer("0.0.0.0", 9001, testBaseURL, contractFile, filterName, filterNotName, filter, filterNot, dictFile)
+                server = ExamplesInteractiveServer(
+                    "0.0.0.0",
+                    9001,
+                    testBaseURL,
+                    contractFile,
+                    filterName,
+                    filterNotName,
+                    filter,
+                    filterNot,
+                    dictFile,
+                    allowOnlyMandatoryKeysInJSONObject
+                )
                 addShutdownHook()
 
                 consoleLog(StringLog("Examples Interactive server is running on http://0.0.0.0:9001/_specmatic/examples. Ctrl + C to stop."))

--- a/application/src/main/kotlin/application/ExamplesCommand.kt
+++ b/application/src/main/kotlin/application/ExamplesCommand.kt
@@ -367,8 +367,8 @@ For example:
         var testBaseURL: String? = null
 
         @Option(
-            names = ["--allow-only-mandatory-keys-in-json"],
-            description = ["Allow only mandatory keys in the json request and response objects"],
+            names = ["--allow-only-mandatory-keys-in-payload"],
+            description = ["Generate examples with only mandatory keys in the json request and response payloads"],
             required = false
         )
         var allowOnlyMandatoryKeysInJSONObject: Boolean = false

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -149,10 +149,18 @@ data class Feature(
         }
     }
 
-    fun generateDiscriminatorBasedRequestResponseList(scenario: Scenario): List<DiscriminatorBasedRequestResponse> {
+    fun generateDiscriminatorBasedRequestResponseList(
+        scenario: Scenario,
+        allowOnlyMandatoryKeysInJSONObject: Boolean = false
+    ): List<DiscriminatorBasedRequestResponse> {
         try {
-            val requests = scenario.generateHttpRequestV2()
-            val responses = scenario.generateHttpResponseV2(serverState)
+            val requests = scenario.generateHttpRequestV2(
+                allowOnlyMandatoryKeysInJSONObject = allowOnlyMandatoryKeysInJSONObject
+            )
+            val responses = scenario.generateHttpResponseV2(
+                serverState,
+                allowOnlyMandatoryKeysInJSONObject = allowOnlyMandatoryKeysInJSONObject
+            )
 
             val discriminatorBasedRequestResponseList = if (requests.size > responses.size) {
                 requests.map { (requestDiscriminator, request) ->

--- a/core/src/main/kotlin/io/specmatic/core/Resolver.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Resolver.kt
@@ -23,6 +23,10 @@ val alwaysReturnStringValue: (resolver: Resolver, pattern: Pattern, rowValue: St
     StringValue(rowValue)
 }
 
+data class JSONObjectResolver(
+    val allowOnlyMandatoryKeys: Boolean = false
+)
+
 data class Resolver(
     val factStore: FactStore = CheckFacts(),
     val mockMode: Boolean = false,
@@ -37,7 +41,8 @@ data class Resolver(
     val defaultExampleResolver: DefaultExampleResolver = DoNotUseDefaultExample,
     val generation: GenerationStrategies = NonGenerativeTests,
     val dictionary: Map<String, Value> = emptyMap(),
-    val dictionaryLookupPath: String = ""
+    val dictionaryLookupPath: String = "",
+    val jsonObjectResolver: JSONObjectResolver = JSONObjectResolver()
 ) {
     constructor(facts: Map<String, Value> = emptyMap(), mockMode: Boolean = false, newPatterns: Map<String, Pattern> = emptyMap()) : this(CheckFacts(facts), mockMode, newPatterns)
     constructor() : this(emptyMap(), false)
@@ -47,8 +52,17 @@ data class Resolver(
             return builtInPatterns.plus(newPatterns)
         }
 
+    val allowOnlyMandatoryKeysInJsonObject: Boolean
+        get() {
+            return this.jsonObjectResolver.allowOnlyMandatoryKeys
+        }
+
     fun withUnexpectedKeyCheck(unexpectedKeyCheck: UnexpectedKeyCheck): Resolver {
         return this.copy(findKeyErrorCheck = this.findKeyErrorCheck.withUnexpectedKeyCheck(unexpectedKeyCheck))
+    }
+
+    fun withOnlyMandatoryKeysInJSONObject(): Resolver {
+        return this.copy(jsonObjectResolver = this.jsonObjectResolver.copy(allowOnlyMandatoryKeys = true))
     }
 
     fun disableOverrideUnexpectedKeycheck(): Resolver {


### PR DESCRIPTION
To allow only mandatory keys, we can start the examples interactive server using the command -
```
specmatic examples interactive --allow-only-mandatory-keys-in-json=true --contract-file=api.yaml
```

To disable the same -
```
specmatic examples interactive --allow-only-mandatory-keys-in-json=false --contract-file=api.yaml
```

- [x] Tests