### PR TITLE
Fix EnumPattern to properly fill-in pattern tokens

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/pattern/EnumPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/EnumPattern.kt
@@ -76,7 +76,7 @@ data class EnumPattern(
             else -> resolvedPattern.value
         }
 
-        return if (isPatternToken(value) && patternToConsider == this) HasValue(generate(resolver))
+        return if (isPatternToken(value) && patternToConsider == this) HasValue(resolver.generate(this))
         else pattern.fillInTheBlanks(value, resolver)
     }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Fix EnumPattern to properly fill-in pattern tokens

<!-- Why are these changes necessary? -->

**Why**:  So the value is looked up from dictionary

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
<!-- feel free to add additional comments -->
