### PR TITLE
Fix the AnyPattern logic to retrieve the pattern for a given discriminator value

### DIFF
--- a/core/src/test/kotlin/io/specmatic/core/pattern/AnyPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/AnyPatternTest.kt
@@ -14,6 +14,36 @@ import org.junit.jupiter.api.Test
 
 internal class AnyPatternTest {
     @Test
+    fun `should be able to generate for a discriminator value when it's nested inside another AnyPattern`() {
+        val discriminator = Discriminator(
+            property = "type",
+            values = setOf("simple", "complex"),
+            mapping = mapOf("simple" to "#/components/schemas/Simple", "complex" to "#/components/schemas/Complex")
+        )
+
+        val otherPattern =  AnyPattern(pattern = listOf(
+                JSONObjectPattern(mapOf("type" to "simple".toDiscriminator(), "prop1" to StringPattern()), typeAlias = "(Simple)"),
+                JSONObjectPattern(mapOf("type" to "complex".toDiscriminator(), "prop2" to NumberPattern()), typeAlias = "(Complex)"),
+            ), discriminator = discriminator)
+        val pattern = AnyPattern(pattern = listOf(otherPattern), discriminator = discriminator)
+
+        val simpleObject = pattern.generateValue(Resolver(), "simple")
+        val complexObject = pattern.generateValue(Resolver(), "complex")
+
+        println(simpleObject)
+        assertThat(simpleObject).isInstanceOf(JSONObjectValue::class.java)
+        simpleObject as JSONObjectValue
+        assertThat(simpleObject.keys()).containsExactlyInAnyOrder("type", "prop1")
+        assertThat(simpleObject.getString("type")).isEqualTo("simple")
+
+        println(complexObject)
+        assertThat(complexObject).isInstanceOf(JSONObjectValue::class.java)
+        complexObject as JSONObjectValue
+        assertThat(complexObject.keys()).containsExactlyInAnyOrder("type", "prop2")
+        assertThat(complexObject.getString("type")).isEqualTo("complex")
+    }
+
+    @Test
     fun `should match multiple patterns`() {
         val pattern = AnyPattern(listOf(NumberPattern(), StringPattern()))
         val string = StringValue("hello")
@@ -441,5 +471,9 @@ internal class AnyPatternTest {
             val values = pattern.generateForEveryDiscriminatorValue(Resolver())
             assertThat(values).isNotEmpty
         }
+    }
+
+    private fun String.toDiscriminator(): ExactValuePattern {
+        return ExactValuePattern(StringValue(this))
     }
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Fix the AnyPattern logic to retrieve the pattern for a given discriminator value

<!-- Why are these changes necessary? -->

**Why**: The Discriminator Pattern can be nested within another AnyPattern, and the getDiscriminatorBased function should handle this scenario.


<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

<!-- feel free to add additional comments -->
