### PR TITLE
Hide Filters Legacy Command- CLI

### DIFF
--- a/application/src/main/kotlin/application/ExamplesCommand.kt
+++ b/application/src/main/kotlin/application/ExamplesCommand.kt
@@ -45,14 +45,16 @@ class ExamplesCommand : Callable<Int> {
     @Option(
         names = ["--filter-name"],
         description = ["Use only APIs with this value in their name"],
-        defaultValue = "\${env:SPECMATIC_FILTER_NAME}"
+        defaultValue = "\${env:SPECMATIC_FILTER_NAME}",
+        hidden = true
     )
     var filterName: String = ""
 
     @Option(
         names = ["--filter-not-name"],
         description = ["Use only APIs which do not have this value in their name"],
-        defaultValue = "\${env:SPECMATIC_FILTER_NOT_NAME}"
+        defaultValue = "\${env:SPECMATIC_FILTER_NOT_NAME}",
+        hidden = true
     )
     var filterNotName: String = ""
 
@@ -186,14 +188,16 @@ For example, to filter by HTTP methods:
         @Option(
             names = ["--filter-name"],
             description = ["Validate examples of only APIs with this value in their name"],
-            defaultValue = "\${env:SPECMATIC_FILTER_NAME}"
+            defaultValue = "\${env:SPECMATIC_FILTER_NAME}",
+            hidden = true
         )
         var filterName: String = ""
 
         @Option(
             names = ["--filter-not-name"],
             description = ["Validate examples of only APIs which do not have this value in their name"],
-            defaultValue = "\${env:SPECMATIC_FILTER_NOT_NAME}"
+            defaultValue = "\${env:SPECMATIC_FILTER_NOT_NAME}",
+            hidden = true
         )
         var filterNotName: String = ""
 
@@ -423,14 +427,16 @@ For example, to filter by HTTP methods:
         @Option(
             names = ["--filter-name"],
             description = ["Use only APIs with this value in their name"],
-            defaultValue = "\${env:SPECMATIC_FILTER_NAME}"
+            defaultValue = "\${env:SPECMATIC_FILTER_NAME}",
+            hidden = true
         )
         var filterName: String = ""
 
         @Option(
             names = ["--filter-not-name"],
             description = ["Use only APIs which do not have this value in their name"],
-            defaultValue = "\${env:SPECMATIC_FILTER_NOT_NAME}"
+            defaultValue = "\${env:SPECMATIC_FILTER_NOT_NAME}",
+            hidden = true
         )
         var filterNotName: String = ""
 

--- a/application/src/main/kotlin/application/TestCommand.kt
+++ b/application/src/main/kotlin/application/TestCommand.kt
@@ -80,10 +80,10 @@ class TestCommand : Callable<Unit> {
     @Option(names = ["--suggestions"], description = ["A json value with scenario name and multiple suggestions"], defaultValue = "")
     var suggestions: String = ""
 
-    @Option(names = ["--filter-name"], description = ["Run only tests with this value in their name"], defaultValue = "\${env:SPECMATIC_FILTER_NAME}")
+    @Option(names = ["--filter-name"], description = ["Run only tests with this value in their name"], defaultValue = "\${env:SPECMATIC_FILTER_NAME}", hidden = true)
     var filterName: String = ""
 
-    @Option(names = ["--filter-not-name"], description = ["Run only tests which do not have this value in their name"], defaultValue = "\${env:SPECMATIC_FILTER_NOT_NAME}")
+    @Option(names = ["--filter-not-name"], description = ["Run only tests which do not have this value in their name"], defaultValue = "\${env:SPECMATIC_FILTER_NOT_NAME}", hidden = true)
     var filterNotName: String = ""
 
     @Option(


### PR DESCRIPTION
- This PR hides the legacy filter commands `(--filter-name and --filter-not-name)` from the CLI help output, as these commands are planned for deprecation in an upcoming release.

- Existing users can still use the legacy commands for now, but they will be deprecated in the next releases, encouraging users to transition to the new filter system.