### PR TITLE
Make Version Field of Specmatic Config Private

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.specmatic.core.Configuration.Companion.configFilePath
 import io.specmatic.core.config.SpecmaticConfigVersion
+import io.specmatic.core.config.SpecmaticConfigVersion.VERSION_1
 import io.specmatic.core.config.toSpecmaticConfig
 import io.specmatic.core.log.logger
 import io.specmatic.core.pattern.ContractException
@@ -127,7 +128,7 @@ data class SpecmaticConfig(
     val attributeSelectionPattern: AttributeSelectionPattern = AttributeSelectionPattern(),
     val allPatternsMandatory: Boolean? = null,
     val defaultPatternValues: Map<String, Any> = emptyMap(),
-    val version: SpecmaticConfigVersion? = null
+    private val version: SpecmaticConfigVersion? = null
 ) {
     @JsonIgnore
     fun attributeSelectionQueryParamKey(): String {
@@ -182,6 +183,11 @@ data class SpecmaticConfig(
     @JsonIgnore
     fun getAllPatternsMandatory(): Boolean {
         return allPatternsMandatory ?: getBooleanValue(Flags.ALL_PATTERNS_MANDATORY)
+    }
+
+    @JsonIgnore
+    fun getVersion(): SpecmaticConfigVersion {
+        return this.version ?: VERSION_1
     }
 }
 

--- a/core/src/test/kotlin/io/specmatic/core/config/SpecmaticConfigAllTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/SpecmaticConfigAllTest.kt
@@ -62,7 +62,7 @@ internal class SpecmaticConfigAllTest {
     @ParameterizedTest
     fun `should create SpecmaticConfig given SpecmaticConfigV1`(version: SpecmaticConfigVersion, configFile: String) {
         val config: SpecmaticConfig = loadSpecmaticConfig(configFile)
-        assertThat(config.version).isEqualTo(version)
+        assertThat(config.getVersion()).isEqualTo(version)
         assertThat(config.sources.size).isEqualTo(2)
         val expectedSources = listOf(
             Source(provider= SourceProvider.git, repository="https://contracts", branch = "1.0.1", test= listOf("com/petstore/1.yaml"), stub= listOf("com/petstore/payment.yaml")),


### PR DESCRIPTION
- Changed the visibility of the version field in the SpecmaticConfig class from public to private.
- Added relevant wrapper methods.
- Updated code references accordingly to maintain functionality.