### PR TITLE
Fix Amber vaidation and resource example handling in Examples Command

### DIFF
--- a/application/src/main/kotlin/application/ExamplesCommand.kt
+++ b/application/src/main/kotlin/application/ExamplesCommand.kt
@@ -375,8 +375,9 @@ For example:
 
                 validationResults.forEach { (exampleFileName, result) ->
                     if (!result.isSuccess()) {
-                        val failureType = if (result.isPartialFailure()) "warning" else "error"
-                        logger.log(System.lineSeparator() + "$tag $exampleFileName has the following validation $failureType(s):")
+                        val errorPrefix = if (result.isPartialFailure()) "Warning" else "Error"
+
+                        logger.log("\n$errorPrefix(s) found in the following $tag $exampleFileName:")
                         logger.log(result.reportString())
                     }
                 }

--- a/application/src/main/kotlin/application/ExamplesCommand.kt
+++ b/application/src/main/kotlin/application/ExamplesCommand.kt
@@ -238,7 +238,7 @@ For example:
 
                 printValidationResult(validationResults, "Example directory")
                 if (exitCode == 1) return FAILURE_EXIT_CODE
-                if (validationResults.containsFailure()) return FAILURE_EXIT_CODE
+                if (validationResults.containsOnlyCompleteFailures()) return FAILURE_EXIT_CODE
                 return SUCCESS_EXIT_CODE
             }
 
@@ -303,7 +303,7 @@ For example:
             }.toMap()
             logger.log("Summary:")
             printValidationResult(validationResults, "Overall")
-            if (validationResults.containsFailure()) return FAILURE_EXIT_CODE
+            if (validationResults.containsOnlyCompleteFailures()) return FAILURE_EXIT_CODE
             return SUCCESS_EXIT_CODE
         }
 
@@ -324,7 +324,7 @@ For example:
             }
 
             val hasFailures =
-                inlineExampleValidationResults.containsFailure() || externalExampleValidationResults.containsFailure()
+                inlineExampleValidationResults.containsOnlyCompleteFailures() || externalExampleValidationResults.containsOnlyCompleteFailures()
 
             printValidationResult(inlineExampleValidationResults, "Inline example")
             printValidationResult(externalExampleValidationResults, "Example file")
@@ -369,7 +369,7 @@ For example:
 
             val titleTag = tag.split(" ").joinToString(" ") { if (it.isBlank()) it else it.capitalizeFirstChar() }
 
-            if (validationResults.containsFailureWithPartials()) {
+            if (validationResults.containsFailuresOrPartialFailures()) {
                 println()
                 logger.log("=============== $titleTag Validation Results ===============")
 
@@ -390,11 +390,11 @@ For example:
             logger.log("=".repeat(summaryTitle.length))
         }
 
-        private fun Map<String, Result>.containsFailure(): Boolean {
+        private fun Map<String, Result>.containsOnlyCompleteFailures(): Boolean {
             return this.any { it.value is Result.Failure && !it.value.isPartialFailure() }
         }
 
-        private fun Map<String, Result>.containsFailureWithPartials(): Boolean {
+        private fun Map<String, Result>.containsFailuresOrPartialFailures(): Boolean {
             return this.any { it.value is Result.Failure }
         }
 

--- a/application/src/main/kotlin/application/ExamplesCommand.kt
+++ b/application/src/main/kotlin/application/ExamplesCommand.kt
@@ -369,13 +369,14 @@ For example:
 
             val titleTag = tag.split(" ").joinToString(" ") { if (it.isBlank()) it else it.capitalizeFirstChar() }
 
-            if (validationResults.containsFailure()) {
+            if (validationResults.containsFailureWithPartials()) {
                 println()
                 logger.log("=============== $titleTag Validation Results ===============")
 
                 validationResults.forEach { (exampleFileName, result) ->
                     if (!result.isSuccess()) {
-                        logger.log(System.lineSeparator() + "$tag $exampleFileName has the following validation error(s):")
+                        val failureType = if (result.isPartialFailure()) "warning" else "error"
+                        logger.log(System.lineSeparator() + "$tag $exampleFileName has the following validation $failureType(s):")
                         logger.log(result.reportString())
                     }
                 }
@@ -389,6 +390,10 @@ For example:
         }
 
         private fun Map<String, Result>.containsFailure(): Boolean {
+            return this.any { it.value is Result.Failure && !it.value.isPartialFailure() }
+        }
+
+        private fun Map<String, Result>.containsFailureWithPartials(): Boolean {
             return this.any { it.value is Result.Failure }
         }
 

--- a/core/src/main/kotlin/io/specmatic/core/Results.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Results.kt
@@ -95,10 +95,20 @@ data class Results(val results: List<Result> = emptyList()) {
         return Results(uniqueResults)
     }
 
+    fun getResultCounts(): Triple<Int, Int, Int> {
+        val successCount = successCount
+        val failureCount = failureCount
+        val partialFailureCount = results.count { it.isPartialFailure() }
+
+        return Triple(successCount, failureCount - partialFailureCount, partialFailureCount)
+    }
+
     fun summary(): String {
+        val (successCount, failureCount, partialFailureCount) = getResultCounts()
         return when {
-            successCount > 0 && failureCount == 0 -> "All $successCount example(s) are valid."
-            successCount == 0 && failureCount > 0 -> "All $failureCount example(s) are invalid."
+            successCount == results.size -> "All $successCount example(s) are valid."
+            failureCount == results.size -> "All $failureCount example(s) are invalid."
+            partialFailureCount > 0 -> "$successCount example(s) are valid. $failureCount example(s) are invalid. $partialFailureCount example(s) have warnings."
             else -> "$successCount example(s) are valid. $failureCount example(s) are invalid."
         }
     }

--- a/core/src/main/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServer.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServer.kt
@@ -626,7 +626,7 @@ class ExamplesInteractiveServer(
 
         private fun validateExample(feature: Feature, schemaExample: SchemaExample): Result {
             if (schemaExample.value is NullValue) {
-                return Result.Failure("Empty Resource Example", isPartial = true)
+                return Result.Success()
             }
 
             return feature.matchResultSchemaFlagBased(schemaExample.discriminatorBasedOn, schemaExample.schemaBasedOn, schemaExample.value, InteractiveExamplesMismatchMessages)

--- a/core/src/main/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServer.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServer.kt
@@ -625,6 +625,10 @@ class ExamplesInteractiveServer(
         }
 
         private fun validateExample(feature: Feature, schemaExample: SchemaExample): Result {
+            if (schemaExample.value is NullValue) {
+                return Result.Success()
+            }
+
             return feature.matchResultSchemaFlagBased(schemaExample.discriminatorBasedOn, schemaExample.schemaBasedOn, schemaExample.value, InteractiveExamplesMismatchMessages)
         }
 
@@ -672,13 +676,13 @@ class ExamplesInteractiveServer(
         }
 
         fun File.getExamplesFromDir(): List<ExampleFromFile> {
-            return this.listFiles()?.mapNotNull {
+            return this.listFiles().orEmpty().filter { it.extension == "json" }.mapNotNull {
                 ExampleFromFile.fromFile(it).realise(
                     hasValue = { example, _ -> example },
                     orException = { err -> consoleDebug(exceptionCauseMessage(err.t)); null },
                     orFailure = { null }
                 )
-            } ?: emptyList()
+            }
         }
 
         fun File.getSchemaExamplesWithValidation(feature: Feature): List<Pair<SchemaExample, Result?>> {
@@ -690,13 +694,13 @@ class ExamplesInteractiveServer(
         }
 
         private fun File.getSchemaExamples(): List<SchemaExample> {
-            return this.listFiles()?.mapNotNull {
+            return this.listFiles().orEmpty().filter { it.extension == "json" }.mapNotNull {
                 SchemaExample.fromFile(it).realise(
                     hasValue = { example, _ -> example },
                     orException = { err -> consoleDebug(exceptionCauseMessage(err.t)); null },
                     orFailure = { null }
                 )
-            } ?: emptyList()
+            }
         }
 
         private fun getExampleFileNameBasedOn(

--- a/core/src/main/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServer.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServer.kt
@@ -626,7 +626,7 @@ class ExamplesInteractiveServer(
 
         private fun validateExample(feature: Feature, schemaExample: SchemaExample): Result {
             if (schemaExample.value is NullValue) {
-                return Result.Success()
+                return Result.Failure("Empty Resource Example", isPartial = true)
             }
 
             return feature.matchResultSchemaFlagBased(schemaExample.discriminatorBasedOn, schemaExample.schemaBasedOn, schemaExample.value, InteractiveExamplesMismatchMessages)

--- a/core/src/main/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServer.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServer.kt
@@ -821,7 +821,7 @@ object InteractiveExamplesMismatchMessages : MismatchMessages {
     }
 
     override fun optionalKeyMissing(keyLabel: String, keyName: String): String {
-        return "Optional ${keyLabel.capitalizeFirstChar()} $keyName in the specification is missing from the example"
+        return "Warning: Optional ${keyLabel.capitalizeFirstChar()} $keyName in the specification is missing from the example"
     }
 
     override fun expectedKeyWasMissing(keyLabel: String, keyName: String): String {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Fix Amber validation and resource example handling in Examples Command

<!-- Why are these changes necessary? -->

**Why**:
- Exit code depends on amber validation.
- Resource examples are validated, and skipped if found to be empty
- Warnings count for amber validation failures

<!-- How were these changes implemented? -->


<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [ ] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #123

<!-- feel free to add additional comments -->
