### PR TITLE
Make Report Field of Specmatic Config Private

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -187,7 +187,7 @@ data class SpecmaticConfig(
     val environments: Map<String, Environment>? = null,
     private val hooks: Map<String, String> = emptyMap(),
     private val repository: RepositoryInfo? = null,
-    val report: ReportConfigurationDetails? = null,
+    private val report: ReportConfigurationDetails? = null,
     private val security: SecurityConfiguration? = null,
     private val test: TestConfiguration? = TestConfiguration(),
     private val stub: StubConfiguration = StubConfiguration(),
@@ -202,6 +202,10 @@ data class SpecmaticConfig(
     private val version: SpecmaticConfigVersion? = null
 ) {
     companion object {
+        fun getReport(specmaticConfig: SpecmaticConfig): ReportConfigurationDetails? {
+            return specmaticConfig.report
+        }
+
         @JsonIgnore
         fun getSources(specmaticConfig: SpecmaticConfig): List<Source> {
             return specmaticConfig.sources
@@ -524,6 +528,11 @@ data class SpecmaticConfig(
     @JsonIgnore
     private fun String.canonicalPath(relativeTo: File): String {
         return relativeTo.parentFile?.resolve(this)?.canonicalPath ?: File(this).canonicalPath
+    }
+
+    fun updateReportConfiguration(reportConfiguration: ReportConfiguration): SpecmaticConfig {
+        val reportConfigurationDetails = reportConfiguration as? ReportConfigurationDetails ?: return this
+        return this.copy(report = reportConfigurationDetails)
     }
 }
 

--- a/core/src/main/kotlin/io/specmatic/core/config/v1/SpecmaticConfigV1.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v1/SpecmaticConfigV1.kt
@@ -17,7 +17,7 @@ data class SpecmaticConfigV1 (
 	val environments: Map<String, Environment>? = null,
 	val hooks: Map<String, String> = emptyMap(),
 	val repository: RepositoryInfo? = null,
-	val report: ReportConfiguration? = null,
+	val report: ReportConfigurationDetails? = null,
 	val security: SecurityConfiguration? = null,
 	val test: TestConfiguration? = TestConfiguration(),
 	val stub: StubConfiguration = StubConfiguration(),

--- a/core/src/main/kotlin/io/specmatic/core/config/v2/SpecmaticConfigV2.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v2/SpecmaticConfigV2.kt
@@ -76,7 +76,7 @@ data class SpecmaticConfigV2(
                 environments = config.environments,
                 hooks = config.getHooks(),
                 repository = getRepository(config),
-                report = config.report,
+                report = SpecmaticConfig.getReport(config),
                 security = getSecurityConfiguration(config),
                 test = getTestConfiguration(config),
                 stub = getStubConfiguration(config),

--- a/core/src/main/kotlin/io/specmatic/core/config/v2/SpecmaticConfigV2.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v2/SpecmaticConfigV2.kt
@@ -26,7 +26,7 @@ data class SpecmaticConfigV2(
     val environments: Map<String, Environment>? = null,
     val hooks: Map<String, String> = emptyMap(),
     val repository: RepositoryInfo? = null,
-    val report: ReportConfiguration? = null,
+    val report: ReportConfigurationDetails? = null,
     val security: SecurityConfiguration? = null,
     val test: TestConfiguration? = TestConfiguration(),
     val stub: StubConfiguration = StubConfiguration(),

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3.kt
@@ -70,7 +70,7 @@ data class SpecmaticConfigV3(
                 environments = config.environments,
                 hooks = config.getHooks(),
                 repository = getRepository(config),
-                report = config.report,
+                report = SpecmaticConfig.getReport(config),
                 security = getSecurityConfiguration(config),
                 test = SpecmaticConfig.getTestConfiguration(config),
                 stub = SpecmaticConfig.getStubConfiguration(config),

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3.kt
@@ -20,7 +20,7 @@ data class SpecmaticConfigV3(
     val environments: Map<String, Environment>? = null,
     val hooks: Map<String, String> = emptyMap(),
     val repository: RepositoryInfo? = null,
-    val report: ReportConfiguration? = null,
+    val report: ReportConfigurationDetails? = null,
     val security: SecurityConfiguration? = null,
     val test: TestConfiguration? = TestConfiguration(),
     val stub: StubConfiguration = StubConfiguration(),

--- a/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigKtTest.kt
@@ -51,13 +51,13 @@ internal class SpecmaticConfigKtTest {
         assertThat(config.environments?.get("staging")?.variables?.get("username")).isEqualTo("jackie")
         assertThat(config.environments?.get("staging")?.variables?.get("password")).isEqualTo("PaSsWoRd")
 
-        assertThat(ReportConfiguration.getFormatters(config.report)?.get(0)?.type).isEqualTo(ReportFormatterType.TEXT)
-        assertThat(ReportConfiguration.getFormatters(config.report)?.get(0)?.layout).isEqualTo(ReportFormatterLayout.TABLE)
-        assertThat(ReportConfiguration.getTypes(config.report)?.apiCoverage?.openAPI?.successCriteria?.minThresholdPercentage).isEqualTo(70)
-        assertThat(ReportConfiguration.getTypes(config.report)?.apiCoverage?.openAPI?.successCriteria?.maxMissedEndpointsInSpec).isEqualTo(3)
-        assertThat(ReportConfiguration.getTypes(config.report)?.apiCoverage?.openAPI?.successCriteria?.enforce).isTrue()
-        assertThat(ReportConfiguration.getTypes(config.report)?.apiCoverage?.openAPI?.excludedEndpoints?.get(0)).isEqualTo("/heartbeat")
-        assertThat(ReportConfiguration.getTypes(config.report)?.apiCoverage?.openAPI?.excludedEndpoints?.get(1)).isEqualTo("/health")
+        assertThat(ReportConfigurationDetails.getFormatters(config.report)?.get(0)?.type).isEqualTo(ReportFormatterType.TEXT)
+        assertThat(ReportConfigurationDetails.getFormatters(config.report)?.get(0)?.layout).isEqualTo(ReportFormatterLayout.TABLE)
+        assertThat(ReportConfigurationDetails.getTypes(config.report)?.apiCoverage?.openAPI?.successCriteria?.minThresholdPercentage).isEqualTo(70)
+        assertThat(ReportConfigurationDetails.getTypes(config.report)?.apiCoverage?.openAPI?.successCriteria?.maxMissedEndpointsInSpec).isEqualTo(3)
+        assertThat(ReportConfigurationDetails.getTypes(config.report)?.apiCoverage?.openAPI?.successCriteria?.enforce).isTrue()
+        assertThat(ReportConfigurationDetails.getTypes(config.report)?.apiCoverage?.openAPI?.excludedEndpoints?.get(0)).isEqualTo("/heartbeat")
+        assertThat(ReportConfigurationDetails.getTypes(config.report)?.apiCoverage?.openAPI?.excludedEndpoints?.get(1)).isEqualTo("/health")
 
         assertThat(
             (config.getOpenAPISecurityConfigurationScheme("oAuth2AuthCode") as OAuth2SecuritySchemeConfiguration).token
@@ -85,7 +85,7 @@ internal class SpecmaticConfigKtTest {
         assertThat(config.getStubDelayInMilliseconds()).isEqualTo(1000L)
         assertThat(config.getStubGenerative()).isEqualTo(false)
 
-        val htmlConfig = ReportConfiguration.getFormatters(config.report)?.first { it.type == ReportFormatterType.HTML }
+        val htmlConfig = ReportConfigurationDetails.getFormatters(config.report)?.first { it.type == ReportFormatterType.HTML }
         assertThat(htmlConfig?.title).isEqualTo("Test Report")
         assertThat(htmlConfig?.heading).isEqualTo("Test Results")
         assertThat(htmlConfig?.outputDirectory).isEqualTo("output")
@@ -145,13 +145,13 @@ internal class SpecmaticConfigKtTest {
         assertThat(config.environments?.get("staging")?.variables?.get("username")).isEqualTo("jackie")
         assertThat(config.environments?.get("staging")?.variables?.get("password")).isEqualTo("PaSsWoRd")
 
-        assertThat(ReportConfiguration.getFormatters(config.report)?.get(0)?.type).isEqualTo(ReportFormatterType.TEXT)
-        assertThat(ReportConfiguration.getFormatters(config.report)?.get(0)?.layout).isEqualTo(ReportFormatterLayout.TABLE)
-        assertThat(ReportConfiguration.getTypes(config.report)?.apiCoverage?.openAPI?.successCriteria?.minThresholdPercentage).isEqualTo(70)
-        assertThat(ReportConfiguration.getTypes(config.report)?.apiCoverage?.openAPI?.successCriteria?.maxMissedEndpointsInSpec).isEqualTo(3)
-        assertThat(ReportConfiguration.getTypes(config.report)?.apiCoverage?.openAPI?.successCriteria?.enforce).isTrue()
-        assertThat(ReportConfiguration.getTypes(config.report)?.apiCoverage?.openAPI?.excludedEndpoints?.get(0)).isEqualTo("/heartbeat")
-        assertThat(ReportConfiguration.getTypes(config.report)?.apiCoverage?.openAPI?.excludedEndpoints?.get(1)).isEqualTo("/health")
+        assertThat(ReportConfigurationDetails.getFormatters(config.report)?.get(0)?.type).isEqualTo(ReportFormatterType.TEXT)
+        assertThat(ReportConfigurationDetails.getFormatters(config.report)?.get(0)?.layout).isEqualTo(ReportFormatterLayout.TABLE)
+        assertThat(ReportConfigurationDetails.getTypes(config.report)?.apiCoverage?.openAPI?.successCriteria?.minThresholdPercentage).isEqualTo(70)
+        assertThat(ReportConfigurationDetails.getTypes(config.report)?.apiCoverage?.openAPI?.successCriteria?.maxMissedEndpointsInSpec).isEqualTo(3)
+        assertThat(ReportConfigurationDetails.getTypes(config.report)?.apiCoverage?.openAPI?.successCriteria?.enforce).isTrue()
+        assertThat(ReportConfigurationDetails.getTypes(config.report)?.apiCoverage?.openAPI?.excludedEndpoints?.get(0)).isEqualTo("/heartbeat")
+        assertThat(ReportConfigurationDetails.getTypes(config.report)?.apiCoverage?.openAPI?.excludedEndpoints?.get(1)).isEqualTo("/health")
 
         assertThat(
             (config.getOpenAPISecurityConfigurationScheme("oAuth2AuthCode") as OAuth2SecuritySchemeConfiguration).token

--- a/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigKtTest.kt
@@ -51,13 +51,13 @@ internal class SpecmaticConfigKtTest {
         assertThat(config.environments?.get("staging")?.variables?.get("username")).isEqualTo("jackie")
         assertThat(config.environments?.get("staging")?.variables?.get("password")).isEqualTo("PaSsWoRd")
 
-        assertThat(config.report?.formatters?.get(0)?.type).isEqualTo(ReportFormatterType.TEXT)
-        assertThat(config.report?.formatters?.get(0)?.layout).isEqualTo(ReportFormatterLayout.TABLE)
-        assertThat(config.report?.types?.apiCoverage?.openAPI?.successCriteria?.minThresholdPercentage).isEqualTo(70)
-        assertThat(config.report?.types?.apiCoverage?.openAPI?.successCriteria?.maxMissedEndpointsInSpec).isEqualTo(3)
-        assertThat(config.report?.types?.apiCoverage?.openAPI?.successCriteria?.enforce).isTrue()
-        assertThat(config.report?.types?.apiCoverage?.openAPI?.excludedEndpoints?.get(0)).isEqualTo("/heartbeat")
-        assertThat(config.report?.types?.apiCoverage?.openAPI?.excludedEndpoints?.get(1)).isEqualTo("/health")
+        assertThat(ReportConfiguration.getFormatters(config.report)?.get(0)?.type).isEqualTo(ReportFormatterType.TEXT)
+        assertThat(ReportConfiguration.getFormatters(config.report)?.get(0)?.layout).isEqualTo(ReportFormatterLayout.TABLE)
+        assertThat(ReportConfiguration.getTypes(config.report)?.apiCoverage?.openAPI?.successCriteria?.minThresholdPercentage).isEqualTo(70)
+        assertThat(ReportConfiguration.getTypes(config.report)?.apiCoverage?.openAPI?.successCriteria?.maxMissedEndpointsInSpec).isEqualTo(3)
+        assertThat(ReportConfiguration.getTypes(config.report)?.apiCoverage?.openAPI?.successCriteria?.enforce).isTrue()
+        assertThat(ReportConfiguration.getTypes(config.report)?.apiCoverage?.openAPI?.excludedEndpoints?.get(0)).isEqualTo("/heartbeat")
+        assertThat(ReportConfiguration.getTypes(config.report)?.apiCoverage?.openAPI?.excludedEndpoints?.get(1)).isEqualTo("/health")
 
         assertThat(
             (config.getOpenAPISecurityConfigurationScheme("oAuth2AuthCode") as OAuth2SecuritySchemeConfiguration).token
@@ -85,7 +85,7 @@ internal class SpecmaticConfigKtTest {
         assertThat(config.getStubDelayInMilliseconds()).isEqualTo(1000L)
         assertThat(config.getStubGenerative()).isEqualTo(false)
 
-        val htmlConfig = config.report?.formatters?.first { it.type == ReportFormatterType.HTML }
+        val htmlConfig = ReportConfiguration.getFormatters(config.report)?.first { it.type == ReportFormatterType.HTML }
         assertThat(htmlConfig?.title).isEqualTo("Test Report")
         assertThat(htmlConfig?.heading).isEqualTo("Test Results")
         assertThat(htmlConfig?.outputDirectory).isEqualTo("output")
@@ -145,13 +145,13 @@ internal class SpecmaticConfigKtTest {
         assertThat(config.environments?.get("staging")?.variables?.get("username")).isEqualTo("jackie")
         assertThat(config.environments?.get("staging")?.variables?.get("password")).isEqualTo("PaSsWoRd")
 
-        assertThat(config.report?.formatters?.get(0)?.type).isEqualTo(ReportFormatterType.TEXT)
-        assertThat(config.report?.formatters?.get(0)?.layout).isEqualTo(ReportFormatterLayout.TABLE)
-        assertThat(config.report?.types?.apiCoverage?.openAPI?.successCriteria?.minThresholdPercentage).isEqualTo(70)
-        assertThat(config.report?.types?.apiCoverage?.openAPI?.successCriteria?.maxMissedEndpointsInSpec).isEqualTo(3)
-        assertThat(config.report?.types?.apiCoverage?.openAPI?.successCriteria?.enforce).isTrue()
-        assertThat(config.report?.types?.apiCoverage?.openAPI?.excludedEndpoints?.get(0)).isEqualTo("/heartbeat")
-        assertThat(config.report?.types?.apiCoverage?.openAPI?.excludedEndpoints?.get(1)).isEqualTo("/health")
+        assertThat(ReportConfiguration.getFormatters(config.report)?.get(0)?.type).isEqualTo(ReportFormatterType.TEXT)
+        assertThat(ReportConfiguration.getFormatters(config.report)?.get(0)?.layout).isEqualTo(ReportFormatterLayout.TABLE)
+        assertThat(ReportConfiguration.getTypes(config.report)?.apiCoverage?.openAPI?.successCriteria?.minThresholdPercentage).isEqualTo(70)
+        assertThat(ReportConfiguration.getTypes(config.report)?.apiCoverage?.openAPI?.successCriteria?.maxMissedEndpointsInSpec).isEqualTo(3)
+        assertThat(ReportConfiguration.getTypes(config.report)?.apiCoverage?.openAPI?.successCriteria?.enforce).isTrue()
+        assertThat(ReportConfiguration.getTypes(config.report)?.apiCoverage?.openAPI?.excludedEndpoints?.get(0)).isEqualTo("/heartbeat")
+        assertThat(ReportConfiguration.getTypes(config.report)?.apiCoverage?.openAPI?.excludedEndpoints?.get(1)).isEqualTo("/health")
 
         assertThat(
             (config.getOpenAPISecurityConfigurationScheme("oAuth2AuthCode") as OAuth2SecuritySchemeConfiguration).token

--- a/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigKtTest.kt
@@ -51,13 +51,13 @@ internal class SpecmaticConfigKtTest {
         assertThat(config.environments?.get("staging")?.variables?.get("username")).isEqualTo("jackie")
         assertThat(config.environments?.get("staging")?.variables?.get("password")).isEqualTo("PaSsWoRd")
 
-        assertThat(ReportConfigurationDetails.getFormatters(config.report)?.get(0)?.type).isEqualTo(ReportFormatterType.TEXT)
-        assertThat(ReportConfigurationDetails.getFormatters(config.report)?.get(0)?.layout).isEqualTo(ReportFormatterLayout.TABLE)
-        assertThat(ReportConfigurationDetails.getTypes(config.report)?.apiCoverage?.openAPI?.successCriteria?.minThresholdPercentage).isEqualTo(70)
-        assertThat(ReportConfigurationDetails.getTypes(config.report)?.apiCoverage?.openAPI?.successCriteria?.maxMissedEndpointsInSpec).isEqualTo(3)
-        assertThat(ReportConfigurationDetails.getTypes(config.report)?.apiCoverage?.openAPI?.successCriteria?.enforce).isTrue()
-        assertThat(ReportConfigurationDetails.getTypes(config.report)?.apiCoverage?.openAPI?.excludedEndpoints?.get(0)).isEqualTo("/heartbeat")
-        assertThat(ReportConfigurationDetails.getTypes(config.report)?.apiCoverage?.openAPI?.excludedEndpoints?.get(1)).isEqualTo("/health")
+        assertThat(ReportConfigurationDetails.getFormatters(SpecmaticConfig.getReport(config))?.get(0)?.type).isEqualTo(ReportFormatterType.TEXT)
+        assertThat(ReportConfigurationDetails.getFormatters(SpecmaticConfig.getReport(config))?.get(0)?.layout).isEqualTo(ReportFormatterLayout.TABLE)
+        assertThat(ReportConfigurationDetails.getTypes(SpecmaticConfig.getReport(config))?.apiCoverage?.openAPI?.successCriteria?.minThresholdPercentage).isEqualTo(70)
+        assertThat(ReportConfigurationDetails.getTypes(SpecmaticConfig.getReport(config))?.apiCoverage?.openAPI?.successCriteria?.maxMissedEndpointsInSpec).isEqualTo(3)
+        assertThat(ReportConfigurationDetails.getTypes(SpecmaticConfig.getReport(config))?.apiCoverage?.openAPI?.successCriteria?.enforce).isTrue()
+        assertThat(ReportConfigurationDetails.getTypes(SpecmaticConfig.getReport(config))?.apiCoverage?.openAPI?.excludedEndpoints?.get(0)).isEqualTo("/heartbeat")
+        assertThat(ReportConfigurationDetails.getTypes(SpecmaticConfig.getReport(config))?.apiCoverage?.openAPI?.excludedEndpoints?.get(1)).isEqualTo("/health")
 
         assertThat(
             (config.getOpenAPISecurityConfigurationScheme("oAuth2AuthCode") as OAuth2SecuritySchemeConfiguration).token
@@ -85,7 +85,7 @@ internal class SpecmaticConfigKtTest {
         assertThat(config.getStubDelayInMilliseconds()).isEqualTo(1000L)
         assertThat(config.getStubGenerative()).isEqualTo(false)
 
-        val htmlConfig = ReportConfigurationDetails.getFormatters(config.report)?.first { it.type == ReportFormatterType.HTML }
+        val htmlConfig = ReportConfigurationDetails.getFormatters(SpecmaticConfig.getReport(config))?.first { it.type == ReportFormatterType.HTML }
         assertThat(htmlConfig?.title).isEqualTo("Test Report")
         assertThat(htmlConfig?.heading).isEqualTo("Test Results")
         assertThat(htmlConfig?.outputDirectory).isEqualTo("output")
@@ -145,13 +145,13 @@ internal class SpecmaticConfigKtTest {
         assertThat(config.environments?.get("staging")?.variables?.get("username")).isEqualTo("jackie")
         assertThat(config.environments?.get("staging")?.variables?.get("password")).isEqualTo("PaSsWoRd")
 
-        assertThat(ReportConfigurationDetails.getFormatters(config.report)?.get(0)?.type).isEqualTo(ReportFormatterType.TEXT)
-        assertThat(ReportConfigurationDetails.getFormatters(config.report)?.get(0)?.layout).isEqualTo(ReportFormatterLayout.TABLE)
-        assertThat(ReportConfigurationDetails.getTypes(config.report)?.apiCoverage?.openAPI?.successCriteria?.minThresholdPercentage).isEqualTo(70)
-        assertThat(ReportConfigurationDetails.getTypes(config.report)?.apiCoverage?.openAPI?.successCriteria?.maxMissedEndpointsInSpec).isEqualTo(3)
-        assertThat(ReportConfigurationDetails.getTypes(config.report)?.apiCoverage?.openAPI?.successCriteria?.enforce).isTrue()
-        assertThat(ReportConfigurationDetails.getTypes(config.report)?.apiCoverage?.openAPI?.excludedEndpoints?.get(0)).isEqualTo("/heartbeat")
-        assertThat(ReportConfigurationDetails.getTypes(config.report)?.apiCoverage?.openAPI?.excludedEndpoints?.get(1)).isEqualTo("/health")
+        assertThat(ReportConfigurationDetails.getFormatters(SpecmaticConfig.getReport(config))?.get(0)?.type).isEqualTo(ReportFormatterType.TEXT)
+        assertThat(ReportConfigurationDetails.getFormatters(SpecmaticConfig.getReport(config))?.get(0)?.layout).isEqualTo(ReportFormatterLayout.TABLE)
+        assertThat(ReportConfigurationDetails.getTypes(SpecmaticConfig.getReport(config))?.apiCoverage?.openAPI?.successCriteria?.minThresholdPercentage).isEqualTo(70)
+        assertThat(ReportConfigurationDetails.getTypes(SpecmaticConfig.getReport(config))?.apiCoverage?.openAPI?.successCriteria?.maxMissedEndpointsInSpec).isEqualTo(3)
+        assertThat(ReportConfigurationDetails.getTypes(SpecmaticConfig.getReport(config))?.apiCoverage?.openAPI?.successCriteria?.enforce).isTrue()
+        assertThat(ReportConfigurationDetails.getTypes(SpecmaticConfig.getReport(config))?.apiCoverage?.openAPI?.excludedEndpoints?.get(0)).isEqualTo("/heartbeat")
+        assertThat(ReportConfigurationDetails.getTypes(SpecmaticConfig.getReport(config))?.apiCoverage?.openAPI?.excludedEndpoints?.get(1)).isEqualTo("/health")
 
         assertThat(
             (config.getOpenAPISecurityConfigurationScheme("oAuth2AuthCode") as OAuth2SecuritySchemeConfiguration).token

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -100,12 +100,12 @@ open class SpecmaticJUnitSupport {
             }
         }
 
-        private fun getReportConfiguration(): ReportConfiguration {
+        private fun getReportConfiguration(): ReportConfigurationDetails {
             val reportConfiguration = specmaticConfig?.report
 
             if (reportConfiguration == null) {
                 logger.log("Could not load report configuration, coverage will be calculated but no coverage threshold will be enforced")
-                return ReportConfiguration.default
+                return ReportConfigurationDetails.default
             }
 
             return reportConfiguration.withDefaultFormattersIfMissing()

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -101,30 +101,14 @@ open class SpecmaticJUnitSupport {
         }
 
         private fun getReportConfiguration(): ReportConfiguration {
-            return when (val reportConfiguration = specmaticConfig?.report) {
-                null -> {
-                    logger.log("Could not load report configuration, coverage will be calculated but no coverage threshold will be enforced")
-                    ReportConfiguration(
-                        formatters = listOf(
-                            ReportFormatter(ReportFormatterType.TEXT, ReportFormatterLayout.TABLE),
-                            ReportFormatter(ReportFormatterType.HTML)
-                        ), types = ReportTypes()
-                    )
-                }
+            val reportConfiguration = specmaticConfig?.report
 
-                else -> {
-                    val htmlReportFormatter = reportConfiguration.formatters?.firstOrNull {
-                        it.type == ReportFormatterType.HTML
-                    } ?: ReportFormatter(ReportFormatterType.HTML)
-                    val textReportFormatter = reportConfiguration.formatters?.firstOrNull {
-                        it.type == ReportFormatterType.TEXT
-                    } ?: ReportFormatter(ReportFormatterType.TEXT)
-                    ReportConfiguration(
-                        formatters = listOf(htmlReportFormatter, textReportFormatter),
-                        types = reportConfiguration.types
-                    )
-                }
+            if (reportConfiguration == null) {
+                logger.log("Could not load report configuration, coverage will be calculated but no coverage threshold will be enforced")
+                return ReportConfiguration.default
             }
+
+            return reportConfiguration.withDefaultFormattersIfMissing()
         }
 
         enum class ActuatorSetupResult(val failed: Boolean) {

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -88,7 +88,7 @@ open class SpecmaticJUnitSupport {
         fun report() {
             val reportProcessors = listOf(OpenApiCoverageReportProcessor(openApiCoverageReportInput))
             val reportConfiguration = getReportConfiguration()
-            val config = specmaticConfig?.copy(report = reportConfiguration) ?: SpecmaticConfig(report = reportConfiguration)
+            val config = specmaticConfig?.updateReportConfiguration(reportConfiguration) ?: SpecmaticConfig().updateReportConfiguration(reportConfiguration)
 
             reportProcessors.forEach { it.process(config) }
 
@@ -100,8 +100,8 @@ open class SpecmaticJUnitSupport {
             }
         }
 
-        private fun getReportConfiguration(): ReportConfigurationDetails {
-            val reportConfiguration = specmaticConfig?.report
+        private fun getReportConfiguration(): ReportConfiguration {
+            val reportConfiguration = specmaticConfig?.getReport()
 
             if (reportConfiguration == null) {
                 logger.log("Could not load report configuration, coverage will be calculated but no coverage threshold will be enforced")

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/OpenApiCoverageReportProcessor.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/OpenApiCoverageReportProcessor.kt
@@ -1,5 +1,6 @@
 package io.specmatic.test.reports
 
+import io.specmatic.core.ReportConfiguration
 import io.specmatic.core.ReportConfigurationDetails
 import io.specmatic.core.ReportFormatterType
 import io.specmatic.core.SpecmaticConfig
@@ -22,7 +23,7 @@ class OpenApiCoverageReportProcessor (private val openApiCoverageReportInput: Op
     }
 
     override fun process(specmaticConfig: SpecmaticConfig) {
-        val reportConfiguration = specmaticConfig.report!!
+        val reportConfiguration = specmaticConfig.getReport()!!
 
         openApiCoverageReportInput.addExcludedAPIs(reportConfiguration.excludedOpenAPIEndpoints() + excludedEndpointsFromEnv())
         val openAPICoverageReport = openApiCoverageReportInput.generate()
@@ -39,7 +40,7 @@ class OpenApiCoverageReportProcessor (private val openApiCoverageReportInput: Op
         assertSuccessCriteria(reportConfiguration, openAPICoverageReport)
     }
 
-    override fun configureReportRenderers(reportConfiguration: ReportConfigurationDetails): List<ReportRenderer<OpenAPICoverageConsoleReport>> {
+    override fun configureReportRenderers(reportConfiguration: ReportConfiguration): List<ReportRenderer<OpenAPICoverageConsoleReport>> {
         return reportConfiguration.mapRenderers { formatterType: ReportFormatterType ->
             when (formatterType) {
                 ReportFormatterType.TEXT -> CoverageReportTextRenderer()
@@ -66,7 +67,7 @@ class OpenApiCoverageReportProcessor (private val openApiCoverageReportInput: Op
     }
 
     override fun assertSuccessCriteria(
-        reportConfiguration: ReportConfigurationDetails,
+        reportConfiguration: ReportConfiguration,
         report: OpenAPICoverageConsoleReport
     ) {
         val successCriteria = reportConfiguration.getSuccessCriteria()

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/OpenApiCoverageReportProcessor.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/OpenApiCoverageReportProcessor.kt
@@ -1,6 +1,6 @@
 package io.specmatic.test.reports
 
-import io.specmatic.core.ReportConfiguration
+import io.specmatic.core.ReportConfigurationDetails
 import io.specmatic.core.ReportFormatterType
 import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.log.logger
@@ -39,7 +39,7 @@ class OpenApiCoverageReportProcessor (private val openApiCoverageReportInput: Op
         assertSuccessCriteria(reportConfiguration, openAPICoverageReport)
     }
 
-    override fun configureReportRenderers(reportConfiguration: ReportConfiguration): List<ReportRenderer<OpenAPICoverageConsoleReport>> {
+    override fun configureReportRenderers(reportConfiguration: ReportConfigurationDetails): List<ReportRenderer<OpenAPICoverageConsoleReport>> {
         return reportConfiguration.mapRenderers { formatterType: ReportFormatterType ->
             when (formatterType) {
                 ReportFormatterType.TEXT -> CoverageReportTextRenderer()
@@ -66,7 +66,7 @@ class OpenApiCoverageReportProcessor (private val openApiCoverageReportInput: Op
     }
 
     override fun assertSuccessCriteria(
-        reportConfiguration: ReportConfiguration,
+        reportConfiguration: ReportConfigurationDetails,
         report: OpenAPICoverageConsoleReport
     ) {
         val successCriteria = reportConfiguration.getSuccessCriteria()

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/ReportProcessor.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/ReportProcessor.kt
@@ -1,5 +1,6 @@
 package io.specmatic.test.reports
 
+import io.specmatic.core.ReportConfiguration
 import io.specmatic.core.ReportConfigurationDetails
 import io.specmatic.core.SpecmaticConfig
 import io.specmatic.test.reports.renderers.ReportRenderer
@@ -7,7 +8,7 @@ import io.specmatic.test.reports.renderers.ReportRenderer
 interface ReportProcessor<T> {
     fun process(specmaticConfig: SpecmaticConfig)
 
-    fun configureReportRenderers(reportConfiguration: ReportConfigurationDetails): List<ReportRenderer<T>>
+    fun configureReportRenderers(reportConfiguration: ReportConfiguration): List<ReportRenderer<T>>
 
-    fun assertSuccessCriteria(reportConfiguration: ReportConfigurationDetails, report: T)
+    fun assertSuccessCriteria(reportConfiguration: ReportConfiguration, report: T)
 }

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/ReportProcessor.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/ReportProcessor.kt
@@ -1,13 +1,13 @@
 package io.specmatic.test.reports
 
-import io.specmatic.core.ReportConfiguration
+import io.specmatic.core.ReportConfigurationDetails
 import io.specmatic.core.SpecmaticConfig
 import io.specmatic.test.reports.renderers.ReportRenderer
 
 interface ReportProcessor<T> {
     fun process(specmaticConfig: SpecmaticConfig)
 
-    fun configureReportRenderers(reportConfiguration: ReportConfiguration): List<ReportRenderer<T>>
+    fun configureReportRenderers(reportConfiguration: ReportConfigurationDetails): List<ReportRenderer<T>>
 
-    fun assertSuccessCriteria(reportConfiguration: ReportConfiguration, report: T)
+    fun assertSuccessCriteria(reportConfiguration: ReportConfigurationDetails, report: T)
 }

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/html/HtmlReport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/html/HtmlReport.kt
@@ -2,7 +2,7 @@ package io.specmatic.test.reports.coverage.html
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
-import io.specmatic.core.ReportFormatter
+import io.specmatic.core.ReportFormatterDetails
 import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.SuccessCriteria
 import io.specmatic.core.TestResult
@@ -188,7 +188,7 @@ class HtmlReport(private val htmlReportInformation: HtmlReportInformation) {
 }
 
 data class HtmlReportInformation(
-    val reportFormat: ReportFormatter,
+    val reportFormat: ReportFormatterDetails,
     val specmaticConfig: SpecmaticConfig,
     val successCriteria: SuccessCriteria,
     val specmaticImplementation: String,

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/renderers/CoverageReportHtmlRenderer.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/renderers/CoverageReportHtmlRenderer.kt
@@ -1,7 +1,6 @@
 package io.specmatic.test.reports.renderers
 
-import io.specmatic.core.ReportFormatter
-import io.specmatic.core.ReportFormatterType
+import io.specmatic.core.ReportFormatterDetails
 import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.log.HttpLogMessage
 import io.specmatic.core.log.logger
@@ -35,8 +34,8 @@ class CoverageReportHtmlRenderer : ReportRenderer<OpenAPICoverageConsoleReport> 
     override fun render(report: OpenAPICoverageConsoleReport, specmaticConfig: SpecmaticConfig): String {
         logger.log("Generating HTML report...")
         val reportConfiguration = specmaticConfig.report!!
-        val htmlReportConfiguration = reportConfiguration.formatters!!.first { it.type == ReportFormatterType.HTML }
-        val openApiSuccessCriteria = reportConfiguration.types.apiCoverage.openAPI.successCriteria
+        val htmlReportConfiguration = reportConfiguration.getHTMLFormatter()
+        val openApiSuccessCriteria = reportConfiguration.getSuccessCriteria()
 
         val reportData = HtmlReportData(
             totalCoveragePercentage = report.totalCoveragePercentage, actuatorEnabled = actuatorEnabled,
@@ -62,7 +61,7 @@ class CoverageReportHtmlRenderer : ReportRenderer<OpenAPICoverageConsoleReport> 
         return props.getProperty("version")
     }
 
-    private fun makeTableRows(report: OpenAPICoverageConsoleReport, htmlReportConfiguration: ReportFormatter): List<TableRow> {
+    private fun makeTableRows(report: OpenAPICoverageConsoleReport, htmlReportConfiguration: ReportFormatterDetails): List<TableRow> {
         val updatedCoverageRows = when(htmlReportConfiguration.lite) {
             true -> reCreateCoverageRowsForLite(report, report.coverageRows)
             else -> report.coverageRows

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/renderers/CoverageReportHtmlRenderer.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/renderers/CoverageReportHtmlRenderer.kt
@@ -33,7 +33,7 @@ class CoverageReportHtmlRenderer : ReportRenderer<OpenAPICoverageConsoleReport> 
 
     override fun render(report: OpenAPICoverageConsoleReport, specmaticConfig: SpecmaticConfig): String {
         logger.log("Generating HTML report...")
-        val reportConfiguration = specmaticConfig.report!!
+        val reportConfiguration = specmaticConfig.getReport()!!
         val htmlReportConfiguration = reportConfiguration.getHTMLFormatter()!!
         val openApiSuccessCriteria = reportConfiguration.getSuccessCriteria()
 

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/renderers/CoverageReportHtmlRenderer.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/renderers/CoverageReportHtmlRenderer.kt
@@ -34,7 +34,7 @@ class CoverageReportHtmlRenderer : ReportRenderer<OpenAPICoverageConsoleReport> 
     override fun render(report: OpenAPICoverageConsoleReport, specmaticConfig: SpecmaticConfig): String {
         logger.log("Generating HTML report...")
         val reportConfiguration = specmaticConfig.report!!
-        val htmlReportConfiguration = reportConfiguration.getHTMLFormatter()
+        val htmlReportConfiguration = reportConfiguration.getHTMLFormatter()!!
         val openApiSuccessCriteria = reportConfiguration.getSuccessCriteria()
 
         val reportData = HtmlReportData(


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

The report field itself remains public, but the various values it exposes are encapsulated on ReportConfiguration, whose variables have been made private.

**Why**:

This will make it easier to alter the structure of the configuration without impacting the code.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [ ] Tests
- [ ] Sonar Quality Gate

