### PR TITLE
Fix partial example loading and validation with extensible schema

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/KeyCheck.kt
+++ b/core/src/main/kotlin/io/specmatic/core/KeyCheck.kt
@@ -37,6 +37,10 @@ data class KeyCheck(val patternKeyCheck: KeyErrorCheck = CheckOnlyPatternKeys,
     fun isPartial(): Boolean {
         return patternKeyCheck == noPatternKeyCheck
     }
+
+    fun toPartialKeyCheck(): KeyCheck {
+        return this.copy(patternKeyCheck = noPatternKeyCheck)
+    }
 }
 
 private fun overrideUnexpectedKeyCheck(keyCheck: KeyCheck, unexpectedKeyCheck: UnexpectedKeyCheck): KeyCheck {

--- a/core/src/main/kotlin/io/specmatic/core/Resolver.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Resolver.kt
@@ -436,6 +436,10 @@ ${matchResult.reportString()}
     fun isPartial(): Boolean {
         return this.findKeyErrorCheck.isPartial()
     }
+
+    fun toPartial(): Resolver {
+        return this.copy(findKeyErrorCheck = findKeyErrorCheck.toPartialKeyCheck())
+    }
 }
 
 private fun ExactValuePattern.hasPatternToken(): Boolean {

--- a/core/src/main/kotlin/io/specmatic/core/Resolver.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Resolver.kt
@@ -433,12 +433,16 @@ ${matchResult.reportString()}
         return this.copy(cycleMarker = lookupPath(jsonPattern.typeAlias, key))
     }
 
-    fun isPartial(): Boolean {
+    fun hasPartialKeyCheck(): Boolean {
         return this.findKeyErrorCheck.isPartial()
     }
 
-    fun toPartial(): Resolver {
+    fun partializeKeyCheck(): Resolver {
         return this.copy(findKeyErrorCheck = findKeyErrorCheck.toPartialKeyCheck())
+    }
+
+    fun getPartialKeyCheck(): KeyCheck {
+        return findKeyErrorCheck.toPartialKeyCheck()
     }
 }
 

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -335,7 +335,7 @@ data class Scenario(
             resolver.copy(
                 mockMode = true,
                 mismatchMessages = mismatchMessages,
-                findKeyErrorCheck = if (isPartial) resolver.findKeyErrorCheck.toPartialKeyCheck() else resolver.findKeyErrorCheck
+                findKeyErrorCheck = if (isPartial) resolver.getPartialKeyCheck() else resolver.findKeyErrorCheck
             )
         )
 
@@ -559,7 +559,7 @@ data class Scenario(
                 return "The $keyLabel $keyName in the specification was missing in example ${row.name}"
             }
         },
-        findKeyErrorCheck = if (row.isPartial) updatedResolver.findKeyErrorCheck.toPartialKeyCheck() else updatedResolver.findKeyErrorCheck,
+        findKeyErrorCheck = if (row.isPartial) updatedResolver.getPartialKeyCheck() else updatedResolver.findKeyErrorCheck,
         mockMode = true
     )
 
@@ -839,7 +839,7 @@ data class Scenario(
     }
 
     fun matchesPartial(template: ScenarioStub): Result {
-        val updatedResolver = resolver.copy(mockMode = true).toPartial()
+        val updatedResolver = resolver.copy(mockMode = true).partializeKeyCheck()
 
         val requestMatch = attempt(breadCrumb = "REQUEST") {
             if (template.response.status !in invalidRequestStatuses) {
@@ -901,7 +901,7 @@ data class Scenario(
         ).update(
             resolver.copy(
                 mockMode = true,
-                findKeyErrorCheck = if (isPartial) resolver.findKeyErrorCheck.toPartialKeyCheck() else resolver.findKeyErrorCheck
+                findKeyErrorCheck = if (isPartial) resolver.getPartialKeyCheck() else resolver.findKeyErrorCheck
             )
         )
 

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -335,7 +335,7 @@ data class Scenario(
             resolver.copy(
                 mockMode = true,
                 mismatchMessages = mismatchMessages,
-                findKeyErrorCheck = if (isPartial) PARTIAL_KEYCHECK else resolver.findKeyErrorCheck
+                findKeyErrorCheck = if (isPartial) resolver.findKeyErrorCheck.toPartialKeyCheck() else resolver.findKeyErrorCheck
             )
         )
 
@@ -559,7 +559,7 @@ data class Scenario(
                 return "The $keyLabel $keyName in the specification was missing in example ${row.name}"
             }
         },
-        findKeyErrorCheck = if (row.isPartial) PARTIAL_KEYCHECK else updatedResolver.findKeyErrorCheck,
+        findKeyErrorCheck = if (row.isPartial) updatedResolver.findKeyErrorCheck.toPartialKeyCheck() else updatedResolver.findKeyErrorCheck,
         mockMode = true
     )
 
@@ -839,7 +839,7 @@ data class Scenario(
     }
 
     fun matchesPartial(template: ScenarioStub): Result {
-        val updatedResolver = resolver.copy(findKeyErrorCheck = PARTIAL_KEYCHECK, mockMode = true)
+        val updatedResolver = resolver.copy(mockMode = true).toPartial()
 
         val requestMatch = attempt(breadCrumb = "REQUEST") {
             if (template.response.status !in invalidRequestStatuses) {
@@ -901,7 +901,7 @@ data class Scenario(
         ).update(
             resolver.copy(
                 mockMode = true,
-                findKeyErrorCheck = if (isPartial) PARTIAL_KEYCHECK else resolver.findKeyErrorCheck
+                findKeyErrorCheck = if (isPartial) resolver.findKeyErrorCheck.toPartialKeyCheck() else resolver.findKeyErrorCheck
             )
         )
 
@@ -973,8 +973,3 @@ val noPatternKeyCheck = object : KeyErrorCheck {
         return emptyList()
     }
 }
-
-val PARTIAL_KEYCHECK = KeyCheck(
-    patternKeyCheck = noPatternKeyCheck,
-    unexpectedKeyCheck = ValidateUnexpectedKeys
-)

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -509,10 +509,8 @@ data class Scenario(
     fun validExamplesOrException(flagsBased: FlagsBased) {
         val rowsToValidate = examples.flatMap { it.rows }
 
-        val updatedResolver = flagsBased.update(resolver)
-
         val errors = rowsToValidate.mapNotNull { row ->
-            val resolverForExample = resolverForValidation(updatedResolver, row)
+            val resolverForExample = flagsBased.update(resolverForValidation(resolver, row))
 
             val requestError = nullOrExceptionString {
                 validateRequestExample(row, resolverForExample)

--- a/core/src/main/kotlin/io/specmatic/core/pattern/Discriminator.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/Discriminator.kt
@@ -94,7 +94,7 @@ class Discriminator(
         if (sampleData !is JSONObjectValue)
             return jsonObjectMismatchError(resolver, sampleData)
 
-        if (!valueHasDiscriminator(sampleData) && resolver.isPartial()) {
+        if (!valueHasDiscriminator(sampleData) && resolver.hasPartialKeyCheck()) {
             return _matches_partial(sampleData, pattern, key, resolver)
         }
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/Discriminator.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/Discriminator.kt
@@ -1,7 +1,6 @@
 package io.specmatic.core.pattern
 
 import io.specmatic.core.FailureReason
-import io.specmatic.core.PARTIAL_KEYCHECK
 import io.specmatic.core.Resolver
 import io.specmatic.core.Result
 import io.specmatic.core.pattern.AnyPattern.AnyPatternMatch
@@ -95,7 +94,7 @@ class Discriminator(
         if (sampleData !is JSONObjectValue)
             return jsonObjectMismatchError(resolver, sampleData)
 
-        if (!valueHasDiscriminator(sampleData) && resolver.findKeyErrorCheck.isPartial()) {
+        if (!valueHasDiscriminator(sampleData) && resolver.isPartial()) {
             return _matches_partial(sampleData, pattern, key, resolver)
         }
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/Discriminator.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/Discriminator.kt
@@ -95,7 +95,7 @@ class Discriminator(
         if (sampleData !is JSONObjectValue)
             return jsonObjectMismatchError(resolver, sampleData)
 
-        if (!valueHasDiscriminator(sampleData) && resolver.findKeyErrorCheck == PARTIAL_KEYCHECK) {
+        if (!valueHasDiscriminator(sampleData) && resolver.findKeyErrorCheck.isPartial()) {
             return _matches_partial(sampleData, pattern, key, resolver)
         }
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
@@ -605,7 +605,7 @@ private fun generateIfPatternToken(value: Value, resolver: Resolver): ReturnValu
 }
 
 private fun adjustedPattern(jsonPatternMap: Map<String, Pattern>, resolver: Resolver): Map<String, Pattern> {
-    if (resolver.isPartial()) return emptyMap()
+    if (resolver.hasPartialKeyCheck()) return emptyMap()
     if (!resolver.allPatternsAreMandatory) return jsonPatternMap.filterKeys { !isOptional(it) }
     return jsonPatternMap.mapKeys { withoutOptionality(it.key) }
 }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
@@ -14,7 +14,7 @@ data class ListPattern(
 
     override fun fixValue(value: Value, resolver: Resolver): Value {
         if (resolver.matchesPattern(null, this, value).isSuccess()) return value
-        if (value !is JSONArrayValue || (value.list.isEmpty() && resolver.allPatternsAreMandatory && !resolver.isPartial())) {
+        if (value !is JSONArrayValue || (value.list.isEmpty() && resolver.allPatternsAreMandatory && !resolver.hasPartialKeyCheck())) {
             return pattern.listOf(0.until(randomNumber(3)).mapIndexed { index, _ ->
                 attempt(breadCrumb = "[$index (random)]") { pattern.fixValue(NullValue, resolver) }
             }, resolver)

--- a/core/src/test/kotlin/io/specmatic/core/HttpHeadersPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpHeadersPatternTest.kt
@@ -718,7 +718,7 @@ internal class HttpHeadersPatternTest {
         @Test
         fun `should not add missing mandatory keys when resolver is set to partial`() {
             val httpHeaders = HttpHeadersPattern(mapOf("number" to NumberPattern(), "string" to StringPattern()))
-            val resolver = Resolver(dictionary = mapOf("(number)" to NumberValue(999), "(string)" to StringValue("TODO"))).toPartial()
+            val resolver = Resolver(dictionary = mapOf("(number)" to NumberValue(999), "(string)" to StringValue("TODO"))).partializeKeyCheck()
             val partialInvalidValue = mapOf("number" to "(string)")
             val fixedValue = httpHeaders.fixValue(partialInvalidValue, resolver)
 

--- a/core/src/test/kotlin/io/specmatic/core/HttpHeadersPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpHeadersPatternTest.kt
@@ -718,7 +718,7 @@ internal class HttpHeadersPatternTest {
         @Test
         fun `should not add missing mandatory keys when resolver is set to partial`() {
             val httpHeaders = HttpHeadersPattern(mapOf("number" to NumberPattern(), "string" to StringPattern()))
-            val resolver = Resolver(findKeyErrorCheck = PARTIAL_KEYCHECK, dictionary = mapOf("(number)" to NumberValue(999), "(string)" to StringValue("TODO")))
+            val resolver = Resolver(dictionary = mapOf("(number)" to NumberValue(999), "(string)" to StringValue("TODO"))).toPartial()
             val partialInvalidValue = mapOf("number" to "(string)")
             val fixedValue = httpHeaders.fixValue(partialInvalidValue, resolver)
 

--- a/core/src/test/kotlin/io/specmatic/core/HttpQueryParamPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpQueryParamPatternTest.kt
@@ -669,7 +669,7 @@ class HttpQueryParamPatternTest {
         @Test
         fun `should not add missing mandatory keys when resolver is set to partial`() {
             val httpQueryPattern = HttpQueryParamPattern(mapOf("number" to NumberPattern(), "boolean" to BooleanPattern()))
-            val resolver = Resolver(dictionary = mapOf("(number)" to NumberValue(999), "(boolean)" to BooleanValue(true))).toPartial()
+            val resolver = Resolver(dictionary = mapOf("(number)" to NumberValue(999), "(boolean)" to BooleanValue(true))).partializeKeyCheck()
             val partialInvalidValue = QueryParameters(mapOf("number" to "(string)"))
             val fixedValue = httpQueryPattern.fixValue(partialInvalidValue, resolver)
 

--- a/core/src/test/kotlin/io/specmatic/core/HttpQueryParamPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpQueryParamPatternTest.kt
@@ -669,7 +669,7 @@ class HttpQueryParamPatternTest {
         @Test
         fun `should not add missing mandatory keys when resolver is set to partial`() {
             val httpQueryPattern = HttpQueryParamPattern(mapOf("number" to NumberPattern(), "boolean" to BooleanPattern()))
-            val resolver = Resolver(findKeyErrorCheck = PARTIAL_KEYCHECK, dictionary = mapOf("(number)" to NumberValue(999), "(boolean)" to BooleanValue(true)))
+            val resolver = Resolver(dictionary = mapOf("(number)" to NumberValue(999), "(boolean)" to BooleanValue(true))).toPartial()
             val partialInvalidValue = QueryParameters(mapOf("number" to "(string)"))
             val fixedValue = httpQueryPattern.fixValue(partialInvalidValue, resolver)
 

--- a/core/src/test/kotlin/io/specmatic/core/KeyCheckTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/KeyCheckTest.kt
@@ -172,4 +172,16 @@ internal class KeyCheckTest {
         assertThat(errors[0].name).isEqualTo("key1")
         assertThat(errors[1].name).isEqualTo("key2")
     }
+
+    @Test
+    fun `isPartial should return true when keyCheck is partial key check`() {
+        val partialKeyChecks = listOf(
+            KeyCheck(patternKeyCheck = noPatternKeyCheck, unexpectedKeyCheck = IgnoreUnexpectedKeys),
+            KeyCheck(patternKeyCheck = noPatternKeyCheck, unexpectedKeyCheck = ValidateUnexpectedKeys),
+        )
+
+        assertThat(partialKeyChecks).allSatisfy {
+            assertThat(it.isPartial()).isTrue()
+        }
+    }
 }

--- a/core/src/test/kotlin/io/specmatic/core/pattern/AnyPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/AnyPatternTest.kt
@@ -412,7 +412,7 @@ internal class AnyPatternTest {
             )
         )
         val invalidValue = JSONObjectValue(mapOf("newKey" to StringValue("value"), "prop" to BooleanValue(true)))
-        val result = pattern.matches(invalidValue, Resolver().toPartial())
+        val result = pattern.matches(invalidValue, Resolver().partializeKeyCheck())
 
         assertThat(result).isInstanceOf(Result.Failure::class.java)
         assertThat(result.reportString()).isEqualToNormalizingWhitespace("""    
@@ -443,7 +443,7 @@ internal class AnyPatternTest {
         )
 
         val partialResolvers = listOf(
-            Resolver().toPartial(),
+            Resolver().partializeKeyCheck(),
             Resolver(findKeyErrorCheck = KeyCheck(noPatternKeyCheck, IgnoreUnexpectedKeys)),
             Resolver(findKeyErrorCheck = KeyCheck(noPatternKeyCheck, ValidateUnexpectedKeys)),
         )
@@ -789,7 +789,7 @@ internal class AnyPatternTest {
                     mapping = mapOf("sub1" to "#/components/schemas/Sub1", "sub2" to "#/components/schemas/Sub2")
                 )
             )
-            val resolver = Resolver(dictionary = mapOf("(number)" to NumberValue(999))).toPartial()
+            val resolver = Resolver(dictionary = mapOf("(number)" to NumberValue(999))).partializeKeyCheck()
             val partialValue = JSONObjectValue(mapOf("extra" to StringValue("(string)")))
             val fixedValue = pattern.fixValue(partialValue, resolver)
 

--- a/core/src/test/kotlin/io/specmatic/core/pattern/AnyPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/AnyPatternTest.kt
@@ -412,7 +412,7 @@ internal class AnyPatternTest {
             )
         )
         val invalidValue = JSONObjectValue(mapOf("newKey" to StringValue("value"), "prop" to BooleanValue(true)))
-        val result = pattern.matches(invalidValue, Resolver(findKeyErrorCheck = PARTIAL_KEYCHECK))
+        val result = pattern.matches(invalidValue, Resolver().toPartial())
 
         assertThat(result).isInstanceOf(Result.Failure::class.java)
         assertThat(result.reportString()).isEqualToNormalizingWhitespace("""    
@@ -443,7 +443,7 @@ internal class AnyPatternTest {
         )
 
         val partialResolvers = listOf(
-            Resolver(findKeyErrorCheck = PARTIAL_KEYCHECK),
+            Resolver().toPartial(),
             Resolver(findKeyErrorCheck = KeyCheck(noPatternKeyCheck, IgnoreUnexpectedKeys)),
             Resolver(findKeyErrorCheck = KeyCheck(noPatternKeyCheck, ValidateUnexpectedKeys)),
         )
@@ -789,7 +789,7 @@ internal class AnyPatternTest {
                     mapping = mapOf("sub1" to "#/components/schemas/Sub1", "sub2" to "#/components/schemas/Sub2")
                 )
             )
-            val resolver = Resolver(findKeyErrorCheck = PARTIAL_KEYCHECK, dictionary = mapOf("(number)" to NumberValue(999)))
+            val resolver = Resolver(dictionary = mapOf("(number)" to NumberValue(999))).toPartial()
             val partialValue = JSONObjectValue(mapOf("extra" to StringValue("(string)")))
             val fixedValue = pattern.fixValue(partialValue, resolver)
 

--- a/core/src/test/kotlin/io/specmatic/core/pattern/JSONObjectPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/JSONObjectPatternTest.kt
@@ -2327,7 +2327,7 @@ components:
         @Test
         fun `should not add missing mandatory keys when resolver is set to partial`() {
             val pattern = JSONObjectPattern(mapOf("number" to NumberPattern(), "string" to StringPattern()), typeAlias = "(Test)")
-            val resolver = Resolver(dictionary = mapOf("(number)" to NumberValue(999), "(string)" to StringValue("TODO"))).toPartial()
+            val resolver = Resolver(dictionary = mapOf("(number)" to NumberValue(999), "(string)" to StringValue("TODO"))).partializeKeyCheck()
             val partialInvalidValue = JSONObjectValue(mapOf("number" to StringValue("(string)")))
             val fixedValue = pattern.fixValue(partialInvalidValue, resolver)
 

--- a/core/src/test/kotlin/io/specmatic/core/pattern/JSONObjectPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/JSONObjectPatternTest.kt
@@ -2327,10 +2327,7 @@ components:
         @Test
         fun `should not add missing mandatory keys when resolver is set to partial`() {
             val pattern = JSONObjectPattern(mapOf("number" to NumberPattern(), "string" to StringPattern()), typeAlias = "(Test)")
-            val resolver = Resolver(
-                findKeyErrorCheck = PARTIAL_KEYCHECK,
-                dictionary = mapOf("(number)" to NumberValue(999), "(string)" to StringValue("TODO"))
-            )
+            val resolver = Resolver(dictionary = mapOf("(number)" to NumberValue(999), "(string)" to StringValue("TODO"))).toPartial()
             val partialInvalidValue = JSONObjectValue(mapOf("number" to StringValue("(string)")))
             val fixedValue = pattern.fixValue(partialInvalidValue, resolver)
 

--- a/core/src/test/kotlin/io/specmatic/core/pattern/ListPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/ListPatternTest.kt
@@ -563,7 +563,7 @@ Feature: Recursive test
         fun `should not generate values when list is empty and resolver is partial`() {
             val innerPattern = JSONObjectPattern(mapOf("number" to NumberPattern()), typeAlias = "(Object)")
             val pattern = ListPattern(innerPattern, typeAlias = "(List)")
-            val resolver = Resolver(newPatterns = mapOf("(List)" to pattern, "(Object)" to innerPattern)).toPartial()
+            val resolver = Resolver(newPatterns = mapOf("(List)" to pattern, "(Object)" to innerPattern)).partializeKeyCheck()
             val partialValue = JSONArrayValue(listOf())
 
             val fixedValue = pattern.fixValue(partialValue, resolver)

--- a/core/src/test/kotlin/io/specmatic/core/pattern/ListPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/ListPatternTest.kt
@@ -563,7 +563,7 @@ Feature: Recursive test
         fun `should not generate values when list is empty and resolver is partial`() {
             val innerPattern = JSONObjectPattern(mapOf("number" to NumberPattern()), typeAlias = "(Object)")
             val pattern = ListPattern(innerPattern, typeAlias = "(List)")
-            val resolver = Resolver(newPatterns = mapOf("(List)" to pattern, "(Object)" to innerPattern), findKeyErrorCheck = PARTIAL_KEYCHECK)
+            val resolver = Resolver(newPatterns = mapOf("(List)" to pattern, "(Object)" to innerPattern)).toPartial()
             val partialValue = JSONArrayValue(listOf())
 
             val fixedValue = pattern.fixValue(partialValue, resolver)

--- a/core/src/test/resources/openapi/partial_with_discriminator/extended_partial/partial_example.json
+++ b/core/src/test/resources/openapi/partial_with_discriminator/extended_partial/partial_example.json
@@ -1,0 +1,22 @@
+{
+  "partial": {
+    "http-request": {
+      "path": "/pets",
+      "method": "POST",
+      "body": {
+        "livesLeft": "(number)",
+        "extraKey": "extraValue"
+      }
+    },
+    "http-response": {
+      "status": 201,
+      "body": {
+        "id": 1
+      },
+      "status-text": "Created",
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  }
+}


### PR DESCRIPTION
**What**: Fix partial example loading and validation with extensible schema

**Why**: Enabling extensible schema should not affect partial example validation, and vice versa.

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)