### PR TITLE
Fallback for actuator query failures

### DIFF
--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -142,6 +142,7 @@ open class SpecmaticJUnitSupport {
             val response = httpClient.execute(request)
 
             if (response.status != 200) {
+                logger.log("Failed to query swaggerUI, status code: ${response.status}")
                 return ActuatorSetupResult.Failure
             }
 
@@ -156,11 +157,15 @@ open class SpecmaticJUnitSupport {
 
         fun queryActuator(): ActuatorSetupResult {
             val endpointsAPI: String = Flags.getStringValue(ENDPOINTS_API) ?: return ActuatorSetupResult.Failure
-
             val request = HttpRequest("GET")
             val response = HttpClient(endpointsAPI, log = ignoreLog).execute(request)
-            logger.debug(response.toLogString())
 
+            if (response.status != 200) {
+                logger.log("Failed to query actuator, status code: ${response.status}")
+                return ActuatorSetupResult.Failure
+            }
+
+            logger.debug(response.toLogString())
             openApiCoverageReportInput.setEndpointsAPIFlag(true)
             val endpointData = response.body as JSONObjectValue
             val apis: List<API> = endpointData.getJSONObject("contexts").entries.flatMap { entry ->


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Fallback for actuator query failures

<!-- How were these changes implemented? -->

**How**: If a non-200 response is returned, the actuator should fall back to the next mechanism.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

<!-- feel free to add additional comments -->