### PR TITLE
Fix resiliency testing with dictionary for parameters and headers

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -717,7 +717,7 @@ data class Feature(
 
             negativeTestScenarios.filterNot { negativeTestScenarioR ->
                 negativeTestScenarioR.withDefault(false) { negativeTestScenario ->
-                    val sampleRequest = negativeTestScenario.httpRequestPattern.generate(negativeTestScenario.resolver)
+                    val sampleRequest = negativeTestScenario.generateHttpRequest()
                     originalScenario.httpRequestPattern.matches(sampleRequest, originalScenario.resolver).isSuccess()
                 }
             }.mapIndexed { index, negativeTestScenarioR ->

--- a/core/src/main/kotlin/io/specmatic/core/Resolver.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Resolver.kt
@@ -208,7 +208,7 @@ data class Resolver(
         val value = dictionary[dictionaryLookupPath] ?: defaultPatternValueFromDictionary(pattern) ?: return pattern.generate(this)
 
         val dictionaryValueMatchResult = pattern.matches(value, this)
-
+        if (dictionaryValueMatchResult is Result.Failure && isNegative) return pattern.generate(this)
         dictionaryValueMatchResult.throwOnFailure()
 
         return value

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -279,7 +279,11 @@ data class Scenario(
 
     fun generateHttpRequest(flagsBased: FlagsBased = DefaultStrategies): HttpRequest =
         scenarioBreadCrumb(this) {
-            httpRequestPattern.generate(flagsBased.update(resolver.copy(factStore = CheckFacts(expectedFacts))))
+            httpRequestPattern.generate(
+                flagsBased.update(
+                    resolver.copy(factStore = CheckFacts(expectedFacts), isNegative = this.isNegative)
+                )
+            )
         }
 
     fun generateHttpRequestV2(

--- a/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
@@ -397,14 +397,13 @@ data class JSONObjectPattern(
             pattern.minus("..."),
             Row(),
             null,
-            null, returnValues { pattern: Map<String, Pattern> ->
-                newBasedOn(pattern, withNullPattern(resolver))
-            }).map { it.value }.map { toJSONObjectPattern(it) }
+            null, returnValues { pattern: Map<String, Pattern> -> newBasedOn(pattern, withNullPattern(resolver)) }
+        ).map { it.value }.map { toJSONObjectPattern(it, typeAlias) }
 
     override fun negativeBasedOn(row: Row, resolver: Resolver, config: NegativePatternConfiguration): Sequence<ReturnValue<Pattern>> =
         allOrNothingCombinationIn(pattern.minus("...")) { pattern ->
             AllNegativePatterns().negativeBasedOn(pattern, row, withNullPattern(resolver), config)
-        }.map { it.ifValue { toJSONObjectPattern(it) } }
+        }.map { it.ifValue { toJSONObjectPattern(it, typeAlias) } }
 
     override fun parse(value: String, resolver: Resolver): Value = parsedJSONObject(value, resolver.mismatchMessages)
     override fun hashCode(): Int = pattern.hashCode()

--- a/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
@@ -77,12 +77,6 @@ data class ScenarioAsTest(
         )
     }
 
-    private fun logComment() {
-        if (annotations != null) {
-            logger.log(annotations)
-        }
-    }
-
     private fun executeTestAndReturnResultAndResponse(
         testScenario: Scenario,
         testExecutor: TestExecutor,

--- a/core/src/test/kotlin/integration_tests/DictionaryTest.kt
+++ b/core/src/test/kotlin/integration_tests/DictionaryTest.kt
@@ -1,19 +1,16 @@
 package integration_tests
 
 import io.specmatic.conversions.OpenApiSpecification
-import io.specmatic.core.HttpRequest
-import io.specmatic.core.HttpResponse
-import io.specmatic.core.SPECMATIC_STUB_DICTIONARY
-import io.specmatic.core.pattern.parsedJSON
-import io.specmatic.core.pattern.parsedJSONObject
-import io.specmatic.core.value.JSONArrayValue
-import io.specmatic.core.value.JSONObjectValue
+import io.specmatic.core.*
+import io.specmatic.core.pattern.*
+import io.specmatic.core.value.*
 import io.specmatic.stub.HttpStub
 import io.specmatic.stub.createStubFromContracts
 import io.specmatic.stub.httpRequestLog
 import io.specmatic.stub.httpResponseLog
 import io.specmatic.test.TestExecutor
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class DictionaryTest {
@@ -353,5 +350,134 @@ class DictionaryTest {
         }
 
         assertThat(testCountWithDictionary).isEqualTo(testCountWithoutDictionary)
+    }
+
+    @Nested
+    inner class NegativeBasedOnTests {
+
+        @Test
+        fun `negative based path parameters should still be generated when dictionary contains substitutions`() {
+            val dictionary = mapOf("PATH-PARAMS.id" to NumberValue(123))
+            val scenario = Scenario(ScenarioInfo(
+                httpRequestPattern = HttpRequestPattern(httpPathPattern = buildHttpPathPattern("/orders/(id:number)"), method = "GET"),
+                httpResponsePattern = HttpResponsePattern(status = 200)
+            )).copy(dictionary = dictionary)
+            val feature = Feature(listOf(scenario), name = "")
+
+            val result = feature.enableGenerativeTesting().executeTests(object: TestExecutor {
+                override fun execute(request: HttpRequest): HttpResponse {
+                    return HttpResponse.OK.also {
+                        val logs = listOf(request.toLogString(), it.toLogString())
+                        println(logs.joinToString(separator = "\n", postfix = "\n\n"))
+
+                        assertThat(request.path).satisfiesAnyOf(
+                            { path -> assertThat(path).isEqualTo("/orders/123") },
+                            { path -> assertThat(path).matches("/orders/(false|true)") },
+                            { path -> assertThat(path).matches("/orders/[a-zA-Z]+") },
+                        )
+                    }
+                }
+            })
+
+            assertThat(result.results).hasSize(3)
+        }
+
+        @Test
+        fun `negative based query parameters should still be generated when dictionary contains substitutions`() {
+            val dictionary = mapOf("QUERY-PARAMS.id" to NumberValue(123))
+            val scenario = Scenario(ScenarioInfo(
+                httpRequestPattern = HttpRequestPattern(
+                    httpPathPattern = buildHttpPathPattern("/orders"), method = "GET",
+                    httpQueryParamPattern = HttpQueryParamPattern(mapOf("id" to QueryParameterScalarPattern(NumberPattern())))
+                ),
+                httpResponsePattern = HttpResponsePattern(status = 200)
+            )).copy(dictionary = dictionary)
+            val feature = Feature(listOf(scenario), name = "")
+
+            val result = feature.enableGenerativeTesting().executeTests(object: TestExecutor {
+                override fun execute(request: HttpRequest): HttpResponse {
+                    return HttpResponse.OK.also {
+                        val logs = listOf(request.toLogString(), it.toLogString())
+                        println(logs.joinToString(separator = "\n", postfix = "\n\n"))
+
+                        assertThat(request.queryParams.keys).contains("id")
+                        assertThat(request.queryParams.getOrElse("id") { throw AssertionError("Query param id not found") }).satisfiesAnyOf(
+                            { id -> assertThat(id).isEqualTo("123") },
+                            { id -> assertThat(id).matches("(false|true)") },
+                            { id -> assertThat(id).matches("[a-zA-Z]+") },
+                            { id -> assertThat(id).isEmpty() }
+                        )
+                    }
+                }
+            })
+
+            assertThat(result.results).hasSize(4)
+        }
+
+        @Test
+        fun `negative based headers should still be generated when dictionary contains substitutions`() {
+            val dictionary = mapOf("HEADERS.ID" to NumberValue(123))
+            val scenario = Scenario(ScenarioInfo(
+                httpRequestPattern = HttpRequestPattern(
+                    httpPathPattern = buildHttpPathPattern("/orders"), method = "GET",
+                    headersPattern = HttpHeadersPattern(mapOf("ID" to NumberPattern()))
+                ),
+                httpResponsePattern = HttpResponsePattern(status = 200)
+            )).copy(dictionary = dictionary)
+            val feature = Feature(listOf(scenario), name = "")
+
+            val result = feature.enableGenerativeTesting().executeTests(object: TestExecutor {
+                override fun execute(request: HttpRequest): HttpResponse {
+                    return HttpResponse.OK.also {
+                        val logs = listOf(request.toLogString(), it.toLogString())
+                        println(logs.joinToString(separator = "\n", postfix = "\n\n"))
+
+                        assertThat(request.headers).containsKey("ID")
+                        assertThat(request.headers["ID"]).satisfiesAnyOf(
+                            { id -> assertThat(id).isEqualTo("123") },
+                            { id -> assertThat(id).matches("(false|true)") },
+                            { id -> assertThat(id).matches("[a-zA-Z]+") },
+                            { id -> assertThat(id).isEmpty() }
+                        )
+                    }
+                }
+            })
+
+            assertThat(result.results).hasSize(4)
+        }
+
+        @Test
+        fun `negative based bodies should still be generated when dictionary contains substitutions`() {
+            val dictionary = mapOf("OBJECT.id" to NumberValue(123))
+            val scenario = Scenario(ScenarioInfo(
+                httpRequestPattern = HttpRequestPattern(
+                    httpPathPattern = buildHttpPathPattern("/orders"), method = "GET",
+                    body = JSONObjectPattern(mapOf(
+                        "id" to NumberPattern()
+                    ), typeAlias = "(OBJECT)")
+                ),
+                httpResponsePattern = HttpResponsePattern(status = 200)
+            )).copy(dictionary = dictionary)
+            val feature = Feature(listOf(scenario), name = "")
+
+            val result = feature.enableGenerativeTesting().executeTests(object: TestExecutor {
+                override fun execute(request: HttpRequest): HttpResponse {
+                    return HttpResponse.OK.also {
+                        val logs = listOf(request.toLogString(), it.toLogString())
+                        println(logs.joinToString(separator = "\n", postfix = "\n\n"))
+
+                        assertThat(request.body).isInstanceOf(JSONObjectValue::class.java)
+                        assertThat((request.body as JSONObjectValue).findFirstChildByName("id")).satisfiesAnyOf(
+                            { id -> assertThat(id).isEqualTo(NumberValue(123)) },
+                            { id -> assertThat(id).isInstanceOf(StringValue::class.java) },
+                            { id -> assertThat(id).isInstanceOf(BooleanValue::class.java) },
+                            { id -> assertThat(id).isInstanceOf(NullValue::class.java) }
+                        )
+                    }
+                }
+            })
+
+            assertThat(result.results).hasSize(4)
+        }
     }
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Fix resiliency testing with dictionary for parameters and headers and body.

<!-- Why are these changes necessary? -->

**Why**: Path parameters, query parameters,headers and bodies should be capable of generating mutated values, even when a matching key is present in the dictionary.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

<!-- feel free to add additional comments -->
