### PR TITLE
Add support for partial examples and pattern tokens in tests, fixes in stub

### DIFF
--- a/application/src/test/kotlin/io/specmatic/test/ScenarioTestGenerationFailureTest.kt
+++ b/application/src/test/kotlin/io/specmatic/test/ScenarioTestGenerationFailureTest.kt
@@ -35,7 +35,7 @@ class ScenarioTestGenerationFailureTest {
         )
 
         val testGenerationFailure =
-            ScenarioTestGenerationFailure(scenario, Result.Failure("error"))
+            ScenarioTestGenerationFailure(scenario, Result.Failure("error"), "error")
         val scenarioMetadata = testGenerationFailure.toScenarioMetadata()
 
         assertThat(scenarioMetadata.method).isEqualTo("POST")

--- a/core/src/main/kotlin/io/specmatic/conversions/APIKeyInHeaderSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/APIKeyInHeaderSecurityScheme.kt
@@ -26,5 +26,10 @@ data class APIKeyInHeaderSecurityScheme(val name: String, private val apiKey:Str
         return addToHeaderType(name, row, requestPattern)
     }
 
+    override fun copyFromTo(originalRequest: HttpRequest, newHttpRequest: HttpRequest): HttpRequest {
+        if (!originalRequest.headers.containsKey(name)) return newHttpRequest
+        return newHttpRequest.addSecurityHeader(name, originalRequest.headers.getValue(name))
+    }
+
     override fun isInRow(row: Row): Boolean = row.containsField(name)
 }

--- a/core/src/main/kotlin/io/specmatic/conversions/APIKeyInQueryParamSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/APIKeyInQueryParamSecurityScheme.kt
@@ -39,5 +39,11 @@ data class APIKeyInQueryParamSecurityScheme(val name: String, private val apiKey
         )
     }
 
+    override fun copyFromTo(originalRequest: HttpRequest, newHttpRequest: HttpRequest): HttpRequest {
+        if (!originalRequest.queryParams.containsKey(name)) return newHttpRequest
+        val apiKeyValue = originalRequest.queryParams.getValues(name).first()
+        return newHttpRequest.copy(queryParams = newHttpRequest.queryParams.plus(name to apiKeyValue))
+    }
+
     override fun isInRow(row: Row): Boolean = row.containsField(name)
 }

--- a/core/src/main/kotlin/io/specmatic/conversions/BasicAuthSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/BasicAuthSecurityScheme.kt
@@ -54,6 +54,11 @@ data class BasicAuthSecurityScheme(private val token: String? = null) : OpenAPIS
         return addToHeaderType(AUTHORIZATION, row, requestPattern)
     }
 
+    override fun copyFromTo(originalRequest: HttpRequest, newHttpRequest: HttpRequest): HttpRequest {
+        if (!originalRequest.headers.containsKey(AUTHORIZATION)) return newHttpRequest
+        return newHttpRequest.addSecurityHeader(AUTHORIZATION, originalRequest.headers.getValue(AUTHORIZATION))
+    }
+
     override fun isInRow(row: Row): Boolean = row.containsField(AUTHORIZATION)
     private fun getAuthorizationHeaderValue(resolver: Resolver): String {
         val validToken = when {

--- a/core/src/main/kotlin/io/specmatic/conversions/BearerSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/BearerSecurityScheme.kt
@@ -47,4 +47,9 @@ data class BearerSecurityScheme(private val configuredToken: String? = null) : O
     private fun getAuthorizationHeaderValue(resolver: Resolver): String {
         return "Bearer " + (configuredToken ?: resolver.generate("HEADERS", AUTHORIZATION, StringPattern()).toStringLiteral())
     }
+
+    override fun copyFromTo(originalRequest: HttpRequest, newHttpRequest: HttpRequest): HttpRequest {
+        if (!originalRequest.headers.containsKey(AUTHORIZATION)) return newHttpRequest
+        return newHttpRequest.addSecurityHeader(AUTHORIZATION, originalRequest.headers.getValue(AUTHORIZATION))
+    }
 }

--- a/core/src/main/kotlin/io/specmatic/conversions/ExampleFromFile.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/ExampleFromFile.kt
@@ -58,10 +58,10 @@ class ExampleFromFile(val json: JSONObjectValue, val file: File) {
             values,
             name = testName,
             fileSource = this.file.canonicalPath,
-            exactResponseExample = responseExample.takeUnless { this.isPartial() },
+            exactResponseExample = responseExample,
             responseExampleForAssertion = response,
             requestExample = scenarioStub.getRequestWithAdditionalParamsIfAny(specmaticConfig.getAdditionalExampleParamsFilePath()),
-            responseExample = response.takeUnless { this.isPartial() },
+            responseExample = response,
             isPartial = scenarioStub.partial != null
         ).let { ExampleProcessor.resolve(it, ExampleProcessor::ifNotExitsToLookupPattern) }
     }

--- a/core/src/main/kotlin/io/specmatic/conversions/ExampleRequestBuilder.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/ExampleRequestBuilder.kt
@@ -1,5 +1,6 @@
 package io.specmatic.conversions
 
+import io.specmatic.core.CONTENT_TYPE
 import io.specmatic.core.HttpPathPattern
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.pattern.parsedValue
@@ -18,7 +19,7 @@ class ExampleRequestBuilder(
                 examplesBasedOnParameters.getValue(exampleName).map { exampleRequest ->
                     exampleRequest
                         .copy(
-                            headers = exampleRequest.headers + mapOf("Content-Type" to contentType),
+                            headers = exampleRequest.headers + if(CONTENT_TYPE !in exampleRequest.headers) mapOf("Content-Type" to contentType) else exampleRequest.headers,
                             body = parsedValue(bodyValue))
                 }
             } else {

--- a/core/src/main/kotlin/io/specmatic/conversions/NoSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/NoSecurityScheme.kt
@@ -31,6 +31,10 @@ class NoSecurityScheme : OpenAPISecurityScheme {
         return requestPattern
     }
 
+    override fun copyFromTo(originalRequest: HttpRequest, newHttpRequest: HttpRequest): HttpRequest {
+        return newHttpRequest
+    }
+
     override fun isInRow(row: Row): Boolean {
         return false
     }

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenAPISecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenAPISecurityScheme.kt
@@ -12,6 +12,7 @@ interface OpenAPISecurityScheme {
     fun removeParam(httpRequest: HttpRequest): HttpRequest
     fun addTo(httpRequest: HttpRequest, resolver: Resolver = Resolver()): HttpRequest
     fun addTo(requestPattern: HttpRequestPattern, row: Row): HttpRequestPattern
+    fun copyFromTo(originalRequest: HttpRequest, newHttpRequest: HttpRequest): HttpRequest
     fun isInRow(row: Row): Boolean
 }
 

--- a/core/src/main/kotlin/io/specmatic/conversions/WsdlSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/WsdlSpecification.kt
@@ -80,7 +80,7 @@ class WsdlSpecification(private val wsdlFile: WSDLContent) : IncludedSpecificati
 
         val matchingScenarioInfos = wsdlScenarioInfos.filter {
             it.httpResponsePattern.matches(
-                specmaticScenarioInfo.httpResponsePattern.generateResponse(
+                specmaticScenarioInfo.httpResponsePattern.fillInTheBlanks(
                     Resolver()
                 ), Resolver()
             ).isSuccess()

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -500,9 +500,12 @@ data class Feature(
         if(results.any { it.isSuccess() })
             return Results(results).withoutFluff()
 
-        val deepErrors = results.filterNot {
-            val acceptedFluffLevel = if(isBadRequest) 1 else 0
-            it.isFluffy(acceptedFluffLevel)
+        val deepErrors: List<Result> = results.filterNot {
+            it.isFluffy()
+        }.ifEmpty {
+            results.filter {
+                it is Result.Failure && it.hasReason(FailureReason.URLPathParamMismatchButSameStructure)
+            }
         }
 
         if(deepErrors.isNotEmpty())

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -621,7 +621,7 @@ data class Feature(
                     scenarioAsTest(concreteTestScenario, comment, workflow, originalScenario, originalScenarios)
                 },
                 orFailure = {
-                    ScenarioTestGenerationFailure(originalScenario, it.failure)
+                    ScenarioTestGenerationFailure(originalScenario, it.failure, it.message)
                 },
                 orException = {
                     ScenarioTestGenerationException(originalScenario, it.t, it.message, it.breadCrumb)

--- a/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
@@ -2,33 +2,8 @@ package io.specmatic.core
 
 import io.ktor.http.*
 import io.specmatic.core.log.logger
-import io.specmatic.core.pattern.ContractException
-import io.specmatic.core.pattern.ExactValuePattern
-import io.specmatic.core.pattern.HasException
-import io.specmatic.core.pattern.HasFailure
-import io.specmatic.core.pattern.HasValue
-import io.specmatic.core.pattern.IgnoreUnexpectedKeys
-import io.specmatic.core.pattern.JSONObjectPattern
-import io.specmatic.core.pattern.NegativeNonStringlyPatterns
-import io.specmatic.core.pattern.Pattern
-import io.specmatic.core.pattern.ReturnValue
-import io.specmatic.core.pattern.Row
-import io.specmatic.core.pattern.allOrNothingCombinationIn
-import io.specmatic.core.pattern.attempt
-import io.specmatic.core.pattern.breadCrumb
-import io.specmatic.core.pattern.exception
-import io.specmatic.core.pattern.fix
-import io.specmatic.core.pattern.forEachKeyCombinationGivenRowIn
+import io.specmatic.core.pattern.*
 import io.specmatic.core.pattern.isOptional
-import io.specmatic.core.pattern.isPatternToken
-import io.specmatic.core.pattern.mapFold
-import io.specmatic.core.pattern.newBasedOn
-import io.specmatic.core.pattern.newMapBasedOn
-import io.specmatic.core.pattern.parsedValue
-import io.specmatic.core.pattern.resolvedHop
-import io.specmatic.core.pattern.returnValue
-import io.specmatic.core.pattern.returnValues
-import io.specmatic.core.pattern.withoutOptionality
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.StringValue
 import io.specmatic.core.value.Value
@@ -443,7 +418,7 @@ data class HttpHeadersPattern(
             runCatching { pattern.parse(value, resolver) }.getOrDefault(StringValue(value))
         }
 
-        return fillInTheBlanks(
+        return fill(
             jsonPatternMap = pattern, jsonValueMap = headersValue,
             resolver = resolver.withUnexpectedKeyCheck(IgnoreUnexpectedKeys),
             typeAlias = "($HEADERS_BREADCRUMB)"

--- a/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
@@ -414,7 +414,7 @@ data class HttpHeadersPattern(
     }
 
     fun fillInTheBlanks(headers: Map<String, String>, resolver: Resolver): ReturnValue<Map<String, String>> {
-        val headersWithContentType = if (contentType != null) {
+        val headersWithContentType = if (contentType != null && CONTENT_TYPE !in headers) {
             headers.plus(CONTENT_TYPE to contentType)
         } else headers
 

--- a/core/src/main/kotlin/io/specmatic/core/HttpPathPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpPathPattern.kt
@@ -83,7 +83,7 @@ data class HttpPathPattern(
         val finalMatchResult = Result.fromResults(failures)
 
         val failureReason = if (structureMatches(path, resolver)) {
-            FailureReason.URLPathMismatchButSameStructure
+            FailureReason.URLPathParamMismatchButSameStructure
         } else FailureReason.URLPathMisMatch
 
         return finalMatchResult.withFailureReason(failureReason)

--- a/core/src/main/kotlin/io/specmatic/core/HttpPathPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpPathPattern.kt
@@ -291,15 +291,13 @@ data class HttpPathPattern(
         val generatedSegments = pathSegmentPatterns.zip(pathSegments).map { (urlPathPattern, token) ->
             val updatedResolver = resolver.updateLookupPath(PATH_BREAD_CRUMB, urlPathPattern.key.orEmpty())
             urlPathPattern.fillInTheBlanks(urlPathPattern.tryParse(token, updatedResolver), updatedResolver)
+        }.listFold()
+
+        return generatedSegments.ifValue { value ->
+            value.joinToString(separator = "/", prefix = "/".takeIf { pathHadPrefix }.orEmpty()) {
+                it.toStringLiteral()
+            }
         }
-
-        val failures = generatedSegments.filterIsInstance<ReturnFailure>()
-            .fold(emptyList<Failure>()) { acc, failure -> acc + failure.toFailure() }
-
-        return if (failures.isNotEmpty()) return HasFailure(Failure.fromFailures(failures))
-        else HasValue(generatedSegments.joinToString(separator = "/", prefix = "/".takeIf { pathHadPrefix }.orEmpty()) {
-            it.value.toStringLiteral()
-        })
     }
 }
 

--- a/core/src/main/kotlin/io/specmatic/core/HttpQueryParamPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpQueryParamPattern.kt
@@ -211,6 +211,31 @@ data class HttpQueryParamPattern(val queryPatterns: Map<String, Pattern>, val ad
 
         return QueryParameters(fixedQueryParams.mapValues { it.value.toStringLiteral() })
     }
+
+    fun fillInTheBlanks(queryParams: QueryParameters?, resolver: Resolver): ReturnValue<QueryParameters> {
+        val adjustedQueryParams = when {
+            queryParams == null || queryParams.paramPairs.isEmpty() -> QueryParameters(emptyMap())
+            additionalProperties != null -> queryParams.withoutMatching(queryPatterns.keys, additionalProperties, resolver)
+            else -> queryParams
+        }
+
+        val updatedResolver = if (Flags.getBooleanValue(EXTENSIBLE_QUERY_PARAMS)) {
+            resolver.withUnexpectedKeyCheck(IgnoreUnexpectedKeys)
+        } else resolver.withUnexpectedKeyCheck(ValidateUnexpectedKeys)
+
+        val parsedQueryParams = adjustedQueryParams.asValueMap().mapValues { (key, value) ->
+            val pattern = queryPatterns[key] ?: queryPatterns["${key}?"] ?: return@mapValues value
+            runCatching { pattern.parse(value.toStringLiteral(), resolver) }.getOrDefault(value)
+        }
+
+        return fillInTheBlanks(
+            jsonPatternMap = queryPatterns, jsonValueMap = parsedQueryParams,
+            resolver = updatedResolver, typeAlias = "($QUERY_PARAMS_BREADCRUMB)"
+        ).realise(
+            hasValue = { valuesMap, _ -> HasValue(QueryParameters(valuesMap.mapValues { it.value.toStringLiteral() })) },
+            orException = { e -> e.cast() }, orFailure = { f -> f.cast() }
+        )
+    }
 }
 
 internal fun buildQueryPattern(

--- a/core/src/main/kotlin/io/specmatic/core/HttpQueryParamPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpQueryParamPattern.kt
@@ -228,7 +228,7 @@ data class HttpQueryParamPattern(val queryPatterns: Map<String, Pattern>, val ad
             runCatching { pattern.parse(value.toStringLiteral(), resolver) }.getOrDefault(value)
         }
 
-        return fillInTheBlanks(
+        return fill(
             jsonPatternMap = queryPatterns, jsonValueMap = parsedQueryParams,
             resolver = updatedResolver, typeAlias = "($QUERY_PARAMS_BREADCRUMB)"
         ).realise(

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
@@ -562,7 +562,9 @@ data class HttpRequestPattern(
 
         return returnValue(breadCrumb = "REQUEST") {
             val newHttpPathPatterns: Sequence<ReturnValue<HttpPathPattern?>> = httpPathPattern?.let { httpPathPattern ->
-                val newURLPathSegmentPatternsList = httpPathPattern.newBasedOn(row, resolver)
+                val newURLPathSegmentPatternsList = if (status.toString().startsWith("2")) {
+                    httpPathPattern.newBasedOn(row, resolver)
+                } else httpPathPattern.readFrom(row, resolver)
                 newURLPathSegmentPatternsList.map { HttpPathPattern(it, httpPathPattern.path) }.map { HasValue(it) }
             } ?: sequenceOf(HasValue(null))
 

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
@@ -910,8 +910,15 @@ data class HttpRequestPattern(
             .combine(queryParams) { req, it -> req.copy(queryParams = it) }
             .combine(headers) { req, it -> req.copy(headers = it) }
             .combine(body) { req, it -> req.copy(body = it) }
+            .ifValue { copySecuritySchemes(request, it) }
             .breadCrumb("REQUEST")
             .value
+    }
+
+    private fun copySecuritySchemes(originalRequest: HttpRequest, request: HttpRequest): HttpRequest {
+        return securitySchemes.fold(request) { req, securityScheme ->
+            securityScheme.copyFromTo(originalRequest, req)
+        }
     }
 
     private fun withoutSecuritySchemes(request: HttpRequest): HttpRequest {

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
@@ -20,7 +20,7 @@ const val METHOD_BREAD_CRUMB = "METHOD"
 private const val FORM_FIELDS_BREADCRUMB = "FORM-FIELDS"
 const val CONTENT_TYPE = "Content-Type"
 
-private val invalidRequestStatuses = listOf(400, 422)
+val invalidRequestStatuses = listOf(400, 422)
 
 data class HeaderMatchParams(val request: HttpRequest, val headersResolver: Resolver?, val defaultResolver: Resolver, val failures: List<Failure>)
 
@@ -896,6 +896,28 @@ data class HttpRequestPattern(
         return this.copy(
             httpPathPattern = this.httpPathPattern?.withWildcardPathSegments()
         )
+    }
+
+    fun fillInTheBlanks(request: HttpRequest, resolver: Resolver): HttpRequest {
+        val sanitizedRequest = withoutSecuritySchemes(request)
+        val path = httpPathPattern?.fillInTheBlanks(sanitizedRequest.path, resolver)?.breadCrumb("PATH-PARAMS") ?: HasValue(null)
+        val queryParams = httpQueryParamPattern.fillInTheBlanks(sanitizedRequest.queryParams, resolver).breadCrumb("QUERY-PARAMS")
+        val headers = headersPattern.fillInTheBlanks(sanitizedRequest.headers, resolver).breadCrumb("HEADERS")
+        val body = body.fillInTheBlanks(sanitizedRequest.body, resolver).breadCrumb("BODY")
+
+        return HasValue(request)
+            .combine(path) { req, it -> req.copy(path = it) }
+            .combine(queryParams) { req, it -> req.copy(queryParams = it) }
+            .combine(headers) { req, it -> req.copy(headers = it) }
+            .combine(body) { req, it -> req.copy(body = it) }
+            .breadCrumb("REQUEST")
+            .value
+    }
+
+    private fun withoutSecuritySchemes(request: HttpRequest): HttpRequest {
+        return securitySchemes.fold(request) { req, securityScheme ->
+            securityScheme.removeParam(req)
+        }
     }
 }
 

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
@@ -83,12 +83,12 @@ data class HttpRequestPattern(
 
         val matchFailureButSameStructure = (
             incomingHttpRequest.method == method &&
-            (result as? Failure)?.hasReason(FailureReason.URLPathMismatchButSameStructure) == true
+            (result as? Failure)?.hasReason(FailureReason.URLPathParamMismatchButSameStructure) == true
         )
 
         return when (result) {
             is Failure -> result.failureReason(
-                failureReason = if (matchFailureButSameStructure) FailureReason.URLPathMismatchButSameStructure else result.failureReason
+                failureReason = if (matchFailureButSameStructure) FailureReason.URLPathParamMismatchButSameStructure else result.failureReason
             ).breadCrumb("REQUEST")
             else -> result
         }

--- a/core/src/main/kotlin/io/specmatic/core/HttpResponsePattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpResponsePattern.kt
@@ -19,7 +19,7 @@ data class HttpResponsePattern(
 ) {
     constructor(response: HttpResponse) : this(HttpHeadersPattern(response.headers.mapValues { stringToPattern(it.value, it.key) }), response.status, response.body.exactMatchElseType())
 
-    fun generateResponse(resolver: Resolver): HttpResponse {
+    fun fillInTheBlanks(resolver: Resolver): HttpResponse {
         return generateResponseWith(
             value = resolver.withCyclePrevention(body, body::generate),
             resolver = resolver
@@ -201,7 +201,7 @@ data class HttpResponsePattern(
         )
     }
 
-    fun generateResponse(partial: HttpResponse, resolver: Resolver): HttpResponse {
+    fun fillInTheBlanks(partial: HttpResponse, resolver: Resolver): HttpResponse {
         val headers = headersPattern.fillInTheBlanks(partial.headers, resolver).breadCrumb("HEADERS")
         val body: ReturnValue<Value> = body.fillInTheBlanks(partial.body, resolver).breadCrumb("BODY")
 

--- a/core/src/main/kotlin/io/specmatic/core/NoBodyPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/NoBodyPattern.kt
@@ -41,6 +41,10 @@ object NoBodyPattern : Pattern {
         return Result.Failure("Expected no body, but found ${otherPattern.typeName}")
     }
 
+    override fun fillInTheBlanks(value: Value, resolver: Resolver): ReturnValue<Value> {
+        return runCatching { parse(value.toStringLiteral(), resolver) }.map(::HasValue).getOrElse(::HasException)
+    }
+
     override fun listOf(valueList: List<Value>, resolver: Resolver): Value = JSONArrayValue(valueList)
 
     override val typeAlias: String?

--- a/core/src/main/kotlin/io/specmatic/core/Resolver.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Resolver.kt
@@ -202,6 +202,9 @@ data class Resolver(
     }
 
     fun generate(pattern: Pattern): Value {
+        if(dictionaryLookupPath.isBlank())
+            return pattern.generate(this)
+
         val value = dictionary[dictionaryLookupPath] ?: defaultPatternValueFromDictionary(pattern) ?: return pattern.generate(this)
 
         val dictionaryValueMatchResult = pattern.matches(value, this)

--- a/core/src/main/kotlin/io/specmatic/core/Resolver.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Resolver.kt
@@ -202,9 +202,6 @@ data class Resolver(
     }
 
     fun generate(pattern: Pattern): Value {
-        if(dictionaryLookupPath.isBlank())
-            return pattern.generate(this)
-
         val value = dictionary[dictionaryLookupPath] ?: defaultPatternValueFromDictionary(pattern) ?: return pattern.generate(this)
 
         val dictionaryValueMatchResult = pattern.matches(value, this)

--- a/core/src/main/kotlin/io/specmatic/core/Result.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Result.kt
@@ -345,6 +345,7 @@ enum class FailureReason(val fluffLevel: Int, val objectMatchOccurred: Boolean) 
     ContentTypeMismatch(1, false),
     RequestMismatchButStatusAlsoWrong(2, false),
     URLPathMisMatch(2, false),
+    URLPathMismatchButSameStructure(1, false),
     SOAPActionMismatch(2, false),
     DiscriminatorMismatch(0, true),
     FailedButDiscriminatorMatched(0, true),

--- a/core/src/main/kotlin/io/specmatic/core/Result.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Result.kt
@@ -75,7 +75,7 @@ sealed class Result {
     abstract fun testResult(): TestResult
     abstract fun withFailureReason(urlPathMisMatch: FailureReason): Result
     abstract fun throwOnFailure(): Success
-    abstract fun <T> toReturnValue(returnValue: T, errorMessage: String): ReturnValue<T>
+    abstract fun <T> toReturnValue(returnValue: T, errorMessage: String? = null): ReturnValue<T>
     abstract fun <V> onSuccessElseNull(function: () -> V): V?
 
     data class FailureCause(val message: String="", var cause: Failure? = null) {
@@ -180,8 +180,8 @@ sealed class Result {
             throw ContractException(this.toFailureReport())
         }
 
-        override fun <T> toReturnValue(returnValue: T, errorMessage: String): ReturnValue<T> {
-            return HasFailure(this)
+        override fun <T> toReturnValue(returnValue: T, errorMessage: String?): ReturnValue<T> {
+            return HasFailure(this, errorMessage.orEmpty())
         }
 
         override fun <V> onSuccessElseNull(function: () -> V): V? {
@@ -318,7 +318,7 @@ sealed class Result {
             return this
         }
 
-        override fun <T> toReturnValue(returnValue: T, errorMessage: String): ReturnValue<T> {
+        override fun <T> toReturnValue(returnValue: T, errorMessage: String?): ReturnValue<T> {
             return HasValue(returnValue)
         }
 

--- a/core/src/main/kotlin/io/specmatic/core/Result.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Result.kt
@@ -345,7 +345,7 @@ enum class FailureReason(val fluffLevel: Int, val objectMatchOccurred: Boolean) 
     ContentTypeMismatch(1, false),
     RequestMismatchButStatusAlsoWrong(2, false),
     URLPathMisMatch(2, false),
-    URLPathMismatchButSameStructure(1, false),
+    URLPathParamMismatchButSameStructure(1, false),
     SOAPActionMismatch(2, false),
     DiscriminatorMismatch(0, true),
     FailedButDiscriminatorMatched(0, true),

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -794,7 +794,9 @@ data class Scenario(
         return externalisedJSONExamples.filter { (operationId, rows) ->
             operationId.requestMethod.equals(method, ignoreCase = true)
                     && operationId.responseStatus == status
-                    && httpRequestPattern.matchesPath(operationId.requestPath, patternMatchingResolver).isSuccess()
+                    && httpRequestPattern.matchesPath(operationId.requestPath, patternMatchingResolver).let {
+                        (it as? Result.Failure)?.failureReason == FailureReason.URLPathMismatchButSameStructure || it.isSuccess()
+                    }
                     && matchesRequestContentType(operationId)
                     && matchesResponseContentType(operationId)
         }

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -472,7 +472,7 @@ data class Scenario(
             if (resolved.requestExample == null) return@mapCatching resolved
             val updatedResolver = resolver.copy(isNegative = resolver.isNegative || httpResponsePattern.status in invalidRequestStatuses)
             val resolvedRequest = httpRequestPattern.fillInTheBlanks(resolved.requestExample, updatedResolver)
-            resolved.updateRequest(resolvedRequest)
+            resolved.updateRequest(resolvedRequest, httpRequestPattern, resolver)
         }.map(::HasValue).getOrElse { e ->
             when(e) {
                 is ContractException -> HasFailure(e.failure(), message = row.name)

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -472,7 +472,7 @@ data class Scenario(
             if (resolved.requestExample == null) return@mapCatching resolved
             val updatedResolver = resolver.copy(isNegative = resolver.isNegative || httpResponsePattern.status in invalidRequestStatuses)
             val resolvedRequest = httpRequestPattern.fillInTheBlanks(resolved.requestExample, updatedResolver)
-            resolved.updateRequestIfExists(resolvedRequest)
+            resolved.updateRequest(resolvedRequest)
         }.map(::HasValue).getOrElse { e ->
             when(e) {
                 is ContractException -> HasFailure(e.failure(), message = row.name)

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -428,8 +428,7 @@ data class Scenario(
 
         return scenarioBreadCrumb(this) {
             attempt {
-                val updatedResolver = resolver.copy(isNegative = isNegative)
-                val rowValue =  when(val resolvedRow = resolveRow(row, updatedResolver)) {
+                val rowValue =  when(val resolvedRow = resolveRow(row, resolver)) {
                     is HasValue -> resolvedRow.value
                     is HasException -> return@attempt sequenceOf(resolvedRow.cast())
                     is HasFailure -> return@attempt sequenceOf(resolvedRow.cast())
@@ -438,8 +437,8 @@ data class Scenario(
                 val newResponsePattern: HttpResponsePattern = this.httpResponsePattern.withResponseExampleValue(rowValue, resolver)
 
                 val (newRequestPatterns: Sequence<ReturnValue<HttpRequestPattern>>, generativePrefix: String) = when (isNegative) {
-                    false -> Pair(httpRequestPattern.newBasedOn(rowValue, updatedResolver, httpResponsePattern.status), flagsBased.positivePrefix)
-                    else -> Pair(httpRequestPattern.negativeBasedOn(rowValue, updatedResolver), flagsBased.negativePrefix)
+                    false -> Pair(httpRequestPattern.newBasedOn(rowValue, resolver, httpResponsePattern.status), flagsBased.positivePrefix)
+                    else -> Pair(httpRequestPattern.negativeBasedOn(rowValue, resolver.copy(isNegative = isNegative)), flagsBased.negativePrefix)
                 }
 
                 newRequestPatterns.map { newHttpRequestPattern ->

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -471,7 +471,7 @@ data class Scenario(
         return runCatching {
             ExampleProcessor.resolve(row.requestExample, ExampleProcessor::defaultIfNotExits)
         }.mapCatching { resolved ->
-            val updatedResolver = resolver.copy(isNegative = resolver.isNegative || httpResponsePattern.status in invalidRequestStatuses)
+            val updatedResolver = resolver.copy(isNegative = httpResponsePattern.status in invalidRequestStatuses)
             httpRequestPattern.fillInTheBlanks(resolved, updatedResolver)
         }.mapCatching { resolved ->
             row.updateRequest(resolved, httpRequestPattern, resolver)
@@ -797,7 +797,7 @@ data class Scenario(
             operationId.requestMethod.equals(method, ignoreCase = true)
                     && operationId.responseStatus == status
                     && httpRequestPattern.matchesPath(operationId.requestPath, patternMatchingResolver).let {
-                        (it as? Result.Failure)?.failureReason == FailureReason.URLPathMismatchButSameStructure || it.isSuccess()
+                        it.isSuccess() || (it as? Result.Failure)?.failureReason == FailureReason.URLPathMismatchButSameStructure
                     }
                     && matchesRequestContentType(operationId)
                     && matchesResponseContentType(operationId)

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -686,7 +686,7 @@ data class Scenario(
             val requestMatchResult = attempt(breadCrumb = "REQUEST") {
                 if (response.status !in invalidRequestStatuses) return@attempt httpRequestPattern.matches(request, resolver)
                 httpRequestPattern.matchesPathAndMethod(request, resolver).takeUnless {
-                    it is Result.Failure && it.hasReason(FailureReason.URLPathMismatchButSameStructure)
+                    it is Result.Failure && it.hasReason(FailureReason.URLPathParamMismatchButSameStructure)
                 } ?: Result.Success()
             }
 
@@ -799,7 +799,7 @@ data class Scenario(
             operationId.requestMethod.equals(method, ignoreCase = true)
                     && operationId.responseStatus == status
                     && httpRequestPattern.matchesPath(operationId.requestPath, patternMatchingResolver).let {
-                        it.isSuccess() || (it as? Result.Failure)?.failureReason == FailureReason.URLPathMismatchButSameStructure
+                        it.isSuccess() || (it as? Result.Failure)?.failureReason == FailureReason.URLPathParamMismatchButSameStructure
                     }
                     && matchesRequestContentType(operationId)
                     && matchesResponseContentType(operationId)
@@ -838,7 +838,7 @@ data class Scenario(
                 return@attempt httpRequestPattern.matches(template.request, updatedResolver, updatedResolver)
             }
             httpRequestPattern.matchesPathAndMethod(template.request, updatedResolver).takeUnless {
-                it is Result.Failure && it.hasReason(FailureReason.URLPathMismatchButSameStructure)
+                it is Result.Failure && it.hasReason(FailureReason.URLPathParamMismatchButSameStructure)
             } ?: Result.Success()
         }
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/AnyNonNullJSONValue.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/AnyNonNullJSONValue.kt
@@ -25,6 +25,10 @@ data class AnyNonNullJSONValue(override val pattern: Pattern = AnythingPattern):
         }
     }
 
+    override fun fillInTheBlanks(value: Value, resolver: Resolver): ReturnValue<Value> {
+        return fillInTheBlanksWithPattern(value, resolver, this)
+    }
+
     override fun fixValue(value: Value, resolver: Resolver): Value {
         return value.takeIf { this.matches(it, resolver).isSuccess() } ?: resolver.generate(pattern)
     }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
@@ -113,7 +113,8 @@ data class AnyPattern(
         if(successfulGeneration != null)
             return successfulGeneration
 
-        val failures = results.toList().filterIsInstance<Failure>()
+        val resultList = results.toList()
+        val failures = resultList.filterIsInstance<ReturnFailure>().map { it.toFailure() }
 
         return HasFailure(Failure.fromFailures(failures))
     }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/DictionaryPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/DictionaryPattern.kt
@@ -14,7 +14,7 @@ data class DictionaryPattern(val keyPattern: Pattern, val valuePattern: Pattern,
     }
 
     override fun fillInTheBlanks(value: Value, resolver: Resolver): ReturnValue<Value> {
-        val jsonObject = value as? JSONObjectValue ?: return HasFailure("Can't generate object value from partial of type ${value.displayableType()}")
+        val jsonObject = value as? JSONObjectValue ?: return HasFailure("Can't generate object value from type ${value.displayableType()}")
 
         val returnValue = jsonObject.jsonObject.mapValues { (key, value) ->
             val matchResult = valuePattern.matches(value, resolver)

--- a/core/src/main/kotlin/io/specmatic/core/pattern/DictionaryPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/DictionaryPattern.kt
@@ -41,7 +41,7 @@ data class DictionaryPattern(val keyPattern: Pattern, val valuePattern: Pattern,
             valuePattern.resolveSubstitutions(substitution, value, resolver, key)
         }
 
-        return updatedMap.mapFold().ifValue { value.copy(it) }
+        return updatedMap.mapFoldException().ifValue { value.copy(it) }
     }
 
     override fun getTemplateTypes(key: String, value: Value, resolver: Resolver): ReturnValue<Map<String, Pattern>> {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/EmailPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/EmailPattern.kt
@@ -35,6 +35,10 @@ class EmailPattern (private val stringPatternDelegate: StringPattern) :
         }
     }
 
+    override fun fillInTheBlanks(value: Value, resolver: Resolver): ReturnValue<Value> {
+        return fillInTheBlanksWithPattern(value, resolver, this)
+    }
+
     override fun generate(resolver: Resolver): Value {
         val localPart = randomString(5).lowercase(Locale.getDefault())
         val domain = randomString(5).lowercase(Locale.getDefault())

--- a/core/src/main/kotlin/io/specmatic/core/pattern/EnumPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/EnumPattern.kt
@@ -71,13 +71,13 @@ data class EnumPattern(
     }
 
     override fun fillInTheBlanks(value: Value, resolver: Resolver): ReturnValue<Value> {
-        val patternToConsider = when (val resolvedPattern = resolveToPattern(value, resolver)) {
+        val patternToConsider = when (val resolvedPattern = resolveToPattern(value, resolver, this)) {
             is ReturnFailure -> return resolvedPattern.cast()
             else -> resolvedPattern.value
         }
 
         return if (isPatternToken(value) && patternToConsider == this) HasValue(generate(resolver))
-        else super.fillInTheBlanks(value, resolver)
+        else pattern.fillInTheBlanks(value, resolver)
     }
 
     override fun equals(other: Any?): Boolean = other is EnumPattern && other.pattern == this.pattern

--- a/core/src/main/kotlin/io/specmatic/core/pattern/EnumPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/EnumPattern.kt
@@ -70,6 +70,16 @@ data class EnumPattern(
         }
     }
 
+    override fun fillInTheBlanks(value: Value, resolver: Resolver): ReturnValue<Value> {
+        val patternToConsider = when (val resolvedPattern = resolveToPattern(value, resolver)) {
+            is ReturnFailure -> return resolvedPattern.cast()
+            else -> resolvedPattern.value
+        }
+
+        return if (isPatternToken(value) && patternToConsider == this) HasValue(generate(resolver))
+        else super.fillInTheBlanks(value, resolver)
+    }
+
     override fun equals(other: Any?): Boolean = other is EnumPattern && other.pattern == this.pattern
 
     override fun hashCode(): Int = pattern.hashCode()

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ExactValuePattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ExactValuePattern.kt
@@ -9,8 +9,6 @@ import io.specmatic.core.value.Value
 
 data class ExactValuePattern(override val pattern: Value, override val typeAlias: String? = null, val discriminator: Boolean = false) : Pattern {
     override fun matches(sampleData: Value?, resolver: Resolver): Result {
-        if (isPatternToken(sampleData)) return Result.Success()
-
         return when (pattern == sampleData) {
             true -> Result.Success()
             else -> {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/HasException.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/HasException.kt
@@ -34,7 +34,13 @@ data class HasException<T>(val t: Throwable, val message: String = "", val bread
     }
 
     override fun <U, V> combine(acc: ReturnValue<U>, fn: (T, U) -> V): ReturnValue<V> {
-        return cast()
+        val otherReturnValue = when(acc) {
+            is HasException -> acc.toHasFailure()
+            is HasFailure -> acc
+            else -> return cast()
+        }
+
+        return this.toHasFailure().combine(otherReturnValue, fn)
     }
 
     override fun <V> cast(): ReturnValue<V> {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/HasException.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/HasException.kt
@@ -50,6 +50,10 @@ data class HasException<T>(val t: Throwable, val message: String = "", val bread
     override val value: T
         get() = throw t
 
+    override fun <U, V> exceptionElseCombine(acc: ReturnValue<U>, fn: (T, U) -> V): ReturnValue<V> {
+        return cast()
+    }
+
     override fun <U> ifHasValue(fn: (HasValue<T>) -> ReturnValue<U>): ReturnValue<U> {
         return cast()
     }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/HasException.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/HasException.kt
@@ -23,7 +23,6 @@ data class HasException<T>(val t: Throwable, val message: String = "", val bread
 
     override fun <U> ifValue(fn: (T) -> U): ReturnValue<U> {
         return cast()
-
     }
 
     override fun update(fn: (T) -> T): ReturnValue<T> {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/HasFailure.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/HasFailure.kt
@@ -36,6 +36,14 @@ data class HasFailure<T>(val failure: Result.Failure, val message: String = "") 
     override val value: T
         get() = throw ContractException(failure.toFailureReport())
 
+    override fun <U, V> exceptionElseCombine(acc: ReturnValue<U>, fn: (T, U) -> V): ReturnValue<V> {
+        return when (acc) {
+            is HasFailure<*> -> combine(acc).cast()
+            is HasException<*> -> acc.cast()
+            else -> cast()
+        }
+    }
+
     override fun <U> ifHasValue(fn: (HasValue<T>) -> ReturnValue<U>): ReturnValue<U> {
         return cast()
     }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/HasFailure.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/HasFailure.kt
@@ -10,7 +10,7 @@ data class HasFailure<T>(val failure: Result.Failure, val message: String = "") 
     }
 
     override fun <U> ifValue(fn: (T) -> U): ReturnValue<U> {
-        return HasFailure(failure)
+        return cast()
     }
 
     override fun update(fn: (T) -> T): ReturnValue<T> {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/HasFailure.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/HasFailure.kt
@@ -22,7 +22,11 @@ data class HasFailure<T>(val failure: Result.Failure, val message: String = "") 
     }
 
     override fun <U, V> combine(acc: ReturnValue<U>, fn: (T, U) -> V): ReturnValue<V> {
-        return cast()
+        return when (acc) {
+            is HasFailure<*> -> combine(acc).cast()
+            is HasException<*> -> combine(acc.toHasFailure()).cast()
+            else -> cast()
+        }
     }
 
     override fun <U> cast(): ReturnValue<U> {
@@ -46,5 +50,12 @@ data class HasFailure<T>(val failure: Result.Failure, val message: String = "") 
 
     override fun <U> realise(hasValue: (T, String?) -> U, orFailure: (HasFailure<T>) -> U, orException: (HasException<T>) -> U): U {
         return orFailure(this)
+    }
+
+    private fun combine(other: HasFailure<*>): HasFailure<T> {
+        return HasFailure(
+            failure = Result.Failure.fromFailures(listOf(this.failure, other.failure)),
+            message = listOf(this.message, other.message).filter { it.isNotBlank() }.joinToString("\n\n")
+        )
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/HasValue.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/HasValue.kt
@@ -78,7 +78,17 @@ data class HasValue<T>(override val value: T, val valueDetails: List<ValueDetail
 
     override fun <U, V> combine(acc: ReturnValue<U>, fn: (T, U) -> V): ReturnValue<V> {
         if(acc is ReturnFailure) return acc.cast()
+        acc as HasValue<U>
+        return try {
+            val newValue = fn(value, acc.value)
+            HasValue(newValue, valueDetails.plus(acc.valueDetails))
+        } catch(t: Throwable) {
+            HasException(t)
+        }
+    }
 
+    override fun <U, V> exceptionElseCombine(acc: ReturnValue<U>, fn: (T, U) -> V): ReturnValue<V> {
+        if (acc is ReturnFailure) return acc.cast()
         acc as HasValue<U>
         return try {
             val newValue = fn(value, acc.value)

--- a/core/src/main/kotlin/io/specmatic/core/pattern/HasValue.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/HasValue.kt
@@ -77,11 +77,9 @@ data class HasValue<T>(override val value: T, val valueDetails: List<ValueDetail
     }
 
     override fun <U, V> combine(acc: ReturnValue<U>, fn: (T, U) -> V): ReturnValue<V> {
-        if(acc is ReturnFailure)
-            return acc.cast()
+        if(acc is ReturnFailure) return acc.cast()
 
         acc as HasValue<U>
-
         return try {
             val newValue = fn(value, acc.value)
             HasValue(newValue, valueDetails.plus(acc.valueDetails))

--- a/core/src/main/kotlin/io/specmatic/core/pattern/HasValue.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/HasValue.kt
@@ -88,14 +88,7 @@ data class HasValue<T>(override val value: T, val valueDetails: List<ValueDetail
     }
 
     override fun <U, V> exceptionElseCombine(acc: ReturnValue<U>, fn: (T, U) -> V): ReturnValue<V> {
-        if (acc is ReturnFailure) return acc.cast()
-        acc as HasValue<U>
-        return try {
-            val newValue = fn(value, acc.value)
-            HasValue(newValue, valueDetails.plus(acc.valueDetails))
-        } catch(t: Throwable) {
-            HasException(t)
-        }
+        return combine(acc, fn)
     }
 
     override fun addDetails(message: String, breadCrumb: String): ReturnValue<T> {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
@@ -127,7 +127,7 @@ data class JSONObjectPattern(
     }
 
     override fun fillInTheBlanks(value: Value, resolver: Resolver): ReturnValue<Value> {
-        val patternToConsider = when (val resolvedPattern = resolveToPattern(value, resolver)) {
+        val patternToConsider = when (val resolvedPattern = resolveToPattern(value, resolver, this)) {
             is ReturnFailure -> return resolvedPattern.cast()
             else -> (resolvedPattern.value as? JSONObjectPattern) ?: return when(resolver.isNegative) {
                 true -> fillInIfPatternToken(value, resolvedPattern.value, resolver)

--- a/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
@@ -566,6 +566,8 @@ fun fill(jsonPatternMap: Map<String, Pattern>, jsonValueMap: Map<String, Value>,
         pattern.fillInTheBlanks(value, updatedResolver).breadCrumb(key)
     }.mapFold()
 
+    if (resolver.isNegative) return resolvedValuesMap
+
     val missingKeysToPattern = jsonPatternMap.filterKeys { !isOptional(it) && it !in jsonValueMap }
     val generatedValuesMap = missingKeysToPattern.mapValues { (key, pattern) ->
         runCatching {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
@@ -127,7 +127,8 @@ data class JSONObjectPattern(
     }
 
     override fun fillInTheBlanks(value: Value, resolver: Resolver): ReturnValue<Value> {
-        val jsonObject = value as? JSONObjectValue ?: return HasFailure("Can't generate object value from partial of type ${value.displayableType()}")
+        val jsonObject = value as? JSONObjectValue
+            ?: return HasFailure("Can't generate object value from type ${value.displayableType()}")
 
         return fillInTheBlanks(
             jsonPatternMap = pattern, jsonValueMap = jsonObject.jsonObject,

--- a/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
@@ -130,9 +130,9 @@ data class JSONObjectPattern(
         val jsonObject = value as? JSONObjectValue
             ?: return HasFailure("Can't generate object value from type ${value.displayableType()}")
 
-        return fillInTheBlanks(
+        return fill(
             jsonPatternMap = pattern, jsonValueMap = jsonObject.jsonObject,
-            typeAlias = this.typeAlias.orEmpty(), resolver = resolver
+            typeAlias = typeAlias.orEmpty(), resolver = resolver
         ).realise(
             hasValue = { valuesMap, _ -> HasValue(JSONObjectValue(valuesMap)) },
             orException = { e -> e.cast() }, orFailure = { f -> f.cast() }
@@ -554,7 +554,7 @@ fun fix(jsonPatternMap: Map<String, Pattern>, jsonValueMap: Map<String, Value>, 
     .mapValues { (_, opt) -> opt.get() }
 }
 
-fun fillInTheBlanks(jsonPatternMap: Map<String, Pattern>, jsonValueMap: Map<String, Value>, resolver: Resolver, typeAlias: String): ReturnValue<Map<String, Value>> {
+fun fill(jsonPatternMap: Map<String, Pattern>, jsonValueMap: Map<String, Value>, resolver: Resolver, typeAlias: String): ReturnValue<Map<String, Value>> {
     val resolvedValuesMap = jsonValueMap.mapValues { (key, value) ->
         val pattern = jsonPatternMap[key] ?: jsonPatternMap["$key?"] ?: return@mapValues when(resolver.findKeyErrorCheck.unexpectedKeyCheck) {
             IgnoreUnexpectedKeys -> HasValue(value)

--- a/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
@@ -188,7 +188,7 @@ data class JSONObjectPattern(
             pattern.resolveSubstitutions(substitution, value, resolver, key).breadCrumb(key)
         }
 
-        return updatedMap.mapFold().ifValue { value.copy(it) }
+        return updatedMap.mapFoldException().ifValue { value.copy(it) }
     }
 
     override fun getTemplateTypes(key: String, value: Value, resolver: Resolver): ReturnValue<Map<String, Pattern>> {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
@@ -48,8 +48,12 @@ data class ListPattern(
     }
 
     override fun fillInTheBlanks(value: Value, resolver: Resolver): ReturnValue<Value> {
-        val listValue = value as? JSONArrayValue ?: return HasFailure("Cannot generate a list from partial of type ${value.displayableType()}")
-        val newList = listValue.list.map { pattern.fillInTheBlanks(it, resolver.plusDictionaryLookupDetails(null, "[*]")) }.listFold()
+        val listValue = value as? JSONArrayValue
+            ?: return HasFailure("Cannot generate a list from type ${value.displayableType()}")
+
+        val newList = listValue.list.map {
+            pattern.fillInTheBlanks(it, resolver.plusDictionaryLookupDetails(null, "[*]"))
+        }.listFold()
 
         return newList.ifValue { listValue.copy(list = it) }
     }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
@@ -45,7 +45,7 @@ data class ListPattern(
     }
 
     override fun fillInTheBlanks(value: Value, resolver: Resolver): ReturnValue<Value> {
-        val patternToConsider = when (val resolvedPattern = resolveToPattern(value, resolver)) {
+        val patternToConsider = when (val resolvedPattern = resolveToPattern(value, resolver, this)) {
             is ReturnFailure -> return resolvedPattern.cast()
             else -> (resolvedPattern.value as? ListPattern) ?: return when(resolver.isNegative) {
                 true -> fillInIfPatternToken(value, resolvedPattern.value, resolver)

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
@@ -78,7 +78,7 @@ data class ListPattern(
 
         val updatedList = value.list.mapIndexed { index, listItem ->
             pattern.resolveSubstitutions(substitution, listItem, resolver).breadCrumb("[$index]")
-        }.listFold()
+        }.listFoldException()
 
         return updatedList.ifValue { value.copy(list = it) }
     }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/QueryParameterScalarPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/QueryParameterScalarPattern.kt
@@ -19,12 +19,7 @@ data class QueryParameterScalarPattern(override val pattern: Pattern): Pattern b
         }
 
         return try {
-            val parsedValue = if(isPatternToken(sampleDataString)) {
-                StringValue(sampleDataString)
-            }
-            else {
-                pattern.parse(sampleDataString, resolver)
-            }
+            val parsedValue = runCatching { pattern.parse(sampleDataString, resolver) }.getOrDefault(StringValue(sampleDataString))
             resolver.matchesPattern(null, pattern, parsedValue)
         } catch (e: Throwable) {
             Result.Failure(exceptionCauseMessage(e))

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ResponseExample.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ResponseExample.kt
@@ -3,7 +3,7 @@ package io.specmatic.core.pattern
 import io.specmatic.core.HttpHeadersPattern
 import io.specmatic.core.HttpResponse
 
-sealed interface ResponseExample {
+interface ResponseExample {
     fun bodyPattern(): Pattern
     fun headersPattern(): HttpHeadersPattern
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ResponseExample.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ResponseExample.kt
@@ -3,7 +3,7 @@ package io.specmatic.core.pattern
 import io.specmatic.core.HttpHeadersPattern
 import io.specmatic.core.HttpResponse
 
-interface ResponseExample {
+sealed interface ResponseExample {
     fun bodyPattern(): Pattern
     fun headersPattern(): HttpHeadersPattern
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ResponseValueExample.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ResponseValueExample.kt
@@ -3,7 +3,7 @@ package io.specmatic.core.pattern
 import io.specmatic.core.HttpHeadersPattern
 import io.specmatic.core.HttpResponse
 
-class ResponseValueExample(override val responseExample: HttpResponse) : ResponseExample {
+data class ResponseValueExample(override val responseExample: HttpResponse) : ResponseExample {
     override fun bodyPattern(): Pattern {
         return responseExample.body.exactMatchElseType()
     }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ResponseValueExample.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ResponseValueExample.kt
@@ -3,7 +3,7 @@ package io.specmatic.core.pattern
 import io.specmatic.core.HttpHeadersPattern
 import io.specmatic.core.HttpResponse
 
-data class ResponseValueExample(override val responseExample: HttpResponse) : ResponseExample {
+class ResponseValueExample(override val responseExample: HttpResponse) : ResponseExample {
     override fun bodyPattern(): Pattern {
         return responseExample.body.exactMatchElseType()
     }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ReturnValue.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ReturnValue.kt
@@ -51,7 +51,7 @@ fun <ValueType> List<ReturnValue<ValueType>>.listFold(): ReturnValue<List<ValueT
     val initial: ReturnValue<List<ValueType>> = HasValue(emptyList())
 
     return this.fold(initial) { accR: ReturnValue<List<ValueType>>, valueR: ReturnValue<ValueType> ->
-        accR.assimilate(valueR) { acc, value ->
+        accR.combine(valueR) { acc, value ->
             acc.plus(value)
         }
     }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ReturnValue.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ReturnValue.kt
@@ -19,6 +19,7 @@ sealed interface ReturnValue<T> {
     fun update(fn: (T) -> T): ReturnValue<T>
     fun <U> assimilate(acc: ReturnValue<U>, fn: (T, U) -> T): ReturnValue<T>
     fun <U, V> combine(acc: ReturnValue<U>, fn: (T, U) -> V): ReturnValue<V>
+    fun <U, V> exceptionElseCombine(acc: ReturnValue<U>, fn: (T, U) -> V): ReturnValue<V>
     fun <U> realise(hasValue: (T, String?) -> U, orFailure: (HasFailure<T>) -> U, orException: (HasException<T>) -> U): U
     fun addDetails(message: String, breadCrumb: String): ReturnValue<T>
 }
@@ -37,12 +38,32 @@ fun <ReturnType> returnValue(errorMessage: String = "", breadCrumb: String = "",
     }
 }
 
+fun <K, ValueType> Map<K, ReturnValue<out ValueType>>.mapFoldException(): ReturnValue<Map<K, ValueType>> {
+    val initial: ReturnValue<Map<K, ValueType>> = HasValue(emptyMap())
+
+    return this.entries.fold(initial) { accR, (key, valueR) ->
+        accR.exceptionElseCombine(valueR) { acc, value ->
+            acc.plus(key to value)
+        }
+    }
+}
+
 fun <K, ValueType> Map<K, ReturnValue<out ValueType>>.mapFold(): ReturnValue<Map<K, ValueType>> {
     val initial: ReturnValue<Map<K, ValueType>> = HasValue(emptyMap())
 
     return this.entries.fold(initial) { accR, (key, valueR) ->
         accR.combine(valueR) { acc, value ->
             acc.plus(key to value)
+        }
+    }
+}
+
+fun <ValueType> List<ReturnValue<ValueType>>.listFoldException(): ReturnValue<List<ValueType>> {
+    val initial: ReturnValue<List<ValueType>> = HasValue(emptyList())
+
+    return this.fold(initial) { accR: ReturnValue<List<ValueType>>, valueR: ReturnValue<ValueType> ->
+        accR.exceptionElseCombine(valueR) { acc, value ->
+            acc.plus(value)
         }
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ReturnValue.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ReturnValue.kt
@@ -41,7 +41,7 @@ fun <K, ValueType> Map<K, ReturnValue<out ValueType>>.mapFold(): ReturnValue<Map
     val initial: ReturnValue<Map<K, ValueType>> = HasValue(emptyMap())
 
     return this.entries.fold(initial) { accR, (key, valueR) ->
-        accR.assimilate(valueR) { acc, value ->
+        accR.combine(valueR) { acc, value ->
             acc.plus(key to value)
         }
     }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ReturnValue.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ReturnValue.kt
@@ -37,10 +37,10 @@ fun <ReturnType> returnValue(errorMessage: String = "", breadCrumb: String = "",
     }
 }
 
-fun <K, ValueType> Map<K, ReturnValue<ValueType>>.mapFold(): ReturnValue<Map<K, ValueType>> {
+fun <K, ValueType> Map<K, ReturnValue<out ValueType>>.mapFold(): ReturnValue<Map<K, ValueType>> {
     val initial: ReturnValue<Map<K, ValueType>> = HasValue(emptyMap())
 
-    return this.entries.fold(initial) { accR: ReturnValue<Map<K, ValueType>>, (key: K, valueR: ReturnValue<ValueType>) ->
+    return this.entries.fold(initial) { accR, (key, valueR) ->
         accR.assimilate(valueR) { acc, value ->
             acc.plus(key to value)
         }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/Row.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/Row.kt
@@ -7,6 +7,7 @@ import io.specmatic.core.value.JSONObjectValue
 
 const val DEREFERENCE_PREFIX = "$"
 const val FILENAME_PREFIX = "@"
+const val REQUEST_BODY_FIELD = "(REQUEST-BODY)"
 
 data class Row(
     val columnNames: List<String> = emptyList(),
@@ -166,9 +167,9 @@ data class Row(
         val headers = request.headers
         val queryParams = request.queryParams.asValueMap().mapValues { it.value.toStringLiteral() }
         val bodyEntry = if (request.body !is NoBodyValue) {
-            mapOf("(REQUEST-BODY)" to request.body.toStringLiteral())
+            mapOf(REQUEST_BODY_FIELD to request.body.toStringLiteral())
         } else emptyMap()
 
-        return this.addFields(path + headers + queryParams + bodyEntry).copy(requestExample = request)
+        return this.copy(columnNames = emptyList(), values = emptyList()).addFields(path + headers + queryParams + bodyEntry).copy(requestExample = request)
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/Row.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/Row.kt
@@ -4,7 +4,6 @@ import io.specmatic.core.*
 import io.specmatic.core.value.JSONArrayValue
 import io.specmatic.core.value.JSONComposite
 import io.specmatic.core.value.JSONObjectValue
-import io.specmatic.core.value.StringValue
 
 const val DEREFERENCE_PREFIX = "$"
 const val FILENAME_PREFIX = "@"

--- a/core/src/main/kotlin/io/specmatic/core/pattern/Row.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/Row.kt
@@ -160,4 +160,18 @@ data class Row(
             withoutColumn.copy(requestBodyJSONExample = updatedJSONExample)
         } ?: withoutColumn
     }
+    
+    fun updateRequestIfExists(request: HttpRequest): Row {
+        val updatedColumnsNames = columnNames.toSet() + "(REQUEST-BODY)"
+        val updatedValues = values.mapIndexed { index, it ->
+            if (columnNames[index] != "(REQUEST-BODY)") return@mapIndexed it
+            request.body.toStringLiteral()
+        }
+
+        return this.copy(
+            requestExample = request,
+            columnNames = updatedColumnsNames.toList(),
+            values = updatedValues
+        )
+    }
 }

--- a/core/src/main/kotlin/io/specmatic/stub/ThreadSafeListOfStubs.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/ThreadSafeListOfStubs.kt
@@ -3,6 +3,7 @@ package io.specmatic.stub
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.KeyCheck
 import io.specmatic.core.Result
+import io.specmatic.core.invalidRequestStatuses
 import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.pattern.IgnoreUnexpectedKeys
 import io.specmatic.mock.ScenarioStub
@@ -149,8 +150,9 @@ class ThreadSafeListOfStubs(
                 val partialResult = requestPattern.generate(partial.request, resolver)
                     .matches(httpRequest, partialResolver, partialResolver)
 
-                if (!partialResult.isSuccess()) partialResult to stubData
-                else Pair(stubData.matches(httpRequest), stubData)
+                if (!partialResult.isSuccess()) return@map partialResult to stubData
+                if (partial.response.status in invalidRequestStatuses) return@map partialResult to stubData
+                Pair(stubData.matches(httpRequest), stubData)
             }
     }
 

--- a/core/src/main/kotlin/io/specmatic/stub/ThreadSafeListOfStubs.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/ThreadSafeListOfStubs.kt
@@ -89,7 +89,7 @@ class ThreadSafeListOfStubs(
             if (result !is Result.Success) return@map Pair(result, stubData)
 
             val response = if (stubData.partial == null) stubData.response
-            else stubData.responsePattern.generateResponse(stubData.partial.response, stubData.resolver)
+            else stubData.responsePattern.fillInTheBlanks(stubData.partial.response, stubData.resolver)
 
             val stubResponse = HttpStubResponse(
                 response,

--- a/core/src/main/kotlin/io/specmatic/test/ExamplePostValidator.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ExamplePostValidator.kt
@@ -9,6 +9,7 @@ import io.specmatic.test.asserts.parsedAssert
 object ExamplePostValidator: ResponseValidator {
 
     override fun postValidate(scenario: Scenario, httpRequest: HttpRequest, httpResponse: HttpResponse): Result? {
+        if (scenario.isNegative) return null
         val asserts  = scenario.exampleRow?.toAsserts()?.takeIf { it.isNotEmpty() } ?: return null
 
         val actualFactStore = httpRequest.toFactStore() + ExampleProcessor.getFactStore()

--- a/core/src/main/kotlin/io/specmatic/test/ExamplePostValidator.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ExamplePostValidator.kt
@@ -10,7 +10,7 @@ object ExamplePostValidator: ResponseValidator {
 
     override fun postValidate(scenario: Scenario, httpRequest: HttpRequest, httpResponse: HttpResponse): Result? {
         if (scenario.isNegative) return null
-        val asserts  = scenario.exampleRow?.toAsserts()?.takeIf { it.isNotEmpty() } ?: return null
+        val asserts  = scenario.exampleRow?.toAsserts(scenario)?.takeIf { it.isNotEmpty() } ?: return null
 
         val actualFactStore = httpRequest.toFactStore() + ExampleProcessor.getFactStore()
         val currentFactStore = httpResponse.toFactStore()
@@ -21,16 +21,16 @@ object ExamplePostValidator: ResponseValidator {
         return Result.fromFailures(finalResults)
     }
 
-    private fun Row.toAsserts(): List<Assert> {
+    private fun Row.toAsserts(scenario: Scenario): List<Assert> {
         val responseExampleBody = this.responseExampleForAssertion ?: return emptyList()
 
         val headerAsserts = responseExampleBody.headers.map {
-            parsedAssert("RESPONSE.HEADERS", it.key, StringValue(it.value))
+            parsedAssert("RESPONSE.HEADERS", it.key, StringValue(it.value), scenario.resolver)
         }.filterNotNull()
 
         return responseExampleBody.body.traverse(
-            onScalar = { value, key -> mapOf(key to parsedAssert("RESPONSE.BODY", key, value)) },
-            onAssert = { value, key -> mapOf(key to parsedAssert("RESPONSE.BODY", key, value)) }
+            onScalar = { value, key -> mapOf(key to parsedAssert("RESPONSE.BODY", key, value, scenario.resolver)) },
+            onAssert = { value, key -> mapOf(key to parsedAssert("RESPONSE.BODY", key, value, scenario.resolver)) }
         ).values.filterNotNull() + headerAsserts
     }
 

--- a/core/src/main/kotlin/io/specmatic/test/ScenarioTestGenerationFailure.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ScenarioTestGenerationFailure.kt
@@ -10,13 +10,14 @@ import io.specmatic.core.log.logger
 
 class ScenarioTestGenerationFailure(
     var scenario: Scenario,
-    val failure: Result.Failure
+    val failure: Result.Failure,
+    val message: String,
 ): ContractTest {
 
     init {
-        val exampleRow = scenario.examples.flatMap { it.rows }.firstOrNull { it.name == failure.message }
+        val exampleRow = scenario.examples.flatMap { it.rows }.firstOrNull { it.name == message }
         if (exampleRow != null) {
-            scenario = scenario.copy(exampleRow = exampleRow, exampleName = failure.message)
+            scenario = scenario.copy(exampleRow = exampleRow, exampleName = message)
         }
     }
 

--- a/core/src/main/kotlin/io/specmatic/test/asserts/Assert.kt
+++ b/core/src/main/kotlin/io/specmatic/test/asserts/Assert.kt
@@ -42,7 +42,7 @@ interface Assert {
     }
 }
 
-fun parsedAssert(prefix: String, key: String, value: Value, resolver: Resolver): Assert? {
+fun parsedAssert(prefix: String, key: String, value: Value, resolver: Resolver = Resolver()): Assert? {
     return Assert.parse(prefix, key, value, resolver)
 }
 

--- a/core/src/main/kotlin/io/specmatic/test/asserts/Assert.kt
+++ b/core/src/main/kotlin/io/specmatic/test/asserts/Assert.kt
@@ -1,5 +1,6 @@
 package io.specmatic.test.asserts
 
+import io.specmatic.core.Resolver
 import io.specmatic.core.Result
 import io.specmatic.core.value.JSONArrayValue
 import io.specmatic.core.value.ScalarValue
@@ -25,24 +26,24 @@ interface Assert {
     val key: String
 
     companion object {
-        fun parse(prefix: String, key: String, value: Value): Assert? {
+        fun parse(prefix: String, key: String, value: Value, resolver: Resolver): Assert? {
             return when (key) {
-                "\$if" -> AssertConditional.parse(prefix, key, value)
-                else -> if (value is ScalarValue) { parseScalarValue(prefix, key, value) } else null
+                "\$if" -> AssertConditional.parse(prefix, key, value, resolver)
+                else -> if (value is ScalarValue) { parseScalarValue(prefix, key, value, resolver) } else null
             }
         }
 
-        private fun parseScalarValue(prefix: String, key: String, value: Value): Assert? {
+        private fun parseScalarValue(prefix: String, key: String, value: Value, resolver: Resolver): Assert? {
             return AssertComparison.parse(prefix, key, value)
                     ?: AssertArray.parse(prefix, key, value)
-                    ?: AssertPattern.parse(prefix, key, value)
+                    ?: AssertPattern.parse(prefix, key, value, resolver)
                     ?: AssertExistence.parse(prefix, key, value)
         }
     }
 }
 
-fun parsedAssert(prefix: String, key: String, value: Value): Assert? {
-    return Assert.parse(prefix, key, value)
+fun parsedAssert(prefix: String, key: String, value: Value, resolver: Resolver): Assert? {
+    return Assert.parse(prefix, key, value, resolver)
 }
 
 fun <T> Value.suffixIfMoreThanOne(block: (suffix: String, suffixValue: Value) -> T): List<T> {

--- a/core/src/main/kotlin/io/specmatic/test/asserts/AssertConditional.kt
+++ b/core/src/main/kotlin/io/specmatic/test/asserts/AssertConditional.kt
@@ -1,6 +1,7 @@
 package io.specmatic.test.asserts
 
 import io.ktor.http.*
+import io.specmatic.core.Resolver
 import io.specmatic.core.Result
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.Value
@@ -44,13 +45,13 @@ class AssertConditional(override val prefix: String, val conditionalAsserts: Lis
     override val key: String = ""
 
     companion object {
-        private fun toAsserts(prefix: String, jsonObjectValue: JSONObjectValue?): List<Assert> {
+        private fun toAsserts(prefix: String, jsonObjectValue: JSONObjectValue?, resolver: Resolver): List<Assert> {
             return jsonObjectValue?.jsonObject?.entries?.mapNotNull { (key, value) ->
-                parsedAssert(prefix, key, value)
+                parsedAssert(prefix, key, value, resolver)
             }.orEmpty()
         }
 
-        fun parse(prefix: String, key: String, value: Value): AssertConditional? {
+        fun parse(prefix: String, key: String, value: Value, resolver: Resolver): AssertConditional? {
             val conditions = (value as? JSONObjectValue)?.findFirstChildByPath("\$conditions") as? JSONObjectValue ?: return null
             val thenConditions = (value as? JSONObjectValue)?.findFirstChildByPath("\$then") as? JSONObjectValue
             val elseConditions = (value as? JSONObjectValue)?.findFirstChildByPath("\$else") as? JSONObjectValue
@@ -59,8 +60,9 @@ class AssertConditional(override val prefix: String, val conditionalAsserts: Lis
 
             return AssertConditional(
                 prefix = prefix,
-                conditionalAsserts = toAsserts(prefix, conditions),
-                thenAsserts = toAsserts(prefix, thenConditions), elseAsserts = toAsserts(prefix, elseConditions)
+                conditionalAsserts = toAsserts(prefix, conditions, resolver),
+                thenAsserts = toAsserts(prefix, thenConditions, resolver),
+                elseAsserts = toAsserts(prefix, elseConditions, resolver)
             )
         }
     }

--- a/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
+++ b/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
@@ -621,7 +621,7 @@ class LoadTestsFromExternalisedFiles {
                         return HttpResponse(
                             status = 201,
                             body = parsedJSONObject("""{"id": 1}""").mergeWith(request.body)
-                        )
+                        ).also { println(request.toLogString()); println(it.toLogString()) }
                     }
                 }).results
                 val failure = results.filterIsInstance<Result.Failure>().first()
@@ -632,21 +632,23 @@ class LoadTestsFromExternalisedFiles {
                 assertThat(results).hasSize(2)
                 assertThat(failure.scenario?.testDescription()).containsIgnoringWhitespaces("Scenario: PATCH /pets/(id:number) -> 200 | EX:patch")
                 assertThat(failure.reportString()).containsIgnoringWhitespaces("""
-                >> REQUEST.BODY
-                >> name
+                >> REQUEST.BODY.name
                 Contract expected string but found value 10 (number)
-                >> tag[0]
+                >> REQUEST.BODY.tag
                 Contract expected string but found value 10 (number)
-                >> details
-                Contract expected JSON object but found value 10 (number)
-                >> adopted
+                >> REQUEST.BODY.details
+                Can't generate object value from type number
+                >> REQUEST.BODY.adopted
                 Contract expected boolean but found value "false"
-                >> age
+                >> REQUEST.BODY.age
                 Contract expected number but found value "20"
-                >> birthdate
+                >> REQUEST.BODY.birthdate
                 Date types can only be represented using strings
-                """.trimIndent())
+             """.trimIndent())
             }
+
+            // Ideally >> REQUEST.BODY.details
+            // Should contain "Contract expected JSON object but found value 10 (number)"
         }
 
         @Test

--- a/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
+++ b/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
@@ -636,7 +636,7 @@ class LoadTestsFromExternalisedFiles {
                 assertThat(failure.reportString()).containsIgnoringWhitespaces("""
                 >> REQUEST.BODY.name
                 Contract expected string but found value 10 (number)
-                >> REQUEST.BODY.tag
+                >> REQUEST.BODY.tag[0]
                 Contract expected string but found value 10 (number)
                 >> REQUEST.BODY.details
                 Can't generate object value from type number

--- a/core/src/test/kotlin/integration_tests/PartialExampleTest.kt
+++ b/core/src/test/kotlin/integration_tests/PartialExampleTest.kt
@@ -570,4 +570,42 @@ class PartialExampleTest {
             }
         }
     }
+
+    @Test
+    fun `should be able to load 400 partial example without errors and respond back`() {
+        val examplesDir = "src/test/resources/openapi/partial_example_tests/bad_request_valid_example"
+        val apiSpecification = "src/test/resources/openapi/partial_example_tests/simple.yaml"
+
+        createStubFromContracts(listOf(apiSpecification), listOf(examplesDir), timeoutMillis = 0).use { stub ->
+            val httpRequest = HttpRequest(
+                path = "/creators/abc/pets/def", method = "PATCH",
+                body = parsedJSONObject("""{"creatorId": "JohnDoe", "petId": 123}""")
+            )
+
+            stub.client.execute(httpRequest).let { response -> 
+                assertThat(response.status).isEqualTo(400)
+                assertThat(response.body).isEqualTo(parsedJSONObject("""
+                {"code": 400, "message": "Bad Request"}
+                """.trimIndent()))
+            }
+        }
+    }
+
+    @Test
+    fun `should result in failure when partial 400 example has invalid response`() {
+        val examplesDir = "src/test/resources/openapi/partial_example_tests/bad_request_invalid_example"
+        val apiSpecification ="src/test/resources/openapi/partial_example_tests/simple.yaml"
+
+        val (output, _) = captureStandardOutput { createStubFromContracts(listOf(apiSpecification), listOf(examplesDir)).also { it.close() } }
+        val exampleFile = osAgnosticPath("src/test/resources/openapi/partial_example_tests/bad_request_invalid_example/pets_post.json")
+
+        print(output)
+        assertThat(output).containsIgnoringWhitespaces("""
+        Could not load partial example $exampleFile
+        >> RESPONSE.BODY.code
+        Expected number, actual was "400"
+        >> RESPONSE.BODY.message
+        Expected string, actual was number
+        """.trimIndent())
+    }
 }

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -10491,7 +10491,7 @@ paths:
     }
 
     @Test
-    fun `if inline of overridden request Content Type header is wrong then parse should error out`() {
+    fun `if inline example of overridden request Content Type header is wrong then parse should error out`() {
         val spec = """
             openapi: 3.0.3
             info:
@@ -10502,17 +10502,17 @@ paths:
                 post:
                   summary: Add a new product
                   parameters:
-                    - in: header
-                      name: Content-Type
-                      schema:
-                        type: string
-                        enum:
-                        - application/json; charset=utf-8
-                      examples:
-                        SUCCESS:
-                          value: application/json
-                      required: true
-                      description: Unneeded content type
+                  - in: header
+                    name: Content-Type
+                    schema:
+                      type: string
+                      enum:
+                      - application/json; charset=utf-8
+                    examples:
+                      SUCCESS:
+                        value: application/json
+                    required: true
+                    description: Unneeded content type
                   requestBody:
                     required: true
                     content:

--- a/core/src/test/kotlin/io/specmatic/core/HttpHeadersPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpHeadersPatternTest.kt
@@ -12,6 +12,7 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.assertThrows
 import java.util.function.Consumer
 import kotlin.collections.HashMap
 
@@ -712,5 +713,60 @@ internal class HttpHeadersPatternTest {
             assertThat(fixedValue).isEqualTo(mapOf("number" to "999", "boolean" to "true"))
         }
     }
-}
 
+    @Nested
+    inner class FillInTheBlanksTests {
+        @Test
+        fun `should generate values for missing mandatory keys and pattern tokens`() {
+            val httpHeaders = HttpHeadersPattern(mapOf("number" to NumberPattern(), "boolean" to BooleanPattern()))
+            val headers = mapOf("number" to "(number)")
+            val dictionary = mapOf(
+                "HEADERS.number" to NumberValue(999), "HEADERS.boolean" to BooleanValue(true)
+            )
+            val filledHeaders = httpHeaders.fillInTheBlanks(headers, Resolver(dictionary = dictionary)).value
+
+            assertThat(filledHeaders).isEqualTo(mapOf("number" to "999", "boolean" to "true"))
+        }
+
+        @Test
+        fun `should not generate missing optional keys`() {
+            val httpHeaders = HttpHeadersPattern(mapOf("number" to NumberPattern(), "boolean?" to BooleanPattern()))
+            val headers = mapOf("number" to "999")
+            val dictionary = mapOf(
+                "HEADERS.number" to NumberValue(999), "HEADERS.boolean" to BooleanValue(true)
+            )
+            val filledHeaders = httpHeaders.fillInTheBlanks(headers, Resolver(dictionary = dictionary)).value
+
+            assertThat(filledHeaders).isEqualTo(mapOf("number" to "999"))
+        }
+
+        @Test
+        fun `should handle any-value pattern token as a special case`() {
+            val httpHeaders = HttpHeadersPattern(mapOf("number" to NumberPattern(), "boolean" to BooleanPattern()))
+            val headers = mapOf("number" to "(anyvalue)")
+            val dictionary = mapOf(
+                "HEADERS.number" to NumberValue(999), "HEADERS.boolean" to BooleanValue(true)
+            )
+            val filledHeaders = httpHeaders.fillInTheBlanks(headers, Resolver(dictionary = dictionary)).value
+
+            assertThat(filledHeaders).isEqualTo(mapOf("number" to "999", "boolean" to "true"))
+        }
+
+        @Test
+        fun `should complain when pattern-token does not match the underlying pattern`() {
+            val httpHeaders = HttpHeadersPattern(mapOf("number" to NumberPattern(), "boolean" to BooleanPattern()))
+            val headers = mapOf("number" to "(string)")
+            val dictionary = mapOf(
+                "HEADERS.number" to NumberValue(999), "HEADERS.boolean" to BooleanValue(true)
+            )
+            val exception = assertThrows<ContractException> {
+                httpHeaders.fillInTheBlanks(headers, Resolver(dictionary = dictionary)).value
+            }
+
+            assertThat(exception.failure().reportString()).isEqualToNormalizingWhitespace("""
+            >> number
+            Expected number, actual was string
+            """.trimIndent())
+        }
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/HttpPathPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpPathPatternTest.kt
@@ -34,7 +34,7 @@ internal class HttpPathPatternTest {
         val result = pattern.matches(URI(path), Resolver())
 
         assertThat(result).isInstanceOf(Result.Failure::class.java)
-        assertThat((result as Result.Failure).failureReason).isEqualTo(FailureReason.URLPathMismatchButSameStructure)
+        assertThat((result as Result.Failure).failureReason).isEqualTo(FailureReason.URLPathParamMismatchButSameStructure)
     }
 
     @ParameterizedTest
@@ -266,7 +266,7 @@ internal class HttpPathPatternTest {
         val pattern = buildHttpPathPattern("/pets/(petid:number)/file/(fileid:number)")
         val mismatchResult = pattern.matches(URI("/pets/abc/file/def")) as Result.Failure
 
-        assertThat(mismatchResult.failureReason).isEqualTo(FailureReason.URLPathMismatchButSameStructure)
+        assertThat(mismatchResult.failureReason).isEqualTo(FailureReason.URLPathParamMismatchButSameStructure)
         assertThat(mismatchResult.reportString())
             .contains("PATH.petid")
             .contains("PATH.fileid")

--- a/core/src/test/kotlin/io/specmatic/core/HttpPathPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpPathPatternTest.kt
@@ -8,9 +8,11 @@ import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import io.specmatic.core.pattern.*
+import io.specmatic.core.value.BooleanValue
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.assertThrows
 import java.io.UnsupportedEncodingException
 import java.net.URI
 import java.net.URISyntaxException
@@ -316,7 +318,7 @@ internal class HttpPathPatternTest {
             val urlPattern = buildHttpPathPattern("/pets/(id:number)")
             val invalidPath = "/pets/abc"
 
-            val dictionary = mapOf("PATH.id" to NumberValue(999))
+            val dictionary = mapOf("PATH-PARAMS.id" to NumberValue(999))
             val fixedPath = urlPattern.fixValue(invalidPath, Resolver(dictionary = dictionary))
             println(fixedPath)
 
@@ -326,7 +328,7 @@ internal class HttpPathPatternTest {
         @Test
         fun `should only add the prefix if the path already had it`() {
             val urlPattern = buildHttpPathPattern("/pets/(id:number)")
-            val dictionary = mapOf("PATH.id" to NumberValue(999))
+            val dictionary = mapOf("PATH-PARAMS.id" to NumberValue(999))
             val resolver = Resolver(dictionary = dictionary)
 
             val prefixedPath = "/pets/abc"
@@ -343,7 +345,7 @@ internal class HttpPathPatternTest {
         @Test
         fun `should retain pattern token if it matches when resolver is in mock mode`() {
             val urlPattern = buildHttpPathPattern("/pets/(id:number)")
-            val dictionary = mapOf("PATH.id" to NumberValue(999))
+            val dictionary = mapOf("PATH-PARAMS.id" to NumberValue(999))
             val resolver = Resolver(dictionary = dictionary, mockMode = true)
             val validValue = "/pets/(number)"
 
@@ -355,7 +357,7 @@ internal class HttpPathPatternTest {
         @Test
         fun `should generate value when pattern token does not match when resolver is in mock mode`() {
             val urlPattern = buildHttpPathPattern("/pets/(id:number)")
-            val dictionary = mapOf("PATH.id" to NumberValue(999))
+            val dictionary = mapOf("PATH-PARAMS.id" to NumberValue(999))
             val resolver = Resolver(dictionary = dictionary, mockMode = true)
             val validValue = "/pets/(string)"
 
@@ -367,13 +369,81 @@ internal class HttpPathPatternTest {
         @Test
         fun `should generate values even if pattern token matches but resolver is not in mock mode`() {
             val urlPattern = buildHttpPathPattern("/pets/(id:number)")
-            val dictionary = mapOf("PATH.id" to NumberValue(999))
+            val dictionary = mapOf("PATH-PARAMS.id" to NumberValue(999))
             val resolver = Resolver(dictionary = dictionary)
             val validValue = "/pets/(number)"
 
             val fixedPath = urlPattern.fixValue(validValue, resolver)
             println(fixedPath)
             assertThat(fixedPath).isEqualTo("/pets/999")
+        }
+
+        @Test
+        fun `should work when pattern-token contains key`() {
+            val urlPattern = buildHttpPathPattern("/pets/(id:number)")
+            val dictionary = mapOf("PATH-PARAMS.id" to NumberValue(999))
+            val resolver = Resolver(dictionary = dictionary)
+            val validValue = "/pets/(id:number)"
+
+            val fixedPath = urlPattern.fixValue(validValue, resolver)
+            println(fixedPath)
+            assertThat(fixedPath).isEqualTo("/pets/999")
+        }
+    }
+
+    @Nested
+    inner class FillInTheBlanksTests {
+        @Test
+        fun `should generate values for missing mandatory keys and pattern tokens`() {
+            val pathPattern = buildHttpPathPattern("/pets/(id:number)/owners/(flag:boolean)")
+            val path = "/pets/(number)/owners/(boolean)"
+            val dictionary = mapOf(
+                "PATH-PARAMS.id" to NumberValue(999), "PATH-PARAMS.flag" to BooleanValue(true)
+            )
+            val filledPath = pathPattern.fillInTheBlanks(path, Resolver(dictionary = dictionary)).value
+
+            assertThat(filledPath).isEqualTo("/pets/999/owners/true")
+        }
+
+        @Test
+        fun `should handle any-value pattern token as a special case`() {
+            val pathPattern = buildHttpPathPattern("/pets/(id:number)/owners/(flag:boolean)")
+            val path = "/pets/(anyvalue)/owners/(boolean)"
+            val dictionary = mapOf(
+                "PATH-PARAMS.id" to NumberValue(999), "PATH-PARAMS.flag" to BooleanValue(true)
+            )
+            val filledPath = pathPattern.fillInTheBlanks(path, Resolver(dictionary = dictionary)).value
+
+            assertThat(filledPath).isEqualTo("/pets/999/owners/true")
+        }
+
+        @Test
+        fun `should complain when pattern-token does not match the underlying pattern`() {
+            val pathPattern = buildHttpPathPattern("/pets/(id:number)/owners/(flag:boolean)")
+            val path = "/pets/(string)/owners/(boolean)"
+            val dictionary = mapOf(
+                "PATH-PARAMS.id" to NumberValue(999), "PATH-PARAMS.flag" to BooleanValue(true)
+            )
+            val exception = assertThrows<ContractException> {
+                pathPattern.fillInTheBlanks(path, Resolver(dictionary = dictionary)).value
+            }
+
+            assertThat(exception.failure().reportString()).isEqualToNormalizingWhitespace("""
+            >> id
+            Expected number, actual was string
+            """.trimIndent())
+        }
+
+        @Test
+        fun `should work when pattern-token contains key`() {
+            val pathPattern = buildHttpPathPattern("/pets/(id:number)/owners/(flag:boolean)")
+            val path = "/pets/(id:number)/owners/(flag:boolean)"
+            val dictionary = mapOf(
+                "PATH-PARAMS.id" to NumberValue(999), "PATH-PARAMS.flag" to BooleanValue(true)
+            )
+            val filledPath = pathPattern.fillInTheBlanks(path, Resolver(dictionary = dictionary)).value
+
+            assertThat(filledPath).isEqualTo("/pets/999/owners/true")
         }
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/HttpQueryParamPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpQueryParamPatternTest.kt
@@ -441,7 +441,7 @@ class HttpQueryParamPatternTest {
             assertThat(result.reportString().trimmedLinesList()).isEqualTo("""
                 >> QUERY-PARAMS.product_id
 
-                   Expected number, actual was "abc"
+                   Expected 1 (number), actual was "abc"
             """.trimIndent().trimmedLinesList())
         }
 

--- a/core/src/test/kotlin/io/specmatic/core/HttpResponsePatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpResponsePatternTest.kt
@@ -67,7 +67,7 @@ internal class HttpResponsePatternTest {
             status = 203,
             body = NoBodyPattern
         )
-        val response = httpResponsePattern.generateResponse(Resolver())
+        val response = httpResponsePattern.fillInTheBlanks(Resolver())
 
         assertThat(response.status).isEqualTo(203)
         assertThat(response.headers["Content-Type"]).isNull()

--- a/core/src/test/kotlin/io/specmatic/core/examples/module/ExampleValidationModuleTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/examples/module/ExampleValidationModuleTest.kt
@@ -92,13 +92,13 @@ class ExampleValidationModuleTest {
 
         val result = exampleValidationModule.validateExample(Feature(listOf(scenario), name= ""), example)
         assertThat(result.report()).isEqualToNormalizingWhitespace("""
-            In scenario ""
-            API: POST /add -> 200      
-            >> REQUEST.BODY.first
-            Specification expected number but example contained "(string)"        
-            >> RESPONSE.BODY.result
-            Specification expected number but example contained "(uuid)"
-            """.trimIndent())
+        In scenario ""
+        API: POST /add -> 200
+        >> REQUEST.BODY.first
+        Specification expected number but example contained string
+        >> RESPONSE.BODY.result
+        Specification expected number but example contained uuid
+        """.trimIndent())
     }
 
     @Test
@@ -124,8 +124,8 @@ class ExampleValidationModuleTest {
         val result = feature.matchResultSchemaFlagBased(null, "Test", example, DefaultMismatchMessages)
         assertThat(result).isInstanceOf(Result.Failure::class.java)
         assertThat(result.reportString()).isEqualToNormalizingWhitespace("""
-            >> first
-            Expected number, actual was "(string)"
-            """.trimIndent())
+        >> first
+        Expected number, actual was string
+        """.trimIndent())
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/pattern/EmailPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/EmailPatternTest.kt
@@ -3,6 +3,7 @@ package io.specmatic.core.pattern
 import io.specmatic.GENERATION
 import io.specmatic.core.Resolver
 import io.specmatic.core.Result
+import io.specmatic.core.value.StringValue
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -27,4 +28,15 @@ class EmailPatternTest {
         ).isInstanceOf(Result.Failure::class.java)
     }
 
+    @Test
+    fun `fillInTheBlanks should handle any-value pattern token correctly`() {
+        val pattern = EmailPattern()
+        val resolver = Resolver()
+        val value = StringValue("(anyvalue)")
+
+        val filledInValue = pattern.fillInTheBlanks(value, resolver).value
+        val matchResult = pattern.matches(filledInValue, resolver)
+
+        assertThat(matchResult.isSuccess()).withFailMessage(matchResult.reportString()).isTrue()
+    }
 }

--- a/core/src/test/kotlin/io/specmatic/core/pattern/ListPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/ListPatternTest.kt
@@ -686,5 +686,24 @@ Feature: Recursive test
                 assertThat(it).isEqualTo(NumberValue(999))
             }
         }
+
+        @Test
+        fun `should allow invalid pattern tokens when resolver is negative`() {
+            val listPattern = ListPattern(StringPattern())
+            val invalidPatterns = listOf(
+                JSONObjectPattern(mapOf("key" to StringPattern())),
+                ListPattern(BooleanPattern()),
+                NumberPattern()
+            )
+
+            assertThat(invalidPatterns).allSatisfy {
+                val resolver = Resolver(newPatterns = mapOf("(Test)" to it), isNegative = true)
+                val value = StringValue("(Test)")
+                val result = listPattern.fillInTheBlanks(value, resolver)
+
+                assertThat(result).isInstanceOf(HasValue::class.java); result as HasValue
+                println(result.value)
+            }
+        }
     }
 }

--- a/core/src/test/kotlin/io/specmatic/test/asserts/AssertConditionalTest.kt
+++ b/core/src/test/kotlin/io/specmatic/test/asserts/AssertConditionalTest.kt
@@ -1,5 +1,6 @@
 package io.specmatic.test.asserts
 
+import io.specmatic.core.Resolver
 import io.specmatic.core.Result
 import io.specmatic.core.value.JSONArrayValue
 import io.specmatic.core.value.JSONObjectValue
@@ -220,7 +221,7 @@ class AssertConditionalTest {
             ))
         ))
 
-        val assert = AssertConditional.parse("REQUEST.BODY", "\$if", assertSyntax)
+        val assert = AssertConditional.parse("REQUEST.BODY", "\$if", assertSyntax, Resolver())
 
         assertThat(assert).isInstanceOf(AssertConditional::class.java)
         assert as AssertConditional

--- a/core/src/test/resources/openapi/partial_example_tests/bad_request_invalid_example/pets_post.json
+++ b/core/src/test/resources/openapi/partial_example_tests/bad_request_invalid_example/pets_post.json
@@ -1,0 +1,18 @@
+{
+  "partial": {
+    "http-request": {
+      "path": "/creators/abc/pets/(petId:string)",
+      "method": "PATCH",
+      "body": {
+        "creatorId": "JohnDoe"
+      }
+    },
+    "http-response": {
+      "status": 400,
+      "body": {
+        "code": "400",
+        "message": "(number)"
+      }
+    }
+  }
+}

--- a/core/src/test/resources/openapi/partial_example_tests/bad_request_valid_example/pets_post.json
+++ b/core/src/test/resources/openapi/partial_example_tests/bad_request_valid_example/pets_post.json
@@ -1,0 +1,19 @@
+{
+  "partial": {
+    "http-request": {
+      "path": "/creators/abc/pets/(petId:string)",
+      "method": "PATCH",
+      "body": {
+        "creatorId": "JohnDoe",
+        "petId": "(number)"
+      }
+    },
+    "http-response": {
+      "status": 400,
+      "body": {
+        "code": 400,
+        "message": "Bad Request"
+      }
+    }
+  }
+}

--- a/core/src/test/resources/openapi/partial_example_tests/invalid_partial/pets_post.json
+++ b/core/src/test/resources/openapi/partial_example_tests/invalid_partial/pets_post.json
@@ -1,0 +1,34 @@
+{
+  "partial": {
+    "http-request": {
+      "path": "/creators/abc/pets/(string)",
+      "method": "PATCH",
+      "headers": {
+        "Content-Type": "application/json",
+        "CREATOR-ID": "abc",
+        "PET-ID": "(string)"
+      },
+      "query": {
+        "creatorId": "abc",
+        "petId": "(string)"
+      },
+      "body": {
+        "creatorId": "123",
+        "petId": "(string)"
+      }
+    },
+    "http-response": {
+      "status": 201,
+      "body": {
+        "id": "(string)",
+        "traceId": "(number)",
+        "creatorId": "123",
+        "petId": "(number)"
+      },
+      "status-text": "Created",
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  }
+}

--- a/core/src/test/resources/openapi/partial_example_tests/simple.yaml
+++ b/core/src/test/resources/openapi/partial_example_tests/simple.yaml
@@ -1,0 +1,80 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: Simple API
+paths:
+  /creators/{creatorId}/pets/{petId}:
+    patch:
+      parameters:
+        - name: creatorId
+          in: path
+          schema:
+            type: number
+          required: true
+        - name: petId
+          in: path
+          schema:
+            type: number
+          required: true
+        - name: creatorId
+          in: query
+          schema:
+            type: number
+          required: true
+        - name: petId
+          in: query
+          schema:
+            type: number
+          required: true
+        - name: CREATOR-ID
+          in: header
+          schema:
+            type: number
+          required: true
+        - name: PET-ID
+          in: header
+          schema:
+            type: number
+      description: Creates a new pet in the store. Duplicates are allowed
+      requestBody:
+        description: Pet to add to the store
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewPet'
+      responses:
+        '201':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - creatorId
+        - petId
+        - traceId
+      properties:
+        id:
+          type: number
+        traceId:
+          type: string
+        creatorId:
+          type: number
+        petId:
+          type: number
+    NewPet:
+      type: object
+      required:
+        - creatorId
+        - petId
+      properties:
+        creatorId:
+          type: number
+        petId:
+          type: number

--- a/core/src/test/resources/openapi/partial_example_tests/simple.yaml
+++ b/core/src/test/resources/openapi/partial_example_tests/simple.yaml
@@ -53,6 +53,10 @@ paths:
                 $ref: '#/components/schemas/Pet'
         '400':
           description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 components:
   schemas:
     Pet:
@@ -81,3 +85,13 @@ components:
           type: number
         petId:
           type: number
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: number
+        message:
+          type: string

--- a/core/src/test/resources/openapi/partial_example_tests/simple.yaml
+++ b/core/src/test/resources/openapi/partial_example_tests/simple.yaml
@@ -35,6 +35,7 @@ paths:
           in: header
           schema:
             type: number
+          required: true
       description: Creates a new pet in the store. Duplicates are allowed
       requestBody:
         description: Pet to add to the store

--- a/core/src/test/resources/openapi/partial_example_tests/simple.yaml
+++ b/core/src/test/resources/openapi/partial_example_tests/simple.yaml
@@ -50,6 +50,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Pet'
+        '400':
+          description: bad request
 components:
   schemas:
     Pet:

--- a/core/src/test/resources/openapi/partial_example_tests/simple_dictionary.json
+++ b/core/src/test/resources/openapi/partial_example_tests/simple_dictionary.json
@@ -1,0 +1,10 @@
+{
+  "PATH-PARAMS.creatorId": 123,
+  "PATH-PARAMS.petId": 999,
+  "HEADERS.CREATOR-ID": 123,
+  "HEADERS.PET-ID": 999,
+  "QUERY-PARAMS.creatorId": 123,
+  "QUERY-PARAMS.petId": 999,
+  "NewPet.creatorId": 123,
+  "NewPet.petId": 999
+}

--- a/core/src/test/resources/openapi/partial_example_tests/valid_partial/pets_post.json
+++ b/core/src/test/resources/openapi/partial_example_tests/valid_partial/pets_post.json
@@ -1,0 +1,34 @@
+{
+  "partial": {
+    "http-request": {
+      "path": "/creators/123/pets/(number)",
+      "method": "PATCH",
+      "headers": {
+        "Content-Type": "application/json",
+        "CREATOR-ID": 123,
+        "PET-ID": "(number)"
+      },
+      "query": {
+        "creatorId": 123,
+        "petId": "(number)"
+      },
+      "body": {
+        "creatorId": 123,
+        "petId": "(number)"
+      }
+    },
+    "http-response": {
+      "status": 201,
+      "body": {
+        "id": "(number)",
+        "traceId": "(string)",
+        "creatorId": 123,
+        "petId": "(number)"
+      },
+      "status-text": "Created",
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  }
+}

--- a/core/src/test/resources/openapi/partial_example_tests/valid_without_mandatory/pets_post.json
+++ b/core/src/test/resources/openapi/partial_example_tests/valid_without_mandatory/pets_post.json
@@ -1,0 +1,17 @@
+{
+  "partial": {
+    "http-request": {
+      "path": "/creators/(number)/pets/(number)",
+      "method": "PATCH",
+      "body": {}
+    },
+    "http-response": {
+      "status": 201,
+      "body": {},
+      "status-text": "Created",
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  }
+}

--- a/core/src/test/resources/openapi/simple_partial_non_partial_examples_with_dictionary/simple_pets.yaml
+++ b/core/src/test/resources/openapi/simple_partial_non_partial_examples_with_dictionary/simple_pets.yaml
@@ -1,0 +1,99 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: Simple API
+paths:
+  /pets:
+    post:
+      parameters:
+        - name: CREATOR-ID
+          in: header
+          schema:
+            type: string
+          required: true
+      description: Creates a new pet in the store. Duplicates are allowed
+      requestBody:
+        description: Pet to add to the store
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewPet'
+      responses:
+        '201':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+    get:
+      description: Returns all pets from the system that the user has access to
+      parameters:
+        - name: tag
+          in: query
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: A list of pets of type
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+  /pets/{id}:
+    patch:
+      description: Updates a pet in the store with form data
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+        - name: CREATOR-ID
+          in: header
+          schema:
+            type: string
+          required: true
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewPet'
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        name:
+          type: string
+        tag:
+          type: string
+        color:
+          type: string
+        id:
+          type: integer
+    NewPet:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+        tag:
+          type: string
+        color:
+          type: string

--- a/core/src/test/resources/openapi/simple_partial_non_partial_examples_with_dictionary/simple_pets_dictionary.json
+++ b/core/src/test/resources/openapi/simple_partial_non_partial_examples_with_dictionary/simple_pets_dictionary.json
@@ -1,0 +1,12 @@
+{
+  "QUERY-PARAMS.tag": "cat",
+  "PATH-PARAMS.id": 1,
+  "HEADERS.CREATOR-ID": "John",
+  "NewPet.name": "Tom",
+  "NewPet.tag": "cat",
+  "NewPet.color": "black",
+  "Pet.id": 1,
+  "Pet.name": "Tom",
+  "Pet.tag": "cat",
+  "Pet.color": "black"
+}

--- a/core/src/test/resources/openapi/simple_partial_non_partial_examples_with_dictionary/simple_pets_examples/pets_get.json
+++ b/core/src/test/resources/openapi/simple_partial_non_partial_examples_with_dictionary/simple_pets_examples/pets_get.json
@@ -1,0 +1,25 @@
+{
+  "partial": {
+    "http-request": {
+      "path": "/pets",
+      "method": "GET",
+      "query": {
+        "tag": "(string)"
+      }
+    },
+    "http-response": {
+      "status": 200,
+      "body": [
+        {
+          "id": "(number)",
+          "name": "(string)",
+          "tag": "(string)"
+        }
+      ],
+      "status-text": "OK",
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  }
+}

--- a/core/src/test/resources/openapi/simple_partial_non_partial_examples_with_dictionary/simple_pets_examples/pets_patch.json
+++ b/core/src/test/resources/openapi/simple_partial_non_partial_examples_with_dictionary/simple_pets_examples/pets_patch.json
@@ -1,0 +1,26 @@
+{
+  "http-request": {
+    "path": "/pets/(number)",
+    "method": "PATCH",
+    "headers": {
+      "Content-Type": "application/json",
+      "CREATOR-ID": "(string)"
+    },
+    "body": {
+      "name": "(string)",
+      "tag": "cat"
+    }
+  },
+  "http-response": {
+    "status": 200,
+    "body": {
+      "id": "(number)",
+      "name": "(string)",
+      "tag": "(string)"
+    },
+    "status-text": "Created",
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}

--- a/core/src/test/resources/openapi/simple_partial_non_partial_examples_with_dictionary/simple_pets_examples/pets_post.json
+++ b/core/src/test/resources/openapi/simple_partial_non_partial_examples_with_dictionary/simple_pets_examples/pets_post.json
@@ -1,0 +1,28 @@
+{
+  "partial": {
+    "http-request": {
+      "path": "/pets",
+      "method": "POST",
+      "headers": {
+        "Content-Type": "application/json"
+      },
+      "body": {
+        "tag": "cat",
+        "color": "(string)"
+      }
+    },
+    "http-response": {
+      "status": 201,
+      "body": {
+        "id": "(number)",
+        "name": "(string)",
+        "tag": "(string)",
+        "color": "(string)"
+      },
+      "status-text": "Created",
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  }
+}


### PR DESCRIPTION
**What**: Add support for partial examples and pattern tokens in tests, fixes in stub

<!-- How were these changes implemented? -->

**Changelog**:
- Added support for partial examples in tests
- Implemented pattern token filling in test examples
- Resolved issues with partial 4xx examples when executing the stub

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
