### PR TITLE
Integrated trivy for scanning the image vuln in the workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,7 +38,16 @@ jobs:
           
       - name: Build Docker Image
         run: docker build --no-cache -t znsio/specmatic:${{ steps.read_version.outputs.VERSION }} .
-        
+
+      - name: Fail build on High/Criticial Vulnerabilities
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: 'image'
+          scan-ref: 'znsio/specmatic:${{ steps.read_version.outputs.VERSION }}'
+          ignore-unfixed: true
+          severity: 'HIGH,CRITICAL'
+          exit-code: '1'
+
       - name: Push Docker Image
         run: docker push znsio/specmatic:${{ steps.read_version.outputs.VERSION }}
 


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Integrated trivy to scan and fail the docker push incase of any high or critical fixable severity vulnerability found in the docker image or code.

**Why**:

This will ensure the docker images are secure and does not contain any security vulnerability.