### PR TITLE
Add missing `yml` extension to readValue

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/pattern/Grammar.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/Grammar.kt
@@ -393,7 +393,7 @@ private fun processContent(content: String?, extension: String): Value {
     return runCatching {
         when(extension.lowercase()) {
             "json" -> parsedJSON(trimmedContent)
-            "yaml" -> yamlStringToValue(trimmedContent)
+            "yaml", "yml" -> yamlStringToValue(trimmedContent)
             "xml" -> toXMLNode(trimmedContent)
             else -> parsedScalarValue(trimmedContent)
         }

--- a/core/src/test/kotlin/io/specmatic/core/pattern/GrammarKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/GrammarKtTest.kt
@@ -6,15 +6,30 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.*
 import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
+import java.io.File
 import java.nio.charset.Charset
 import java.util.function.Consumer
+import java.util.stream.Stream
 
 internal class GrammarKtTest {
     companion object {
         @JvmStatic
         fun bomProvider(): List<ByteOrderMark> {
             return ByteOrderMark::class.java.fields.mapNotNull { it.get(null) as? ByteOrderMark }
+        }
+
+        @JvmStatic
+        fun contentToFormatProvider(): Stream<Arguments> {
+            val expectedValue = JSONObjectValue(mapOf("hello" to StringValue("world")))
+            val expectedXmlValue = XMLNode("hello", "hello", emptyMap(), listOf(StringValue("world")), "", emptyMap())
+            return Stream.of(
+                Arguments.of("{\"hello\": \"world\"}", "json", expectedValue),
+                Arguments.of("hello: world", "yaml", expectedValue),
+                Arguments.of("hello: world", "yml", expectedValue),
+                Arguments.of("<hello>world</hello>", "xml", expectedXmlValue),
+            )
         }
     }
 
@@ -136,5 +151,13 @@ internal class GrammarKtTest {
     fun `email pattern should be recognized as a built-in pattern`() {
         val pattern = getBuiltInPattern("(email)")
         assertThat(pattern).isInstanceOf(EmailPattern::class.java)
+    }
+
+    @ParameterizedTest
+    @MethodSource("contentToFormatProvider")
+    fun `readValue should be able to read various file formats`(content: String, extension: String, expected: Value) {
+        val contentFile = File.createTempFile("content", ".$extension").apply { writeText(content) }
+        val value = readValue(contentFile)
+        assertThat(value).isEqualTo(expected)
     }
 }


### PR DESCRIPTION
**What**: Add missing `yml` extension to processContent, to ensure readValue can process yml files

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)