### PR TITLE
Fix the typeAlias for patterns in AnyPattern when a discriminator exists

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/DiscriminatorDetails.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/DiscriminatorDetails.kt
@@ -15,6 +15,11 @@ data class DiscriminatorDetails(private val discriminatorData: DiscriminatorData
         return discriminatorData.isNotEmpty()
     }
 
+    val schemaNames: List<String>
+        get() {
+            return discriminatorData.entries.firstOrNull()?.value?.values?.map { it.first }.orEmpty()
+        }
+
     val values: List<String>
         get() {
             return discriminatorData.entries.firstOrNull()?.value?.keys?.toList() ?: emptyList()

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -1237,7 +1237,7 @@ class OpenApiSpecification(
                 }
 
                 val mappingWithSchema: Map<String, Pair<String, List<Schema<Any>>>> = mappingWithSchemaListAndDiscriminator.mapValues { entry: Map.Entry<String, Pair<String, Pair<List<Schema<Any>>, DiscriminatorDetails>>> ->
-                    entry.key to (entry.value.second.first)
+                    entry.value.first to (entry.value.second.first)
                 }
 
                 Triple(propertyName, mappingWithSchema, mergedDiscriminatorDetailsFromMappingSchemas)
@@ -1407,12 +1407,15 @@ class OpenApiSpecification(
                         AnyPattern(oneOfs, typeAlias = "(${patternName})")
                     else if(allDiscriminators.isNotEmpty())
                         AnyPattern(
-                            schemaProperties.map { toJSONObjectPattern(it, "(${patternName})") },
+                            pattern = schemaProperties.zip(allDiscriminators.schemaNames).map { (properties, schemaName) ->
+                                toJSONObjectPattern(properties, "(${schemaName})")
+                            },
                             discriminator = Discriminator.create(
                                 allDiscriminators.key,
                                 allDiscriminators.values.toSet(),
                                 schema.discriminator?.mapping.orEmpty()
-                            )
+                            ),
+                            typeAlias = "(${patternName})"
                         )
                     else if(schemaProperties.size > 1)
                         AnyPattern(schemaProperties.map { toJSONObjectPattern(it, "(${patternName})") })


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Fix the typeAlias for patterns in AnyPattern

<!-- Why are these changes necessary? -->

**Why**: When a discriminator is present, the typeAlias of the subPatterns should correspond to the schema name.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

<!-- feel free to add additional comments -->
