### PR TITLE
Should throw error if there are unused examples due to some error in strictMode for test

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -1786,9 +1786,9 @@ data class Feature(
                 try {
                     val example = ScenarioStub.parse(File(externalizedExamplePath).readText())
 
-                    val method = example.request.method
-                    val path = example.request.path
-                    val responseCode = example.response.status
+                    val method = example.requestMethod()
+                    val path = example.requestPath()
+                    val responseCode = example.responseStatus()
                     val errorMessage = "    $method $path -> $responseCode does not match any operation in the specification"
                     if(strictMode.not()) logger.log(errorMessage)
                     "The example $externalizedExamplePath is unused due to error: $errorMessage"

--- a/core/src/main/kotlin/io/specmatic/mock/ScenarioStub.kt
+++ b/core/src/main/kotlin/io/specmatic/mock/ScenarioStub.kt
@@ -34,6 +34,12 @@ data class ScenarioStub(
     val filePath: String? = null,
     val partial: ScenarioStub? = null
 ) {
+    fun requestMethod() = request.method ?: partial?.request?.method
+
+    fun requestPath() = request.path ?: partial?.request?.path
+
+    fun responseStatus() = response.status.takeIf { it != 0 } ?: partial?.response?.status
+
     fun toJSON(): JSONObjectValue {
         val mockInteraction = mutableMapOf<String, Value>()
 


### PR DESCRIPTION



**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->


<!-- feel free to add additional comments -->
