### PR TITLE
Validation should not display a warning when the Specmatic config file is missing

### DIFF
--- a/application/src/main/kotlin/application/ExamplesCommand.kt
+++ b/application/src/main/kotlin/application/ExamplesCommand.kt
@@ -187,7 +187,7 @@ For example, to filter by HTTP methods:
         }
 
         private fun validateExamplesDir(contractFile: File, examplesDir: File): Pair<Int, Map<String, Result>> =
-            validateExamplesDir(parseContractFileToFeature(contractFile, specmaticConfig = EMPTY_SPECMATIC_CONFIG), examplesDir)
+            validateExamplesDir(parseContractFileWithNoMissingConfigWarning(contractFile), examplesDir)
 
         private fun validateExamplesDir(feature: Feature, examplesDir: File): Pair<Int, Map<String, Result>> {
             val (externalExampleDir, externalExamples) = ExampleModule().loadExternalExamples(examplesDir = examplesDir)
@@ -237,7 +237,7 @@ For example, to filter by HTTP methods:
         }
 
         private fun validateImplicitExamplesFrom(contractFile: File): Int {
-            val feature = parseContractFileToFeature(contractFile, specmaticConfig = EMPTY_SPECMATIC_CONFIG)
+            val feature = parseContractFileWithNoMissingConfigWarning(contractFile)
 
             val (validateInline, validateExternal) = getValidateInlineAndValidateExternalFlags()
 

--- a/application/src/main/kotlin/application/ExamplesCommand.kt
+++ b/application/src/main/kotlin/application/ExamplesCommand.kt
@@ -1,9 +1,7 @@
 package application
 
-import io.specmatic.core.CONTRACT_EXTENSIONS
-import io.specmatic.core.Feature
-import io.specmatic.core.Result
-import io.specmatic.core.Results
+import io.specmatic.core.*
+import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.examples.module.ExampleModule
 import io.specmatic.core.examples.module.ExampleValidationModule
 import io.specmatic.core.examples.server.ScenarioFilter
@@ -12,7 +10,6 @@ import io.specmatic.core.log.ConsolePrinter
 import io.specmatic.core.log.NonVerbose
 import io.specmatic.core.log.Verbose
 import io.specmatic.core.log.logger
-import io.specmatic.core.parseContractFileToFeature
 import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.utilities.capitalizeFirstChar
 import io.specmatic.core.utilities.exceptionCauseMessage
@@ -190,7 +187,7 @@ For example, to filter by HTTP methods:
         }
 
         private fun validateExamplesDir(contractFile: File, examplesDir: File): Pair<Int, Map<String, Result>> =
-            validateExamplesDir(parseContractFileToFeature(contractFile), examplesDir)
+            validateExamplesDir(parseContractFileToFeature(contractFile, specmaticConfig = EMPTY_SPECMATIC_CONFIG), examplesDir)
 
         private fun validateExamplesDir(feature: Feature, examplesDir: File): Pair<Int, Map<String, Result>> {
             val (externalExampleDir, externalExamples) = ExampleModule().loadExternalExamples(examplesDir = examplesDir)
@@ -240,7 +237,7 @@ For example, to filter by HTTP methods:
         }
 
         private fun validateImplicitExamplesFrom(contractFile: File): Int {
-            val feature = parseContractFileToFeature(contractFile)
+            val feature = parseContractFileToFeature(contractFile, specmaticConfig = EMPTY_SPECMATIC_CONFIG)
 
             val (validateInline, validateExternal) = getValidateInlineAndValidateExternalFlags()
 

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -60,6 +60,10 @@ fun checkExists(file: File) = file.also {
         throw ContractException("File ${file.path} does not exist (absolute path ${file.canonicalPath})")
 }
 
+fun parseContractFileWithNoMissingConfigWarning(contractFile: File): Feature {
+    return parseContractFileToFeature(contractFile, specmaticConfig = SpecmaticConfig())
+}
+
 fun parseContractFileToFeature(
     file: File,
     hook: Hook = PassThroughHook(),

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -47,8 +47,6 @@ import java.io.File
 private const val excludedEndpointsWarning =
     "WARNING: excludedEndpoints is not supported in Specmatic config v2. . Refer to https://specmatic.io/documentation/configuration.html#report-configuration to see how to exclude endpoints."
 
-val EMPTY_SPECMATIC_CONFIG = SpecmaticConfig()
-
 const val APPLICATION_NAME = "Specmatic"
 const val APPLICATION_NAME_LOWER_CASE = "specmatic"
 const val CONFIG_FILE_NAME_WITHOUT_EXT = "specmatic"

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -47,6 +47,8 @@ import java.io.File
 private const val excludedEndpointsWarning =
     "WARNING: excludedEndpoints is not supported in Specmatic config v2. . Refer to https://specmatic.io/documentation/configuration.html#report-configuration to see how to exclude endpoints."
 
+val EMPTY_SPECMATIC_CONFIG = SpecmaticConfig()
+
 const val APPLICATION_NAME = "Specmatic"
 const val APPLICATION_NAME_LOWER_CASE = "specmatic"
 const val CONFIG_FILE_NAME_WITHOUT_EXT = "specmatic"

--- a/core/src/main/kotlin/io/specmatic/core/examples/module/ExampleValidationModule.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/module/ExampleValidationModule.kt
@@ -52,7 +52,7 @@ class ExampleValidationModule {
     }
 
     fun validateExample(contractFile: File, exampleFile: File): Result {
-        val feature = parseContractFileToFeature(contractFile, specmaticConfig = EMPTY_SPECMATIC_CONFIG)
+        val feature = parseContractFileWithNoMissingConfigWarning(contractFile)
         val result = validateExample(feature, exampleFile)
         callLifecycleHook(feature, ExampleModule().getExamplesFromFiles(listOf(exampleFile)))
         return result

--- a/core/src/main/kotlin/io/specmatic/core/examples/module/ExampleValidationModule.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/module/ExampleValidationModule.kt
@@ -1,16 +1,13 @@
 package io.specmatic.core.examples.module
 
 import io.specmatic.conversions.ExampleFromFile
-import io.specmatic.core.Feature
-import io.specmatic.core.Result
-import io.specmatic.core.Results
+import io.specmatic.core.*
 import io.specmatic.core.examples.server.InteractiveExamplesMismatchMessages
 import io.specmatic.core.examples.server.ScenarioFilter
 import io.specmatic.core.examples.server.SchemaExample
 import io.specmatic.core.lifecycle.ExamplesUsedFor
 import io.specmatic.core.lifecycle.LifecycleHooks
 import io.specmatic.core.log.logger
-import io.specmatic.core.parseContractFileToFeature
 import io.specmatic.core.value.NullValue
 import io.specmatic.mock.ScenarioStub
 import java.io.File
@@ -55,7 +52,7 @@ class ExampleValidationModule {
     }
 
     fun validateExample(contractFile: File, exampleFile: File): Result {
-        val feature = parseContractFileToFeature(contractFile)
+        val feature = parseContractFileToFeature(contractFile, specmaticConfig = EMPTY_SPECMATIC_CONFIG)
         val result = validateExample(feature, exampleFile)
         callLifecycleHook(feature, ExampleModule().getExamplesFromFiles(listOf(exampleFile)))
         return result

--- a/core/src/test/kotlin/io/specmatic/core/FeatureKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FeatureKtTest.kt
@@ -11,6 +11,7 @@ import io.specmatic.mock.mockFromJSON
 import io.specmatic.osAgnosticPath
 import io.mockk.every
 import io.mockk.mockk
+import io.specmatic.stub.captureStandardOutput
 import io.swagger.v3.core.util.Yaml
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -784,5 +785,14 @@ paths:
     private fun String.toFeatureString(): String {
         val parsedJSONValue = parsedJSON(this) as JSONObjectValue
         return toGherkinFeature(NamedStub("Test Feature", mockFromJSON(parsedJSONValue.jsonObject)))
+    }
+
+    @Test
+    fun `should be able to parse a spec with no warning about missing config`() {
+        val (stdout, _) = captureStandardOutput {
+            parseContractFileWithNoMissingConfigWarning(File("src/test/resources/openapi/jsonAndYamlEquivalence/openapi.yaml"))
+        }
+
+        assertThat(stdout).doesNotContain("Could not find the Specmatic configuration at path")
     }
 }


### PR DESCRIPTION
We do not want warnings about missing Specmatic config file to appear when running the validate command. This is because this command is run in CI, and there will be no need for specmatic.yaml.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
