### PR TITLE
Fix for handling of responses for objects with "additionalProperties"

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
@@ -206,6 +206,9 @@ data class JSONObjectPattern(
         if(value !is JSONObjectValue)
             return HasFailure(Result.Failure("Cannot resolve substitutions, expected object but got ${value.displayableType()}"))
 
+        if(pattern.isEmpty())
+            return HasValue(value)
+
         val updatedMap = value.jsonObject.mapValues { (key, value) ->
             val pattern = attempt("Could not find key in json object", key) { pattern[key] ?: pattern["$key?"] ?: throw MissingDataException("Could not find key $key") }
             pattern.resolveSubstitutions(substitution, value, resolver, key).breadCrumb(key)

--- a/core/src/test/kotlin/io/specmatic/core/pattern/JSONObjectPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/JSONObjectPatternTest.kt
@@ -20,7 +20,6 @@ import io.specmatic.stub.captureStandardOutput
 import io.specmatic.trimmedLinesString
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.checkerframework.common.value.qual.StringVal
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.params.ParameterizedTest
@@ -2324,6 +2323,19 @@ components:
                 }
             )
         }
+    }
+
+    @Test
+    fun `should be able to resolve substitutions for an object with no properties`() {
+        val pattern = JSONObjectPattern(emptyMap())
+        val request = HttpRequest("GET", "/")
+        val substitution = Substitution(request, request, buildHttpPathPattern("/"), HttpHeadersPattern(), pattern, Resolver(), JSONObjectValue(emptyMap()))
+
+        val originalJson = parsedJSONObject("""{"Hello": "world"}""")
+        val jsonAfterSubstitutions = pattern.resolveSubstitutions(substitution, originalJson, Resolver()).value
+
+        assertThat(jsonAfterSubstitutions).isEqualTo(originalJson)
+
     }
 
     companion object {


### PR DESCRIPTION
`additionalProperties` is now handled by JSONObjectPattern, instead of DictionaryPattern, as of version `2.7.2`. JSONObjectPattern was not handling substitutions correctly when additionalProperties was permitted.