### PR TITLE
Ensure random resolve failures appear in HTML report with example names.

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -416,7 +416,10 @@ data class Scenario(
             attempt {
                 val newResponsePattern: HttpResponsePattern = this.httpResponsePattern.withResponseExampleValue(row, resolver)
 
-                val resolvedRow = ExampleProcessor.resolve(row, ExampleProcessor::defaultIfNotExits)
+                val resolvedRow = try { ExampleProcessor.resolve(row, ExampleProcessor::defaultIfNotExits) } catch (e: Throwable) {
+                    return@attempt sequenceOf(HasException<Scenario>(e, message = row.name, breadCrumb = ""))
+                }
+
                 val (newRequestPatterns: Sequence<ReturnValue<HttpRequestPattern>>, generativePrefix: String) = when (isNegative) {
                     false -> Pair(httpRequestPattern.newBasedOn(resolvedRow, resolver, httpResponsePattern.status), flagsBased.positivePrefix)
                     else -> Pair(httpRequestPattern.negativeBasedOn(resolvedRow, resolver.copy(isNegative = true)), flagsBased.negativePrefix)

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -440,7 +440,7 @@ data class Scenario(
                                 ), (newHttpRequestPattern as HasValue<HttpRequestPattern>).valueDetails
                             )
                         },
-                        orException = { e -> e.addDetails(message = row.name, breadCrumb = "").cast() },
+                        orException = { e -> e.copy(message = row.name).cast() },
                         orFailure = { f -> f.addDetails(message = row.name, breadCrumb = "").cast() }
                     )
                 }

--- a/core/src/main/kotlin/io/specmatic/test/ExamplePreProcessor.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ExamplePreProcessor.kt
@@ -3,7 +3,6 @@ package io.specmatic.test
 import io.ktor.http.*
 import io.ktor.util.*
 import io.specmatic.core.*
-import io.specmatic.core.log.consoleLog
 import io.specmatic.core.pattern.*
 import io.specmatic.core.utilities.exceptionCauseMessage
 import io.specmatic.core.value.*
@@ -30,13 +29,11 @@ object ExampleProcessor {
 
         val configFile = File(configFilePath)
         if (!configFile.exists()) {
-            consoleLog("Could not find the CONFIG at path ${configFile.canonicalPath}")
-            return JSONObjectValue(emptyMap())
+            throw ContractException(breadCrumb = configFilePath, errorMessage = "Could not find the CONFIG at path ${configFile.canonicalPath}")
         }
 
         return runCatching { parsedJSONObject(configFile.readText()) }.getOrElse { e ->
-            consoleLog("Error loading CONFIG $configFilePath: ${exceptionCauseMessage(e)}")
-            JSONObjectValue(emptyMap())
+            throw ContractException(breadCrumb = configFilePath, errorMessage = "Could not parse the CONFIG at path ${configFile.canonicalPath}: ${exceptionCauseMessage(e)}")
         }.also {
             it.findFirstChildByPath("url")?.let {
                 url -> System.setProperty("testBaseURL", url.toStringLiteral())

--- a/core/src/main/kotlin/io/specmatic/test/ScenarioTestGenerationException.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ScenarioTestGenerationException.kt
@@ -25,6 +25,7 @@ class ScenarioTestGenerationException(
     }
 
     private val httpRequest: HttpRequest = scenario.exampleRow?.requestExample ?: HttpRequest(path = scenario.path, method = scenario.method)
+    private val errorMessage: String = if (scenario.exampleRow != null && e is ContractException) "" else message
 
     override fun toScenarioMetadata() = scenario.toScenarioMetadata()
 
@@ -65,8 +66,8 @@ class ScenarioTestGenerationException(
 
     fun error(): Pair<Result, HttpResponse?> {
         val result: Result = when(e) {
-            is ContractException -> Result.Failure(message, e.failure(), breadCrumb = breadCrumb ?: "").updateScenario(scenario)
-            else -> Result.Failure(message + " - " + exceptionCauseMessage(e), breadCrumb = breadCrumb ?: "").updateScenario(scenario)
+            is ContractException -> Result.Failure(errorMessage, e.failure(), breadCrumb = breadCrumb ?: "").updateScenario(scenario)
+            else -> Result.Failure(errorMessage + " - " + exceptionCauseMessage(e), breadCrumb = breadCrumb ?: "").updateScenario(scenario)
         }
 
         return Pair(result, null)

--- a/core/src/test/resources/openapi/config_and_entity_tests/incomplete_config.json
+++ b/core/src/test/resources/openapi/config_and_entity_tests/incomplete_config.json
@@ -1,0 +1,28 @@
+{
+  "post": {
+    "Pet": {
+      "name": "Tom",
+      "tag": ["cat"],
+      "details": {
+        "color": "black"
+      },
+      "adopted": true,
+      "age": 10,
+      "birthdate": "2025-01-01"
+    }
+  },
+  "patch": {
+    "Pet": {
+      "name": ["Tom"],
+      "tag": [
+        ["cat"]
+      ],
+      "details": [
+        { "color": "black" }
+      ],
+      "adopted": [true],
+      "age": [10],
+      "birthdate": ["2025-01-01"]
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Address the issue of random resolve failures not being displayed in the HTML report.

<!-- Why are these changes necessary? -->

**Why**:
- When a random value cannot be resolved, an error is thrown. This error is not handled correctly, resulting in the scenario not appearing in the HTML report.
- Additionally, the ExampleProcessor now throws an exception if the defined config is not found or fails to parse.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

<!-- feel free to add additional comments -->
