### PR TITLE
Slash issue with GUI Rectified

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/examples/server/ExampleValidationErrorMessage.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/server/ExampleValidationErrorMessage.kt
@@ -32,7 +32,7 @@ data class ExampleValidationErrorMessage(val fullErrorMessageString: String) {
                 .replace("BODY", "body")
                 .replace(BREADCRUMB_DELIMITER, JSONPATH_DELIMITER)
                 .replace(Regex("\\[(\\d+)]")) { matchResult -> "/${matchResult.groupValues[1]}" }
-                .let { if (it.startsWith(HTTP_RESPONSE) || it.startsWith(HTTP_REQUEST)) "/$it" else it }
+                .let { "/${it.trimStart('/')}" }
         }
     }
 


### PR DESCRIPTION
There was a small issue on putting a hard check on http-request and http-response to embed a forward slash for json path, rectified it.

Now whenever we iterate through breadcrumb it assures we have a forward slash appended before the start so that it gets a valid json path