### PR TITLE
Fixes to HttpRequest to pattern conversion for bad requests

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -1668,7 +1668,7 @@ data class Feature(
             pattern is NumberPattern || (pattern is DeferredPattern && pattern.pattern == "(number)") -> NumberSchema()
             pattern is BooleanPattern || (pattern is DeferredPattern && pattern.pattern == "(boolean)") -> BooleanSchema()
             pattern is DateTimePattern || (pattern is DeferredPattern && pattern.pattern == "(datetime)") -> StringSchema()
-            pattern is StringPattern || pattern is EmptyStringPattern || (pattern is DeferredPattern && pattern.pattern == "(string)") || (pattern is DeferredPattern && pattern.pattern == "(nothing)") -> StringSchema()
+            pattern is StringPattern || pattern is EmptyStringPattern || (pattern is DeferredPattern && pattern.pattern == "(string)") || (pattern is DeferredPattern && pattern.pattern == "(emptystring)") -> StringSchema()
             pattern is NullPattern || (pattern is DeferredPattern && pattern.pattern == "(null)") -> Schema<Any>().apply {
                 this.nullable = true
             }

--- a/core/src/main/kotlin/io/specmatic/core/HttpPathPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpPathPattern.kt
@@ -346,6 +346,12 @@ data class HttpPathPattern(
 
         return true
     }
+
+    companion object {
+        fun from(path: String): HttpPathPattern {
+            return buildHttpPathPattern(path)
+        }
+    }
 }
 
 fun buildHttpPathPattern(

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
@@ -12,6 +12,7 @@ import io.specmatic.core.discriminator.DiscriminatorBasedValueGenerator
 import io.specmatic.core.discriminator.DiscriminatorMetadata
 import io.specmatic.core.utilities.Flags
 import io.specmatic.core.utilities.Flags.Companion.EXTENSIBLE_QUERY_PARAMS
+import io.specmatic.core.value.EmptyString
 import io.specmatic.core.value.JSONArrayValue
 import io.specmatic.core.value.JSONObjectValue
 
@@ -318,6 +319,7 @@ data class HttpRequestPattern(
             requestPattern = attempt(breadCrumb = "BODY") {
                 requestPattern.copy(
                     body = when (request.body) {
+                        EmptyString -> NoBodyPattern
                         is StringValue -> encompassedType(request.bodyString, null, body, resolver)
                         else -> request.body.exactMatchElseType()
                     }
@@ -445,7 +447,7 @@ data class HttpRequestPattern(
     private fun encompassedType(valueString: String, key: String?, type: Pattern, resolver: Resolver): Pattern {
         return when {
             isPatternToken(valueString) -> resolvedHop(parsedPattern(valueString, key), resolver)
-            else -> type.parseToType(valueString, resolver)
+            else -> runCatching { type.parseToType(valueString, resolver) }.getOrElse { StringValue(valueString).exactMatchElseType() }
         }
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
@@ -319,7 +319,8 @@ data class HttpRequestPattern(
             requestPattern = attempt(breadCrumb = "BODY") {
                 requestPattern.copy(
                     body = when (request.body) {
-                        EmptyString -> NoBodyPattern
+                        EmptyString -> EmptyStringPattern
+                        NoBodyValue -> NoBodyPattern
                         is StringValue -> encompassedType(request.bodyString, null, body, resolver)
                         else -> request.body.exactMatchElseType()
                     }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/EmptyStringPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/EmptyStringPattern.kt
@@ -44,5 +44,5 @@ object EmptyStringPattern : Pattern {
 
     override val pattern: Any = ""
 
-    override fun toString(): String = "(nothing)"
+    override fun toString(): String = "(emptystring)"
 }

--- a/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
@@ -1,15 +1,13 @@
 package io.specmatic.core
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import io.mockk.every
 import io.mockk.mockk
 import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.core.discriminator.DiscriminatorBasedItem
 import io.specmatic.core.discriminator.DiscriminatorMetadata
-import io.specmatic.core.pattern.ContractException
-import io.specmatic.core.pattern.HasValue
-import io.specmatic.core.pattern.NumberPattern
-import io.specmatic.core.pattern.StringPattern
-import io.specmatic.core.pattern.parsedJSONObject
+import io.specmatic.core.pattern.*
 import io.specmatic.core.utilities.exceptionCauseMessage
 import io.specmatic.core.value.*
 import io.specmatic.stub.captureStandardOutput
@@ -2699,6 +2697,27 @@ paths:
 
             assertTrue(pairs.isEmpty())
         }
+    }
+
+    @Test
+    fun `EmptyStringPattern in request should result in no request body`() {
+        val httpRequestPattern = HttpRequestPattern(
+            method = "POST",
+            httpPathPattern = HttpPathPattern.from("/data"),
+            body = EmptyStringPattern
+        )
+
+        val scenario = Scenario(
+            "",
+            httpRequestPattern,
+            HttpResponsePattern(status = 200),
+            exampleName = "example"
+        )
+
+        val feature = Feature(name = "", scenarios = listOf(scenario))
+
+        val openAPI = feature.toOpenApi()
+        assertThat(openAPI.paths["/data"]?.post?.requestBody).isNull()
     }
 
     companion object {

--- a/core/src/test/kotlin/io/specmatic/core/HttpRequestPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpRequestPatternTest.kt
@@ -842,7 +842,7 @@ internal class HttpRequestPatternTest {
         val httpRequest = HttpRequest(path = "/", method = "GET")
         val newRequestPattern = httpRequestPattern.generate(httpRequest, Resolver())
 
-        assertThat(newRequestPattern.body).isEqualTo(NoBodyPattern)
+        assertThat(newRequestPattern.body).isEqualTo(EmptyStringPattern)
     }
 
     private fun String.toExactValuePattern(): ExactValuePattern = ExactValuePattern(StringValue(this))


### PR DESCRIPTION
**What**: Fixes to HttpRequest for pattern conversion for bad requests

**How**:
- In the case of a parsing failure, the value should be converted to the ExactValue pattern of stringValue
- An EmptyString Body should be converted into the NoBodyPattern

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)

**Issue ID**:
Closes: #1494
Closes: #1498
