### PR TITLE
Multi port stub should return generated responses only if the request comes on the port where the spec specific to that request is being served on

### DIFF
--- a/application/src/main/kotlin/application/HTTPStubEngine.kt
+++ b/application/src/main/kotlin/application/HTTPStubEngine.kt
@@ -23,7 +23,8 @@ class HTTPStubEngine {
         specmaticConfigPath: String? = null,
         httpClientFactory: HttpClientFactory,
         workingDirectory: WorkingDirectory,
-        gracefulRestartTimeoutInMs: Long
+        gracefulRestartTimeoutInMs: Long,
+        specToPortMap: Map<String, Int?>
     ): HttpStub {
         return HttpStub(
             features = stubs.map { it.first },
@@ -37,18 +38,19 @@ class HTTPStubEngine {
             httpClientFactory = httpClientFactory,
             workingDirectory = workingDirectory,
             specmaticConfigPath = specmaticConfigPath,
-            timeoutMillis = gracefulRestartTimeoutInMs
+            timeoutMillis = gracefulRestartTimeoutInMs,
+            specToStubPortMap = specToPortMap
         ).also {
             consoleLog(NewLineLogMessage)
-            consoleLog(StringLog(serverStartupMessage(it.specToStubPortMap)))
+            consoleLog(StringLog(serverStartupMessage(specToPortMap)))
             consoleLog(StringLog("Press Ctrl + C to stop."))
         }
     }
 
-    private fun serverStartupMessage(specToStubPortMap: Map<String, Int>): String {
+    private fun serverStartupMessage(specToStubPortMap: Map<String, Int?>): String {
         val newLine = System.lineSeparator()
         val portToSpecs: Map<Int, List<String>> = specToStubPortMap.entries
-            .groupBy({ it.value }, { it.key })
+            .groupBy({ it.value ?: 9000 }, { it.key })
 
         val messageBuilder = StringBuilder("Stub server is running on the following URLs:")
 

--- a/application/src/main/kotlin/application/SamplesCommand.kt
+++ b/application/src/main/kotlin/application/SamplesCommand.kt
@@ -24,7 +24,13 @@ class SamplesCommand : Callable<Unit> {
             try {
                 val feature = parseContractFileToFeature(contractFile)
 
-                HttpStub(feature, emptyList(), "127.0.0.1", 56789).use { stub ->
+                HttpStub(
+                    feature,
+                    emptyList(),
+                    "127.0.0.1",
+                    56789,
+                    specToStubPortMap = mapOf(feature.specification.orEmpty() to 56789)
+                ).use { stub ->
                     feature.executeTests(stub.client)
                     Contract(feature).samples(stub)
                 }

--- a/application/src/main/kotlin/application/SamplesCommand.kt
+++ b/application/src/main/kotlin/application/SamplesCommand.kt
@@ -28,8 +28,7 @@ class SamplesCommand : Callable<Unit> {
                     feature,
                     emptyList(),
                     "127.0.0.1",
-                    56789,
-                    specToStubPortMap = mapOf(feature.specification.orEmpty() to 56789)
+                    56789
                 ).use { stub ->
                     feature.executeTests(stub.client)
                     Contract(feature).samples(stub)

--- a/application/src/main/kotlin/application/StubCommand.kt
+++ b/application/src/main/kotlin/application/StubCommand.kt
@@ -5,6 +5,7 @@ import io.specmatic.core.Configuration.Companion.DEFAULT_HTTP_STUB_HOST
 import io.specmatic.core.Configuration.Companion.DEFAULT_HTTP_STUB_PORT
 import io.specmatic.core.log.*
 import io.specmatic.core.utilities.ContractPathData
+import io.specmatic.core.utilities.ContractPathData.Companion.specToPortMap
 import io.specmatic.core.utilities.Flags.Companion.SPECMATIC_STUB_DELAY
 import io.specmatic.core.utilities.exitIfAnyDoNotExist
 import io.specmatic.core.utilities.throwExceptionIfDirectoriesAreInvalid
@@ -192,7 +193,19 @@ class StubCommand : Callable<Unit> {
             true -> if (portIsInUse(host, port)) findRandomFreePort() else port
             false -> port
         }
-        httpStub = httpStubEngine.runHTTPStub(stubData, host, port, certInfo, strictMode, passThroughTargetBase, specmaticConfigPath, httpClientFactory, workingDirectory, gracefulRestartTimeoutInMs)
+        httpStub = httpStubEngine.runHTTPStub(
+            stubs = stubData,
+            host = host,
+            port = port,
+            certInfo = certInfo,
+            strictMode = strictMode,
+            passThroughTargetBase = passThroughTargetBase,
+            specmaticConfigPath = specmaticConfigPath,
+            httpClientFactory = httpClientFactory,
+            workingDirectory = workingDirectory,
+            gracefulRestartTimeoutInMs = gracefulRestartTimeoutInMs,
+            specToPortMap = contractSources.specToPortMap()
+        )
 
         LogTail.storeSnapshot()
     }

--- a/application/src/main/kotlin/application/SubscribeCommand.kt
+++ b/application/src/main/kotlin/application/SubscribeCommand.kt
@@ -37,7 +37,7 @@ class SubscribeCommand: Callable<Unit> {
                     sourceGit.pull()
 
                     for(contract in source.testContracts + source.stubContracts) {
-                        val contractPath = sourceDir.resolve(File(contract))
+                        val contractPath = sourceDir.resolve(File(contract.path))
                         subscribeToContract(manifestData, sourceDir.resolve(contractPath).path, sourceGit)
                     }
 

--- a/application/src/test/kotlin/application/SamplesCommandKtTest.kt
+++ b/application/src/test/kotlin/application/SamplesCommandKtTest.kt
@@ -44,7 +44,7 @@ internal class SamplesCommandKtTest {
 
         val (data, _) = captureStandardOutput {
             val gherkin = specFile.readText().trim()
-            HttpStub(gherkin, emptyList(), "localhost", 9000).use { fake ->
+            HttpStub(gherkin, emptyList(), "localhost", 56789).use { fake ->
                 Contract.fromGherkin(gherkin).samples(fake)
             }
         }
@@ -62,7 +62,7 @@ internal class SamplesCommandKtTest {
             command.contractFile = specFile
 
             val gherkin = specFile.readText().trim()
-            HttpStub(gherkin, emptyList(), "localhost", 9000).use { fake ->
+            HttpStub(gherkin, emptyList(), "localhost", 56789).use { fake ->
                 Contract.fromGherkin(gherkin).samples(fake)
             }
         }

--- a/application/src/test/kotlin/application/StubCommandTest.kt
+++ b/application/src/test/kotlin/application/StubCommandTest.kt
@@ -118,7 +118,8 @@ internal class StubCommandTest {
                     any(),
                     httpClientFactory = any(),
                     workingDirectory = any(),
-                    gracefulRestartTimeoutInMs = any()
+                    gracefulRestartTimeoutInMs = any(),
+                    specToPortMap = any()
                 )
             }.returns(
                 mockk {
@@ -143,7 +144,8 @@ internal class StubCommandTest {
                     any(),
                     httpClientFactory = any(),
                     workingDirectory = any(),
-                    gracefulRestartTimeoutInMs = any()
+                    gracefulRestartTimeoutInMs = any(),
+                    specToPortMap = any()
                 )
             }
         } finally {
@@ -232,7 +234,8 @@ internal class StubCommandTest {
                     passThroughTargetBase,
                     httpClientFactory = any(),
                     workingDirectory = any(),
-                    gracefulRestartTimeoutInMs = any()
+                    gracefulRestartTimeoutInMs = any(),
+                    specToPortMap = any()
                 )
             }.returns(
                 mockk {
@@ -260,7 +263,8 @@ internal class StubCommandTest {
                     any(),
                     httpClientFactory = any(),
                     workingDirectory = any(),
-                    gracefulRestartTimeoutInMs = any()
+                    gracefulRestartTimeoutInMs = any(),
+                    specToPortMap = any()
                 )
             }
         } finally {

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -22,6 +22,7 @@ import io.specmatic.core.log.logger
 import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.pattern.parsedJSONObject
 import io.specmatic.core.utilities.ContractSource
+import io.specmatic.core.utilities.ContractSourceEntry
 import io.specmatic.core.utilities.Flags
 import io.specmatic.core.utilities.Flags.Companion.EXAMPLE_DIRECTORIES
 import io.specmatic.core.utilities.Flags.Companion.EXTENSIBLE_SCHEMA
@@ -283,11 +284,6 @@ data class SpecmaticConfig(
     }
 
     @JsonIgnore
-    fun specToStubPortMap(defaultPort: Int, relativeTo: File = File(".")): Map<String, Int> {
-        return sources.flatMap { it.specToStubPortMap(defaultPort, relativeTo).entries }.associate { it.key to it.value }
-    }
-
-    @JsonIgnore
     fun stubPorts(defaultPort: Int): List<Int> {
         return sources.flatMap {
             it.stub.orEmpty().map { consumes ->
@@ -327,30 +323,18 @@ data class SpecmaticConfig(
     @JsonIgnore
     fun loadSources(): List<ContractSource> {
         return sources.map { source ->
+            val stubPaths = source.specToStubPortMap().entries.map { ContractSourceEntry(it.key, it.value) }
+            val testPaths = source.test.orEmpty().map { ContractSourceEntry(it) }
+
             when (source.provider) {
-                git -> {
-                    val stubPaths = source.specsUsedAsStub()
-                    val testPaths = source.test ?: emptyList()
-
-                    when (source.repository) {
-                        null -> GitMonoRepo(testPaths, stubPaths, source.provider.toString())
-                        else -> GitRepo(source.repository, source.branch, testPaths, stubPaths, source.provider.toString())
-                    }
+                git -> when (source.repository) {
+                    null -> GitMonoRepo(testPaths, stubPaths, source.provider.toString())
+                    else -> GitRepo(source.repository, source.branch, testPaths, stubPaths, source.provider.toString())
                 }
 
-                filesystem -> {
-                    val stubPaths = source.specsUsedAsStub()
-                    val testPaths = source.test ?: emptyList()
+                filesystem -> LocalFileSystemSource(source.directory ?: ".", testPaths, stubPaths)
 
-                    LocalFileSystemSource(source.directory ?: ".", testPaths, stubPaths)
-                }
-
-                web -> {
-                    val stubPaths = source.specsUsedAsStub()
-                    val testPaths = source.test ?: emptyList()
-
-                    WebSource(testPaths, stubPaths)
-                }
+                web -> WebSource(testPaths, stubPaths)
             }
         }
     }
@@ -677,12 +661,12 @@ data class Source(
         }
     }
 
-    fun specToStubPortMap(defaultPort: Int, relativeTo: File = File(".")): Map<String, Int> {
+    fun specToStubPortMap(): Map<String, Int?> {
         return stub.orEmpty().flatMap {
             when (it) {
-                is Consumes.StringValue -> listOf(it.value.canonicalPath(relativeTo) to defaultPort)
+                is Consumes.StringValue -> listOf(it.value to null)
                 is Consumes.ObjectValue -> it.specs.map { specPath ->
-                    specPath.canonicalPath(relativeTo) to it.port
+                    specPath to it.port
                 }
             }
         }.toMap()

--- a/core/src/main/kotlin/io/specmatic/core/utilities/ContractSource.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/ContractSource.kt
@@ -5,10 +5,15 @@ import io.specmatic.core.git.SystemGit
 import io.specmatic.core.git.exitErrorMessageContains
 import java.io.File
 
+data class ContractSourceEntry(
+    val path: String,
+    val port: Int? = null
+)
+
 sealed interface ContractSource {
     val type:String?
-    val testContracts: List<String>
-    val stubContracts: List<String>
+    val testContracts: List<ContractSourceEntry>
+    val stubContracts: List<ContractSourceEntry>
     fun pathDescriptor(path: String): String
     fun install(workingDirectory: File)
     fun directoryRelativeTo(workingDirectory: File): File

--- a/core/src/main/kotlin/io/specmatic/core/utilities/GitMonoRepo.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/GitMonoRepo.kt
@@ -3,7 +3,7 @@ package io.specmatic.core.utilities
 import io.specmatic.core.git.SystemGit
 import java.io.File
 
-data class GitMonoRepo(override val testContracts: List<String>, override val stubContracts: List<String>,
+data class GitMonoRepo(override val testContracts: List<ContractSourceEntry>, override val stubContracts: List<ContractSourceEntry>,
                        override val type: String?) : ContractSource, GitSource {
     override fun pathDescriptor(path: String): String = path
     override fun install(workingDirectory: File) {
@@ -11,10 +11,10 @@ data class GitMonoRepo(override val testContracts: List<String>, override val st
 
         val contracts = testContracts + stubContracts
 
-        for (path in contracts) {
+        for (contract in contracts) {
             val existenceMessage = when {
-                File(path).exists() -> "$path exists"
-                else -> "$path NOT FOUND!"
+                File(contract.path).exists() -> "${contract.path} exists"
+                else -> "${contract.path} NOT FOUND!"
             }
 
             println(existenceMessage)
@@ -38,9 +38,10 @@ data class GitMonoRepo(override val testContracts: List<String>, override val st
         return selector.select(this).map {
             ContractPathData(
                 monoRepoBaseDir.canonicalPath,
-                configFileLocation.resolve(it).canonicalPath,
+                configFileLocation.resolve(it.path).canonicalPath,
                 provider = type,
-                specificationPath = it
+                specificationPath = it.path,
+                port = it.port
             )
         }
     }

--- a/core/src/main/kotlin/io/specmatic/core/utilities/GitRepo.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/GitRepo.kt
@@ -13,8 +13,8 @@ interface GitSource
 data class GitRepo(
     val gitRepositoryURL: String,
     val branchName: String?,
-    override val testContracts: List<String>,
-    override val stubContracts: List<String>,
+    override val testContracts: List<ContractSourceEntry>,
+    override val stubContracts: List<ContractSourceEntry>,
     override val type: String?
 ) : ContractSource, GitSource {
     private val repoName = gitRepositoryURL.split("/").last().removeSuffix(".git")
@@ -81,7 +81,15 @@ data class GitRepo(
         }
 
         return selector.select(this).map {
-            ContractPathData(repoDir.path, repoDir.resolve(it).path, type, gitRepositoryURL, branchName, it)
+            ContractPathData(
+                repoDir.path,
+                repoDir.resolve(it.path).path,
+                type,
+                gitRepositoryURL,
+                branchName,
+                it.path,
+                it.port
+            )
         }
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/utilities/LocalFileSystemSource.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/LocalFileSystemSource.kt
@@ -6,8 +6,8 @@ import java.io.File
 
 data class LocalFileSystemSource(
     val directory: String = ".",
-    override val testContracts: List<String>,
-    override val stubContracts: List<String>
+    override val testContracts: List<ContractSourceEntry>,
+    override val stubContracts: List<ContractSourceEntry>
 ) : ContractSource {
     override val type = "filesystem"
 
@@ -38,13 +38,14 @@ data class LocalFileSystemSource(
         configFilePath: String
     ): List<ContractPathData> {
         return selector.select(this).map {
-            val resolvedPath = File(directory).resolve(it)
+            val resolvedPath = File(directory).resolve(it.path)
 
             ContractPathData(
                 directory,
                 resolvedPath.path,
                 provider = type,
                 specificationPath = resolvedPath.canonicalPath,
+                port = it.port
             )
         }
     }

--- a/core/src/main/kotlin/io/specmatic/core/utilities/Utilities.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/Utilities.kt
@@ -187,8 +187,8 @@ fun loadSources(configJson: JSONObjectValue): List<ContractSource> {
                 val testPaths = jsonArray(source, "test")
 
                 when (repositoryURL) {
-                    null -> GitMonoRepo(testPaths, stubPaths, type)
-                    else -> GitRepo(repositoryURL, branch, testPaths, stubPaths, type)
+                    null -> GitMonoRepo(testPaths.toContractSourceEntries(), stubPaths.toContractSourceEntries(), type)
+                    else -> GitRepo(repositoryURL, branch, testPaths.toContractSourceEntries(), stubPaths.toContractSourceEntries(), type)
                 }
             }
             "filesystem" -> {
@@ -196,16 +196,20 @@ fun loadSources(configJson: JSONObjectValue): List<ContractSource> {
                 val stubPaths = jsonArray(source, "stub")
                 val testPaths = jsonArray(source, "test")
 
-                LocalFileSystemSource(directory, testPaths, stubPaths)
+                LocalFileSystemSource(directory, testPaths.toContractSourceEntries(), stubPaths.toContractSourceEntries())
             }
             "web" -> {
                 val stubPaths = jsonArray(source, "stub")
                 val testPaths = jsonArray(source, "test")
-                WebSource(testPaths, stubPaths)
+                WebSource(testPaths.toContractSourceEntries(), stubPaths.toContractSourceEntries())
             }
             else -> throw ContractException("Provider ${nativeString(source.jsonObject, "provider")} not recognised in $configFilePath")
         }
     }
+}
+
+private fun List<String>.toContractSourceEntries(): List<ContractSourceEntry> {
+    return this.map { ContractSourceEntry(it) }
 }
 
 internal fun jsonArray(source: JSONObjectValue, key: String): List<String> {
@@ -250,7 +254,7 @@ fun contractStubPaths(configFileName: String): List<ContractPathData> {
 }
 
 fun interface ContractsSelectorPredicate {
-    fun select(source: ContractSource): List<String>
+    fun select(source: ContractSource): List<ContractSourceEntry>
 }
 
 fun contractTestPathsFrom(configFilePath: String, workingDirectory: String): List<ContractPathData> {
@@ -268,8 +272,15 @@ data class ContractPathData(
     val provider: String? = null,
     val repository: String? = null,
     val branch: String? = null,
-    val specificationPath: String? = null
-)
+    val specificationPath: String? = null,
+    val port: Int? = null
+) {
+    companion object {
+        fun List<ContractPathData>.specToPortMap(): Map<String, Int?> {
+            return this.associate { it.path to it.port }
+        }
+    }
+}
 
 fun contractFilePathsFrom(configFilePath: String, workingDirectory: String, selector: ContractsSelectorPredicate): List<ContractPathData> {
     logger.log("Loading config file $configFilePath")

--- a/core/src/main/kotlin/io/specmatic/core/utilities/Utilities.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/Utilities.kt
@@ -277,7 +277,7 @@ data class ContractPathData(
 ) {
     companion object {
         fun List<ContractPathData>.specToPortMap(): Map<String, Int?> {
-            return this.associate { it.path to it.port }
+            return this.associate { File(it.path).path to it.port }
         }
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/utilities/WebSource.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/WebSource.kt
@@ -8,7 +8,7 @@ import java.io.File
 import java.net.ServerSocket
 import java.net.URL
 
-class WebSource(override val testContracts: List<String>, override val stubContracts: List<String>) : ContractSource {
+class WebSource(override val testContracts: List<ContractSourceEntry>, override val stubContracts: List<ContractSourceEntry>) : ContractSource {
     override val type: String = "web"
     override fun pathDescriptor(path: String): String {
         return ""
@@ -38,7 +38,7 @@ class WebSource(override val testContracts: List<String>, override val stubContr
         configFilePath: String
     ): List<ContractPathData> {
         val resolvedPath = File(workingDirectory).resolve("web")
-        return selector.select(this).map { url ->
+        return selector.select(this).map { (url, port) ->
             val path = toSpecificationPath(URL(url))
 
             val initialDownloadPath = resolvedPath.resolve(path).canonicalFile
@@ -50,7 +50,8 @@ class WebSource(override val testContracts: List<String>, override val stubContr
                 resolvedPath.path,
                 actualDownloadPath.path,
                 provider = type,
-                specificationPath = initialDownloadPath.canonicalPath
+                specificationPath = initialDownloadPath.canonicalPath,
+                port = port
             )
         }
     }

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -424,7 +424,7 @@ class HttpStub(
     ): List<Feature> {
         val specsForGivenPort = specToStubPortMap.entries.groupBy(
             { it.value }, { it.key }
-        )[port].orEmpty().map { File(it).canonicalPath }.toSet()
+        )[port].orEmpty().mapNotNull { runCatching { File(it).canonicalPath }.getOrNull() }.toSet()
 
         return features.filter { feature ->
             val spec = feature.specification ?: return@filter false

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -75,7 +75,7 @@ class HttpStub(
     val workingDirectory: WorkingDirectory? = null,
     val specmaticConfigPath: String? = null,
     private val timeoutMillis: Long = 0,
-    private val specToStubPortMap: Map<String, Int?> = features.associate { it.specification.orEmpty() to port }
+    private val specToStubPortMap: Map<String, Int?> = features.associate { it.path to port }
 ) : ContractStub {
     constructor(
         feature: Feature,
@@ -83,7 +83,7 @@ class HttpStub(
         host: String = "localhost",
         port: Int = 9000,
         log: (event: LogMessage) -> Unit = dontPrintToConsole,
-        specToStubPortMap: Map<String, Int> = mapOf(feature.specification.orEmpty() to port)
+        specToStubPortMap: Map<String, Int> = mapOf(feature.path to port)
     ) : this(
         listOf(feature),
         contractInfoToHttpExpectations(listOf(Pair(feature, scenarioStubs))),
@@ -105,7 +105,7 @@ class HttpStub(
         host,
         port,
         log,
-        specToStubPortMap = emptyMap()
+        specToStubPortMap = mapOf(parseGherkinStringToFeature(gherkinData).path to port)
     )
 
     companion object {
@@ -409,9 +409,9 @@ class HttpStub(
     ): HttpStubResponse {
         return getHttpResponse(
             httpRequest = httpRequest,
-            features = featuresAssociatedTo(port, features, specToPortMap).ifEmpty { features },
-            threadSafeStubs = threadSafeHttpStubs.stubAssociatedTo(defaultPort, port),
-            threadSafeStubQueue = threadSafeHttpStubQueue.stubAssociatedTo(defaultPort, port),
+            features = featuresAssociatedTo(port, features, specToPortMap),
+            threadSafeStubs = threadSafeHttpStubs.stubAssociatedTo(port, defaultPort),
+            threadSafeStubQueue = threadSafeHttpStubQueue.stubAssociatedTo(port, defaultPort),
             strictMode = strictMode,
             passThroughTargetBase = passThroughTargetBase,
             httpClientFactory = httpClientFactory,

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -401,9 +401,10 @@ class HttpStub(
         return getHttpResponse(
             httpRequest = httpRequest,
             features = featuresAssociatedTo(port).ifEmpty { features },
-            threadSafeStubs = threadSafeHttpStubs.stubAssociatedTo(defaultPort, port) ?: threadSafeHttpStubs,
+            threadSafeStubs = threadSafeHttpStubs.stubAssociatedTo(defaultPort, port)
+                ?: ThreadSafeListOfStubs.emptyStub(),
             threadSafeStubQueue = threadSafeHttpStubQueue.stubAssociatedTo(defaultPort, port)
-                ?: threadSafeHttpStubQueue,
+                ?: ThreadSafeListOfStubs.emptyStub(),
             strictMode = strictMode,
             passThroughTargetBase = passThroughTargetBase,
             httpClientFactory = httpClientFactory,

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -162,10 +162,6 @@ class HttpStub(
         requestHandlers.add(requestHandler)
     }
 
-    private fun specmaticConfigFile(): File {
-        return if (specmaticConfigPath == null) File(".") else File(specmaticConfigPath)
-    }
-
     private fun staticHttpStubData(rawHttpStubs: List<HttpStubData>): MutableList<HttpStubData> {
         val staticStubs = rawHttpStubs.filter { it.stubToken == null }
 
@@ -414,10 +410,8 @@ class HttpStub(
         return getHttpResponse(
             httpRequest = httpRequest,
             features = featuresAssociatedTo(port, features, specToPortMap).ifEmpty { features },
-            threadSafeStubs = threadSafeHttpStubs.stubAssociatedTo(defaultPort, port)
-                ?: ThreadSafeListOfStubs.emptyStub(),
-            threadSafeStubQueue = threadSafeHttpStubQueue.stubAssociatedTo(defaultPort, port)
-                ?: ThreadSafeListOfStubs.emptyStub(),
+            threadSafeStubs = threadSafeHttpStubs.stubAssociatedTo(defaultPort, port),
+            threadSafeStubQueue = threadSafeHttpStubQueue.stubAssociatedTo(defaultPort, port),
             strictMode = strictMode,
             passThroughTargetBase = passThroughTargetBase,
             httpClientFactory = httpClientFactory,

--- a/core/src/main/kotlin/io/specmatic/stub/ThreadSafeListOfStubs.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/ThreadSafeListOfStubs.kt
@@ -16,7 +16,7 @@ class ThreadSafeListOfStubs(
             return httpStubs.size
         }
 
-    fun stubAssociatedTo(defaultPort: Int, port: Int): ThreadSafeListOfStubs {
+    fun stubAssociatedTo(port: Int, defaultPort: Int): ThreadSafeListOfStubs {
         return portToListOfStubsMap(defaultPort)[port] ?: emptyStubs()
     }
 

--- a/core/src/main/kotlin/io/specmatic/stub/ThreadSafeListOfStubs.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/ThreadSafeListOfStubs.kt
@@ -135,6 +135,12 @@ class ThreadSafeListOfStubs(
                 else Pair(stubData.matches(httpRequest), stubData)
             }
     }
+
+    companion object {
+        fun emptyStub(): ThreadSafeListOfStubs {
+            return ThreadSafeListOfStubs(mutableListOf(), emptyMap())
+        }
+    }
 }
 
 

--- a/core/src/main/kotlin/io/specmatic/stub/ThreadSafeListOfStubs.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/ThreadSafeListOfStubs.kt
@@ -108,7 +108,7 @@ class ThreadSafeListOfStubs(
 
     private fun portToListOfStubsMap(defaultPort: Int): Map<Int, ThreadSafeListOfStubs> {
         synchronized(this) {
-            return httpStubs.groupBy { File(it.contractPath).canonicalPath }
+            return httpStubs.groupBy { it.contractPath }
                 .mapKeys {
                     Pair(it.key, specToPortMap[it.key] ?: defaultPort)
                 }.entries.groupBy(

--- a/core/src/main/kotlin/io/specmatic/stub/ThreadSafeListOfStubs.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/ThreadSafeListOfStubs.kt
@@ -108,11 +108,14 @@ class ThreadSafeListOfStubs(
 
     private fun portToListOfStubsMap(defaultPort: Int): Map<Int, ThreadSafeListOfStubs> {
         synchronized(this) {
-            return httpStubs.groupBy { File(it.contractPath).canonicalPath }.mapKeys {
-                specToPortMap[it.key] ?: defaultPort
-            }.mapValues {
-                ThreadSafeListOfStubs(it.value as MutableList<HttpStubData>, specToPortMap)
-            }
+            return httpStubs.groupBy { File(it.contractPath).canonicalPath }
+                .mapKeys {
+                    Pair(it.key, specToPortMap[it.key] ?: defaultPort)
+                }.entries.groupBy(
+                    { it.key.second }, { it.value }
+                ).mapValues { (_, stubs) ->
+                    ThreadSafeListOfStubs(stubs.flatten() as MutableList<HttpStubData>, specToPortMap)
+                }
         }
     }
 

--- a/core/src/test/kotlin/io/specmatic/TestUtilities.kt
+++ b/core/src/test/kotlin/io/specmatic/TestUtilities.kt
@@ -2,6 +2,7 @@ package io.specmatic
 
 import io.specmatic.core.*
 import io.specmatic.core.pattern.*
+import io.specmatic.core.utilities.ContractSourceEntry
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.Value
 import io.specmatic.mock.ScenarioStub
@@ -19,6 +20,10 @@ fun toReport(result: Result, scenarioMessage: String? = null): String {
         }
         else -> SuccessReport
     }.toString()
+}
+
+fun List<String>.toContractSourceEntries(): List<ContractSourceEntry> {
+    return this.map { ContractSourceEntry(it) }
 }
 
 object Utils {

--- a/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigKtTest.kt
@@ -251,60 +251,6 @@ internal class SpecmaticConfigKtTest {
     @Nested
     inner class StubPortConfigTests {
         @Test
-        fun `should return the spec to stub port map from sources`() {
-            val source1 = Source(
-                stub = listOf(
-                    Consumes.StringValue("9000_first.yaml"),
-                    Consumes.StringValue("9000_second.yaml"),
-                    Consumes.ObjectValue(
-                        specs = listOf("9001_first.yaml", "9001_second.yaml"),
-                        port = 9001
-                    ),
-                    Consumes.ObjectValue(
-                        specs = listOf("9002_first.yaml"),
-                        port = 9002
-                    ),
-                )
-            )
-
-            val source2 = Source(
-                stub = listOf(
-                    Consumes.StringValue("9000_third.yaml"),
-                    Consumes.ObjectValue(
-                        specs = listOf("9001_third.yaml", "9001_fourth.yaml"),
-                        port = 9001
-                    ),
-                    Consumes.ObjectValue(
-                        specs = listOf("9002_second.yaml"),
-                        port = 9002
-                    ),
-                )
-            )
-
-            val specmaticConfig = SpecmaticConfig(
-                sources = listOf(source1, source2)
-            )
-
-            val expectedMap = mapOf(
-                "9000_first.yaml" to 9000,
-                "9000_second.yaml" to 9000,
-                "9000_third.yaml" to 9000,
-                "9001_first.yaml" to 9001,
-                "9001_second.yaml" to 9001,
-                "9001_third.yaml" to 9001,
-                "9001_fourth.yaml" to 9001,
-                "9002_first.yaml" to 9002,
-                "9002_second.yaml" to 9002,
-            )
-
-            assertThat(
-                specmaticConfig.specToStubPortMap(
-                    9000
-                ).mapKeys { it.key.substringAfterLast(File.separator) }
-            ).isEqualTo(expectedMap)
-        }
-
-        @Test
         fun `should return all stub ports from sources`() {
             val source1 = Source(
                 stub = listOf(

--- a/core/src/test/kotlin/io/specmatic/core/config/SpecmaticConfigAllTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/SpecmaticConfigAllTest.kt
@@ -18,10 +18,11 @@ import io.specmatic.core.config.v3.Consumes
 import io.specmatic.core.loadSpecmaticConfig
 import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.pattern.parsedJSON
+import io.specmatic.core.utilities.ContractSourceEntry
 import io.specmatic.core.utilities.GitRepo
 import io.specmatic.core.utilities.LocalFileSystemSource
+import io.specmatic.toContractSourceEntries
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.io.TempDir
@@ -854,14 +855,14 @@ internal class SpecmaticConfigAllTest {
             GitRepo(
                 gitRepositoryURL = "https://contracts",
                 branchName = "1.0.1",
-                testContracts = listOf("com/petstore/1.yaml"),
-                stubContracts = listOf("com/petstore/payment.yaml"),
+                testContracts = listOf("com/petstore/1.yaml").toContractSourceEntries(),
+                stubContracts = listOf("com/petstore/payment.yaml").toContractSourceEntries(),
                 type = git.name
             ),
             LocalFileSystemSource(
                 directory = "contracts",
-                testContracts = listOf("com/petstore/1.yaml"),
-                stubContracts = listOf("com/petstore/payment.yaml", "com/petstore/order.yaml")
+                testContracts = listOf("com/petstore/1.yaml").toContractSourceEntries(),
+                stubContracts = listOf("com/petstore/payment.yaml", "com/petstore/order.yaml").toContractSourceEntries()
             )
         )
 
@@ -883,17 +884,17 @@ internal class SpecmaticConfigAllTest {
             GitRepo(
                 gitRepositoryURL = "https://contracts",
                 branchName = "1.0.1",
-                testContracts = listOf("com/petstore/1.yaml"),
-                stubContracts = listOf("com/petstore/payment.yaml"),
+                testContracts = listOf("com/petstore/1.yaml").toContractSourceEntries(),
+                stubContracts = listOf("com/petstore/payment.yaml").toContractSourceEntries(),
                 type = git.name
             ),
             LocalFileSystemSource(
                 directory = "contracts",
-                testContracts = listOf("com/petstore/1.yaml"),
+                testContracts = listOf("com/petstore/1.yaml").toContractSourceEntries(),
                 stubContracts = listOf(
-                    "com/petstore/payment.yaml",
-                    "com/petstore/order1.yaml",
-                    "com/petstore/order2.yaml"
+                    ContractSourceEntry("com/petstore/payment.yaml"),
+                    ContractSourceEntry("com/petstore/order1.yaml", 9001),
+                    ContractSourceEntry("com/petstore/order2.yaml", 9001)
                 )
             )
         )

--- a/core/src/test/kotlin/io/specmatic/core/utilities/LocalFileSystemSourceTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/utilities/LocalFileSystemSourceTest.kt
@@ -2,13 +2,14 @@ package io.specmatic.core.utilities
 
 import io.specmatic.core.DEFAULT_WORKING_DIRECTORY
 import io.specmatic.osAgnosticPath
+import io.specmatic.toContractSourceEntries
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class LocalFileSystemSourceTest {
     @Test
     fun temp() {
-        val localFileSystemSource = LocalFileSystemSource("dir", emptyList(), listOf("spec.yaml"))
+        val localFileSystemSource = LocalFileSystemSource("dir", emptyList(), listOf("spec.yaml").toContractSourceEntries())
         val specSourceData = localFileSystemSource.loadContracts({ source -> source.stubContracts }, DEFAULT_WORKING_DIRECTORY, "")
 
         assertThat(specSourceData).hasSize(1)

--- a/core/src/test/kotlin/io/specmatic/core/utilities/WebSourceTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/utilities/WebSourceTest.kt
@@ -6,6 +6,7 @@ import io.ktor.server.engine.*
 import io.ktor.server.netty.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
+import io.specmatic.toContractSourceEntries
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
@@ -31,7 +32,7 @@ class WebSourceTest {
 
             val webSource = WebSource(
                 listOf(),
-                listOf(specificationOnTheWeb)
+                listOf(specificationOnTheWeb).toContractSourceEntries()
             )
 
             val contractData = webSource.loadContracts({ source -> source.stubContracts }, DEFAULT_WORKING_DIRECTORY, "")

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
@@ -6,8 +6,10 @@ import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.core.*
 import io.specmatic.core.pattern.*
 import io.specmatic.core.utilities.ContractPathData
+import io.specmatic.core.utilities.ContractPathData.Companion.specToPortMap
 import io.specmatic.core.utilities.Flags
 import io.specmatic.core.utilities.Flags.Companion.EXTENSIBLE_SCHEMA
+import io.specmatic.core.utilities.contractStubPaths
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.NumberValue
 import io.specmatic.core.value.StringValue
@@ -2251,86 +2253,40 @@ components:
         }
     }
 
-    @Test
-    fun `should serve multiple specs on the same port`() {
-        val specmaticConfigFile = File("src/test/resources/multi_spec_stub_on_same_port/specmatic.yaml")
-        val specmaticConfig = loadSpecmaticConfig(specmaticConfigFile.absolutePath)
-
-        val scenarioStubs = specmaticConfig.stubContracts(specmaticConfigFile).map { specPath ->
-            OpenApiSpecification.fromFile(specPath).toFeature() to loadContractStubsFromImplicitPaths(
-                contractPathDataList = listOf(ContractPathData("", specPath)),
-                specmaticConfig = specmaticConfig
-            ).flatMap { it.second }
-        }
-
-        HttpStub(
-            features = specmaticConfig.stubContracts(specmaticConfigFile).map {
-                OpenApiSpecification.fromFile(it).toFeature()
-            },
-            rawHttpStubs = contractInfoToHttpExpectations(scenarioStubs),
-            specmaticConfigPath = specmaticConfigFile.canonicalPath
-        ).use {
-            val postProductResponse = HttpClient(
-                endPointFromHostAndPort("localhost", 9000, null)
-            ).execute(
-                HttpRequest(
-                    method = "POST",
-                    path = "/products",
-                    body = parsedJSONObject("""{"name": "Xiaomi", "category": "Mobile"}""")
-                )
-            )
-
-            assertThat(postProductResponse.status).isEqualTo(201)
-            assertThat(
-                (postProductResponse.body as JSONObjectValue).findFirstChildByPath("id")?.toStringLiteral()
-            ).isEqualTo("100")
-
-
-            val postOrderResponse = HttpClient(
-                endPointFromHostAndPort("localhost", 9000, null)
-            ).execute(
-                HttpRequest(
-                    method = "POST",
-                    path = "/orders",
-                    body = parsedJSONObject("""
-                         {
-                            "productId": "10",
-                            "quantity": 500,
-                            "totalPrice": 800.0
-                         }
-                    """.trimIndent())
-                )
-            )
-
-            assertThat(postOrderResponse.status).isEqualTo(201)
-            assertThat(
-                (postOrderResponse.body as JSONObjectValue).findFirstChildByPath("id")?.toStringLiteral()
-            ).isEqualTo("222")
-        }
-    }
-
     @Nested
     inner class MultiPortStubTests {
+
+        private fun scenarioStubsFrom(
+            specmaticConfigFile: File,
+            contractPathData: List<ContractPathData>,
+            specmaticConfig: SpecmaticConfig
+        ): List<Pair<Feature, List<ScenarioStub>>> {
+            return contractPathData.map {
+                val specPath = specmaticConfigFile.parentFile.resolve(it.path).absolutePath
+                OpenApiSpecification.fromFile(specPath).toFeature().copy(path = it.path) to loadContractStubsFromImplicitPaths(
+                    contractPathDataList = listOf(ContractPathData("", specPath)),
+                    specmaticConfig = specmaticConfig
+                ).flatMap { it.second }
+            }
+        }
+
+        private fun List<Pair<Feature, List<ScenarioStub>>>.features(): List<Feature> {
+            return this.map { it.first }
+        }
 
         @Test
         fun `should serve requests from multiple ports as configured in specmatic config where stubs are loaded from examples`() {
             val specmaticConfigFile = File("src/test/resources/multi_port_stub/specmatic.yaml")
             val specmaticConfig = loadSpecmaticConfig(specmaticConfigFile.absolutePath)
-
-            val scenarioStubs = specmaticConfig.stubContracts(specmaticConfigFile).map { specPath ->
-                OpenApiSpecification.fromFile(specPath).toFeature() to loadContractStubsFromImplicitPaths(
-                    contractPathDataList = listOf(ContractPathData("", specPath)),
-                    specmaticConfig = specmaticConfig
-                ).flatMap { it.second }
-            }
+            val contractPathData = contractStubPaths(specmaticConfigFile.absolutePath)
+            val scenarioStubs = scenarioStubsFrom(specmaticConfigFile, contractPathData, specmaticConfig)
 
             HttpStub(
-                features = specmaticConfig.stubContracts(specmaticConfigFile).map {
-                    OpenApiSpecification.fromFile(it).toFeature()
-                },
+                features = scenarioStubs.features(),
                 rawHttpStubs = contractInfoToHttpExpectations(scenarioStubs),
-                specmaticConfigPath = specmaticConfigFile.canonicalPath
-            ).use { stub ->
+                specmaticConfigPath = specmaticConfigFile.canonicalPath,
+                specToStubPortMap = contractPathData.specToPortMap()
+            ).use { _ ->
                 val request = HttpRequest(
                     method = "POST",
                     path = "/products",
@@ -2365,20 +2321,14 @@ components:
         fun `should serve requests from multiple ports as configured in specmatic config where no examples are loaded as stubs`() {
             val specmaticConfigFile = File("src/test/resources/multi_port_stub_without_examples/specmatic.yaml")
             val specmaticConfig = loadSpecmaticConfig(specmaticConfigFile.absolutePath)
-
-            val scenarioStubs = specmaticConfig.stubContracts(specmaticConfigFile).map { specPath ->
-                OpenApiSpecification.fromFile(specPath).toFeature() to loadContractStubsFromImplicitPaths(
-                    contractPathDataList = listOf(ContractPathData("", specPath)),
-                    specmaticConfig = specmaticConfig
-                ).flatMap { it.second }
-            }
+            val contractPathData = contractStubPaths(specmaticConfigFile.absolutePath)
+            val scenarioStubs = scenarioStubsFrom(specmaticConfigFile, contractPathData, specmaticConfig)
 
             HttpStub(
-                features = specmaticConfig.stubContracts(specmaticConfigFile).map {
-                    OpenApiSpecification.fromFile(it).toFeature().copy(specification = it)
-                },
+                features = scenarioStubs.features(),
                 rawHttpStubs = contractInfoToHttpExpectations(scenarioStubs),
-                specmaticConfigPath = specmaticConfigFile.canonicalPath
+                specmaticConfigPath = specmaticConfigFile.canonicalPath,
+                specToStubPortMap = contractPathData.specToPortMap()
             ).use {
                 val productWithoutCategoryResponse = HttpClient(
                     endPointFromHostAndPort("localhost", 9000, null)
@@ -2411,20 +2361,14 @@ components:
         fun `should return an error if a request for a specific specification is sent to the wrong port`() {
             val specmaticConfigFile = File("src/test/resources/multi_port_stub_without_examples/specmatic.yaml")
             val specmaticConfig = loadSpecmaticConfig(specmaticConfigFile.absolutePath)
-
-            val scenarioStubs = specmaticConfig.stubContracts(specmaticConfigFile).map { specPath ->
-                OpenApiSpecification.fromFile(specPath).toFeature() to loadContractStubsFromImplicitPaths(
-                    contractPathDataList = listOf(ContractPathData("", specPath)),
-                    specmaticConfig = specmaticConfig
-                ).flatMap { it.second }
-            }
+            val contractPathData = contractStubPaths(specmaticConfigFile.absolutePath)
+            val scenarioStubs = scenarioStubsFrom(specmaticConfigFile, contractPathData, specmaticConfig)
 
             HttpStub(
-                features = specmaticConfig.stubContracts(specmaticConfigFile).map {
-                    OpenApiSpecification.fromFile(it).toFeature().copy(specification = it)
-                },
+                features = scenarioStubs.features(),
                 rawHttpStubs = contractInfoToHttpExpectations(scenarioStubs),
-                specmaticConfigPath = specmaticConfigFile.canonicalPath
+                specmaticConfigPath = specmaticConfigFile.canonicalPath,
+                specToStubPortMap = contractPathData.specToPortMap()
             ).use {
 
                 val productWithoutCategoryExampleBasedRequest = HttpRequest(
@@ -2456,20 +2400,14 @@ components:
         fun `should return generated response even if the request matches the stub being served on another port`() {
             val specmaticConfigFile = File("src/test/resources/multi_port_stub_with_stubbed_unstubbed_specs/specmatic.yaml")
             val specmaticConfig = loadSpecmaticConfig(specmaticConfigFile.absolutePath)
-
-            val scenarioStubs = specmaticConfig.stubContracts(specmaticConfigFile).map { specPath ->
-                OpenApiSpecification.fromFile(specPath).toFeature() to loadContractStubsFromImplicitPaths(
-                    contractPathDataList = listOf(ContractPathData("", specPath)),
-                    specmaticConfig = specmaticConfig
-                ).flatMap { it.second }
-            }
+            val contractPathData = contractStubPaths(specmaticConfigFile.absolutePath)
+            val scenarioStubs = scenarioStubsFrom(specmaticConfigFile, contractPathData, specmaticConfig)
 
             HttpStub(
-                features = specmaticConfig.stubContracts(specmaticConfigFile).map {
-                    OpenApiSpecification.fromFile(it).toFeature().copy(specification = it)
-                },
+                features = scenarioStubs.features(),
                 rawHttpStubs = contractInfoToHttpExpectations(scenarioStubs),
-                specmaticConfigPath = specmaticConfigFile.canonicalPath
+                specmaticConfigPath = specmaticConfigFile.canonicalPath,
+                specToStubPortMap = contractPathData.specToPortMap()
             ).use {
                 val exportedProductStubbedRequest = HttpRequest(
                     method = "POST",
@@ -2499,20 +2437,14 @@ components:
         fun `should serve requests where the specs are configured using string based syntax`() {
             val specmaticConfigFile = File("src/test/resources/multi_port_stub_string_syntax/specmatic.yaml")
             val specmaticConfig = loadSpecmaticConfig(specmaticConfigFile.absolutePath)
-
-            val scenarioStubs = specmaticConfig.stubContracts(specmaticConfigFile).map { specPath ->
-                OpenApiSpecification.fromFile(specPath).toFeature() to loadContractStubsFromImplicitPaths(
-                    contractPathDataList = listOf(ContractPathData("", specPath)),
-                    specmaticConfig = specmaticConfig
-                ).flatMap { it.second }
-            }
+            val contractPathData = contractStubPaths(specmaticConfigFile.absolutePath)
+            val scenarioStubs = scenarioStubsFrom(specmaticConfigFile, contractPathData, specmaticConfig)
 
             HttpStub(
-                features = specmaticConfig.stubContracts(specmaticConfigFile).map {
-                    OpenApiSpecification.fromFile(it).toFeature()
-                },
+                features = scenarioStubs.features(),
                 rawHttpStubs = contractInfoToHttpExpectations(scenarioStubs),
-                specmaticConfigPath = specmaticConfigFile.canonicalPath
+                specmaticConfigPath = specmaticConfigFile.canonicalPath,
+                specToStubPortMap = contractPathData.specToPortMap()
             ).use {
                 val productsResponse = HttpClient(
                     endPointFromHostAndPort("localhost", 9000, null)
@@ -2553,20 +2485,14 @@ components:
         fun `should serve requests from multiple ports when the specs are configured using a mixture of string based and object based syntax`() {
             val specmaticConfigFile = File("src/test/resources/multi_port_stub_string_and_object_syntax/specmatic.yaml")
             val specmaticConfig = loadSpecmaticConfig(specmaticConfigFile.absolutePath)
-
-            val scenarioStubs = specmaticConfig.stubContracts(specmaticConfigFile).map { specPath ->
-                OpenApiSpecification.fromFile(specPath).toFeature() to loadContractStubsFromImplicitPaths(
-                    contractPathDataList = listOf(ContractPathData("", specPath)),
-                    specmaticConfig = specmaticConfig
-                ).flatMap { it.second }
-            }
+            val contractPathData = contractStubPaths(specmaticConfigFile.absolutePath)
+            val scenarioStubs = scenarioStubsFrom(specmaticConfigFile, contractPathData, specmaticConfig)
 
             HttpStub(
-                features = specmaticConfig.stubContracts(specmaticConfigFile).map {
-                    OpenApiSpecification.fromFile(it).toFeature()
-                },
+                features = scenarioStubs.features(),
                 rawHttpStubs = contractInfoToHttpExpectations(scenarioStubs),
-                specmaticConfigPath = specmaticConfigFile.canonicalPath
+                specmaticConfigPath = specmaticConfigFile.canonicalPath,
+                specToStubPortMap = contractPathData.specToPortMap()
             ).use {
                 val productsResponse = HttpClient(
                     endPointFromHostAndPort("localhost", 9000, null)
@@ -2619,6 +2545,58 @@ components:
             }
         }
 
+        @Test
+        fun `should serve multiple specs on the same port`() {
+            val specmaticConfigFile = File("src/test/resources/multi_spec_stub_on_same_port/specmatic.yaml")
+            val specmaticConfig = loadSpecmaticConfig(specmaticConfigFile.absolutePath)
+            val contractPathData = contractStubPaths(specmaticConfigFile.absolutePath)
+            val scenarioStubs = scenarioStubsFrom(specmaticConfigFile, contractPathData, specmaticConfig)
+
+            HttpStub(
+                features = scenarioStubs.features(),
+                rawHttpStubs = contractInfoToHttpExpectations(scenarioStubs),
+                specmaticConfigPath = specmaticConfigFile.canonicalPath,
+                specToStubPortMap = contractPathData.specToPortMap()
+            ).use {
+                val postProductResponse = HttpClient(
+                    endPointFromHostAndPort("localhost", 9000, null)
+                ).execute(
+                    HttpRequest(
+                        method = "POST",
+                        path = "/products",
+                        body = parsedJSONObject("""{"name": "Xiaomi", "category": "Mobile"}""")
+                    )
+                )
+
+                assertThat(postProductResponse.status).isEqualTo(201)
+                assertThat(
+                    (postProductResponse.body as JSONObjectValue).findFirstChildByPath("id")?.toStringLiteral()
+                ).isEqualTo("100")
+
+
+                val postOrderResponse = HttpClient(
+                    endPointFromHostAndPort("localhost", 9000, null)
+                ).execute(
+                    HttpRequest(
+                        method = "POST",
+                        path = "/orders",
+                        body = parsedJSONObject("""
+                         {
+                            "productId": "10",
+                            "quantity": 500,
+                            "totalPrice": 800.0
+                         }
+                    """.trimIndent())
+                    )
+                )
+
+                assertThat(postOrderResponse.status).isEqualTo(201)
+                assertThat(
+                    (postOrderResponse.body as JSONObjectValue).findFirstChildByPath("id")?.toStringLiteral()
+                ).isEqualTo("222")
+            }
+        }
+
         @Nested
         inner class FeaturesAssociatedToTests {
 
@@ -2629,16 +2607,18 @@ components:
             @Test
             fun `should return feature associated with given port`() {
                 val specToStubPortMap = mapOf(
-                    "spec1.yaml".canonicalPath() to 8080,
-                    "spec2.yaml".canonicalPath() to 9090
+                    "spec1.yaml" to 8080,
+                    "spec2.yaml" to 9090
                 )
                 val features = listOf<Feature>(
                     mockk {
+                        every { path } returns "spec1.yaml"
                         every { specification } returns "spec1.yaml"
                         every { stubsFromExamples } returns emptyMap()
                         every { scenarios } returns emptyList()
                     },
                     mockk {
+                        every { path } returns "spec2.yaml"
                         every { specification } returns "spec2.yaml"
                         every { stubsFromExamples } returns emptyMap()
                         every { scenarios } returns emptyList()
@@ -2659,11 +2639,13 @@ components:
                 )
                 val features = listOf<Feature>(
                     mockk {
+                        every { path } returns "spec3.yaml"
                         every { specification } returns "spec3.yaml"
                         every { stubsFromExamples } returns emptyMap()
                         every { scenarios } returns emptyList()
                     },
                     mockk {
+                        every { path } returns "spec4.yaml"
                         every { specification } returns "spec4.yaml"
                         every { stubsFromExamples } returns emptyMap()
                         every { scenarios } returns emptyList()
@@ -2681,11 +2663,13 @@ components:
                 val specToStubPortMap = emptyMap<String, Int>()
                 val features = listOf<Feature>(
                     mockk {
+                        every { path } returns "spec3.yaml"
                         every { specification } returns "spec3.yaml"
                         every { stubsFromExamples } returns emptyMap()
                         every { scenarios } returns emptyList()
                     },
                     mockk {
+                        every { path } returns "spec4.yaml"
                         every { specification } returns "spec4.yaml"
                         every { stubsFromExamples } returns emptyMap()
                         every { scenarios } returns emptyList()
@@ -2712,35 +2696,19 @@ components:
             }
 
             @Test
-            fun `should return empty list when feature specification is null`() {
-                val specToStubPortMap = mapOf("spec1.yaml" to 8080)
-                val features = listOf<Feature>(
-                    mockk {
-                        every { specification } returns null
-                        every { stubsFromExamples } returns emptyMap()
-                        every { scenarios } returns emptyList()
-                    }
-                )
-
-                HttpStub(features = features).use { stub ->
-                    val result = stub.featuresAssociatedTo(8080, features, specToStubPortMap)
-
-                    assertEquals(emptyList<Feature>(), result)
-                }
-            }
-
-            @Test
             fun `should return multiple features associated with the same port`() {
                 val specToStubPortMap = mapOf(
-                    "spec1.yaml".canonicalPath() to 8080,
-                    "spec2.yaml".canonicalPath() to 8080
+                    "spec1.yaml" to 8080,
+                    "spec2.yaml" to 8080
                 )
                 val feature1 = mockk<Feature> {
+                    every { path } returns "spec1.yaml"
                     every { specification } returns "spec1.yaml"
                     every { stubsFromExamples } returns emptyMap()
                     every { scenarios } returns emptyList()
                 }
                 val feature2 = mockk<Feature> {
+                    every { path } returns "spec2.yaml"
                     every { specification } returns "spec2.yaml"
                     every { stubsFromExamples } returns emptyMap()
                     every { scenarios } returns emptyList()

--- a/core/src/test/kotlin/io/specmatic/stub/ThreadSafeListOfStubsTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/ThreadSafeListOfStubsTest.kt
@@ -1,0 +1,129 @@
+package io.specmatic.stub
+
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class ThreadSafeListOfStubsTest {
+
+    @Nested
+    inner class StubAssociatedToTests {
+
+        private fun String.canonicalPath(): String {
+            return File(this).canonicalPath
+        }
+
+        @Test
+        fun `should return a ThreadSafeListOfStubs for a given port`() {
+            val specToPortMap = mapOf(
+                "spec1.yaml".canonicalPath() to 8080
+            )
+            val httpStubs = mutableListOf(
+                mockk<HttpStubData> {
+                    every { contractPath } returns "spec1.yaml"
+                },
+                mockk<HttpStubData> {
+                    every { contractPath } returns "spec2.yaml"
+                }
+            )
+
+            val threadSafeList = ThreadSafeListOfStubs(httpStubs, specToPortMap)
+
+            val result = threadSafeList.stubAssociatedTo(defaultPort = 9090, port = 8080)
+
+            assertNotNull(result)
+            assertThat(result?.size).isEqualTo(1)
+        }
+
+        @Test
+        fun `should return null if port has no associated stubs`() {
+            val specToPortMap = mapOf(
+                "spec1.yaml".canonicalPath() to 8080,
+                "spec2.yaml".canonicalPath() to 8080,
+                "spec3.yaml".canonicalPath() to 8000
+            )
+            val httpStubs = mutableListOf(
+                mockk<HttpStubData> {
+                    every { contractPath } returns "spec1.yaml"
+                },
+                mockk<HttpStubData> {
+                    every { contractPath } returns "spec2.yaml"
+                }
+            )
+
+            val threadSafeList = ThreadSafeListOfStubs(httpStubs, specToPortMap)
+
+            val result = threadSafeList.stubAssociatedTo(defaultPort = 9090, port = 8000)
+
+            assertNull(result)
+        }
+
+        @Test
+        fun `should return a ThreadSafeListOfStubs for the default port if port not found in map`() {
+            val specToPortMap = mapOf(
+                "spec1.yaml".canonicalPath() to 8080
+            )
+            val httpStubs = mutableListOf(
+                mockk<HttpStubData> {
+                    every { contractPath } returns "spec1.yaml"
+                },
+                mockk<HttpStubData> {
+                    every { contractPath } returns "spec2.yaml"
+                },
+                mockk<HttpStubData> {
+                    every { contractPath } returns "spec3.yaml"
+                }
+            )
+
+            val threadSafeList = ThreadSafeListOfStubs(httpStubs, specToPortMap)
+
+            val result = threadSafeList.stubAssociatedTo(defaultPort = 9090, port = 9090)
+
+            assertNotNull(result)
+            assertEquals(2, result!!.size)
+        }
+
+        @Test
+        fun `should return multiple stubs associated with the same port`() {
+            val specToPortMap = mapOf(
+                "spec1.yaml".canonicalPath() to 8080,
+                "spec2.yaml".canonicalPath() to 8080,
+                "spec3.yaml".canonicalPath() to 8080
+            )
+            val httpStubs = mutableListOf(
+                mockk<HttpStubData> {
+                    every { contractPath } returns "spec1.yaml"
+                },
+                mockk<HttpStubData> {
+                    every { contractPath } returns "spec2.yaml"
+                },
+                mockk<HttpStubData> {
+                    every { contractPath } returns "spec3.yaml"
+                }
+            )
+
+            val threadSafeList = ThreadSafeListOfStubs(httpStubs, specToPortMap)
+
+            val result = threadSafeList.stubAssociatedTo(defaultPort = 9090, port = 8080)
+
+            assertNotNull(result)
+            assertEquals(3, result!!.size)
+        }
+
+        @Test
+        fun `should return null if no stubs exist`() {
+            val specToPortMap = mapOf("spec1.yaml" to 8080)
+            val httpStubs = mutableListOf<HttpStubData>()
+
+            val threadSafeList = ThreadSafeListOfStubs(httpStubs, specToPortMap)
+
+            val result = threadSafeList.stubAssociatedTo(defaultPort = 9090, port = 8080)
+
+            assertNull(result)
+        }
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/stub/ThreadSafeListOfStubsTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/ThreadSafeListOfStubsTest.kt
@@ -6,21 +6,16 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import java.io.File
 
 class ThreadSafeListOfStubsTest {
 
     @Nested
     inner class StubAssociatedToTests {
 
-        private fun String.canonicalPath(): String {
-            return File(this).canonicalPath
-        }
-
         @Test
         fun `should return a ThreadSafeListOfStubs for a given port`() {
             val specToPortMap = mapOf(
-                "spec1.yaml".canonicalPath() to 8080
+                "spec1.yaml" to 8080
             )
             val httpStubs = mutableListOf(
                 mockk<HttpStubData> {
@@ -42,9 +37,9 @@ class ThreadSafeListOfStubsTest {
         @Test
         fun `should return null if port has no associated stubs`() {
             val specToPortMap = mapOf(
-                "spec1.yaml".canonicalPath() to 8080,
-                "spec2.yaml".canonicalPath() to 8080,
-                "spec3.yaml".canonicalPath() to 8000
+                "spec1.yaml" to 8080,
+                "spec2.yaml" to 8080,
+                "spec3.yaml" to 8000
             )
             val httpStubs = mutableListOf(
                 mockk<HttpStubData> {
@@ -65,7 +60,7 @@ class ThreadSafeListOfStubsTest {
         @Test
         fun `should return a ThreadSafeListOfStubs for the default port if port not found in map`() {
             val specToPortMap = mapOf(
-                "spec1.yaml".canonicalPath() to 8080
+                "spec1.yaml" to 8080
             )
             val httpStubs = mutableListOf(
                 mockk<HttpStubData> {
@@ -90,9 +85,9 @@ class ThreadSafeListOfStubsTest {
         @Test
         fun `should return multiple stubs associated with the same port`() {
             val specToPortMap = mapOf(
-                "spec1.yaml".canonicalPath() to 8080,
-                "spec2.yaml".canonicalPath() to 8080,
-                "spec3.yaml".canonicalPath() to 8080
+                "spec1.yaml" to 8080,
+                "spec2.yaml" to 8080,
+                "spec3.yaml" to 8080
             )
             val httpStubs = mutableListOf(
                 mockk<HttpStubData> {

--- a/core/src/test/kotlin/io/specmatic/stub/ThreadSafeListOfStubsTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/ThreadSafeListOfStubsTest.kt
@@ -54,7 +54,7 @@ class ThreadSafeListOfStubsTest {
 
             val result = threadSafeList.stubAssociatedTo(defaultPort = 9090, port = 8000)
 
-            assertNull(result)
+            assertThat(result.size).isEqualTo(0)
         }
 
         @Test
@@ -110,7 +110,7 @@ class ThreadSafeListOfStubsTest {
         }
 
         @Test
-        fun `should return null if no stubs exist`() {
+        fun `should return an empty list if no stubs exist`() {
             val specToPortMap = mapOf("spec1.yaml" to 8080)
             val httpStubs = mutableListOf<HttpStubData>()
 
@@ -118,7 +118,7 @@ class ThreadSafeListOfStubsTest {
 
             val result = threadSafeList.stubAssociatedTo(defaultPort = 9090, port = 8080)
 
-            assertNull(result)
+            assertThat(result.size).isEqualTo(0)
         }
     }
 }

--- a/core/src/test/kotlin/io/specmatic/stub/ThreadSafeListOfStubsTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/ThreadSafeListOfStubsTest.kt
@@ -28,7 +28,7 @@ class ThreadSafeListOfStubsTest {
 
             val threadSafeList = ThreadSafeListOfStubs(httpStubs, specToPortMap)
 
-            val result = threadSafeList.stubAssociatedTo(defaultPort = 9090, port = 8080)
+            val result = threadSafeList.stubAssociatedTo(port = 8080, defaultPort = 9090)
 
             assertNotNull(result)
             assertThat(result?.size).isEqualTo(1)
@@ -52,7 +52,7 @@ class ThreadSafeListOfStubsTest {
 
             val threadSafeList = ThreadSafeListOfStubs(httpStubs, specToPortMap)
 
-            val result = threadSafeList.stubAssociatedTo(defaultPort = 9090, port = 8000)
+            val result = threadSafeList.stubAssociatedTo(port = 8000, defaultPort = 9090)
 
             assertThat(result.size).isEqualTo(0)
         }
@@ -76,7 +76,7 @@ class ThreadSafeListOfStubsTest {
 
             val threadSafeList = ThreadSafeListOfStubs(httpStubs, specToPortMap)
 
-            val result = threadSafeList.stubAssociatedTo(defaultPort = 9090, port = 9090)
+            val result = threadSafeList.stubAssociatedTo(port = 9090, defaultPort = 9090)
 
             assertNotNull(result)
             assertEquals(2, result!!.size)
@@ -103,7 +103,7 @@ class ThreadSafeListOfStubsTest {
 
             val threadSafeList = ThreadSafeListOfStubs(httpStubs, specToPortMap)
 
-            val result = threadSafeList.stubAssociatedTo(defaultPort = 9090, port = 8080)
+            val result = threadSafeList.stubAssociatedTo(port = 8080, defaultPort = 9090)
 
             assertNotNull(result)
             assertEquals(3, result!!.size)
@@ -116,7 +116,7 @@ class ThreadSafeListOfStubsTest {
 
             val threadSafeList = ThreadSafeListOfStubs(httpStubs, specToPortMap)
 
-            val result = threadSafeList.stubAssociatedTo(defaultPort = 9090, port = 8080)
+            val result = threadSafeList.stubAssociatedTo(port = 8080, defaultPort = 9090)
 
             assertThat(result.size).isEqualTo(0)
         }

--- a/core/src/test/kotlin/utilities/UtilitiesTest.kt
+++ b/core/src/test/kotlin/utilities/UtilitiesTest.kt
@@ -21,6 +21,7 @@ import io.ktor.server.netty.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.mockk.*
+import io.specmatic.toContractSourceEntries
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
@@ -47,7 +48,7 @@ internal class UtilitiesTest {
 
     @Test
     fun `contractFilePathsFrom sources when contracts repo dir does not exist`() {
-        val sources = listOf(GitRepo("https://repo1", null, listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION"), SourceProvider.git.toString()))
+        val sources = listOf(GitRepo("https://repo1", null, listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION").toContractSourceEntries(), SourceProvider.git.toString()))
         File(".spec").deleteRecursively()
 
         mockkStatic("io.specmatic.core.utilities.Utilities")
@@ -71,7 +72,7 @@ internal class UtilitiesTest {
     fun `contractFilePathsFrom sources with branch when contracts repo dir does not exist`() {
         val branchName = "featureBranch"
         val sources = listOf(GitRepo("https://repo1",
-            branchName, listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION"), SourceProvider.git.toString()))
+            branchName, listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION").toContractSourceEntries(), SourceProvider.git.toString()))
         File(".spec").deleteRecursively()
 
         mockkStatic("io.specmatic.core.utilities.Utilities")
@@ -101,7 +102,7 @@ internal class UtilitiesTest {
 
     @Test
     fun `contractFilePathsFrom sources when contracts repo dir exists and is clean`() {
-        val sources = listOf(GitRepo("https://repo1", null, listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION"), SourceProvider.git.toString()))
+        val sources = listOf(GitRepo("https://repo1", null, listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION").toContractSourceEntries(), SourceProvider.git.toString()))
         File(".spec").deleteRecursively()
         File(".spec/repos/repo1").mkdirs()
 
@@ -147,7 +148,7 @@ internal class UtilitiesTest {
 
     @Test
     fun `contractFilePathsFrom sources when contracts repo dir exists and is not clean`() {
-        val sources = listOf(GitRepo("https://repo1", null, listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION"), SourceProvider.git.toString()))
+        val sources = listOf(GitRepo("https://repo1", null, listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION").toContractSourceEntries(), SourceProvider.git.toString()))
         File(".spec").deleteRecursively()
         File(".spec/repos/repo1").mkdirs()
 
@@ -174,7 +175,7 @@ internal class UtilitiesTest {
 
     @Test
     fun `contractFilePathsFrom sources when contracts repo dir exists and is behind remote`() {
-        val sources = listOf(GitRepo("https://repo1", null, listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION"), SourceProvider.git.toString()))
+        val sources = listOf(GitRepo("https://repo1", null, listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION").toContractSourceEntries(), SourceProvider.git.toString()))
         File(".spec").deleteRecursively()
         File(".spec/repos/repo1").mkdirs()
 
@@ -203,10 +204,10 @@ internal class UtilitiesTest {
     fun `contractFilePathsFrom sources with mono repo`() {
         val configFilePath = "monorepo/configLoc/specmatic.json"
 
-        val monorepoContents = listOf(configFilePath, "monorepo/a/1.$CONTRACT_EXTENSION", "monorepo/b/1.$CONTRACT_EXTENSION", "monorepo/c/1.$CONTRACT_EXTENSION")
+        val monorepoContents = listOf(configFilePath, "monorepo/a/1.$CONTRACT_EXTENSION", "monorepo/b/1.$CONTRACT_EXTENSION", "monorepo/c/1.$CONTRACT_EXTENSION").toContractSourceEntries()
         monorepoContents.forEach {
-            File(it).parentFile.mkdirs()
-            File(it).createNewFile()
+            File(it.path).parentFile.mkdirs()
+            File(it.path).createNewFile()
         }
 
         File(configFilePath).printWriter().use { it.println(
@@ -244,7 +245,7 @@ internal class UtilitiesTest {
         val specmaticJson = "{\"sources\": [{\"provider\": \"git\",\"repository\": \"https://repo1\",\"stub\": [\"a/1.$CONTRACT_EXTENSION\",\"b/1.$CONTRACT_EXTENSION\",\"c/1.$CONTRACT_EXTENSION\"]}]}"
         val configJson = parsedJSON(specmaticJson) as JSONObjectValue
         val sources = loadSources(configJson)
-        val expectedSources = listOf(GitRepo("https://repo1", null, listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION"), SourceProvider.git.toString()))
+        val expectedSources = listOf(GitRepo("https://repo1", null, listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION").toContractSourceEntries(), SourceProvider.git.toString()))
         assertThat(sources == expectedSources).isTrue
     }
 
@@ -255,8 +256,8 @@ internal class UtilitiesTest {
         val configJson = parsedJSON(specmaticJson) as JSONObjectValue
         val sources = loadSources(configJson)
         val expectedSources = listOf(
-                GitRepo("https://repo1",null, listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION"), SourceProvider.git.toString()),
-                GitRepo("https://repo2",null, listOf(), listOf("c/1.$CONTRACT_EXTENSION"), SourceProvider.git.toString())
+                GitRepo("https://repo1",null, listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION").toContractSourceEntries(), SourceProvider.git.toString()),
+                GitRepo("https://repo2",null, listOf(), listOf("c/1.$CONTRACT_EXTENSION").toContractSourceEntries(), SourceProvider.git.toString())
         )
         assertThat(sources == expectedSources).isTrue
     }
@@ -266,7 +267,7 @@ internal class UtilitiesTest {
         val specmaticJson = "{\"sources\": [{\"provider\": \"git\",\"stub\": [\"a/1.$CONTRACT_EXTENSION\",\"b/1.$CONTRACT_EXTENSION\",\"c/1.$CONTRACT_EXTENSION\"]}]}"
         val configJson = parsedJSON(specmaticJson) as JSONObjectValue
         val sources = loadSources(configJson)
-        val expectedSources = listOf(GitMonoRepo(listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION"), SourceProvider.git.toString()))
+        val expectedSources = listOf(GitMonoRepo(listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION").toContractSourceEntries(), SourceProvider.git.toString()))
         assertThat(sources == expectedSources).isTrue
     }
 
@@ -275,7 +276,7 @@ internal class UtilitiesTest {
         val specmaticJson = "{\"sources\": [{\"provider\": \"git\",\"test\": [\"a/1.$CONTRACT_EXTENSION\",\"b/1.$CONTRACT_EXTENSION\",\"c/1.$CONTRACT_EXTENSION\"]}]}"
         val configJson = parsedJSON(specmaticJson) as JSONObjectValue
         val sources = loadSources(configJson)
-        val expectedSources = listOf(GitMonoRepo(listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION"), listOf(), SourceProvider.git.toString()))
+        val expectedSources = listOf(GitMonoRepo(listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION", "c/1.$CONTRACT_EXTENSION").toContractSourceEntries(), listOf(), SourceProvider.git.toString()))
         assertThat(sources == expectedSources).isTrue
     }
 
@@ -284,7 +285,7 @@ internal class UtilitiesTest {
         val specmaticJson = "{\"sources\": [{\"provider\": \"git\",\"test\": [\"a/1.$CONTRACT_EXTENSION\",\"b/1.$CONTRACT_EXTENSION\"],\"stub\": [\"c/1.$CONTRACT_EXTENSION\"]}]}"
         val configJson = parsedJSON(specmaticJson) as JSONObjectValue
         val sources = loadSources(configJson)
-        val expectedSources = listOf(GitMonoRepo(listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION"), listOf("c/1.$CONTRACT_EXTENSION"), SourceProvider.git.toString()))
+        val expectedSources = listOf(GitMonoRepo(listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION").toContractSourceEntries(), listOf("c/1.$CONTRACT_EXTENSION").toContractSourceEntries(), SourceProvider.git.toString()))
         assertThat(sources == expectedSources).isTrue
     }
 
@@ -295,8 +296,8 @@ internal class UtilitiesTest {
         val configJson = parsedJSON(specmaticJson) as JSONObjectValue
         val sources = loadSources(configJson)
         val expectedSources = listOf(
-            GitMonoRepo(listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION"), SourceProvider.git.toString()),
-                GitMonoRepo(listOf(), listOf("c/1.$CONTRACT_EXTENSION"), SourceProvider.git.toString())
+            GitMonoRepo(listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION").toContractSourceEntries(), SourceProvider.git.toString()),
+                GitMonoRepo(listOf(), listOf("c/1.$CONTRACT_EXTENSION").toContractSourceEntries(), SourceProvider.git.toString())
         )
         assertThat(sources == expectedSources).isTrue
     }
@@ -308,8 +309,8 @@ internal class UtilitiesTest {
         val configJson = parsedJSON(specmaticJson) as JSONObjectValue
         val sources = loadSources(configJson)
         val expectedSources = listOf(
-                GitRepo("https://repo1", null, listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION"), SourceProvider.git.toString()),
-                GitMonoRepo(listOf(), listOf("c/1.$CONTRACT_EXTENSION"), SourceProvider.git.toString())
+                GitRepo("https://repo1", null, listOf(), listOf("a/1.$CONTRACT_EXTENSION", "b/1.$CONTRACT_EXTENSION").toContractSourceEntries(), SourceProvider.git.toString()),
+                GitMonoRepo(listOf(), listOf("c/1.$CONTRACT_EXTENSION").toContractSourceEntries(), SourceProvider.git.toString())
         )
         assertThat(sources == expectedSources).isTrue
     }
@@ -524,7 +525,7 @@ internal class UtilitiesTest {
                 loadSources(specmaticJSON.path).flatMap { source ->
                     source.testContracts
                 }.map { specPath ->
-                    OpenApiSpecification.fromFile(specPath).toFeature().executeTests(stub.client)
+                    OpenApiSpecification.fromFile(specPath.path).toFeature().executeTests(stub.client)
                 }
             }
 

--- a/core/src/test/resources/multi_port_stub/specmatic.yaml
+++ b/core/src/test/resources/multi_port_stub/specmatic.yaml
@@ -3,12 +3,12 @@ contracts:
   - filesystem:
       directory: "."
     consumes:
-      - port: 9000
-        specs:
-          - imported_product/imported_product.yaml
       - port: 9001
         specs:
-          - exported_product/exported_product.yaml
+          - imported_product/imported_product.yaml
       - port: 9002
+        specs:
+          - exported_product/exported_product.yaml
+      - port: 9003
         specs:
           - another_exported_product/exported_product.yaml

--- a/core/src/test/resources/multi_port_stub_string_and_object_syntax/exported_product/exported_product.yaml
+++ b/core/src/test/resources/multi_port_stub_string_and_object_syntax/exported_product/exported_product.yaml
@@ -1,0 +1,53 @@
+openapi: 3.0.3
+info:
+  title: Exported Product API
+  version: 1.0.0
+paths:
+  /products:
+    get:
+      summary: Get exported products
+      description: Retrieve a list of exported products along with their destination country.
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                    name:
+                      type: string
+                    destinationCountry:
+                      type: string
+    post:
+      summary: Add a new product
+      description: Create a new product entry.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                category:
+                  type: string
+      responses:
+        '201':
+          description: Product created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  name:
+                    type: string
+                  category:
+                    type: string

--- a/core/src/test/resources/multi_port_stub_string_and_object_syntax/exported_product/exported_product_examples/products_GET_200_2.json
+++ b/core/src/test/resources/multi_port_stub_string_and_object_syntax/exported_product/exported_product_examples/products_GET_200_2.json
@@ -1,0 +1,20 @@
+{
+    "http-request": {
+        "path": "/products",
+        "method": "GET"
+    },
+    "http-response": {
+        "status": 200,
+        "body": [
+            {
+                "id": "10",
+                "name": "Macbook Pro",
+                "destinationCountry": "India"
+            }
+        ],
+        "status-text": "OK",
+        "headers": {
+            "Content-Type": "application/json"
+        }
+    }
+}

--- a/core/src/test/resources/multi_port_stub_string_and_object_syntax/exported_product/exported_product_examples/products_POST_201_1.json
+++ b/core/src/test/resources/multi_port_stub_string_and_object_syntax/exported_product/exported_product_examples/products_POST_201_1.json
@@ -1,0 +1,25 @@
+{
+    "http-request": {
+        "path": "/products",
+        "method": "POST",
+        "headers": {
+            "Content-Type": "application/json"
+        },
+        "body": {
+            "name": "Xiaomi",
+            "category": "Mobile"
+        }
+    },
+    "http-response": {
+        "status": 201,
+        "body": {
+            "id": "200",
+            "name": "Xiaomi",
+            "category": "Mobile"
+        },
+        "status-text": "Created",
+        "headers": {
+            "Content-Type": "application/json"
+        }
+    }
+}

--- a/core/src/test/resources/multi_port_stub_string_and_object_syntax/order.yaml
+++ b/core/src/test/resources/multi_port_stub_string_and_object_syntax/order.yaml
@@ -1,0 +1,68 @@
+openapi: 3.0.3
+info:
+  title: Order API
+  version: 1.0.0
+paths:
+  /orders:
+    post:
+      summary: Create a new order
+      operationId: createOrder
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Order"
+      responses:
+        "201":
+          description: Order created successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Order"
+  /orders/{orderId}:
+    get:
+      summary: Get an order by ID
+      operationId: getOrderById
+      parameters:
+        - name: orderId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Order retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Order"
+        "404":
+          description: Order not found
+components:
+  schemas:
+    OrderRequest:
+      type: object
+      properties:
+        productId:
+          type: string
+        quantity:
+          type: integer
+          format: int32
+        totalPrice:
+          type: number
+          format: double
+
+    Order:
+      type: object
+      properties:
+        id:
+          type: string
+        productId:
+          type: string
+        quantity:
+          type: integer
+          format: int32
+        totalPrice:
+          type: number
+          format: double

--- a/core/src/test/resources/multi_port_stub_string_and_object_syntax/product.yaml
+++ b/core/src/test/resources/multi_port_stub_string_and_object_syntax/product.yaml
@@ -1,0 +1,62 @@
+openapi: 3.0.3
+info:
+  title:  Product API
+  version: 1.0.0
+paths:
+  /products:
+    get:
+      summary: Get products
+      description: Retrieve a list of products along with their country of origin.
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                    name:
+                      type: string
+                    originCountry:
+                      type: string
+    post:
+      summary: Add a new product
+      description: Create a new product entry.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                category:
+                  type: string
+            examples:
+              POST_XIAOMI:
+                name: Xiaomi
+                type: Mobile
+      responses:
+        '201':
+          description: Product created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  name:
+                    type: string
+                  category:
+                    type: string
+              examples:
+                POST_XIAOMI:
+                  id: 100
+                  name: Xiaomi
+                  type: Mobile

--- a/core/src/test/resources/multi_port_stub_string_and_object_syntax/specmatic.yaml
+++ b/core/src/test/resources/multi_port_stub_string_and_object_syntax/specmatic.yaml
@@ -1,0 +1,10 @@
+version: 2
+contracts:
+  - filesystem:
+      directory: "."
+    consumes:
+      - ./product.yaml
+      - port: 9001
+        specs:
+          - ./order.yaml
+          - ./exported_product/exported_product.yaml

--- a/core/src/test/resources/multi_port_stub_string_syntax/order.yaml
+++ b/core/src/test/resources/multi_port_stub_string_syntax/order.yaml
@@ -1,0 +1,68 @@
+openapi: 3.0.3
+info:
+  title: Order API
+  version: 1.0.0
+paths:
+  /orders:
+    post:
+      summary: Create a new order
+      operationId: createOrder
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Order"
+      responses:
+        "201":
+          description: Order created successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Order"
+  /orders/{orderId}:
+    get:
+      summary: Get an order by ID
+      operationId: getOrderById
+      parameters:
+        - name: orderId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Order retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Order"
+        "404":
+          description: Order not found
+components:
+  schemas:
+    OrderRequest:
+      type: object
+      properties:
+        productId:
+          type: string
+        quantity:
+          type: integer
+          format: int32
+        totalPrice:
+          type: number
+          format: double
+
+    Order:
+      type: object
+      properties:
+        id:
+          type: string
+        productId:
+          type: string
+        quantity:
+          type: integer
+          format: int32
+        totalPrice:
+          type: number
+          format: double

--- a/core/src/test/resources/multi_port_stub_string_syntax/product.yaml
+++ b/core/src/test/resources/multi_port_stub_string_syntax/product.yaml
@@ -1,0 +1,62 @@
+openapi: 3.0.3
+info:
+  title:  Product API
+  version: 1.0.0
+paths:
+  /products:
+    get:
+      summary: Get products
+      description: Retrieve a list of products along with their country of origin.
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                    name:
+                      type: string
+                    originCountry:
+                      type: string
+    post:
+      summary: Add a new product
+      description: Create a new product entry.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                category:
+                  type: string
+            examples:
+              POST_XIAOMI:
+                name: Xiaomi
+                type: Mobile
+      responses:
+        '201':
+          description: Product created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  name:
+                    type: string
+                  category:
+                    type: string
+              examples:
+                POST_XIAOMI:
+                  id: 100
+                  name: Xiaomi
+                  type: Mobile

--- a/core/src/test/resources/multi_port_stub_string_syntax/specmatic.yaml
+++ b/core/src/test/resources/multi_port_stub_string_syntax/specmatic.yaml
@@ -1,0 +1,7 @@
+version: 2
+contracts:
+  - filesystem:
+      directory: "."
+    consumes:
+      - ./product.yaml
+      - ./order.yaml

--- a/core/src/test/resources/multi_port_stub_with_stubbed_unstubbed_specs/exported_product/exported_product.yaml
+++ b/core/src/test/resources/multi_port_stub_with_stubbed_unstubbed_specs/exported_product/exported_product.yaml
@@ -1,0 +1,53 @@
+openapi: 3.0.3
+info:
+  title: Exported Product API
+  version: 1.0.0
+paths:
+  /products:
+    get:
+      summary: Get exported products
+      description: Retrieve a list of exported products along with their destination country.
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                    name:
+                      type: string
+                    destinationCountry:
+                      type: string
+    post:
+      summary: Add a new product
+      description: Create a new product entry.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                category:
+                  type: string
+      responses:
+        '201':
+          description: Product created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  name:
+                    type: string
+                  category:
+                    type: string

--- a/core/src/test/resources/multi_port_stub_with_stubbed_unstubbed_specs/exported_product/exported_product_examples/products_GET_200_2.json
+++ b/core/src/test/resources/multi_port_stub_with_stubbed_unstubbed_specs/exported_product/exported_product_examples/products_GET_200_2.json
@@ -1,0 +1,20 @@
+{
+    "http-request": {
+        "path": "/products",
+        "method": "GET"
+    },
+    "http-response": {
+        "status": 200,
+        "body": [
+            {
+                "id": "10",
+                "name": "Macbook Pro",
+                "destinationCountry": "India"
+            }
+        ],
+        "status-text": "OK",
+        "headers": {
+            "Content-Type": "application/json"
+        }
+    }
+}

--- a/core/src/test/resources/multi_port_stub_with_stubbed_unstubbed_specs/exported_product/exported_product_examples/products_POST_201_1.json
+++ b/core/src/test/resources/multi_port_stub_with_stubbed_unstubbed_specs/exported_product/exported_product_examples/products_POST_201_1.json
@@ -1,0 +1,25 @@
+{
+    "http-request": {
+        "path": "/products",
+        "method": "POST",
+        "headers": {
+            "Content-Type": "application/json"
+        },
+        "body": {
+            "name": "Xiaomi",
+            "category": "Mobile"
+        }
+    },
+    "http-response": {
+        "status": 201,
+        "body": {
+            "id": "200",
+            "name": "Xiaomi",
+            "category": "Mobile"
+        },
+        "status-text": "Created",
+        "headers": {
+            "Content-Type": "application/json"
+        }
+    }
+}

--- a/core/src/test/resources/multi_port_stub_with_stubbed_unstubbed_specs/imported_product/imported_product.yaml
+++ b/core/src/test/resources/multi_port_stub_with_stubbed_unstubbed_specs/imported_product/imported_product.yaml
@@ -1,0 +1,53 @@
+openapi: 3.0.3
+info:
+  title: Imported Product API
+  version: 1.0.0
+paths:
+  /products:
+    get:
+      summary: Get imported products
+      description: Retrieve a list of imported products along with their country of origin.
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                    name:
+                      type: string
+                    originCountry:
+                      type: string
+    post:
+      summary: Add a new product
+      description: Create a new product entry.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                category:
+                  type: string
+      responses:
+        '201':
+          description: Product created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  name:
+                    type: string
+                  category:
+                    type: string

--- a/core/src/test/resources/multi_port_stub_with_stubbed_unstubbed_specs/specmatic.yaml
+++ b/core/src/test/resources/multi_port_stub_with_stubbed_unstubbed_specs/specmatic.yaml
@@ -1,0 +1,11 @@
+version: 2
+contracts:
+  - filesystem:
+      directory: "."
+    consumes:
+      - port: 9000
+        specs:
+          - imported_product/imported_product.yaml
+      - port: 9001
+        specs:
+          - exported_product/exported_product.yaml

--- a/core/src/test/resources/multi_port_stub_without_examples/product_with_category.yaml
+++ b/core/src/test/resources/multi_port_stub_without_examples/product_with_category.yaml
@@ -1,0 +1,99 @@
+openapi: 3.0.3
+info:
+  title: Product API
+  version: 1.0.0
+paths:
+  /products:
+    post:
+      summary: Add a new product
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+                - price
+                - category
+              properties:
+                name:
+                  type: string
+                price:
+                  type: number
+                category:
+                  type: string
+                  enum:
+                    - Electronics
+                    - Clothing
+                    - Books
+            examples:
+              ADD_PRODUCT_SUCCESS:
+                value:
+                  name: "Widget"
+                  price: 9.99
+                  category: "Electronics"
+      responses:
+        '201':
+          description: Product created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Product'
+              examples:
+                ADD_PRODUCT_SUCCESS:
+                  value:
+                    id: 1
+                    name: "Widget"
+                    price: 9.99
+                    category: "Electronics"
+    get:
+      summary: List all products
+      responses:
+        '200':
+          description: A list of products
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Product'
+              examples:
+                LIST_PRODUCTS_SUCCESS:
+                  value:
+                    - id: 1
+                      name: "Widget"
+                      price: 9.99
+                    - id: 2
+                      name: "Gadget"
+                      price: 19.99
+components:
+  schemas:
+    ProductId:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: integer
+    ProductDetails:
+      type: object
+      required:
+        - name
+        - price
+        - category
+      properties:
+        name:
+          type: string
+        price:
+          type: number
+        category:
+          type: string
+          enum:
+            - Electronics
+            - Clothing
+            - Books
+    Product:
+      allOf:
+        - $ref: '#/components/schemas/ProductId'
+        - $ref: '#/components/schemas/ProductDetails'

--- a/core/src/test/resources/multi_port_stub_without_examples/product_without_category.yaml
+++ b/core/src/test/resources/multi_port_stub_without_examples/product_without_category.yaml
@@ -1,0 +1,83 @@
+openapi: 3.0.3
+info:
+  title: Product API
+  version: 1.0.0
+paths:
+  /products:
+    post:
+      summary: Add a new product
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+                - price
+              properties:
+                name:
+                  type: string
+                price:
+                  type: number
+            examples:
+              ADD_PRODUCT_SUCCESS:
+                value:
+                  name: "Widget"
+                  price: 9.99
+      responses:
+        '201':
+          description: Product created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Product'
+              examples:
+                ADD_PRODUCT_SUCCESS:
+                  value:
+                    id: 1
+                    name: "Widget"
+                    price: 9.99
+    get:
+      summary: List all products
+      responses:
+        '200':
+          description: A list of products
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Product'
+              examples:
+                LIST_PRODUCTS_SUCCESS:
+                  value:
+                    - id: 1
+                      name: "Widget"
+                      price: 9.99
+                    - id: 2
+                      name: "Gadget"
+                      price: 19.99
+components:
+  schemas:
+    ProductId:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: integer
+    ProductDetails:
+      type: object
+      required:
+        - name
+        - price
+      properties:
+        name:
+          type: string
+        price:
+          type: number
+    Product:
+      allOf:
+        - $ref: '#/components/schemas/ProductId'
+        - $ref: '#/components/schemas/ProductDetails'

--- a/core/src/test/resources/multi_port_stub_without_examples/specmatic.yaml
+++ b/core/src/test/resources/multi_port_stub_without_examples/specmatic.yaml
@@ -1,0 +1,7 @@
+version: 2
+contracts:
+  - consumes:
+      - product_without_category.yaml
+      - specs:
+          - product_with_category.yaml
+        port: 9001

--- a/core/src/test/resources/multi_spec_stub_on_same_port/order/order.yaml
+++ b/core/src/test/resources/multi_spec_stub_on_same_port/order/order.yaml
@@ -1,0 +1,68 @@
+openapi: 3.0.3
+info:
+  title: Order API
+  version: 1.0.0
+paths:
+  /orders:
+    post:
+      summary: Create a new order
+      operationId: createOrder
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Order"
+      responses:
+        "201":
+          description: Order created successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Order"
+  /orders/{orderId}:
+    get:
+      summary: Get an order by ID
+      operationId: getOrderById
+      parameters:
+        - name: orderId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Order retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Order"
+        "404":
+          description: Order not found
+components:
+  schemas:
+    OrderRequest:
+      type: object
+      properties:
+        productId:
+          type: string
+        quantity:
+          type: integer
+          format: int32
+        totalPrice:
+          type: number
+          format: double
+
+    Order:
+      type: object
+      properties:
+        id:
+          type: string
+        productId:
+          type: string
+        quantity:
+          type: integer
+          format: int32
+        totalPrice:
+          type: number
+          format: double

--- a/core/src/test/resources/multi_spec_stub_on_same_port/order/order_examples/POST_order.json
+++ b/core/src/test/resources/multi_spec_stub_on_same_port/order/order_examples/POST_order.json
@@ -1,0 +1,20 @@
+{
+    "http-request": {
+        "path": "/orders",
+        "method": "POST",
+        "body": {
+            "productId": "10",
+            "quantity": 500,
+            "totalPrice": 800.0
+        }
+    },
+    "http-response": {
+        "status": 201,
+        "body": {
+            "id": "222",
+            "productId": "10",
+            "quantity": 500,
+            "totalPrice": 800.0
+        }
+    }
+}

--- a/core/src/test/resources/multi_spec_stub_on_same_port/product/product.yaml
+++ b/core/src/test/resources/multi_spec_stub_on_same_port/product/product.yaml
@@ -1,0 +1,53 @@
+openapi: 3.0.3
+info:
+  title:  Product API
+  version: 1.0.0
+paths:
+  /products:
+    get:
+      summary: Get products
+      description: Retrieve a list of products along with their country of origin.
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                    name:
+                      type: string
+                    originCountry:
+                      type: string
+    post:
+      summary: Add a new product
+      description: Create a new product entry.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                category:
+                  type: string
+      responses:
+        '201':
+          description: Product created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  name:
+                    type: string
+                  category:
+                    type: string

--- a/core/src/test/resources/multi_spec_stub_on_same_port/product/product_examples/POST_product.json
+++ b/core/src/test/resources/multi_spec_stub_on_same_port/product/product_examples/POST_product.json
@@ -1,0 +1,25 @@
+{
+  "http-request": {
+    "path": "/products",
+    "method": "POST",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "name": "Xiaomi",
+      "category": "Mobile"
+    }
+  },
+  "http-response": {
+    "status": 201,
+    "body": {
+      "id": "100",
+      "name": "Xiaomi",
+      "category": "Mobile"
+    },
+    "status-text": "Created",
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}

--- a/core/src/test/resources/multi_spec_stub_on_same_port/specmatic.yaml
+++ b/core/src/test/resources/multi_spec_stub_on_same_port/specmatic.yaml
@@ -1,0 +1,7 @@
+version: 2
+contracts:
+  - filesystem:
+      directory: "."
+    consumes:
+      - ./product/product.yaml
+      - ./order/order.yaml


### PR DESCRIPTION



**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->


<!-- feel free to add additional comments -->
