### PR TITLE
Modify the OpenAPI parsing and toPattern logic for allOf schema.

### DIFF
--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -9352,6 +9352,40 @@ paths:
         assertThat(resolvedBodyPattern.pattern.keys).doesNotContain("id?")
     }
 
+    @Test
+    fun `should not resolve deep discriminators in an allOf schema`() {
+        val specFile = "src/test/resources/openapi/vehicle_deep_allof.yaml"
+        val feature = OpenApiSpecification.fromFile(specFile).toFeature()
+
+        assertThat(feature.scenarios).allSatisfy { scenario ->
+            val responseBodyPattern = resolvedHop(scenario.httpResponsePattern.body, scenario.resolver).let {
+                when (it) {
+                    is ListPattern -> resolvedHop(it.pattern, scenario.resolver)
+                    else -> it
+                }
+            }
+            val requestBodyPattern = scenario.httpRequestPattern.body.takeIf { it !is NoBodyPattern }?.let {
+                resolvedHop(scenario.httpRequestPattern.body, scenario.resolver)
+            }
+
+            assertThat(responseBodyPattern).isNotInstanceOf(AnyPattern::class.java)
+            if (requestBodyPattern != null) {
+                when (scenario.method) {
+                    "POST" -> {
+                        assertThat(requestBodyPattern).isInstanceOf(AnyPattern::class.java)
+                        (requestBodyPattern as AnyPattern).let {
+                            assertThat(it.pattern).hasSize(2)
+                            assertThat(it.discriminator!!.property).isEqualTo("type")
+                            assertThat(it.discriminator!!.values).containsExactlyInAnyOrder("car", "truck")
+                        }
+                    }
+                    "PATCH" -> assertThat(requestBodyPattern).isNotInstanceOf(AnyPattern::class.java)
+                    else -> Exception("Unexpected method: ${scenario.method}")
+                }
+            }
+        }
+    }
+
     private fun ignoreButLogException(function: () -> OpenApiSpecification) {
         try {
             function()
@@ -9360,4 +9394,5 @@ paths:
         }
     }
 }
+
 

--- a/core/src/test/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServerTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServerTest.kt
@@ -8,11 +8,17 @@ import io.specmatic.core.value.NumberValue
 import io.specmatic.core.value.StringValue
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.io.File
 
 class ExamplesInteractiveServerTest {
+    @BeforeEach
+    fun resetCounter() {
+        ExamplesInteractiveServer.resetExampleFileNameCounter()
+    }
+
     @Nested
     inner class ExternaliseInlineExamplesTests {
 

--- a/core/src/test/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServerTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServerTest.kt
@@ -7,6 +7,7 @@ import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.NumberValue
 import io.specmatic.core.value.StringValue
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.io.File
@@ -63,6 +64,58 @@ class ExamplesInteractiveServerTest {
             } finally {
                 examplesDir?.deleteRecursively()
             }
+        }
+    }
+
+    @Nested
+    inner class DiscriminatorExamplesGenerationTests {
+        private val specFile = File("src/test/resources/openapi/vehicle_deep_allof.yaml")
+        private val examplesDir = specFile.parentFile.resolve("vehicle_deep_allof_examples")
+
+        @AfterEach
+        fun cleanUp() {
+            if (examplesDir.exists()) {
+                examplesDir.listFiles()?.forEach { it.delete() }
+                examplesDir.delete()
+            }
+        }
+
+        @Test
+        fun `should generate multiple examples for top level discriminator`() {
+            val generatedExamples = ExamplesInteractiveServer.generate(
+                contractFile = specFile,
+                method = "POST", path = "/vehicles", responseStatusCode = 201,
+                bulkMode = false, allowOnlyMandatoryKeysInJSONObject = false
+            )
+
+            assertThat(generatedExamples).hasSize(2)
+            assertThat(generatedExamples).allSatisfy {
+                assertThat(it.created).isTrue()
+                assertThat(it.path).satisfiesAnyOf(
+                    { path -> assertThat(path).contains("car") }, { path -> assertThat(path).contains("truck") }
+                )
+            }
+        }
+
+        @Test
+        fun `should not generate multiple examples for deep nested discriminator`() {
+            val generatedGetExamples = ExamplesInteractiveServer.generate(
+                contractFile = specFile,
+                method = "GET", path = "/vehicles", responseStatusCode = 200,
+                bulkMode = false, allowOnlyMandatoryKeysInJSONObject = false
+            )
+
+            assertThat(generatedGetExamples).hasSize(1)
+            assertThat(generatedGetExamples.first().path).contains("GET")
+
+            val generatedPatchExamples = ExamplesInteractiveServer.generate(
+                contractFile = specFile,
+                method = "PATCH", path = "/vehicles", responseStatusCode = 200,
+                bulkMode = false, allowOnlyMandatoryKeysInJSONObject = false
+            )
+
+            assertThat(generatedPatchExamples).hasSize(1)
+            assertThat(generatedPatchExamples.first().path).contains("PATCH")
         }
     }
 }

--- a/core/src/test/resources/openapi/vehicle_deep_allof.yaml
+++ b/core/src/test/resources/openapi/vehicle_deep_allof.yaml
@@ -1,0 +1,82 @@
+openapi: 3.0.3
+info:
+  title: Vehicle Inventory API
+  description: An API to manage a catalog of vehicles available for sale
+  version: 1.0.0
+paths:
+  /vehicles:
+    get:
+      responses:
+        '200':
+          description: A list of vehicles
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/VehicleResponse'
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Vehicle'
+      responses:
+        '201':
+          description: Vehicle created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VehicleResponse'
+    patch:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VehicleResponse'
+      responses:
+        '200':
+          description: Vehicle updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VehicleResponse'
+components:
+  schemas:
+    VehicleResponse:
+      allOf:
+        - $ref: '#/components/schemas/Vehicle'
+      required:
+        - id
+    BaseVehicle:
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+      required:
+        - type
+    Vehicle:
+      allOf:
+        - $ref: '#/components/schemas/BaseVehicle'
+      discriminator:
+        propertyName: type
+        mapping:
+          car: '#/components/schemas/Car'
+          truck: '#/components/schemas/Truck'
+    Car:
+      allOf:
+        - $ref: '#/components/schemas/BaseVehicle'
+        - type: object
+          properties:
+            seatingCapacity:
+              type: integer
+    Truck:
+      allOf:
+        - $ref: '#/components/schemas/BaseVehicle'
+        - type: object
+          properties:
+            trailer:
+              type: boolean


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Modify the OpenAPI parsing and toPattern logic for allOf schema.

<!-- Why are these changes necessary? -->

**Why**:
- The allOf schema discriminators are currently resolved at multiple levels, with the selection of discriminators taking place not only at the schema level but also within the deeper structure.
- This restricts the discriminators resolving to only the top level of the schema.

<!-- How were these changes implemented? -->

**How**:
- Using a `topLevel` flag when processing allOf schemas.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation `N/A`
- [x] Tests
- [ ] Sonar Quality Gate `N/A`
