### PR TITLE
Pass the 4xx error messages in message or msg key if it is found else fallback to default logic

### DIFF
--- a/core/src/main/kotlin/io/specmatic/stub/stateful/StatefulHttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/stateful/StatefulHttpStub.kt
@@ -370,15 +370,15 @@ class StatefulHttpStub(
     private fun messageKeyFor4xxResponseMessage(
         responseBodyJsonObjectPattern: JSONObjectPattern?
     ): String? {
-        val firstKeyWithStringType = responseBodyJsonObjectPattern?.pattern?.entries?.firstOrNull {
-            it.value is StringPattern
-        }?.key
-
         val messageKeyWithStringType = responseBodyJsonObjectPattern?.pattern?.entries?.firstOrNull {
             it.value is StringPattern && withoutOptionality(it.key) in setOf("message", "msg")
         }?.key
 
-        return messageKeyWithStringType ?: firstKeyWithStringType
+        if (messageKeyWithStringType != null) return messageKeyWithStringType
+
+        return responseBodyJsonObjectPattern?.pattern?.entries?.firstOrNull {
+            it.value is StringPattern
+        }?.key
     }
 
     private fun resourcePathAndIdFrom(httpRequest: HttpRequest): Pair<String, String> {

--- a/core/src/main/kotlin/io/specmatic/stub/stateful/StatefulHttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/stateful/StatefulHttpStub.kt
@@ -353,9 +353,9 @@ class StatefulHttpStub(
         }
         val responseBodyJsonObjectPattern =
             (responseBodyPattern as PossibleJsonObjectPatternContainer).jsonObjectPattern(resolver)
-        val messageKey =
-            responseBodyJsonObjectPattern?.pattern?.entries?.firstOrNull { it.value is StringPattern }?.key
-        if (messageKey == null) {
+
+        val messageKey = messageKeyFor4xxResponseMessage(responseBodyJsonObjectPattern)
+        if (messageKey == null || responseBodyJsonObjectPattern == null) {
             return HttpResponse(statusCode, "$message${System.lineSeparator()}$warningMessage")
         }
 
@@ -365,6 +365,20 @@ class StatefulHttpStub(
             mapOf(withoutOptionality(messageKey) to StringValue(message))
         )
         return HttpResponse(statusCode, JSONObjectValue(jsonObject = jsonObjectWithNotFoundMessage))
+    }
+
+    private fun messageKeyFor4xxResponseMessage(
+        responseBodyJsonObjectPattern: JSONObjectPattern?
+    ): String? {
+        val firstKeyWithStringType = responseBodyJsonObjectPattern?.pattern?.entries?.firstOrNull {
+            it.value is StringPattern
+        }?.key
+
+        val messageKeyWithStringType = responseBodyJsonObjectPattern?.pattern?.entries?.firstOrNull {
+            it.value is StringPattern && withoutOptionality(it.key) in setOf("message", "msg")
+        }?.key
+
+        return messageKeyWithStringType ?: firstKeyWithStringType
     }
 
     private fun resourcePathAndIdFrom(httpRequest: HttpRequest): Pair<String, String> {

--- a/core/src/test/kotlin/io/specmatic/stub/stateful/StatefulHttpStubTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/stateful/StatefulHttpStubTest.kt
@@ -299,8 +299,8 @@ class StatefulHttpStubTest {
 
         assertThat(response.status).isEqualTo(404)
         val responseBody = response.body as JSONObjectValue
-        val error = responseBody.getStringValue("error")
-        assertThat(error).isEqualTo("Resource with resourceId '0' not found")
+        val message = responseBody.getStringValue("message")
+        assertThat(message).isEqualTo("Resource with resourceId '0' not found")
     }
 
     @Test

--- a/core/src/test/resources/openapi/spec_with_strictly_restful_apis/spec_with_strictly_restful_apis.yaml
+++ b/core/src/test/resources/openapi/spec_with_strictly_restful_apis/spec_with_strictly_restful_apis.yaml
@@ -219,5 +219,5 @@ components:
       properties:
         error:
           type: string
-        message:
+        reason:
           type: string


### PR DESCRIPTION

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Pass the 4xx error messages in a key named "message" or "msg" in the response body for a virtual-service.
If the keys are not found, pass the message in the first key that of type string.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->


<!-- feel free to add additional comments -->
