### PR TITLE
Fix Stub not accepting extra fields when extensible schema is set

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -211,7 +211,12 @@ data class Feature(
         mismatchMessages: MismatchMessages = DefaultMismatchMessages
     ): Pair<ResponseBuilder?, Results> {
         try {
-            val resultList = matchingScenarioToResultList(httpRequest, serverState, mismatchMessages)
+            val resultList = matchingScenarioToResultList(
+                httpRequest = httpRequest,
+                serverState = serverState,
+                mismatchMessages = mismatchMessages,
+                unexpectedKeyCheck = flagsBased.unexpectedKeyCheck ?: ValidateUnexpectedKeys
+            )
 
             return matchingScenario(resultList)?.let {
                 Pair(ResponseBuilder(it, serverState), Results())


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Fix Stub not accepting extra fields when extensible schema is set

<!-- Why are these changes necessary? -->

**Why**: On random response generation, the stub responds with a bad request when additional fields are included in the request, even if the extensible schema is enabled.

<!-- How were these changes implemented? -->

**How**: Update the unexpectedKeyCheck based on Feature.flagBased

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

<!-- feel free to add additional comments -->
