### PR TITLE
Parse unreferenced and indirectly referenced schemas to patterns.

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -223,16 +223,30 @@ class OpenApiSpecification(
         val name = File(openApiFilePath).name
 
         val (scenarioInfos, stubsFromExamples) = toScenarioInfos()
+        val unreferencedSchemaPatterns = parseUnreferencedSchemas()
+        val updatedScenarios = scenarioInfos.map {
+            Scenario(it).copy(
+                dictionary = dictionary,
+                attributeSelectionPattern = specmaticConfig.attributeSelectionPattern,
+                patterns = it.patterns + unreferencedSchemaPatterns
+            )
+        }
 
         return Feature(
-            scenarioInfos.map { Scenario(it).copy(dictionary = dictionary, attributeSelectionPattern = specmaticConfig.attributeSelectionPattern) }, name = name, path = openApiFilePath, sourceProvider = sourceProvider,
+            updatedScenarios, name = name, path = openApiFilePath, sourceProvider = sourceProvider,
             sourceRepository = sourceRepository,
             sourceRepositoryBranch = sourceRepositoryBranch,
             specification = specificationPath,
             serviceType = SERVICE_TYPE_HTTP,
             stubsFromExamples = stubsFromExamples,
-            specmaticConfig = specmaticConfig
+            specmaticConfig = specmaticConfig,
         )
+    }
+
+    private fun parseUnreferencedSchemas(): Map<String, Pattern> {
+        return openApiSchemas().filterNot { withPatternDelimiters(it.key) in patterns }.map {
+            withPatternDelimiters(it.key) to toSpecmaticPattern(it.value, emptyList())
+        }.toMap()
     }
 
     override fun toScenarioInfos(): Pair<List<ScenarioInfo>, Map<String, List<Pair<HttpRequest, HttpResponse>>>> {
@@ -790,6 +804,8 @@ class OpenApiSpecification(
         }
 
     private fun openApiPaths() = parsedOpenApi.paths.orEmpty()
+
+    private fun openApiSchemas() = parsedOpenApi.components?.schemas.orEmpty()
 
     private fun isNumber(value: String): Boolean {
         return value.toIntOrNull() != null


### PR DESCRIPTION
**What**: Parse unreferenced and indirectly referenced schemas to patterns.

<!-- Why are these changes necessary? -->

**Why**: This ensures that these patterns are accessible when required, such as for schema-based example generation.

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation `N/A`
- [x] Tests
- [ ] Sonar Quality Gate `N/A`