### PR TITLE
Interactive Examples Editor Error Highlighting Improvements

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/pattern/Discriminator.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/Discriminator.kt
@@ -81,8 +81,9 @@ class Discriminator(
         if (isPatternToken(actualDiscriminatorValue) || ExampleProcessor.isSubstitutionToken(actualDiscriminatorValue)) return Result.Success()
 
         if (actualDiscriminatorValue.toStringLiteral() !in values) {
-            val message =
-                "Expected the value of discriminator property to be $discriminatorCsvClause but it was ${actualDiscriminatorValue.toStringLiteral()}"
+            val message = "Expected the value of discriminator property to be $discriminatorCsvClause but it was ${
+                actualDiscriminatorValue.toStringLiteral().takeUnless { it.isEmpty() } ?: "\"\""
+            }"
 
             return Result.Failure(
                 message,

--- a/core/src/main/kotlin/io/specmatic/core/pattern/Discriminator.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/Discriminator.kt
@@ -79,10 +79,10 @@ class Discriminator(
         )
 
         if (isPatternToken(actualDiscriminatorValue) || ExampleProcessor.isSubstitutionToken(actualDiscriminatorValue)) return Result.Success()
-
         if (actualDiscriminatorValue.toStringLiteral() !in values) {
             val message = "Expected the value of discriminator property to be $discriminatorCsvClause but it was ${
-                actualDiscriminatorValue.toStringLiteral().takeUnless { it.isEmpty() } ?: "\"\""
+                actualDiscriminatorValue.toStringLiteral()
+                    .takeUnless { it.isEmpty() } ?: "' '"
             }"
 
             return Result.Failure(

--- a/core/src/main/kotlin/io/specmatic/core/pattern/Discriminator.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/Discriminator.kt
@@ -82,7 +82,7 @@ class Discriminator(
         if (actualDiscriminatorValue.toStringLiteral() !in values) {
             val message = "Expected the value of discriminator property to be $discriminatorCsvClause but it was ${
                 actualDiscriminatorValue.toStringLiteral()
-                    .takeUnless { it.isEmpty() } ?: "' '"
+                    .takeUnless { it.isEmpty() } ?: "\"\""
             }"
 
             return Result.Failure(

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ExactValuePattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ExactValuePattern.kt
@@ -16,7 +16,7 @@ data class ExactValuePattern(override val pattern: Value, override val typeAlias
             else -> {
                 if (discriminator) {
                     val errorMessage = "Expected the value of discriminator property to be ${pattern.displayableValue()} but it was ${
-                        sampleData?.displayableValue().takeUnless { it.isNullOrEmpty() } ?: "' '"
+                        sampleData?.displayableValue().takeUnless { it.isNullOrEmpty() } ?: "\"\""
                     }"
                     Result.Failure(errorMessage, failureReason = FailureReason.DiscriminatorMismatch)
                 } else

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ExactValuePattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ExactValuePattern.kt
@@ -16,7 +16,7 @@ data class ExactValuePattern(override val pattern: Value, override val typeAlias
             else -> {
                 if (discriminator) {
                     val errorMessage = "Expected the value of discriminator property to be ${pattern.displayableValue()} but it was ${
-                        sampleData?.displayableValue().takeUnless { it.isNullOrEmpty() } ?: "\"\""
+                        sampleData?.displayableValue().takeUnless { it.isNullOrEmpty() } ?: "' '"
                     }"
                     Result.Failure(errorMessage, failureReason = FailureReason.DiscriminatorMismatch)
                 } else

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ExactValuePattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ExactValuePattern.kt
@@ -15,7 +15,9 @@ data class ExactValuePattern(override val pattern: Value, override val typeAlias
             true -> Result.Success()
             else -> {
                 if (discriminator) {
-                    val errorMessage = "Expected the value of discriminator property to be ${pattern.displayableValue()} but it was ${sampleData?.displayableValue()}"
+                    val errorMessage = "Expected the value of discriminator property to be ${pattern.displayableValue()} but it was ${
+                        sampleData?.displayableValue().takeUnless { it.isNullOrEmpty() } ?: "\"\""
+                    }"
                     Result.Failure(errorMessage, failureReason = FailureReason.DiscriminatorMismatch)
                 } else
                     mismatchResult(pattern, sampleData, resolver.mismatchMessages)

--- a/core/src/main/resources/static/example-server.js
+++ b/core/src/main/resources/static/example-server.js
@@ -630,15 +630,16 @@ function createExampleDropDown(example) {
                 decorationsField,
                 editorFacet,
                 window.EditorView.updateListener.of((update) => {
-                    if (update.docChanged) {
-                        isSaved = false;
-                        const editorElement = editor.dom;
-                        updateBorderColorExampleBlock(editorElement, examplePreDiv);
-                        if (example.errorList && example.errorList.length > 0) {
-                            highlightErrorLines(editor, example.errorList, update.state.doc.toString());
-                        }
-                        savedEditorResponse = update.state.doc.toString();
-                    }
+                  if (!update.docChanged) return;
+                  const docContent = editor.state.doc.toString();
+
+                  isSaved = false;
+                  const editorElement = editor.dom;
+                  updateBorderColorExampleBlock(editorElement, examplePreDiv);
+                  if (example.errorList && example.errorList.length > 0) {
+                      highlightErrorLines(editor, example.errorList, docContent);
+                  }
+                  savedEditorResponse = docContent;
                 })
             ],
         }),
@@ -748,16 +749,16 @@ function highlightErrorLines(editor, metadata, exampleJson) {
             const className = "specmatic-editor-line-error";
             const tokenStart = lineLength.from;
             const tokenEnd = lineLength.to;
-            if (!decorations.some(decoration => decoration.from === tokenStart && decoration.to === tokenEnd)) {
-                           decorations.push(
-                               window.Decoration.mark({
-                                   class: className,
-                                   attributes: {
-                                       "data-validation-error-message": combinedDescriptions
-                                   }
-                               }).range(tokenStart, tokenEnd)
-                           );
-                       }
+           if (decorations.some(decoration => decoration.from === tokenStart && decoration.to === tokenEnd)) return;
+
+           decorations.push(
+               window.Decoration.mark({
+                   class: className,
+                   attributes: {
+                       "data-validation-error-message": combinedDescriptions
+                   }
+               }).range(tokenStart, tokenEnd)
+           );
 
             const existingError = errorMetadata.find(err => err.line === lineNumber + 1);
             if (existingError) {

--- a/core/src/main/resources/static/example-server.js
+++ b/core/src/main/resources/static/example-server.js
@@ -631,14 +631,13 @@ function createExampleDropDown(example) {
                 editorFacet,
                 window.EditorView.updateListener.of((update) => {
                   if (!update.docChanged) return;
-                  const docContent = editor.state.doc.toString();
+                  const docContent = update.state.doc.toString();
 
                   isSaved = false;
                   const editorElement = editor.dom;
                   updateBorderColorExampleBlock(editorElement, examplePreDiv);
-                  if (example.errorList && example.errorList.length > 0) {
-                      highlightErrorLines(editor, example.errorList, docContent);
-                  }
+                  if (!example.errorList.length > 0) return;
+                  highlightErrorLines(editor, example.errorList, docContent);
                   savedEditorResponse = docContent;
                 })
             ],
@@ -749,7 +748,8 @@ function highlightErrorLines(editor, metadata, exampleJson) {
             const className = "specmatic-editor-line-error";
             const tokenStart = lineLength.from;
             const tokenEnd = lineLength.to;
-           if (decorations.some(decoration => decoration.from === tokenStart && decoration.to === tokenEnd)) return;
+            const existingDecoration = decorations.filter(decoration => decoration.from === tokenStart && decoration.to === tokenEnd);
+           if (existingDecoration.length !== 0) return;
 
            decorations.push(
                window.Decoration.mark({

--- a/core/src/main/resources/static/example-server.js
+++ b/core/src/main/resources/static/example-server.js
@@ -635,7 +635,7 @@ function createExampleDropDown(example) {
                         const editorElement = editor.dom;
                         updateBorderColorExampleBlock(editorElement, examplePreDiv);
                         if (example.errorList && example.errorList.length > 0) {
-                            highlightErrorLines(editor, example.errorList, example.exampleJson);
+                            highlightErrorLines(editor, example.errorList, update.state.doc.toString());
                         }
                         savedEditorResponse = update.state.doc.toString();
                     }

--- a/core/src/main/resources/static/example-server.js
+++ b/core/src/main/resources/static/example-server.js
@@ -749,16 +749,16 @@ function highlightErrorLines(editor, metadata, exampleJson) {
             const tokenStart = lineLength.from;
             const tokenEnd = lineLength.to;
             const existingDecoration = decorations.filter(decoration => decoration.from === tokenStart && decoration.to === tokenEnd);
-           if (existingDecoration.length !== 0) return;
+            if (existingDecoration.length !== 0) return;
 
-           decorations.push(
-               window.Decoration.mark({
-                   class: className,
-                   attributes: {
-                       "data-validation-error-message": combinedDescriptions
-                   }
-               }).range(tokenStart, tokenEnd)
-           );
+            decorations.push(
+                window.Decoration.mark({
+                    class: className,
+                    attributes: {
+                        "data-validation-error-message": combinedDescriptions
+                    }
+                }).range(tokenStart, tokenEnd)
+            );
 
             const existingError = errorMetadata.find(err => err.line === lineNumber + 1);
             if (existingError) {

--- a/core/src/main/resources/static/example-server.js
+++ b/core/src/main/resources/static/example-server.js
@@ -746,15 +746,19 @@ function highlightErrorLines(editor, metadata, exampleJson) {
             existingMarkers.get(lineNumber).push(meta.description);
             const combinedDescriptions = existingMarkers.get(lineNumber).join('\n\n');
             const className = "specmatic-editor-line-error";
+            const tokenStart = lineLength.from;
+            const tokenEnd = lineLength.to;
+            if (!decorations.some(decoration => decoration.from === tokenStart && decoration.to === tokenEnd)) {
+                           decorations.push(
+                               window.Decoration.mark({
+                                   class: className,
+                                   attributes: {
+                                       "data-validation-error-message": combinedDescriptions
+                                   }
+                               }).range(tokenStart, tokenEnd)
+                           );
+                       }
 
-            decorations.push(
-                window.Decoration.line({
-                    class: className,
-                    attributes: {
-                        "data-validation-error-message": combinedDescriptions
-                    }
-                }).range(lineLength.from)
-            );
             const existingError = errorMetadata.find(err => err.line === lineNumber + 1);
             if (existingError) {
                 existingError.message = combinedDescriptions;
@@ -768,6 +772,7 @@ function highlightErrorLines(editor, metadata, exampleJson) {
         }
     });
     decorations.sort((a, b) => a.from - b.from);
+
     const decorationSet = window.Decoration.set(decorations);
     const transaction = editor.state.update({
         effects: setDecorationsEffect.of(decorationSet)

--- a/core/src/main/resources/static/setup.css
+++ b/core/src/main/resources/static/setup.css
@@ -297,7 +297,7 @@ video {
 }
 
 .specmatic-editor-line-error {
-    background-color: rgba(255, 0, 0, 0.2) !important;
+   background-color: rgba(255, 0, 0,0.2);
     overflow: hidden;
 }
 
@@ -313,4 +313,5 @@ video {
     position: fixed;
     border-left: 4px solid red;
 }
+
 

--- a/core/src/main/resources/static/setup.css
+++ b/core/src/main/resources/static/setup.css
@@ -297,7 +297,7 @@ video {
 }
 
 .specmatic-editor-line-error {
-    background-color: rgba(255, 0, 0, 0.2);
+    background-color: rgba(255, 0, 0, 0.2) !important;
     overflow: hidden;
 }
 

--- a/core/src/main/resources/static/setup.css
+++ b/core/src/main/resources/static/setup.css
@@ -297,7 +297,7 @@ video {
 }
 
 .specmatic-editor-line-error {
-   background-color: rgba(255, 0, 0,0.2);
+    background-color: rgba(255, 0, 0, 0.2);
     overflow: hidden;
 }
 
@@ -313,5 +313,4 @@ video {
     position: fixed;
     border-left: 4px solid red;
 }
-
 


### PR DESCRIPTION
The following issues are fixed as a part of this PR-

- The error highlighting disappears on the line where we hover / is currently under focus. If it is the first line which has the error then focus by default is on that line, so no error highlights are seen.
- The statement “Expected value but it was” is displayed for empty Strings. It should be `Expected value but it was “”` 
- When the editor is updated, the line decorations should continue to remain on the errors
- Changed the line decoration to highlight only the part of a line that has errors so that users instinctively hover on chars to see the tooltip