### PR TITLE
Regex validation, response code coordination between stub and test, startup timeout

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -402,6 +402,8 @@ class OpenApiSpecification(
         val data: List<Pair<List<ScenarioInfo>, Map<String, List<Pair<HttpRequest, HttpResponse>>>>> =
             openApiPaths().map { (openApiPath, pathItem) ->
                 val scenariosAndExamples = openApiOperations(pathItem).map { (httpMethod, openApiOperation) ->
+                    logger.debug("\n\nProcessing $httpMethod $openApiPath")
+
                     try {
                         openApiOperation.validateParameters()
                     } catch (e: ContractException) {
@@ -825,6 +827,8 @@ class OpenApiSpecification(
 
     private fun toHttpResponsePatterns(responses: ApiResponses?): List<ResponsePatternData> {
         return responses.orEmpty().map { (status, response) ->
+            logger.debug("Processing response payload with status $status")
+
             val headersMap = openAPIHeadersToSpecmatic(response)
             if(!isNumber(status) && status != "default")
                 throw ContractException("Response status codes are expected to be numbers, but \"$status\" was found")
@@ -835,6 +839,8 @@ class OpenApiSpecification(
 
     private fun openAPIHeadersToSpecmatic(response: ApiResponse) =
         response.headers.orEmpty().map { (headerName, header) ->
+            logger.debug("Processing response header $headerName")
+
             toSpecmaticParamName(header.required != true, headerName) to toSpecmaticPattern(
                 resolveResponseHeader(header)?.schema ?: throw ContractException(
                     headerComponentMissingError(
@@ -893,6 +899,8 @@ class OpenApiSpecification(
                 }
 
         return response.content.map { (contentType, mediaType) ->
+            logger.debug("Processing response with content type $contentType")
+
             val responsePattern = HttpResponsePattern(
                 headersPattern = HttpHeadersPattern(headersMap, contentType = contentType),
                 status = if (status == "default") 1000 else status.toInt(),
@@ -932,6 +940,7 @@ class OpenApiSpecification(
         httpMethod: String,
         operation: Operation
     ): List<RequestPatternsData> {
+        logger.debug("Processing requests for $httpMethod")
 
         val securitySchemes: Map<String, OpenAPISecurityScheme> =
             parsedOpenApi.components?.securitySchemes?.mapValues { (schemeName, scheme) ->
@@ -952,6 +961,8 @@ class OpenApiSpecification(
         val parameters = operation.parameters
 
         val headersMap = parameters.orEmpty().filterIsInstance<HeaderParameter>().associate {
+            logger.debug("Processing request header ${it.name}")
+
             toSpecmaticParamName(it.required != true, it.name) to toSpecmaticPattern(it.schema, emptyList())
         }
 
@@ -986,6 +997,8 @@ class OpenApiSpecification(
             )
 
         return requestBody.content.map { (contentType, mediaType) ->
+            logger.debug("Processing request payload with media type $contentType")
+
             when (contentType.lowercase()) {
                 "multipart/form-data" -> {
                     val partSchemas = if (mediaType.schema.`$ref` == null) {
@@ -1116,6 +1129,8 @@ class OpenApiSpecification(
         operation: Operation,
         contractSecuritySchemes: Map<String, OpenAPISecurityScheme>
     ): List<OpenAPISecurityScheme> {
+        logger.debug("Associating security schemes")
+
         val globalSecurityRequirements: List<String> =
             parsedOpenApi.security?.map { it.keys.toList() }?.flatten() ?: emptyList()
         val operationSecurityRequirements: List<String> =
@@ -1275,6 +1290,8 @@ class OpenApiSpecification(
     private fun toSpecmaticPattern(
         schema: Schema<*>, typeStack: List<String>, patternName: String = "", jsonInFormData: Boolean = false
     ): Pattern {
+        if(patternName.isNotBlank()) logger.debug("Processing schema $patternName")
+
         val preExistingResult = patterns["($patternName)"]
         val pattern = if (preExistingResult != null && patternName.isNotBlank())
             preExistingResult
@@ -1849,6 +1866,8 @@ class OpenApiSpecification(
         val parameters = operation.parameters ?: return HttpQueryParamPattern(emptyMap())
 
         val queryPattern: Map<String, Pattern> = parameters.filterIsInstance<QueryParameter>().associate {
+            logger.debug("Processing query parameter ${it.name}")
+
             val specmaticPattern: Pattern? = if (it.schema.type == "array") {
                 QueryParameterArrayPattern(listOf(toSpecmaticPattern(schema = it.schema.items, typeStack = emptyList())), it.name)
             } else if (it.schema.type != "object") {
@@ -1898,6 +1917,8 @@ class OpenApiSpecification(
             }
 
         val pathPattern: List<URLPathSegmentPattern> = pathSegments.map { pathSegment ->
+            logger.debug("Processing path segment $pathSegment")
+
             if (isParameter(pathSegment)) {
                 val paramName = pathSegment.removeSurrounding("{", "}")
 

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
@@ -11,6 +11,7 @@ import io.ktor.http.*
 import io.ktor.http.content.*
 import io.specmatic.core.utilities.Flags.Companion.SPECMATIC_PRETTY_PRINT
 import io.specmatic.core.utilities.Flags.Companion.getBooleanValue
+import io.specmatic.stub.SPECMATIC_RESPONSE_CODE_HEADER
 import org.apache.http.client.utils.URLEncodedUtils
 import org.apache.http.message.BasicNameValuePair
 import java.io.File
@@ -64,6 +65,10 @@ data class HttpRequest(
         multiPartFormData = multiPartFormData,
         metadata = metadata
     )
+
+    fun addHeader(name: String, value: String): HttpRequest {
+        return this.copy(headers = headers.plus(name to value))
+    }
 
     fun updateQueryParams(otherQueryParams: Map<String, String>): HttpRequest =
         copy(queryParams = queryParams.plus(otherQueryParams))
@@ -383,6 +388,10 @@ data class HttpRequest(
             headers = updatedHeaders,
             metadata = updatedMetadata
         )
+    }
+
+    fun expectedResponseCode(): Int? {
+        return headers[SPECMATIC_RESPONSE_CODE_HEADER]?.toIntOrNull()
     }
 }
 

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -97,7 +97,8 @@ data class StubConfiguration(
     private val generative: Boolean? = null,
     private val delayInMilliseconds: Long? = null,
     private val dictionary: String? = null,
-    private val includeMandatoryAndRequestedKeysInResponse: Boolean? = null
+    private val includeMandatoryAndRequestedKeysInResponse: Boolean? = null,
+    private val startTimeoutInMilliseconds: Long? = null
 ) {
     fun getGenerative(): Boolean? {
         return generative
@@ -113,6 +114,10 @@ data class StubConfiguration(
 
     fun getIncludeMandatoryAndRequestedKeysInResponse(): Boolean? {
         return includeMandatoryAndRequestedKeysInResponse
+    }
+
+    fun getStartTimeoutInMilliseconds(): Long? {
+        return startTimeoutInMilliseconds
     }
 }
 
@@ -308,6 +313,11 @@ data class SpecmaticConfig(
                 }
             }
         }.plus(defaultPort).distinct()
+    }
+
+    @JsonIgnore
+    fun getStubStartTimeoutInMilliseconds(): Long {
+        return stub.getStartTimeoutInMilliseconds() ?: 20_000L
     }
 
     fun logDependencyProjects(azure: AzureAPI) {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/RegExSpec.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/RegExSpec.kt
@@ -24,6 +24,7 @@ class RegExSpec(regex: String?) {
     private val isFinite = this.regex != null && !Generex(this.regex).isInfinite
 
     fun validateMinLength(minLength: Int?) {
+        if (regex == null) return
         minLength?.let {
             val shortestString = generateShortestString()
             if (it > shortestString.length && isFinite) {
@@ -36,6 +37,7 @@ class RegExSpec(regex: String?) {
     }
 
     fun validateMaxLength(maxLength: Int?) {
+        if (regex == null) return
         maxLength?.let {
             val shortestPossibleString = generateShortestString()
             if (shortestPossibleString.length > it) {
@@ -51,7 +53,8 @@ class RegExSpec(regex: String?) {
         return Generex(regex).random(minLen, minLen)
     }
 
-    private fun generateShortestString(): String = RegExp(regex).toAutomaton().getShortestExample(true)
+    private fun generateShortestString(): String =
+        regex?.let { RegExp(it).toAutomaton().getShortestExample(true) } ?: ""
 
     fun generateLongestStringOrRandom(maxLen: Int): String {
         if (regex == null) return randomString(maxLen)

--- a/core/src/main/kotlin/io/specmatic/core/pattern/RegExSpec.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/RegExSpec.kt
@@ -8,10 +8,12 @@ class RegExSpec(val regex: String?) {
 
     fun generateShortestStringOrRandom(minLen: Int): String {
         if (regex == null) return randomString(minLen)
-        val shortestExample = RegExp(regex).toAutomaton().getShortestExample(true)
+        val shortestExample = generateShortestString()
         if (minLen <= shortestExample.length) return shortestExample
         return Generex(regex).random(minLen, minLen)
     }
+
+    fun generateShortestString(): String = RegExp(regex).toAutomaton().getShortestExample(true)
 
     fun generateLongestStringOrRandom(maxLen: Int): String {
         if (regex == null) return randomString(maxLen)
@@ -54,4 +56,10 @@ class RegExSpec(val regex: String?) {
         memo[key] = best
         return best
     }
+
+    val isFinite: Boolean
+        get() {
+            if (regex == null) return false
+            return !Generex(regex).isInfinite
+        }
 }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/RegExSpec.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/RegExSpec.kt
@@ -3,8 +3,46 @@ package io.specmatic.core.pattern
 import com.mifmif.common.regex.Generex
 import dk.brics.automaton.RegExp
 import dk.brics.automaton.State
+import io.specmatic.core.value.StringValue
+import io.specmatic.core.value.Value
+import kotlin.collections.MutableMap
+import kotlin.collections.forEach
+import kotlin.collections.mutableMapOf
+import kotlin.collections.set
 
-class RegExSpec(val regex: String?) {
+internal const val WORD_BOUNDARY = "\\b"
+
+class RegExSpec(regex: String?) {
+    private val originalRegex = regex
+    private val regex = regex?.let {
+        validateRegex(replaceRegexLowerBounds(it))
+            .removePrefix("^").removeSuffix("$")
+            .removePrefix(WORD_BOUNDARY).removeSuffix(WORD_BOUNDARY)
+            .let { regexWithoutSurroundingDelimiters -> replaceShorthandEscapeSeq(regexWithoutSurroundingDelimiters) }
+    }
+
+    private val isFinite = this.regex != null && !Generex(this.regex).isInfinite
+
+    fun validateMinLength(minLength: Int?) {
+        minLength?.let {
+            val shortestString = generateShortestString()
+            if (it > shortestString.length && isFinite) {
+                val longestString = generateLongestStringOrRandom(it)
+                if (longestString.length < it) {
+                    throw IllegalArgumentException("minLength $it cannot be greater than the length of longest possible string that matches regex ${this.originalRegex}")
+                }
+            }
+        }
+    }
+
+    fun validateMaxLength(maxLength: Int?) {
+        maxLength?.let {
+            val shortestPossibleString = generateShortestString()
+            if (shortestPossibleString.length > it) {
+                throw IllegalArgumentException("maxLength $it cannot be less than the length of shortest possible string that matches regex ${this.originalRegex}")
+            }
+        }
+    }
 
     fun generateShortestStringOrRandom(minLen: Int): String {
         if (regex == null) return randomString(minLen)
@@ -13,7 +51,7 @@ class RegExSpec(val regex: String?) {
         return Generex(regex).random(minLen, minLen)
     }
 
-    fun generateShortestString(): String = RegExp(regex).toAutomaton().getShortestExample(true)
+    private fun generateShortestString(): String = RegExp(regex).toAutomaton().getShortestExample(true)
 
     fun generateLongestStringOrRandom(maxLen: Int): String {
         if (regex == null) return randomString(maxLen)
@@ -24,6 +62,53 @@ class RegExSpec(val regex: String?) {
         val automaton = RegExp(regex).toAutomaton()
         return longestFrom(automaton.initialState, maxLen, mutableMapOf())
             ?: throw IllegalStateException("No valid string found")
+    }
+
+    fun match(sampleData: StringValue) =
+        regex?.let { Regex(it).matches(sampleData.toStringLiteral()) } ?: true
+
+    private fun replaceRegexLowerBounds(regex: String): String {
+        val pattern = Regex("""\{,(\d+)}""")
+        return regex.replace(pattern) { matchResult ->
+            "{0,${matchResult.groupValues[1]}}"
+        }
+    }
+
+    private fun validateRegex(regex: String): String {
+        if (regex.startsWith("/") && regex.endsWith("/")) {
+            throw IllegalArgumentException("Invalid regex $originalRegex. OpenAPI follows ECMA-262 regular expressions, which do not support / / delimiters like those used in many programming languages")
+        }
+        return runCatching { RegExp(regex); regex }.getOrElse {
+                e -> throw IllegalArgumentException("Failed to parse regex $originalRegex\nReason: ${e.message}")
+        }
+    }
+
+    private fun replaceShorthandEscapeSeq(regex: String): String {
+        // This regex matches a character class: a '[' followed by either an escaped char (e.g. \])
+        // or any char that is not a ']', until the first unescaped ']'
+        val charClassRegex = Regex("""\[(?:\\.|[^\]])*]""")
+
+        return charClassRegex.replace(regex) { matchResult ->
+            val charClass = matchResult.value
+
+            // Check if the class is negated (i.e. starts with "[^")
+            val isNegated = charClass.startsWith("[^")
+            // Extract the inner content (skip the starting '[' or "[^" and the ending ']')
+            val innerContent = if (isNegated)
+                charClass.substring(2, charClass.length - 1)
+            else
+                charClass.substring(1, charClass.length - 1)
+
+            // Replace shorthand escapes inside the character class.
+            // Note: The replacements are applied only to the inner content.
+            val replaced = innerContent
+                .replace(Regex("""\\w"""), """a-zA-Z0-9_""")
+                .replace(Regex("""\\s"""), """ \\t\\r\\n""")
+                .replace(Regex("""\\d"""), """0-9""")
+
+            // Rebuild the character class with its original negation if present.
+            if (isNegated) "[^$replaced]" else "[$replaced]"
+        }
     }
 
     /**
@@ -57,9 +142,34 @@ class RegExSpec(val regex: String?) {
         return best
     }
 
-    val isFinite: Boolean
-        get() {
-            if (regex == null) return false
-            return !Generex(regex).isInfinite
+    fun generateRandomString(minLength: Int, maxLength: Int? = null): Value {
+        return regex?.let {
+            StringValue(generateFromRegex(it, minLength, maxLength))
+        } ?: StringValue(randomString(patternBaseLength(minLength, maxLength)))
+    }
+
+    private fun patternBaseLength(minLength: Int, maxLength: Int?): Int {
+        return when {
+            5 < minLength -> minLength
+            maxLength != null && 5 > maxLength -> maxLength
+            else -> 5
         }
+    }
+
+    private fun generateFromRegex(regex: String, minLength: Int, maxLength: Int? = null): String {
+        return try {
+            if (maxLength == null) {
+                Generex(regex).random(minLength)
+            } else {
+                Generex(regex).random(minLength, maxLength)
+            }
+        } catch (e: StackOverflowError) {
+            //TODO: This is a workaround for a bug in Generex. Remove this when the bug is fixed.
+            generateFromRegex(regex, minLength, maxLength)
+        }
+    }
+
+    override fun toString(): String {
+        return regex ?: "regex not set"
+    }
 }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/RegExSpec.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/RegExSpec.kt
@@ -1,0 +1,57 @@
+package io.specmatic.core.pattern
+
+import com.mifmif.common.regex.Generex
+import dk.brics.automaton.RegExp
+import dk.brics.automaton.State
+
+class RegExSpec(val regex: String?) {
+
+    fun generateShortestStringOrRandom(minLen: Int): String {
+        if (regex == null) return randomString(minLen)
+        val shortestExample = RegExp(regex).toAutomaton().getShortestExample(true)
+        if (minLen <= shortestExample.length) return shortestExample
+        return Generex(regex).random(minLen, minLen)
+    }
+
+    fun generateLongestStringOrRandom(maxLen: Int): String {
+        if (regex == null) return randomString(maxLen)
+        val generex = Generex(regex)
+        if (generex.isInfinite) {
+            return generex.random(maxLen, maxLen)
+        }
+        val automaton = RegExp(regex).toAutomaton()
+        return longestFrom(automaton.initialState, maxLen, mutableMapOf())
+            ?: throw IllegalStateException("No valid string found")
+    }
+
+    /**
+     * Recursively computes the longest accepted string (using at most [remaining] transitions)
+     * from [state]. Returns null if no accepted string can be formed within the given limit.
+     *
+     * The tie-breaker when strings have the same length is the lexicographical order.
+     */
+    private fun longestFrom(state: State, remaining: Int, memo: MutableMap<Pair<State, Int>, String?>): String? {
+        val key = state to remaining
+        memo[key]?.let { return it }
+
+        var best: String? = if (state.isAccept) "" else null
+
+        if (remaining > 0) {
+            state.transitions.forEach { t ->
+                val sub = longestFrom(t.dest, remaining - 1, memo)
+                sub?.let {
+                    val candidate = t.max.toString() + it
+                    best = when {
+                        best == null -> candidate
+                        candidate.length > best!!.length -> candidate
+                        candidate.length == best!!.length && candidate > best!! -> candidate
+                        else -> best
+                    }
+                }
+            }
+        }
+
+        memo[key] = best
+        return best
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/core/pattern/StringPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/StringPattern.kt
@@ -100,7 +100,7 @@ data class StringPattern (
 
         if (doesNotMatchRegex(sampleData)) {
             return mismatchResult(
-                """string that matches regex /$validRegex/""",
+                """string that matches regex $validRegex""",
                 sampleData,
                 resolver.mismatchMessages
             )

--- a/core/src/main/kotlin/io/specmatic/core/pattern/StringPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/StringPattern.kt
@@ -26,10 +26,10 @@ data class StringPattern (
 
     init {
         if (effectiveMinLength < 0) {
-            throw IllegalArgumentException("minimumLength cannot be less than 0")
+            throw IllegalArgumentException("minLength cannot be less than 0")
         }
         if (effectiveMinLength > effectiveMaxLength) {
-            throw IllegalArgumentException("maximumLength cannot be less than minimumLength")
+            throw IllegalArgumentException("maxLength cannot be less than minLength")
         }
 
         validRegex?.let {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/StringPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/StringPattern.kt
@@ -49,7 +49,7 @@ data class StringPattern (
 
     private fun validateRegex(regex: String): String {
         if (regex.startsWith("/") && regex.endsWith("/")) {
-            throw IllegalArgumentException("Invalid String Constraints - $regex is not valid. OpenAPI follows ECMA-262 regular expressions, which do not support / / delimiters like those used in many programming languages")
+            throw IllegalArgumentException("Invalid String Constraints - Regex $regex is not valid. OpenAPI follows ECMA-262 regular expressions, which do not support / / delimiters like those used in many programming languages")
         }
         return runCatching { RegExp(regex); regex }.getOrElse {
                 e -> throw IllegalArgumentException("Failed to parse regex ${regex.quote()}\nReason: ${e.message}")

--- a/core/src/main/kotlin/io/specmatic/core/pattern/StringPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/StringPattern.kt
@@ -48,6 +48,9 @@ data class StringPattern (
     }
 
     private fun validateRegex(regex: String): String {
+        if (regex.startsWith("/") && regex.endsWith("/")) {
+            throw IllegalArgumentException("Invalid String Constraints - $regex is not valid. OpenAPI follows ECMA-262 regular expressions, which do not support / / delimiters like those used in many programming languages")
+        }
         return runCatching { RegExp(regex); regex }.getOrElse {
                 e -> throw IllegalArgumentException("Failed to parse regex ${regex.quote()}\nReason: ${e.message}")
         }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/StringPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/StringPattern.kt
@@ -1,8 +1,5 @@
 package io.specmatic.core.pattern
 
-import com.mifmif.common.regex.Generex
-import dk.brics.automaton.RegExp
-import io.ktor.http.*
 import io.specmatic.core.Resolver
 import io.specmatic.core.Result
 import io.specmatic.core.mismatchResult
@@ -13,8 +10,6 @@ import io.specmatic.core.value.Value
 import java.nio.charset.StandardCharsets
 import java.util.*
 
-const val WORD_BOUNDARY = "\\b"
-
 data class StringPattern (
     override val typeAlias: String? = null,
     val minLength: Int? = null,
@@ -22,13 +17,7 @@ data class StringPattern (
     override val example: String? = null,
     val regex: String? = null
 ) : Pattern, ScalarType, HasDefaultExample {
-    val validRegex
-        get() = regex?.let {
-            validateRegex(replaceRegexLowerBounds(it))
-                .removePrefix("^").removeSuffix("$")
-                .removePrefix(WORD_BOUNDARY).removeSuffix(WORD_BOUNDARY)
-                .let { regexWithoutSurroundingDelimiters -> replaceShorthandEscapeSeq(regexWithoutSurroundingDelimiters) }
-        }
+    private val regExSpec get() = RegExSpec(regex)
     private val effectiveMinLength get() = minLength ?: 0
 
     init {
@@ -40,76 +29,8 @@ data class StringPattern (
                 throw IllegalArgumentException("maxLength $it cannot be less than minLength $effectiveMinLength")
             }
         }
-        validRegex?.let {
-            regexMinLengthValidation(it)
-            regexMaxLengthValidation(it)
-        }
-    }
-
-    private fun replaceRegexLowerBounds(regex: String): String {
-        val pattern = Regex("""\{,(\d+)}""")
-        return regex.replace(pattern) { matchResult ->
-            "{0,${matchResult.groupValues[1]}}"
-        }
-    }
-
-    private fun validateRegex(regex: String): String {
-        if (regex.startsWith("/") && regex.endsWith("/")) {
-            throw IllegalArgumentException("Invalid String Constraints - Regex $regex is not valid. OpenAPI follows ECMA-262 regular expressions, which do not support / / delimiters like those used in many programming languages")
-        }
-        return runCatching { RegExp(regex); regex }.getOrElse {
-                e -> throw IllegalArgumentException("Failed to parse regex ${regex.quote()}\nReason: ${e.message}")
-        }
-    }
-
-    private fun replaceShorthandEscapeSeq(regex: String): String {
-        // This regex matches a character class: a '[' followed by either an escaped char (e.g. \])
-        // or any char that is not a ']', until the first unescaped ']'
-        val charClassRegex = Regex("""\[(?:\\.|[^\]])*]""")
-
-        return charClassRegex.replace(regex) { matchResult ->
-            val charClass = matchResult.value
-
-            // Check if the class is negated (i.e. starts with "[^")
-            val isNegated = charClass.startsWith("[^")
-            // Extract the inner content (skip the starting '[' or "[^" and the ending ']')
-            val innerContent = if (isNegated)
-                charClass.substring(2, charClass.length - 1)
-            else
-                charClass.substring(1, charClass.length - 1)
-
-            // Replace shorthand escapes inside the character class.
-            // Note: The replacements are applied only to the inner content.
-            val replaced = innerContent
-                .replace(Regex("""\\w"""), "a-zA-Z0-9_")
-                .replace(Regex("""\\s"""), " \\t\\r\\n\\f")
-                .replace(Regex("""\\d"""), "0-9")
-
-            // Rebuild the character class with its original negation if present.
-            if (isNegated) "[^$replaced]" else "[$replaced]"
-        }
-    }
-
-    private fun regexMinLengthValidation(regex: String) {
-        minLength?.let {
-            val regExSpec = RegExSpec(regex)
-            val shortestString = regExSpec.generateShortestString()
-            if (it > shortestString.length && regExSpec.isFinite) {
-                val longestString = regExSpec.generateLongestStringOrRandom(it)
-                if (longestString.length < it) {
-                    throw IllegalArgumentException("Invalid String Constraints - minLength $it cannot be greater than the length of longest possible string that matches regex ${this.regex}")
-                }
-            }
-        }
-    }
-
-    private fun regexMaxLengthValidation(regex: String) {
-        maxLength?.let {
-            val shortestPossibleString = RegExSpec(regex).generateShortestString()
-            if (shortestPossibleString.length > it) {
-                throw IllegalArgumentException("Invalid String Constraints - maxLength $it cannot be less than the length of shortest possible string that matches regex ${this.regex}")
-            }
-        }
+        regExSpec.validateMinLength(minLength)
+        regExSpec.validateMaxLength(maxLength)
     }
 
     override fun matches(sampleData: Value?, resolver: Resolver): Result {
@@ -129,9 +50,9 @@ data class StringPattern (
             sampleData, resolver.mismatchMessages
         )
 
-        if (doesNotMatchRegex(sampleData)) {
+        if (!regExSpec.match(sampleData)) {
             return mismatchResult(
-                """string that matches regex $validRegex""",
+                """string that matches regex $regex""",
                 sampleData,
                 resolver.mismatchMessages
             )
@@ -139,9 +60,6 @@ data class StringPattern (
 
         return Result.Success()
     }
-
-    private fun doesNotMatchRegex(sampleData: StringValue) =
-        validRegex?.let { !Regex(it).matches(sampleData.toStringLiteral()) } ?: false
 
     private fun lengthAboveUpperBound(sampleData: StringValue) =
         maxLength?.let { sampleData.toStringLiteral().length > it } ?: false
@@ -162,13 +80,6 @@ data class StringPattern (
         return JSONArrayValue(valueList)
     }
 
-    private val patternBaseLength: Int =
-        when {
-            5 < effectiveMinLength -> effectiveMinLength
-            maxLength != null && 5 > maxLength -> maxLength
-            else -> 5
-        }
-
     override fun generate(resolver: Resolver): Value {
         val defaultExample = resolver.resolveExample(example, this)
 
@@ -178,26 +89,10 @@ data class StringPattern (
             return it
         }
 
-        return validRegex?.let {
-            StringValue(generateFromRegex(it, effectiveMinLength, maxLength))
-        } ?: StringValue(randomString(patternBaseLength))
-    }
-
-    private fun generateFromRegex(regex: String, minLength: Int, maxLength: Int? = null): String {
-        return try {
-            if (maxLength == null) {
-                Generex(regex).random(minLength)
-            } else {
-                Generex(regex).random(minLength, maxLength)
-            }
-        } catch (e: StackOverflowError) {
-            //TODO: This is a workaround for a bug in Generex. Remove this when the bug is fixed.
-            generateFromRegex(regex, minLength, maxLength)
-        }
+        return regExSpec.generateRandomString(effectiveMinLength, maxLength)
     }
 
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
-        val regExSpec = RegExSpec(validRegex)
         val minLengthExample: ReturnValue<Pattern>? = minLength?.let { minLen ->
             val exampleString = regExSpec.generateShortestStringOrRandom(minLen)
             HasValue(ExactValuePattern(StringValue(exampleString)), "minimum length string")

--- a/core/src/main/kotlin/io/specmatic/core/pattern/StringPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/StringPattern.kt
@@ -27,11 +27,11 @@ data class StringPattern (
 
     init {
         if (effectiveMinLength < 0) {
-            throw IllegalArgumentException("minLength cannot be less than 0")
+            throw IllegalArgumentException("minLength $effectiveMinLength cannot be less than 0")
         }
         maxLength?.let {
             if (effectiveMinLength > it) {
-                throw IllegalArgumentException("maxLength cannot be less than minLength")
+                throw IllegalArgumentException("maxLength $it cannot be less than minLength $effectiveMinLength")
             }
         }
         validRegex?.let {
@@ -60,10 +60,10 @@ data class StringPattern (
                     Generex(regex).random(it)
                 }
                 if (someValue.length < it) {
-                    throw IllegalArgumentException("Invalid String Constraints - minLength cannot be greater than the length of longest possible string that matches regex")
+                    throw IllegalArgumentException("Invalid String Constraints - minLength $it cannot be greater than the length of longest possible string that matches regex $regex")
                 }
             } catch (e: TimeoutException) {
-                throw IllegalArgumentException("Invalid String Constraints - minLength cannot be greater than the length of longest possible string that matches regex")
+                throw IllegalArgumentException("Invalid String Constraints - minLength $it cannot be greater than the length of longest possible string that matches regex $regex")
             }
         }
     }
@@ -72,8 +72,8 @@ data class StringPattern (
         maxLength?.let {
             val automaton = RegExp(regex).toAutomaton()
             val shortestPossibleLengthOfRegex = automaton.getShortestExample(true).length
-            if (shortestPossibleLengthOfRegex > maxLength) {
-                throw IllegalArgumentException("Invalid String Constraints - maxLength cannot be less than the length of shortest possible string that matches regex")
+            if (shortestPossibleLengthOfRegex > it) {
+                throw IllegalArgumentException("Invalid String Constraints - maxLength $it cannot be less than the length of shortest possible string that matches regex $regex")
             }
         }
     }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/StringPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/StringPattern.kt
@@ -20,9 +20,9 @@ data class StringPattern (
     override val example: String? = null,
     val regex: String? = null
 ) : Pattern, ScalarType, HasDefaultExample {
+    val validRegex = regex?.let { validateRegex(replaceRegexLowerBounds(it)).removePrefix("^").removeSuffix("$") }
     private val effectiveMinLength = minLength ?: 0
-    private val effectiveMaxLength = maxLength ?: (effectiveMinLength + 5)
-    val validRegex = regex?.let { replaceRegexLowerBounds(it) }
+    private val effectiveMaxLength = maxLength ?: (effectiveMinLength + 5) //TODO: we should do this only for infinite regex
 
     init {
         if (effectiveMinLength < 0) {
@@ -33,9 +33,8 @@ data class StringPattern (
         }
 
         validRegex?.let {
-            val regexWithoutCaretAndDollar = validateRegex(it).removePrefix("^").removeSuffix("$")
-            regexMinLengthValidation(regexWithoutCaretAndDollar)
-            regexMaxLengthValidation(regexWithoutCaretAndDollar)
+            regexMinLengthValidation(validRegex)
+            regexMaxLengthValidation(validRegex)
         }
     }
 
@@ -135,8 +134,7 @@ data class StringPattern (
         }
 
         return validRegex?.let {
-            val regexWithoutCaretAndDollar = it.removePrefix("^").removeSuffix("$")
-            StringValue(generateFromRegex(regexWithoutCaretAndDollar, patternBaseLength, effectiveMaxLength))
+            StringValue(generateFromRegex(validRegex, patternBaseLength, effectiveMaxLength))
         } ?: StringValue(randomString(patternBaseLength))
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/utilities/Utilities.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/Utilities.kt
@@ -390,7 +390,7 @@ fun <T> runWithTimeout(timeout: Long, task: Callable<T>): T {
         future.cancel(true)
         throw e
     } catch (e: ExecutionException) {
-        throw RuntimeException("Task execution failed", e.cause)
+        throw e.cause ?: e
     } finally {
         executor.shutdown() // Shut down the executor
     }

--- a/core/src/main/kotlin/io/specmatic/core/value/JSONObjectValue.kt
+++ b/core/src/main/kotlin/io/specmatic/core/value/JSONObjectValue.kt
@@ -97,6 +97,11 @@ data class JSONObjectValue(val jsonObject: Map<String, Value> = emptyMap()) : Va
         jsonObject[name]
 
     fun keys() = jsonObject.keys
+    fun addEntry(key: String, value: String): JSONObjectValue {
+        return this.copy(
+            jsonObject = jsonObject.plus(key to StringValue(value))
+        )
+    }
 
 }
 

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -62,6 +62,8 @@ import java.nio.charset.Charset
 import java.util.*
 import kotlin.text.toCharArray
 
+const val SPECMATIC_RESPONSE_CODE_HEADER = "Specmatic-Response-Code"
+
 class HttpStub(
     private val features: List<Feature>,
     rawHttpStubs: List<HttpStubData> = emptyList(),

--- a/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
@@ -7,6 +7,7 @@ import io.specmatic.core.log.LogMessage
 import io.specmatic.core.log.logger
 import io.specmatic.core.utilities.exceptionCauseMessage
 import io.specmatic.core.value.Value
+import io.specmatic.stub.SPECMATIC_RESPONSE_CODE_HEADER
 
 data class ScenarioAsTest(
     val scenario: Scenario,
@@ -85,7 +86,7 @@ data class ScenarioAsTest(
     ): Pair<Result, HttpResponse?> {
         val request = testScenario.generateHttpRequest(flagsBased).let {
             workflow.updateRequest(it, originalScenario)
-        }
+        }.addHeader(SPECMATIC_RESPONSE_CODE_HEADER, testScenario.status.toString())
 
         try {
             testExecutor.setServerState(testScenario.serverState)

--- a/core/src/test/kotlin/integration_tests/ResponseCodeHintingTest.kt
+++ b/core/src/test/kotlin/integration_tests/ResponseCodeHintingTest.kt
@@ -1,0 +1,353 @@
+package integration_tests
+
+import io.specmatic.conversions.OpenApiSpecification
+import io.specmatic.core.HttpRequest
+import io.specmatic.core.HttpResponse
+import io.specmatic.core.SPECMATIC_TYPE_HEADER
+import io.specmatic.core.pattern.parsedJSONObject
+import io.specmatic.mock.ScenarioStub
+import io.specmatic.mock.TRANSIENT_MOCK_ID
+import io.specmatic.stub.HttpStub
+import io.specmatic.stub.SPECMATIC_RESPONSE_CODE_HEADER
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ResponseCodeHintingTest {
+    @Test
+    fun `stub should return stubbed response as per the hinted status code`() {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+            openapi: 3.0.0
+            info:
+              title: Sample API
+              version: 1.0.0
+            paths:
+              /person:
+                post:
+                  summary: Simple POST endpoint
+                  requestBody:
+                    content:
+                      application/json:
+                        schema:
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            name:
+                              type: string
+                  responses:
+                    '200':
+                      description: OK
+                      content:
+                        text/plain:
+                          schema:
+                            type: string
+                    '202':
+                      description: OK
+                      content:
+                        text/plain:
+                          schema:
+                              type: string
+            """.trimIndent(), ""
+        ).toFeature()
+
+        HttpStub(listOf(feature)).use { stub ->
+            val request = HttpRequest("POST", "/person", body = parsedJSONObject("""{"name": "John Doe"}"""))
+
+            val dynamic200Example = ScenarioStub(request, HttpResponse.ok("200 response")).toJSON()
+            val dynamic202Example = ScenarioStub(request, HttpResponse(202, "202 response")).toJSON()
+
+            listOf(dynamic202Example, dynamic200Example).forEach {
+                stub.client.execute(HttpRequest("POST", "/_specmatic/expectations", body = it)).let { response ->
+                    assertThat(response.status).isIn(200)
+                }
+            }
+
+            stub.client.execute(request.addHeader(SPECMATIC_RESPONSE_CODE_HEADER, "200")).let { response ->
+                assertThat(response.status).isEqualTo(200)
+                assertThat(response.headers).doesNotContainEntry(SPECMATIC_TYPE_HEADER, "random")
+            }
+
+            stub.client.execute(request.addHeader(SPECMATIC_RESPONSE_CODE_HEADER, "202")).let { response ->
+                assertThat(response.status).isEqualTo(202)
+                assertThat(response.headers).doesNotContainEntry(SPECMATIC_TYPE_HEADER, "random")
+            }
+        }
+    }
+
+    @Test
+    fun `stub should generate random response as per the hinted status code`() {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+            openapi: 3.0.0
+            info:
+              title: Sample API
+              version: 1.0.0
+            paths:
+              /:
+                post:
+                  summary: Simple POST endpoint
+                  requestBody:
+                    content:
+                      application/json:
+                        schema:
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            name:
+                              type: string
+                  responses:
+                    '200':
+                      description: OK
+                      content:
+                        text/plain:
+                          schema:
+                            type: string
+                    '202':
+                      description: OK
+                      content:
+                        text/plain:
+                          schema:
+                              type: string
+            """.trimIndent(), ""
+        ).toFeature()
+
+        HttpStub(listOf(feature)).use { stub ->
+            val request = HttpRequest("POST", "/", body = parsedJSONObject("""{"name": "John Doe"}"""))
+
+            stub.client.execute(request.addHeader(SPECMATIC_RESPONSE_CODE_HEADER, "200")).let { response ->
+                assertThat(response.status).isEqualTo(200)
+                assertThat(response.headers).containsEntry(SPECMATIC_TYPE_HEADER, "random")
+            }
+
+            stub.client.execute(request.addHeader(SPECMATIC_RESPONSE_CODE_HEADER, "202")).let { response ->
+                assertThat(response.status).isEqualTo(202)
+                assertThat(response.headers).containsEntry(SPECMATIC_TYPE_HEADER, "random")
+            }
+        }
+    }
+
+    @Test
+    fun `random response should be generated by the stub using the hinted status code even if a matching stub is found for the same request with another status code`() {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+            openapi: 3.0.0
+            info:
+              title: Sample API
+              version: 1.0.0
+            paths:
+              /person:
+                post:
+                  summary: Simple POST endpoint
+                  requestBody:
+                    content:
+                      application/json:
+                        schema:
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            name:
+                              type: string
+                  responses:
+                    '200':
+                      description: OK
+                      content:
+                        text/plain:
+                          schema:
+                            type: string
+                    '202':
+                      description: OK
+                      content:
+                        text/plain:
+                          schema:
+                              type: string
+            """.trimIndent(), ""
+        ).toFeature()
+
+        HttpStub(listOf(feature)).use { stub ->
+            val request = HttpRequest("POST", "/person", body = parsedJSONObject("""{"name": "John Doe"}"""))
+
+            val dynamic200Example = ScenarioStub(request, HttpResponse.ok("200 response")).toJSON()
+
+            stub.client.execute(HttpRequest("POST", "/_specmatic/expectations", body = dynamic200Example)).let { response ->
+                assertThat(response.status).isIn(200)
+                assertThat(response.headers).doesNotContainEntry(SPECMATIC_TYPE_HEADER, "random")
+            }
+
+            stub.client.execute(request.addHeader(SPECMATIC_RESPONSE_CODE_HEADER, "202")).let { response ->
+                assertThat(response.status).isEqualTo(202)
+                assertThat(response.headers).containsEntry(SPECMATIC_TYPE_HEADER, "random")
+            }
+        }
+    }
+
+    @Test
+    fun `stub should return response from transient mock if it has the expected status code`() {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+            openapi: 3.0.0
+            info:
+              title: Sample API
+              version: 1.0.0
+            paths:
+              /person:
+                post:
+                  summary: Simple POST endpoint
+                  requestBody:
+                    content:
+                      application/json:
+                        schema:
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            name:
+                              type: string
+                  responses:
+                    '200':
+                      description: OK
+                      content:
+                        text/plain:
+                          schema:
+                            type: string
+                    '202':
+                      description: OK
+                      content:
+                        text/plain:
+                          schema:
+                              type: string
+            """.trimIndent(), ""
+        ).toFeature()
+
+        HttpStub(listOf(feature)).use { stub ->
+            val request = HttpRequest("POST", "/person", body = parsedJSONObject("""{"name": "John Doe"}"""))
+
+            val dynamic200Example = ScenarioStub(request, HttpResponse(202, "202 response")).toJSON().addEntry(TRANSIENT_MOCK_ID, "abc123")
+
+            stub.client.execute(HttpRequest("POST", "/_specmatic/expectations", body = dynamic200Example)).let { response ->
+                assertThat(response.status).isIn(200)
+                assertThat(response.headers).doesNotContainEntry(SPECMATIC_TYPE_HEADER, "random")
+            }
+
+            stub.client.execute(request.addHeader(SPECMATIC_RESPONSE_CODE_HEADER, "202")).let { response ->
+                assertThat(response.status).isEqualTo(202)
+                assertThat(response.headers).doesNotContainEntry(SPECMATIC_TYPE_HEADER, "random")
+            }
+
+            stub.client.execute(request.addHeader(SPECMATIC_RESPONSE_CODE_HEADER, "202")).let { response ->
+                assertThat(response.status).isEqualTo(202)
+                assertThat(response.headers).containsEntry(SPECMATIC_TYPE_HEADER, "random")
+            }
+        }
+    }
+
+    @Test
+    fun `stub should return a random response if it has a matching transient mock but not with the expected status code`() {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+            openapi: 3.0.0
+            info:
+              title: Sample API
+              version: 1.0.0
+            paths:
+              /person:
+                post:
+                  summary: Simple POST endpoint
+                  requestBody:
+                    content:
+                      application/json:
+                        schema:
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            name:
+                              type: string
+                  responses:
+                    '200':
+                      description: OK
+                      content:
+                        text/plain:
+                          schema:
+                            type: string
+                    '202':
+                      description: OK
+                      content:
+                        text/plain:
+                          schema:
+                              type: string
+            """.trimIndent(), ""
+        ).toFeature()
+
+        HttpStub(listOf(feature)).use { stub ->
+            val request = HttpRequest("POST", "/person", body = parsedJSONObject("""{"name": "John Doe"}"""))
+
+            val dynamic200Example = ScenarioStub(request, HttpResponse(202, "202 response")).toJSON().addEntry(TRANSIENT_MOCK_ID, "abc123")
+
+            stub.client.execute(HttpRequest("POST", "/_specmatic/expectations", body = dynamic200Example)).let { response ->
+                assertThat(response.status).isIn(200)
+                assertThat(response.headers).doesNotContainEntry(SPECMATIC_TYPE_HEADER, "random")
+            }
+
+            stub.client.execute(request.addHeader(SPECMATIC_RESPONSE_CODE_HEADER, "200")).let { response ->
+                assertThat(response.status).isEqualTo(200)
+                assertThat(response.headers).containsEntry(SPECMATIC_TYPE_HEADER, "random")
+            }
+        }
+    }
+
+    @Test
+    fun `strict mode stub should return a failure if a status code is hinted but it is not stubbed out`() {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+            openapi: 3.0.0
+            info:
+              title: Sample API
+              version: 1.0.0
+            paths:
+              /:
+                post:
+                  summary: Simple POST endpoint
+                  requestBody:
+                    content:
+                      application/json:
+                        schema:
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            name:
+                              type: string
+                  responses:
+                    '200':
+                      description: OK
+                      content:
+                        text/plain:
+                          schema:
+                            type: string
+                    '202':
+                      description: OK
+                      content:
+                        text/plain:
+                          schema:
+                              type: string
+            """.trimIndent(), ""
+        ).toFeature()
+
+        HttpStub(listOf(feature), strictMode = true).use { stub ->
+            val request = HttpRequest("POST", "/", body = parsedJSONObject("""{"name": "John Doe"}"""))
+
+            val dynamic200Example = ScenarioStub(request, HttpResponse.ok("200 response")).toJSON()
+
+            stub.client.execute(HttpRequest("POST", "/_specmatic/expectations", body = dynamic200Example)).let { response ->
+                assertThat(response.status).isIn(200)
+            }
+
+            stub.client.execute(request.addHeader(SPECMATIC_RESPONSE_CODE_HEADER, "202")).let { response ->
+                assertThat(response.status).isEqualTo(400)
+            }
+        }
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/pattern/RegExSpecTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/RegExSpecTest.kt
@@ -1,13 +1,52 @@
 package io.specmatic.core.pattern
 
-import com.mifmif.common.regex.Generex
-import dk.brics.automaton.RegExp
+import io.specmatic.core.value.StringValue
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 
 class RegExSpecTest {
+    @Test
+    fun `should not allow construction with invalid regex`() {
+        val invalidRegex = "/^a{10}\$/"
+        assertThrows<Exception> { RegExSpec(invalidRegex) }
+            .also { assertThat(it.message).isEqualTo("Invalid regex $invalidRegex. OpenAPI follows ECMA-262 regular expressions, which do not support / / delimiters like those used in many programming languages") }
+    }
+
+    @Test
+    fun `should not allow construction with minLength greater that what is possible with regex`() {
+        val tenOccurrencesOfAlphabetA = "^a{10}\$"
+        val minLength = 15
+        assertThrows<Exception> { RegExSpec(tenOccurrencesOfAlphabetA).validateMinLength(minLength) }
+            .also { assertThat(it.message).isEqualTo("minLength $minLength cannot be greater than the length of longest possible string that matches regex $tenOccurrencesOfAlphabetA") }
+    }
+
+    @Test
+    fun `should not allow construction with maxLength lesser that what is possible with regex`() {
+        val tenOccurrencesOfAlphabetA = "^a{10}\$"
+        val maxLength = 8
+        assertThrows<Exception> { RegExSpec(tenOccurrencesOfAlphabetA).validateMaxLength(maxLength) }
+            .also { assertThat(it.message).isEqualTo("maxLength $maxLength cannot be less than the length of shortest possible string that matches regex $tenOccurrencesOfAlphabetA") }
+    }
+
+    @Test
+    fun `should throw an exception with the regex parse failure from the regex library` () {
+        assertThatThrownBy { RegExSpec("yes|no|") }.hasMessageContaining("unexpected end-of-string")
+    }
+
+    @Test
+    fun `minLength greater than upper bound in the regex should not be accepted`() {
+        val regex = "[A-Z]{10,20}"
+        val minLength = 21
+        assertThatThrownBy {
+            RegExSpec(regex).validateMinLength(minLength)
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessage("minLength $minLength cannot be greater than the length of longest possible string that matches regex $regex")
+    }
+
     @ParameterizedTest
     @CsvSource(
         "[a-zA-Z0-9]{1,3}; 1; 1",
@@ -59,107 +98,55 @@ class RegExSpecTest {
         assertThat(randomString).hasSize(10)
     }
 
-    @ParameterizedTest
-    @CsvSource(
-        "[a-zA-Z0-9]{10,20}; 9",
-        "[a-zA-Z0-9]{0,20}; -1",
-        "[a-zA-Z0-9]{10}; 9",
-        "[a-zA-Z0-9]{5}[a-zA-Z0-9]{5}; 9",
-        delimiterString = "; "
-    )
-    fun `min is less than lower bound of a finite regex should be accept`(regex: String, min: Int) {
-        val automaton = RegExp(regex).toAutomaton()
-        assertThat(automaton.isFinite).isTrue
-        automaton.getShortestExample(true).let {
-            assertThat(it.length).isGreaterThan(min)
-        }
+    @Test
+    fun `should strip out word boundary in regex`() {
+        val possibleValues = "Cat|Dog|Lion|Tiger"
+        val regExSpec = RegExSpec("$WORD_BOUNDARY($possibleValues)$WORD_BOUNDARY")
+        possibleValues.split("|").forEach { assertThat(regExSpec.match(StringValue(it))).isTrue }
     }
 
     @ParameterizedTest
     @CsvSource(
-        "[a-zA-Z0-9]{10,20}; 21",
-        "[a-zA-Z0-9]{0,20}; 21",
-        "[a-zA-Z0-9]{10}; 11",
-        "[a-zA-Z0-9]{5}[a-zA-Z0-9]{5}; 11",
+        "^[A-Z]{5,10}\$; [A-Z]{5,10}",
+        "[A-Z]{,10}; [A-Z]{0,10}",
+        "$WORD_BOUNDARY[A-Z]{5,10}$WORD_BOUNDARY; [A-Z]{5,10}",
+        "A-Z\\s0-9; A-Z\\s0-9",
+        "A-Z\\d0-9; A-Z\\d0-9",
+        "A-Z\\w0-9; A-Z\\w0-9",
+        "a[A-Z\\s0-9]b; a[A-Z \\t\\r\\n0-9]b",
+        "a[A-Z\\da-z]b; a[A-Z0-9a-z]b",
+        "a[A-Z\\w0-9]b; a[A-Za-zA-Z0-9_0-9]b",
+        "a[^A-Z\\s0-9]b; a[^A-Z \\t\\r\\n0-9]b",
+        "a[^A-Z\\da-z]b; a[^A-Z0-9a-z]b",
+        "a[^A-Z\\w0-9]b; a[^A-Za-zA-Z0-9_0-9]b",
+        "A-Z\\S0-9; A-Z\\S0-9",
+        "A-Z\\D0-9; A-Z\\D0-9",
+        "A-Z\\W0-9; A-Z\\W0-9",
+        "a[A-Z\\S0-9]b; a[A-Z\\S0-9]b",
+        "a[A-Z\\Da-z]b; a[A-Z\\Da-z]b",
+        "a[A-Z\\W0-9]b; a[A-Z\\W0-9]b",
         delimiterString = "; "
     )
-    fun `min is greater than upper bound of a finite regex should be rejected`(regex: String, min: Int) {
-        val automaton = RegExp(regex).toAutomaton()
-        assertThat(automaton.isFinite).isTrue
-        automaton.getShortestExample(true).let {
-            assertThat(it.length).isLessThan(min)
-        }
-        assertThat(Generex(regex).getMatchedStrings(min).size).isNotZero()
+    fun `cleans up the regex at construction`(inputRegex: String, expectedRegex: String) {
+        val regExSpec = RegExSpec(inputRegex)
+        val toString = regExSpec.toString()
+        assertThat(toString).isEqualTo(expectedRegex)
     }
 
     @ParameterizedTest
     @CsvSource(
-        "[a-zA-Z0-9]{10,20}; 9",
-        "[a-zA-Z0-9]{0,20}; 0",
-        "[a-zA-Z0-9]{10}; 9",
-        "[a-zA-Z0-9]{5}[a-zA-Z0-9]{5}; 9",
+        "null; 3; null; 5; 5",
+        "null; 3; 4; 4; 4",
+        "null; 3; 10; 5; 5",
+        "^[A-Z]{5,10}\$; 5; 10; 5; 10",
+        "[A-Z]{,10}; 0; 10; 0; 10",
+        "[A-Z]{3,}; 0; 10; 3; 10",
         delimiterString = "; "
     )
-    fun `max is less than lower bound of a finite regex should be rejected`(regex: String, max: Int) {
-        val automaton = RegExp(regex).toAutomaton()
-        assertThat(automaton.isFinite).isTrue
-        automaton.getShortestExample(true).let {
-            assertThat(it.length).isGreaterThanOrEqualTo(max)
-        }
-        assertThat(Generex(regex).getMatchedStrings(max).size).isZero()
-    }
-
-    @ParameterizedTest
-    @CsvSource(
-        "[a-zA-Z0-9]{10,20}; 21",
-        "[a-zA-Z0-9]{0,20}; 21",
-        "[a-zA-Z0-9]{10}; 11",
-        "[a-zA-Z0-9]{5}[a-zA-Z0-9]{5}; 11",
-        delimiterString = "; "
-    )
-    fun `max is greater than upper bound of a finite regex should be accepted`(regex: String, max: Int) {
-        val automaton = RegExp(regex).toAutomaton()
-        assertThat(automaton.isFinite).isTrue
-        automaton.getShortestExample(true).let {
-            assertThat(it.length).isLessThan(max)
-        }
-        assertThat(Generex(regex).getMatchedStrings(max).size).isNotZero()
-    }
-
-    @ParameterizedTest
-    @CsvSource(
-        "[a-zA-Z0-9]{10,}; 9",
-        "[a-zA-Z0-9]{0,}; -1",
-        "[a-zA-Z0-9]{5,}[a-zA-Z0-9]{5,}; 9",
-        "[a-zA-Z0-9]+; 0",
-        ".*; -1",
-        ".+; 0",
-        delimiterString = "; "
-    )
-    fun `min is less than lower bound of an infinite regex should be accept`(regex: String, min: Int) {
-        val automaton = RegExp(regex).toAutomaton()
-        assertThat(automaton.isFinite).isFalse
-        automaton.getShortestExample(true).let {
-            assertThat(it.length).isGreaterThan(min)
-        }
-    }
-
-    @ParameterizedTest
-    @CsvSource(
-        "[a-zA-Z0-9]{10,}; 9",
-        "[a-zA-Z0-9]{0,}; 0",
-        "[a-zA-Z0-9]{5,}[a-zA-Z0-9]{5,}; 9",
-        "[a-zA-Z0-9]+; 0",
-        ".*; 0",
-        ".+; 0",
-        delimiterString = "; "
-    )
-    fun `max is less than lower bound of an infinite regex should be rejected`(regex: String, max: Int) {
-        val automaton = RegExp(regex).toAutomaton()
-        assertThat(automaton.isFinite).isFalse
-        automaton.getShortestExample(true).let {
-            assertThat(it.length).isGreaterThanOrEqualTo(max)
-        }
-        assertThat(Generex(regex).getMatchedStrings(max).size).isZero()
+    fun `Generate random string when regex is empty`(regex: String, min: Int, max: String, expectedMinLen: Int, expectedMaxLen: Int) {
+        val generatedString = RegExSpec(regex.takeIf { it != "null" }).generateRandomString(min, max.toIntOrNull()).toStringLiteral()
+        assertThat(generatedString.length)
+            .isGreaterThanOrEqualTo(expectedMinLen)
+            .isLessThanOrEqualTo(expectedMaxLen)
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/pattern/RegExSpecTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/RegExSpecTest.kt
@@ -1,0 +1,165 @@
+package io.specmatic.core.pattern
+
+import com.mifmif.common.regex.Generex
+import dk.brics.automaton.RegExp
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+
+class RegExSpecTest {
+    @ParameterizedTest
+    @CsvSource(
+        "[a-zA-Z0-9]{1,3}; 1; 1",
+        "[a-zA-Z0-9]{1,3}; 2; 2",
+        "[a-zA-Z0-9]{1,3}; 0; 1",
+        "[a-zA-Z0-9]{1,}; 1; 1",
+        "[a-zA-Z0-9]{1,}; 30; 30",
+        "[a-zA-Z0-9]*; 0; 0",
+        "[a-zA-Z0-9]*; 30; 30",
+        "[a-zA-Z0-9]+; 1; 1",
+        "[a-zA-Z0-9]+; 30; 30",
+        "[a-zA-Z0-9]{1,3}-[a-zA-Z0-9]{1,3}; 3; 3",
+        "[a-zA-Z0-9]{1,3}-[a-zA-Z0-9]{1,3}; 2; 3",
+        "[a-zA-Z0-9]{1,3}-[a-zA-Z0-9]{1,3}; 5; 5",
+        delimiterString = "; "
+    )
+    fun `should generate min length based on the regex and min length`(regex: String, minLen: Int, expectedLength: Int) {
+        val shortestString = RegExSpec(regex).generateShortestStringOrRandom(minLen)
+        assertThat(shortestString).hasSize(expectedLength)
+    }
+
+    @Test
+    fun `should generate random min length string when regex is null`() {
+        val randomString = RegExSpec(null).generateShortestStringOrRandom(10)
+        assertThat(randomString).hasSize(10)
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        "[a-zA-Z0-9]{1,3}; 3; 3",
+        "[a-zA-Z0-9]{1,3}; 2; 2",
+        "[a-zA-Z0-9]{1,3}; 4; 3",
+        "[a-zA-Z0-9]{1,}; 30; 30",
+        "[a-zA-Z0-9]*; 30; 30",
+        "[a-zA-Z0-9]+; 30; 30",
+        "[a-zA-Z0-9]{1,3}-[a-zA-Z0-9]{1,3}; 7; 7",
+        "[a-zA-Z0-9]{1,3}-[a-zA-Z0-9]{1,3}; 6; 6",
+        "[a-zA-Z0-9]{1,3}-[a-zA-Z0-9]{1,3}; 8; 7",
+        delimiterString = "; "
+    )
+    fun `should generate max length based on the regex and max length`(regex: String, max: Int, expectedLength: Int) {
+        val longestString = RegExSpec(regex).generateLongestStringOrRandom(max)
+        assertThat(longestString).hasSize(expectedLength)
+    }
+
+    @Test
+    fun `should generate random max length string when regex is null`() {
+        val randomString = RegExSpec(null).generateLongestStringOrRandom(10)
+        assertThat(randomString).hasSize(10)
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        "[a-zA-Z0-9]{10,20}; 9",
+        "[a-zA-Z0-9]{0,20}; -1",
+        "[a-zA-Z0-9]{10}; 9",
+        "[a-zA-Z0-9]{5}[a-zA-Z0-9]{5}; 9",
+        delimiterString = "; "
+    )
+    fun `min is less than lower bound of a finite regex should be accept`(regex: String, min: Int) {
+        val automaton = RegExp(regex).toAutomaton()
+        assertThat(automaton.isFinite).isTrue
+        automaton.getShortestExample(true).let {
+            assertThat(it.length).isGreaterThan(min)
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        "[a-zA-Z0-9]{10,20}; 21",
+        "[a-zA-Z0-9]{0,20}; 21",
+        "[a-zA-Z0-9]{10}; 11",
+        "[a-zA-Z0-9]{5}[a-zA-Z0-9]{5}; 11",
+        delimiterString = "; "
+    )
+    fun `min is greater than upper bound of a finite regex should be rejected`(regex: String, min: Int) {
+        val automaton = RegExp(regex).toAutomaton()
+        assertThat(automaton.isFinite).isTrue
+        automaton.getShortestExample(true).let {
+            assertThat(it.length).isLessThan(min)
+        }
+        assertThat(Generex(regex).getMatchedStrings(min).size).isNotZero()
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        "[a-zA-Z0-9]{10,20}; 9",
+        "[a-zA-Z0-9]{0,20}; 0",
+        "[a-zA-Z0-9]{10}; 9",
+        "[a-zA-Z0-9]{5}[a-zA-Z0-9]{5}; 9",
+        delimiterString = "; "
+    )
+    fun `max is less than lower bound of a finite regex should be rejected`(regex: String, max: Int) {
+        val automaton = RegExp(regex).toAutomaton()
+        assertThat(automaton.isFinite).isTrue
+        automaton.getShortestExample(true).let {
+            assertThat(it.length).isGreaterThanOrEqualTo(max)
+        }
+        assertThat(Generex(regex).getMatchedStrings(max).size).isZero()
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        "[a-zA-Z0-9]{10,20}; 21",
+        "[a-zA-Z0-9]{0,20}; 21",
+        "[a-zA-Z0-9]{10}; 11",
+        "[a-zA-Z0-9]{5}[a-zA-Z0-9]{5}; 11",
+        delimiterString = "; "
+    )
+    fun `max is greater than upper bound of a finite regex should be accepted`(regex: String, max: Int) {
+        val automaton = RegExp(regex).toAutomaton()
+        assertThat(automaton.isFinite).isTrue
+        automaton.getShortestExample(true).let {
+            assertThat(it.length).isLessThan(max)
+        }
+        assertThat(Generex(regex).getMatchedStrings(max).size).isNotZero()
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        "[a-zA-Z0-9]{10,}; 9",
+        "[a-zA-Z0-9]{0,}; -1",
+        "[a-zA-Z0-9]{5,}[a-zA-Z0-9]{5,}; 9",
+        "[a-zA-Z0-9]+; 0",
+        ".*; -1",
+        ".+; 0",
+        delimiterString = "; "
+    )
+    fun `min is less than lower bound of an infinite regex should be accept`(regex: String, min: Int) {
+        val automaton = RegExp(regex).toAutomaton()
+        assertThat(automaton.isFinite).isFalse
+        automaton.getShortestExample(true).let {
+            assertThat(it.length).isGreaterThan(min)
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        "[a-zA-Z0-9]{10,}; 9",
+        "[a-zA-Z0-9]{0,}; 0",
+        "[a-zA-Z0-9]{5,}[a-zA-Z0-9]{5,}; 9",
+        "[a-zA-Z0-9]+; 0",
+        ".*; 0",
+        ".+; 0",
+        delimiterString = "; "
+    )
+    fun `max is less than lower bound of an infinite regex should be rejected`(regex: String, max: Int) {
+        val automaton = RegExp(regex).toAutomaton()
+        assertThat(automaton.isFinite).isFalse
+        automaton.getShortestExample(true).let {
+            assertThat(it.length).isGreaterThanOrEqualTo(max)
+        }
+        assertThat(Generex(regex).getMatchedStrings(max).size).isZero()
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/pattern/StringPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/StringPatternTest.kt
@@ -27,7 +27,7 @@ internal class StringPatternTest {
     @Test
     fun `should not allow maxLength less than minLength`() {
         val exception = assertThrows<IllegalArgumentException> { StringPattern(minLength = 6, maxLength = 4) }
-        assertThat(exception.message).isEqualTo("maxLength cannot be less than minLength")
+        assertThat(exception.message).isEqualTo("maxLength 4 cannot be less than minLength 6")
     }
 
     @Test
@@ -271,21 +271,23 @@ internal class StringPatternTest {
         val exception = assertThrows<IllegalArgumentException> {
             StringPattern(minLength = 6, maxLength = 4)
         }
-        assertThat(exception.message).isEqualTo("maxLength cannot be less than minLength")
+        assertThat(exception.message).isEqualTo("maxLength 4 cannot be less than minLength 6")
     }
 
     @Test
     fun `should not allow construction of string with minLength is greater that what is possible with regex`() {
-        val tenOccurrencesOfAlphabetA = "^a{10}\$"
-        assertThrows<Exception> { StringPattern(minLength = 15, maxLength = 20, regex = tenOccurrencesOfAlphabetA) }
-            .also { assertThat(it.message).isEqualTo("Invalid String Constraints - minLength cannot be greater than the length of longest possible string that matches regex") }
+        val tenOccurrencesOfAlphabetA = "a{10}"
+        val minLength = 15
+        assertThrows<Exception> { StringPattern(minLength = minLength, maxLength = 20, regex = tenOccurrencesOfAlphabetA) }
+            .also { assertThat(it.message).isEqualTo("Invalid String Constraints - minLength $minLength cannot be greater than the length of longest possible string that matches regex $tenOccurrencesOfAlphabetA") }
     }
 
     @Test
     fun `should not allow construction of string with maxLength is lesser that what is possible with regex`() {
-        val tenOccurrencesOfAlphabetA = "^a{10}\$"
-        assertThrows<Exception> { StringPattern(minLength = 5, maxLength = 8, regex = tenOccurrencesOfAlphabetA) }
-            .also { assertThat(it.message).isEqualTo("Invalid String Constraints - maxLength cannot be less than the length of shortest possible string that matches regex") }
+        val tenOccurrencesOfAlphabetA = "a{10}"
+        val maxLength = 8
+        assertThrows<Exception> { StringPattern(minLength = 5, maxLength = maxLength, regex = tenOccurrencesOfAlphabetA) }
+            .also { assertThat(it.message).isEqualTo("Invalid String Constraints - maxLength $maxLength cannot be less than the length of shortest possible string that matches regex $tenOccurrencesOfAlphabetA") }
     }
 
     @Test
@@ -295,13 +297,15 @@ internal class StringPatternTest {
 
     @Test
     fun `minLength greater than upper bound in the regex should not be accepted`() {
+        val regex = "[A-Z]{10,20}"
+        val minLength = 21
         assertThatThrownBy {
             StringPattern(
-                regex = "[A-Z]{10,20}",
-                minLength = 21
+                regex = regex,
+                minLength = minLength
             )
         }.isInstanceOf(IllegalArgumentException::class.java)
-            .hasMessage("Invalid String Constraints - minLength cannot be greater than the length of longest possible string that matches regex")
+            .hasMessage("Invalid String Constraints - minLength $minLength cannot be greater than the length of longest possible string that matches regex $regex")
     }
 
     @ParameterizedTest

--- a/core/src/test/kotlin/io/specmatic/core/pattern/StringPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/StringPatternTest.kt
@@ -275,6 +275,13 @@ internal class StringPatternTest {
     }
 
     @Test
+    fun `should not allow construction of string with invalid regex`() {
+        val invalidRegex = "/^a{10}\$/"
+        assertThrows<Exception> { StringPattern(regex = invalidRegex) }
+            .also { assertThat(it.message).isEqualTo("Invalid String Constraints - $invalidRegex is not valid. OpenAPI follows ECMA-262 regular expressions, which do not support / / delimiters like those used in many programming languages") }
+    }
+
+    @Test
     fun `should not allow construction of string with minLength is greater that what is possible with regex`() {
         val tenOccurrencesOfAlphabetA = "a{10}"
         val minLength = 15

--- a/core/src/test/kotlin/io/specmatic/core/pattern/StringPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/StringPatternTest.kt
@@ -414,6 +414,7 @@ internal class StringPatternTest {
         automaton.getShortestExample(true).let {
             assertThat(it.length).isLessThan(min)
         }
+        assertThat(Generex(regex).getMatchedStrings(min).size).isNotZero()
     }
 
     @ParameterizedTest

--- a/core/src/test/kotlin/io/specmatic/core/pattern/StringPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/StringPatternTest.kt
@@ -278,7 +278,7 @@ internal class StringPatternTest {
     fun `should not allow construction of string with invalid regex`() {
         val invalidRegex = "/^a{10}\$/"
         assertThrows<Exception> { StringPattern(regex = invalidRegex) }
-            .also { assertThat(it.message).isEqualTo("Invalid String Constraints - $invalidRegex is not valid. OpenAPI follows ECMA-262 regular expressions, which do not support / / delimiters like those used in many programming languages") }
+            .also { assertThat(it.message).isEqualTo("Invalid String Constraints - Regex $invalidRegex is not valid. OpenAPI follows ECMA-262 regular expressions, which do not support / / delimiters like those used in many programming languages") }
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/core/pattern/StringPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/StringPatternTest.kt
@@ -299,6 +299,17 @@ internal class StringPatternTest {
         assertThatThrownBy { StringPattern(regex = "yes|no|") }.hasMessageContaining("unexpected end-of-string")
     }
 
+    @Test
+    fun `minLength greater than upper bound in the regex should not be accepted`() {
+        assertThatThrownBy {
+            StringPattern(
+                regex = "[A-Z]{10,20}",
+                minLength = 21
+            )
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessage("Invalid String Constraints - minLength cannot be greater than length of longest possible string that matches regex")
+    }
+
     @ParameterizedTest
     @CsvSource(
         "'^[A-Z]{10,12}$';9;null;true;9;12",

--- a/core/src/test/kotlin/io/specmatic/core/pattern/StringPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/StringPatternTest.kt
@@ -94,7 +94,8 @@ internal class StringPatternTest {
     @CsvSource(
         "'^\\w+(-\\w+)*$',null,10,1",
         "'^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$',1,10,1",
-        "'^[a-z]*$', null, null, 5",
+        "'^[a-z]*$', null, null, 0",
+        "'^[a-z]*$', 5, null, 5",
         "'^[a-z0-9]{6,10}',6,10,6",
         "null, 1, 10, 1"
     )
@@ -277,21 +278,14 @@ internal class StringPatternTest {
     fun `should not allow construction of string with minLength is greater that what is possible with regex`() {
         val tenOccurrencesOfAlphabetA = "^a{10}\$"
         assertThrows<Exception> { StringPattern(minLength = 15, maxLength = 20, regex = tenOccurrencesOfAlphabetA) }
-            .also { assertThat(it.message).isEqualTo("Invalid String Constraints - minLength cannot be greater than length of shortest possible string that matches regex") }
+            .also { assertThat(it.message).isEqualTo("Invalid String Constraints - minLength cannot be greater than the length of longest possible string that matches regex") }
     }
 
     @Test
     fun `should not allow construction of string with maxLength is lesser that what is possible with regex`() {
         val tenOccurrencesOfAlphabetA = "^a{10}\$"
         assertThrows<Exception> { StringPattern(minLength = 5, maxLength = 8, regex = tenOccurrencesOfAlphabetA) }
-            .also { assertThat(it.message).isEqualTo("Invalid String Constraints - maxLength cannot be less than length of shortest possible string that matches regex") }
-    }
-
-    @Test
-    fun `should not allow construction of string with maxLength is greater that what is possible with regex`() {
-        val fiveToElevenOccurrencesOfAlphabetA = "^a{5,11}\$"
-        assertThrows<Exception> { StringPattern(minLength = 5, maxLength = 10, regex = fiveToElevenOccurrencesOfAlphabetA) }
-            .also { assertThat(it.message).isEqualTo("Invalid String Constraints - regex cannot generate / match string greater than maxLength") }
+            .also { assertThat(it.message).isEqualTo("Invalid String Constraints - maxLength cannot be less than the length of shortest possible string that matches regex") }
     }
 
     @Test
@@ -307,80 +301,78 @@ internal class StringPatternTest {
                 minLength = 21
             )
         }.isInstanceOf(IllegalArgumentException::class.java)
-            .hasMessage("Invalid String Constraints - minLength cannot be greater than length of longest possible string that matches regex")
+            .hasMessage("Invalid String Constraints - minLength cannot be greater than the length of longest possible string that matches regex")
     }
 
     @ParameterizedTest
     @CsvSource(
-        "'^[A-Z]{10,12}$';9;null;true;9;12",
-        "'^[A-Z]{10,12}$';10;null;true;10;12",
-        "'^[A-Z]{10,20}$';20;null;true;20;20",
-        "'^[A-Z]{10,20}$';21;null;false;0;0",
-        "'^[A-Z]{10,20}$';null;9;false;0;0",
-        "'^[A-Z]{10,20}$';null;10;true;10;10",
-        "'^[A-Z]{10,20}$';null;20;true;10;20",
-        "'^[A-Z]{10,20}$';null;21;true;10;20",
-        "'^[A-Z]{10,20}$';9;20;true;10;20",
-        "'^[A-Z]{10,20}$';8;9;false;0;0",
-        "'^[A-Z]{10,20}$';10;20;true;10;20",
-        "'^[A-Z]{10,20}$';11;19;true;11;19",
-        "'^[A-Z]{,20}$';0;null;true;0;20",
-        "'^[A-Z]{,20}$';20;null;true;20;20",
-        "'^[A-Z]{,20}$';21;null;false;0;0",
-        "'^[A-Z]{,20}$';null;20;true;0;20",
-        "'^[A-Z]{,20}$';null;21;true;0;20",
-        "'^[A-Z]{20}$';19;null;true;20;20",
-        "'^[A-Z]{20}$';20;null;true;20;20",
-        "'^[A-Z]{20}$';21;null;false;0;0",
-        "'^[A-Z]{20}$';null;19;false;0;0",
-        "'^[A-Z]{20}$';null;20;true;20;20",
-        "'^[A-Z]{20}$';null;21;true;20;20",
-        "'^[A-Z]{10,}$';9;null;true;9;99999999",
-        "'^[A-Z]{10,}$';10;null;true;10;99999999",
-        "'^[A-Z]{10,}$';101;null;false;101;99999999",
-        "'^[A-Z]{10,}$';null;9;false;0;0",
-        "'^[A-Z]{10,}$';null;10;true;10;10",
-        "'^[A-Z]{10,}$';null;21;true;10;21",
-        "'^[A-Z]*$';0;null;true;0;99999999",
-        "'^[A-Z]*$';10;null;true;10;99999999",
-        "'^[A-Z]*$';null;0;true;0;0",
-        "'^[A-Z]*$';null;10;true;0;10",
-        "'^[A-Z]+$';0;null;false;0;0",
-        "'^[A-Z]+$';1;null;true;1;99999999",
-        "'^[A-Z]+$';10;null;true;10;99999999",
-        "'^[A-Z]+$';null;0;false;0;0",
-        "'^[A-Z]+$';null;1;true;1;1",
-        "'^[A-Z]+$';null;10;true;1;10",
+        "'^[a-zA-Z0-9]{10,12}$';9;null;true;9;12",
+        "'^[a-zA-Z0-9]{10,12}$';10;null;true;10;12",
+        "'^[a-zA-Z0-9]{10,20}$';20;null;true;20;20",
+        "'^[a-zA-Z0-9]{10,20}$';21;null;false;0;0",
+        "'^[a-zA-Z0-9]{10,20}$';null;9;false;0;0",
+        "'^[a-zA-Z0-9]{10,20}$';null;10;true;10;10",
+        "'^[a-zA-Z0-9]{10,20}$';null;20;true;10;20",
+        "'^[a-zA-Z0-9]{10,20}$';null;21;true;10;20",
+        "'^[a-zA-Z0-9]{10,20}$';9;20;true;10;20",
+        "'^[a-zA-Z0-9]{10,20}$';8;9;false;0;0",
+        "'^[a-zA-Z0-9]{10,20}$';10;20;true;10;20",
+        "'^[a-zA-Z0-9]{10,20}$';11;19;true;11;19",
+        "'^[a-zA-Z0-9]{,20}$';0;null;true;0;20",
+        "'^[a-zA-Z0-9]{,20}$';20;null;true;20;20",
+        "'^[a-zA-Z0-9]{,20}$';21;null;false;0;0",
+        "'^[a-zA-Z0-9]{,20}$';null;20;true;0;20",
+        "'^[a-zA-Z0-9]{,20}$';null;21;true;0;20",
+        "'^[a-zA-Z0-9]{20}$';19;null;true;20;20",
+        "'^[a-zA-Z0-9]{20}$';20;null;true;20;20",
+        "'^[a-zA-Z0-9]{20}$';21;null;false;0;0",
+        "'^[a-zA-Z0-9]{20}$';null;19;false;0;0",
+        "'^[a-zA-Z0-9]{20}$';null;20;true;20;20",
+        "'^[a-zA-Z0-9]{20}$';null;21;true;20;20",
+        "'^[a-zA-Z0-9]{10,}$';9;null;true;9;99999999",
+        "'^[a-zA-Z0-9]{10,}$';10;null;true;10;99999999",
+        "'^[a-zA-Z0-9]{10,}$';101;null;true;101;99999999",
+        "'^[a-zA-Z0-9]{10,}$';null;9;false;0;0",
+        "'^[a-zA-Z0-9]{10,}$';null;10;true;10;10",
+        "'^[a-zA-Z0-9]{10,}$';null;21;true;10;21",
+        "'^[a-zA-Z0-9]*$';0;null;true;0;99999999",
+        "'^[a-zA-Z0-9]*$';10;null;true;10;99999999",
+        "'^[a-zA-Z0-9]*$';null;0;true;0;0",
+        "'^[a-zA-Z0-9]*$';null;10;true;0;10",
+        "'^[a-zA-Z0-9]+$';0;null;true;1;99999999",
+        "'^[a-zA-Z0-9]+$';1;null;true;1;99999999",
+        "'^[a-zA-Z0-9]+$';10;null;true;10;99999999",
+        "'^[a-zA-Z0-9]+$';null;0;false;0;0",
+        "'^[a-zA-Z0-9]+$';null;1;true;1;1",
+        "'^[a-zA-Z0-9]+$';null;10;true;1;10",
         delimiterString = ";"
     )
     fun `generate string value as per regex in conjunction with minimum and maximum`(
         regex: String?, minInput: String?, maxInput: String?, valid:Boolean, expectedMinLength: Int, expectedMaxLength: Int
     ) {
-        repeat(10) {
-            val min = minInput?.toIntOrNull()
-            val max = maxInput?.toIntOrNull()
-            val patternRegex = if (regex == "null") null else regex
+        val min = minInput?.toIntOrNull()
+        val max = maxInput?.toIntOrNull()
+        val patternRegex = if (regex == "null") null else regex
 
-            try {
-                val stringPattern = StringPattern(
-                    minLength = min,
-                    maxLength = max,
-                    regex = patternRegex
-                )
-                val result = stringPattern.generate(Resolver()) as StringValue
-                if (valid) {
-                    val generatedString = result.string
-                    val generatedLength = generatedString.length
+        try {
+            val stringPattern = StringPattern(
+                minLength = min,
+                maxLength = max,
+                regex = patternRegex
+            )
+            val result = stringPattern.generate(Resolver()) as StringValue
+            if (valid) {
+                val generatedString = result.string
+                val generatedLength = generatedString.length
 
-                    assertThat(generatedLength).isGreaterThanOrEqualTo(expectedMinLength)
-                    assertThat(generatedLength).isLessThanOrEqualTo(expectedMaxLength)
-                    patternRegex?.let { assertThat(generatedString).matches(stringPattern.validRegex) }
-                } else {
-                    fail("Expected an exception to be thrown")
-                }
-            } catch (e: Exception) {
-                if (valid) throw e
+                assertThat(generatedLength).isGreaterThanOrEqualTo(expectedMinLength)
+                assertThat(generatedLength).isLessThanOrEqualTo(expectedMaxLength)
+                patternRegex?.let { assertThat(generatedString).matches(stringPattern.validRegex) }
+            } else {
+                fail("Expected an exception to be thrown")
             }
+        } catch (e: Exception) {
+            if (valid) throw e
         }
     }
 

--- a/core/src/test/kotlin/io/specmatic/core/pattern/StringPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/StringPatternTest.kt
@@ -51,6 +51,30 @@ internal class StringPatternTest {
     }
 
     @Test
+    fun `should match valid string`() {
+        assertThat(StringPattern(regex = "[0-9A-Z]{32}").matches(StringValue("VAKTIGOOIXJDKQWGBBAPFXRKIHLEONUP"), Resolver()).isSuccess()).isTrue
+    }
+
+    @Test
+    fun `should not match an invalid string`() {
+        val regex = "[0-9a-z]{32}"
+        val candidate = "VAKTIGOOIXJDKQWGBBAPFXRKIHLEONUP"
+        val result = StringPattern(regex = regex).matches(StringValue(candidate), Resolver())
+        assertThat(result.isSuccess()).isFalse
+        assertThat(result.reportString()).isEqualTo("""Expected string that matches regex $regex, actual was "$candidate"""")
+    }
+
+    @Test
+    fun `should match valid string when min is specified`() {
+        assertThat(StringPattern(regex = "[0-9A-Z]{32}", minLength = 32).matches(StringValue("VAKTIGOOIXJDKQWGBBAPFXRKIHLEONUP"), Resolver()).isSuccess()).isTrue
+    }
+
+    @Test
+    fun `should match valid string when max is specified`() {
+        assertThat(StringPattern(regex = "[0-9A-Z]{32}", maxLength = 32).matches(StringValue("VAKTIGOOIXJDKQWGBBAPFXRKIHLEONUP"), Resolver()).isSuccess()).isTrue
+    }
+
+    @Test
     fun `should match string of any length when min and max are not specified`() {
         val randomString = RandomStringUtils.randomAlphabetic((0..99).random())
         assertThat(StringPattern().matches(StringValue(randomString), Resolver()).isSuccess()).isTrue

--- a/core/src/test/kotlin/io/specmatic/core/pattern/StringPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/StringPatternTest.kt
@@ -1,5 +1,7 @@
 package io.specmatic.core.pattern
 
+import com.mifmif.common.regex.Generex
+import dk.brics.automaton.RegExp
 import io.specmatic.GENERATION
 import io.specmatic.core.Resolver
 import io.specmatic.core.Result
@@ -296,5 +298,82 @@ internal class StringPatternTest {
     @Test
     fun `should throw an exception with the regex parse failure from the regex library` () {
         assertThatThrownBy { StringPattern(regex = "yes|no|") }.hasMessageContaining("unexpected end-of-string")
+    }
+
+    @Test
+    fun `test max infinite length`() {
+        val regex = "[a-zA-Z0-9]*"
+        val generex = Generex(regex)
+
+        println(generex.random(10, 32))
+
+    }
+
+    @Test
+    fun `test min length finite regex`() {
+        val regex = "[a-zA-Z0-9]{32}"
+        val generex = Generex(regex)
+
+        println(generex.random(10))
+    }
+
+    @Test
+    fun `test min length with finite regex where min is more than regex max`() {
+        val regex = "[a-zA-Z0-9]{32}"
+        val min = 33
+
+        val briks = RegExp(regex).toAutomaton()
+
+        val shortestExample = briks.getShortestExample(true)
+
+        assertThat(shortestExample.length).isLessThan(min)
+
+    }
+
+    @Test
+    fun `test max length with finite regex where max is less than regex length`() {
+        val regex = "[a-zA-Z0-9]{5}[a-zA-Z0-9]{5}"
+        val max = 10
+
+        val generex = Generex(regex)
+
+        val briks = RegExp(regex).toAutomaton()
+
+        val matchedStrings = generex.getMatchedStrings(max)
+
+        assertThat(matchedStrings).isNotEmpty()
+    }
+
+    @Test
+    fun `test max length with infinite regex where max is less than regex min`() {
+        val regex = "([a-zA-Z0-9]{5})+"
+        val max = 4
+
+        val generex = Generex(regex)
+
+        val briks = RegExp(regex).toAutomaton()
+
+        val shortestString = briks.getShortestExample(true)
+        assertThat(shortestString.length).isGreaterThan(max)
+
+//        val matchedStrings = generex.getMatchedStrings(max)
+
+//        val matchedStrings = generex.random(0, max)
+
+//        assertThat(matchedStrings).isNotEmpty()
+    }
+
+    @Test
+    fun temp() {
+        val min = 33
+
+        val regex = "[a-zA-Z0-9]{1,32}"
+        val generex = Generex(regex)
+
+        val briks = RegExp(regex).toAutomaton()
+
+        generex.random(33)
+
+        generex.getMatchedStrings(10)
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/pattern/StringPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/StringPatternTest.kt
@@ -383,7 +383,7 @@ internal class StringPatternTest {
                     .isGreaterThanOrEqualTo(expectedMinLen)
                     .isLessThanOrEqualTo(expectedMaxLen)
 
-                assertThat(generatedString).matches(regex)
+                assertThat(generatedString).matches(RegExSpec(regex).toString())
             } else {
                 fail("Expected an exception to be thrown")
             }

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=2.4.1
+version=2.5.0


### PR DESCRIPTION
This pull request introduces the following improvements:
* debug logging statements to the `OpenApiSpecification` class
* timeout to the stub start
* improvements and bug fixes to `pattern` support for json-schema `string` types
* tests now send the Specmatic-Response-Code header as a hint to the stub to return an appropriate response code. This helps the stub send a response of a matching response code which the test would recognize, when there are multiple status codes in the possible responses to a request in the spec.