### PR TITLE
Implement partial fixing for the fixValue methods

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/KeyCheck.kt
+++ b/core/src/main/kotlin/io/specmatic/core/KeyCheck.kt
@@ -34,6 +34,9 @@ data class KeyCheck(val patternKeyCheck: KeyErrorCheck = CheckOnlyPatternKeys,
         return patternKeyCheck.validateListCaseInsensitive(pattern, actual).plus(unexpectedKeyCheck.validateListCaseInsensitive(pattern, actual))
     }
 
+    fun isPartial(): Boolean {
+        return patternKeyCheck == noPatternKeyCheck
+    }
 }
 
 private fun overrideUnexpectedKeyCheck(keyCheck: KeyCheck, unexpectedKeyCheck: UnexpectedKeyCheck): KeyCheck {

--- a/core/src/main/kotlin/io/specmatic/core/Resolver.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Resolver.kt
@@ -435,6 +435,10 @@ ${matchResult.reportString()}
     fun cyclePast(jsonPattern: Pattern, key: String): Resolver {
         return this.copy(cycleMarker = lookupPath(jsonPattern.typeAlias, key))
     }
+
+    fun isPartial(): Boolean {
+        return this.findKeyErrorCheck.isPartial()
+    }
 }
 
 private fun ExactValuePattern.hasPatternToken(): Boolean {

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -894,13 +894,18 @@ data class Scenario(
         return defaultAttributeSelectionFields.plus(attributeSelectionFieldsFromRequest)
     }
 
-    fun fixRequestResponse(httpRequest: HttpRequest, httpResponse: HttpResponse, flagsBased: FlagsBased): Pair<HttpRequest, HttpResponse> {
+    fun fixRequestResponse(httpRequest: HttpRequest, httpResponse: HttpResponse, flagsBased: FlagsBased, isPartial: Boolean): Pair<HttpRequest, HttpResponse> {
         val updatedResolver = flagsBased.copy(
             unexpectedKeyCheck = when {
                 isRequestAttributeSelected(httpRequest) -> ValidateUnexpectedKeys
                 else -> flagsBased.unexpectedKeyCheck
             }
-        ).update(resolver).copy(mockMode = true)
+        ).update(
+            resolver.copy(
+                mockMode = true,
+                findKeyErrorCheck = if (isPartial) PARTIAL_KEYCHECK else resolver.findKeyErrorCheck
+            )
+        )
 
         this.newBasedOnAttributeSelectionFields(httpRequest.queryParams).let { newScenario ->
             return Pair(

--- a/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
@@ -605,6 +605,7 @@ private fun generateIfPatternToken(value: Value, resolver: Resolver): ReturnValu
 }
 
 private fun adjustedPattern(jsonPatternMap: Map<String, Pattern>, resolver: Resolver): Map<String, Pattern> {
+    if (resolver.findKeyErrorCheck.isPartial()) return emptyMap()
     if (!resolver.allPatternsAreMandatory) return jsonPatternMap.filterKeys { !isOptional(it) }
     return jsonPatternMap.mapKeys { withoutOptionality(it.key) }
 }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
@@ -605,7 +605,7 @@ private fun generateIfPatternToken(value: Value, resolver: Resolver): ReturnValu
 }
 
 private fun adjustedPattern(jsonPatternMap: Map<String, Pattern>, resolver: Resolver): Map<String, Pattern> {
-    if (resolver.findKeyErrorCheck.isPartial()) return emptyMap()
+    if (resolver.isPartial()) return emptyMap()
     if (!resolver.allPatternsAreMandatory) return jsonPatternMap.filterKeys { !isOptional(it) }
     return jsonPatternMap.mapKeys { withoutOptionality(it.key) }
 }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
@@ -14,7 +14,7 @@ data class ListPattern(
 
     override fun fixValue(value: Value, resolver: Resolver): Value {
         if (resolver.matchesPattern(null, this, value).isSuccess()) return value
-        if (value !is JSONArrayValue || (value.list.isEmpty() && resolver.allPatternsAreMandatory)) {
+        if (value !is JSONArrayValue || (value.list.isEmpty() && resolver.allPatternsAreMandatory && !resolver.findKeyErrorCheck.isPartial())) {
             return pattern.listOf(0.until(randomNumber(3)).mapIndexed { index, _ ->
                 attempt(breadCrumb = "[$index (random)]") { pattern.fixValue(NullValue, resolver) }
             }, resolver)

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
@@ -14,7 +14,7 @@ data class ListPattern(
 
     override fun fixValue(value: Value, resolver: Resolver): Value {
         if (resolver.matchesPattern(null, this, value).isSuccess()) return value
-        if (value !is JSONArrayValue || (value.list.isEmpty() && resolver.allPatternsAreMandatory && !resolver.findKeyErrorCheck.isPartial())) {
+        if (value !is JSONArrayValue || (value.list.isEmpty() && resolver.allPatternsAreMandatory && !resolver.isPartial())) {
             return pattern.listOf(0.until(randomNumber(3)).mapIndexed { index, _ ->
                 attempt(breadCrumb = "[$index (random)]") { pattern.fixValue(NullValue, resolver) }
             }, resolver)

--- a/core/src/test/kotlin/io/specmatic/core/HttpHeadersPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpHeadersPatternTest.kt
@@ -714,6 +714,16 @@ internal class HttpHeadersPatternTest {
             println(fixedValue)
             assertThat(fixedValue).isEqualTo(mapOf("number" to "999", "boolean" to "true"))
         }
+
+        @Test
+        fun `should not add missing mandatory keys when resolver is set to partial`() {
+            val httpHeaders = HttpHeadersPattern(mapOf("number" to NumberPattern(), "string" to StringPattern()))
+            val resolver = Resolver(findKeyErrorCheck = PARTIAL_KEYCHECK, dictionary = mapOf("(number)" to NumberValue(999), "(string)" to StringValue("TODO")))
+            val partialInvalidValue = mapOf("number" to "(string)")
+            val fixedValue = httpHeaders.fixValue(partialInvalidValue, resolver)
+
+            assertThat(fixedValue).isEqualTo(mapOf("number" to "999"))
+        }
     }
 
     @ParameterizedTest

--- a/core/src/test/kotlin/io/specmatic/core/HttpQueryParamPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpQueryParamPatternTest.kt
@@ -665,6 +665,16 @@ class HttpQueryParamPatternTest {
             println(fixedValue)
             assertThat(fixedValue.asMap()).isEqualTo(mapOf("number" to "999", "boolean" to "true"))
         }
+
+        @Test
+        fun `should not add missing mandatory keys when resolver is set to partial`() {
+            val httpQueryPattern = HttpQueryParamPattern(mapOf("number" to NumberPattern(), "boolean" to BooleanPattern()))
+            val resolver = Resolver(findKeyErrorCheck = PARTIAL_KEYCHECK, dictionary = mapOf("(number)" to NumberValue(999), "(boolean)" to BooleanValue(true)))
+            val partialInvalidValue = QueryParameters(mapOf("number" to "(string)"))
+            val fixedValue = httpQueryPattern.fixValue(partialInvalidValue, resolver)
+
+            assertThat(fixedValue.asMap()).isEqualTo(mapOf("number" to "999"))
+        }
     }
 
     @Nested

--- a/core/src/test/kotlin/io/specmatic/core/pattern/AnyPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/AnyPatternTest.kt
@@ -690,6 +690,26 @@ internal class AnyPatternTest {
                 assertThat(fixedValue).isNotEqualTo(it).isInstanceOf(JSONObjectValue::class.java)
             }
         }
+
+        @Test
+        fun `should be able to fix invalid values with a partial resolver`() {
+            val pattern = AnyPattern(
+                listOf(
+                    JSONObjectPattern(mapOf("type" to "sub1".toDiscriminator(), "prop" to StringPattern(), "extra" to NumberPattern()), typeAlias = "(Sub1)"),
+                    JSONObjectPattern(mapOf("type" to "sub2".toDiscriminator(), "prop" to NumberPattern()), typeAlias = "(Sub2)")
+                ), typeAlias = "(Base)",
+                discriminator = Discriminator(
+                    property = "type",
+                    values = setOf("sub1", "sub2"),
+                    mapping = mapOf("sub1" to "#/components/schemas/Sub1", "sub2" to "#/components/schemas/Sub2")
+                )
+            )
+            val resolver = Resolver(findKeyErrorCheck = PARTIAL_KEYCHECK, dictionary = mapOf("(number)" to NumberValue(999)))
+            val partialValue = JSONObjectValue(mapOf("extra" to StringValue("(string)")))
+            val fixedValue = pattern.fixValue(partialValue, resolver)
+
+            assertThat(fixedValue).isEqualTo(JSONObjectValue(mapOf("extra" to NumberValue(999))))
+        }
     }
 
     @Nested

--- a/core/src/test/kotlin/io/specmatic/core/pattern/JSONObjectPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/JSONObjectPatternTest.kt
@@ -2323,6 +2323,19 @@ components:
                 }
             )
         }
+
+        @Test
+        fun `should not add missing mandatory keys when resolver is set to partial`() {
+            val pattern = JSONObjectPattern(mapOf("number" to NumberPattern(), "string" to StringPattern()), typeAlias = "(Test)")
+            val resolver = Resolver(
+                findKeyErrorCheck = PARTIAL_KEYCHECK,
+                dictionary = mapOf("(number)" to NumberValue(999), "(string)" to StringValue("TODO"))
+            )
+            val partialInvalidValue = JSONObjectValue(mapOf("number" to StringValue("(string)")))
+            val fixedValue = pattern.fixValue(partialInvalidValue, resolver)
+
+            assertThat(fixedValue).isEqualTo(JSONObjectValue(mapOf("number" to NumberValue(999))))
+        }
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/core/pattern/ListPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/ListPatternTest.kt
@@ -558,6 +558,17 @@ Feature: Recursive test
                 assertThat((fixedValue as JSONArrayValue).list).hasOnlyElementsOfType(JSONObjectValue::class.java)
             }
         }
+
+        @Test
+        fun `should not generate values when list is empty and resolver is partial`() {
+            val innerPattern = JSONObjectPattern(mapOf("number" to NumberPattern()), typeAlias = "(Object)")
+            val pattern = ListPattern(innerPattern, typeAlias = "(List)")
+            val resolver = Resolver(newPatterns = mapOf("(List)" to pattern, "(Object)" to innerPattern), findKeyErrorCheck = PARTIAL_KEYCHECK)
+            val partialValue = JSONArrayValue(listOf())
+
+            val fixedValue = pattern.fixValue(partialValue, resolver)
+            assertThat(fixedValue).isEqualTo(partialValue)
+        }
     }
 
     @Nested


### PR DESCRIPTION
**What**: Implement partial fixing for the fixValue methods

**Why**: Fixing a partial value should not result in the addition of any missing mandatory keys

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
