### PR TITLE
Fix the way directory is computed if the source is a non-filesystem one while loading examples as stubs from explicit directories

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/utilities/ContractSource.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/ContractSource.kt
@@ -20,6 +20,7 @@ sealed interface ContractSource {
     fun getLatest(sourceGit: SystemGit)
     fun pushUpdates(sourceGit: SystemGit)
     fun loadContracts(selector: ContractsSelectorPredicate, workingDirectory: String, configFilePath: String): List<ContractPathData>
+    fun stubDirectoryToContractPath(contractPathDataList: List<ContractPathData>): List<Pair<String, String>>
 }
 
 fun commitAndPush(sourceGit: SystemGit) {

--- a/core/src/main/kotlin/io/specmatic/core/utilities/GitMonoRepo.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/GitMonoRepo.kt
@@ -45,4 +45,14 @@ data class GitMonoRepo(override val testContracts: List<ContractSourceEntry>, ov
             )
         }
     }
+
+    override fun stubDirectoryToContractPath(contractPathDataList: List<ContractPathData>): List<Pair<String, String>> {
+        return stubContracts.mapNotNull { contractSourceEntry ->
+            val directory = contractPathDataList.firstOrNull {
+                it.specificationPath.orEmpty() == contractSourceEntry.path
+            }?.baseDir ?: return@mapNotNull null
+
+            directory to contractSourceEntry.path
+        }
+    }
 }

--- a/core/src/main/kotlin/io/specmatic/core/utilities/GitRepo.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/GitRepo.kt
@@ -93,6 +93,16 @@ data class GitRepo(
         }
     }
 
+    override fun stubDirectoryToContractPath(contractPathDataList: List<ContractPathData>): List<Pair<String, String>> {
+        return stubContracts.mapNotNull { contractSourceEntry ->
+            val directory = contractPathDataList.firstOrNull {
+                it.specificationPath.orEmpty() == contractSourceEntry.path
+            }?.baseDir ?: return@mapNotNull null
+
+            directory to contractSourceEntry.path
+        }
+    }
+
     private fun isClean(contractsRepoDir: File): Boolean {
         val sourceGit = getSystemGit(contractsRepoDir.path)
         return sourceGit.statusPorcelain().isEmpty()

--- a/core/src/main/kotlin/io/specmatic/core/utilities/LocalFileSystemSource.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/LocalFileSystemSource.kt
@@ -49,4 +49,10 @@ data class LocalFileSystemSource(
             )
         }
     }
+
+    override fun stubDirectoryToContractPath(contractPathDataList: List<ContractPathData>): List<Pair<String, String>> {
+        return stubContracts.map { contractSourceEntry ->
+            directory to contractSourceEntry.path
+        }
+    }
 }

--- a/core/src/main/kotlin/io/specmatic/core/utilities/WebSource.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/WebSource.kt
@@ -56,6 +56,10 @@ class WebSource(override val testContracts: List<ContractSourceEntry>, override 
         }
     }
 
+    override fun stubDirectoryToContractPath(contractPathDataList: List<ContractPathData>): List<Pair<String, String>> {
+        return emptyList()
+    }
+
     private fun toSpecificationPath(url: URL): String {
         val path = url.host + "/" + url.path.removePrefix("/")
         return path


### PR DESCRIPTION
- [x] Tests