### PR TITLE
Logging capabilities

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/log/CompositePrinter.kt
+++ b/core/src/main/kotlin/io/specmatic/core/log/CompositePrinter.kt
@@ -1,9 +1,9 @@
 package io.specmatic.core.log
 
 open class CompositePrinter(private var printers: List<LogPrinter> = listOf(ConsolePrinter)) : LogPrinter {
-    override fun print(msg: LogMessage) {
+    override fun print(msg: LogMessage, indentation: String) {
         printers.forEach { printer ->
-            printer.print(msg)
+            printer.print(msg, indentation)
         }
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/log/ConsolePrinter.kt
+++ b/core/src/main/kotlin/io/specmatic/core/log/ConsolePrinter.kt
@@ -1,7 +1,7 @@
 package io.specmatic.core.log
 
 object ConsolePrinter: LogPrinter {
-    override fun print(msg: LogMessage) {
-        println(msg.toLogString())
+    override fun print(msg: LogMessage, indentation: String) {
+        println(msg.toLogString().prependIndent(indentation))
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/log/HttpLogMessage.kt
+++ b/core/src/main/kotlin/io/specmatic/core/log/HttpLogMessage.kt
@@ -19,8 +19,7 @@ data class HttpLogMessage(
     val comment: String? = null,
     var scenario: Scenario? = null,
     var exception: Exception? = null
-) :
-    LogMessage {
+) : LogMessage {
     fun addRequest(httpRequest: HttpRequest) {
         requestTime = CurrentDate()
         this.request = httpRequest

--- a/core/src/main/kotlin/io/specmatic/core/log/JSONConsoleLogPrinter.kt
+++ b/core/src/main/kotlin/io/specmatic/core/log/JSONConsoleLogPrinter.kt
@@ -1,7 +1,7 @@
 package io.specmatic.core.log
 
 object JSONConsoleLogPrinter: LogPrinter {
-    override fun print(msg: LogMessage) {
+    override fun print(msg: LogMessage, indentation: String) {
         println(msg.toJSONObject().toStringLiteral())
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/log/JSONFilePrinter.kt
+++ b/core/src/main/kotlin/io/specmatic/core/log/JSONFilePrinter.kt
@@ -1,7 +1,7 @@
 package io.specmatic.core.log
 
 class JSONFilePrinter(private val file: LogFile): LogPrinter {
-    override fun print(msg: LogMessage) {
+    override fun print(msg: LogMessage, indentation: String) {
         file.appendText("${msg.toJSONObject()}\n")
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/log/LogMessage.kt
+++ b/core/src/main/kotlin/io/specmatic/core/log/LogMessage.kt
@@ -5,4 +5,7 @@ import io.specmatic.core.value.JSONObjectValue
 interface LogMessage {
     fun toJSONObject(): JSONObjectValue
     fun toLogString(): String
+    fun toOneLineString(): String {
+        return toLogString().lines().joinToString(" ") { it.trim() }
+    }
 }

--- a/core/src/main/kotlin/io/specmatic/core/log/LogPrinter.kt
+++ b/core/src/main/kotlin/io/specmatic/core/log/LogPrinter.kt
@@ -1,5 +1,5 @@
 package io.specmatic.core.log
 
 interface LogPrinter {
-    fun print(msg: LogMessage)
+    fun print(msg: LogMessage, indentation: String = "")
 }

--- a/core/src/main/kotlin/io/specmatic/core/log/LogStrategy.kt
+++ b/core/src/main/kotlin/io/specmatic/core/log/LogStrategy.kt
@@ -1,6 +1,6 @@
 package io.specmatic.core.log
 
-interface LogStrategy {
+interface LogStrategy : UsesIndentation {
     val printer: CompositePrinter
     var infoLoggingEnabled: Boolean
 

--- a/core/src/main/kotlin/io/specmatic/core/log/LogStrategy.kt
+++ b/core/src/main/kotlin/io/specmatic/core/log/LogStrategy.kt
@@ -1,6 +1,6 @@
 package io.specmatic.core.log
 
-interface LogStrategy : UsesIndentation {
+interface LogStrategy : UsesIndentation, UsesBoundary {
     val printer: CompositePrinter
     var infoLoggingEnabled: Boolean
 
@@ -10,7 +10,7 @@ interface LogStrategy : UsesIndentation {
     fun log(e: Throwable, msg: String? = null)
     fun log(msg: String)
     fun log(msg: LogMessage)
-    fun logError(e:Throwable)
+    fun logError(e: Throwable)
     fun newLine()
     fun debug(msg: String): String
     fun debug(msg: LogMessage)
@@ -18,6 +18,7 @@ interface LogStrategy : UsesIndentation {
     fun disableInfoLogging() {
         infoLoggingEnabled = false
     }
+
     fun enableInfoLogging() {
         infoLoggingEnabled = true
     }

--- a/core/src/main/kotlin/io/specmatic/core/log/NonVerbose.kt
+++ b/core/src/main/kotlin/io/specmatic/core/log/NonVerbose.kt
@@ -5,7 +5,7 @@ import io.specmatic.core.utilities.exceptionCauseMessage
 class NonVerbose(
     override val printer: CompositePrinter,
     override var infoLoggingEnabled: Boolean = true
-) : LogStrategy, UsesIndentation by UsesIndentationImpl() {
+) : LogStrategy, UsesIndentation by UsesIndentationImpl(), UsesBoundary by UsesBoundaryImpl() {
     private val readyMessage = ReadyMessage()
 
     override fun keepReady(msg: LogMessage) {
@@ -13,6 +13,9 @@ class NonVerbose(
     }
 
     fun print(msg: LogMessage) {
+        val hadBoundary = removeBoundary()
+        if(hadBoundary)
+            printer.print(NewLineLogMessage)
         readyMessage.printLogString(printer, currentIndentation())
         printer.print(msg, currentIndentation())
     }

--- a/core/src/main/kotlin/io/specmatic/core/log/NonVerbose.kt
+++ b/core/src/main/kotlin/io/specmatic/core/log/NonVerbose.kt
@@ -5,7 +5,7 @@ import io.specmatic.core.utilities.exceptionCauseMessage
 class NonVerbose(
     override val printer: CompositePrinter,
     override var infoLoggingEnabled: Boolean = true
-) : LogStrategy, UsesIndentation by UsesIndentationImpl(), UsesBoundary by UsesBoundaryImpl() {
+) : LogStrategy, UsesIndentationWithHelpers by UsesIndentationImpl(), UsesBoundaryWithHelpers by UsesBoundaryImpl() {
     private val readyMessage = ReadyMessage()
 
     override fun keepReady(msg: LogMessage) {

--- a/core/src/main/kotlin/io/specmatic/core/log/NonVerbose.kt
+++ b/core/src/main/kotlin/io/specmatic/core/log/NonVerbose.kt
@@ -5,7 +5,7 @@ import io.specmatic.core.utilities.exceptionCauseMessage
 class NonVerbose(
     override val printer: CompositePrinter,
     override var infoLoggingEnabled: Boolean = true
-) : LogStrategy {
+) : LogStrategy, UsesIndentation by UsesIndentationImpl() {
     private val readyMessage = ReadyMessage()
 
     override fun keepReady(msg: LogMessage) {
@@ -13,8 +13,8 @@ class NonVerbose(
     }
 
     fun print(msg: LogMessage) {
-        readyMessage.printLogString(printer)
-        printer.print(msg)
+        readyMessage.printLogString(printer, currentIndentation())
+        printer.print(msg, currentIndentation())
     }
 
     override fun exceptionString(e: Throwable, msg: String?): String {

--- a/core/src/main/kotlin/io/specmatic/core/log/OneLinePrinter.kt
+++ b/core/src/main/kotlin/io/specmatic/core/log/OneLinePrinter.kt
@@ -1,0 +1,7 @@
+package io.specmatic.core.log
+
+object OneLinePrinter: LogPrinter {
+    override fun print(msg: LogMessage, indentation: String) {
+        println(msg.toOneLineString().prependIndent(indentation))
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/core/log/ReadyMessage.kt
+++ b/core/src/main/kotlin/io/specmatic/core/log/ReadyMessage.kt
@@ -1,10 +1,10 @@
 package io.specmatic.core.log
 
 class ReadyMessage(var msg: LogMessage? = null) {
-    fun printLogString(printer: LogPrinter) {
+    fun printLogString(printer: LogPrinter, indentation: String = "") {
         msg?.let {
             msg = null
-            printer.print(it)
+            printer.print(it, indentation)
         }
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/log/TextFilePrinter.kt
+++ b/core/src/main/kotlin/io/specmatic/core/log/TextFilePrinter.kt
@@ -1,7 +1,7 @@
 package io.specmatic.core.log
 
 class TextFilePrinter(private val file: LogFile): LogPrinter {
-    override fun print(msg: LogMessage) {
-        file.appendText("${msg.toLogString()}\n")
+    override fun print(msg: LogMessage, indentation: String) {
+        file.appendText("${msg.toLogString().prependIndent(indentation)}\n")
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/log/UsesBoundary.kt
+++ b/core/src/main/kotlin/io/specmatic/core/log/UsesBoundary.kt
@@ -1,0 +1,6 @@
+package io.specmatic.core.log
+
+interface UsesBoundary {
+    fun boundary() {}
+    fun removeBoundary(): Boolean { return false }
+}

--- a/core/src/main/kotlin/io/specmatic/core/log/UsesBoundary.kt
+++ b/core/src/main/kotlin/io/specmatic/core/log/UsesBoundary.kt
@@ -2,5 +2,5 @@ package io.specmatic.core.log
 
 interface UsesBoundary {
     fun boundary() {}
-    fun removeBoundary(): Boolean { return false }
 }
+

--- a/core/src/main/kotlin/io/specmatic/core/log/UsesBoundaryImpl.kt
+++ b/core/src/main/kotlin/io/specmatic/core/log/UsesBoundaryImpl.kt
@@ -1,6 +1,6 @@
 package io.specmatic.core.log
 
-class UsesBoundaryImpl : UsesBoundary {
+class UsesBoundaryImpl : UsesBoundaryWithHelpers {
     var boundary: Boolean = false
 
     override fun boundary() {

--- a/core/src/main/kotlin/io/specmatic/core/log/UsesBoundaryImpl.kt
+++ b/core/src/main/kotlin/io/specmatic/core/log/UsesBoundaryImpl.kt
@@ -1,0 +1,16 @@
+package io.specmatic.core.log
+
+class UsesBoundaryImpl : UsesBoundary {
+    var boundary: Boolean = false
+
+    override fun boundary() {
+        boundary = true
+    }
+
+    override fun removeBoundary(): Boolean {
+        val oldBoundary = boundary
+        boundary = false
+        return oldBoundary
+    }
+
+}

--- a/core/src/main/kotlin/io/specmatic/core/log/UsesBoundaryWithHelpers.kt
+++ b/core/src/main/kotlin/io/specmatic/core/log/UsesBoundaryWithHelpers.kt
@@ -1,0 +1,5 @@
+package io.specmatic.core.log
+
+interface UsesBoundaryWithHelpers : UsesBoundary {
+    fun removeBoundary(): Boolean { return false }
+}

--- a/core/src/main/kotlin/io/specmatic/core/log/UsesIndentation.kt
+++ b/core/src/main/kotlin/io/specmatic/core/log/UsesIndentation.kt
@@ -5,19 +5,3 @@ interface UsesIndentation {
     fun currentIndentation(): String
 }
 
-class UsesIndentationImpl(private var indentation: Int = 0) : UsesIndentation {
-    @Synchronized
-    override fun <T> withIndentation(count: Int, block: () -> T): T {
-        indentation += count
-        return try {
-            block()
-        } finally {
-            indentation -= count
-        }
-    }
-
-    @Synchronized
-    override fun currentIndentation(): String {
-        return " ".repeat(indentation)
-    }
-}

--- a/core/src/main/kotlin/io/specmatic/core/log/UsesIndentation.kt
+++ b/core/src/main/kotlin/io/specmatic/core/log/UsesIndentation.kt
@@ -1,0 +1,23 @@
+package io.specmatic.core.log
+
+interface UsesIndentation {
+    fun <T> withIndentation(count: Int, block: () -> T): T
+    fun currentIndentation(): String
+}
+
+class UsesIndentationImpl(private var indentation: Int = 0) : UsesIndentation {
+    @Synchronized
+    override fun <T> withIndentation(count: Int, block: () -> T): T {
+        indentation += count
+        return try {
+            block()
+        } finally {
+            indentation -= count
+        }
+    }
+
+    @Synchronized
+    override fun currentIndentation(): String {
+        return " ".repeat(indentation)
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/core/log/UsesIndentation.kt
+++ b/core/src/main/kotlin/io/specmatic/core/log/UsesIndentation.kt
@@ -2,6 +2,5 @@ package io.specmatic.core.log
 
 interface UsesIndentation {
     fun <T> withIndentation(count: Int, block: () -> T): T
-    fun currentIndentation(): String
 }
 

--- a/core/src/main/kotlin/io/specmatic/core/log/UsesIndentationImpl.kt
+++ b/core/src/main/kotlin/io/specmatic/core/log/UsesIndentationImpl.kt
@@ -1,6 +1,6 @@
 package io.specmatic.core.log
 
-class UsesIndentationImpl(private var indentation: Int = 0) : UsesIndentation {
+class UsesIndentationImpl(private var indentation: Int = 0) : UsesIndentationWithHelpers {
     @Synchronized
     override fun <T> withIndentation(count: Int, block: () -> T): T {
         indentation += count

--- a/core/src/main/kotlin/io/specmatic/core/log/UsesIndentationImpl.kt
+++ b/core/src/main/kotlin/io/specmatic/core/log/UsesIndentationImpl.kt
@@ -1,0 +1,18 @@
+package io.specmatic.core.log
+
+class UsesIndentationImpl(private var indentation: Int = 0) : UsesIndentation {
+    @Synchronized
+    override fun <T> withIndentation(count: Int, block: () -> T): T {
+        indentation += count
+        return try {
+            block()
+        } finally {
+            indentation -= count
+        }
+    }
+
+    @Synchronized
+    override fun currentIndentation(): String {
+        return " ".repeat(indentation)
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/core/log/UsesIndentationWithHelpers.kt
+++ b/core/src/main/kotlin/io/specmatic/core/log/UsesIndentationWithHelpers.kt
@@ -1,0 +1,5 @@
+package io.specmatic.core.log
+
+interface UsesIndentationWithHelpers : UsesIndentation {
+    fun currentIndentation(): String
+}

--- a/core/src/main/kotlin/io/specmatic/core/log/Verbose.kt
+++ b/core/src/main/kotlin/io/specmatic/core/log/Verbose.kt
@@ -5,7 +5,7 @@ import io.specmatic.core.utilities.exceptionCauseMessage
 class Verbose(
     override val printer: CompositePrinter = CompositePrinter(),
     override var infoLoggingEnabled: Boolean = true
-) : LogStrategy {
+) : LogStrategy, UsesIndentation by UsesIndentationImpl() {
     private val readyMessage = ReadyMessage()
 
     override fun keepReady(msg: LogMessage) {
@@ -14,7 +14,7 @@ class Verbose(
 
     fun print(msg: LogMessage) {
         readyMessage.printLogString(printer)
-        printer.print(msg)
+        printer.print(msg, currentIndentation())
     }
 
     override fun exceptionString(e: Throwable, msg: String?): String {

--- a/core/src/main/kotlin/io/specmatic/core/log/Verbose.kt
+++ b/core/src/main/kotlin/io/specmatic/core/log/Verbose.kt
@@ -5,7 +5,7 @@ import io.specmatic.core.utilities.exceptionCauseMessage
 class Verbose(
     override val printer: CompositePrinter = CompositePrinter(),
     override var infoLoggingEnabled: Boolean = true
-) : LogStrategy, UsesIndentation by UsesIndentationImpl(), UsesBoundary by UsesBoundaryImpl() {
+) : LogStrategy, UsesIndentationWithHelpers by UsesIndentationImpl(), UsesBoundaryWithHelpers by UsesBoundaryImpl() {
     private val readyMessage = ReadyMessage()
 
     override fun keepReady(msg: LogMessage) {

--- a/core/src/main/kotlin/io/specmatic/core/log/Verbose.kt
+++ b/core/src/main/kotlin/io/specmatic/core/log/Verbose.kt
@@ -5,7 +5,7 @@ import io.specmatic.core.utilities.exceptionCauseMessage
 class Verbose(
     override val printer: CompositePrinter = CompositePrinter(),
     override var infoLoggingEnabled: Boolean = true
-) : LogStrategy, UsesIndentation by UsesIndentationImpl() {
+) : LogStrategy, UsesIndentation by UsesIndentationImpl(), UsesBoundary by UsesBoundaryImpl() {
     private val readyMessage = ReadyMessage()
 
     override fun keepReady(msg: LogMessage) {

--- a/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
+++ b/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
@@ -157,7 +157,7 @@ class LoadTestsFromExternalisedFiles {
         val logBuffer = object : CompositePrinter(emptyList()) {
             var buffer: MutableList<String> = mutableListOf()
 
-            override fun print(msg: LogMessage) {
+            override fun print(msg: LogMessage, indentation: String) {
                 buffer.add(msg.toLogString())
             }
         }

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -6303,6 +6303,14 @@ paths:
                 return ""
             }
 
+            override fun boundary() {
+                TODO("Not yet implemented")
+            }
+
+            override fun removeBoundary(): Boolean {
+                return false
+            }
+
         }
 
         ignoreButLogException {

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -6295,6 +6295,14 @@ paths:
                 TODO("Not yet implemented")
             }
 
+            override fun <T> withIndentation(count: Int, block: () -> T): T {
+                return block()
+            }
+
+            override fun currentIndentation(): String {
+                return ""
+            }
+
         }
 
         ignoreButLogException {
@@ -6384,6 +6392,14 @@ paths:
 
             override fun debug(e: Throwable, msg: String?) {
                 TODO("Not yet implemented")
+            }
+
+            override fun <T> withIndentation(count: Int, block: () -> T): T {
+                return block()
+            }
+
+            override fun currentIndentation(): String {
+                return ""
             }
 
         }

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -6299,18 +6299,9 @@ paths:
                 return block()
             }
 
-            override fun currentIndentation(): String {
-                return ""
-            }
-
             override fun boundary() {
                 TODO("Not yet implemented")
             }
-
-            override fun removeBoundary(): Boolean {
-                return false
-            }
-
         }
 
         ignoreButLogException {
@@ -6405,11 +6396,6 @@ paths:
             override fun <T> withIndentation(count: Int, block: () -> T): T {
                 return block()
             }
-
-            override fun currentIndentation(): String {
-                return ""
-            }
-
         }
 
         ignoreButLogException {

--- a/core/src/test/kotlin/io/specmatic/core/LoggingKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/LoggingKtTest.kt
@@ -1,6 +1,8 @@
 package io.specmatic.core
 
+import io.specmatic.core.log.InfoLogger
 import io.specmatic.core.log.logFileNameSuffix
+import io.specmatic.stub.captureStandardOutput
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -11,5 +13,42 @@ internal class LoggingKtTest {
         assertThat(logFileNameSuffix("", "log")).isEqualTo(".log")
         assertThat(logFileNameSuffix("json", "")).isEqualTo("-json")
         assertThat(logFileNameSuffix("", "")).isEqualTo("")
+    }
+
+    @Test
+    fun `log with no indentation`() {
+        val (output, _) = captureStandardOutput(trim = false) {
+            InfoLogger.log("Hello")
+        }
+
+        assertThat(output.trimEnd()).isEqualTo("Hello")
+    }
+
+    @Test
+    fun `log with indentation`() {
+        val (output, _) = captureStandardOutput(trim = false) {
+            InfoLogger.withIndentation(2) {
+                InfoLogger.log("Hello")
+            }
+        }
+
+        assertThat(output.trimEnd()).isEqualTo(" ".repeat(2) + "Hello")
+    }
+
+    @Test
+    fun `log with nested indentation`() {
+        val (output, _) = captureStandardOutput(trim = false) {
+            InfoLogger.log("Outer")
+            InfoLogger.withIndentation(2) {
+                InfoLogger.log("Inner")
+                InfoLogger.withIndentation(2) {
+                    InfoLogger.log("Innermost")
+                }
+                InfoLogger.log("Return to inner")
+            }
+            InfoLogger.log("Return to outer")
+        }
+
+        assertThat(output.trimEnd()).isEqualTo("Outer${System.lineSeparator()}  Inner${System.lineSeparator()}    Innermost${System.lineSeparator()}  Return to inner${System.lineSeparator()}Return to outer")
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/LoggingKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/LoggingKtTest.kt
@@ -1,7 +1,8 @@
 package io.specmatic.core
 
-import io.specmatic.core.log.InfoLogger
-import io.specmatic.core.log.logFileNameSuffix
+import io.specmatic.core.log.*
+import io.specmatic.core.value.JSONObjectValue
+import io.specmatic.core.value.StringValue
 import io.specmatic.stub.captureStandardOutput
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -50,5 +51,16 @@ internal class LoggingKtTest {
         }
 
         assertThat(output.trimEnd()).isEqualTo("Outer${System.lineSeparator()}  Inner${System.lineSeparator()}    Innermost${System.lineSeparator()}  Return to inner${System.lineSeparator()}Return to outer")
+    }
+
+    @Test
+    fun `log in one line`() {
+        val (output, _) = captureStandardOutput {
+            val oneLineLogger = NonVerbose(CompositePrinter(listOf(OneLinePrinter)))
+            val json = JSONObjectValue(mapOf("data" to StringValue("information")))
+            oneLineLogger.log(json.toStringLiteral())
+        }
+
+        assertThat(output).isEqualTo("""{ "data": "information" }""")
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/LoggingKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/LoggingKtTest.kt
@@ -63,4 +63,27 @@ internal class LoggingKtTest {
 
         assertThat(output).isEqualTo("""{ "data": "information" }""")
     }
+
+    @Test
+    fun `render a boundary`() {
+        val (output, _) = captureStandardOutput {
+            InfoLogger.log("one")
+            InfoLogger.boundary()
+            InfoLogger.log("two")
+        }
+
+        assertThat(output).isEqualTo("one${System.lineSeparator()}${System.lineSeparator()}two")
+    }
+
+    @Test
+    fun `render a single boundary even though boundary is called twice`() {
+        val (output, _) = captureStandardOutput {
+            InfoLogger.log("one")
+            InfoLogger.boundary()
+            InfoLogger.boundary()
+            InfoLogger.log("two")
+        }
+
+        assertThat(output).isEqualTo("one${System.lineSeparator()}${System.lineSeparator()}two")
+    }
 }

--- a/core/src/test/kotlin/io/specmatic/core/log/CompositePrinterTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/log/CompositePrinterTest.kt
@@ -9,7 +9,7 @@ internal class CompositePrinterTest {
         var printed = 0
 
         val printer = CompositePrinter(listOf(object: LogPrinter {
-                override fun print(msg: LogMessage) {
+                override fun print(msg: LogMessage, indentation: String) {
                     assertThat(msg.toLogString()).isEqualTo("Hello")
                     printed += 1
                 }

--- a/core/src/test/kotlin/io/specmatic/core/log/NonVerboseTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/log/NonVerboseTest.kt
@@ -7,7 +7,7 @@ internal class NonVerboseTest {
     private val printer = object: LogPrinter {
         val logged: MutableList<LogMessage> = mutableListOf()
 
-        override fun print(msg: LogMessage) {
+        override fun print(msg: LogMessage, indentation: String) {
             logged.add(msg)
         }
     }

--- a/core/src/test/kotlin/io/specmatic/core/log/ReadyMessageTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/log/ReadyMessageTest.kt
@@ -10,7 +10,7 @@ internal class ReadyMessageTest {
         val messages = mutableListOf<LogMessage>()
 
         val printer = object: LogPrinter {
-            override fun print(msg: LogMessage) {
+            override fun print(msg: LogMessage, indentation: String) {
                 messages.add(msg)
             }
         }

--- a/core/src/test/kotlin/io/specmatic/core/log/VerboseTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/log/VerboseTest.kt
@@ -7,7 +7,7 @@ internal class VerboseTest {
     private val printer = object: LogPrinter {
         val logged: MutableList<LogMessage> = mutableListOf()
 
-        override fun print(msg: LogMessage) {
+        override fun print(msg: LogMessage, indentation: String) {
             logged.add(msg)
         }
     }

--- a/core/src/test/kotlin/io/specmatic/stub/ApiKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/ApiKtTest.kt
@@ -574,7 +574,7 @@ Feature: Math API
     }
 }
 
-fun <ReturnType> captureStandardOutput(fn: () -> ReturnType): Pair<String, ReturnType> {
+fun <ReturnType> captureStandardOutput(trim: Boolean = true, fn: () -> ReturnType): Pair<String, ReturnType> {
     val originalOut = System.out
 
     val byteArrayOutputStream = ByteArrayOutputStream()
@@ -584,8 +584,10 @@ fun <ReturnType> captureStandardOutput(fn: () -> ReturnType): Pair<String, Retur
     val result = fn()
 
     System.out.flush()
-    System.setOut(originalOut) // So you can print again
-    return Pair(String(byteArrayOutputStream.toByteArray()).trim(), result)
+    System.setOut(originalOut)
+    val string = String(byteArrayOutputStream.toByteArray())
+    val trimmed = if(trim) string.trim() else string
+    return Pair(trimmed, result)
 }
 
 fun contractInfoToExpectations(contractInfo: List<Pair<Feature, List<ScenarioStub>>>): StubDataItems {

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=2.7.2
+version=2.8.0

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=2.8.0
+version=2.7.2


### PR DESCRIPTION
Added the following
- boundaries: `logger.boundary()` can be called as many times as needed and it will print a newline just once
- indentation: `logger.withIndentation(2) { logger.log("Loading spec") }` will print `"  Loading spec"`. Calls to `logger.withIndentation` can be nested.
- one line format: The format now exists (`LogMessage.oneLine`) and can be configured. Appropriate flags need to be added and some existing pieces (e.g. HTTP request log) needs to be given a one line format.