### PR TITLE
Make DefaultPatternValues Field of Specmatic Config Private

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -126,7 +126,7 @@ data class SpecmaticConfig(
     val additionalExampleParamsFilePath: String? = getStringValue(Flags.ADDITIONAL_EXAMPLE_PARAMS_FILE),
     val attributeSelectionPattern: AttributeSelectionPattern = AttributeSelectionPattern(),
     val allPatternsMandatory: Boolean? = null,
-    val defaultPatternValues: Map<String, Any> = emptyMap(),
+    private val defaultPatternValues: Map<String, Any> = emptyMap(),
     val version: SpecmaticConfigVersion? = null
 ) {
     @JsonIgnore
@@ -182,6 +182,11 @@ data class SpecmaticConfig(
     @JsonIgnore
     fun getAllPatternsMandatory(): Boolean {
         return allPatternsMandatory ?: getBooleanValue(Flags.ALL_PATTERNS_MANDATORY)
+    }
+
+    @JsonIgnore
+    fun getDefaultPatternValues(): Map<String, Any> {
+        return defaultPatternValues
     }
 }
 

--- a/core/src/main/kotlin/io/specmatic/core/config/v2/SpecmaticConfigV2.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v2/SpecmaticConfigV2.kt
@@ -78,7 +78,7 @@ data class SpecmaticConfigV2(
                 additionalExampleParamsFilePath = config.additionalExampleParamsFilePath,
                 attributeSelectionPattern = config.attributeSelectionPattern,
                 allPatternsMandatory = config.allPatternsMandatory,
-                defaultPatternValues = config.defaultPatternValues
+                defaultPatternValues = config.getDefaultPatternValues()
             )
         }
     }


### PR DESCRIPTION
- Changed the visibility of the defaultPatternValues field in the SpecmaticConfig class from public to private.
- Added relevant wrapper methods.
- Updated code references accordingly to maintain functionality.