### PR TITLE
Netty Version Upgrade

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -36,7 +36,7 @@ def jgit_version = "7.0.0.202409031743-r"
 
 dependencies {
     // TODO Put library reference overrides here to eliminate vulnerabilities, and remove the override when no longer needed
-    implementation 'io.netty:netty-codec-http:4.1.114.Final' // used by ktor-server-netty-jvm 2.3.9 in core
+    implementation 'io.netty:netty-codec-http:4.1.115.Final' // used by ktor-server-netty-jvm 2.3.9 in core
     implementation 'joda-time:joda-time:2.13.0' // used by swagger-parser 2.1.22
 
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -24,7 +24,7 @@ def junit_version = "5.11.3"
 
 dependencies {
     // TODO Fix to eliminate vulnerabilities, remove when the enclosing library supports it
-    implementation 'io.netty:netty-codec-http:4.1.114.Final' // used by ktor-server-netty-jvm 2.3.9 in core
+    implementation 'io.netty:netty-codec-http:4.1.115.Final' // used by ktor-server-netty-jvm 2.3.9 in core
     implementation 'joda-time:joda-time:2.13.0' // used by swagger-parser 2.1.22
 
     implementation 'io.cucumber:gherkin:22.0.0'

--- a/junit5-support/build.gradle
+++ b/junit5-support/build.gradle
@@ -16,7 +16,7 @@ def junit_version = "5.11.3"
 
 dependencies {
     // TODO Fix to eliminate vulnerabilities, remove when the enclosing library supports it
-    implementation 'io.netty:netty-codec-http:4.1.114.Final' // used by ktor-server-netty-jvm 2.3.9 in core
+    implementation 'io.netty:netty-codec-http:4.1.115.Final' // used by ktor-server-netty-jvm 2.3.9 in core
 
     api project(':core')
     implementation "org.junit.jupiter:junit-jupiter-engine:${junit_version}"


### PR DESCRIPTION
The Netty version has been upgraded from the previous version to 4.1.15, ensuring compatibility with the latest features, bug fixes, and performance improvements.

This update addresses security vulnerabilities identified in the previous versions, ensuring the application is secure and up to date.