### PR TITLE
Improved support for time

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/pattern/ISO8601.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ISO8601.kt
@@ -4,7 +4,7 @@ import io.specmatic.core.value.StringValue
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 
-class RFC8601 {
+class ISO8601 {
     companion object{
         fun validatedStringValue(time: String): StringValue {
             return try {
@@ -15,8 +15,9 @@ class RFC8601 {
             }
         }
 
-        fun currentTime(): String = LocalTime.now().format(
-            DateTimeFormatter.ISO_TIME
-        )
+        val currentTime: String get() =
+            LocalTime.now().format(
+                DateTimeFormatter.ISO_TIME
+            )
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/RFC8601.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/RFC8601.kt
@@ -1,26 +1,22 @@
 package io.specmatic.core.pattern
 
+import io.specmatic.core.value.StringValue
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
-import java.util.regex.Pattern
-
-private val ISO8601_PATTERN: Pattern = Pattern.compile (
-    """^(?<hour>2[0-3]|[01][0-9]):?(?<minute>[0-5][0-9]):?(?<second>[0-5][0-9])(?<timezone>Z|[+-](?:2[0-3]|[01][0-9])(?::?(?:[0-5][0-9]))?)?$"""
-)
 
 class RFC8601 {
     companion object{
-        private val timeFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss")
-
-        fun parse(dateTime: String) {
-            val matcher = ISO8601_PATTERN.matcher(dateTime)
-            if(!matcher.matches()) {
-                throw ContractException("Error while parsing the time as per ISO 8601: $dateTime")
+        fun validatedStringValue(time: String): StringValue {
+            return try {
+                LocalTime.parse(time, DateTimeFormatter.ISO_TIME)
+                StringValue(time)
+            } catch (e: Exception) {
+                throw ContractException("Error while parsing $time as per ISO 8601: ${e.message}")
             }
         }
 
         fun currentTime(): String = LocalTime.now().format(
-            timeFormatter
+            DateTimeFormatter.ISO_TIME
         )
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/TimePattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/TimePattern.kt
@@ -22,7 +22,7 @@ object TimePattern : Pattern, ScalarType {
         }
     }
 
-    override fun generate(resolver: Resolver): StringValue = StringValue(RFC8601.currentTime())
+    override fun generate(resolver: Resolver): StringValue = StringValue(ISO8601.currentTime)
 
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> = sequenceOf(HasValue(this))
 
@@ -37,7 +37,7 @@ object TimePattern : Pattern, ScalarType {
     }
 
     override fun parse(value: String, resolver: Resolver): StringValue {
-        return RFC8601.validatedStringValue(value)
+        return ISO8601.validatedStringValue(value)
     }
 
     override fun encompasses(otherPattern: Pattern, thisResolver: Resolver, otherResolver: Resolver, typeStack: TypeStack): Result {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/TimePattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/TimePattern.kt
@@ -28,15 +28,17 @@ object TimePattern : Pattern, ScalarType {
 
     override fun newBasedOn(resolver: Resolver): Sequence<TimePattern> = sequenceOf(this)
 
-    override fun negativeBasedOn(row: Row, resolver: Resolver, config: NegativePatternConfiguration): Sequence<ReturnValue<Pattern>> {
+    override fun negativeBasedOn(
+        row: Row,
+        resolver: Resolver,
+        config: NegativePatternConfiguration
+    ): Sequence<ReturnValue<Pattern>> {
         return scalarAnnotation(this, sequenceOf(NullPattern))
     }
 
-    override fun parse(value: String, resolver: Resolver): StringValue =
-        attempt {
-            RFC8601.parse(value)
-            StringValue(value)
-        }
+    override fun parse(value: String, resolver: Resolver): StringValue {
+        return RFC8601.validatedStringValue(value)
+    }
 
     override fun encompasses(otherPattern: Pattern, thisResolver: Resolver, otherResolver: Resolver, typeStack: TypeStack): Result {
         return encompasses(this, otherPattern, thisResolver, otherResolver, typeStack)

--- a/core/src/test/kotlin/io/specmatic/core/pattern/TimePatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/TimePatternTest.kt
@@ -11,21 +11,7 @@ import org.junit.jupiter.params.provider.CsvSource
 
 class TimePatternTest {
     @Test
-    fun testValidTimeMatch() {
-        val timeString = "10:05:59"
-        val result = TimePattern.matches(StringValue(timeString), Resolver())
-        assertTrue(result is Result.Success)
-    }
-
-    @Test
-    fun testInvalidTimeMatch() {
-        val timeString = "invalid-time"
-        val result = TimePattern.matches(StringValue(timeString), Resolver())
-        assertTrue(result is Result.Failure)
-    }
-
-    @Test
-    fun testGeneratedTimeIsValid() {
+    fun `should be able to generate a time`() {
         val generated = TimePattern.generate(Resolver())
         println(generated)
         val result = TimePattern.matches(generated, Resolver())
@@ -33,13 +19,7 @@ class TimePatternTest {
     }
 
     @Test
-    fun testParseValidTime() {
-        val parsed = TimePattern.parse("23:59:59", Resolver())
-        assertEquals("23:59:59", parsed.string)
-    }
-
-    @Test
-    fun testNewBasedOn() {
+    fun `should generate new time values for test`() {
         val row = Row()
         val patterns = TimePattern.newBasedOn(row, Resolver()).map { it.value }.toList()
 
@@ -55,23 +35,26 @@ class TimePatternTest {
 
     @ParameterizedTest
     @CsvSource(
-        "01:01:01, true",
-        "a23:59:59, false",
-        "235959, true",
-        "01:01:01Z, true",
-        "010101Z, true",
-        "01:01:01+05:30, true",
-        "01:01:01+05:30d, false",
-        "010101+0530, true",
-        "010101d+0530, false",
-        "010101+0530d, false",
-        "01:01:01-01:00, true",
-        "01:01:01b-01:00a, false",
-        "010101-0100, true",
-        "010101c-0100d, false",
+        "01:01:01, valid",
+        "a23:59:59, invalid",
+        "01:01:01Z, valid",
+        "01:01:01T, invalid",
+        "01:01:01+05:30, valid",
+        "01:01:01+05:30d, invalid",
+        "01:01:01-01:00, valid",
+        "01:01:01b-01:00a, invalid",
+        "not-a-time, invalid",
+        "aa:bb:cc, invalid"
     )
-    fun `RFC 6801 regex should validate time`(time: String, isValid: Boolean) {
+    fun `RFC 6801 regex should validate time`(time: String, validity: String) {
         val result = TimePattern.matches(StringValue(time), Resolver())
+
+        val isValid = when(validity) {
+            "valid" -> true
+            "invalid" -> false
+            else -> IllegalArgumentException("Unknown validity: $validity")
+        }
+
         assertEquals(isValid, result is Result.Success)
     }
 }


### PR DESCRIPTION
This pull request includes significant changes to the handling and validation of ISO 8601 time patterns in the `core` module. This PR updates the time validation code to use the built-in `LocalTime.parse` method, instead of a regex.