### PR TITLE
Make AdditionalExampleParamsFilePath Field of Specmatic Config Private

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/ExampleFromFile.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/ExampleFromFile.kt
@@ -1,9 +1,20 @@
 package io.specmatic.conversions
 
-import io.specmatic.core.*
+import io.specmatic.core.HttpRequest
+import io.specmatic.core.HttpResponse
+import io.specmatic.core.NoBodyValue
+import io.specmatic.core.QueryParameters
+import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.examples.server.SchemaExample
 import io.specmatic.core.log.logger
-import io.specmatic.core.pattern.*
+import io.specmatic.core.pattern.HasFailure
+import io.specmatic.core.pattern.HasValue
+import io.specmatic.core.pattern.ResponseExample
+import io.specmatic.core.pattern.ResponseValueExample
+import io.specmatic.core.pattern.ReturnValue
+import io.specmatic.core.pattern.Row
+import io.specmatic.core.pattern.attempt
+import io.specmatic.core.pattern.parsedJSONObject
 import io.specmatic.core.utilities.URIUtils.parseQuery
 import io.specmatic.core.value.EmptyString
 import io.specmatic.core.value.JSONObjectValue
@@ -49,7 +60,7 @@ class ExampleFromFile(val json: JSONObjectValue, val file: File) {
             fileSource = this.file.canonicalPath,
             exactResponseExample = responseExample.takeUnless { this.isPartial() },
             responseExampleForAssertion = response,
-            requestExample = scenarioStub.getRequestWithAdditionalParamsIfAny(specmaticConfig.additionalExampleParamsFilePath),
+            requestExample = scenarioStub.getRequestWithAdditionalParamsIfAny(specmaticConfig.getAdditionalExampleParamsFilePath()),
             responseExample = response.takeUnless { this.isPartial() },
             isPartial = scenarioStub.partial != null
         ).let { ExampleProcessor.resolve(it, ExampleProcessor::ifNotExitsToLookupPattern) }

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -123,7 +123,7 @@ data class SpecmaticConfig(
     val examples: List<String> = getStringValue(EXAMPLE_DIRECTORIES)?.split(",") ?: emptyList(),
     val workflow: WorkflowConfiguration? = null,
     val ignoreInlineExamples: Boolean? = null,
-    val additionalExampleParamsFilePath: String? = getStringValue(Flags.ADDITIONAL_EXAMPLE_PARAMS_FILE),
+    private val additionalExampleParamsFilePath: String? = null,
     val attributeSelectionPattern: AttributeSelectionPattern = AttributeSelectionPattern(),
     val allPatternsMandatory: Boolean? = null,
     val defaultPatternValues: Map<String, Any> = emptyMap(),
@@ -182,6 +182,11 @@ data class SpecmaticConfig(
     @JsonIgnore
     fun getAllPatternsMandatory(): Boolean {
         return allPatternsMandatory ?: getBooleanValue(Flags.ALL_PATTERNS_MANDATORY)
+    }
+
+    @JsonIgnore
+    fun getAdditionalExampleParamsFilePath(): String? {
+        return additionalExampleParamsFilePath ?: getStringValue(Flags.ADDITIONAL_EXAMPLE_PARAMS_FILE)
     }
 }
 

--- a/core/src/main/kotlin/io/specmatic/core/config/v2/SpecmaticConfigV2.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v2/SpecmaticConfigV2.kt
@@ -75,7 +75,7 @@ data class SpecmaticConfigV2(
                 examples = config.examples,
                 workflow = config.workflow,
                 ignoreInlineExamples = config.ignoreInlineExamples,
-                additionalExampleParamsFilePath = config.additionalExampleParamsFilePath,
+                additionalExampleParamsFilePath = config.getAdditionalExampleParamsFilePath(),
                 attributeSelectionPattern = config.attributeSelectionPattern,
                 allPatternsMandatory = config.allPatternsMandatory,
                 defaultPatternValues = config.defaultPatternValues

--- a/core/src/main/kotlin/io/specmatic/test/ExamplePreProcessor.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ExamplePreProcessor.kt
@@ -2,10 +2,21 @@ package io.specmatic.test
 
 import io.ktor.http.*
 import io.ktor.util.*
-import io.specmatic.core.*
-import io.specmatic.core.pattern.*
+import io.specmatic.core.HttpRequest
+import io.specmatic.core.HttpResponse
+import io.specmatic.core.QueryParameters
+import io.specmatic.core.SpecmaticConfig
+import io.specmatic.core.loadSpecmaticConfig
+import io.specmatic.core.pattern.ContractException
+import io.specmatic.core.pattern.Row
+import io.specmatic.core.pattern.parsedJSONObject
+import io.specmatic.core.pattern.parsedValue
 import io.specmatic.core.utilities.exceptionCauseMessage
-import io.specmatic.core.value.*
+import io.specmatic.core.value.JSONArrayValue
+import io.specmatic.core.value.JSONObjectValue
+import io.specmatic.core.value.ScalarValue
+import io.specmatic.core.value.StringValue
+import io.specmatic.core.value.Value
 import io.specmatic.test.asserts.isKeyAssert
 import java.io.File
 
@@ -24,8 +35,8 @@ object ExampleProcessor {
 
     private fun loadConfig(): JSONObjectValue {
         val configFilePath = runCatching {
-            loadSpecmaticConfig().additionalExampleParamsFilePath
-        }.getOrElse { SpecmaticConfig().additionalExampleParamsFilePath } ?: return JSONObjectValue(emptyMap())
+            loadSpecmaticConfig().getAdditionalExampleParamsFilePath()
+        }.getOrElse { SpecmaticConfig().getAdditionalExampleParamsFilePath() } ?: return JSONObjectValue(emptyMap())
 
         val configFile = File(configFilePath)
         if (!configFile.exists()) {


### PR DESCRIPTION
- Changed the visibility of the additionalExampleParamsFilePath field in the SpecmaticConfig class from public to private.
- Added relevant wrapper methods.
- Updated code references accordingly to maintain functionality.