### PR TITLE
Additional example params file in config

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/ExampleFromFile.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/ExampleFromFile.kt
@@ -38,7 +38,7 @@ class ExampleFromFile(val json: JSONObjectValue, val file: File) {
 
         }
 
-        val requestExample = mockFromJSON(json.jsonObject).getRequestWithAdditionalParamsIfAny()
+        val requestExample = mockFromJSON(json.jsonObject).getRequestWithAdditionalParamsIfAny(request, specmaticConfig.additionalExampleParamsFilePath)
 
         return Row(
             columnNames,

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -101,7 +101,8 @@ data class SpecmaticConfig(
     val stub: StubConfiguration = StubConfiguration(),
     val examples: List<String> = getStringValue(EXAMPLE_DIRECTORIES)?.split(",") ?: emptyList(),
     val workflow: WorkflowConfiguration? = null,
-    val ignoreInlineExamples: Boolean = getBooleanValue(Flags.IGNORE_INLINE_EXAMPLES)
+    val ignoreInlineExamples: Boolean = getBooleanValue(Flags.IGNORE_INLINE_EXAMPLES),
+    val additionalExampleParamsFilePath: String? = getStringValue(Flags.ADDITIONAL_EXAMPLE_PARAMS_FILE)
 ) {
     @JsonIgnore
     fun isExtensibleSchemaEnabled(): Boolean {

--- a/core/src/main/kotlin/io/specmatic/core/utilities/Flags.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/Flags.kt
@@ -21,6 +21,7 @@ class Flags {
         const val EXAMPLE_DIRECTORIES = "EXAMPLE_DIRECTORIES"
 
         const val EXTENSIBLE_QUERY_PARAMS = "EXTENSIBLE_QUERY_PARAMS"
+        const val ADDITIONAL_EXAMPLE_PARAMS_FILE = "ADDITIONAL_EXAMPLE_PARAMS_FILE"
 
         fun getStringValue(flagName: String): String? = System.getenv(flagName) ?: System.getProperty(flagName)
 

--- a/core/src/test/kotlin/io/specmatic/conversions/ExampleFromFileTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/ExampleFromFileTest.kt
@@ -1,6 +1,7 @@
 package io.specmatic.conversions
 
 import io.specmatic.core.NoBodyValue
+import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.pattern.parsedJSONObject
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -107,4 +108,32 @@ class ExampleFromFileTest {
         assertThat(request.queryParams.asMap()).containsExactlyEntriesOf(mapOf("filter" to "active"))
     }
 
+    @Test
+    fun `should load extra header params from additional params file`() {
+        val example = """
+        {
+            "http-request": {
+                "method": "POST",
+                "path": "/api/resource?filter=active",
+                "headers": {
+                    "Content-Type": "application/json"
+                },
+                "body": {
+                    "key": "value"
+                }
+            },
+            "http-response": {
+                "status": 200,
+                "body": "ok"
+            }
+        }
+    """.trimIndent().let {
+            ExampleFromFile(parsedJSONObject(it), File("./data.json"))
+        }
+
+        val row =
+            example.toRow(SpecmaticConfig(additionalExampleParamsFilePath = "src/test/resources/additionalParamsFile.json"))
+
+        assertThat(row.requestExample?.headers.orEmpty()).containsEntry("X-Tra", "info")
+    }
 }

--- a/core/src/test/resources/additionalParamsFile.json
+++ b/core/src/test/resources/additionalParamsFile.json
@@ -1,0 +1,5 @@
+{
+  "headers": {
+    "X-Tra": "info"
+  }
+}


### PR DESCRIPTION
**What**:

Accept a config file for additional parameters, from which to load headers.

**Why**:

This is useful in case when running contract tests there is an extra header required by the infrastructure, such as an auth token, which is required by an API gateway but is not in the spec.

This works only for external examples for now.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate
