### PR TITLE
Append stub usage reports

### DIFF
--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -595,19 +595,19 @@ class HttpStub(
                 encodeDefaults = false
             }
             val generatedReport = stubUsageReport.generate()
-            val reportJson: String
-
-            val reportFile = File(JSON_REPORT_PATH).resolve(JSON_REPORT_FILE_NAME)
-            if (reportFile.exists()) {
-                reportJson = try {
-                    val existingReport = Json.decodeFromString(reportFile.readText()) as StubUsageReportJson
-                    json.encodeToString(generatedReport.merge(existingReport))
-                } catch (exception: SerializationException) {
-                    logger.log("The existing report file is not a valid Stub Usage Report. ${exception.message}")
+            val reportJson: String = File(JSON_REPORT_PATH).resolve(JSON_REPORT_FILE_NAME).let { reportFile ->
+                if (reportFile.exists()) {
+                    try {
+                        val existingReport = Json.decodeFromString<StubUsageReportJson>(reportFile.readText())
+                        json.encodeToString(generatedReport.merge(existingReport))
+                    } catch (exception: SerializationException) {
+                        logger.log("The existing report file is not a valid Stub Usage Report. ${exception.message}")
+                        json.encodeToString(generatedReport)
+                    }
+                } else {
                     json.encodeToString(generatedReport)
                 }
-            } else
-                reportJson = json.encodeToString(generatedReport)
+            }
 
             saveJsonFile(reportJson, JSON_REPORT_PATH, JSON_REPORT_FILE_NAME)
         }

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -595,16 +595,16 @@ class HttpStub(
                 encodeDefaults = false
             }
             val generatedReport = stubUsageReport.generate()
-            var reportJson: String
+            val reportJson: String
 
             val reportFile = File(JSON_REPORT_PATH).resolve(JSON_REPORT_FILE_NAME)
             if (reportFile.exists()) {
-                try {
+                reportJson = try {
                     val existingReport = Json.decodeFromString(reportFile.readText()) as StubUsageReportJson
-                    reportJson = json.encodeToString(generatedReport.merge(existingReport))
+                    json.encodeToString(generatedReport.merge(existingReport))
                 } catch (exception: SerializationException) {
                     logger.log("The existing report file is not a valid Stub Usage Report. ${exception.message}")
-                    reportJson = json.encodeToString(generatedReport)
+                    json.encodeToString(generatedReport)
                 }
             } else
                 reportJson = json.encodeToString(generatedReport)

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -601,7 +601,7 @@ class HttpStub(
             if (reportFile.exists()) {
                 try {
                     val existingReport = Json.decodeFromString(reportFile.readText()) as StubUsageReportJson
-                    reportJson = json.encodeToString(generatedReport.append(existingReport))
+                    reportJson = json.encodeToString(generatedReport.merge(existingReport))
                 } catch (exception: SerializationException) {
                     logger.log("The existing report file is not a valid Stub Usage Report. ${exception.message}")
                     reportJson = json.encodeToString(generatedReport)

--- a/core/src/main/kotlin/io/specmatic/stub/report/StubUsageReportJson.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/report/StubUsageReportJson.kt
@@ -7,42 +7,25 @@ data class StubUsageReportJson (
     val specmaticConfigPath:String,
     val stubUsage:List<StubUsageReportRow>
 ) {
-    fun append(other: StubUsageReportJson): StubUsageReportJson {
-        val mergedStubUsage = mutableListOf<StubUsageReportRow>()
+    fun merge(other: StubUsageReportJson): StubUsageReportJson {
+        val mergedStubUsageRows: MutableList<StubUsageReportRow> = mutableListOf<StubUsageReportRow>()
 
         val allStubUsageRows = (other.stubUsage + this.stubUsage)
 
-        for (row in allStubUsageRows) {
-            val existingRow = mergedStubUsage.find { it.isSameAs(row) }
+        for (stubUsageReportRow in allStubUsageRows) {
+            val existingRow = mergedStubUsageRows.find { it.hasSameRowIdentifiers(stubUsageReportRow) }
 
             if (existingRow == null) {
-                mergedStubUsage += row
+                mergedStubUsageRows.add(stubUsageReportRow)
                 continue
             }
 
-            val allOperations = existingRow.operations + row.operations
-
-            val mergedOperations = mutableListOf<StubUsageReportOperation>()
-
-            for (operation in allOperations) {
-                val existingOperation = mergedOperations.find { it.isSameAs(operation) }
-
-                if (existingOperation != null) {
-                    mergedOperations[mergedOperations.indexOf(existingOperation)] =
-                        existingOperation.merge(operation)
-                } else {
-                    mergedOperations += operation
-                }
-            }
-
-            mergedStubUsage[mergedStubUsage.indexOf(existingRow)] = existingRow.copy(
-                operations = mergedOperations
-            )
+            mergedStubUsageRows[mergedStubUsageRows.indexOf(existingRow)] = existingRow.merge(stubUsageReportRow)
         }
 
         return StubUsageReportJson(
             specmaticConfigPath = other.specmaticConfigPath,
-            stubUsage = mergedStubUsage
+            stubUsage = mergedStubUsageRows
         )
     }
 }

--- a/core/src/main/kotlin/io/specmatic/stub/report/StubUsageReportJson.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/report/StubUsageReportJson.kt
@@ -6,4 +6,39 @@ import kotlinx.serialization.Serializable
 data class StubUsageReportJson (
     val specmaticConfigPath:String,
     val stubUsage:List<StubUsageReportRow>
-)
+) {
+    fun append(anotherStubUsageReport: StubUsageReportJson): StubUsageReportJson {
+        val mergedStubUsage = mutableListOf<StubUsageReportRow>()
+
+        val allStubUsageRows = (anotherStubUsageReport.stubUsage + this.stubUsage).groupBy {
+            Triple(it.type, it.repository, it.specification)
+        }
+
+        for ((_, rows) in allStubUsageRows) {
+            val mergedOperations = mutableListOf<StubUsageReportOperation>()
+
+            rows.flatMap { it.operations }.groupBy { op ->
+                Triple(op.path, op.method, op.responseCode)
+            }.forEach { (_, ops) ->
+                val combinedCount = ops.sumOf { it.count }
+                val sampleOp = ops.first()
+                mergedOperations += sampleOp.copy(count = combinedCount)
+            }
+
+            val firstRow = rows.first()
+            mergedStubUsage += StubUsageReportRow(
+                type = firstRow.type,
+                repository = firstRow.repository,
+                branch = firstRow.branch,
+                specification = firstRow.specification,
+                serviceType = firstRow.serviceType,
+                operations = mergedOperations
+            )
+        }
+
+        return StubUsageReportJson(
+            specmaticConfigPath = anotherStubUsageReport.specmaticConfigPath,
+            stubUsage = mergedStubUsage
+        )
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/stub/report/StubUsageReportOperation.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/report/StubUsageReportOperation.kt
@@ -3,13 +3,13 @@ package io.specmatic.stub.report
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class StubUsageReportOperation (
+data class StubUsageReportOperation(
     val path: String?,
     val method: String?,
     val responseCode: Int,
     val count: Int
 ) {
-    fun isSameAs(other: StubUsageReportOperation): Boolean {
+    fun hasSameOperationIdentifiers(other: StubUsageReportOperation): Boolean {
         return this.path.equals(other.path) && this.method.equals(other.method) && this.responseCode == other.responseCode
     }
 

--- a/core/src/main/kotlin/io/specmatic/stub/report/StubUsageReportOperation.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/report/StubUsageReportOperation.kt
@@ -8,4 +8,8 @@ data class StubUsageReportOperation (
     val method: String?,
     val responseCode: Int,
     val count: Int
-)
+) {
+    fun isSameAs(other: StubUsageReportOperation): Boolean {
+        return this.path.equals(other.path) && this.method.equals(other.method) && this.responseCode == other.responseCode
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/stub/report/StubUsageReportOperation.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/report/StubUsageReportOperation.kt
@@ -12,4 +12,8 @@ data class StubUsageReportOperation (
     fun isSameAs(other: StubUsageReportOperation): Boolean {
         return this.path.equals(other.path) && this.method.equals(other.method) && this.responseCode == other.responseCode
     }
+
+    fun merge(other: StubUsageReportOperation): StubUsageReportOperation {
+        return this.copy(count = this.count + other.count)
+    }
 }

--- a/core/src/main/kotlin/io/specmatic/stub/report/StubUsageReportRow.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/report/StubUsageReportRow.kt
@@ -10,4 +10,10 @@ data class StubUsageReportRow(
     val specification: String? = null,
     val serviceType: String? = null,
     val operations: List<StubUsageReportOperation>
-)
+) {
+    fun isSameAs(other: StubUsageReportRow): Boolean {
+        return type.equals(other.type) && repository.equals(other.repository)
+                && branch.equals(other.branch) && specification.equals(other.specification)
+                && serviceType.equals(other.serviceType)
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/stub/report/StubUsageReportRow.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/report/StubUsageReportRow.kt
@@ -11,9 +11,30 @@ data class StubUsageReportRow(
     val serviceType: String? = null,
     val operations: List<StubUsageReportOperation>
 ) {
-    fun isSameAs(other: StubUsageReportRow): Boolean {
+    fun hasSameRowIdentifiers(other: StubUsageReportRow): Boolean {
         return type.equals(other.type) && repository.equals(other.repository)
                 && branch.equals(other.branch) && specification.equals(other.specification)
                 && serviceType.equals(other.serviceType)
+    }
+
+    fun merge(other: StubUsageReportRow): StubUsageReportRow {
+        val allOperations = this.operations + other.operations
+
+        val mergedOperations = mutableListOf<StubUsageReportOperation>()
+
+        for (operation in allOperations) {
+            val existingOperation = mergedOperations.find { it.hasSameOperationIdentifiers(operation) }
+
+            if (existingOperation != null) {
+                mergedOperations[mergedOperations.indexOf(existingOperation)] =
+                    existingOperation.merge(operation)
+            } else {
+                mergedOperations.add(operation)
+            }
+        }
+
+        return copy(
+            operations = mergedOperations
+        )
     }
 }

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubStubCoverageTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubStubCoverageTest.kt
@@ -9,6 +9,7 @@ import io.specmatic.stub.report.StubUsageReportRow
 import kotlinx.serialization.json.Json
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.springframework.web.client.RestTemplate
 import java.io.File
@@ -18,9 +19,10 @@ class HttpStubStubCoverageTest {
     companion object {
         private val stubUsageReportFile = File("./build/reports/specmatic/stub_usage_report.json")
 
+        @BeforeAll
         @AfterAll
         @JvmStatic
-        fun tearDownAll() {
+        fun cleanUpAnyExistingReports() {
             stubUsageReportFile.delete()
         }
 

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubUsageReportTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubUsageReportTest.kt
@@ -15,7 +15,7 @@ import org.springframework.web.client.RestTemplate
 import java.io.File
 import kotlin.concurrent.thread
 
-class HttpStubStubCoverageTest {
+class HttpStubUsageReportTest {
     companion object {
         private val stubUsageReportFile = File("./build/reports/specmatic/stub_usage_report.json")
 

--- a/core/src/test/kotlin/io/specmatic/stub/report/StubUsageReportJsonTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/report/StubUsageReportJsonTest.kt
@@ -1,6 +1,5 @@
 package io.specmatic.stub.report
 
-import io.specmatic.stub
 import org.assertj.core.api.AssertionsForClassTypes.assertThat
 import org.junit.jupiter.api.Test
 
@@ -11,7 +10,11 @@ class StubUsageReportJsonTest {
         val newReport = StubUsageReportJson(
             specmaticConfigPath = "./specmatic.yaml",
             stubUsage = listOf(
-                stubUsageReportRow(1, "/path1", "GET", 200)
+                stubUsageReportRow(
+                    "in/specmatic/examples/store/api1.yaml", listOf(
+                        StubUsageReportOperation("/path1", "GET", 200, 1)
+                    )
+                )
             )
         )
 
@@ -23,7 +26,11 @@ class StubUsageReportJsonTest {
         val expectedMergedReport = StubUsageReportJson(
             specmaticConfigPath = "./specmatic.yaml",
             stubUsage = listOf(
-                stubUsageReportRow(1, "/path1", "GET", 200)
+                stubUsageReportRow(
+                    "in/specmatic/examples/store/api1.yaml", listOf(
+                        StubUsageReportOperation("/path1", "GET", 200, 1)
+                    )
+                )
             )
         )
 
@@ -33,25 +40,37 @@ class StubUsageReportJsonTest {
     }
 
     @Test
-    fun `append an new report with existing report with additional counts sums the count`() {
+    fun `append an new report wit existing report with additional counts sums the count`() {
         val newReport = StubUsageReportJson(
             specmaticConfigPath = "./specmatic.yaml",
             stubUsage = listOf(
-                stubUsageReportRow(1, "/path1", "GET", 200)
+                stubUsageReportRow(
+                    "in/specmatic/examples/store/api1.yaml", listOf(
+                        StubUsageReportOperation("/path1", "GET", 200, 1)
+                    )
+                )
             )
         )
 
         val existingReport = StubUsageReportJson(
             specmaticConfigPath = "./specmatic.yaml",
             stubUsage = listOf(
-                stubUsageReportRow(2, "/path1", "GET", 200)
+                stubUsageReportRow(
+                    "in/specmatic/examples/store/api1.yaml", listOf(
+                        StubUsageReportOperation("/path1", "GET", 200, 2)
+                    )
+                )
             )
         )
 
         val expectedMergedReport = StubUsageReportJson(
             specmaticConfigPath = "./specmatic.yaml",
             stubUsage = listOf(
-                stubUsageReportRow(3, "/path1", "GET", 200)
+                stubUsageReportRow(
+                    "in/specmatic/examples/store/api1.yaml", listOf(
+                        StubUsageReportOperation("/path1", "GET", 200, 3)
+                    )
+                )
             )
         )
 
@@ -60,21 +79,184 @@ class StubUsageReportJsonTest {
         assertThat(mergedReport).isEqualTo(expectedMergedReport)
     }
 
-    private fun stubUsageReportRow(count: Int, path: String, httpMethod: String, responseCode: Int): StubUsageReportRow {
+    @Test
+    fun `adds separate operation when existing report contains another path for the same spec`() {
+        val newReport = StubUsageReportJson(
+            specmaticConfigPath = "./specmatic.yaml",
+            stubUsage = listOf(
+                stubUsageReportRow(
+                    "in/specmatic/examples/store/api1.yaml", listOf(
+                        StubUsageReportOperation("/path1", "GET", 200, 1)
+                    )
+                )
+            )
+        )
+
+        val existingReport = StubUsageReportJson(
+            specmaticConfigPath = "./specmatic.yaml",
+            stubUsage = listOf(
+                stubUsageReportRow(
+                    "in/specmatic/examples/store/api1.yaml", listOf(
+                        StubUsageReportOperation("/path2", "GET", 200, 2)
+                    )
+                )
+            )
+        )
+
+        val expectedMergedReport = StubUsageReportJson(
+            specmaticConfigPath = "./specmatic.yaml",
+            stubUsage = listOf(
+                stubUsageReportRow(
+                    "in/specmatic/examples/store/api1.yaml", listOf(
+                        StubUsageReportOperation("/path2", "GET", 200, 2),
+                        StubUsageReportOperation("/path1", "GET", 200, 1)
+                    )
+                ),
+            )
+        )
+
+        val mergedReport = newReport.append(existingReport)
+
+        assertThat(mergedReport).isEqualTo(expectedMergedReport)
+    }
+
+    @Test
+    fun `add separate row when existing report contains another path for the different spec`() {
+        val newReport = StubUsageReportJson(
+            specmaticConfigPath = "./specmatic.yaml",
+            stubUsage = listOf(
+                stubUsageReportRow(
+                    "in/specmatic/examples/store/api1.yaml", listOf(
+                        StubUsageReportOperation("/path1", "GET", 200, 1)
+                    )
+                )
+            )
+        )
+
+        val existingReport = StubUsageReportJson(
+            specmaticConfigPath = "./specmatic.yaml",
+            stubUsage = listOf(
+                stubUsageReportRow(
+                    "in/specmatic/examples/store/api2.yaml", listOf(
+                        StubUsageReportOperation("/path2", "GET", 200, 2)
+                    )
+                )
+            )
+        )
+
+        val expectedMergedReport = StubUsageReportJson(
+            specmaticConfigPath = "./specmatic.yaml",
+            stubUsage = listOf(
+                stubUsageReportRow(
+                    "in/specmatic/examples/store/api2.yaml", listOf(
+                        StubUsageReportOperation("/path2", "GET", 200, 2),
+                    )
+                ),
+                stubUsageReportRow(
+                    "in/specmatic/examples/store/api1.yaml", listOf(
+                        StubUsageReportOperation("/path1", "GET", 200, 1)
+                    )
+                ),
+            )
+        )
+
+        val mergedReport = newReport.append(existingReport)
+
+        assertThat(mergedReport).isEqualTo(expectedMergedReport)
+    }
+
+    @Test
+    fun `add separate operation when response code is different in existing report`() {
+        val newReport = StubUsageReportJson(
+            specmaticConfigPath = "./specmatic.yaml",
+            stubUsage = listOf(
+                stubUsageReportRow(
+                    "in/specmatic/examples/store/api1.yaml", listOf(
+                        StubUsageReportOperation("/path1", "GET", 200, 1)
+                    )
+                )
+            )
+        )
+
+        val existingReport = StubUsageReportJson(
+            specmaticConfigPath = "./specmatic.yaml",
+            stubUsage = listOf(
+                stubUsageReportRow(
+                    "in/specmatic/examples/store/api1.yaml", listOf(
+                        StubUsageReportOperation("/path1", "GET", 404, 2)
+                    )
+                )
+            )
+        )
+
+        val expectedMergedReport = StubUsageReportJson(
+            specmaticConfigPath = "./specmatic.yaml",
+            stubUsage = listOf(
+                stubUsageReportRow(
+                    "in/specmatic/examples/store/api1.yaml", listOf(
+                        StubUsageReportOperation("/path1", "GET", 404, 2),
+                        StubUsageReportOperation("/path1", "GET", 200, 1),
+                    )
+                ),
+            )
+        )
+
+        val mergedReport = newReport.append(existingReport)
+
+        assertThat(mergedReport).isEqualTo(expectedMergedReport)
+    }
+
+    @Test
+    fun `add separate operation when method is different in existing report`() {
+        val newReport = StubUsageReportJson(
+            specmaticConfigPath = "./specmatic.yaml",
+            stubUsage = listOf(
+                stubUsageReportRow(
+                    "in/specmatic/examples/store/api1.yaml", listOf(
+                        StubUsageReportOperation("/path1", "GET", 200, 1)
+                    )
+                )
+            )
+        )
+
+        val existingReport = StubUsageReportJson(
+            specmaticConfigPath = "./specmatic.yaml",
+            stubUsage = listOf(
+                stubUsageReportRow(
+                    "in/specmatic/examples/store/api1.yaml", listOf(
+                        StubUsageReportOperation("/path1", "POST", 200, 2)
+                    )
+                )
+            )
+        )
+
+        val expectedMergedReport = StubUsageReportJson(
+            specmaticConfigPath = "./specmatic.yaml",
+            stubUsage = listOf(
+                stubUsageReportRow(
+                    "in/specmatic/examples/store/api1.yaml", listOf(
+                        StubUsageReportOperation("/path1", "POST", 200, 2),
+                        StubUsageReportOperation("/path1", "GET", 200, 1),
+                    )
+                ),
+            )
+        )
+
+        val mergedReport = newReport.append(existingReport)
+
+        assertThat(mergedReport).isEqualTo(expectedMergedReport)
+    }
+
+    private fun stubUsageReportRow(
+        specification: String, stubUsageReportOperations: List<StubUsageReportOperation>
+    ): StubUsageReportRow {
         return StubUsageReportRow(
             type = "git",
             repository = "https://github.com/znsio/specmatic-order-contracts.git",
             branch = "main",
-            specification = "in/specmatic/examples/store/route1.yaml",
+            specification = specification,
             serviceType = "HTTP",
-            operations = listOf(
-                StubUsageReportOperation(
-                    path = path,
-                    method = httpMethod,
-                    responseCode = responseCode,
-                    count = count
-                )
-            )
+            operations = stubUsageReportOperations
         )
     }
 }

--- a/core/src/test/kotlin/io/specmatic/stub/report/StubUsageReportJsonTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/report/StubUsageReportJsonTest.kt
@@ -1,0 +1,80 @@
+package io.specmatic.stub.report
+
+import io.specmatic.stub
+import org.assertj.core.api.AssertionsForClassTypes.assertThat
+import org.junit.jupiter.api.Test
+
+class StubUsageReportJsonTest {
+
+    @Test
+    fun `append an empty existing report does not change the new report`() {
+        val newReport = StubUsageReportJson(
+            specmaticConfigPath = "./specmatic.yaml",
+            stubUsage = listOf(
+                stubUsageReportRow(1, "/path1", "GET", 200)
+            )
+        )
+
+        val existingReport = StubUsageReportJson(
+            specmaticConfigPath = "./specmatic.yaml",
+            stubUsage = emptyList()
+        )
+
+        val expectedMergedReport = StubUsageReportJson(
+            specmaticConfigPath = "./specmatic.yaml",
+            stubUsage = listOf(
+                stubUsageReportRow(1, "/path1", "GET", 200)
+            )
+        )
+
+        val mergedReport = newReport.append(existingReport)
+
+        assertThat(mergedReport).isEqualTo(expectedMergedReport)
+    }
+
+    @Test
+    fun `append an new report with existing report with additional counts sums the count`() {
+        val newReport = StubUsageReportJson(
+            specmaticConfigPath = "./specmatic.yaml",
+            stubUsage = listOf(
+                stubUsageReportRow(1, "/path1", "GET", 200)
+            )
+        )
+
+        val existingReport = StubUsageReportJson(
+            specmaticConfigPath = "./specmatic.yaml",
+            stubUsage = listOf(
+                stubUsageReportRow(2, "/path1", "GET", 200)
+            )
+        )
+
+        val expectedMergedReport = StubUsageReportJson(
+            specmaticConfigPath = "./specmatic.yaml",
+            stubUsage = listOf(
+                stubUsageReportRow(3, "/path1", "GET", 200)
+            )
+        )
+
+        val mergedReport = newReport.append(existingReport)
+
+        assertThat(mergedReport).isEqualTo(expectedMergedReport)
+    }
+
+    private fun stubUsageReportRow(count: Int, path: String, httpMethod: String, responseCode: Int): StubUsageReportRow {
+        return StubUsageReportRow(
+            type = "git",
+            repository = "https://github.com/znsio/specmatic-order-contracts.git",
+            branch = "main",
+            specification = "in/specmatic/examples/store/route1.yaml",
+            serviceType = "HTTP",
+            operations = listOf(
+                StubUsageReportOperation(
+                    path = path,
+                    method = httpMethod,
+                    responseCode = responseCode,
+                    count = count
+                )
+            )
+        )
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/stub/report/StubUsageReportJsonTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/report/StubUsageReportJsonTest.kt
@@ -40,7 +40,7 @@ class StubUsageReportJsonTest {
     }
 
     @Test
-    fun `append an new report wit existing report with additional counts sums the count`() {
+    fun `append an new report with existing report with additional counts sums the count`() {
         val newReport = StubUsageReportJson(
             specmaticConfigPath = "./specmatic.yaml",
             stubUsage = listOf(

--- a/core/src/test/kotlin/io/specmatic/stub/report/StubUsageReportJsonTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/report/StubUsageReportJsonTest.kt
@@ -34,7 +34,7 @@ class StubUsageReportJsonTest {
             )
         )
 
-        val mergedReport = newReport.append(existingReport)
+        val mergedReport = newReport.merge(existingReport)
 
         assertThat(mergedReport).isEqualTo(expectedMergedReport)
     }
@@ -74,7 +74,7 @@ class StubUsageReportJsonTest {
             )
         )
 
-        val mergedReport = newReport.append(existingReport)
+        val mergedReport = newReport.merge(existingReport)
 
         assertThat(mergedReport).isEqualTo(expectedMergedReport)
     }
@@ -115,7 +115,7 @@ class StubUsageReportJsonTest {
             )
         )
 
-        val mergedReport = newReport.append(existingReport)
+        val mergedReport = newReport.merge(existingReport)
 
         assertThat(mergedReport).isEqualTo(expectedMergedReport)
     }
@@ -160,7 +160,7 @@ class StubUsageReportJsonTest {
             )
         )
 
-        val mergedReport = newReport.append(existingReport)
+        val mergedReport = newReport.merge(existingReport)
 
         assertThat(mergedReport).isEqualTo(expectedMergedReport)
     }
@@ -201,7 +201,7 @@ class StubUsageReportJsonTest {
             )
         )
 
-        val mergedReport = newReport.append(existingReport)
+        val mergedReport = newReport.merge(existingReport)
 
         assertThat(mergedReport).isEqualTo(expectedMergedReport)
     }
@@ -242,7 +242,7 @@ class StubUsageReportJsonTest {
             )
         )
 
-        val mergedReport = newReport.append(existingReport)
+        val mergedReport = newReport.merge(existingReport)
 
         assertThat(mergedReport).isEqualTo(expectedMergedReport)
     }

--- a/core/src/test/kotlin/io/specmatic/stub/report/StubUsageReportOperationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/report/StubUsageReportOperationTest.kt
@@ -1,0 +1,43 @@
+package io.specmatic.stub.report
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+
+class StubUsageReportOperationTest {
+
+    @Test
+    fun `hasSameOperationIdentifiers should return true for matching identifiers`() {
+        val operation1 = StubUsageReportOperation(path = "/api/test", method = "GET", responseCode = 200, count = 5)
+        val operation2 = StubUsageReportOperation(path = "/api/test", method = "GET", responseCode = 200, count = 10)
+
+        val result = operation1.hasSameOperationIdentifiers(operation2)
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `hasSameOperationIdentifiers should return false for non-matching identifiers`() {
+        val operation1 = StubUsageReportOperation(path = "/api/test", method = "GET", responseCode = 200, count = 5)
+        val operation2 = StubUsageReportOperation(path = "/api/other", method = "POST", responseCode = 404, count = 10)
+
+        val result = operation1.hasSameOperationIdentifiers(operation2)
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `merge should combine counts of two operations`() {
+        val operation1 = StubUsageReportOperation(path = "/api/test", method = "GET", responseCode = 200, count = 5)
+        val operation2 = StubUsageReportOperation(path = "/api/test", method = "GET", responseCode = 200, count = 10)
+
+        val mergedOperation = operation1.merge(operation2)
+
+        assertThat(mergedOperation.count).isEqualTo(15)
+        assertThat(mergedOperation.path).isEqualTo(operation1.path)
+        assertThat(mergedOperation.method).isEqualTo(operation1.method)
+        assertThat(mergedOperation.responseCode).isEqualTo(operation1.responseCode)
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/stub/report/StubUsageReportRowTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/report/StubUsageReportRowTest.kt
@@ -1,0 +1,53 @@
+package io.specmatic.stub.report
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class StubUsageReportRowTest {
+    private val operation1 = StubUsageReportOperation(path = "/api/test1", method = "GET", responseCode = 200, count = 5)
+    private val operation2 = StubUsageReportOperation(path = "/api/test2", method = "POST", responseCode = 201, count = 10)
+    private val operation3 = StubUsageReportOperation(path = "/api/test1", method = "GET", responseCode = 200, count = 2)
+
+    @Test
+    fun `hasSameRowIdentifiers should return true for matching identifiers`() {
+        val row1 = StubUsageReportRow(type = "type1", repository = "repo1", branch = "main", specification = "spec1", serviceType = "serviceA", operations = listOf(operation1))
+        val row2 = StubUsageReportRow(type = "type1", repository = "repo1", branch = "main", specification = "spec1", serviceType = "serviceA", operations = listOf(operation2))
+
+        val result = row1.hasSameRowIdentifiers(row2)
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `hasSameRowIdentifiers should return false for non-matching identifiers`() {
+        val row1 = StubUsageReportRow(type = "type1", repository = "repo1", branch = "main", specification = "spec1", serviceType = "serviceA", operations = listOf(operation1))
+        val row2 = StubUsageReportRow(type = "type2", repository = "repo1", branch = "main", specification = "spec1", serviceType = "serviceA", operations = listOf(operation2))
+
+        val result = row1.hasSameRowIdentifiers(row2)
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `merge should combine operations of two rows with unique operations`() {
+        val row1 = StubUsageReportRow(type = "type1", repository = "repo1", branch = "main", specification = "spec1", serviceType = "serviceA", operations = listOf(operation1))
+        val row2 = StubUsageReportRow(type = "type1", repository = "repo1", branch = "main", specification = "spec1", serviceType = "serviceA", operations = listOf(operation2))
+
+        val mergedRow = row1.merge(row2)
+
+        assertThat(mergedRow.operations).hasSize(2)
+        assertThat(mergedRow.operations).containsExactlyInAnyOrder(operation1, operation2)
+    }
+
+    @Test
+    fun `merge should combine operations of two rows with overlapping operations`() {
+        val row1 = StubUsageReportRow(type = "type1", repository = "repo1", branch = "main", specification = "spec1", serviceType = "serviceA", operations = listOf(operation1))
+        val row2 = StubUsageReportRow(type = "type1", repository = "repo1", branch = "main", specification = "spec1", serviceType = "serviceA", operations = listOf(operation3))
+
+        val mergedRow = row1.merge(row2)
+
+        assertThat(mergedRow.operations).hasSize(1)
+        assertThat(mergedRow.operations[0].count).isEqualTo(7)
+    }
+}

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=2.0.32
+version=2.0.33


### PR DESCRIPTION
**What**:

Merge HTTP stub usage reports instead of overwriting existing reports

**Why**:

When there are several HTTP stub servers that are started and stopped as part of various test suites in a single build, we want to retain data for all those stub servers

**How**:

Detect if a report already exists and merge the contents

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

