### PR TITLE
Fix asserts execution when body is a pattern token

### DIFF
--- a/core/src/main/kotlin/io/specmatic/test/asserts/Assert.kt
+++ b/core/src/main/kotlin/io/specmatic/test/asserts/Assert.kt
@@ -26,6 +26,8 @@ interface Assert {
 
     val prefix: String
     val key: String
+    val combinedKey: String
+        get() = listOf(prefix, key).filter(String::isNotEmpty).joinToString(".")
 
     companion object {
         fun parse(prefix: String, key: String, value: Value, resolver: Resolver): Assert? {

--- a/core/src/main/kotlin/io/specmatic/test/asserts/AssertComparison.kt
+++ b/core/src/main/kotlin/io/specmatic/test/asserts/AssertComparison.kt
@@ -15,7 +15,7 @@ class AssertComparison(override val prefix: String, override val key: String, va
 
         val dynamicList = dynamicAsserts(prefixValue)
         val results = dynamicList.map { newAssert ->
-            val finalKey = "${newAssert.prefix}.${newAssert.key}"
+            val finalKey = newAssert.combinedKey
             val actualValue = currentFactStore[finalKey] ?: return@map Result.Failure(breadCrumb = finalKey, message = "Could not resolve ${finalKey.quote()} in current fact store")
             assert(finalKey, actualValue, expectedValue)
         }

--- a/core/src/main/kotlin/io/specmatic/test/asserts/AssertExistence.kt
+++ b/core/src/main/kotlin/io/specmatic/test/asserts/AssertExistence.kt
@@ -24,7 +24,7 @@ class AssertExistence(override val prefix: String, override val key: String, val
 
         val dynamicList = dynamicAsserts(prefixValue)
         val results = dynamicList.map { newAssert ->
-            val finalKey = "${newAssert.prefix}.${newAssert.key}"
+            val finalKey = newAssert.combinedKey
             val actualValue = currentFactStore[finalKey]
             assert(finalKey, actualValue)
         }

--- a/core/src/main/kotlin/io/specmatic/test/asserts/AssertPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/test/asserts/AssertPattern.kt
@@ -15,7 +15,7 @@ class AssertPattern(override val prefix: String, override val key: String, val p
 
         val dynamicList = dynamicAsserts(prefixValue)
         val results = dynamicList.map { newAssert ->
-            val finalKey = "${newAssert.prefix}.${newAssert.key}"
+            val finalKey = newAssert.combinedKey
             val actualValue = currentFactStore[finalKey] ?: return@map Result.Failure(breadCrumb = finalKey, message = "Could not resolve ${finalKey.quote()} in current fact store")
             runCatching {
                 pattern.matches(actualValue, resolver).breadCrumb(finalKey)

--- a/core/src/test/kotlin/io/specmatic/test/asserts/AssertComparisonTest.kt
+++ b/core/src/test/kotlin/io/specmatic/test/asserts/AssertComparisonTest.kt
@@ -169,4 +169,16 @@ class AssertComparisonTest {
         Could not resolve "REQUEST.BODY" in current fact store
         """.trimIndent())
     }
+
+    @Test
+    fun `should not combine key if key is empty with prefix`() {
+        val assert = AssertComparison(prefix = "REQUEST.BODY", key = "", lookupKey = "ENTITY.name", isEqualityCheck = true)
+        val actualStore = mapOf("ENTITY.name" to StringValue("John"))
+        val bodyValue = StringValue("John")
+        val currentStore = bodyValue.toFactStore("REQUEST.BODY")
+
+        val result = assert.assert(currentStore, actualStore)
+        println(result.reportString())
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+    }
 }

--- a/core/src/test/kotlin/io/specmatic/test/asserts/AssertExistenceTest.kt
+++ b/core/src/test/kotlin/io/specmatic/test/asserts/AssertExistenceTest.kt
@@ -97,4 +97,16 @@ class AssertExistenceTest {
         Expected "REQUEST.BODY.name" to be null
         """.trimIndent())
     }
+
+    @Test
+    fun `should not combine key if key is empty with prefix`() {
+        val assert = AssertExistence(prefix = "REQUEST.BODY", key = "", checkType = ExistenceCheckType.EXISTS)
+        val actualStore = mapOf("ENTITY.name" to StringValue("John"))
+        val bodyValue = StringValue("John")
+        val currentStore = bodyValue.toFactStore("REQUEST.BODY")
+
+        val result = assert.assert(currentStore, actualStore)
+        println(result.reportString())
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+    }
 }

--- a/core/src/test/kotlin/io/specmatic/test/asserts/AssertPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/test/asserts/AssertPatternTest.kt
@@ -173,4 +173,16 @@ class AssertPatternTest {
         val result = assert.assert(currentStore, currentStore)
         assertThat(result).isInstanceOf(Result.Failure::class.java)
     }
+
+    @Test
+    fun `should not combine key if key is empty with prefix`() {
+        val assert = AssertPattern(prefix = "REQUEST.BODY", key = "", pattern = StringPattern(), resolver = Resolver())
+        val actualStore = mapOf("ENTITY.name" to StringValue("John"))
+        val bodyValue = StringValue("John")
+        val currentStore = bodyValue.toFactStore("REQUEST.BODY")
+
+        val result = assert.assert(currentStore, actualStore)
+        println(result.reportString())
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+    }
 }

--- a/core/src/test/resources/openapi/partial_with_discriminator/partial_with_body_token/get_example.json
+++ b/core/src/test/resources/openapi/partial_with_discriminator/partial_with_body_token/get_example.json
@@ -1,0 +1,18 @@
+{
+  "partial": {
+    "http-request": {
+      "path": "/pets",
+      "method": "GET"
+    },
+    "http-response": {
+      "status": 200,
+      "body": [
+        "(PetWithId)"
+      ],
+      "status-text": "Created",
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  }
+}

--- a/core/src/test/resources/openapi/partial_with_discriminator/partial_with_body_token/post_example.json
+++ b/core/src/test/resources/openapi/partial_with_discriminator/partial_with_body_token/post_example.json
@@ -1,0 +1,17 @@
+{
+  "partial": {
+    "http-request": {
+      "path": "/pets",
+      "method": "POST",
+      "body": "(Cat)"
+    },
+    "http-response": {
+      "status": 201,
+      "body": "(PetWithId)",
+      "status-text": "Created",
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  }
+}


### PR DESCRIPTION
**What**: Fix asserts execution when body is a pattern token

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
