### PR TITLE
Fix YAML serialization issue by ensuring @JsonProperty is respected in SpecmaticConfig class

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -64,6 +64,8 @@ dependencies {
     implementation "io.ktor:ktor-network-tls:$ktor_version"
     implementation "io.ktor:ktor-network-tls-certificates:$ktor_version"
 
+    implementation 'com.fasterxml.jackson.module:jackson-module-kotlin:2.18.2'
+
     implementation 'org.junit.platform:junit-platform-launcher:1.11.3'
     implementation 'org.junit.platform:junit-platform-reporting:1.11.4'
 

--- a/application/src/main/kotlin/application/ConfigCommand.kt
+++ b/application/src/main/kotlin/application/ConfigCommand.kt
@@ -3,6 +3,7 @@ package application
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import io.specmatic.core.config.SpecmaticConfigVersion
 import io.specmatic.core.config.SpecmaticConfigVersion.Companion.convertToLatestVersionedConfig
 import io.specmatic.core.config.SpecmaticConfigVersion.Companion.getLatestVersion
@@ -84,12 +85,15 @@ class ConfigCommand : Callable<Int> {
         }
 
         private fun getObjectMapper(): ObjectMapper {
-            val objectMapper = ObjectMapper(YAMLFactory()).setDefaultPropertyInclusion(
-                JsonInclude.Value.construct(
-                    JsonInclude.Include.CUSTOM,
-                    JsonInclude.Include.CUSTOM
-                ).withValueFilter(EmptyCollectionFilter::class.java)
-            )
+            val objectMapper = ObjectMapper(YAMLFactory()).apply {
+                registerKotlinModule()
+                setDefaultPropertyInclusion(
+                    JsonInclude.Value.construct(
+                        JsonInclude.Include.CUSTOM,
+                        JsonInclude.Include.CUSTOM
+                    ).withValueFilter(EmptyCollectionFilter::class.java)
+                )
+            }
             return objectMapper
         }
 

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -607,8 +607,8 @@ data class ResiliencyTestsConfig(
 }
 
 data class Auth(
-    @JsonProperty("bearer-file") private val bearerFile: String = "bearer.txt",
-    @JsonProperty("bearer-environment-variable") private val bearerEnvironmentVariable: String? = null
+    @param:JsonProperty("bearer-file") private val bearerFile: String = "bearer.txt",
+    @param:JsonProperty("bearer-environment-variable") private val bearerEnvironmentVariable: String? = null
 ) {
     fun getBearerFile(): String {
         return bearerFile
@@ -803,12 +803,12 @@ enum class ReportFormatterLayout {
 }
 
 data class ReportTypes (
-    @JsonProperty("APICoverage")
+    @param:JsonProperty("APICoverage")
     val apiCoverage: APICoverage = APICoverage()
 )
 
 data class APICoverage (
-    @JsonProperty("OpenAPI")
+    @param:JsonProperty("OpenAPI")
     val openAPI: APICoverageConfiguration = APICoverageConfiguration()
 )
 
@@ -824,7 +824,7 @@ data class SuccessCriteria(
 )
 
 data class SecurityConfiguration(
-    @JsonProperty("OpenAPI")
+    @param:JsonProperty("OpenAPI")
     private val OpenAPI: OpenAPISecurityConfiguration?
 ) {
     fun getOpenAPISecurityScheme(scheme: String): SecuritySchemeConfiguration? {


### PR DESCRIPTION
- Registered jackson-module-kotlin to properly handle Kotlin-specific serialization. 
- Added @param:JsonProperty annotations to constructor parameters to ensure correct property naming in both JSON and YAML serialization. 
- Fixed issue where YAML output ignored custom property names defined via @JsonProperty.