### PR TITLE
Fix example load error for non-scalar value with random resolve.

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/ExampleFromFile.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/ExampleFromFile.kt
@@ -52,7 +52,7 @@ class ExampleFromFile(val json: JSONObjectValue, val file: File) {
             requestExample = scenarioStub.getRequestWithAdditionalParamsIfAny(specmaticConfig.additionalExampleParamsFilePath),
             responseExample = response.takeUnless { this.isPartial() },
             isPartial = scenarioStub.partial != null
-        ).let { ExampleProcessor.resolveLookupIfPresent(it) }
+        ).let { ExampleProcessor.resolve(it, ExampleProcessor::ifNotExitsToLookupPattern) }
     }
 
     constructor(file: File) : this(json = attempt("Error reading example file ${file.canonicalPath}") { parsedJSONObject(file.readText()) }, file = file)

--- a/core/src/main/kotlin/io/specmatic/core/Resolver.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Resolver.kt
@@ -6,6 +6,7 @@ import io.specmatic.core.value.JSONArrayValue
 import io.specmatic.core.value.StringValue
 import io.specmatic.core.value.True
 import io.specmatic.core.value.Value
+import io.specmatic.test.ExampleProcessor
 
 val actualMatch: (resolver: Resolver, factKey: String?, pattern: Pattern, sampleValue: Value) -> Result = { resolver: Resolver, factKey: String?, pattern: Pattern, sampleValue: Value ->
     resolver.actualPatternMatch(factKey, pattern, sampleValue)
@@ -90,8 +91,9 @@ data class Resolver(
     }
 
     fun actualPatternMatch(factKey: String?, pattern: Pattern, sampleValue: Value): Result {
-        val patternFromSampleValue = patternFromTokenBased(sampleValue)
+        if (mockMode && ExampleProcessor.isSubstitutionToken(sampleValue)) return Result.Success()
 
+        val patternFromSampleValue = patternFromTokenBased(sampleValue)
         if (mockMode
             && patternFromSampleValue != null
             && (patternFromSampleValue is AnyValuePattern ||

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -11,6 +11,7 @@ import io.specmatic.core.utilities.nullOrExceptionString
 import io.specmatic.core.value.*
 import io.specmatic.mock.ScenarioStub
 import io.specmatic.stub.RequestContext
+import io.specmatic.test.ExampleProcessor
 
 object ContractAndStubMismatchMessages : MismatchMessages {
     override fun mismatchMessage(expected: String, actual: String): String {
@@ -415,9 +416,10 @@ data class Scenario(
             attempt {
                 val newResponsePattern: HttpResponsePattern = this.httpResponsePattern.withResponseExampleValue(row, resolver)
 
+                val resolvedRow = ExampleProcessor.resolve(row, ExampleProcessor::defaultIfNotExits)
                 val (newRequestPatterns: Sequence<ReturnValue<HttpRequestPattern>>, generativePrefix: String) = when (isNegative) {
-                    false -> Pair(httpRequestPattern.newBasedOn(row, resolver, httpResponsePattern.status), flagsBased.positivePrefix)
-                    else -> Pair(httpRequestPattern.negativeBasedOn(row, resolver.copy(isNegative = true)), flagsBased.negativePrefix)
+                    false -> Pair(httpRequestPattern.newBasedOn(resolvedRow, resolver, httpResponsePattern.status), flagsBased.positivePrefix)
+                    else -> Pair(httpRequestPattern.negativeBasedOn(resolvedRow, resolver.copy(isNegative = true)), flagsBased.negativePrefix)
                 }
 
                 newRequestPatterns.map { newHttpRequestPattern ->

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -416,11 +416,10 @@ data class Scenario(
             attempt {
                 val newResponsePattern: HttpResponsePattern = this.httpResponsePattern.withResponseExampleValue(row, resolver)
 
-                val prefix = if (isNegative) flagsBased.negativePrefix else flagsBased.positivePrefix
                 val resolvedRow = ExampleProcessor.resolve(row, ExampleProcessor::defaultIfNotExits)
                 val (newRequestPatterns: Sequence<ReturnValue<HttpRequestPattern>>, generativePrefix: String) = when (isNegative) {
-                    false -> Pair(httpRequestPattern.newBasedOn(resolvedRow, resolver, httpResponsePattern.status), prefix)
-                    else -> Pair(httpRequestPattern.negativeBasedOn(resolvedRow, resolver.copy(isNegative = true)), prefix)
+                    false -> Pair(httpRequestPattern.newBasedOn(resolvedRow, resolver, httpResponsePattern.status), flagsBased.positivePrefix)
+                    else -> Pair(httpRequestPattern.negativeBasedOn(resolvedRow, resolver.copy(isNegative = true)), flagsBased.negativePrefix)
                 }
 
                 newRequestPatterns.map { newHttpRequestPattern ->
@@ -438,8 +437,8 @@ data class Scenario(
                                 ), (newHttpRequestPattern as HasValue<HttpRequestPattern>).valueDetails
                             )
                         },
-                        orException = { e -> e.addDetails(message = row.name, breadCrumb = prefix).cast() },
-                        orFailure = { f -> f.addDetails(message = row.name, breadCrumb = prefix).cast() }
+                        orException = { e -> e.addDetails(message = row.name, breadCrumb = "").cast() },
+                        orFailure = { f -> f.addDetails(message = row.name, breadCrumb = "").cast() }
                     )
                 }
             }

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -435,7 +435,7 @@ data class Scenario(
                                     exampleName = row.name,
                                     exampleRow = row,
                                     generativePrefix = generativePrefix,
-                                )
+                                ), (newHttpRequestPattern as HasValue<HttpRequestPattern>).valueDetails
                             )
                         },
                         orException = { e -> e.addDetails(message = row.name, breadCrumb = prefix).cast() },

--- a/core/src/main/kotlin/io/specmatic/core/pattern/HasException.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/HasException.kt
@@ -49,7 +49,7 @@ data class HasException<T>(val t: Throwable, val message: String = "", val bread
         return cast()
     }
 
-    override fun addDetails(message: String, breadCrumb: String): ReturnValue<T> {
+    override fun addDetails(message: String, breadCrumb: String): HasException<T> {
         val newE = toException(message, breadCrumb, toException())
 
         return HasException(newE)

--- a/core/src/main/kotlin/io/specmatic/core/pattern/HasFailure.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/HasFailure.kt
@@ -40,7 +40,7 @@ data class HasFailure<T>(val failure: Result.Failure, val message: String = "") 
         return Result.Failure(message, failure)
     }
 
-    override fun addDetails(message: String, breadCrumb: String): ReturnValue<T> {
+    override fun addDetails(message: String, breadCrumb: String): HasFailure<T> {
         return HasFailure(Result.Failure(message, this.toFailure(), breadCrumb))
     }
 

--- a/core/src/main/kotlin/io/specmatic/test/ExamplePreProcessor.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ExamplePreProcessor.kt
@@ -85,11 +85,11 @@ object ExampleProcessor {
     }
 
     /* RESOLVER HELPERS */
-    fun resolveLookupIfPresent(row: Row): Row {
+    fun resolve(row: Row, ifNotExists: (lookupKey: String, type: SubstitutionType) -> Value = ::ifNotExitsToLookupPattern): Row {
         return row.copy(
-            requestExample = row.requestExample?.let { resolve(it, ::ifNotExitsToLookupPattern) },
-            responseExample = row.responseExample?.let { resolve(it, ::ifNotExitsToLookupPattern) },
-            values = row.values.map { resolve(parsedValue(it), ::ifNotExitsToLookupPattern).toStringLiteral() }
+            requestExample = row.requestExample?.let { resolve(it, ifNotExists) },
+            responseExample = row.responseExample?.let { resolve(it, ifNotExists) },
+            values = row.values.map { resolve(parsedValue(it), ifNotExists).toStringLiteral() }
         )
     }
 

--- a/core/src/main/kotlin/io/specmatic/test/ScenarioTestGenerationException.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ScenarioTestGenerationException.kt
@@ -20,8 +20,7 @@ class ScenarioTestGenerationException(
     init {
         val exampleRow = scenario.examples.flatMap { it.rows }.firstOrNull { it.name == message }
         if (exampleRow != null) {
-            val generativePrefix = breadCrumb.orEmpty()
-            scenario = scenario.copy(exampleRow = exampleRow, exampleName = message, generativePrefix = generativePrefix)
+            scenario = scenario.copy(exampleRow = exampleRow, exampleName = message)
         }
     }
 

--- a/core/src/main/kotlin/io/specmatic/test/ScenarioTestGenerationException.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ScenarioTestGenerationException.kt
@@ -1,23 +1,48 @@
 package io.specmatic.test
 
+import io.specmatic.conversions.convertPathParameterStyle
+import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpResponse
 import io.specmatic.core.Result
 import io.specmatic.core.Scenario
-import io.specmatic.core.filters.ScenarioMetadata
+import io.specmatic.core.log.LogMessage
+import io.specmatic.core.log.logger
 import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.utilities.exceptionCauseMessage
 
 class ScenarioTestGenerationException(
-    val scenario: Scenario,
+    var scenario: Scenario,
     val e: Throwable,
     val message: String,
     val breadCrumb: String?
 ) : ContractTest {
 
+    init {
+        val exampleRow = scenario.examples.flatMap { it.rows }.firstOrNull { it.name == message }
+        if (exampleRow != null) {
+            val generativePrefix = breadCrumb.orEmpty()
+            scenario = scenario.copy(exampleRow = exampleRow, exampleName = message, generativePrefix = generativePrefix)
+        }
+    }
+
+    private val httpRequest: HttpRequest = scenario.exampleRow?.requestExample ?: HttpRequest(path = scenario.path, method = scenario.method)
+
     override fun toScenarioMetadata() = scenario.toScenarioMetadata()
 
-    override fun testResultRecord(result: Result, response: HttpResponse?): TestResultRecord? {
-        return null
+    override fun testResultRecord(result: Result, response: HttpResponse?): TestResultRecord {
+        return TestResultRecord(
+            convertPathParameterStyle(scenario.path),
+            scenario.method,
+            scenario.status,
+            result.testResult(),
+            scenario.sourceProvider,
+            scenario.sourceRepository,
+            scenario.sourceRepositoryBranch,
+            scenario.specification,
+            scenario.serviceType,
+            actualResponseStatus = 0,
+            scenarioResult = result
+        )
     }
 
     override fun testDescription(): String {
@@ -25,10 +50,13 @@ class ScenarioTestGenerationException(
     }
 
     override fun runTest(testBaseURL: String, timeoutInMilliseconds: Long): Pair<Result, HttpResponse?> {
-        return error()
+        val log: (LogMessage) -> Unit = { logMessage -> logger.log(logMessage) }
+        val httpClient = HttpClient(testBaseURL, log = log, timeoutInMilliseconds = timeoutInMilliseconds)
+        return runTest(httpClient)
     }
 
     override fun runTest(testExecutor: TestExecutor): Pair<Result, HttpResponse?> {
+        testExecutor.preExecuteScenario(scenario, httpRequest)
         return error()
     }
 

--- a/core/src/main/kotlin/io/specmatic/test/ScenarioTestGenerationFailure.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ScenarioTestGenerationFailure.kt
@@ -1,18 +1,45 @@
 package io.specmatic.test
 
+import io.specmatic.conversions.convertPathParameterStyle
+import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpResponse
 import io.specmatic.core.Result
 import io.specmatic.core.Scenario
-import io.specmatic.core.filters.ScenarioMetadata
+import io.specmatic.core.log.LogMessage
+import io.specmatic.core.log.logger
 
 class ScenarioTestGenerationFailure(
-    val scenario: Scenario,
+    var scenario: Scenario,
     val failure: Result.Failure
 ): ContractTest {
+
+    init {
+        val exampleRow = scenario.examples.flatMap { it.rows }.firstOrNull { it.name == failure.message }
+        if (exampleRow != null) {
+            val generativePrefix = failure.breadCrumb
+            scenario = scenario.copy(exampleRow = exampleRow, exampleName = failure.message, generativePrefix = generativePrefix)
+        }
+    }
+
+    private val httpRequest: HttpRequest = scenario.exampleRow?.requestExample ?: HttpRequest(path = scenario.path, method = scenario.method)
+    private val failureCause: Result.Failure = if (scenario.exampleRow != null && failure.cause != null) failure.cause else failure
+
     override fun toScenarioMetadata() = scenario.toScenarioMetadata()
 
-    override fun testResultRecord(result: Result, response: HttpResponse?): TestResultRecord? {
-        return null
+    override fun testResultRecord(result: Result, response: HttpResponse?): TestResultRecord {
+        return TestResultRecord(
+            convertPathParameterStyle(scenario.path),
+            scenario.method,
+            scenario.status,
+            result.testResult(),
+            scenario.sourceProvider,
+            scenario.sourceRepository,
+            scenario.sourceRepositoryBranch,
+            scenario.specification,
+            scenario.serviceType,
+            actualResponseStatus = 0,
+            scenarioResult = result
+        )
     }
 
     override fun testDescription(): String {
@@ -20,11 +47,14 @@ class ScenarioTestGenerationFailure(
     }
 
     override fun runTest(testBaseURL: String, timeoutInMilliseconds: Long): Pair<Result, HttpResponse?> {
-        return Pair(failure.updateScenario(scenario), null)
+        val log: (LogMessage) -> Unit = { logMessage -> logger.log(logMessage) }
+        val httpClient = HttpClient(testBaseURL, log = log, timeoutInMilliseconds = timeoutInMilliseconds)
+        return runTest(httpClient)
     }
 
     override fun runTest(testExecutor: TestExecutor): Pair<Result, HttpResponse?> {
-        return Pair(failure.updateScenario(scenario), null)
+        testExecutor.preExecuteScenario(scenario, httpRequest)
+        return Pair(failureCause.updateScenario(scenario), null)
     }
 
     override fun plusValidator(validator: ResponseValidator): ContractTest {

--- a/core/src/main/kotlin/io/specmatic/test/ScenarioTestGenerationFailure.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ScenarioTestGenerationFailure.kt
@@ -16,8 +16,7 @@ class ScenarioTestGenerationFailure(
     init {
         val exampleRow = scenario.examples.flatMap { it.rows }.firstOrNull { it.name == failure.message }
         if (exampleRow != null) {
-            val generativePrefix = failure.breadCrumb
-            scenario = scenario.copy(exampleRow = exampleRow, exampleName = failure.message, generativePrefix = generativePrefix)
+            scenario = scenario.copy(exampleRow = exampleRow, exampleName = failure.message)
         }
     }
 

--- a/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
+++ b/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
@@ -614,12 +614,15 @@ class LoadTestsFromExternalisedFiles {
                             body = parsedJSONObject("""{"id": 1}""").mergeWith(request.body)
                         )
                     }
-                }).results.filterIsInstance<Result.Failure>()
-                println(results.first().reportString())
+                }).results
+                val failure = results.filterIsInstance<Result.Failure>().first()
+                println(failure.scenario?.testDescription())
+                println(failure.reportString())
 
                 assertThat(requestsCount).isEqualTo(1)
-                assertThat(results).hasSize(1)
-                assertThat(results.first().reportString()).containsIgnoringWhitespaces("""
+                assertThat(results).hasSize(2)
+                assertThat(failure.scenario?.testDescription()).containsIgnoringWhitespaces("Scenario: PATCH /pets/(id:number) -> 200 | EX:patch")
+                assertThat(failure.reportString()).containsIgnoringWhitespaces("""
                 >> REQUEST.BODY
                 >> name
                 Contract expected string but found value 10 (number)

--- a/core/src/test/kotlin/io/specmatic/test/ExampleProcessorTest.kt
+++ b/core/src/test/kotlin/io/specmatic/test/ExampleProcessorTest.kt
@@ -98,7 +98,7 @@ class ExampleProcessorTest {
                 )
             )
 
-            val resolvedExampleRow = ExampleProcessor.resolveLookupIfPresent(exampleRow)
+            val resolvedExampleRow = ExampleProcessor.resolve(exampleRow)
             println(resolvedExampleRow.requestExample)
 
             assertThat(resolvedExampleRow.requestExample?.headers).isEqualTo(mapOf("Bearer" to "token"))

--- a/core/src/test/resources/openapi/config_and_entity_tests/config.json
+++ b/core/src/test/resources/openapi/config_and_entity_tests/config.json
@@ -1,0 +1,32 @@
+{
+  "post": {
+    "Pet": {
+      "name": "Tom",
+      "tag": ["cat"],
+      "details": {
+        "color": "black"
+      },
+      "adopted": true,
+      "age": 10,
+      "birthdate": "2025-01-01"
+    }
+  },
+  "patch": {
+    "Pet": {
+      "name": ["Tom", "Bob", "Sally"],
+      "tag": [
+        ["cat"],
+        ["dog"],
+        ["cat", "dog"]
+      ],
+      "details": [
+        { "color": "black" },
+        { "color": "white" },
+        { "color": "blue" }
+      ],
+      "adopted": [true, false],
+      "age": [10, 20, 30],
+      "birthdate": ["2025-01-01", "2026-01-01", "2027-01-01"]
+    }
+  }
+}

--- a/core/src/test/resources/openapi/config_and_entity_tests/invalid_config.json
+++ b/core/src/test/resources/openapi/config_and_entity_tests/invalid_config.json
@@ -1,0 +1,27 @@
+{
+  "post": {
+    "Pet": {
+      "name": "Tom",
+      "tag": ["cat"],
+      "details": {
+        "color": "black"
+      },
+      "adopted": true,
+      "age": 10,
+      "birthdate": "2025-01-01"
+    }
+  },
+  "patch": {
+    "Pet": {
+      "name": ["Tom", 10],
+      "tag": [ ["cat"], [10] ],
+      "details": [
+        { "color": "black" },
+        10
+      ],
+      "adopted": [true, "false"],
+      "age": [10, "20"],
+      "birthdate": ["2025-01-01", false]
+    }
+  }
+}

--- a/core/src/test/resources/openapi/config_and_entity_tests/spec.yaml
+++ b/core/src/test/resources/openapi/config_and_entity_tests/spec.yaml
@@ -1,0 +1,81 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: Simple API
+paths:
+  /pets:
+    post:
+      description: Creates a new pet in the store. Duplicates are allowed
+      requestBody:
+        description: Pet to add to the store
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewPet'
+      responses:
+        '201':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+  /pets/{id}:
+    patch:
+      description: Updates a pet in the store with form data
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewPet'
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Base:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: integer
+    Pet:
+      allOf:
+        - $ref: '#/components/schemas/Base'
+        - $ref: '#/components/schemas/NewPet'
+    NewPet:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+        tag:
+          type: array
+          items:
+            type: string
+        details:
+          $ref: '#/components/schemas/Details'
+        adopted:
+          type: boolean
+        age:
+          type: integer
+        birthdate:
+          type: date
+    Details:
+      type: object
+      properties:
+        color:
+          type: string

--- a/core/src/test/resources/openapi/config_and_entity_tests/spec.yaml
+++ b/core/src/test/resources/openapi/config_and_entity_tests/spec.yaml
@@ -73,7 +73,8 @@ components:
         age:
           type: integer
         birthdate:
-          type: date
+          type: string
+          format: date
     Details:
       type: object
       properties:

--- a/core/src/test/resources/openapi/config_and_entity_tests/spec_examples/patch.json
+++ b/core/src/test/resources/openapi/config_and_entity_tests/spec_examples/patch.json
@@ -1,0 +1,35 @@
+{
+  "partial": {
+    "http-request": {
+      "path": "/pets/$(ENTITY.id)",
+      "method": "PATCH",
+      "headers": {
+        "Content-Type": "application/json"
+      },
+      "body": {
+        "name": "$rand(CONFIG.patch.Pet.name)",
+        "tag": "$rand(CONFIG.patch.Pet.tag)",
+        "details": "$rand(CONFIG.patch.Pet.details)",
+        "adopted": "$rand(CONFIG.patch.Pet.adopted)",
+        "age": "$rand(CONFIG.patch.Pet.age)",
+        "birthdate": "$rand(CONFIG.patch.Pet.birthdate)"
+      }
+    },
+    "http-response": {
+      "status": 200,
+      "body": {
+        "id": "$eq(ENTITY.id)",
+        "name": "$eq(REQUEST.BODY.name)",
+        "tag": "$eq(REQUEST.BODY.tag)",
+        "details": "$eq(REQUEST.BODY.details)",
+        "adopted": "$eq(REQUEST.BODY.adopted)",
+        "age": "$eq(REQUEST.BODY.age)",
+        "birthdate": "$eq(REQUEST.BODY.birthdate)"
+      },
+      "status-text": "Created",
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  }
+}

--- a/core/src/test/resources/openapi/config_and_entity_tests/spec_examples/post.json
+++ b/core/src/test/resources/openapi/config_and_entity_tests/spec_examples/post.json
@@ -1,0 +1,28 @@
+{
+  "partial": {
+    "http-request": {
+      "path": "/pets",
+      "method": "POST",
+      "headers": {
+        "Content-Type": "application/json"
+      },
+      "body": "$(CONFIG.post.Pet)"
+    },
+    "http-response": {
+      "status": 201,
+      "body": {
+        "id": "(anyvalue)",
+        "name": "$eq(REQUEST.BODY.name)",
+        "tag": "$eq(REQUEST.BODY.tag)",
+        "details": "$eq(REQUEST.BODY.details)",
+        "adopted": "$eq(REQUEST.BODY.adopted)",
+        "age": "$eq(REQUEST.BODY.age)",
+        "birthdate": "$eq(REQUEST.BODY.birthdate)"
+      },
+      "status-text": "Created",
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Fix example load error for non-scalar value with rand resolve.

<!-- Why are these changes necessary? -->

**Why**: This addresses issues with `$rand` resolutions in instances where the schema is of a non-scalar or non-string type.

<!-- How were these changes implemented? -->

**How**:
- Substitution tokens are not validated against patterns during the example load
- The example resolution is now done in Scenario.newBasedOn and is compatible with all scalar and non-scalar schemas.
- ScenarioTestGenerationException and ScenarioTestGenerationFailure are now included in the HTML report.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

<!-- feel free to add additional comments -->
