### PR TITLE
Fix examples validate exitCode when directory is empty

### DIFF
--- a/application/src/main/kotlin/application/ExamplesCommand.kt
+++ b/application/src/main/kotlin/application/ExamplesCommand.kt
@@ -289,7 +289,7 @@ For example, to filter by HTTP methods:
                 logger.log("$externalExampleDir does not exist, did not find any files to validate")
                 return FAILURE_EXIT_CODE to emptyMap()
             }
-            if (externalExamples.none()) {
+            if (externalExamples.isEmpty()) {
                 logger.log("No example files found in $externalExampleDir")
                 return SUCCESS_EXIT_CODE to emptyMap()
             }

--- a/application/src/main/kotlin/application/ExamplesCommand.kt
+++ b/application/src/main/kotlin/application/ExamplesCommand.kt
@@ -291,7 +291,7 @@ For example, to filter by HTTP methods:
             }
             if (externalExamples.none()) {
                 logger.log("No example files found in $externalExampleDir")
-                return FAILURE_EXIT_CODE to emptyMap()
+                return SUCCESS_EXIT_CODE to emptyMap()
             }
             return SUCCESS_EXIT_CODE to validateExternalExamples(feature, externalExamples)
         }

--- a/application/src/test/kotlin/application/ExamplesCommandTest.kt
+++ b/application/src/test/kotlin/application/ExamplesCommandTest.kt
@@ -511,6 +511,24 @@ paths:
                 assertThat(examplesToValidate.name).isEqualTo(expected)
             }
         }
+
+        @Test
+        fun `should not result in exit code 1 when example folder is empty`(@TempDir tempDir: File) {
+            val copiedSpecFile = specFile.copyTo(tempDir.resolve("spec.yaml"))
+            val examplesDir = tempDir.resolve("spec_examples").also { it.mkdirs() }
+
+            val command = ExamplesCommand.Validate().also {
+                it.contractFile = copiedSpecFile
+                it.examplesToValidate = ExamplesCommand.Validate.ExamplesToValidate.EXTERNAL
+            }
+            val (stdOut, exitCode) = captureStandardOutput { command.call() }
+            println(stdOut)
+
+            assertThat(exitCode).isEqualTo(0)
+            assertThat(stdOut).containsIgnoringWhitespaces("""
+            No example files found in ${examplesDir}
+            """.trimIndent())
+        }
     }
 
     @Nested

--- a/application/src/test/kotlin/application/ExamplesCommandTest.kt
+++ b/application/src/test/kotlin/application/ExamplesCommandTest.kt
@@ -526,7 +526,7 @@ paths:
 
             assertThat(exitCode).isEqualTo(0)
             assertThat(stdOut).containsIgnoringWhitespaces("""
-            No example files found in ${examplesDir}
+            No example files found in $examplesDir
             """.trimIndent())
         }
     }


### PR DESCRIPTION
**What**: Fix examples validate exitCode when directory is empty

**Why**: Examples validate command should exit with code `0`  when directory is empty

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation `N\A`
- [x] Tests
- [ ] Sonar Quality Gate `N\A`