### PR TITLE
Check only root level keys in the response during test matching when attribute selection is turned on

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/HttpResponse.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpResponse.kt
@@ -170,6 +170,17 @@ data class HttpResponse(
 
     private fun headersHasOnlyTextPlainContentTypeHeader() = headers.size == 1 && headers[CONTENT_TYPE] == "text/plain"
 
+    fun checkIfAllRootLevelKeysAreAttributeSelected(
+        attributeSelectedFields: Set<String>,
+        resolver: Resolver
+    ): Result {
+        if (body !is JSONComposite) return Result.Success()
+
+        return body.checkIfAllRootLevelKeysAreAttributeSelected(
+            attributeSelectedFields,
+            resolver
+        ).breadCrumb("RESPONSE.BODY")
+    }
 }
 
 fun isVanillaPatternToken(token: String) = isPatternToken(token) && token.indexOf(':') < 0

--- a/core/src/main/kotlin/io/specmatic/core/value/JSONArrayValue.kt
+++ b/core/src/main/kotlin/io/specmatic/core/value/JSONArrayValue.kt
@@ -1,6 +1,8 @@
 package io.specmatic.core.value
 
 import io.specmatic.core.ExampleDeclarations
+import io.specmatic.core.Resolver
+import io.specmatic.core.Result
 import io.specmatic.core.pattern.*
 import io.specmatic.core.utilities.valueArrayToJsonString
 
@@ -59,6 +61,19 @@ data class JSONArrayValue(override val list: List<Value>) : Value, ListValue, JS
 
     override fun typeDeclarationWithoutKey(exampleKey: String, types: Map<String, Pattern>, exampleDeclarations: ExampleDeclarations): Pair<TypeDeclaration, ExampleDeclarations> =
             typeDeclaration(exampleKey, types, exampleDeclarations) { value, innerKey, innerTypes, newExamples -> value.typeDeclarationWithoutKey(innerKey, innerTypes, newExamples) }
+
+    override fun checkIfAllRootLevelKeysAreAttributeSelected(
+        attributeSelectedFields: Set<String>,
+        resolver: Resolver
+    ): Result {
+        if(list.all { it is JSONObjectValue }.not()) return Result.Success()
+
+        return Result.fromResults(
+            results = list.map {
+                (it as JSONObjectValue).checkIfAllRootLevelKeysAreAttributeSelected(attributeSelectedFields, resolver)
+            }
+        )
+    }
 
     override fun toString() = valueArrayToJsonString(list)
     fun getElementAtIndex(first: String, rest: List<String>): Value? {

--- a/core/src/main/kotlin/io/specmatic/core/value/JSONComposite.kt
+++ b/core/src/main/kotlin/io/specmatic/core/value/JSONComposite.kt
@@ -1,3 +1,8 @@
 package io.specmatic.core.value
 
-sealed interface JSONComposite
+import io.specmatic.core.Resolver
+import io.specmatic.core.Result
+
+sealed interface JSONComposite {
+    fun checkIfAllRootLevelKeysAreAttributeSelected(attributeSelectedFields: Set<String>, resolver: Resolver): Result
+}

--- a/core/src/main/kotlin/io/specmatic/core/value/JSONObjectValue.kt
+++ b/core/src/main/kotlin/io/specmatic/core/value/JSONObjectValue.kt
@@ -1,6 +1,8 @@
 package io.specmatic.core.value
 
 import io.specmatic.core.ExampleDeclarations
+import io.specmatic.core.Resolver
+import io.specmatic.core.Result
 import io.specmatic.core.pattern.*
 import io.specmatic.core.utilities.*
 
@@ -27,6 +29,22 @@ data class JSONObjectValue(val jsonObject: Map<String, Value> = emptyMap()) : Va
         }.mapKeys {
             withoutOptionality(it.key)
         })
+    }
+
+    override fun checkIfAllRootLevelKeysAreAttributeSelected(
+        attributeSelectedFields: Set<String>,
+        resolver: Resolver
+    ): Result {
+        if (jsonObject.keys == attributeSelectedFields) return Result.Success()
+
+        return Result.fromResults(
+            results = resolver.findKeyErrorList(
+                attributeSelectedFields.associateBy { it },
+                jsonObject
+            ).map {
+                it.missingKeyToResult("key", resolver.mismatchMessages).breadCrumb(it.name)
+            }
+        )
     }
 
     override fun toString() = valueMapToPrettyJsonString(jsonObject)

--- a/core/src/test/kotlin/io/specmatic/core/value/JSONObjectValueKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/value/JSONObjectValueKtTest.kt
@@ -1,5 +1,6 @@
 package io.specmatic.core.value
 
+import io.specmatic.core.Resolver
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -20,5 +21,40 @@ internal class JSONObjectValueKtTest {
     fun `format for rendering a JSON object in a snippet`() {
         val value = JSONObjectValue(mapOf("id" to NumberValue(10)))
         assertThat(value.valueErrorSnippet()).startsWith("JSON object ")
+    }
+
+    @Test
+    fun `checkIfAllRootLevelKeysAreAttributeSelected should return an error with the key error check list`() {
+        val value = JSONObjectValue(
+            mapOf(
+                "id" to NumberValue(10),
+                "name" to StringValue("name")
+            )
+        )
+
+        val result = value.checkIfAllRootLevelKeysAreAttributeSelected(
+            attributeSelectedFields = setOf("id", "age"),
+            resolver = Resolver()
+        )
+
+        assertThat(result.reportString()).contains("""Expected key named "age" was missing""")
+        assertThat(result.reportString()).contains("""Key named "name" was unexpected""")
+    }
+
+    @Test
+    fun `checkIfAllRootLevelKeysAreAttributeSelected should return Success if all the attribute selected keys are present`() {
+        val value = JSONObjectValue(
+            mapOf(
+                "id" to NumberValue(10),
+                "name" to StringValue("name")
+            )
+        )
+
+        val result = value.checkIfAllRootLevelKeysAreAttributeSelected(
+            attributeSelectedFields = setOf("id", "name"),
+            resolver = Resolver()
+        )
+
+        assertThat(result.isSuccess()).isTrue()
     }
 }


### PR DESCRIPTION
…

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->


**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->


<!-- feel free to add additional comments -->
