### PR TITLE
Ability for Partial scenarioStubs to serialize into partial examples

### DIFF
--- a/core/src/main/kotlin/io/specmatic/mock/ScenarioStub.kt
+++ b/core/src/main/kotlin/io/specmatic/mock/ScenarioStub.kt
@@ -47,28 +47,23 @@ data class ScenarioStub(
     fun isPartial() = partial != null
 
     fun toJSON(): JSONObjectValue {
-        if (partial != null) return this.toPartialJSON()
+        val requestResponse: Map<String, Value> =
+            if (partial != null) {
+                mapOf(
+                    PARTIAL to JSONObjectValue(serializeRequestResponse(partial))
+                )
+            } else {
+                serializeRequestResponse(this)
+            }
 
-        val mockInteraction = mutableMapOf<String, Value>()
-        mockInteraction.putAll(data.jsonObject)
-
-        mockInteraction[MOCK_HTTP_REQUEST] = request.toJSON()
-        mockInteraction[MOCK_HTTP_RESPONSE] = response.toJSON()
-
-        return JSONObjectValue(mockInteraction)
+        return JSONObjectValue(requestResponse + data.jsonObject)
     }
 
-    private fun toPartialJSON(): JSONObjectValue {
-        if (partial == null) return this.toJSON()
-        val exampleJson = JSONObjectValue(buildMap{
-            put(MOCK_HTTP_REQUEST, partial.request.toJSON())
-            put(MOCK_HTTP_RESPONSE, partial.response.toJSON())
-        })
-
-        return JSONObjectValue(buildMap {
-            putAll(data.jsonObject)
-            put(PARTIAL, exampleJson)
-        })
+    private fun serializeRequestResponse(scenarioStub: ScenarioStub): Map<String, Value> {
+        return mapOf(
+            MOCK_HTTP_REQUEST to scenarioStub.request.toJSON(),
+            MOCK_HTTP_RESPONSE to scenarioStub.response.toJSON()
+        )
     }
 
     private fun getHttpResponse(): HttpResponse {

--- a/core/src/main/kotlin/io/specmatic/mock/ScenarioStub.kt
+++ b/core/src/main/kotlin/io/specmatic/mock/ScenarioStub.kt
@@ -47,6 +47,8 @@ data class ScenarioStub(
     fun isPartial() = partial != null
 
     fun toJSON(): JSONObjectValue {
+        if (partial != null) return this.toPartialJSON()
+
         val mockInteraction = mutableMapOf<String, Value>()
         mockInteraction.putAll(data.jsonObject)
 
@@ -56,8 +58,37 @@ data class ScenarioStub(
         return JSONObjectValue(mockInteraction)
     }
 
+    private fun toPartialJSON(): JSONObjectValue {
+        if (partial == null) return this.toJSON()
+        val exampleJson = JSONObjectValue(buildMap{
+            put(MOCK_HTTP_REQUEST, partial.request.toJSON())
+            put(MOCK_HTTP_RESPONSE, partial.response.toJSON())
+        })
+
+        return JSONObjectValue(buildMap {
+            putAll(data.jsonObject)
+            put(PARTIAL, exampleJson)
+        })
+    }
+
     private fun getHttpResponse(): HttpResponse {
         return this.partial?.response ?: this.response
+    }
+
+    fun updateRequest(request: HttpRequest): ScenarioStub {
+        if (partial != null) {
+            return this.copy(partial = this.partial.updateRequest(request))
+        }
+
+        return this.copy(request = request)
+    }
+
+    fun updateResponse(response: HttpResponse): ScenarioStub {
+        if (partial != null) {
+            return this.copy(partial = this.partial.updateResponse(response))
+        }
+
+        return this.copy(response = response)
     }
 
     fun getRequestWithAdditionalParamsIfAny(additionalExampleParamsFilePath: String?): HttpRequest {

--- a/core/src/test/kotlin/io/specmatic/mock/ScenarioStubKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/mock/ScenarioStubKtTest.kt
@@ -932,7 +932,7 @@ paths:
         val scenarioStub = ScenarioStub(partial = ScenarioStub(request, response), data = additionalData)
 
         val json = scenarioStub.toJSON()
-        assertThat(json.keys()).containsExactly("foo", PARTIAL)
+        assertThat(json.keys()).containsExactlyInAnyOrder("foo", PARTIAL)
         assertThat(json.jsonObject["foo"]).isEqualTo(StringValue("bar"))
     }
 


### PR DESCRIPTION
**What**: Ability for Partial scenarioStubs to serialize into partial examples

**Why**: Enables proper serialization and the creation of partial examples

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
