### PR TITLE
Fix security schema validation and handling for examples

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/APIKeyInHeaderSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/APIKeyInHeaderSecurityScheme.kt
@@ -5,8 +5,12 @@ import io.specmatic.core.pattern.Row
 import io.specmatic.core.pattern.StringPattern
 
 data class APIKeyInHeaderSecurityScheme(val name: String, private val apiKey:String?) : OpenAPISecurityScheme {
-    override fun matches(httpRequest: HttpRequest): Result {
-        return if (httpRequest.headers.containsKey(name)) Result.Success() else Result.Failure("API-key named $name was not present as a header")
+    override fun matches(httpRequest: HttpRequest, resolver: Resolver): Result {
+        return if (httpRequest.headers.containsKey(name) || resolver.mockMode) Result.Success()
+        else Result.Failure(
+            breadCrumb = "HEADERS.$name",
+            message = resolver.mismatchMessages.expectedKeyWasMissing("API-Key", name)
+        )
     }
 
     override fun removeParam(httpRequest: HttpRequest): HttpRequest {

--- a/core/src/main/kotlin/io/specmatic/conversions/APIKeyInQueryParamSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/APIKeyInQueryParamSecurityScheme.kt
@@ -8,8 +8,12 @@ import io.specmatic.core.pattern.*
 import io.specmatic.core.value.StringValue
 
 data class APIKeyInQueryParamSecurityScheme(val name: String, private val apiKey:String?) : OpenAPISecurityScheme {
-    override fun matches(httpRequest: HttpRequest): Result {
-        return if (httpRequest.queryParams.containsKey(name)) Result.Success() else Result.Failure("API-key named $name was not present in query string")
+    override fun matches(httpRequest: HttpRequest, resolver: Resolver): Result {
+        return if (httpRequest.queryParams.containsKey(name) || resolver.mockMode) Result.Success()
+        else Result.Failure(
+            breadCrumb = "QUERY-PARAMS.$name",
+            message = resolver.mismatchMessages.expectedKeyWasMissing("API-Key", name)
+        )
     }
 
     override fun removeParam(httpRequest: HttpRequest): HttpRequest {

--- a/core/src/main/kotlin/io/specmatic/conversions/BearerSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/BearerSecurityScheme.kt
@@ -6,17 +6,22 @@ import io.specmatic.core.pattern.StringPattern
 import org.apache.http.HttpHeaders.AUTHORIZATION
 
 data class BearerSecurityScheme(private val configuredToken: String? = null) : OpenAPISecurityScheme {
-    override fun matches(httpRequest: HttpRequest): Result {
-        val authHeaderValue: String? = httpRequest.headers.entries.find {
-            it.key.equals(AUTHORIZATION.lowercase(), ignoreCase = true)
-        }?.value
-
-        if (authHeaderValue == null) {
-            return Result.Failure("$AUTHORIZATION header is missing in request")
+    override fun matches(httpRequest: HttpRequest, resolver: Resolver): Result {
+        val authHeaderValue = httpRequest.headers.entries.find {
+            it.key.equals(AUTHORIZATION, ignoreCase = true)
+        } ?: return when(resolver.mockMode) {
+            true -> Result.Success()
+            else -> Result.Failure(
+                breadCrumb = "HEADERS.$AUTHORIZATION",
+                message = resolver.mismatchMessages.expectedKeyWasMissing("Header", AUTHORIZATION)
+            )
         }
 
-        if (!authHeaderValue.lowercase().startsWith("bearer")) {
-            return Result.Failure("$AUTHORIZATION header must be prefixed with \"Bearer\"")
+        if (!authHeaderValue.value.lowercase().startsWith("bearer")) {
+            return Result.Failure(
+                breadCrumb = "HEADERS.$AUTHORIZATION",
+                message = "$AUTHORIZATION header must be prefixed with \"Bearer\""
+            )
         }
 
         return Result.Success()

--- a/core/src/main/kotlin/io/specmatic/conversions/NoSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/NoSecurityScheme.kt
@@ -7,7 +7,7 @@ import io.specmatic.core.Result
 import io.specmatic.core.pattern.Row
 
 class NoSecurityScheme : OpenAPISecurityScheme {
-    override fun matches(httpRequest: HttpRequest): Result {
+    override fun matches(httpRequest: HttpRequest, resolver: Resolver): Result {
         return Result.Success()
     }
 

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenAPISecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenAPISecurityScheme.kt
@@ -8,7 +8,7 @@ import io.specmatic.core.pattern.*
 import io.specmatic.core.value.StringValue
 
 interface OpenAPISecurityScheme {
-    fun matches(httpRequest: HttpRequest): Result
+    fun matches(httpRequest: HttpRequest, resolver: Resolver): Result
     fun removeParam(httpRequest: HttpRequest): HttpRequest
     fun addTo(httpRequest: HttpRequest, resolver: Resolver = Resolver()): HttpRequest
     fun addTo(requestPattern: HttpRequestPattern, row: Row): HttpRequestPattern

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
@@ -92,7 +92,7 @@ data class HttpRequestPattern(
 
         val matchFailures = mutableListOf<Failure>()
         val matchingSecurityScheme: OpenAPISecurityScheme = securitySchemes.firstOrNull {
-            when (val result = it.matches(httpRequest)) {
+            when (val result = it.matches(httpRequest, resolver)) {
                 is Failure -> false.also { matchFailures.add(result) }
                 is Success -> true
             }

--- a/core/src/test/kotlin/io/specmatic/conversions/APIKeyInHeaderSecuritySchemeTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/APIKeyInHeaderSecuritySchemeTest.kt
@@ -1,0 +1,31 @@
+package io.specmatic.conversions
+
+import io.specmatic.core.HttpRequest
+import io.specmatic.core.Resolver
+import io.specmatic.core.Result
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class APIKeyInHeaderSecuritySchemeTest {
+    @Test
+    fun `should result in failure when header api key is missing`() {
+        val httpRequest = HttpRequest(headers = emptyMap())
+        val resolver = Resolver(mockMode = false)
+        val result = APIKeyInHeaderSecurityScheme(name = "API-KEY", apiKey = "123").matches(httpRequest, resolver)
+
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
+        assertThat(result.reportString()).isEqualToNormalizingWhitespace("""
+        >> HEADERS.API-KEY
+        Expected api-key named "API-KEY" was missing
+        """.trimIndent())
+    }
+
+    @Test
+    fun `should not result in failure when header api key is missing and resolver is in mock mode`() {
+        val httpRequest = HttpRequest(headers = emptyMap())
+        val resolver = Resolver(mockMode = true)
+        val result = APIKeyInHeaderSecurityScheme(name = "API-KEY", apiKey = "123").matches(httpRequest, resolver)
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/conversions/APIKeyInQueryParamSecuritySchemeTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/APIKeyInQueryParamSecuritySchemeTest.kt
@@ -1,0 +1,32 @@
+package io.specmatic.conversions
+
+import io.specmatic.core.HttpRequest
+import io.specmatic.core.Resolver
+import io.specmatic.core.Result
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class APIKeyInQueryParamSecuritySchemeTest {
+
+    @Test
+    fun `should result in failure when query api key is missing`() {
+        val httpRequest = HttpRequest(headers = emptyMap())
+        val resolver = Resolver(mockMode = false)
+        val result = APIKeyInQueryParamSecurityScheme(name = "API-KEY", apiKey = "123").matches(httpRequest, resolver)
+
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
+        assertThat(result.reportString()).isEqualToNormalizingWhitespace("""
+        >> QUERY-PARAMS.API-KEY
+        Expected api-key named "API-KEY" was missing
+        """.trimIndent())
+    }
+
+    @Test
+    fun `should not result in failure when query api key is missing and resolver is in mock mode`() {
+        val httpRequest = HttpRequest(headers = emptyMap())
+        val resolver = Resolver(mockMode = true)
+        val result = APIKeyInQueryParamSecurityScheme(name = "API-KEY", apiKey = "123").matches(httpRequest, resolver)
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/conversions/BasicAuthSecuritySchemeTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/BasicAuthSecuritySchemeTest.kt
@@ -2,6 +2,7 @@ package io.specmatic.conversions
 
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.Resolver
+import io.specmatic.core.Result
 import io.specmatic.core.Result.*
 import io.specmatic.core.pattern.Row
 import org.apache.http.HttpHeaders.AUTHORIZATION
@@ -102,5 +103,14 @@ class BasicAuthSecuritySchemeTest {
         val result = basicAuthSecurityScheme.isInRow(row)
 
         assertFalse(result, "Expected false when authorization header is not present in row")
+    }
+
+    @Test
+    fun `should not result in failure when authorization header is missing and resolver is in mock mode`() {
+        val httpRequest = HttpRequest(headers = emptyMap())
+        val resolver = Resolver(mockMode = true)
+        val result = basicAuthSecurityScheme.matches(httpRequest, resolver)
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
     }
 }

--- a/core/src/test/kotlin/io/specmatic/conversions/BasicAuthSecuritySchemeTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/BasicAuthSecuritySchemeTest.kt
@@ -1,6 +1,7 @@
 package io.specmatic.conversions
 
 import io.specmatic.core.HttpRequest
+import io.specmatic.core.Resolver
 import io.specmatic.core.Result.*
 import io.specmatic.core.pattern.Row
 import org.apache.http.HttpHeaders.AUTHORIZATION
@@ -16,7 +17,7 @@ class BasicAuthSecuritySchemeTest {
     fun `matches should return failure when authorization header is missing`() {
         val httpRequest = HttpRequest(headers = emptyMap())
 
-        val result = basicAuthSecurityScheme.matches(httpRequest)
+        val result = basicAuthSecurityScheme.matches(httpRequest, Resolver())
 
         assertTrue(result is Failure, "Expected failure when authorization header is missing")
     }
@@ -25,7 +26,7 @@ class BasicAuthSecuritySchemeTest {
     fun `matches should return failure when authorization header is not prefixed with Basic`() {
         val httpRequest = HttpRequest(headers = mapOf(AUTHORIZATION to "Bearer token"))
 
-        val result = basicAuthSecurityScheme.matches(httpRequest)
+        val result = basicAuthSecurityScheme.matches(httpRequest, Resolver())
 
         assertTrue(result is Failure, "Expected failure when authorization header is not prefixed with Basic")
     }
@@ -35,7 +36,7 @@ class BasicAuthSecuritySchemeTest {
         val credentials = "charlie123:pqrxyz"
         val httpRequest = HttpRequest(headers = mapOf(AUTHORIZATION to "Basic ${String(Base64.getEncoder().encode(credentials.toByteArray()))}"))
 
-        val result = basicAuthSecurityScheme.matches(httpRequest)
+        val result = basicAuthSecurityScheme.matches(httpRequest, Resolver())
 
         assertThat(result).withFailMessage(result.reportString()).isInstanceOf(Success::class.java)
     }
@@ -45,7 +46,7 @@ class BasicAuthSecuritySchemeTest {
         val credentialsWithoutPassword = "charlie123"
         val httpRequest = HttpRequest(headers = mapOf(AUTHORIZATION to "Basic ${String(Base64.getEncoder().encode(credentialsWithoutPassword.toByteArray()))}"))
 
-        val result = basicAuthSecurityScheme.matches(httpRequest)
+        val result = basicAuthSecurityScheme.matches(httpRequest, Resolver())
 
         assertThat(result).withFailMessage(result.reportString()).isInstanceOf(Failure::class.java)
     }
@@ -55,7 +56,7 @@ class BasicAuthSecuritySchemeTest {
         val nonBase64String = "!@#$%"
         val httpRequest = HttpRequest(headers = mapOf(AUTHORIZATION to "Basic $nonBase64String"))
 
-        val result = basicAuthSecurityScheme.matches(httpRequest)
+        val result = basicAuthSecurityScheme.matches(httpRequest, Resolver())
 
         assertThat(result.reportString()).contains("Invalid base64 encoding")
     }

--- a/core/src/test/kotlin/io/specmatic/conversions/BearerSecuritySchemeTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/BearerSecuritySchemeTest.kt
@@ -1,6 +1,7 @@
 package io.specmatic.conversions
 
 import io.specmatic.core.HttpRequest
+import io.specmatic.core.Resolver
 import org.apache.http.HttpHeaders.AUTHORIZATION
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -25,22 +26,24 @@ class BearerSecuritySchemeTest {
     @ValueSource(strings = [AUTHORIZATION, "authorization", "AUTHORIZATION"])
     fun `Bearer security scheme authorization header matching should be case insensitive`(authorizationHeaderName: String) {
         val requestWithBearer = HttpRequest(method = "POST", path = "/customer", headers = mapOf(authorizationHeaderName to "Bearer foo"))
-        assertThat(scheme.matches(requestWithBearer).isSuccess()).isTrue
+        assertThat(scheme.matches(requestWithBearer, Resolver()).isSuccess()).isTrue
     }
 
     @Test
     fun `Bearer security scheme does not matches requests with authorization header not set`() {
         val requestWithoutHeader = HttpRequest(method = "POST", path = "/customer")
-        with(scheme.matches(requestWithoutHeader)) {
+        with(scheme.matches(requestWithoutHeader, Resolver())) {
             assertThat(isSuccess()).isFalse
-            assertThat(this.reportString()).contains("Authorization header is missing in request")
+            assertThat(this.reportString())
+                .contains(">> HEADERS.Authorization")
+                .contains("Expected header named \"Authorization\" was missing")
         }
     }
 
     @Test
     fun `Bearer security scheme does not matches requests with authorization header without bearer prefix`() {
         val requestWithoutBearer = HttpRequest(method = "POST", path = "/customer", headers = mapOf(AUTHORIZATION to "foo"))
-        with(scheme.matches(requestWithoutBearer)) {
+        with(scheme.matches(requestWithoutBearer, Resolver())) {
             assertThat(isSuccess()).isFalse
             assertThat(this.reportString()).contains("must be prefixed")
         }

--- a/core/src/test/kotlin/io/specmatic/conversions/BearerSecuritySchemeTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/BearerSecuritySchemeTest.kt
@@ -2,6 +2,7 @@ package io.specmatic.conversions
 
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.Resolver
+import io.specmatic.core.Result
 import org.apache.http.HttpHeaders.AUTHORIZATION
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -68,5 +69,14 @@ class BearerSecuritySchemeTest {
                 ignoreCase = true
             )
         }.count()).isEqualTo(1)
+    }
+
+    @Test
+    fun `should not result in failure when authorization header is missing and resolver is in mock mode`() {
+        val httpRequest = HttpRequest(headers = emptyMap())
+        val resolver = Resolver(mockMode = true)
+        val result = BearerSecurityScheme("abcd1234").matches(httpRequest, resolver)
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
     }
 }

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiIntegrationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiIntegrationTest.kt
@@ -184,7 +184,9 @@ Examples:
                 )
                 val result = feature.scenarios.first().httpRequestPattern.matches(httpRequest, Resolver())
                 assertThat(result).isInstanceOf(Result.Failure::class.java)
-                assertThat(result.reportString()).contains("Authorization header is missing in request")
+                assertThat(result.reportString())
+                    .contains(">> REQUEST.HEADERS.Authorization")
+                    .contains("Expected header named \"Authorization\" was missing")
             }
 
             @Test
@@ -557,7 +559,9 @@ Background:
             )
             val result = feature.scenarios.first().httpRequestPattern.matches(httpRequest, Resolver())
             assertThat(result).isInstanceOf(Result.Failure::class.java)
-            assertThat(result.reportString()).contains("Authorization header is missing in request")
+            assertThat(result.reportString())
+                .contains(">> REQUEST.HEADERS.Authorization")
+                .contains("Expected header named \"Authorization\" was missing")
         }
 
         @Test

--- a/core/src/test/kotlin/io/specmatic/core/RunContractTestsUsingScenario.kt
+++ b/core/src/test/kotlin/io/specmatic/core/RunContractTestsUsingScenario.kt
@@ -8,10 +8,16 @@ import io.specmatic.mock.ScenarioStub
 import io.specmatic.test.TestExecutor
 import io.mockk.every
 import io.mockk.mockk
+import io.specmatic.conversions.APIKeyInHeaderSecurityScheme
+import io.specmatic.conversions.APIKeyInQueryParamSecurityScheme
+import io.specmatic.conversions.OpenAPISecurityScheme
 import io.specmatic.test.ScenarioAsTest
+import org.apache.http.HttpHeaders.AUTHORIZATION
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 import java.util.*
 import java.util.function.Consumer
 
@@ -723,5 +729,97 @@ paths:
         >> RESPONSE.STATUS
         Expected status 201, actual was status 202
         """.trimIndent())
+    }
+
+    @ParameterizedTest
+    @MethodSource("io.specmatic.core.ScenarioTest#securitySchemaProvider")
+    fun `should use security schema values from examples when provided`(securitySchema: OpenAPISecurityScheme) {
+        val request = securitySchema.addTo(HttpRequest("POST", "/"))
+        val scenario = Scenario(
+            name = "SIMPLE POST",
+            httpRequestPattern = HttpRequestPattern(
+                httpPathPattern = buildHttpPathPattern("/"), method = "POST",
+                securitySchemes = listOf(securitySchema)
+            ),
+            httpResponsePattern = HttpResponsePattern(status = 200),
+            examples = listOf(
+                Examples(
+                    emptyList(),
+                    listOf(Row(requestExample = request))
+                )
+            )
+        )
+        val feature = Feature(name = "", scenarios = listOf(scenario))
+
+        val extractValue: (HttpRequest) -> String = { it ->
+            when(securitySchema) {
+                is APIKeyInHeaderSecurityScheme -> it.headers.getValue(securitySchema.name)
+                is APIKeyInQueryParamSecurityScheme -> it.queryParams.getValues(securitySchema.name).first()
+                else -> it.headers.getValue(AUTHORIZATION)
+            }
+        }
+
+        val results = feature.executeTests(object : TestExecutor {
+            override fun execute(request: HttpRequest): HttpResponse {
+                return HttpResponse.OK.also {
+                    val logs = listOf(request.toLogString(), it.toLogString())
+                    println(logs.joinToString(separator = "\n\n"))
+
+                    val result = securitySchema.matches(request, Resolver())
+                    assertThat(result).isInstanceOf(Result.Success::class.java)
+
+                    val actualValue = extractValue(request)
+                    val expectedValue = extractValue(request)
+                    assertThat(actualValue).isEqualTo(expectedValue)
+                }
+            }
+        })
+
+        assertThat(results.results).allSatisfy { assertThat(it).isInstanceOf(Result.Success::class.java) }
+    }
+
+    @ParameterizedTest
+    @MethodSource("io.specmatic.core.ScenarioTest#securitySchemaProvider")
+    fun `should generate security schema values if missing from examples`(securitySchema: OpenAPISecurityScheme) {
+        val scenario = Scenario(
+            name = "SIMPLE POST",
+            httpRequestPattern = HttpRequestPattern(
+                httpPathPattern = buildHttpPathPattern("/"), method = "POST",
+                securitySchemes = listOf(securitySchema)
+            ),
+            httpResponsePattern = HttpResponsePattern(status = 200),
+            examples = listOf(
+                Examples(
+                    emptyList(),
+                    listOf(Row(requestExample = HttpRequest("POST", "/")))
+                )
+            )
+        )
+        val feature = Feature(name = "", scenarios = listOf(scenario))
+
+        val extractValue: (HttpRequest) -> String = { it ->
+            when(securitySchema) {
+                is APIKeyInHeaderSecurityScheme -> it.headers.getValue(securitySchema.name)
+                is APIKeyInQueryParamSecurityScheme -> it.queryParams.getValues(securitySchema.name).first()
+                else -> it.headers.getValue(AUTHORIZATION)
+            }
+        }
+
+        val results = feature.executeTests(object : TestExecutor {
+            override fun execute(request: HttpRequest): HttpResponse {
+                return HttpResponse.OK.also {
+                    val logs = listOf(request.toLogString(), it.toLogString())
+                    println(logs.joinToString(separator = "\n\n"))
+
+                    val result = securitySchema.matches(request, Resolver())
+                    assertThat(result).isInstanceOf(Result.Success::class.java)
+
+                    val actualValue = extractValue(request)
+                    assertThat(actualValue).isNotEmpty()
+                }
+            }
+        })
+
+        assertThat(results.results).allSatisfy { assertThat(it).isInstanceOf(Result.Success::class.java) }
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/ScenarioTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ScenarioTest.kt
@@ -331,7 +331,7 @@ class ScenarioTest {
     }
 
     @Test
-    fun `should throw when security schema defined in the example is invalid`() {
+    fun `should throw an exception when security schema defined in the example is invalid`() {
         val scenario = Scenario(
             name = "SIMPLE POST",
             httpRequestPattern = HttpRequestPattern(

--- a/core/src/test/kotlin/io/specmatic/core/ScenarioTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ScenarioTest.kt
@@ -2,13 +2,33 @@ package io.specmatic.core
 
 import io.mockk.every
 import io.mockk.mockk
+import io.specmatic.conversions.*
 import io.specmatic.core.pattern.*
+import org.apache.http.HttpHeaders.AUTHORIZATION
 import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 import java.util.function.Consumer
+import java.util.stream.Stream
 
 class ScenarioTest {
+
+    companion object {
+        @JvmStatic
+        fun securitySchemaProvider(): Stream<OpenAPISecurityScheme> {
+            return Stream.of(
+                APIKeyInHeaderSecurityScheme(name = "API-KEY", apiKey = "1234"),
+                APIKeyInQueryParamSecurityScheme(name = "API-KEY", apiKey = "1234"),
+                BasicAuthSecurityScheme(),
+                BearerSecurityScheme()
+            )
+        }
+    }
+
     @Test
     fun `should validate and reject an invalid response in an example row`() {
         val responseExample = HttpResponse(200, """{"id": "abc123"}""")
@@ -287,6 +307,55 @@ class ScenarioTest {
         assertThat(scenarioMetadata.header).isEqualTo(setOf("Authorization", "X-Request-ID"))
         assertThat(scenarioMetadata.statusCode).isEqualTo(200)
         assertThat(scenarioMetadata.exampleName).isEqualTo("example")
+    }
+
+    @ParameterizedTest
+    @MethodSource("securitySchemaProvider")
+    fun `should load examples with security schemas missing`(securitySchema: OpenAPISecurityScheme) {
+        val scenario = Scenario(
+            name = "SIMPLE POST",
+            httpRequestPattern = HttpRequestPattern(
+                httpPathPattern = buildHttpPathPattern("/"), method = "POST",
+                securitySchemes = listOf(securitySchema)
+            ),
+            httpResponsePattern = HttpResponsePattern(status = 200),
+            examples = listOf(
+                Examples(
+                    emptyList(),
+                    listOf(Row(requestExample = HttpRequest(path = "/", method = "POST")))
+                )
+            )
+        )
+
+        assertDoesNotThrow { scenario.validExamplesOrException(DefaultStrategies) }
+    }
+
+    @Test
+    fun `should throw when security schema defined in the example is invalid`() {
+        val scenario = Scenario(
+            name = "SIMPLE POST",
+            httpRequestPattern = HttpRequestPattern(
+                httpPathPattern = buildHttpPathPattern("/"), method = "POST",
+                securitySchemes = listOf(BasicAuthSecurityScheme())
+            ),
+            httpResponsePattern = HttpResponsePattern(status = 200),
+            examples = listOf(
+                Examples(
+                    emptyList(),
+                    listOf(Row(requestExample = HttpRequest(
+                        path = "/", method = "POST",
+                        headers = mapOf(AUTHORIZATION to "Invalid")
+                    )))
+                )
+            )
+        )
+
+        val exception = assertThrows<ContractException> { scenario.validExamplesOrException(DefaultStrategies) }
+        assertThat(exception.report()).isEqualToNormalizingWhitespace("""
+        Error loading example named  for POST / -> 200
+        >> REQUEST.HEADERS.Authorization
+        Authorization header must be prefixed with "Basic"
+        """.trimIndent())
     }
 
     @Nested


### PR DESCRIPTION
**What**: Fix security schema validation and handling for examples

**How**:
- Automatically generate a value if absent from example, without throwing an error at load time.
- Utilize token from the environment variable if it is available, rather than generating a random value.
- Validate the existing value from an example at load time if exists, and utilize it for making requests.

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate `N\A`