### PR TITLE
Update pattern to schema conversion and stub resolution order

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -38,6 +38,7 @@ import io.swagger.v3.oas.models.parameters.RequestBody
 import io.swagger.v3.oas.models.responses.ApiResponse
 import io.swagger.v3.oas.models.responses.ApiResponses
 import io.swagger.v3.oas.models.security.SecurityScheme
+import io.swagger.v3.oas.models.servers.Server
 import io.swagger.v3.parser.OpenAPIV3Parser
 import io.swagger.v3.parser.core.models.ParseOptions
 import io.swagger.v3.parser.core.models.SwaggerParseResult
@@ -271,10 +272,14 @@ class OpenApiSpecification(
         )
     }
 
-    private fun parseUnreferencedSchemas(): Map<String, Pattern> {
+    fun parseUnreferencedSchemas(): Map<String, Pattern> {
         return openApiSchemas().filterNot { withPatternDelimiters(it.key) in patterns }.map {
             withPatternDelimiters(it.key) to toSpecmaticPattern(it.value, emptyList(), it.key)
         }.toMap()
+    }
+
+    fun getServers(): List<Server> {
+        return parsedOpenApi.servers.orEmpty()
     }
 
     override fun toScenarioInfos(): Pair<List<ScenarioInfo>, Map<String, List<Pair<HttpRequest, HttpResponse>>>> {

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -297,7 +297,7 @@ data class Feature(
                 scenario.httpRequestPattern.matches(httpRequest, resolver) is Success
             }
         }
-        
+
         return matchingScenario?.calculatePath(httpRequest) ?: emptySet()
     }
 
@@ -1601,8 +1601,26 @@ data class Feature(
     private fun isJSONPayload(type: Pattern) =
         type is TabularPattern || type is JSONObjectPattern || type is JSONArrayPattern || type is ListPattern
 
-    private fun toOpenApiSchema(pattern: Pattern): Schema<Any> {
+    @Suppress("MemberVisibilityCanBePrivate")
+    fun toOpenApiSchema(pattern: Pattern): Schema<Any> {
         val schema = when {
+            pattern is EmailPattern -> EmailSchema()
+            pattern is NumberPattern -> {
+                val schema = if (pattern.isDoubleFormat) NumberSchema() else IntegerSchema()
+                schema.apply {
+                    minimum = pattern.minimum;
+                    maximum = pattern.maximum;
+                    exclusiveMinimum = pattern.exclusiveMinimum.takeIf { it };
+                    exclusiveMaximum = pattern.exclusiveMaximum.takeIf { it }
+                }
+            }
+            pattern is StringPattern -> {
+                StringSchema().apply {
+                    minLength = pattern.minLength;
+                    maxLength = pattern.maxLength;
+                    this.pattern = pattern.regex
+                }
+            }
             pattern is DictionaryPattern -> {
                 ObjectSchema().apply {
                     additionalProperties = Schema<Any>().apply {
@@ -1692,7 +1710,9 @@ data class Feature(
                 format = null
             }
             pattern is BooleanPattern || (pattern is DeferredPattern && pattern.pattern == "(boolean)") -> BooleanSchema()
-            pattern is DateTimePattern || (pattern is DeferredPattern && pattern.pattern == "(datetime)") -> StringSchema()
+            pattern is DateTimePattern || (pattern is DeferredPattern && pattern.pattern == "(datetime)") -> DateTimeSchema()
+            pattern is DatePattern || (pattern is DeferredPattern && pattern.pattern == "(date)") -> DateSchema()
+            pattern is UUIDPattern || (pattern is DeferredPattern && pattern.pattern == "(uuid)") -> UUIDSchema()
             pattern is StringPattern || pattern is EmptyStringPattern || (pattern is DeferredPattern && pattern.pattern == "(string)") || (pattern is DeferredPattern && pattern.pattern == "(emptystring)") -> StringSchema()
             pattern is NullPattern || (pattern is DeferredPattern && pattern.pattern == "(null)") -> Schema<Any>().apply {
                 this.nullable = true
@@ -1731,8 +1751,8 @@ data class Feature(
             pattern is QueryParameterScalarPattern -> {
                 toOpenApiSchema(pattern.pattern)
             }
-            else ->
-                TODO("Not supported: ${pattern.typeAlias ?: pattern.typeName}, ${pattern.javaClass.name}")
+            pattern is EnumPattern -> toOpenApiSchema(pattern.pattern)
+            else -> TODO("Not supported: ${pattern.typeAlias ?: pattern.typeName}, ${pattern.javaClass.name}")
         }
 
         return schema as Schema<Any>

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -806,7 +806,7 @@ data class Scenario(
             is JSONArrayPattern -> bodyPattern.calculatePath(httpRequest.body, this.resolver)
             else -> emptySet()
         }
-        
+
         // For top-level AnyPattern that returns scalar type names, wrap them in braces
         return if (bodyPattern is AnyPattern) {
             paths.map { path ->
@@ -899,7 +899,7 @@ data class Scenario(
         response: HttpResponse,
         data: JSONObjectValue
     ): HttpResponse {
-        val substitution = httpRequestPattern.getSubstitution(request, originalRequest, resolver, data)
+        val substitution = httpRequestPattern.getSubstitution(request, originalRequest, resolver.copy(mockMode = true), data)
         return httpResponsePattern.resolveSubstitutions(substitution, response)
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -893,7 +893,7 @@ data class Scenario(
         return exampleRequestContentType == patternRequestContentType
     }
 
-    fun resolveSubtitutions(
+    fun resolveSubstitutions(
         request: HttpRequest,
         originalRequest: HttpRequest,
         response: HttpResponse,

--- a/core/src/main/kotlin/io/specmatic/core/pattern/Grammar.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/Grammar.kt
@@ -26,7 +26,7 @@ internal fun withOptionality(key: String): String {
     }
 }
 
-internal fun isOptional(key: String): Boolean =
+fun isOptional(key: String): Boolean =
     key.endsWith(DEFAULT_OPTIONAL_SUFFIX) || key.endsWith(XML_ATTR_OPTIONAL_SUFFIX)
 
 internal fun containsKey(jsonObject: Map<String, Any?>, key: String) =

--- a/core/src/main/kotlin/io/specmatic/core/pattern/Pattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/Pattern.kt
@@ -137,17 +137,10 @@ fun fixValue(value: Value, pattern: Pattern, resolver: Resolver): Value {
     return value.takeIf { resolver.matchesPattern(null, pattern, value).isSuccess() } ?: resolver.generate(pattern)
 }
 
-fun scalarResolveSubstitutions(
-    substitution: Substitution,
-    value: Value,
-    key: String?,
-    pattern: Pattern,
-    resolver: Resolver
-): ReturnValue<Value> {
-    val resolvedValue =
-        runCatching { substitution.resolveIfLookup(value, pattern) }.getOrElse { e -> return HasException(e) }
+fun scalarResolveSubstitutions(substitution: Substitution, value: Value, key: String?, pattern: Pattern, resolver: Resolver): ReturnValue<Value> {
+    val resolvedValue = runCatching { substitution.resolveIfLookup(value, pattern) }.getOrElse { e -> return HasException(e) }
     return substitution.substitute(resolvedValue, pattern, key).ifHasValue { returnValue: HasValue<Value> ->
         val substitutedValue = returnValue.value
-        pattern.matches(substitutedValue, resolver).toReturnValue(substitutedValue)
+        resolver.matchesPattern(null, pattern, substitutedValue).toReturnValue(substitutedValue)
     }
 }

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStubResponse.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStubResponse.kt
@@ -22,7 +22,7 @@ data class HttpStubResponse(
         if(scenario == null)
             return this
 
-        val updatedResponse = scenario.resolveSubtitutions(request, originalRequest, response, data)
+        val updatedResponse = scenario.resolveSubstitutions(request, originalRequest, response, data)
 
         return this.copy(response = updatedResponse)
     }

--- a/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
@@ -163,17 +163,13 @@ data class ScenarioAsTest(
         testScenario: Scenario,
         flagsBased: FlagsBased
     ): Result {
-        val result = when {
-            response.specmaticResultHeaderValue() == "failure" -> Result.Failure(response.body.toStringLiteral())
-                .updateScenario(testScenario)
-
-            else -> testScenario.matchesResponse(
+        val result =
+            testScenario.matchesResponse(
                 request,
                 response,
                 ContractAndResponseMismatch,
-                flagsBased.unexpectedKeyCheck ?: ValidateUnexpectedKeys
+                flagsBased.unexpectedKeyCheck ?: ValidateUnexpectedKeys,
             )
-        }
 
         if (result is Result.Success && result.isPartialSuccess()) {
             logger.log("    PARTIAL SUCCESS: ${result.partialSuccessMessage}")

--- a/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
@@ -1,7 +1,5 @@
 package io.specmatic.core
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import io.mockk.every
 import io.mockk.mockk
 import io.specmatic.conversions.OpenApiSpecification
@@ -17,7 +15,6 @@ import io.specmatic.test.ScenarioTestGenerationException
 import io.specmatic.test.ScenarioTestGenerationFailure
 import io.specmatic.test.TestExecutor
 import io.specmatic.trimmedLinesList
-import io.swagger.v3.oas.models.OpenAPI
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.json.JSONObject
@@ -2914,55 +2911,6 @@ paths:
 
             assertTrue(pairs.isEmpty())
         }
-    }
-
-    @Test
-    fun `it should not inline reffed schemas when converting feature to OpenAPI spec`() {
-        val spec = """
-            openapi: 3.0.3
-            info:
-              title: Simple Product API
-              version: 1.0.0
-            paths:
-              /product:
-                post:
-                  summary: Create a product
-                  requestBody:
-                    required: true
-                    content:
-                      application/json:
-                        schema:
-                          ${"$"}ref: '#/components/schemas/Product'
-                  responses:
-                    '200':
-                      description: The created product
-                      content:
-                        application/json:
-                          schema:
-                            ${"$"}ref: '#/components/schemas/Product'
-            components:
-              schemas:
-                Product:
-                  type: object
-                  properties:
-                    name:
-                      type: string
-                      example: "Sample Product"
-        """.trimIndent()
-
-        val feature = OpenApiSpecification.fromYAML(spec, "").toFeature()
-        val openAPIFromFeature = feature.toOpenApi()
-
-        val post = openAPIFromFeature.paths["/product"]?.post!!
-        val requestBodySchema = post.requestBody?.content?.get("application/json")?.schema!!
-        val responseBodySchema = post.responses?.get("200")?.content?.get("application/json")?.schema!!
-
-        assertThat(requestBodySchema.`$ref`).isEqualTo("#/components/schemas/Product")
-        assertThat(responseBodySchema.`$ref`).isEqualTo("#/components/schemas/Product")
-
-        val componentSchemas = openAPIFromFeature.components.schemas.orEmpty()
-
-        assertThat(componentSchemas).containsKey("Product")
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
@@ -1,5 +1,7 @@
 package io.specmatic.core
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import io.mockk.every
 import io.mockk.mockk
 import io.specmatic.conversions.OpenApiSpecification
@@ -15,6 +17,7 @@ import io.specmatic.test.ScenarioTestGenerationException
 import io.specmatic.test.ScenarioTestGenerationFailure
 import io.specmatic.test.TestExecutor
 import io.specmatic.trimmedLinesList
+import io.swagger.v3.oas.models.OpenAPI
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.json.JSONObject
@@ -2911,6 +2914,55 @@ paths:
 
             assertTrue(pairs.isEmpty())
         }
+    }
+
+    @Test
+    fun `it should not inline reffed schemas when converting feature to OpenAPI spec`() {
+        val spec = """
+            openapi: 3.0.3
+            info:
+              title: Simple Product API
+              version: 1.0.0
+            paths:
+              /product:
+                post:
+                  summary: Create a product
+                  requestBody:
+                    required: true
+                    content:
+                      application/json:
+                        schema:
+                          ${"$"}ref: '#/components/schemas/Product'
+                  responses:
+                    '200':
+                      description: The created product
+                      content:
+                        application/json:
+                          schema:
+                            ${"$"}ref: '#/components/schemas/Product'
+            components:
+              schemas:
+                Product:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                      example: "Sample Product"
+        """.trimIndent()
+
+        val feature = OpenApiSpecification.fromYAML(spec, "").toFeature()
+        val openAPIFromFeature = feature.toOpenApi()
+
+        val post = openAPIFromFeature.paths["/product"]?.post!!
+        val requestBodySchema = post.requestBody?.content?.get("application/json")?.schema!!
+        val responseBodySchema = post.responses?.get("200")?.content?.get("application/json")?.schema!!
+
+        assertThat(requestBodySchema.`$ref`).isEqualTo("#/components/schemas/Product")
+        assertThat(responseBodySchema.`$ref`).isEqualTo("#/components/schemas/Product")
+
+        val componentSchemas = openAPIFromFeature.components.schemas.orEmpty()
+
+        assertThat(componentSchemas).containsKey("Product")
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/core/HttpStubTests.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpStubTests.kt
@@ -760,7 +760,7 @@ Scenario: JSON API to get account details with fact check
     }
 
     @Test
-    fun `should be able to response with matching data substitution based partial example`() {
+    fun `should be able to respond with matching data substitution based partial example`() {
         val openApiFile = File("src/test/resources/openapi/partial_example_tests/simple.yaml")
         val examplesDir = openApiFile.resolveSibling("partial_substitution")
         val feature = OpenApiSpecification.fromFile(openApiFile.canonicalPath).toFeature()

--- a/core/src/test/kotlin/io/specmatic/core/HttpStubTests.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpStubTests.kt
@@ -5,6 +5,8 @@ import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.pattern.NumberPattern
 import io.specmatic.core.pattern.parsedJSON
 import io.specmatic.core.pattern.parsedValue
+import io.specmatic.core.utilities.Flags
+import io.specmatic.core.utilities.Flags.Companion.EXAMPLE_DIRECTORIES
 import io.specmatic.core.utilities.parseXML
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.NullValue
@@ -754,6 +756,26 @@ Scenario: JSON API to get account details with fact check
                 val response = it.client.execute(request)
                 assertThat(response.status).isEqualTo(200)
             }
+        }
+    }
+
+    @Test
+    fun `should be able to response with matching data substitution based partial example`() {
+        val openApiFile = File("src/test/resources/openapi/partial_example_tests/simple.yaml")
+        val examplesDir = openApiFile.resolveSibling("partial_substitution")
+        val feature = OpenApiSpecification.fromFile(openApiFile.canonicalPath).toFeature()
+        val stubs = examplesDir.listFiles().orEmpty().map(ScenarioStub::readFromFile)
+        
+        HttpStub(feature, stubs).use { stub ->
+            val request = feature.scenarios.first().generateHttpRequest()
+            val requestBody = request.body as JSONObjectValue
+
+            val response = stub.client.execute(request)
+            val responseBody = response.body as JSONObjectValue
+
+            assertThat(response.status).isEqualTo(201)
+            assertThat(responseBody.jsonObject["creatorId"]).isEqualTo(requestBody.jsonObject["creatorId"])
+            assertThat(responseBody.jsonObject["petId"]).isEqualTo(requestBody.jsonObject["petId"])
         }
     }
 }

--- a/core/src/test/resources/openapi/partial_example_tests/partial_substitution/pets_post.json
+++ b/core/src/test/resources/openapi/partial_example_tests/partial_substitution/pets_post.json
@@ -1,0 +1,25 @@
+{
+  "partial": {
+    "http-request": {
+      "path": "/creators/(CREATOR-ID:number)/pets/(PET-ID:number)",
+      "method": "PATCH",
+      "body": {
+        "creatorId": "(CREATOR_ID:number)",
+        "petId": "(PET_ID:number)"
+      }
+    },
+    "http-response": {
+      "status": 201,
+      "body": {
+        "id": "(number)",
+        "traceId": "(string)",
+        "creatorId": "$(CREATOR_ID)",
+        "petId": "$(PET_ID)"
+      },
+      "status-text": "Created",
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  }
+}


### PR DESCRIPTION
**What**: Update toOpenApiSchema converter & Stub resolution order
- Add Email, String, Int\Double, Date, UUID, DateTime, Enum to converter
- Resolve substitutions then fillInTheBlanks
- Fixes partial data-substitution based examples matching

**Checklist**:

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate