### PR TITLE
Fix backward compatibility check for external examples

### DIFF
--- a/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckBaseCommand.kt
+++ b/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckBaseCommand.kt
@@ -5,13 +5,13 @@ import io.specmatic.core.Results
 import io.specmatic.core.git.GitCommand
 import io.specmatic.core.git.SystemGit
 import io.specmatic.core.log.logger
+import io.specmatic.core.utilities.SystemExit
 import picocli.CommandLine.Option
 import java.io.File
 import java.nio.file.Paths
 import java.util.concurrent.Callable
 import java.util.regex.Pattern
 import kotlin.io.path.absolutePathString
-import kotlin.system.exitProcess
 
 abstract class BackwardCompatibilityCheckBaseCommand : Callable<Unit> {
     private lateinit var gitCommand: GitCommand
@@ -68,11 +68,11 @@ abstract class BackwardCompatibilityCheckBaseCommand : Callable<Unit> {
             logger.newLine()
             logger.newLine()
             logger.log(e)
-            exitProcess(1)
+            SystemExit.exitWith(1)
         }
 
         logger.log(result.report)
-        exitProcess(result.exitCode)
+        SystemExit.exitWith(result.exitCode)
     }
 
     private fun getChangedSpecs(): Set<String> {
@@ -106,7 +106,7 @@ abstract class BackwardCompatibilityCheckBaseCommand : Callable<Unit> {
         }.toSet().also {
             if (it.isEmpty()) {
                 logger.log("$newLine No specs were changed, skipping the check.$newLine")
-                exitProcess(0)
+                SystemExit.exitWith(0)
             }
         }
     }

--- a/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckCommandV2.kt
+++ b/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckCommandV2.kt
@@ -87,7 +87,7 @@ class BackwardCompatibilityCheckCommandV2: BackwardCompatibilityCheckBaseCommand
 
         val collectedFiles = filesChangedInCurrentBranch.fold(CollectedFiles()) { acc, filePath ->
             val path = Paths.get(filePath)
-            val examplesDir = path.find { it.toString().endsWith("_examples") || it.toString().endsWith("_tests") }
+            val examplesDir = getParentExamplesDirectory(path)
 
             if (examplesDir == null) {
                 acc.ignoredFiles.add(filePath)
@@ -109,7 +109,7 @@ class BackwardCompatibilityCheckCommandV2: BackwardCompatibilityCheckBaseCommand
 
         collectedFiles.examplesMissingSpecifications.forEach { filePath ->
             val path = Paths.get(filePath)
-            val examplesDir = path.find { it.toString().endsWith("_examples") || it.toString().endsWith("_tests") }
+            val examplesDir = getParentExamplesDirectory(path)
             if (examplesDir != null) {
                 val parentPath = examplesDir.parent
                 val strippedPath = parentPath.resolve(examplesDir.fileName.toString().removeSuffix("_examples"))
@@ -123,6 +123,12 @@ class BackwardCompatibilityCheckCommandV2: BackwardCompatibilityCheckBaseCommand
         }
 
         return result
+    }
+
+    private fun getParentExamplesDirectory(path: Path): Path? {
+        return generateSequence(path, Path::getParent).find {
+            it.pathString.endsWith("_examples") || it.pathString.endsWith("_tests")
+        }
     }
 
     override fun areExamplesValid(feature: IFeature, which: String): Boolean {

--- a/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckCommandV2.kt
+++ b/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckCommandV2.kt
@@ -125,7 +125,7 @@ class BackwardCompatibilityCheckCommandV2: BackwardCompatibilityCheckBaseCommand
         return result
     }
 
-    private fun getParentExamplesDirectory(path: Path): Path? {
+    fun getParentExamplesDirectory(path: Path): Path? {
         return generateSequence(path, Path::getParent).find {
             it.pathString.endsWith("_examples") || it.pathString.endsWith("_tests")
         }

--- a/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
+++ b/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
@@ -218,9 +218,9 @@ class BackwardCompatibilityCheckCommandV2Test {
             assertThat(exception.code).isEqualTo(0)
             assertThat(stdOut).containsIgnoringWhitespaces("""
             - Specs that have changed: 
-            1. ${exampleFile.path}
+            1. ${exampleFile.toPath().toRealPath()}
             - Specs whose externalised examples were changed:
-            1. ${tempDir.resolve("api.yaml").path}
+            1. ${tempDir.resolve("api.yaml").toPath().toRealPath()}
             """.trimIndent()).containsIgnoringWhitespaces("""
             Files checked: 2 (Passed: 2, Failed: 0)
             """.trimIndent())

--- a/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
+++ b/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
@@ -14,8 +14,11 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import java.io.File
 import java.nio.file.Files
+import java.nio.file.Paths
 
 class BackwardCompatibilityCheckCommandV2Test {
     private lateinit var tempDir: File
@@ -221,6 +224,19 @@ class BackwardCompatibilityCheckCommandV2Test {
             """.trimIndent()).containsIgnoringWhitespaces("""
             Files checked: 2 (Passed: 2, Failed: 0)
             """.trimIndent())
+        }
+
+        @ParameterizedTest
+        @CsvSource(
+            "/api/api_examples/example.json, /api/api_examples",
+            "/api/api_examples/product/example.json, /api/api_examples",
+            "/api_tests/example.json, /api_tests",
+            "/api/api_config/config.json, ",
+            "/example.json, "
+        )
+        fun `should be able to properly resolve examples dir when by walking up the example file path`(exampleFile: String, expectedDir: String?) {
+            val exampleDir = BackwardCompatibilityCheckCommandV2().getParentExamplesDirectory(Paths.get(exampleFile))
+            assertThat(exampleDir).isEqualTo(expectedDir?.let(Paths::get))
         }
     }
 

--- a/application/src/test/resources/specifications/spec_with_examples/api.yaml
+++ b/application/src/test/resources/specifications/spec_with_examples/api.yaml
@@ -1,0 +1,35 @@
+openapi: 3.0.0
+info:
+  title: Simple API Specification
+  version: 1.0.0
+paths:
+  /test:
+    post:
+      summary: Test endpoint
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TestInput"
+      responses:
+        "201":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TestResponse"
+components:
+  schemas:
+    TestInput:
+      type: object
+      properties:
+        name:
+          type: string
+        email:
+          type: string
+          format: email
+    TestResponse:
+      type: object
+      properties:
+        id:
+          type: integer

--- a/application/src/test/resources/specifications/spec_with_examples/api_examples/example.json
+++ b/application/src/test/resources/specifications/spec_with_examples/api_examples/example.json
@@ -1,0 +1,23 @@
+{
+  "http-request": {
+    "method": "POST",
+    "path": "/test",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "name": "john doe",
+      "email": "john.doe@example.com"
+    }
+  },
+  "http-response": {
+    "status": 201,
+    "status-text": "Created",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "id": 10
+    }
+  }
+}

--- a/core/src/main/kotlin/io/specmatic/core/pattern/EmailPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/EmailPattern.kt
@@ -53,6 +53,10 @@ class EmailPattern (private val stringPatternDelegate: StringPattern) :
         return sequenceOf(HasValue(this))
     }
 
+    override fun newBasedOn(resolver: Resolver): Sequence<Pattern> {
+        return sequenceOf(this)
+    }
+
     override fun negativeBasedOn(row: Row, resolver: Resolver, config: NegativePatternConfiguration): Sequence<ReturnValue<Pattern>> {
         val negativePatterns = stringPatternDelegate.negativeBasedOn(row, resolver).map { it.value }.plus(StringPattern())
         return scalarAnnotation(this, negativePatterns)

--- a/core/src/main/kotlin/io/specmatic/core/utilities/Utilities.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/Utilities.kt
@@ -49,17 +49,17 @@ import javax.xml.transform.dom.DOMSource
 import javax.xml.transform.stream.StreamResult
 import kotlin.system.exitProcess
 
-class SystemExitException(val code: Int, message: String) : Exception(message)
+class SystemExitException(val code: Int, message: String?) : Exception(message)
 
 object SystemExit {
-    private val exitFunc: ThreadLocal<(Int, String) -> Nothing> = ThreadLocal.withInitial { ::defaultExit }
+    private val exitFunc: ThreadLocal<(Int, String?) -> Nothing> = ThreadLocal.withInitial { ::defaultExit }
 
-    private fun defaultExit(code: Int, message: String): Nothing {
+    private fun defaultExit(code: Int, message: String? = null): Nothing {
         logger.log("\n$message\n")
         exitProcess(code)
     }
 
-    fun exitWithMessage(code: Int, message: String): Nothing {
+    fun exitWith(code: Int, message: String? = null): Nothing {
         exitFunc.get().invoke(code, message)
     }
 
@@ -73,7 +73,7 @@ object SystemExit {
     }
 }
 
-fun exitWithMessage(message: String): Nothing = SystemExit.exitWithMessage(1, message)
+fun exitWithMessage(message: String): Nothing = SystemExit.exitWith(1, message)
 
 fun messageStringFrom(e: Throwable): String {
     val messageStack = exceptionMessageStack(e, emptyList())

--- a/core/src/test/kotlin/io/specmatic/core/pattern/EmailPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/EmailPatternTest.kt
@@ -56,4 +56,14 @@ class EmailPatternTest {
             assertThat(fixedValue.jsonObject["email"]).isEqualTo(StringValue("SomeDude@example.com"))
         }
     }
+
+    @Test
+    fun `should be able to create newBasedOn values without row value`() {
+        val jsonPattern = JSONObjectPattern(mapOf("id" to NumberPattern(), "email" to EmailPattern()), typeAlias = "(Details)")
+        val newBased = jsonPattern.newBasedOn(Resolver())
+
+        assertThat(newBased.toList()).allSatisfy {
+            assertThat(it.pattern.getValue("email")).isInstanceOf(EmailPattern::class.java)
+        }
+    }
 }


### PR DESCRIPTION
**What**:
- Fix backward compatibility check for external examples
- Fix newBasedOn for EmailPattern

**How**:
- Instead of using .find, which returns a stripped path, traverse backward using .parent to locate the example directory for the modified external example file
- Override the method to prevent delegation to StringPattern

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)