### PR TITLE
Make Auth Field of Specmatic Config Private

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -205,6 +205,11 @@ data class SpecmaticConfig(
     }
 
     @JsonIgnore
+    fun getAuth(): Auth? {
+        return auth
+    }
+
+    @JsonIgnore
     fun getAuthBearerFile(): String? {
         return auth?.getBearerFile()
     }

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -185,8 +185,13 @@ data class SpecmaticConfig(
     }
 
     @JsonIgnore
-    fun getAuth(): Auth? {
-        return auth
+    fun getAuthBearerFile(): String? {
+        return auth?.getBearerFile()
+    }
+
+    @JsonIgnore
+    fun getAuthBearerEnvironmentVariable(): String? {
+        return auth?.getBearerEnvironmentVariable()
     }
 }
 
@@ -225,10 +230,18 @@ data class ResiliencyTestsConfig(
     }
 }
 
-data class Auth(
-    @JsonProperty("bearer-file") val bearerFile: String = "bearer.txt",
-    @JsonProperty("bearer-environment-variable") val bearerEnvironmentVariable: String? = null
-)
+class Auth(
+    @JsonProperty("bearer-file") private val bearerFile: String = "bearer.txt",
+    @JsonProperty("bearer-environment-variable") private val bearerEnvironmentVariable: String? = null
+) {
+    fun getBearerFile(): String {
+        return bearerFile
+    }
+
+    fun getBearerEnvironmentVariable(): String? {
+        return bearerEnvironmentVariable
+    }
+}
 
 enum class PipelineProvider { azure }
 

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -110,7 +110,7 @@ data class AttributeSelectionPattern(
 
 data class SpecmaticConfig(
     val sources: List<Source> = emptyList(),
-    val auth: Auth? = null,
+    private val auth: Auth? = null,
     val pipeline: Pipeline? = null,
     val environments: Map<String, Environment>? = null,
     val hooks: Map<String, String> = emptyMap(),
@@ -182,6 +182,11 @@ data class SpecmaticConfig(
     @JsonIgnore
     fun getAllPatternsMandatory(): Boolean {
         return allPatternsMandatory ?: getBooleanValue(Flags.ALL_PATTERNS_MANDATORY)
+    }
+
+    @JsonIgnore
+    fun getAuth(): Auth? {
+        return auth
     }
 }
 

--- a/core/src/main/kotlin/io/specmatic/core/config/v2/SpecmaticConfigV2.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v2/SpecmaticConfigV2.kt
@@ -62,7 +62,7 @@ data class SpecmaticConfigV2(
             return SpecmaticConfigV2(
                 version = SpecmaticConfigVersion.VERSION_2,
                 contracts = config.sources.map { ContractConfig(it) },
-                auth = config.getAuthBearerFile()?.let { Auth(it, config.getAuthBearerEnvironmentVariable()) },
+                auth = config.getAuth(),
                 pipeline = config.pipeline,
                 environments = config.environments,
                 hooks = config.getHooks(),

--- a/core/src/main/kotlin/io/specmatic/core/config/v2/SpecmaticConfigV2.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v2/SpecmaticConfigV2.kt
@@ -62,7 +62,7 @@ data class SpecmaticConfigV2(
             return SpecmaticConfigV2(
                 version = SpecmaticConfigVersion.VERSION_2,
                 contracts = config.sources.map { ContractConfig(it) },
-                auth = config.auth,
+                auth = config.getAuth(),
                 pipeline = config.pipeline,
                 environments = config.environments,
                 hooks = config.hooks,

--- a/core/src/main/kotlin/io/specmatic/core/config/v2/SpecmaticConfigV2.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v2/SpecmaticConfigV2.kt
@@ -62,7 +62,7 @@ data class SpecmaticConfigV2(
             return SpecmaticConfigV2(
                 version = SpecmaticConfigVersion.VERSION_2,
                 contracts = config.sources.map { ContractConfig(it) },
-                auth = config.getAuth(),
+                auth = config.getAuthBearerFile()?.let { Auth(it, config.getAuthBearerEnvironmentVariable()) },
                 pipeline = config.pipeline,
                 environments = config.environments,
                 hooks = config.hooks,

--- a/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigKtTest.kt
@@ -8,8 +8,8 @@ import io.specmatic.core.utilities.Flags.Companion.MAX_TEST_REQUEST_COMBINATIONS
 import io.specmatic.core.utilities.Flags.Companion.ONLY_POSITIVE
 import io.specmatic.core.utilities.Flags.Companion.SCHEMA_EXAMPLE_DEFAULT
 import io.specmatic.core.utilities.Flags.Companion.SPECMATIC_GENERATIVE_TESTS
-import io.specmatic.core.utilities.Flags.Companion.SPECMATIC_TEST_TIMEOUT
 import io.specmatic.core.utilities.Flags.Companion.SPECMATIC_STUB_DELAY
+import io.specmatic.core.utilities.Flags.Companion.SPECMATIC_TEST_TIMEOUT
 import io.specmatic.core.utilities.Flags.Companion.VALIDATE_RESPONSE_VALUE
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -36,7 +36,7 @@ internal class SpecmaticConfigKtTest {
         assertThat(sources.first().test).isEqualTo(listOf("com/petstore/1.spec"))
         assertThat(sources.first().stub).isEqualTo(listOf("com/petstore/payment.spec"))
 
-        assertThat(config.auth?.bearerFile).isEqualTo("bearer.txt")
+        assertThat(config.getAuth()?.bearerFile).isEqualTo("bearer.txt")
 
         assertThat(config.pipeline?.provider).isEqualTo(PipelineProvider.azure)
         assertThat(config.pipeline?.organization).isEqualTo("xnsio")
@@ -120,7 +120,7 @@ internal class SpecmaticConfigKtTest {
         assertThat(sources.first().test).isEqualTo(listOf("com/petstore/1.yaml"))
         assertThat(sources.first().stub).isEqualTo(listOf("com/petstore/payment.yaml"))
 
-        assertThat(config.auth?.bearerFile).isEqualTo("bearer.txt")
+        assertThat(config.getAuth()?.bearerFile).isEqualTo("bearer.txt")
 
         assertThat(config.pipeline?.provider).isEqualTo(PipelineProvider.azure)
         assertThat(config.pipeline?.organization).isEqualTo("xnsio")

--- a/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigKtTest.kt
@@ -36,7 +36,7 @@ internal class SpecmaticConfigKtTest {
         assertThat(sources.first().test).isEqualTo(listOf("com/petstore/1.spec"))
         assertThat(sources.first().stub).isEqualTo(listOf("com/petstore/payment.spec"))
 
-        assertThat(config.getAuth()?.bearerFile).isEqualTo("bearer.txt")
+        assertThat(config.getAuthBearerFile()).isEqualTo("bearer.txt")
 
         assertThat(config.pipeline?.provider).isEqualTo(PipelineProvider.azure)
         assertThat(config.pipeline?.organization).isEqualTo("xnsio")
@@ -120,7 +120,7 @@ internal class SpecmaticConfigKtTest {
         assertThat(sources.first().test).isEqualTo(listOf("com/petstore/1.yaml"))
         assertThat(sources.first().stub).isEqualTo(listOf("com/petstore/payment.yaml"))
 
-        assertThat(config.getAuth()?.bearerFile).isEqualTo("bearer.txt")
+        assertThat(config.getAuthBearerFile()).isEqualTo("bearer.txt")
 
         assertThat(config.pipeline?.provider).isEqualTo(PipelineProvider.azure)
         assertThat(config.pipeline?.organization).isEqualTo("xnsio")

--- a/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigKtTest.kt
@@ -37,6 +37,7 @@ internal class SpecmaticConfigKtTest {
         assertThat(sources.first().stub).isEqualTo(listOf("com/petstore/payment.spec"))
 
         assertThat(config.getAuthBearerFile()).isEqualTo("bearer.txt")
+        assertThat(config.getAuthBearerEnvironmentVariable()).isNull()
 
         assertThat(config.pipeline?.provider).isEqualTo(PipelineProvider.azure)
         assertThat(config.pipeline?.organization).isEqualTo("xnsio")
@@ -121,6 +122,7 @@ internal class SpecmaticConfigKtTest {
         assertThat(sources.first().stub).isEqualTo(listOf("com/petstore/payment.yaml"))
 
         assertThat(config.getAuthBearerFile()).isEqualTo("bearer.txt")
+        assertThat(config.getAuthBearerEnvironmentVariable()).isNull()
 
         assertThat(config.pipeline?.provider).isEqualTo(PipelineProvider.azure)
         assertThat(config.pipeline?.organization).isEqualTo("xnsio")


### PR DESCRIPTION
- Changed the visibility of the auth field in the SpecmaticConfig class from public to private.
- Added relevant wrapper methods.
- Updated code references accordingly to maintain functionality.