### PR TITLE
Fix Http Stub Startup Logs

### DIFF
--- a/application/src/main/kotlin/application/HTTPStubEngine.kt
+++ b/application/src/main/kotlin/application/HTTPStubEngine.kt
@@ -9,7 +9,6 @@ import io.specmatic.mock.ScenarioStub
 import io.specmatic.stub.HttpClientFactory
 import io.specmatic.stub.HttpStub
 import io.specmatic.stub.contractInfoToHttpExpectations
-import io.specmatic.stub.endPointFromHostAndPort
 
 class HTTPStubEngine {
     fun runHTTPStub(
@@ -45,36 +44,25 @@ class HTTPStubEngine {
             consoleLog(NewLineLogMessage)
             consoleLog(
                 StringLog(
-                    serverStartupMessage(
-                        specToBaseUrlMap,
-                        endPointFromHostAndPort(host, port, keyData)
-                    )
+                    serverStartupMessage(it.specToBaseUrlMap)
                 )
             )
             consoleLog(StringLog("Press Ctrl + C to stop."))
         }
     }
 
-    private fun serverStartupMessage(
-        specToStubBaseUrlMap: Map<String, String?>,
-        defaultBaseUrl: String
-    ): String {
-        val newLine = System.lineSeparator()
-        val baseUrlToSpecs: Map<String, List<String>> = specToStubBaseUrlMap.entries
-            .groupBy({ it.value ?: defaultBaseUrl }, { it.key })
+    private fun serverStartupMessage(specToStubBaseUrlMap: Map<String, String>): String {
+        val baseUrlToSpecsMap = specToStubBaseUrlMap.entries.groupBy({ it.value }, { it.key })
 
-        val messageBuilder = StringBuilder("Stub server is running on the following URLs:")
-
-        baseUrlToSpecs.entries
-            .sortedBy { it.key }
-            .forEach { (baseUrl, specs) ->
-                messageBuilder.append("${newLine}- $baseUrl serving endpoints from specs:")
+        return buildString {
+            appendLine("Stub server is running on the following URLs:")
+            baseUrlToSpecsMap.entries.sortedBy { it.key }.forEachIndexed { urlIndex, (url, specs) ->
+                appendLine("- $url serving endpoints from specs:")
                 specs.sorted().forEachIndexed { index, spec ->
-                    messageBuilder.append("$newLine    ${index.inc()}. $spec")
+                    appendLine("\t${index + 1}. $spec")
                 }
-                messageBuilder.append(newLine)
+                if (urlIndex < baseUrlToSpecsMap.size - 1) appendLine()
             }
-
-        return messageBuilder.toString()
+        }
     }
 }

--- a/application/src/main/kotlin/application/HTTPStubEngine.kt
+++ b/application/src/main/kotlin/application/HTTPStubEngine.kt
@@ -41,28 +41,7 @@ class HTTPStubEngine {
             timeoutMillis = gracefulRestartTimeoutInMs,
             specToStubBaseUrlMap = specToBaseUrlMap
         ).also {
-            consoleLog(NewLineLogMessage)
-            consoleLog(
-                StringLog(
-                    serverStartupMessage(it.specToBaseUrlMap)
-                )
-            )
-            consoleLog(StringLog("Press Ctrl + C to stop."))
-        }
-    }
-
-    private fun serverStartupMessage(specToStubBaseUrlMap: Map<String, String>): String {
-        val baseUrlToSpecsMap = specToStubBaseUrlMap.entries.groupBy({ it.value }, { it.key })
-
-        return buildString {
-            appendLine("Stub server is running on the following URLs:")
-            baseUrlToSpecsMap.entries.sortedBy { it.key }.forEachIndexed { urlIndex, (url, specs) ->
-                appendLine("- $url serving endpoints from specs:")
-                specs.sorted().forEachIndexed { index, spec ->
-                    appendLine("\t${index + 1}. $spec")
-                }
-                if (urlIndex < baseUrlToSpecsMap.size - 1) appendLine()
-            }
+            it.printStartupMessage()
         }
     }
 }

--- a/application/src/test/kotlin/application/HTTPStubEngineTest.kt
+++ b/application/src/test/kotlin/application/HTTPStubEngineTest.kt
@@ -1,0 +1,94 @@
+package application
+
+import io.mockk.every
+import io.mockk.mockk
+import io.specmatic.core.Feature
+import io.specmatic.core.WorkingDirectory
+import io.specmatic.stub.HttpClientFactory
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class HTTPStubEngineTest {
+
+    companion object {
+        private fun runHttpStubEngineWithMockPaths(vararg paths: String, specToBaseUrlMap: Map<String, String?>) {
+            HTTPStubEngine().runHTTPStub(
+                stubs = paths.map { it.toMockkFeature() to emptyList() },
+                host = "0.0.0.0",
+                port = 9000,
+                certInfo = CertInfo(),
+                strictMode = false,
+                httpClientFactory = HttpClientFactory(),
+                workingDirectory = WorkingDirectory(),
+                gracefulRestartTimeoutInMs = 0,
+                specToBaseUrlMap = specToBaseUrlMap
+            ).close()
+        }
+
+        private fun String.toMockkFeature(): Feature {
+            return mockk<Feature>(relaxed = true) {
+                every { path } returns this@toMockkFeature
+            }
+        }
+    }
+
+    @Test
+    fun `should log sever startup messages for each base urls`() {
+        val (stdOut, _) = captureStandardOutput {
+            runHttpStubEngineWithMockPaths("api.yaml", "bff.yaml", specToBaseUrlMap = mapOf(
+                "api.yaml" to "http://localhost:8000/api/v3",
+                "bff.yaml" to "http://localhost:9000"
+            ))
+        }
+
+        assertThat(stdOut).isEqualToNormalizingNewlines("""
+        |Stub server is running on the following URLs:
+        |- http://localhost:8000/api/v3 serving endpoints from specs:
+        |\t1. api.yaml
+        |
+        |- http://localhost:9000 serving endpoints from specs:
+        |\t1. bff.yaml
+        |
+        |Press Ctrl + C to stop.
+        """.trimMargin().replace("\\t", "\t"))
+    }
+
+    @Test
+    fun `should only log startup messages for parsed feature and ignore other specifications from baseUrlMap`() {
+        val (stdOut, _) = captureStandardOutput {
+            runHttpStubEngineWithMockPaths("api.yaml", specToBaseUrlMap = mapOf(
+                "api.yaml" to "http://localhost:8000/api/v3",
+                "grpc.proto" to "http://localhost:5000",
+                "kafka.yaml" to null
+            ))
+        }
+
+        assertThat(stdOut).isEqualToNormalizingNewlines("""
+        |Stub server is running on the following URLs:
+        |- http://localhost:8000/api/v3 serving endpoints from specs:
+        |\t1. api.yaml
+        |
+        |Press Ctrl + C to stop.
+        """.trimMargin().replace("\\t", "\t"))
+    }
+
+    @Test
+    fun `should log the final baseUrl for specification which initially was null in specToBaseUrlMap`() {
+        val (stdOut, _) = captureStandardOutput {
+            runHttpStubEngineWithMockPaths("api.yaml", "uuid.yaml", specToBaseUrlMap = mapOf(
+                "api.yaml" to null,
+                "uuid.yaml" to null,
+                "kafka.yaml" to "http://localghost:9092"
+            ))
+        }
+
+        assertThat(stdOut).isEqualToNormalizingNewlines("""
+        |Stub server is running on the following URLs:
+        |- http://0.0.0.0:9000 serving endpoints from specs:
+        |\t1. api.yaml
+        |\t2. uuid.yaml
+        |
+        |Press Ctrl + C to stop.
+        """.trimMargin().replace("\\t", "\t"))
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -156,9 +156,10 @@ class HttpStub(
         else
             SpecmaticConfig()
 
-    private val specToBaseUrlMap = getValidatedBaseUrlsOrExit(
-        specToStubBaseUrlMap.mapValues { (_, value) ->
-            value ?: endPointFromHostAndPort(host, port, keyData)
+    val specToBaseUrlMap = getValidatedBaseUrlsOrExit(
+        features.associate {
+            val baseUrl = specToStubBaseUrlMap[it.path] ?: endPointFromHostAndPort(host, port, keyData)
+            it.path to baseUrl
         }
     )
 

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -156,7 +156,7 @@ class HttpStub(
         else
             SpecmaticConfig()
 
-    val specToBaseUrlMap = getValidatedBaseUrlsOrExit(
+    val specToBaseUrlMap: Map<String, String> = getValidatedBaseUrlsOrExit(
         features.associate {
             val baseUrl = specToStubBaseUrlMap[it.path] ?: endPointFromHostAndPort(host, port, keyData)
             it.path to baseUrl

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -15,11 +15,7 @@ import io.ktor.util.*
 import io.ktor.util.pipeline.*
 import io.specmatic.core.*
 import io.specmatic.core.loadSpecmaticConfig
-import io.specmatic.core.log.HttpLogMessage
-import io.specmatic.core.log.LogMessage
-import io.specmatic.core.log.LogTail
-import io.specmatic.core.log.dontPrintToConsole
-import io.specmatic.core.log.logger
+import io.specmatic.core.log.*
 import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.pattern.parsedValue
 import io.specmatic.core.route.modules.HealthCheckModule.Companion.configureHealthCheckModule
@@ -755,6 +751,32 @@ class HttpStub(
         if (validationResult is Result.Failure) exitWithMessage(validationResult.reportString())
         return specToBaseUrlMap
     }
+
+    fun printStartupMessage() {
+        consoleLog(NewLineLogMessage)
+        consoleLog(
+            StringLog(
+                serverStartupMessage(specToBaseUrlMap)
+            )
+        )
+        consoleLog(StringLog("Press Ctrl + C to stop."))
+    }
+
+    private fun serverStartupMessage(specToStubBaseUrlMap: Map<String, String>): String {
+        val baseUrlToSpecsMap = specToStubBaseUrlMap.entries.groupBy({ it.value }, { it.key })
+
+        return buildString {
+            appendLine("Stub server is running on the following URLs:")
+            baseUrlToSpecsMap.entries.sortedBy { it.key }.forEachIndexed { urlIndex, (url, specs) ->
+                appendLine("- $url serving endpoints from specs:")
+                specs.sorted().forEachIndexed { index, spec ->
+                    appendLine("\t${index + 1}. $spec")
+                }
+                if (urlIndex < baseUrlToSpecsMap.size - 1) appendLine()
+            }
+        }
+    }
+
 }
 
 class CouldNotParseRequest(innerException: Throwable) : Exception(exceptionCauseMessage(innerException))


### PR DESCRIPTION
**What**: Fix Http Stub Startup Logs

**Why**: Startup logs should only reflect parsed OpenAPI specifications and should ignore other specifications present in baseUrlMap (and by extension, from the Specmatic config)

**How**:
- Publicize `HttpStub.specToBaseUrlMap` to be source of startup logs
- Instantiate `specToBaseUrlMap` using features instead of `baseUrlMap`
- Add tests to ensure `serverStartupMessage` are accurate

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)