### PR TITLE
Add OpenAPI preprocessor to workaround the parser reference issue

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiPreProcessor.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiPreProcessor.kt
@@ -58,7 +58,7 @@ data class OpenApiPreProcessor (
 
     private fun relativizePaths(ref: String, from: String): String {
         val to = openApiFilePath.parent ?: return ref
-        val base = Paths.get(from).normalizeAndAbsolute().parent ?: return ref
+        val base = to.resolve(from).normalizeAndAbsolute().parent ?: return ref
         val target = base.resolve(ref).normalizeAndAbsolute()
 
         return to.relativize(target).toString().replace(File.separatorChar, '/')

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiPreProcessor.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiPreProcessor.kt
@@ -1,0 +1,72 @@
+package io.specmatic.conversions
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import java.io.File
+import java.nio.file.Path
+import java.nio.file.Paths
+
+const val REF_KEY = "\$ref"
+
+data class OpenApiPreProcessor (
+    private val parsedYamlContent: Map<*, *>,
+    private val openApiFile: File,
+    private val openApiFilePath: Path = openApiFile.toPath().toAbsolutePath()
+) {
+    constructor(yamlContent: String, openApiFilePath: String): this(
+        parsedYamlContent = mapper.readValue(yamlContent, Map::class.java),
+        openApiFile = File(openApiFilePath).canonicalFile
+    )
+
+    fun toYAML(): String {
+        return mapper.writeValueAsString(parsedYamlContent)
+    }
+
+    fun inlinePathReferences(): OpenApiPreProcessor {
+        val pathsMap = parsedYamlContent["paths"] as? Map<*, *> ?: return this
+        val updatedPaths = pathsMap.mapValues { (path, pathValue) ->
+            if (path !is String || pathValue !is Map<*, *> || !pathValue.isRefValue()) return@mapValues pathValue
+            val ref = pathValue["\$ref"] as? String ?: return@mapValues pathValue
+            readFromRef(ref).relativizeRefs(from = ref)
+        }
+
+        val updatedYamlContent = parsedYamlContent.toMutableMap().apply { this["paths"] = updatedPaths }
+        return this.copy(parsedYamlContent = updatedYamlContent)
+    }
+
+    private fun Any?.isRefValue(): Boolean {
+        return this is Map<*, *> && this.containsKey(REF_KEY)
+    }
+
+    private fun readFromRef(ref: String): Map<*, *> {
+        val refFilePath = openApiFile.canonicalFile.parentFile.resolve(ref)
+        return mapper.readValue(refFilePath, Map::class.java)
+    }
+
+    private fun Any?.relativizeRefs(from: String): Any? {
+        return when (this) {
+            is Map<*, *> -> {
+                this.mapValues { (key, value) ->
+                    if (key != REF_KEY || value !is String) return@mapValues value.relativizeRefs(from)
+                    relativizePaths(value, from)
+                }
+            }
+            is List<*> -> this.map { it.relativizeRefs(from) }
+            else -> this
+        }
+    }
+
+    private fun relativizePaths(ref: String, from: String): String {
+        val to = openApiFilePath.parent ?: return ref
+        val base = Paths.get(from).normalizeAndAbsolute().parent ?: return ref
+        val target = base.resolve(ref).normalizeAndAbsolute()
+
+        return to.relativize(target).toString().replace(File.separatorChar, '/')
+    }
+
+    private fun Path.normalizeAndAbsolute(): Path = this.normalize().toAbsolutePath()
+
+    companion object {
+        private val mapper = ObjectMapper(YAMLFactory())
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiKtTest.kt
@@ -642,12 +642,12 @@ Background:
 
     @Test
     fun `should not throw errors while parsing file with no paths`() {
-        OpenApiSpecification.fromFile("openapi/common.yaml").toFeature()
+        OpenApiSpecification.fromFile("src/test/resources/openapi/common.yaml").toFeature()
     }
 
     @Test
     fun `should run zero tests when the file has no paths`() {
-        val feature = OpenApiSpecification.fromFile("openapi/common.yaml").toFeature()
+        val feature = OpenApiSpecification.fromFile("src/test/resources/openapi/common.yaml").toFeature()
         val results = feature.executeTests(
             object : TestExecutor {
                 override fun execute(request: HttpRequest): HttpResponse = HttpResponse(200)
@@ -1154,7 +1154,7 @@ Background:
                   | testing |
         """.trimIndent(), sourceSpecPath
         )
-        val openapiSpec = OpenApiSpecification.fromFile("openapi/petstore-expanded.yaml")
+        val openapiSpec = OpenApiSpecification.fromFile("src/test/resources/openapi/petstore-expanded.yaml")
 
         val (expectedScenarios, _) = openapiSpec.toScenarioInfos()
         assertThat(feature.scenarios).hasSameSizeAs(expectedScenarios)
@@ -2498,7 +2498,7 @@ components:
 
     @Test
     fun `should work with password and email formats while generating tests`() {
-        val feature = OpenApiSpecification.fromFile("openapi/spec_with_password_and_email_format_strings.yaml").toFeature()
+        val feature = OpenApiSpecification.fromFile("src/test/resources/openapi/spec_with_password_and_email_format_strings.yaml").toFeature()
         var emailDataType: Pattern? = null
         var emailValue: String? = null
         var passwordDataType: Pattern? = null
@@ -2521,7 +2521,7 @@ components:
 
     @Test
     fun `should work with password and email formats while generating stub`() {
-        val feature = OpenApiSpecification.fromFile("openapi/spec_with_password_and_email_format_strings.yaml").toFeature()
+        val feature = OpenApiSpecification.fromFile("src/test/resources/openapi/spec_with_password_and_email_format_strings.yaml").toFeature()
 
         val response = HttpStub(feature).use {
             val restTemplate = RestTemplate()
@@ -2537,7 +2537,7 @@ components:
 
     @Test
     fun `stub should not match email value in request that does not adhere to email format`() {
-        val feature = OpenApiSpecification.fromFile("openapi/spec_with_password_and_email_format_strings.yaml").toFeature()
+        val feature = OpenApiSpecification.fromFile("src/test/resources/openapi/spec_with_password_and_email_format_strings.yaml").toFeature()
 
         val exception = Assertions.assertThrows(HttpClientErrorException::class.java) {
             HttpStub(feature).use {

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiPreProcessorTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiPreProcessorTest.kt
@@ -1,0 +1,38 @@
+package io.specmatic.conversions
+
+import io.specmatic.core.*
+import io.specmatic.core.pattern.DeferredPattern
+import io.specmatic.core.pattern.EnumPattern
+import io.specmatic.core.pattern.JSONObjectPattern
+import io.specmatic.core.value.StringValue
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.io.File
+
+
+class OpenApiPreProcessorTest {
+
+    @Test
+    fun `should be able to to load open-api specification with referenced paths`() {
+        val openApiFile = File("src/test/resources/openapi/has_referenced_paths/api/v1/order.yaml")
+        val specification = OpenApiSpecification.fromFile(openApiFile.canonicalPath)
+        val feature = specification.toFeature()
+
+        assertThat(feature.scenarios).hasSize(1).containsExactly(
+            Scenario(ScenarioInfo(
+                scenarioName = "GET /v1/products. Response: successful operation",
+                httpRequestPattern = HttpRequestPattern(httpPathPattern = HttpPathPattern.from("/v1/products"), method = "GET", body = NoBodyPattern),
+                httpResponsePattern = HttpResponsePattern(
+                    status = 200,
+                    headersPattern = HttpHeadersPattern(contentType = "application/json"),
+                    body = DeferredPattern("(Product)")
+                ),
+                patterns = mapOf(
+                    "(ProductType)" to EnumPattern(values = setOf("FOOD", "GADGET", "OTHER").map { StringValue(it) }, typeAlias = "ProductType"),
+                    "(Product)" to JSONObjectPattern(mapOf("category?" to DeferredPattern("(ProductType)")), typeAlias = "(Product)")
+                ),
+                serviceType = "HTTP"
+            ))
+        )
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiPreProcessorTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiPreProcessorTest.kt
@@ -1,5 +1,7 @@
 package io.specmatic.conversions
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import io.specmatic.core.*
 import io.specmatic.core.pattern.DeferredPattern
 import io.specmatic.core.pattern.EnumPattern
@@ -7,10 +9,22 @@ import io.specmatic.core.pattern.JSONObjectPattern
 import io.specmatic.core.value.StringValue
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 import java.io.File
 
-
 class OpenApiPreProcessorTest {
+
+    companion object {
+        private fun assertYamlEquals(expected: String, actual: String) {
+            val expectedValue = yamlMapper.readValue(expected, Map::class.java)
+            val actualValue = yamlMapper.readValue(actual, Map::class.java)
+            assertThat(actualValue).isEqualTo(expectedValue)
+        }
+
+        private val yamlMapper = ObjectMapper(YAMLFactory())
+        private val mapper = ObjectMapper()
+        private val currentFile = File(".")
+    }
 
     @Test
     fun `should be able to to load open-api specification with referenced paths`() {
@@ -34,5 +48,146 @@ class OpenApiPreProcessorTest {
                 serviceType = "HTTP"
             ))
         )
+    }
+
+    @Test
+    fun `should not modify non referenced paths in open-api specification`() {
+        val openApiSpecification = """
+        openapi: 3.0.3
+        info:
+          title: Check Health
+          version: 1.0.0
+        paths:
+          /check:
+            get:
+              summary: Check Health
+              responses:
+                '200':
+                  description: successful operation
+        """.trimIndent()
+        val preProcessor = OpenApiPreProcessor(openApiSpecification, currentFile.canonicalPath)
+        val processedOpenApiYamlContent = preProcessor.inlinePathReferences().toYAML()
+
+        assertYamlEquals(openApiSpecification, processedOpenApiYamlContent)
+    }
+
+    @Test
+    fun `should work with open api specification in json format`(@TempDir tempDir: File) {
+        val source = File("src/test/resources/openapi/has_referenced_paths")
+        source.copyRecursively(tempDir, true)
+        convertYamlToJsonRecursively(tempDir)
+
+        val openApiFile = File(tempDir, "api/v1/order.json")
+        val specification = OpenApiSpecification.fromFile(openApiFile.canonicalPath)
+        val feature = specification.toFeature()
+
+        assertThat(feature.scenarios).hasSize(1).containsExactly(Scenario(ScenarioInfo(
+            scenarioName = "GET /v1/products. Response: successful operation",
+            httpRequestPattern = HttpRequestPattern(httpPathPattern = HttpPathPattern.from("/v1/products"), method = "GET", body = NoBodyPattern),
+            httpResponsePattern = HttpResponsePattern(
+                status = 200,
+                headersPattern = HttpHeadersPattern(contentType = "application/json"),
+                body = DeferredPattern("(Product)")
+            ),
+            patterns = mapOf(
+                "(ProductType)" to EnumPattern(values = setOf("FOOD", "GADGET", "OTHER").map { StringValue(it) }, typeAlias = "ProductType"),
+                "(Product)" to JSONObjectPattern(mapOf("category?" to DeferredPattern("(ProductType)")), typeAlias = "(Product)")
+            ),
+            serviceType = "HTTP"
+        )))
+    }
+
+    @Test
+    fun `should not modify absolute or http references in open-api specification`(@TempDir tempDir: File) {
+        val specification = """
+        openapi: 3.0.3
+        info:
+          title: Check Health
+          version: 1.0.0
+        paths:
+          /check:
+            ${"$"}ref: ${tempDir.resolve("paths/check.yaml").canonicalPath} 
+        """.trimIndent()
+        val checksSpecification = """
+        get:
+          summary: Check Health
+          responses:
+            '200':
+              description: successful operation
+              content:
+                application/json:
+                  schema:
+                    ${"$"}ref: ${tempDir.resolve("components/schemas/Health.yaml").canonicalPath}
+                text/plain:
+                  schema:
+                    ${"$"}ref: http://example.com/components/schemas/Health.yaml
+        """.trimIndent()
+        val healthSchema = """
+        type: object
+        properties:
+          status:
+            type: string
+        """.trimIndent()
+
+        File(tempDir, "paths").apply { mkdirs() }
+        File(tempDir, "paths/check.yaml").writeText(checksSpecification)
+
+        File(tempDir, "components/schemas").apply { mkdirs() }
+        File(tempDir, "components/schemas/Health.yaml").writeText(healthSchema)
+
+        val openApiSpec = File(tempDir, "api.yaml").apply { writeText(specification) }
+        val processedApiSpec = OpenApiPreProcessor(openApiSpec.readText(), openApiSpec.canonicalPath).inlinePathReferences().toYAML()
+
+        assertYamlEquals(
+            actual = processedApiSpec,
+            expected = """
+            openapi: 3.0.3
+            info:
+              title: Check Health
+              version: 1.0.0
+            paths:
+              /check:
+                get:
+                  summary: Check Health
+                  responses:
+                    '200':
+                      description: successful operation
+                      content:
+                        application/json:
+                          schema:
+                            ${"$"}ref: ${tempDir.resolve("components/schemas/Health.yaml").canonicalPath}
+                        text/plain:
+                          schema:
+                            ${"$"}ref: http://example.com/components/schemas/Health.yaml
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun `should not modify if referenced paths are http references`() {
+        val openApiContent = """
+        openapi: 3.0.3
+        info:
+          title: Check Health
+          version: 1.0.0
+        paths:
+          /check:
+            ${"$"}ref: http://example.com/paths/check.yaml
+        """.trimIndent()
+
+        val preProcessor = OpenApiPreProcessor(openApiContent, currentFile.canonicalPath)
+        val processedOpenApiYamlContent = preProcessor.inlinePathReferences().toYAML()
+
+        assertYamlEquals(openApiContent, processedOpenApiYamlContent)
+    }
+
+    private fun convertYamlToJsonRecursively(file: File, deleteOnConversion: Boolean = true) {
+        file.walkTopDown().filter { it.isFile && (it.extension == "yaml" || it.extension == "yml") }.forEach { yamlFile ->
+            val rawText = yamlFile.readText().replace(".yaml", ".json").replace(".yml", ".json")
+            val data = yamlMapper.readTree(rawText)
+            val jsonFile = File(yamlFile.parentFile, "${yamlFile.nameWithoutExtension}.json")
+            mapper.writeValue(jsonFile, data)
+            if (deleteOnConversion) yamlFile.delete()
+        }
     }
 }

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiPreProcessorTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiPreProcessorTest.kt
@@ -7,6 +7,8 @@ import io.specmatic.core.pattern.DeferredPattern
 import io.specmatic.core.pattern.EnumPattern
 import io.specmatic.core.pattern.JSONObjectPattern
 import io.specmatic.core.value.StringValue
+import io.swagger.v3.parser.OpenAPIV3Parser
+import io.swagger.v3.parser.core.models.ParseOptions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -179,6 +181,22 @@ class OpenApiPreProcessorTest {
         val processedOpenApiYamlContent = preProcessor.inlinePathReferences().toYAML()
 
         assertYamlEquals(openApiContent, processedOpenApiYamlContent)
+    }
+
+    @Test
+    fun `should fail while swagger parser relative references issues are not resolved`() {
+        // Remove this test when relative references handling are resolved in swagger parser
+        val openApiFile = File("src/test/resources/openapi/has_referenced_paths/api/v1/order.yaml")
+        val parseOptions = ParseOptions().also {
+            it.isResolve = true
+            it.isResolveRequestBody = true
+            it.isResolveResponses = true
+        }
+        val result = OpenAPIV3Parser().readContents(openApiFile.readText(), null, parseOptions, openApiFile.canonicalPath)
+
+        assertThat(result.messages).hasSize(1).containsExactly("""
+        Unable to load RELATIVE ref: ../commons/components/schemas/products/enums/ProductType.yaml path: ${openApiFile.parentFile.canonicalPath}
+        """.trimIndent())
     }
 
     private fun convertYamlToJsonRecursively(file: File, deleteOnConversion: Boolean = true) {

--- a/core/src/test/resources/openapi/has_referenced_paths/api/v1/order.yaml
+++ b/core/src/test/resources/openapi/has_referenced_paths/api/v1/order.yaml
@@ -1,0 +1,7 @@
+openapi: 3.0.3
+info:
+  version: 1.0.0
+  title: Products API
+paths:
+  /v1/products:
+    $ref: ./paths/products.yaml

--- a/core/src/test/resources/openapi/has_referenced_paths/api/v1/paths/products.yaml
+++ b/core/src/test/resources/openapi/has_referenced_paths/api/v1/paths/products.yaml
@@ -1,0 +1,8 @@
+get:
+  responses:
+    "200":
+      description: successful operation
+      content:
+        application/json:
+          schema:
+            $ref: ../../../commons/components/schemas/products/Product.yaml

--- a/core/src/test/resources/openapi/has_referenced_paths/commons/components/schemas/products/Product.yaml
+++ b/core/src/test/resources/openapi/has_referenced_paths/commons/components/schemas/products/Product.yaml
@@ -1,0 +1,4 @@
+Product: object
+properties:
+  category:
+    $ref: ./enums/ProductType.yaml

--- a/core/src/test/resources/openapi/has_referenced_paths/commons/components/schemas/products/enums/ProductType.yaml
+++ b/core/src/test/resources/openapi/has_referenced_paths/commons/components/schemas/products/enums/ProductType.yaml
@@ -1,0 +1,5 @@
+type: string
+enum:
+  - FOOD
+  - GADGET
+  - OTHER


### PR DESCRIPTION
**PR CLOSED: Won't Proceed**
We’re not proceeding with this workaround since the parser itself needs a proper fix. Users needing an immediate solution can adjust $ref paths manually.

**What**: Introduce an OpenAPI preprocessor to address Parser reference resolution challenges.

**Why**: The Swagger Parser version 2.1.26 and prior releases encounter difficulties in resolving relative references within OpenAPI specifications, particularly in modularized specifications with intricate file structures

**How**: Add a preprocessor that modifies relative $ref paths prior to parsing, ensuring proper reference resolution

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
