### PR TITLE
Specmatic config revamp fix irrelevant fields popping up in yaml

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -462,12 +462,12 @@ data class SpecmaticConfig(
 
     @JsonIgnore
     fun getAuthBearerFile(): String? {
-        return auth?.getBearerFile()
+        return auth?.bearerFile
     }
 
     @JsonIgnore
     fun getAuthBearerEnvironmentVariable(): String? {
-        return auth?.getBearerEnvironmentVariable()
+        return auth?.bearerEnvironmentVariable
     }
 
     @JsonIgnore
@@ -589,17 +589,9 @@ data class ResiliencyTestsConfig(
 }
 
 data class Auth(
-    @param:JsonProperty("bearer-file") private val bearerFile: String = "bearer.txt",
-    @param:JsonProperty("bearer-environment-variable") private val bearerEnvironmentVariable: String? = null
-) {
-    fun getBearerFile(): String {
-        return bearerFile
-    }
-
-    fun getBearerEnvironmentVariable(): String? {
-        return bearerEnvironmentVariable
-    }
-}
+    @param:JsonProperty("bearer-file") val bearerFile: String = "bearer.txt",
+    @param:JsonProperty("bearer-environment-variable") val bearerEnvironmentVariable: String? = null
+)
 
 enum class PipelineProvider { azure }
 

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -588,6 +588,7 @@ data class ResiliencyTestsConfig(
         enable = getEnableFrom(isResiliencyTestFlagEnabled, isOnlyPositiveFlagEnabled)
     )
 
+    @JsonIgnore
     fun getEnableTestSuite(): ResiliencyTestSuite? {
         return enable
     }
@@ -737,6 +738,7 @@ data class ReportConfigurationDetails(
         }
     }
 
+    @JsonIgnore
     override fun withDefaultFormattersIfMissing(): ReportConfigurationDetails {
         val htmlReportFormatter = formatters?.firstOrNull {
             it.type == ReportFormatterType.HTML
@@ -748,20 +750,24 @@ data class ReportConfigurationDetails(
         return this.copy(formatters = listOf(htmlReportFormatter, textReportFormatter))
     }
 
+    @JsonIgnore
     override fun getHTMLFormatter(): ReportFormatterDetails? {
         return formatters?.firstOrNull { it.type == ReportFormatterType.HTML }
     }
 
+    @JsonIgnore
     override fun getSuccessCriteria(): SuccessCriteria {
         return types.apiCoverage.openAPI.successCriteria ?: SuccessCriteria()
     }
 
+    @JsonIgnore
     override fun <T> mapRenderers(fn: (ReportFormatterType) -> T): List<T> {
         return formatters!!.map {
             fn(it.type)
         }
     }
 
+    @JsonIgnore
     override fun excludedOpenAPIEndpoints(): List<String> {
         return types.apiCoverage.openAPI.excludedEndpoints
     }

--- a/core/src/main/kotlin/io/specmatic/core/config/v2/ContractConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v2/ContractConfig.kt
@@ -18,9 +18,8 @@ data class ContractConfig(
     constructor(
         @JsonProperty("git") git: GitContractSource? = null,
         @JsonProperty("filesystem") filesystem: FileSystemContractSource? = null,
-        provides: List<String>? = null,
-        @JsonDeserialize(using = ConsumesDeserializer::class)
-        consumes: List<Consumes>? = null
+        @JsonProperty("provides") provides: List<String>? = null,
+        @JsonDeserialize(using = ConsumesDeserializer::class) @JsonProperty("consumes") consumes: List<Consumes>? = null
     ) : this(
         contractSource = git ?: filesystem,
         provides = provides,

--- a/core/src/test/kotlin/io/specmatic/core/config/SpecmaticConfigAllTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/SpecmaticConfigAllTest.kt
@@ -4,18 +4,15 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
-import io.specmatic.core.ResiliencyTestSuite
-import io.specmatic.core.Source
+import io.specmatic.core.*
 import io.specmatic.core.SourceProvider.filesystem
 import io.specmatic.core.SourceProvider.git
-import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.config.v1.SpecmaticConfigV1
 import io.specmatic.core.config.v2.ContractConfig
 import io.specmatic.core.config.v2.ContractConfig.FileSystemContractSource
 import io.specmatic.core.config.v2.ContractConfig.GitContractSource
 import io.specmatic.core.config.v2.SpecmaticConfigV2
 import io.specmatic.core.config.v3.Consumes
-import io.specmatic.core.loadSpecmaticConfig
 import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.pattern.parsedJSON
 import io.specmatic.core.utilities.GitRepo
@@ -833,6 +830,150 @@ internal class SpecmaticConfigAllTest {
 
         assertThat(contractSource).isNotNull()
         assertThat(contractSource).isInstanceOf(GitContractSource::class.java)
+    }
+
+    @Test
+    fun `v2 with report gets deserialized` () {
+        val contractConfigYaml = """
+            version: 2
+            contracts:
+              - git:
+                  url: http://source.in
+                provides:
+                - com/petstore/1.yaml
+            report:
+              formatters:
+                - type: text
+                  layout: table
+              types:
+                APICoverage:
+                  OpenAPI:
+                    successCriteria:
+                      minThresholdPercentage: 70
+                      maxMissedEndpointsInSpec: 0
+                      enforce: true
+                    excludedEndpoints:
+                      - /health
+        """.trimIndent()
+
+        val configV2 = objectMapper.readValue(contractConfigYaml, SpecmaticConfigV2::class.java)
+
+        val objectMapper =
+            ObjectMapper(YAMLFactory()).registerKotlinModule().setSerializationInclusion(JsonInclude.Include.NON_EMPTY)
+        val configText = objectMapper.writeValueAsString(configV2)
+        println(configText)
+
+        assertThat(configText)
+            .contains("OpenAPI")
+            .contains("APICoverage")
+
+        assertThat(configV2.report?.formatters?.get(0)?.type).isEqualTo(ReportFormatterType.TEXT)
+        assertThat(configV2.report?.formatters?.get(0)?.layout).isEqualTo(ReportFormatterLayout.TABLE)
+
+        assertThat(configV2.report?.types?.apiCoverage?.openAPI?.successCriteria?.minThresholdPercentage).isEqualTo(70)
+        assertThat(configV2.report?.types?.apiCoverage?.openAPI?.successCriteria?.maxMissedEndpointsInSpec).isEqualTo(0)
+        assertThat(configV2.report?.types?.apiCoverage?.openAPI?.successCriteria?.enforce).isEqualTo(true)
+    }
+
+    @Test
+    fun `v1 config with report gets converted to v2` () {
+        val contractConfigYaml = """
+            sources:
+              - provider: git
+                repository: http://source.in
+                provides:
+                - com/petstore/1.yaml
+            report:
+              formatters:
+                - type: text
+                  layout: table
+              types:
+                APICoverage:
+                  OpenAPI:
+                    successCriteria:
+                      minThresholdPercentage: 70
+                      maxMissedEndpointsInSpec: 0
+                      enforce: true
+                    excludedEndpoints:
+                      - /health
+        """.trimIndent()
+
+        val configV1 = objectMapper.readValue(contractConfigYaml, SpecmaticConfigV1::class.java)
+
+        val dslConfig = configV1.transform()
+
+        val configV2 = SpecmaticConfigV2.loadFrom(dslConfig) as SpecmaticConfigV2
+
+        val objectMapper =
+            ObjectMapper(YAMLFactory()).registerKotlinModule().setSerializationInclusion(JsonInclude.Include.NON_EMPTY)
+        val configText = objectMapper.writeValueAsString(configV2)
+        println(configText)
+
+        assertThat(configText)
+            .contains("OpenAPI")
+            .contains("APICoverage")
+
+        assertThat(configV2.report?.formatters?.get(0)?.type).isEqualTo(ReportFormatterType.TEXT)
+        assertThat(configV2.report?.formatters?.get(0)?.layout).isEqualTo(ReportFormatterLayout.TABLE)
+
+        assertThat(configV2.report?.types?.apiCoverage?.openAPI?.successCriteria?.minThresholdPercentage).isEqualTo(70)
+        assertThat(configV2.report?.types?.apiCoverage?.openAPI?.successCriteria?.maxMissedEndpointsInSpec).isEqualTo(0)
+        assertThat(configV2.report?.types?.apiCoverage?.openAPI?.successCriteria?.enforce).isEqualTo(true)
+    }
+
+    @Test
+    fun `v2 config with auth gets deserialized` () {
+        val contractConfigYaml = """
+            version: 2
+            contracts:
+              - git:
+                  url: http://source.in
+                provides:
+                  - com/petstore/1.yaml
+            auth:
+              bearer-file: bearer.txt
+        """.trimIndent()
+
+        val configV2 = objectMapper.readValue(contractConfigYaml, SpecmaticConfigV2::class.java)
+
+        val objectMapper =
+            ObjectMapper(YAMLFactory()).registerKotlinModule().setSerializationInclusion(JsonInclude.Include.NON_EMPTY)
+        val configText = objectMapper.writeValueAsString(configV2)
+        println(configText)
+
+        assertThat(configText)
+            .contains("bearer-file")
+
+        assertThat(configV2.auth?.bearerFile).isEqualTo("bearer.txt")
+    }
+
+    @Test
+    fun `v1 config with auth gets converted to v2` () {
+        val contractConfigYaml = """
+            sources:
+              - provider: git
+                repository: http://source.in
+                provides:
+                - com/petstore/1.yaml
+            auth:
+              bearer-file: bearer.txt
+        """.trimIndent()
+
+        val configV1 = objectMapper.readValue(contractConfigYaml, SpecmaticConfigV1::class.java)
+
+        val dslConfig = configV1.transform()
+
+        val configV2 = SpecmaticConfigV2.loadFrom(dslConfig) as SpecmaticConfigV2
+
+        val objectMapper =
+            ObjectMapper(YAMLFactory()).registerKotlinModule().setSerializationInclusion(JsonInclude.Include.NON_EMPTY)
+        val configText = objectMapper.writeValueAsString(configV2)
+        println(configText)
+
+        assertThat(configText)
+            .contains("bearer-file")
+
+        assertThat(configV2.auth?.bearerFile).isEqualTo("bearer.txt")
     }
 
     @CsvSource(

--- a/core/src/test/kotlin/io/specmatic/core/config/SpecmaticConfigAllTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/SpecmaticConfigAllTest.kt
@@ -21,7 +21,6 @@ import io.specmatic.core.pattern.parsedJSON
 import io.specmatic.core.utilities.GitRepo
 import io.specmatic.core.utilities.LocalFileSystemSource
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.io.TempDir
@@ -640,10 +639,10 @@ internal class SpecmaticConfigAllTest {
         val configV2 = SpecmaticConfigV2.loadFrom(configFromV1) as SpecmaticConfigV2
 
         configV2.test!!.apply {
-            assertThat(getResiliencyTests().getEnableTestSuite()).isEqualTo(ResiliencyTestSuite.all)
-            assertThat(getValidateResponseValues()).isTrue()
-            assertThat(getAllowExtensibleSchema()).isTrue()
-            assertThat(getTimeoutInMilliseconds()).isEqualTo(10)
+            assertThat(resiliencyTests?.enable).isEqualTo(ResiliencyTestSuite.all)
+            assertThat(validateResponseValues).isTrue()
+            assertThat(allowExtensibleSchema).isTrue()
+            assertThat(timeoutInMilliseconds).isEqualTo(10)
         }
     }
 
@@ -663,10 +662,10 @@ internal class SpecmaticConfigAllTest {
         val configV3 = SpecmaticConfigV2.loadFrom(configFromV2) as SpecmaticConfigV2
 
         configV3.test!!.apply {
-            assertThat(getResiliencyTests().getEnableTestSuite()).isEqualTo(ResiliencyTestSuite.all)
-            assertThat(getValidateResponseValues()).isTrue()
-            assertThat(getAllowExtensibleSchema()).isTrue()
-            assertThat(getTimeoutInMilliseconds()).isEqualTo(10)
+            assertThat(resiliencyTests?.enable).isEqualTo(ResiliencyTestSuite.all)
+            assertThat(validateResponseValues).isTrue()
+            assertThat(allowExtensibleSchema).isTrue()
+            assertThat(timeoutInMilliseconds).isEqualTo(10)
         }
     }
 


### PR DESCRIPTION
**What**:

- Cleaned up private fields and their respective getters in sub structures (where the parent keys are not directly accessible in SpecmaticConfig).
- Added tests for auth and report config
- Fixed deserialization of sources (was breaking for some reason in specmatic-order-api-java, but not in specmatic-order-bff-java)

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

