### PR TITLE
Make example validation look at the relative example directory path from the provided base as per the spec's base path

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServer.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServer.kt
@@ -677,7 +677,7 @@ class ExamplesInteractiveServer(
 
             val results = examples.associate { exampleFile ->
                 logger.debug("Validating ${exampleFile.name}")
-                exampleFile.name to validateExample(updatedFeature, exampleFile)
+                exampleFile.canonicalPath to validateExample(updatedFeature, exampleFile)
             }
 
             return results


### PR DESCRIPTION

If specs directory is `specs/petstore/api.yaml` and examples-base-directory is `examples/stub`, the changes done in this PR will make example validation search the associated examples for api.yaml in the folder `examples/stub/petstore/api_examples`.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->

<!-- feel free to add additional comments -->
