### PR TITLE
Resolve freezing issue in BCC command when handling large changelists

### DIFF
--- a/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckBaseCommand.kt
+++ b/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckBaseCommand.kt
@@ -130,7 +130,8 @@ abstract class BackwardCompatibilityCheckBaseCommand : Callable<Unit> {
             queue.addAll(referringSpecs)
         }
 
-        return visited.map { it.name }.toSet() - specFiles.map { it.name }.toSet()
+        val referencedFiles = visited.filter { it !in specFiles }
+        return referencedFiles.map { it.canonicalPath }.toSet()
     }
 
     internal fun allSpecFiles(): List<File> {

--- a/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
+++ b/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
@@ -85,7 +85,7 @@ class BackwardCompatibilityCheckCommandV2Test {
                 File("file2.yaml").apply { writeText("file4.yaml") }
             )
             val result = command.getSpecsReferringTo(setOf("file3.yaml"))
-            assertEquals(setOf("file1.yaml"), result)
+            assertEquals(setOf(File("file1.yaml").canonicalPath), result)
         }
 
         @Test
@@ -97,7 +97,9 @@ class BackwardCompatibilityCheckCommandV2Test {
                 File("file2.yaml").apply { referTo("schema_file2.yaml") }
             )
             val result = command.getSpecsReferringTo(setOf("schema_file1.yaml"))
-            assertEquals(setOf("file1.yaml", "schema_file2.yaml", "file2.yaml"), result)
+            assertEquals(
+                setOf("file1.yaml", "schema_file2.yaml", "file2.yaml").map { File(it).canonicalPath }.toSet(), result
+            )
         }
 
         @Test
@@ -109,9 +111,9 @@ class BackwardCompatibilityCheckCommandV2Test {
                 File("c.yaml").apply { referTo("a.yaml") }
             )
 
-            assertThat(command.getSpecsReferringTo(setOf("a.yaml"))).isEqualTo(setOf("b.yaml", "c.yaml"))
-            assertThat(command.getSpecsReferringTo(setOf("b.yaml"))).isEqualTo(setOf("c.yaml", "a.yaml"))
-            assertThat(command.getSpecsReferringTo(setOf("c.yaml"))).isEqualTo(setOf("a.yaml", "b.yaml"))
+            assertThat(command.getSpecsReferringTo(setOf("a.yaml"))).isEqualTo(setOf("b.yaml", "c.yaml").map { File(it).canonicalPath }.toSet())
+            assertThat(command.getSpecsReferringTo(setOf("b.yaml"))).isEqualTo(setOf("c.yaml", "a.yaml").map { File(it).canonicalPath }.toSet())
+            assertThat(command.getSpecsReferringTo(setOf("c.yaml"))).isEqualTo(setOf("a.yaml", "b.yaml").map { File(it).canonicalPath }.toSet())
         }
     }
 


### PR DESCRIPTION
**What**: Resolve freezing issue in BCC command when handling large changelists


**How**: 
- Optimize the `getSpecsReferringTo` function for better performance.
- Implement an iterative approach rather than a recursive one.
- Load all specification files into memory in advance to avoid repeated reads.
- Merge the lookup pattern and escape pattern for improved efficiency.
- Detect changes in included files that are not full-fledged OpenAPI specs, which may be yaml files containing schemas that are referenced by other OpenAPI specs, addressing #1647

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [ ] Tests
- [ ] Sonar Quality Gate
