### PR TITLE
Fixes issue in the GUI when there are ~s in the breadcrumbs

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/examples/server/ExampleValidationDetails.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/server/ExampleValidationDetails.kt
@@ -14,6 +14,9 @@ private const val HTTP_HEADERS = "headers"
 private const val HTTP_BODY = "body"
 const val BREADCRUMB_QUERY_PARAMS = "QUERY-PARAMS"
 private const val HTTP_QUERY_PARAMS = "query"
+private const val BREADCRUMB_TILDLE = ".(~~~"
+private const val BREADCRUMB_REGEX_TILDLE = "^\\(~~~"
+private const val BREADCRUMB_WHEN_OBJ = "(when "
 
 data class ExampleValidationDetails(val matchFailureDetailsList: List<MatchFailureDetails>) {
     fun jsonPathToErrorDescriptionMapping(): List<ExampleValidationResult> {
@@ -37,6 +40,7 @@ data class ExampleValidationDetails(val matchFailureDetailsList: List<MatchFailu
         return matchingFailureDetails.flatMap { matchingFailureDetail ->
             val combinedBreadcrumbs = matchingFailureDetail.breadCrumbs
                 .takeIf { it.isNotEmpty() }
+                ?.filterNot { it.startsWith("(") && it.endsWith(")") }
                 ?.joinToString(JSONPATH_DELIMITER) { breadcrumb -> processBreadcrumb(breadcrumb) }
                 ?.let { "/$it" }
                 ?: ""
@@ -52,6 +56,8 @@ data class ExampleValidationDetails(val matchFailureDetailsList: List<MatchFailu
             .replace(BREAD_CRUMB_HEADERS, HTTP_HEADERS)
             .replace(BREADCRUMB_QUERY_PARAMS, HTTP_QUERY_PARAMS)
             .replace(BREADCRUMB_DELIMITER, JSONPATH_DELIMITER)
+            .replace(BREADCRUMB_TILDLE, " $BREADCRUMB_WHEN_OBJ")
+            .replace(Regex(BREADCRUMB_REGEX_TILDLE), BREADCRUMB_WHEN_OBJ)
             .replace(Regex("\\[(\\d+)]")) { matchResult -> "/${matchResult.groupValues[1]}" }.trimStart('/')
     }
 


### PR DESCRIPTION
This PR fixes an issue in the breadcrumb replacement logic where the ~~~ marker was not correctly interpreted.

- Updated logic to replace tildes with (when [ObjectName]), aligning with the existing pattern for tooltips message in the example editor.
- Modified breadcrumb parsing for jsonPath to ensure compatibility with the example editor.