### PR TITLE
Ability to specify which example to validate through CLI arguments

### DIFF
--- a/application/src/main/kotlin/application/ExamplesCommand.kt
+++ b/application/src/main/kotlin/application/ExamplesCommand.kt
@@ -232,7 +232,7 @@ For example:
         var filterNotName: String = ""
 
         @Option(
-            names = ["--validate"],
+            names = ["--examples-to-validate"],
             description = ["Whether to validate inline, external, or both examples. Options: INLINE, EXTERNAL, BOTH"],
             converter = [ExamplesToValidateConverter::class],
             defaultValue = "BOTH"

--- a/application/src/main/kotlin/application/ExamplesCommand.kt
+++ b/application/src/main/kotlin/application/ExamplesCommand.kt
@@ -231,6 +231,22 @@ For example:
         )
         var filterNotName: String = ""
 
+        @Option(
+            names = ["--validate"],
+            description = ["Whether to validate inline, external, or both examples. Options: INLINE, EXTERNAL, BOTH"],
+            converter = [ExamplesToValidateConverter::class],
+            defaultValue = "BOTH"
+        )
+        var examplesToValidate: ExamplesToValidate = ExamplesToValidate.BOTH
+
+        enum class ExamplesToValidate { INLINE, EXTERNAL, BOTH }
+        class ExamplesToValidateConverter : ITypeConverter<ExamplesToValidate> {
+            override fun convert(value: String): ExamplesToValidate {
+                return ExamplesToValidate.entries.firstOrNull { it.name.equals(value, ignoreCase = true) }
+                    ?: throw IllegalArgumentException("Invalid value: $value. Expected one of: ${ExamplesToValidate.entries.joinToString(", ")}")
+            }
+        }
+
         override fun call(): Int {
             configureLogger(this.verbose)
 
@@ -357,12 +373,10 @@ For example:
         }
 
         private fun getValidateInlineAndValidateExternalFlags(): Pair<Boolean, Boolean> {
-            return when {
-                !Flags.getBooleanValue("VALIDATE_INLINE_EXAMPLES") && !Flags.getBooleanValue(
-                    "IGNORE_INLINE_EXAMPLES"
-                ) -> true to true
-
-                else -> Flags.getBooleanValue("VALIDATE_INLINE_EXAMPLES") to Flags.getBooleanValue("IGNORE_INLINE_EXAMPLES")
+            return when(examplesToValidate) {
+                ExamplesToValidate.BOTH -> true to true
+                ExamplesToValidate.INLINE -> true to false
+                ExamplesToValidate.EXTERNAL -> false to true
             }
         }
 

--- a/application/src/test/resources/specifications/simpleSpec/spec.yaml
+++ b/application/src/test/resources/specifications/simpleSpec/spec.yaml
@@ -1,0 +1,35 @@
+openapi: 3.0.0
+info:
+  title: Simple API
+  version: 1.0.0
+paths:
+  /greeting:
+    post:
+      summary: Accepts a name and returns a greeting message
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+            examples:
+              JOHN:
+                value:
+                  name: John
+      responses:
+        '200':
+          description: A personalized greeting message
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+              examples:
+                JOHN:
+                  value:
+                    message: Hello John

--- a/application/src/test/resources/specifications/simpleSpec/spec_examples/JANE.json
+++ b/application/src/test/resources/specifications/simpleSpec/spec_examples/JANE.json
@@ -1,0 +1,22 @@
+{
+  "http-request": {
+    "path": "/greeting",
+    "method": "POST",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "name": "Jane"
+    }
+  },
+  "http-response": {
+    "status": 200,
+    "body": {
+      "message": "Hello Jane"
+    },
+    "status-text": "OK",
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Ability to specify which example to validate through CLI arguments

<!-- How were these changes implemented? -->

**How**: A new argument named `examplesToValidate`, with the following options:
1. BOTH (default)
2. INLINE
3. EXTERNAL

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

<!-- feel free to add additional comments -->
