### PR TITLE
Generate additional extended example when extensible schema is enabled

### DIFF
--- a/application/src/test/kotlin/application/ExamplesCommandTest.kt
+++ b/application/src/test/kotlin/application/ExamplesCommandTest.kt
@@ -87,7 +87,7 @@ paths:
         println(output)
 
         assertThat(returnValue).isNotEqualTo(0)
-        assertThat(output).contains("No matching REST stub or contract found")
+        assertThat(output).contains("No matching found for this example")
     }
 
     @Test

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -337,7 +337,15 @@ data class Feature(
             it.matches(request, response, mismatchMessages, flagsBased)
         }
 
-        return Results(results).withoutFluff()
+        if(results.any { it.isSuccess() })
+            return Results(results).withoutFluff()
+
+        val deepErrors = results.filterNot { it.isFluffy(0) }
+
+        if(deepErrors.isNotEmpty())
+            return Results(deepErrors)
+
+        return Results(listOf(Result.Failure("Match not found")))
     }
 
     fun matchResult(request: HttpRequest, response: HttpResponse): Result {

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -345,7 +345,7 @@ data class Feature(
         if(deepErrors.isNotEmpty())
             return Results(deepErrors)
 
-        return Results(listOf(Result.Failure("Match not found")))
+        return Results(listOf(Result.Failure("No matching found for this example")))
     }
 
     fun matchResult(request: HttpRequest, response: HttpResponse): Result {

--- a/core/src/main/kotlin/io/specmatic/core/HttpResponse.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpResponse.kt
@@ -45,6 +45,8 @@ data class HttpResponse(
         return copy(body = content, headers = headers.minus(CONTENT_TYPE).plus(CONTENT_TYPE to content.httpContentType))
     }
 
+    fun updateBody(body: Value): HttpResponse = copy(body = body)
+
     fun toJSON(): JSONObjectValue =
         JSONObjectValue(mutableMapOf<String, Value>().also { json ->
             json["status"] = NumberValue(status)

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -272,6 +272,7 @@ data class Scenario(
         val requestMatch = matches(httpRequest, mismatchMessages, resolver.findKeyErrorCheck.unexpectedKeyCheck, resolver)
         if (requestMatch is Result.Failure && httpResponse.status != httpResponsePattern.status) {
             return Result.Failure(
+                breadCrumb = "STATUS",
                 cause = requestMatch,
                 failureReason = FailureReason.RequestMismatchButStatusAlsoWrong
             ).updateScenario(this)

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -126,7 +126,7 @@ data class Scenario(
         mismatchMessages: MismatchMessages = DefaultMismatchMessages,
         unexpectedKeyCheck: UnexpectedKeyCheck? = null
     ): Result {
-        val resolver = Resolver(serverState, false, patterns).copy(mismatchMessages = mismatchMessages).let {
+        val resolver = resolver.copy(mismatchMessages = mismatchMessages).let {
             if(unexpectedKeyCheck != null) {
                 val keyCheck = it.findKeyErrorCheck
                 it.copy(findKeyErrorCheck = keyCheck.copy(unexpectedKeyCheck = unexpectedKeyCheck))

--- a/core/src/main/kotlin/io/specmatic/core/examples/server/ExamplesView.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/server/ExamplesView.kt
@@ -16,7 +16,7 @@ class ExamplesView {
     companion object {
         fun getEndpoints(feature: Feature, examplesDir: File): List<Endpoint> {
             val examples = examplesDir.getExamplesFromDir()
-            val scenarioExamplesPairList = getScenarioExamplesPairs(feature.scenarios, examples)
+            val scenarioExamplesPairList = getScenarioExamplesPairs(feature, examples)
 
             return scenarioExamplesPairList.map { (scenario, example) ->
                 Endpoint(
@@ -31,11 +31,11 @@ class ExamplesView {
             }.filterEndpoints()
         }
 
-        private fun getScenarioExamplesPairs(scenarios: List<Scenario>, examples: List<ExampleFromFile>): List<Pair<Scenario, Pair<File, String>?>> {
-            return scenarios.flatMap {
-                getExistingExampleFiles(it, examples).map { exRes ->
-                    it to exRes
-                }.ifEmpty { listOf(it to null) }
+        private fun getScenarioExamplesPairs(feature: Feature, examples: List<ExampleFromFile>): List<Pair<Scenario, Pair<File, String>?>> {
+            return feature.scenarios.flatMap { scenario ->
+                getExistingExampleFiles(feature, scenario, examples).map { exRes ->
+                    scenario to exRes
+                }.ifEmpty { listOf(scenario to null) }
             }
         }
 

--- a/core/src/main/kotlin/io/specmatic/core/examples/server/ExamplesView.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/server/ExamplesView.kt
@@ -39,7 +39,7 @@ class ExamplesView {
 
         private fun Pattern.isDiscriminatorBased(resolver: Resolver): Boolean {
             return when (val resolvedPattern = resolvedHop(this, resolver)) {
-                is AnyPattern -> resolvedPattern.isDiscriminatorPresent()
+                is AnyPattern -> resolvedPattern.isDiscriminatorPresent() && resolvedPattern.hasMultipleDiscriminatorValues()
                 is ListPattern -> resolvedPattern.pattern.isDiscriminatorBased(resolver)
                 else -> false
             }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
@@ -317,6 +317,8 @@ data class AnyPattern(
 
     fun isDiscriminatorPresent() = discriminatorProperty != null && discriminatorValues.isNotEmpty()
 
+    fun hasMultipleDiscriminatorValues() = isDiscriminatorPresent() && discriminatorValues.size > 1
+
     fun generateForEveryDiscriminatorValue(resolver: Resolver): List<DiscriminatorBasedItem<Value>> {
         return discriminatorValues.map { discriminatorValue ->
             DiscriminatorBasedItem(

--- a/core/src/main/resources/templates/examples/index.html
+++ b/core/src/main/resources/templates/examples/index.html
@@ -1122,15 +1122,15 @@
 
                 case "INPUT": {
                     if (target.matches("th > label > input")) {
-                        const {validatedCount, generatedCount, totalCount} = getRowsCount();
+                        const {validatedCount, generatedCount, discAndMainCount, totalCount} = getRowsCount();
                         toggleAllSelects(target.checked);
 
                         if (table.hasAttribute("data-generated") ) {
-                            bulkValidateBtn.setAttribute("data-selected", target.checked ? validatedCount : 0);
+                            bulkValidateBtn.setAttribute("data-selected", target.checked ? generatedCount : 0);
                             bulkTestBtn.setAttribute("data-selected", target.checked ? validatedCount : 0);
                         }
 
-                        return bulkGenerateBtn.setAttribute("data-selected", target.checked ? totalCount - generatedCount : 0);
+                        return bulkGenerateBtn.setAttribute("data-selected", target.checked ? totalCount - generatedCount + discAndMainCount : 0);
                     }
 
                     return handleSingleInput(nearestTableRow, target.checked);
@@ -1298,15 +1298,17 @@
     function getRowsCount() {
         const tableRows = table.querySelectorAll("tbody > tr");
         return Array.from(tableRows).reduce((acc, row) => {
-            const isRowGenerated = (row.getAttribute("data-main") === "true" && row.getAttribute("data-disc") === "true") ? false : row.getAttribute("data-generate") === "success";
+            const isRowGenerated = row.getAttribute("data-generate") === "success";
             const isRowValidated = row.getAttribute("data-valid") === "success";
+            const isRowDiscAndMain = row.getAttribute("data-main") === "true" && row.getAttribute("data-disc") === "true";
 
             acc.validatedCount += isRowValidated ? 1 : 0;
             acc.generatedCount += isRowGenerated ? 1 : 0;
+            acc.discAndMainCount += isRowGenerated && isRowDiscAndMain ? 1 : 0;
             acc.totalCount += 1;
             return acc;
 
-        }, {validatedCount: 0, generatedCount: 0, totalCount: 0});
+        }, {validatedCount: 0, generatedCount: 0, discAndMainCount: 0, totalCount: 0});
     }
 
     function toggleAllSelects(isSelected = true) {

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=2.0.34
+version=2.0.35


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Generate additional extended example when extensible schema is enabled

<!-- How were these changes implemented? -->

**How**:
- Duplicate newly generated examples with additional fields when the extensible schema is enabled, but only if there are no existing examples present.
- Significantly refactor the example validation logic to utilize flags appropriately.
- Implement new methods in the Scenario and Feature classes for validation that makes use of flags.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [ ] Tests
- [ ] Sonar Quality Gate
