### PR TITLE
Enable pattern tokens in schema examples and fix-value in example server and commands

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -435,7 +435,7 @@ data class Feature(
     }
 
     fun fixSchemaFlagBased(discriminatorPatternName: String?, patternName: String, value: Value): Value {
-        val updatedResolver = flagsBased.update(scenarios.last().resolver)
+        val updatedResolver = flagsBased.update(scenarios.last().resolver).copy(mockMode = true)
         val pattern = getSchemaPattern(discriminatorPatternName, patternName, updatedResolver)
 
         if (pattern is AnyPattern && !discriminatorPatternName.isNullOrEmpty()) {

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -396,7 +396,10 @@ data class Feature(
         mismatchMessages: MismatchMessages,
         breadCrumbIfDiscriminatorMismatch: String? = null
     ): Result {
-        val updatedResolver = flagsBased.update(scenarios.last().resolver).copy(mismatchMessages = mismatchMessages)
+        val updatedResolver = flagsBased.update(scenarios.last().resolver).copy(
+            mismatchMessages = mismatchMessages,
+            mockMode = true
+        )
 
         val pattern = runCatching {
             getSchemaPattern(discriminatorPatternName, patternName, updatedResolver)

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -852,7 +852,7 @@ data class Scenario(
                 isRequestAttributeSelected(httpRequest) -> ValidateUnexpectedKeys
                 else -> flagsBased.unexpectedKeyCheck
             }
-        ).update(resolver)
+        ).update(resolver).copy(mockMode = true)
 
         this.newBasedOnAttributeSelectionFields(httpRequest.queryParams).let { newScenario ->
             return Pair(

--- a/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
@@ -46,6 +46,7 @@ data class AnyPattern(
     }
 
     override fun fixValue(value: Value, resolver: Resolver): Value {
+        if (resolver.matchesPattern(null, this, value).isSuccess()) return value
         val discBasedFixedValue = if (discriminator != null && value is JSONObjectValue && discriminator.property in value.jsonObject) {
             val discriminatorValue = value.jsonObject.getValue(discriminator.property).toStringLiteral()
             fixValue(

--- a/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
@@ -29,6 +29,7 @@ data class JSONObjectPattern(
 ) : Pattern, PossibleJsonObjectPatternContainer {
 
     override fun fixValue(value: Value, resolver: Resolver): Value {
+        if (resolver.matchesPattern(null, this, value).isSuccess()) return value
         return JSONObjectValue(
             fix(
                 jsonPatternMap = pattern, jsonValueMap = (value as? JSONObjectValue)?.jsonObject.orEmpty(),

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
@@ -16,6 +16,7 @@ data class ListPattern(
         get() = MemberList(emptyList(), pattern)
 
     override fun fixValue(value: Value, resolver: Resolver): Value {
+        if (resolver.matchesPattern(null, this, value).isSuccess()) return value
         if (value !is JSONArrayValue || (value.list.isEmpty() && resolver.allPatternsAreMandatory)) {
             return pattern.listOf(0.until(randomNumber(3)).mapIndexed { index, _ ->
                 attempt(breadCrumb = "[$index (random)]") { pattern.fixValue(NullValue, resolver) }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/Pattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/Pattern.kt
@@ -93,7 +93,7 @@ interface Pattern {
     }
 
     fun fixValue(value: Value, resolver: Resolver): Value {
-        return value.takeIf { matches(it, resolver).isSuccess() } ?: resolver.generate(this)
+        return value.takeIf { resolver.matchesPattern(null, this, value).isSuccess() } ?: resolver.generate(this)
     }
 
     val typeAlias: String?

--- a/core/src/test/kotlin/io/specmatic/core/HttpPathPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpPathPatternTest.kt
@@ -339,5 +339,41 @@ internal class HttpPathPatternTest {
             println(unPrefixedFixedPath)
             assertThat(unPrefixedFixedPath).isEqualTo("pets/999")
         }
+
+        @Test
+        fun `should retain pattern token if it matches when resolver is in mock mode`() {
+            val urlPattern = buildHttpPathPattern("/pets/(id:number)")
+            val dictionary = mapOf("PATH.id" to NumberValue(999))
+            val resolver = Resolver(dictionary = dictionary, mockMode = true)
+            val validValue = "/pets/(number)"
+
+            val fixedPath = urlPattern.fixValue(validValue, resolver)
+            println(fixedPath)
+            assertThat(fixedPath).isEqualTo(validValue)
+        }
+
+        @Test
+        fun `should generate value when pattern token does not match when resolver is in mock mode`() {
+            val urlPattern = buildHttpPathPattern("/pets/(id:number)")
+            val dictionary = mapOf("PATH.id" to NumberValue(999))
+            val resolver = Resolver(dictionary = dictionary, mockMode = true)
+            val validValue = "/pets/(string)"
+
+            val fixedPath = urlPattern.fixValue(validValue, resolver)
+            println(fixedPath)
+            assertThat(fixedPath).isEqualTo("/pets/999")
+        }
+
+        @Test
+        fun `should generate values even if pattern token matches but resolver is not in mock mode`() {
+            val urlPattern = buildHttpPathPattern("/pets/(id:number)")
+            val dictionary = mapOf("PATH.id" to NumberValue(999))
+            val resolver = Resolver(dictionary = dictionary)
+            val validValue = "/pets/(number)"
+
+            val fixedPath = urlPattern.fixValue(validValue, resolver)
+            println(fixedPath)
+            assertThat(fixedPath).isEqualTo("/pets/999")
+        }
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServerTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServerTest.kt
@@ -406,5 +406,33 @@ class ExamplesInteractiveServerTest {
             Specification expected number but example contained "(uuid)"
             """.trimIndent())
         }
+
+        @Test
+        fun `should match pattern tokens on schema examples`() {
+            val pattern = JSONObjectPattern(mapOf("first" to NumberPattern(), "second" to NumberPattern()))
+            val example = JSONObjectValue(mapOf("first" to StringValue("(number)"), "second" to NumberValue(10)))
+
+            val scenario = Scenario(ScenarioInfo(patterns = mapOf("(Test)" to pattern)))
+            val feature = Feature(listOf(scenario), name= "")
+
+            val result = feature.matchResultSchemaFlagBased(null, "Test", example, DefaultMismatchMessages)
+            assertThat(result).isInstanceOf(Result.Success::class.java)
+        }
+
+        @Test
+        fun `should result in a failure on pattern token mismatch on schema examples`() {
+            val pattern = JSONObjectPattern(mapOf("first" to NumberPattern(), "second" to NumberPattern()))
+            val example = JSONObjectValue(mapOf("first" to StringValue("(string)"), "second" to NumberValue(10)))
+
+            val scenario = Scenario(ScenarioInfo(patterns = mapOf("(Test)" to pattern)))
+            val feature = Feature(listOf(scenario), name= "")
+
+            val result = feature.matchResultSchemaFlagBased(null, "Test", example, DefaultMismatchMessages)
+            assertThat(result).isInstanceOf(Result.Failure::class.java)
+            assertThat(result.reportString()).isEqualToNormalizingWhitespace("""
+            >> first
+            Expected number, actual was "(string)"
+            """.trimIndent())
+        }
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServerTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServerTest.kt
@@ -2,9 +2,7 @@ package io.specmatic.core.examples.server
 
 import io.specmatic.conversions.ExampleFromFile
 import io.specmatic.core.*
-import io.specmatic.core.pattern.JSONObjectPattern
-import io.specmatic.core.pattern.NumberPattern
-import io.specmatic.core.pattern.parsedJSONObject
+import io.specmatic.core.pattern.*
 import io.specmatic.core.utilities.Flags
 import io.specmatic.core.value.*
 import io.specmatic.mock.ScenarioStub
@@ -433,6 +431,73 @@ class ExamplesInteractiveServerTest {
             >> first
             Expected number, actual was "(string)"
             """.trimIndent())
+        }
+    }
+
+    @Nested
+    inner class FixExampleTests {
+        @Test
+        fun `should be able to fix invalid examples while retaining valid pattern tokens`(@TempDir tempDir: File) {
+            val scenario = Scenario(ScenarioInfo(
+                httpRequestPattern = HttpRequestPattern(
+                    method = "POST",
+                    httpPathPattern = buildHttpPathPattern("/"),
+                    body = JSONObjectPattern(mapOf(
+                        "string" to StringPattern(), "number" to NumberPattern(),
+                        "boolean" to BooleanPattern(), "date" to DatePattern
+                    ))
+                ),
+                httpResponsePattern = HttpResponsePattern(status = 200)
+            ))
+            val example = ScenarioStub(
+                request = HttpRequest(
+                    method = "POST", path = "/",
+                    body = JSONObjectValue(mapOf(
+                        "string" to StringValue("OK"),
+                        "number" to StringValue("TODO"),
+                        "boolean" to StringValue("(string)"),
+                        "date" to StringValue("(date)")
+                    ))
+                ),
+                response = HttpResponse.OK
+            )
+
+            val feature = Feature(listOf(scenario), name= "")
+            val exampleFile = File(tempDir, "example.json").apply { writeText(example.toJSON().toStringLiteral()) }
+            val result = ExamplesInteractiveServer.fixExample(feature, exampleFile)
+            val fixedExampleReqBody = ScenarioStub.readFromFile(exampleFile).request.body as JSONObjectValue
+
+            assertThat(result.status).isEqualTo(FixExampleStatus.SUCCEDED)
+            assertThat(fixedExampleReqBody.findFirstChildByName("string")).isEqualTo(StringValue("OK"))
+            assertThat(fixedExampleReqBody.findFirstChildByName("number")).isInstanceOf(NumberValue::class.java)
+            assertThat(fixedExampleReqBody.findFirstChildByName("boolean")).isInstanceOf(BooleanValue::class.java)
+            assertThat(fixedExampleReqBody.findFirstChildByName("date")).isEqualTo(StringValue("(date)"))
+        }
+
+        @Test
+        fun `should be able to fix invalid schema example while retaining valid pattern tokens`(@TempDir tempDir: File) {
+            val pattern = JSONObjectPattern(mapOf(
+                "string" to StringPattern(), "number" to NumberPattern(),
+                "boolean" to BooleanPattern(), "date" to DatePattern
+            ), typeAlias = "(Test)")
+            val example = JSONObjectValue(mapOf(
+                "string" to StringValue("OK"), "number" to StringValue("TODO"),
+                "boolean" to StringValue("(string)"), "date" to StringValue("(date)")
+            ))
+
+            val feature = Feature(listOf(Scenario(ScenarioInfo(patterns = mapOf("(Test)" to pattern)))), name= "")
+            val exampleFile = File(tempDir, "resource.Test.example.json").apply { writeText(example.toStringLiteral()) }
+            val result = ExamplesInteractiveServer.fixExample(feature, exampleFile)
+            val schemaExample = SchemaExample.fromFile(exampleFile).value
+            val exampleValue = schemaExample.value as JSONObjectValue
+
+            assertThat(result.status).isEqualTo(FixExampleStatus.SUCCEDED)
+            assertThat(schemaExample.discriminatorBasedOn).isNull()
+            assertThat(schemaExample.schemaBasedOn).isEqualTo("Test")
+            assertThat(exampleValue.findFirstChildByName("string")).isEqualTo(StringValue("OK"))
+            assertThat(exampleValue.findFirstChildByName("number")).isInstanceOf(NumberValue::class.java)
+            assertThat(exampleValue.findFirstChildByName("boolean")).isInstanceOf(BooleanValue::class.java)
+            assertThat(exampleValue.findFirstChildByName("date")).isEqualTo(StringValue("(date)"))
         }
     }
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Enable pattern tokens in schema examples and fix-value in example server and commands

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

<!-- feel free to add additional comments -->
