### PR TITLE
Ensure that all properties show up when generating an example of an API

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -529,7 +529,9 @@ data class Feature(
     }
 
     private fun positiveTestScenarios(suggestions: List<Scenario>, fn: (Scenario, Row) -> Scenario = { s, _ -> s }): Sequence<Pair<Scenario, ReturnValue<Scenario>>> =
-        scenarios.asSequence().filter { it.isA2xxScenario() || it.examples.isNotEmpty() || it.isGherkinScenario }.map {
+        scenarios.asSequence().filter {
+            it.isA2xxScenario() || it.examples.isNotEmpty() || it.isGherkinScenario
+        }.map {
             it.newBasedOn(suggestions)
         }.flatMap { originalScenario ->
             val resolverStrategies = if(originalScenario.isA2xxScenario())

--- a/core/src/main/kotlin/io/specmatic/core/FlagsBased.kt
+++ b/core/src/main/kotlin/io/specmatic/core/FlagsBased.kt
@@ -1,6 +1,7 @@
 package io.specmatic.core
 
 import io.specmatic.core.pattern.IgnoreUnexpectedKeys
+import io.specmatic.core.utilities.Flags
 import io.specmatic.core.utilities.Flags.Companion.SCHEMA_EXAMPLE_DEFAULT
 import io.specmatic.core.utilities.Flags.Companion.getBooleanValue
 
@@ -60,5 +61,5 @@ val DefaultStrategies = FlagsBased (
     null,
     "",
     "",
-    false
+    Flags.getBooleanValue(Flags.ALL_PATTERNS_MANDATORY, false)
 )

--- a/core/src/main/kotlin/io/specmatic/core/GenerativeTestsEnabled.kt
+++ b/core/src/main/kotlin/io/specmatic/core/GenerativeTestsEnabled.kt
@@ -13,7 +13,7 @@ data class GenerativeTestsEnabled(private val positiveOnly: Boolean) : Generatio
         key: String
     ): Sequence<ReturnValue<Pattern>> {
         // TODO generate value outside
-        return resolver.withCyclePrevention(pattern, isOptional(key)) { cyclePreventedResolver ->
+        return resolver.withCyclePrevention(pattern, key, isOptional(key)) { cyclePreventedResolver ->
             pattern.newBasedOn(Row(), cyclePreventedResolver)
         } ?: emptySequence()
     }

--- a/core/src/main/kotlin/io/specmatic/core/GenerativeTestsEnabled.kt
+++ b/core/src/main/kotlin/io/specmatic/core/GenerativeTestsEnabled.kt
@@ -13,7 +13,7 @@ data class GenerativeTestsEnabled(private val positiveOnly: Boolean) : Generatio
         key: String
     ): Sequence<ReturnValue<Pattern>> {
         // TODO generate value outside
-        return resolver.withCyclePrevention(pattern, key, isOptional(key)) { cyclePreventedResolver ->
+        return resolver.withCyclePrevention(pattern, isOptional(key)) { cyclePreventedResolver ->
             pattern.newBasedOn(Row(), cyclePreventedResolver)
         } ?: emptySequence()
     }

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
@@ -500,9 +500,8 @@ data class HttpRequestPattern(
     private fun HttpRequest.generateAndUpdateBody(resolver: Resolver, body: Pattern): HttpRequest {
         return attempt(breadCrumb = "BODY") {
             resolver.withCyclePrevention(body) {cyclePreventedResolver ->
-                body.generate(cyclePreventedResolver).let { value ->
-                    this.updateBody(value)
-                }
+                val generatedValue = body.generate(cyclePreventedResolver)
+                this.updateBody(generatedValue)
             }
         }
     }

--- a/core/src/main/kotlin/io/specmatic/core/Resolver.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Resolver.kt
@@ -318,6 +318,10 @@ ${matchResult.reportString()}
         return patternsSeenSoFar.contains(pattern.typeAlias)
     }
 
+    fun isInCyclePreventionStack(pattern: Pattern): Boolean {
+        return pattern  in cyclePreventionStack
+    }
+
     fun addPatternAsSeen(pattern: Pattern): Resolver {
         return this.copy(
             patternsSeenSoFar = pattern.typeAlias?.let { patternsSeenSoFar.plus(it) } ?: patternsSeenSoFar

--- a/core/src/main/kotlin/io/specmatic/core/Resolver.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Resolver.kt
@@ -44,7 +44,7 @@ data class Resolver(
     val dictionary: Map<String, Value> = emptyMap(),
     val dictionaryLookupPath: String = "",
     val jsonObjectResolver: JSONObjectResolver = JSONObjectResolver(),
-    val allPatternsAreMandatory: Boolean = Flags.getBooleanValue(Flags.ALL_PATTERNS_MANDATORY, false),
+    val allPatternsAreMandatory: Boolean = false,
     val patternsSeenSoFar: Set<String> = setOf(),
     val lookupPathsSeenSoFar: Set<String> = setOf(),
     val cycleMarker: String = "",

--- a/core/src/main/kotlin/io/specmatic/core/Resolver.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Resolver.kt
@@ -2,6 +2,7 @@ package io.specmatic.core
 
 import io.specmatic.core.log.logger
 import io.specmatic.core.pattern.*
+import io.specmatic.core.utilities.Flags
 import io.specmatic.core.value.JSONArrayValue
 import io.specmatic.core.value.StringValue
 import io.specmatic.core.value.True
@@ -43,8 +44,10 @@ data class Resolver(
     val dictionary: Map<String, Value> = emptyMap(),
     val dictionaryLookupPath: String = "",
     val jsonObjectResolver: JSONObjectResolver = JSONObjectResolver(),
-    val allPatternsAreMandatory: Boolean = false,
-    val patternsSeenSoFar: Set<String> = setOf()
+    val allPatternsAreMandatory: Boolean = Flags.getBooleanValue(Flags.ALL_PATTERNS_MANDATORY, false),
+    val patternsSeenSoFar: Set<String> = setOf(),
+    val lookupPathsSeenSoFar: Set<String> = setOf(),
+    val cycleMarker: String = "",
 ) {
     constructor(facts: Map<String, Value> = emptyMap(), mockMode: Boolean = false, newPatterns: Map<String, Pattern> = emptyMap()) : this(CheckFacts(facts), mockMode, newPatterns)
     constructor() : this(emptyMap(), false)
@@ -126,11 +129,42 @@ data class Resolver(
         return withCyclePrevention(pattern, false, toResult)!!
     }
 
+    fun <T> withCyclePrevention(pattern: Pattern, key: String, returnNullOnCycle: Boolean = false, toResult: (r: Resolver) -> T) : T? {
+        if(!allPatternsAreMandatory)
+            return withCyclePrevention(pattern, returnNullOnCycle, toResult)
+
+        val lookupPath = lookupPath(pattern.typeAlias, key)
+
+        return try {
+            if (key.isNotBlank() && lookupPathSeen(lookupPath) && cycleMarker.isEmpty()) {
+                // Terminate what would otherwise be an infinite cycle.
+                throw ContractException("Invalid pattern cycle: $lookupPath", isCycle = true)
+            } else if (key.isNotBlank() && lookupPathSeen(lookupPath) && cycleMarker.isNotEmpty()) {
+                toResult(this.clearCycleMarker())
+            } else {
+                toResult(this)
+            }
+        } catch (e: ContractException) {
+            if (!e.isCycle || !returnNullOnCycle)
+                throw e
+
+            // Returns null if (and only if) a cycle has been detected and returnNullOnCycle=true
+            null
+        }
+    }
+
+    private fun clearCycleMarker(): Resolver {
+        return this.copy(cycleMarker = "")
+    }
+
     /**
      * Returns non-null if no cycle. If there is a cycle then ContractException(cycle=true) is thrown - unless
      * returnNullOnCycle=true in which case null is returned. Null is never returned if returnNullOnCycle=false.
      */
     fun <T> withCyclePrevention(pattern: Pattern, returnNullOnCycle: Boolean = false, toResult: (r: Resolver) -> T) : T? {
+        if(allPatternsAreMandatory)
+            return withCyclePrevention(pattern, "", returnNullOnCycle, toResult)
+
         val count = cyclePreventionStack.filter { it == pattern }.size
         val newCyclePreventionStack = cyclePreventionStack.plus(pattern)
 
@@ -174,24 +208,58 @@ data class Resolver(
         if (factStore.has(lookupKey))
             return generate(lookupKey, pattern)
 
-        val lookupPath = if(typeAlias.isNullOrBlank()) {
-            if(lookupKey.isBlank())
-                ""
-            else if(lookupKey == "[*]")
-                "$dictionaryLookupPath$lookupKey"
-            else
-                "$dictionaryLookupPath.$lookupKey"
-        } else {
-            "${withoutPatternDelimiters(typeAlias)}.$lookupKey"
-        }
+        val updatedResolver = updateLookupPath(typeAlias, lookupKey)
 
-        val updatedResolver = if(lookupPath.isNotBlank()) {
-            this.copy(dictionaryLookupPath = lookupPath)
+        return updatedResolver.generate(pattern)
+    }
+
+    fun updateLookupPath(typeAlias: String?, lookupKey: String): Resolver {
+        val lookupPath = lookupPath(typeAlias, lookupKey)
+
+        val updatedResolver = if (lookupPath.isNotBlank()) {
+            val updatedLookupPathsSeenSoFar =
+                if(lookupKey.isNotBlank())
+                    lookupPathsSeenSoFar.plus(lookupPath)
+                else
+                    lookupPathsSeenSoFar
+
+            this.copy(dictionaryLookupPath = lookupPath, lookupPathsSeenSoFar = updatedLookupPathsSeenSoFar)
         } else {
             this
         }
 
-        return updatedResolver.generate(pattern)
+        return updatedResolver
+    }
+
+    private fun lookupPath(typeAlias: String?, lookupKey: String): String {
+        val lookupPath = if (typeAlias.isNullOrBlank()) {
+            if (lookupKey.isBlank())
+                ""
+            else if (lookupKey == "[*]")
+                "$dictionaryLookupPath$lookupKey"
+            else
+                "$dictionaryLookupPath.$lookupKey"
+        } else {
+            if (lookupKey.isBlank())
+                "${withoutPatternDelimiters(typeAlias)}"
+            else
+                "${withoutPatternDelimiters(typeAlias)}.$lookupKey"
+        }
+        return lookupPath
+    }
+
+    fun lookupPathSeen(lookupPath: String): Boolean {
+        if(lookupPath.isBlank())
+            return false
+
+        if(lookupPathsSeenSoFar.contains(lookupPath))
+            return true
+
+        val dotTerminatedPath = "$lookupPath."
+        if(lookupPathsSeenSoFar.any { it.startsWith(dotTerminatedPath) })
+            return true
+
+        return false
     }
 
     fun generateList(pattern: Pattern): Value {
@@ -318,6 +386,12 @@ ${matchResult.reportString()}
         return patternsSeenSoFar.contains(pattern.typeAlias)
     }
 
+    fun hasSeenLookupPath(pattern: Pattern, key: String): Boolean {
+        val lookupPath = lookupPath(pattern.typeAlias, key)
+
+        return lookupPath in lookupPathsSeenSoFar
+    }
+
     fun isInCyclePreventionStack(pattern: Pattern): Boolean {
         return pattern  in cyclePreventionStack
     }
@@ -326,6 +400,10 @@ ${matchResult.reportString()}
         return this.copy(
             patternsSeenSoFar = pattern.typeAlias?.let { patternsSeenSoFar.plus(it) } ?: patternsSeenSoFar
         )
+    }
+
+    fun cyclePast(jsonPattern: Pattern, key: String): Resolver {
+        return this.copy(cycleMarker = lookupPath(jsonPattern.typeAlias, key))
     }
 }
 

--- a/core/src/main/kotlin/io/specmatic/core/Resolver.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Resolver.kt
@@ -2,7 +2,6 @@ package io.specmatic.core
 
 import io.specmatic.core.log.logger
 import io.specmatic.core.pattern.*
-import io.specmatic.core.utilities.Flags
 import io.specmatic.core.value.JSONArrayValue
 import io.specmatic.core.value.StringValue
 import io.specmatic.core.value.True
@@ -389,11 +388,7 @@ ${matchResult.reportString()}
     fun hasSeenLookupPath(pattern: Pattern, key: String): Boolean {
         val lookupPath = lookupPath(pattern.typeAlias, key)
 
-        return lookupPath in lookupPathsSeenSoFar
-    }
-
-    fun isInCyclePreventionStack(pattern: Pattern): Boolean {
-        return pattern  in cyclePreventionStack
+        return lookupPathSeen(lookupPath)
     }
 
     fun addPatternAsSeen(pattern: Pattern): Resolver {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
@@ -34,11 +34,11 @@ data class AnyPattern(
 
     override fun removeKeysNotPresentIn(keys: Set<String>, resolver: Resolver): Pattern {
         if(keys.isEmpty()) return this
-        if(this.hasNoAmbiguousPatterns().not()) return this
 
-        val pattern = this.pattern.first { it !is NullPattern }
-        if(pattern is PossibleJsonObjectPatternContainer) return pattern.removeKeysNotPresentIn(keys, resolver)
-        return this
+        return this.copy(pattern = this.pattern.map {
+            if (it !is PossibleJsonObjectPatternContainer) return@map it
+            it.removeKeysNotPresentIn(keys, resolver)
+        })
     }
 
     override fun eliminateOptionalKey(value: Value, resolver: Resolver): Value {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
@@ -155,7 +155,8 @@ data class AnyPattern(
     }
 
     override fun generate(resolver: Resolver): Value {
-        return resolver.resolveExample(example, pattern) ?: generateValue(resolver)
+        return resolver.resolveExample(example, pattern)
+            ?: generateValue(resolver)
     }
 
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
@@ -299,9 +300,44 @@ data class AnyPattern(
                 .generate(resolver)
         }
 
-        val updatedPatterns = discriminator?.updatePatternsWithDiscriminator(pattern, resolver)?.listFold()?.value ?: pattern
+        val updatedPatterns =
+            if(discriminator != null)
+                discriminator.updatePatternsWithDiscriminator(pattern, resolver).listFold().value
+            else
+                pattern
 
-        val chosenPattern = getDiscriminatorBasedPattern(updatedPatterns, discriminatorValue) ?: updatedPatterns.random()
+        val chosenByDiscriminator = getDiscriminatorBasedPattern(updatedPatterns, discriminatorValue)
+        if(chosenByDiscriminator != null)
+            return generate(resolver, chosenByDiscriminator)
+
+        data class GenerationResult(val value: Value? = null, val exception: Throwable? = null) {
+            val isCycle = exception is ContractException && exception.isCycle
+        }
+
+        val generationResults = updatedPatterns.asSequence().map { chosenPattern ->
+            try {
+                GenerationResult(value = generate(resolver, chosenPattern))
+            } catch (e: Throwable) {
+                GenerationResult(exception = e)
+            }
+        }
+
+        val successfulGeneration = generationResults.map { it.value }.filterNotNull().firstOrNull()
+
+        if(successfulGeneration != null)
+            return successfulGeneration
+
+        val cycle = generationResults.filter { it.isCycle }.map { it.exception }.firstOrNull()
+        if(cycle != null)
+            throw cycle
+
+        throw generationResults.firstOrNull { it.exception != null }?.exception ?: ContractException("Could not generate value")
+    }
+
+    private fun generate(
+        resolver: Resolver,
+        chosenPattern: Pattern
+    ): Value {
         val isNullable = pattern.any { it is NullPattern }
         return resolver.withCyclePrevention(chosenPattern, isNullable) { cyclePreventedResolver ->
             when (key) {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/HasException.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/HasException.kt
@@ -5,11 +5,16 @@ import io.specmatic.core.utilities.exceptionCauseMessage
 
 data class HasException<T>(val t: Throwable, val message: String = "", val breadCrumb: String? = null) : ReturnValue<T>, ReturnFailure {
     fun toHasFailure(): HasFailure<T> {
+        val failure: Result.Failure = toFailure()
+        return HasFailure(failure, message)
+    }
+
+    override fun toFailure(): Result.Failure {
         val failure: Result.Failure = Result.Failure(
             message = exceptionCauseMessage(t),
             breadCrumb = breadCrumb ?: ""
         )
-        return HasFailure(failure, message)
+        return failure
     }
 
     override fun <U> withDefault(default: U, fn: (T) -> U): U {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/HasFailure.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/HasFailure.kt
@@ -36,7 +36,7 @@ data class HasFailure<T>(val failure: Result.Failure, val message: String = "") 
         return cast()
     }
 
-    private fun toFailure(): Result.Failure {
+    override fun toFailure(): Result.Failure {
         return Result.Failure(message, failure)
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
@@ -419,7 +419,11 @@ fun generate(jsonPattern: Map<String, Pattern>, resolver: Resolver, typeAlias: S
         .mapValues { (key, pattern) ->
             attempt(breadCrumb = key) {
                 // Handle cycle (represented by null value) by marking this property as removable
-                Optional.ofNullable(resolverWithNullType.withCyclePrevention(pattern, optionalProps.contains(key)) {
+                val propertyIsOptionalInSchema = optionalProps.contains(key)
+
+                val canPropertyBeSkipped = propertyIsOptionalInSchema
+
+                Optional.ofNullable(resolverWithNullType.withCyclePrevention(pattern, canPropertyBeSkipped) {
                     it.generate(typeAlias, key, pattern)
                 })
             }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
@@ -239,7 +239,11 @@ data class JSONObjectPattern(
     private fun shouldMakePatternMandatory(pattern: Pattern, resolver: Resolver): Boolean {
         if (!resolver.allPatternsAreMandatory) return false
 
-        val patternToCheck = if (pattern.typeAlias == null) this else pattern
+        val patternToCheck = when(pattern) {
+            is ListPattern -> pattern.typeAlias?.let { pattern } ?: pattern.pattern
+            else -> pattern.typeAlias?.let { pattern } ?: this
+        }
+
         return !resolver.hasSeenPattern(patternToCheck)
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
@@ -437,11 +437,6 @@ fun generate(jsonPatternMap: Map<String, Pattern>, resolver: Resolver, jsonPatte
                 })
 
                 valueWithCycle
-
-                // if failed and not yet seen
-                // try again until this is seen or exception
-                // if exception, check flag
-                //    if flag is true throw exception else omit property
             }
         }
         .filterValues { it.isPresent }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
@@ -81,7 +81,7 @@ data class ListPattern(
             return Result.Failure(message = "List cannot be empty")
         }
 
-        val updatedResolver = resolverWithEmptyType.addPatternAsSeen(this)
+        val updatedResolver = resolverWithEmptyType.addPatternAsSeen(this.typeAlias?.let { this } ?: this.pattern)
         val failures: List<Result.Failure> = sampleData.list.map {
             updatedResolver.matchesPattern(null, pattern, it)
         }.mapIndexed { index, result ->

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ReturnFailure.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ReturnFailure.kt
@@ -1,5 +1,8 @@
 package io.specmatic.core.pattern
 
+import io.specmatic.core.Result
+
 interface ReturnFailure {
     fun <T> cast(): ReturnValue<T>
+    fun toFailure(): Result.Failure
 }

--- a/core/src/test/kotlin/io/specmatic/core/ResponseBuilderTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ResponseBuilderTest.kt
@@ -53,8 +53,8 @@ class ResponseBuilderTest {
                 TODO("Not yet implemented")
             }
 
-            override val typeAlias: String
-                get() = TODO("Not yet implemented")
+            override val typeAlias: String?
+                get() = null
             override val typeName: String
                 get() = TODO("Not yet implemented")
             override val pattern: Any

--- a/core/src/test/kotlin/io/specmatic/core/pattern/ListPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/ListPatternTest.kt
@@ -1,6 +1,7 @@
 package io.specmatic.core.pattern
 
 import io.specmatic.GENERATION
+import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.core.*
 import io.specmatic.core.value.JSONArrayValue
 import org.assertj.core.api.Assertions.assertThat
@@ -239,5 +240,56 @@ Feature: Recursive test
         println(result.reportString())
 
         assertThat(result).isInstanceOf(Result.Success::class.java)
+    }
+
+    @Test
+    fun `should not result in failure for missing keys when pattern is cycling with an allOf schema`() {
+        val spec = """
+        openapi: 3.0.0
+        info:
+          title: Sample API
+          description: Sample API
+          version: 0.1.9
+        paths:
+          /hello:
+            get:
+              responses:
+                '200':
+                  description: Says hello
+                  content:
+                    application/json:
+                      schema:
+                        ${"$"}ref: '#/components/schemas/MainMessage'
+        components:
+          schemas:
+            MainMessage:
+              allOf:
+                - ${"$"}ref: '#/components/schemas/Message'
+            Message:
+              type: object
+              properties:
+                message:
+                  type: string
+                details:
+                  type: array
+                  items:
+                    ${"$"}ref: '#/components/schemas/Details'
+            Details:
+              oneOf:
+                - ${"$"}ref: '#/components/schemas/Message'
+        """.trimIndent()
+        val feature = OpenApiSpecification.fromYAML(spec, "").toFeature()
+
+        val scenario = feature.scenarios.first()
+        val resolver = scenario.resolver.copy(allPatternsAreMandatory = true)
+
+        val responsePattern = scenario.httpResponsePattern.body
+        val value = responsePattern.generate(resolver)
+        println(value.toStringLiteral())
+
+        val matchResult = responsePattern.matches(value, resolver)
+        println(matchResult.reportString())
+
+        assertThat(matchResult).isInstanceOf(Result.Success::class.java)
     }
 }

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=2.0.37
+version=2.0.38


### PR DESCRIPTION
**What**:

There was a bug in which under certain circumstances the relevant property would fail to show up.

**How**:

Recursion checking now looks at the property name in the context of the schema.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate
