### PR TITLE
Implement store for array responses as entity in stateful contract testing

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -1670,7 +1670,7 @@ data class Feature(
 
         val files = testsDirectory.walk().filterNot { it.isDirectory }.filter {
             it.extension == "json"
-        }.toList()
+        }.toList().sortedBy { it.name }
 
         if (files.isEmpty()) return emptyMap()
 

--- a/core/src/main/kotlin/io/specmatic/test/ExamplePreProcessor.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ExamplePreProcessor.kt
@@ -156,6 +156,15 @@ object ExampleProcessor {
         return JSONArrayValue(value.list.map { resolve(it, ifNotExists) })
     }
 
+    private fun toStoreErrorMessage(exampleRow: Row, type: StoreType): String {
+        val (storeType, storeGrammar) = when (type) {
+            StoreType.REPLACE -> "save" to "as"
+            StoreType.MERGE -> "merge" to "with"
+        }
+
+        return "Could not $storeType http response body $storeGrammar \"ENTITY\" for example ${exampleRow.name.quote()}"
+    }
+
     /* STORE HELPERS */
     fun store(exampleRow: Row, httpRequest: HttpRequest, httpResponse: HttpResponse) {
         if (httpRequest.method == "POST") {
@@ -166,7 +175,7 @@ object ExampleProcessor {
         val bodyToCheck = exampleRow.responseExampleForAssertion?.body
         bodyToCheck?.ifContainsStoreToken { type ->
             val valueToStore = httpResponse.body.getJsonObjectIfExists() ?:
-                throw ContractException(breadCrumb = exampleRow.name, errorMessage = "Could not ${type.name} store http response body as \"ENTITY\" for ${exampleRow.name.quote()}")
+                throw ContractException(breadCrumb = exampleRow.name, errorMessage = toStoreErrorMessage(exampleRow, type))
 
             runningEntity = when (type) {
                 StoreType.REPLACE -> valueToStore.toFactStore(prefix = "ENTITY")

--- a/core/src/main/kotlin/io/specmatic/test/ExamplePreProcessor.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ExamplePreProcessor.kt
@@ -162,7 +162,7 @@ object ExampleProcessor {
             StoreType.MERGE -> "merge" to "with"
         }
 
-        return "Could not $storeType http response body $storeGrammar \"ENTITY\" for example ${exampleRow.name.quote()}"
+        return "Could not $storeType http response body $storeGrammar ENTITY for example ${exampleRow.name.quote()}"
     }
 
     /* STORE HELPERS */

--- a/core/src/main/kotlin/io/specmatic/test/asserts/Assert.kt
+++ b/core/src/main/kotlin/io/specmatic/test/asserts/Assert.kt
@@ -28,7 +28,7 @@ fun parsedAssert(prefix: String, key: String, value: Value): Assert? {
     return when (key) {
         "\$if" -> AssertConditional.parse(prefix, key, value)
         else -> {
-            return AssertComparison.parse(prefix, key, value) ?: AssertArray.parse(prefix, key, value)
+            return AssertComparison.parse(prefix, key, value) ?: AssertArray.parse(prefix, key, value) ?: AssertExistence.parse(prefix, key, value)
         }
     }
 }

--- a/core/src/main/kotlin/io/specmatic/test/asserts/AssertExistence.kt
+++ b/core/src/main/kotlin/io/specmatic/test/asserts/AssertExistence.kt
@@ -1,0 +1,64 @@
+package io.specmatic.test.asserts
+
+import io.ktor.http.*
+import io.specmatic.core.Result
+import io.specmatic.core.value.NullValue
+import io.specmatic.core.value.Value
+
+enum class ExistenceCheckType(val value: String, val errorMessageSuffix: String) {
+    EXISTS("exists", "exist"),
+    NOT_EXISTS("not_exists", "not exist"),
+    IS_NULL("is_null", "be ${NullValue.displayableValue()}"),
+    NOT_NULL("is_not_null", "not be ${NullValue.displayableValue()}"),;
+
+    companion object {
+        fun fromString(value: String): ExistenceCheckType? {
+            return entries.find { it.value == value }
+        }
+    }
+}
+
+class AssertExistence(override val prefix: String, override val key: String, val checkType: ExistenceCheckType): Assert {
+    override fun assert(currentFactStore: Map<String, Value>, actualFactStore: Map<String, Value>): Result {
+        val prefixValue = currentFactStore[prefix] ?: return Result.Failure(breadCrumb = prefix, message = "Could not resolve ${prefix.quote()} in current fact store")
+
+        val dynamicList = dynamicAsserts(prefixValue)
+        val results = dynamicList.map { newAssert ->
+            val finalKey = "${newAssert.prefix}.${newAssert.key}"
+            val actualValue = currentFactStore[finalKey]
+            assert(finalKey, actualValue)
+        }
+
+        return results.toResult()
+    }
+
+    override fun dynamicAsserts(prefixValue: Value): List<Assert> {
+        return prefixValue.suffixIfMoreThanOne {suffix, _ ->
+            AssertExistence(prefix = "$prefix$suffix", key = key, checkType = checkType)
+        }
+    }
+
+    private fun assert(finalKey: String, actualValue: Value?): Result {
+        val success = when (checkType) {
+            ExistenceCheckType.EXISTS -> actualValue != null
+            ExistenceCheckType.NOT_EXISTS -> actualValue == null
+            ExistenceCheckType.NOT_NULL -> actualValue !is NullValue
+            ExistenceCheckType.IS_NULL -> actualValue is NullValue
+        }
+
+        return if (success) { Result.Success() } else Result.Failure(
+            breadCrumb = finalKey,
+            message = "Expected ${finalKey.quote()} to ${checkType.errorMessageSuffix}"
+        )
+    }
+
+    companion object {
+        fun parse(prefix: String, key: String, value: Value): AssertExistence? {
+            val match = ASSERT_PATTERN.find(value.toStringLiteral()) ?: return null
+            val keyPrefix = prefix.removeSuffix(".${key}")
+
+            val assertType = ExistenceCheckType.fromString(match.groupValues[1]) ?: return null
+            return AssertExistence(keyPrefix, key, assertType)
+        }
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/test/ExampleProcessorTest.kt
+++ b/core/src/test/kotlin/io/specmatic/test/ExampleProcessorTest.kt
@@ -271,6 +271,34 @@ class ExampleProcessorTest {
             assertThat(factStore.keys).doesNotContain("ENTITY.name")
             assertThat(factStore.getValue("ENTITY")).isEqualTo(response.body)
         }
+
+        @Test
+        fun `should store the first value of response body array`() {
+            val request = HttpRequest(method = "GET")
+            val response = HttpResponse(
+                body = JSONArrayValue(
+                    listOf(
+                        JSONObjectValue(mapOf("price" to NumberValue(2000))),
+                        JSONObjectValue(mapOf("price" to NumberValue(1000)))
+                    )
+                )
+            )
+            val row = Row(
+                responseExampleForAssertion = HttpResponse(
+                    body = JSONArrayValue(listOf(
+                        JSONObjectValue(mapOf("\$store" to StringValue("replace")))
+                    ))
+                )
+            )
+            ExampleProcessor.store(row, request, response)
+
+            val responseBody = response.body as JSONArrayValue
+            val factStore = ExampleProcessor.getFactStore()
+            println(factStore.getValue("ENTITY"))
+            assertThat(factStore).isNotEmpty
+            assertThat(factStore.getValue("ENTITY")).isEqualTo(responseBody.list.first())
+            assertThat(factStore.getValue("ENTITY.price")).isEqualTo(NumberValue(2000))
+        }
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/test/ExampleProcessorTest.kt
+++ b/core/src/test/kotlin/io/specmatic/test/ExampleProcessorTest.kt
@@ -356,7 +356,7 @@ class ExampleProcessorTest {
         println(exception.report())
         assertThat(exception.report()).containsIgnoringWhitespaces("""
         >> test  
-       Could not save http response body as "ENTITY" for example "test"
+       Could not save http response body as ENTITY for example "test"
         """.trimIndent())
     }
 
@@ -373,7 +373,7 @@ class ExampleProcessorTest {
         println(exception.report())
         assertThat(exception.report()).containsIgnoringWhitespaces("""
         >> test  
-        Could not merge http response body with "ENTITY" for example "test"
+        Could not merge http response body with ENTITY for example "test"
         """.trimIndent())
     }
 }

--- a/core/src/test/kotlin/io/specmatic/test/ExampleProcessorTest.kt
+++ b/core/src/test/kotlin/io/specmatic/test/ExampleProcessorTest.kt
@@ -2,6 +2,7 @@ package io.specmatic.test
 
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpResponse
+import io.specmatic.core.NoBodyValue
 import io.specmatic.core.QueryParameters
 import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.pattern.Row
@@ -311,6 +312,40 @@ class ExampleProcessorTest {
         assertThat(exception.report()).containsIgnoringWhitespaces("""
         >> CONFIG.post.Person  
         Could not resolve "CONFIG.post.Person", key does not exist in fact store
+        """.trimIndent())
+    }
+
+    @Test
+    fun `should throw if response body is not json value when store`() {
+        val request = HttpRequest(body = NoBodyValue)
+        val response = HttpResponse(body = NoBodyValue)
+        val row = Row(
+            name = "test",
+            responseExampleForAssertion = HttpResponse(body = JSONObjectValue(mapOf("\$store" to StringValue("replace"))))
+        )
+
+        val exception = assertThrows<ContractException> { ExampleProcessor.store(row, request, response) }
+        println(exception.report())
+        assertThat(exception.report()).containsIgnoringWhitespaces("""
+        >> test  
+        Could not REPLACE store http response body as "ENTITY" for "test"
+        """.trimIndent())
+    }
+
+    @Test
+    fun `should throw if response body array is empty when store`() {
+        val request = HttpRequest(body = NoBodyValue)
+        val response = HttpResponse(body = JSONArrayValue(emptyList()))
+        val row = Row(
+            name = "test",
+            responseExampleForAssertion = HttpResponse(body = JSONObjectValue(mapOf("\$store" to StringValue("merge"))))
+        )
+
+        val exception = assertThrows<ContractException> { ExampleProcessor.store(row, request, response) }
+        println(exception.report())
+        assertThat(exception.report()).containsIgnoringWhitespaces("""
+        >> test  
+        Could not MERGE store http response body as "ENTITY" for "test"
         """.trimIndent())
     }
 }

--- a/core/src/test/kotlin/io/specmatic/test/ExampleProcessorTest.kt
+++ b/core/src/test/kotlin/io/specmatic/test/ExampleProcessorTest.kt
@@ -344,7 +344,7 @@ class ExampleProcessorTest {
     }
 
     @Test
-    fun `should throw if response body is not json value when store`() {
+    fun `should throw if response body is not json value and asked to store`() {
         val request = HttpRequest(body = NoBodyValue)
         val response = HttpResponse(body = NoBodyValue)
         val row = Row(
@@ -356,12 +356,12 @@ class ExampleProcessorTest {
         println(exception.report())
         assertThat(exception.report()).containsIgnoringWhitespaces("""
         >> test  
-        Could not REPLACE store http response body as "ENTITY" for "test"
+       Could not save http response body as "ENTITY" for example "test"
         """.trimIndent())
     }
 
     @Test
-    fun `should throw if response body array is empty when store`() {
+    fun `should throw if response body array is empty and asked to store`() {
         val request = HttpRequest(body = NoBodyValue)
         val response = HttpResponse(body = JSONArrayValue(emptyList()))
         val row = Row(
@@ -373,7 +373,7 @@ class ExampleProcessorTest {
         println(exception.report())
         assertThat(exception.report()).containsIgnoringWhitespaces("""
         >> test  
-        Could not MERGE store http response body as "ENTITY" for "test"
+        Could not merge http response body with "ENTITY" for example "test"
         """.trimIndent())
     }
 }

--- a/core/src/test/kotlin/io/specmatic/test/asserts/AssertExistenceTest.kt
+++ b/core/src/test/kotlin/io/specmatic/test/asserts/AssertExistenceTest.kt
@@ -1,0 +1,100 @@
+package io.specmatic.test.asserts
+
+import io.specmatic.core.Result
+import io.specmatic.core.value.JSONObjectValue
+import io.specmatic.core.value.NullValue
+import io.specmatic.core.value.StringValue
+import io.specmatic.test.asserts.AssertComparisonTest.Companion.toFactStore
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+
+class AssertExistenceTest {
+    @ParameterizedTest
+    @CsvSource(
+        "REQUEST.BODY.name, name, exists",
+        "REQUEST.BODY,      name, not_exists",
+        "REQUEST.BODY.name, name, is_null",
+        "REQUEST.BODY,      name, is_not_null",
+    )
+    fun `should be able to parse assertions`(prefix: String, key: String, checkTypeString: String) {
+        val checkType = ExistenceCheckType.fromString(checkTypeString)!!
+        val value = StringValue("\$${checkType.value}()")
+
+        println("value: $value, prefix: $prefix, key: $key, checkType: $checkType")
+        val assert = AssertExistence.parse(prefix, key, value)
+        assertThat(assert).isNotNull.isInstanceOf(AssertExistence::class.java)
+        assertThat(assert!!.prefix).isEqualTo("REQUEST.BODY")
+        assertThat(assert.key).isEqualTo(key)
+        assertThat(assert.checkType).isEqualTo(checkType)
+    }
+
+    @Test
+    fun `should return failure when actual value does not exist and check type is exists`() {
+        val assert = AssertExistence(prefix = "REQUEST.BODY", key = "name", checkType = ExistenceCheckType.EXISTS)
+
+        val bodyValue = JSONObjectValue(emptyMap())
+        val currentStore = bodyValue.toFactStore("REQUEST.BODY")
+
+        val result = assert.assert(currentStore, emptyMap())
+        println(result.reportString())
+
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
+        assertThat(result.reportString()).containsIgnoringWhitespaces("""
+        >> REQUEST.BODY.name
+        Expected "REQUEST.BODY.name" to exist
+        """.trimIndent())
+    }
+
+    @Test
+    fun `should return failure when actual value exists and check type is not_exists`() {
+        val assert = AssertExistence(prefix = "REQUEST.BODY", key = "name", checkType = ExistenceCheckType.NOT_EXISTS)
+
+        val bodyValue = JSONObjectValue(mapOf("name" to StringValue("John")))
+        val currentStore = bodyValue.toFactStore("REQUEST.BODY")
+
+        val result = assert.assert(currentStore, emptyMap())
+        println(result.reportString())
+
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
+        assertThat(result.reportString()).containsIgnoringWhitespaces("""
+        >> REQUEST.BODY.name
+        Expected "REQUEST.BODY.name" to not exist
+        """.trimIndent())
+    }
+
+    @Test
+    fun `should return failure when actual value is null and check type is is_not_null`() {
+        val assert = AssertExistence(prefix = "REQUEST.BODY", key = "name", checkType = ExistenceCheckType.NOT_NULL)
+
+        val bodyValue = JSONObjectValue(mapOf("name" to NullValue))
+        val currentStore = bodyValue.toFactStore("REQUEST.BODY")
+
+        val result = assert.assert(currentStore, emptyMap())
+        println(result.reportString())
+
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
+        assertThat(result.reportString()).containsIgnoringWhitespaces("""
+        >> REQUEST.BODY.name
+        Expected "REQUEST.BODY.name" to not be null
+        """.trimIndent())
+    }
+
+    @Test
+    fun `should return failure when actual value is not null check type is is_null`() {
+        val assert = AssertExistence(prefix = "REQUEST.BODY", key = "name", checkType = ExistenceCheckType.IS_NULL)
+
+        val bodyValue = JSONObjectValue(mapOf("name" to StringValue("John")))
+        val currentStore = bodyValue.toFactStore("REQUEST.BODY")
+
+        val result = assert.assert(currentStore, emptyMap())
+        println(result.reportString())
+
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
+        assertThat(result.reportString()).containsIgnoringWhitespaces("""
+        >> REQUEST.BODY.name
+        Expected "REQUEST.BODY.name" to be null
+        """.trimIndent())
+    }
+}

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=2.0.49
+version=2.0.50


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
- Implement store for array responses as entity in stateful contract testing
- New assertions for verifying the existence of a key.

<!-- Why are these changes necessary? -->

**Why**: This enables the storage of the response from a GET collection as an entity, which can then be utilized in subsequent requests and assertions when a POST request does not exist for a specific endpoint.

<!-- How were these changes implemented? -->

**How**:
- The first value of the retrieved collection will be stored as an entity when explicitly specified.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
<!-- feel free to add additional comments -->
