### PR TITLE
Make Pipeline Field of Specmatic Config Private

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -130,6 +130,13 @@ data class SpecmaticConfig(
     private val defaultPatternValues: Map<String, Any> = emptyMap(),
     private val version: SpecmaticConfigVersion? = null
 ) {
+    companion object {
+        @JsonIgnore
+        fun getPipeline(specmaticConfig: SpecmaticConfig): Pipeline? {
+            return specmaticConfig.pipeline
+        }
+    }
+
     @JsonIgnore
     fun attributeSelectionQueryParamKey(): String {
         return attributeSelectionPattern.queryParamKey
@@ -217,11 +224,6 @@ data class SpecmaticConfig(
     @JsonIgnore
     fun getAuthBearerEnvironmentVariable(): String? {
         return auth?.getBearerEnvironmentVariable()
-    }
-
-    @JsonIgnore
-    fun getPipeline(): Pipeline? {
-        return pipeline
     }
 
     @JsonIgnore

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -111,7 +111,7 @@ data class AttributeSelectionPattern(
 data class SpecmaticConfig(
     val sources: List<Source> = emptyList(),
     val auth: Auth? = null,
-    val pipeline: Pipeline? = null,
+    private val pipeline: Pipeline? = null,
     val environments: Map<String, Environment>? = null,
     val hooks: Map<String, String> = emptyMap(),
     val repository: RepositoryInfo? = null,
@@ -183,6 +183,26 @@ data class SpecmaticConfig(
     fun getAllPatternsMandatory(): Boolean {
         return allPatternsMandatory ?: getBooleanValue(Flags.ALL_PATTERNS_MANDATORY)
     }
+
+    @JsonIgnore
+    fun getPipelineProvider(): PipelineProvider? {
+        return pipeline?.getProvider()
+    }
+
+    @JsonIgnore
+    fun getPipelineDefinitionId(): Int? {
+        return pipeline?.getDefinitionId()
+    }
+
+    @JsonIgnore
+    fun getPipelineOrganization(): String? {
+        return pipeline?.getOrganization()
+    }
+
+    @JsonIgnore
+    fun getPipelineProject(): String? {
+        return pipeline?.getProject()
+    }
 }
 
 data class TestConfiguration(
@@ -228,11 +248,27 @@ data class Auth(
 enum class PipelineProvider { azure }
 
 data class Pipeline(
-    val provider: PipelineProvider = PipelineProvider.azure,
-    val organization: String = "",
-    val project: String = "",
-    val definitionId: Int = 0
-)
+    private val provider: PipelineProvider = PipelineProvider.azure,
+    private val organization: String = "",
+    private val project: String = "",
+    private val definitionId: Int = 0
+) {
+    fun getProvider(): PipelineProvider {
+        return provider
+    }
+
+    fun getOrganization(): String {
+        return organization
+    }
+
+    fun getProject(): String {
+        return project
+    }
+
+    fun getDefinitionId(): Int {
+        return definitionId
+    }
+}
 
 data class Environment(
     val baseurls: Map<String, String>? = null,

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -185,6 +185,11 @@ data class SpecmaticConfig(
     }
 
     @JsonIgnore
+    fun getPipeline(): Pipeline? {
+        return pipeline
+    }
+
+    @JsonIgnore
     fun getPipelineProvider(): PipelineProvider? {
         return pipeline?.getProvider()
     }

--- a/core/src/main/kotlin/io/specmatic/core/config/v2/SpecmaticConfigV2.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v2/SpecmaticConfigV2.kt
@@ -63,20 +63,7 @@ data class SpecmaticConfigV2(
                 version = SpecmaticConfigVersion.VERSION_2,
                 contracts = config.sources.map { ContractConfig(it) },
                 auth = config.auth,
-                pipeline = config.getPipelineProvider()?.let { provider ->
-                    config.getPipelineOrganization()?.let { organization ->
-                        config.getPipelineProject()?.let { project ->
-                            config.getPipelineDefinitionId()?.let { definitionId ->
-                                Pipeline(
-                                    provider = provider,
-                                    organization = organization,
-                                    project = project,
-                                    definitionId = definitionId
-                                )
-                            }
-                        }
-                    }
-                },
+                pipeline = config.getPipeline(),
                 environments = config.environments,
                 hooks = config.hooks,
                 repository = config.repository,

--- a/core/src/main/kotlin/io/specmatic/core/config/v2/SpecmaticConfigV2.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v2/SpecmaticConfigV2.kt
@@ -63,7 +63,20 @@ data class SpecmaticConfigV2(
                 version = SpecmaticConfigVersion.VERSION_2,
                 contracts = config.sources.map { ContractConfig(it) },
                 auth = config.auth,
-                pipeline = config.pipeline,
+                pipeline = config.getPipelineProvider()?.let { provider ->
+                    config.getPipelineOrganization()?.let { organization ->
+                        config.getPipelineProject()?.let { project ->
+                            config.getPipelineDefinitionId()?.let { definitionId ->
+                                Pipeline(
+                                    provider = provider,
+                                    organization = organization,
+                                    project = project,
+                                    definitionId = definitionId
+                                )
+                            }
+                        }
+                    }
+                },
                 environments = config.environments,
                 hooks = config.hooks,
                 repository = config.repository,

--- a/core/src/main/kotlin/io/specmatic/core/config/v2/SpecmaticConfigV2.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v2/SpecmaticConfigV2.kt
@@ -15,7 +15,7 @@ data class SpecmaticConfigV2(
     val auth: Auth? = null,
     val pipeline: Pipeline? = null,
     val environments: Map<String, Environment>? = null,
-    private val hooks: Map<String, String> = emptyMap(),
+    val hooks: Map<String, String> = emptyMap(),
     val repository: RepositoryInfo? = null,
     val report: ReportConfiguration? = null,
     val security: SecurityConfiguration? = null,

--- a/core/src/main/kotlin/io/specmatic/core/config/v2/SpecmaticConfigV2.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v2/SpecmaticConfigV2.kt
@@ -63,7 +63,7 @@ data class SpecmaticConfigV2(
                 version = SpecmaticConfigVersion.VERSION_2,
                 contracts = config.sources.map { ContractConfig(it) },
                 auth = config.getAuth(),
-                pipeline = config.getPipeline(),
+                pipeline = SpecmaticConfig.getPipeline(config),
                 environments = config.environments,
                 hooks = config.getHooks(),
                 repository = config.repository,

--- a/core/src/main/kotlin/io/specmatic/core/config/v2/SpecmaticConfigV2.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v2/SpecmaticConfigV2.kt
@@ -2,6 +2,7 @@ package io.specmatic.core.config.v2
 
 import com.fasterxml.jackson.annotation.JsonAlias
 import io.specmatic.core.*
+import io.specmatic.core.SpecmaticConfig.Companion.getPipeline
 import io.specmatic.core.config.SpecmaticConfigVersion
 import io.specmatic.core.config.SpecmaticVersionedConfig
 import io.specmatic.core.config.SpecmaticVersionedConfigLoader
@@ -63,7 +64,7 @@ data class SpecmaticConfigV2(
                 version = SpecmaticConfigVersion.VERSION_2,
                 contracts = config.sources.map { ContractConfig(it) },
                 auth = config.getAuth(),
-                pipeline = SpecmaticConfig.getPipeline(config),
+                pipeline = getPipeline(config),
                 environments = config.environments,
                 hooks = config.getHooks(),
                 repository = config.repository,

--- a/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigKtTest.kt
@@ -8,8 +8,8 @@ import io.specmatic.core.utilities.Flags.Companion.MAX_TEST_REQUEST_COMBINATIONS
 import io.specmatic.core.utilities.Flags.Companion.ONLY_POSITIVE
 import io.specmatic.core.utilities.Flags.Companion.SCHEMA_EXAMPLE_DEFAULT
 import io.specmatic.core.utilities.Flags.Companion.SPECMATIC_GENERATIVE_TESTS
-import io.specmatic.core.utilities.Flags.Companion.SPECMATIC_TEST_TIMEOUT
 import io.specmatic.core.utilities.Flags.Companion.SPECMATIC_STUB_DELAY
+import io.specmatic.core.utilities.Flags.Companion.SPECMATIC_TEST_TIMEOUT
 import io.specmatic.core.utilities.Flags.Companion.VALIDATE_RESPONSE_VALUE
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -38,10 +38,10 @@ internal class SpecmaticConfigKtTest {
 
         assertThat(config.auth?.bearerFile).isEqualTo("bearer.txt")
 
-        assertThat(config.pipeline?.provider).isEqualTo(PipelineProvider.azure)
-        assertThat(config.pipeline?.organization).isEqualTo("xnsio")
-        assertThat(config.pipeline?.project).isEqualTo("XNSIO")
-        assertThat(config.pipeline?.definitionId).isEqualTo(1)
+        assertThat(config.getPipelineProvider()).isEqualTo(PipelineProvider.azure)
+        assertThat(config.getPipelineOrganization()).isEqualTo("xnsio")
+        assertThat(config.getPipelineProject()).isEqualTo("XNSIO")
+        assertThat(config.getPipelineDefinitionId()).isEqualTo(1)
 
         assertThat(config.environments?.get("staging")?.baseurls?.get("auth.spec")).isEqualTo("http://localhost:8080")
         assertThat(config.environments?.get("staging")?.variables?.get("username")).isEqualTo("jackie")
@@ -122,10 +122,10 @@ internal class SpecmaticConfigKtTest {
 
         assertThat(config.auth?.bearerFile).isEqualTo("bearer.txt")
 
-        assertThat(config.pipeline?.provider).isEqualTo(PipelineProvider.azure)
-        assertThat(config.pipeline?.organization).isEqualTo("xnsio")
-        assertThat(config.pipeline?.project).isEqualTo("XNSIO")
-        assertThat(config.pipeline?.definitionId).isEqualTo(1)
+        assertThat(config.getPipelineProvider()).isEqualTo(PipelineProvider.azure)
+        assertThat(config.getPipelineOrganization()).isEqualTo("xnsio")
+        assertThat(config.getPipelineProject()).isEqualTo("XNSIO")
+        assertThat(config.getPipelineDefinitionId()).isEqualTo(1)
 
         assertThat(config.environments?.get("staging")?.baseurls?.get("auth.spec")).isEqualTo("http://localhost:8080")
         assertThat(config.environments?.get("staging")?.variables?.get("username")).isEqualTo("jackie")


### PR DESCRIPTION
- Changed the visibility of the pipeline field in the SpecmaticConfig class from public to private.
- Added relevant wrapper methods.
- Updated code references accordingly to maintain functionality.