### PR TITLE
Fix SystemExit printing null when no exit message is provided

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/utilities/Utilities.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/Utilities.kt
@@ -55,7 +55,7 @@ object SystemExit {
     private val exitFunc: ThreadLocal<(Int, String?) -> Nothing> = ThreadLocal.withInitial { ::defaultExit }
 
     private fun defaultExit(code: Int, message: String? = null): Nothing {
-        logger.log("\n$message\n")
+        message?.let(logger::log)
         exitProcess(code)
     }
 
@@ -73,7 +73,7 @@ object SystemExit {
     }
 }
 
-fun exitWithMessage(message: String): Nothing = SystemExit.exitWith(1, message)
+fun exitWithMessage(message: String): Nothing = SystemExit.exitWith(1, "\n$message\n")
 
 fun messageStringFrom(e: Throwable): String {
     val messageStack = exceptionMessageStack(e, emptyList())


### PR DESCRIPTION
**What**: Fix SystemExit printing null when no exit message is provided

**Checklist**:

- [ ] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
