### PR TITLE
Fix the issue related to missing branch field while deserializing version 2 of the config

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/config/v2/ContractConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v2/ContractConfig.kt
@@ -98,17 +98,28 @@ class ContractConfigDeserializer : StdDeserializer<ContractConfig>(ContractConfi
 
         val contractSource = when {
             node.has("git") -> {
-                val gitNode = node.get("git")
+                val gitNode = node["git"]
+                val url = gitNode["url"]
+                    .takeIf { it != null && it.asText().isNotBlank() } ?: throw JsonMappingException.from(
+                    parser,
+                    "Git contract source must have 'url' field"
+                )
+                val branch = gitNode["branch"]
                 ContractConfig.GitContractSource(
-                    url = gitNode.get("url").asText(),
-                    branch = gitNode.get("branch").asText()
+                    url = url.asText(),
+                    branch = branch?.asText()
                 )
             }
 
             node.has("filesystem") -> {
-                val filesystemNode = node.get("filesystem")
+                val filesystemNode = node["filesystem"]
+                val directory = filesystemNode["directory"]
+                    .takeIf { it != null && it.asText().isNotBlank() } ?: throw JsonMappingException.from(
+                    parser,
+                    "Filesystem contract source must have 'directory' field"
+                )
                 ContractConfig.FileSystemContractSource(
-                    directory = filesystemNode.get("directory").asText()
+                    directory = directory.asText()
                 )
             }
 
@@ -118,8 +129,8 @@ class ContractConfigDeserializer : StdDeserializer<ContractConfig>(ContractConfi
             )
         }
 
-        val provides = node.get("provides").map { it.asText() }
-        val consumes = node.get("consumes").map { it.asText() }
+        val provides = node["provides"]?.map { it.asText() }
+        val consumes = node["consumes"]?.map { it.asText() }
 
         return ContractConfig(contractSource, provides, consumes)
     }

--- a/core/src/test/kotlin/io/specmatic/core/config/SpecmaticConfigAllTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/SpecmaticConfigAllTest.kt
@@ -204,4 +204,38 @@ internal class SpecmaticConfigAllTest {
         }
         assertThat(exception.message).startsWith("Filesystem contract source must have 'directory' field")
     }
+
+    @Test
+    fun `should deserialize ContractConfig successfully when provides is absent`() {
+        val contractConfigYaml = """
+            git:
+              url: https://contracts
+            consumes:
+              - com/petstore/payment.yaml
+        """.trimIndent()
+
+        val contractConfig = objectMapper.readValue(contractConfigYaml, ContractConfig::class.java)
+
+        assertThat(contractConfig.contractSource).isInstanceOf(GitContractSource::class.java)
+        assertThat((contractConfig.contractSource as GitContractSource).url).isEqualTo("https://contracts")
+        assertThat(contractConfig.provides).isNull()
+        assertThat(contractConfig.consumes).containsOnly("com/petstore/payment.yaml")
+    }
+
+    @Test
+    fun `should deserialize ContractConfig successfully when consumes is absent`() {
+        val contractConfigYaml = """
+            git:
+              url: https://contracts
+            provides:
+              - com/petstore/1.yaml
+        """.trimIndent()
+
+        val contractConfig = objectMapper.readValue(contractConfigYaml, ContractConfig::class.java)
+
+        assertThat(contractConfig.contractSource).isInstanceOf(GitContractSource::class.java)
+        assertThat((contractConfig.contractSource as GitContractSource).url).isEqualTo("https://contracts")
+        assertThat(contractConfig.provides).containsOnly("com/petstore/1.yaml")
+        assertThat(contractConfig.consumes).isNull()
+    }
 }

--- a/core/src/test/kotlin/io/specmatic/core/config/SpecmaticConfigAllTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/SpecmaticConfigAllTest.kt
@@ -1,5 +1,6 @@
 package io.specmatic.core.config
 
+import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
@@ -7,6 +8,8 @@ import io.specmatic.core.Source
 import io.specmatic.core.SourceProvider
 import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.config.v2.ContractConfig
+import io.specmatic.core.config.v2.ContractConfig.FileSystemContractSource
+import io.specmatic.core.config.v2.ContractConfig.GitContractSource
 import io.specmatic.core.config.v2.SpecmaticConfigV2
 import io.specmatic.core.loadSpecmaticConfig
 import io.specmatic.core.pattern.ContractException
@@ -18,7 +21,10 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import java.io.File
 
+
 internal class SpecmaticConfigAllTest {
+    private val objectMapper = ObjectMapper(YAMLFactory()).registerKotlinModule()
+
     @Test
     fun `should return the version from the specmatic config`() {
         val config = """
@@ -88,21 +94,20 @@ internal class SpecmaticConfigAllTest {
     )
     @ParameterizedTest
     fun `should serialize ContractConfig successfully`(configFile: String) {
-        val objectMapper = ObjectMapper(YAMLFactory()).registerKotlinModule()
         val specmaticConfigV2 = objectMapper.readValue(File(configFile).readText(), SpecmaticConfigV2::class.java)
 
         val contracts = specmaticConfigV2.contracts
 
         assertThat(contracts.size).isEqualTo(2)
-        assertThat(contracts[0].contractSource).isInstanceOf(ContractConfig.GitContractSource::class.java)
-        val gitContractSource = contracts[0].contractSource as ContractConfig.GitContractSource
+        assertThat(contracts[0].contractSource).isInstanceOf(GitContractSource::class.java)
+        val gitContractSource = contracts[0].contractSource as GitContractSource
         assertThat(gitContractSource.url).isEqualTo("https://contracts")
         assertThat(gitContractSource.branch).isEqualTo("1.0.1")
         assertThat(contracts[0].provides).containsOnly("com/petstore/1.yaml")
         assertThat(contracts[0].consumes).containsOnly("com/petstore/payment.yaml")
 
-        assertThat(contracts[1].contractSource).isInstanceOf(ContractConfig.FileSystemContractSource::class.java)
-        val fileSystemContractSource = contracts[1].contractSource as ContractConfig.FileSystemContractSource
+        assertThat(contracts[1].contractSource).isInstanceOf(FileSystemContractSource::class.java)
+        val fileSystemContractSource = contracts[1].contractSource as FileSystemContractSource
         assertThat(fileSystemContractSource.directory).isEqualTo("contracts")
         assertThat(contracts[1].provides).containsOnly("com/petstore/1.yaml")
         assertThat(contracts[1].consumes).containsOnly("com/petstore/payment.yaml", "com/petstore/order.yaml")
@@ -130,12 +135,12 @@ internal class SpecmaticConfigAllTest {
 
         val contracts = listOf(
             ContractConfig(
-                contractSource = ContractConfig.GitContractSource(url = "https://contracts", branch = "1.0.1"),
+                contractSource = GitContractSource(url = "https://contracts", branch = "1.0.1"),
                 provides = listOf("com/petstore/1.yaml"),
                 consumes = listOf("com/petstore/payment.yaml")
             ),
             ContractConfig(
-                contractSource = ContractConfig.FileSystemContractSource(directory = "contracts"),
+                contractSource = FileSystemContractSource(directory = "contracts"),
                 provides = listOf("com/petstore/1.yaml"),
                 consumes = listOf("com/petstore/payment.yaml", "com/petstore/order.yaml")
             )
@@ -145,5 +150,58 @@ internal class SpecmaticConfigAllTest {
         val contractsJson = objectMapper.writeValueAsString(contracts)
 
         assertThat(parsedJSON(contractsJson)).isEqualTo(parsedJSON(expectedContractsJson))
+    }
+
+    @Test
+    fun `should deserialize ContractConfig successfully when branch field is absent`() {
+        val contractConfigYaml = """
+            git:
+              url: https://contracts
+            provides:
+              - com/petstore/1.yaml
+            consumes:
+              - com/petstore/payment.yaml
+        """.trimIndent()
+
+        val contractConfig = objectMapper.readValue(contractConfigYaml, ContractConfig::class.java)
+
+        assertThat(contractConfig.contractSource).isInstanceOf(GitContractSource::class.java)
+        assertThat((contractConfig.contractSource as GitContractSource).url).isEqualTo("https://contracts")
+        assertThat(contractConfig.provides).containsOnly("com/petstore/1.yaml")
+        assertThat(contractConfig.consumes).containsOnly("com/petstore/payment.yaml")
+    }
+
+    @Test
+    fun `should throw JsonMappingException when Git URL is absent in the Contract`() {
+        val contractConfigYaml = """
+            git:
+              branch: 1.0.1
+            provides:
+              - com/petstore/1.yaml
+            consumes:
+              - com/petstore/payment.yaml
+        """.trimIndent()
+
+        val exception = assertThrows<JsonMappingException> {
+            objectMapper.readValue(contractConfigYaml, ContractConfig::class.java)
+        }
+        assertThat(exception.message).startsWith("Git contract source must have 'url' field")
+    }
+
+    @Test
+    fun `should throw JsonMappingException when Filesystem Directory is empty in the Contract`() {
+        val contractConfigYaml = """
+            filesystem:
+                directory: ""
+            provides:
+              - com/petstore/1.yaml
+            consumes:
+              - com/petstore/payment.yaml
+        """.trimIndent()
+
+        val exception = assertThrows<JsonMappingException> {
+            objectMapper.readValue(contractConfigYaml, ContractConfig::class.java)
+        }
+        assertThat(exception.message).startsWith("Filesystem contract source must have 'directory' field")
     }
 }


### PR DESCRIPTION
When the branch was missing, certain functionality would throw an exception, effectively making the branch mandatory despite it being optional in the config code. This bug has been fixed in this PR.