### PR TITLE
Fix partial test examples with missing discriminator and conditional assertions

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/ValidateUnexpectedKeys.kt
+++ b/core/src/main/kotlin/io/specmatic/core/ValidateUnexpectedKeys.kt
@@ -3,6 +3,7 @@ package io.specmatic.core
 import io.specmatic.core.pattern.Pattern
 import io.specmatic.core.pattern.withoutOptionality
 import io.specmatic.core.value.StringValue
+import io.specmatic.test.asserts.ASSERT_KEYS
 
 object ValidateUnexpectedKeys: UnexpectedKeyCheck {
     override fun validate(pattern: Map<String, Any>, actual: Map<String, Any>): UnexpectedKeyError? {
@@ -17,7 +18,7 @@ object ValidateUnexpectedKeys: UnexpectedKeyCheck {
         val patternKeys = pattern.minus("...").keys.map { withoutOptionality(it) }
         val actualKeys = actual.keys.map { withoutOptionality(it) }
 
-        return actualKeys.minus(patternKeys.toSet()).map {
+        return actualKeys.minus(patternKeys.toSet().plus(ASSERT_KEYS)).map {
             UnexpectedKeyError(it)
         }
     }
@@ -29,6 +30,6 @@ object ValidateUnexpectedKeys: UnexpectedKeyCheck {
         val patternKeys = pattern.minus("...").keys.map { withoutOptionality(it).lowercase() }.toSet()
         val actualKeys = actual.keys.map { withoutOptionality(it) }
 
-        return actualKeys.filter { it.lowercase() !in patternKeys }.map { UnexpectedKeyError(it) }
+        return actualKeys.filter { it.lowercase() !in patternKeys && it !in ASSERT_KEYS }.map { UnexpectedKeyError(it) }
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
@@ -105,8 +105,11 @@ data class AnyPattern(
 
     override fun fillInTheBlanks(value: Value, resolver: Resolver): ReturnValue<Value> {
         val updatedPatterns = getUpdatedPattern(resolver)
+        val newPatterns = updatedPatterns.filter { it.typeAlias != null }.associateBy { it.typeAlias.orEmpty() }
+        val updatedResolver = resolver.copy(newPatterns = resolver.newPatterns.plus(newPatterns) )
+
         val results = updatedPatterns.asSequence().map {
-            it.fillInTheBlanks(value, resolver)
+            it.fillInTheBlanks(value, updatedResolver)
         }
 
         val successfulGeneration = results.firstOrNull { it is HasValue }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
@@ -104,7 +104,8 @@ data class AnyPattern(
     }
 
     override fun fillInTheBlanks(value: Value, resolver: Resolver): ReturnValue<Value> {
-        val results = pattern.asSequence().map {
+        val updatedPatterns = getUpdatedPattern(resolver)
+        val results = updatedPatterns.asSequence().map {
             it.fillInTheBlanks(value, resolver)
         }
 
@@ -161,7 +162,7 @@ data class AnyPattern(
     }
 
     override fun matches(sampleData: Value?, resolver: Resolver): Result {
-        if(discriminator != null) {
+        if (discriminator != null) {
             return discriminator.matches(sampleData, pattern, key, resolver)
         }
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
@@ -104,22 +104,22 @@ data class AnyPattern(
     }
 
     override fun fillInTheBlanks(value: Value, resolver: Resolver): ReturnValue<Value> {
+        val patternToConsider = when (val resolvedPattern = resolveToPattern(value, resolver, this)) {
+            is ReturnFailure -> return resolvedPattern.cast()
+            else -> resolvedPattern.value
+        }
+        if (isPatternToken(value) && patternToConsider == this) return HasValue(resolver.generate(this))
+
         val updatedPatterns = getUpdatedPattern(resolver)
         val newPatterns = updatedPatterns.filter { it.typeAlias != null }.associateBy { it.typeAlias.orEmpty() }
         val updatedResolver = resolver.copy(newPatterns = resolver.newPatterns.plus(newPatterns) )
 
-        val results = updatedPatterns.asSequence().map {
-            it.fillInTheBlanks(value, updatedResolver)
-        }
-
+        val results = updatedPatterns.asSequence().map { it.fillInTheBlanks(value, updatedResolver) }
         val successfulGeneration = results.firstOrNull { it is HasValue }
-
-        if(successfulGeneration != null)
-            return successfulGeneration
+        if(successfulGeneration != null) return successfulGeneration
 
         val resultList = results.toList()
         val failures = resultList.filterIsInstance<ReturnFailure>().map { it.toFailure() }
-
         return HasFailure(Failure.fromFailures(failures))
     }
 

--- a/core/src/main/kotlin/io/specmatic/test/asserts/Assert.kt
+++ b/core/src/main/kotlin/io/specmatic/test/asserts/Assert.kt
@@ -6,6 +6,8 @@ import io.specmatic.core.value.JSONArrayValue
 import io.specmatic.core.value.ScalarValue
 import io.specmatic.core.value.Value
 
+val ASSERT_KEYS = setOf("\$if", "\$then", "\$else")
+
 interface Assert {
     fun assert(currentFactStore: Map<String, Value>, actualFactStore: Map<String, Value>): Result
 

--- a/core/src/test/resources/openapi/partial_with_discriminator/example_with_asserts/get_example.json
+++ b/core/src/test/resources/openapi/partial_with_discriminator/example_with_asserts/get_example.json
@@ -1,0 +1,29 @@
+{
+  "partial": {
+    "http-request": {
+      "path": "/pets",
+      "method": "GET"
+    },
+    "http-response": {
+      "status": 200,
+      "body": [
+        {
+          "id": "$array_has(ENTITY.id)",
+          "$if": {
+            "$conditions": {
+              "id": "$eq(ENTITY.id)"
+            },
+            "$then": {
+              "petType": "$eq(ENTITY.petType)",
+              "color": "$eq(ENTITY.color)"
+            }
+          }
+        }
+      ],
+      "status-text": "Created",
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  }
+}

--- a/core/src/test/resources/openapi/partial_with_discriminator/example_with_asserts/post_example.json
+++ b/core/src/test/resources/openapi/partial_with_discriminator/example_with_asserts/post_example.json
@@ -1,0 +1,21 @@
+{
+  "partial": {
+    "http-request": {
+      "path": "/pets",
+      "method": "POST",
+      "body": "(Cat)"
+    },
+    "http-response": {
+      "status": 201,
+      "body": {
+        "id": "(number)",
+        "petType": "cat",
+        "color": "$eq(REQUEST.BODY.color)"
+      },
+      "status-text": "Created",
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  }
+}

--- a/core/src/test/resources/openapi/partial_with_discriminator/example_with_disc/partial_example.json
+++ b/core/src/test/resources/openapi/partial_with_discriminator/example_with_disc/partial_example.json
@@ -1,0 +1,23 @@
+{
+  "partial": {
+    "http-request": {
+      "path": "/pets",
+      "method": "POST",
+      "body": {
+        "petType": "cat"
+      }
+    },
+    "http-response": {
+      "status": 201,
+      "body": {
+        "id": "(number)",
+        "petType": "cat",
+        "color": "(string)"
+      },
+      "status-text": "Created",
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  }
+}

--- a/core/src/test/resources/openapi/partial_with_discriminator/example_with_invalid_disc/partial_example.json
+++ b/core/src/test/resources/openapi/partial_with_discriminator/example_with_invalid_disc/partial_example.json
@@ -1,0 +1,19 @@
+{
+  "partial": {
+    "http-request": {
+      "path": "/pets",
+      "method": "POST",
+      "body": {
+        "petType": "UNKNOWN"
+      }
+    },
+    "http-response": {
+      "status": 201,
+      "body": {},
+      "status-text": "Created",
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  }
+}

--- a/core/src/test/resources/openapi/partial_with_discriminator/example_with_pattern_token/partial_example.json
+++ b/core/src/test/resources/openapi/partial_with_discriminator/example_with_pattern_token/partial_example.json
@@ -1,0 +1,17 @@
+{
+  "partial": {
+    "http-request": {
+      "path": "/pets",
+      "method": "POST",
+      "body": "(Cat)"
+    },
+    "http-response": {
+      "status": 201,
+      "body": {},
+      "status-text": "Created",
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  }
+}

--- a/core/src/test/resources/openapi/partial_with_discriminator/example_without_disc/partial_example.json
+++ b/core/src/test/resources/openapi/partial_with_discriminator/example_without_disc/partial_example.json
@@ -1,0 +1,21 @@
+{
+  "partial": {
+    "http-request": {
+      "path": "/pets",
+      "method": "POST",
+      "body": {
+        "livesLeft": "(number)"
+      }
+    },
+    "http-response": {
+      "status": 201,
+      "body": {
+        "livesLeft": "(number)"
+      },
+      "status-text": "Created",
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  }
+}

--- a/core/src/test/resources/openapi/partial_with_discriminator/openapi.yaml
+++ b/core/src/test/resources/openapi/partial_with_discriminator/openapi.yaml
@@ -1,0 +1,78 @@
+openapi: 3.0.3
+info:
+  title: Pet API
+  version: 1.0.0
+paths:
+  /pets:
+    post:
+      summary: Add a new pet
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+      responses:
+        '201':
+          description: Pet added successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PetWithId'
+    get:
+      summary: List all pets
+      responses:
+        '200':
+          description: A list of pets
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PetWithId'
+components:
+  schemas:
+    Pet:
+      oneOf:
+        - $ref: '#/components/schemas/Dog'
+        - $ref: '#/components/schemas/Cat'
+      discriminator:
+        propertyName: petType
+        mapping:
+          dog: '#/components/schemas/Dog'
+          cat: '#/components/schemas/Cat'
+      required:
+        - petType
+    PetWithId:
+      allOf:
+        - $ref: '#/components/schemas/Pet'
+        - type: object
+          properties:
+            id:
+              type: number
+          required:
+            - id
+    Dog:
+      type: object
+      properties:
+        petType:
+          type: string
+        breed:
+          type: string
+        barkVolume:
+          type: integer
+      required:
+        - petType
+        - breed
+    Cat:
+      type: object
+      properties:
+        petType:
+          type: string
+        color:
+          type: string
+        livesLeft:
+          type: integer
+      required:
+        - petType
+        - color

--- a/core/src/test/resources/openapi/partial_with_discriminator/openapi_dictionary.json
+++ b/core/src/test/resources/openapi/partial_with_discriminator/openapi_dictionary.json
@@ -1,0 +1,6 @@
+{
+  "Cat.color": "black",
+  "Cat.livesLeft": 9,
+  "Dog.breed": "Golden Retriever",
+  "Dog.barkVolume": 10
+}


### PR DESCRIPTION
**What**: Fix partial test examples with missing discriminator and conditional assertions

**Why**:
- Partial examples that lack a discriminator should still be able to load successfully
- The assertion keys within the examples should be disregarded

**Checklist:**:
- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)