### PR TITLE
Fixed implementation of EXAMPLE-NAME filter

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -101,7 +101,8 @@ data class Scenario(
         sourceRepository = scenarioInfo.sourceRepository,
         sourceRepositoryBranch = scenarioInfo.sourceRepositoryBranch,
         specification = scenarioInfo.specification,
-        serviceType = scenarioInfo.serviceType
+        serviceType = scenarioInfo.serviceType,
+        exampleName = scenarioInfo.examples.firstOrNull()?.rows?.firstOrNull()?.name
     )
 
     val apiIdentifier: String

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -101,8 +101,7 @@ data class Scenario(
         sourceRepository = scenarioInfo.sourceRepository,
         sourceRepositoryBranch = scenarioInfo.sourceRepositoryBranch,
         specification = scenarioInfo.specification,
-        serviceType = scenarioInfo.serviceType,
-        exampleName = scenarioInfo.examples.firstOrNull()?.rows?.firstOrNull()?.name
+        serviceType = scenarioInfo.serviceType
     )
 
     val apiIdentifier: String
@@ -875,7 +874,8 @@ data class Scenario(
             statusCode = this.status,
             header = this.httpRequestPattern.getHeaderKeys(),
             query = this.httpRequestPattern.getQueryParamKeys(),
-            exampleName = this.exampleName.orEmpty()
+            exampleName = this.exampleName.orEmpty(),
+            examples = this.examples
         )
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/filters/ScenarioFilterTags.kt
+++ b/core/src/main/kotlin/io/specmatic/core/filters/ScenarioFilterTags.kt
@@ -12,7 +12,7 @@ enum class ScenarioFilterTags(val key: String) {
     STATUS_CODE(STATUS_BREAD_CRUMB),
     HEADER(HEADERS_BREADCRUMB),
     QUERY(QUERY_PARAMS_BREADCRUMB),
-    EXAMPLE_NAME("EXAMPLE-NAME");
+    EXAMPLE_NAME("EXAMPLE");
 
     companion object {
         fun from(key: String): ScenarioFilterTags {

--- a/core/src/main/kotlin/io/specmatic/core/filters/ScenarioMetadata.kt
+++ b/core/src/main/kotlin/io/specmatic/core/filters/ScenarioMetadata.kt
@@ -1,6 +1,7 @@
 package io.specmatic.core.filters
 
 import com.ezylang.evalex.Expression
+import io.specmatic.core.pattern.Examples
 
 data class ScenarioMetadata(
     val method: String,
@@ -8,9 +9,25 @@ data class ScenarioMetadata(
     val statusCode: Int,
     val header: Set<String>,
     val query: Set<String>,
-    val exampleName: String
+    var exampleName: String,
+    var examples: List<Examples> = emptyList(),
 ) {
     fun populateExpressionData(expression: Expression): Expression {
+        if (exampleName.isEmpty() && expression.expressionString.contains(ScenarioFilterTags.EXAMPLE_NAME.key)) {
+            val matchingExamples = examples.filter { example ->
+                example.rows.any { row -> expression.expressionString.contains(row.name) }
+            }.map { example ->
+                example.copy(rows = example.rows.filter { row ->
+                    expression.expressionString.contains(row.name)
+                })
+            }
+
+            if (matchingExamples.isNotEmpty()) {
+                examples = matchingExamples
+                exampleName = matchingExamples.firstOrNull()?.rows?.firstOrNull()?.name ?: ""
+            }
+        }
+
         return expression
             .with(ScenarioFilterTags.METHOD.key, method)
             .with(ScenarioFilterTags.PATH.key, path)

--- a/core/src/main/kotlin/io/specmatic/core/filters/ScenarioMetadata.kt
+++ b/core/src/main/kotlin/io/specmatic/core/filters/ScenarioMetadata.kt
@@ -17,6 +17,6 @@ data class ScenarioMetadata(
             .with(ScenarioFilterTags.STATUS_CODE.key, statusCode.toString())
             .with(ScenarioFilterTags.HEADER.key, header.joinToString(","))
             .with(ScenarioFilterTags.QUERY.name, query.joinToString(","))
-            .with(ScenarioFilterTags.EXAMPLE_NAME.name, exampleName)
+            .with(ScenarioFilterTags.EXAMPLE_NAME.key, exampleName)
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/filters/ScenarioMetadataFilterTests.kt
+++ b/core/src/test/kotlin/io/specmatic/core/filters/ScenarioMetadataFilterTests.kt
@@ -15,7 +15,8 @@ class ScenarioMetadataFilterTests {
         path: String = "/default",
         statusCode: Int = 200,
         header: Set<String> = emptySet(),
-        query: Set<String> = emptySet()
+        query: Set<String> = emptySet(),
+        exampleName: String = ""
     ): ScenarioMetadata {
         return ScenarioMetadata(
             method = method,
@@ -23,7 +24,7 @@ class ScenarioMetadataFilterTests {
             statusCode = statusCode,
             header = header,
             query = query,
-            exampleName = "example"
+            exampleName = exampleName
         )
     }
 
@@ -558,5 +559,12 @@ class ScenarioMetadataFilterTests {
 
         val methods = filteredItems.map { it.toScenarioMetadata().method }.distinct()
         assertThat(methods).containsOnly("GET")
+    }
+
+    @Test
+    fun `filter by example`() {
+        val exampleName = createScenarioMetadata(exampleName = "SCOOBY_200_OK")
+        val filter = ScenarioMetadataFilter.from("EXAMPLE='SCOOBY_200_OK'")
+        assertTrue(filter.isSatisfiedBy(exampleName))
     }
 }


### PR DESCRIPTION
This PR aims to (https://github.com/znsio/specmatic/issues/1343),
- Fix `EXAMPLE-NAME` filter
- Replace `EXAMPLE-NAME` filter with `EXAMPLE` filter for consistent naming convention across filters

Documentation PR: https://github.com/znsio/docs.specmatic.io/pull/8