### PR TITLE
Fix operation level security to override global security.

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -936,7 +936,7 @@ class OpenApiSpecification(
             } ?: mapOf(NO_SECURITY_SCHEMA_IN_SPECIFICATION to NoSecurityScheme())
 
         val securitySchemesForRequestPattern: Map<String, OpenAPISecurityScheme> =
-            (parsedOpenApi.security.orEmpty() + operation.security.orEmpty())
+            (operation.security ?: parsedOpenApi.security.orEmpty())
                 .flatMap { it.keys }
                 .toSet().associateWith {
                     val securityScheme = securitySchemes[it]


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Fix operation level security to override global security.

<!-- Why are these changes necessary? -->

**Why**: The final security schemas for an operation were implemented as a combination of operation-level and global-level security schemas, which creates problems when attempting to override them for a specific operation.

<!-- How were these changes implemented? -->

**How**:
- Operation-level security schemas are prioritized and utilized if they are present, even if they are an empty list. 
- If not, the global-level security schema will be applied.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #1491

<!-- feel free to add additional comments -->
