### PR TITLE
Enable additional header validation in the validation module

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -337,7 +337,7 @@ data class Scenario(
                 mismatchMessages = mismatchMessages,
                 findKeyErrorCheck = if (isPartial) resolver.getPartialKeyCheck() else resolver.findKeyErrorCheck
             )
-        )
+        ).disableOverrideUnexpectedKeycheck()
 
         val updatedScenario = newBasedOnAttributeSelectionFields(httpRequest.queryParams)
         val requestMatch = when(httpResponse.status in invalidRequestStatuses) {

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -322,7 +322,7 @@ data class Scenario(
 
     fun matches(
         httpRequest: HttpRequest, httpResponse: HttpResponse, mismatchMessages: MismatchMessages,
-        flagsBased: FlagsBased, isPartial: Boolean = false
+        flagsBased: FlagsBased, isPartial: Boolean = false, disableOverrideKeyCheck: Boolean = true
     ): Result {
         if (httpResponsePattern.status == DEFAULT_RESPONSE_CODE || httpResponse.status != httpResponsePattern.status) {
             return Result.Failure(
@@ -337,7 +337,9 @@ data class Scenario(
                 mismatchMessages = mismatchMessages,
                 findKeyErrorCheck = if (isPartial) resolver.getPartialKeyCheck() else resolver.findKeyErrorCheck
             )
-        ).disableOverrideUnexpectedKeycheck()
+        ).let {
+            if (disableOverrideKeyCheck) it.disableOverrideUnexpectedKeycheck() else it
+        }
 
         val updatedScenario = newBasedOnAttributeSelectionFields(httpRequest.queryParams)
         val requestMatch = when(httpResponse.status in invalidRequestStatuses) {

--- a/core/src/test/kotlin/io/specmatic/proxy/ProxyTest.kt
+++ b/core/src/test/kotlin/io/specmatic/proxy/ProxyTest.kt
@@ -323,7 +323,7 @@ internal class ProxyTest {
             val stubResponse =  RestTemplate().postForEntity<String>(fake.endPoint + "/_specmatic/expectations", expectation)
             assertThat(stubResponse.statusCode.value()).isEqualTo(200)
 
-            Proxy(host = "localhost", port = 9001, "", fakeFileWriter, timeoutInMilliseconds = 200).use {
+            Proxy(host = "localhost", port = 9001, "", fakeFileWriter, timeoutInMilliseconds = 250).use {
                 val restProxy = java.net.Proxy(java.net.Proxy.Type.HTTP, InetSocketAddress("localhost", 9001))
                 val requestFactory = SimpleClientHttpRequestFactory()
                 requestFactory.setProxy(restProxy)

--- a/core/src/test/kotlin/io/specmatic/test/ResponseMonitorTest.kt
+++ b/core/src/test/kotlin/io/specmatic/test/ResponseMonitorTest.kt
@@ -2,6 +2,10 @@ package io.specmatic.test
 
 import io.specmatic.core.*
 import io.specmatic.core.pattern.*
+import io.specmatic.core.value.JSONArrayValue
+import io.specmatic.core.value.JSONObjectValue
+import io.specmatic.core.value.NumberValue
+import io.specmatic.core.value.StringValue
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -332,5 +336,43 @@ class ResponseMonitorTest {
         >> MONITOR.RESPONSE.BODY.age
         Expected number, actual was "John"
         """.trimIndent())
+    }
+
+    @Test
+    fun `extraHeaders from monitor response payload should be allowed`() {
+        val feature = Feature(name = "", scenarios = listOf(postScenario, acceptedScenario, monitorScenario))
+        val response = JSONObjectValue(mapOf(
+            "statusCode" to NumberValue(201),
+            "body" to JSONObjectValue(mapOf("name" to StringValue("John"), "age" to NumberValue(20))),
+            "header" to JSONArrayValue(listOf(
+                JSONObjectValue(mapOf("name" to StringValue("Content-Type"), "value" to StringValue("application/json"))),
+                JSONObjectValue(mapOf("name" to StringValue("X-Extra"), "value" to StringValue("Extra-Value"))),
+            ))
+        ))
+
+        val result = ResponseMonitor(feature, postScenario, response = HttpResponse(
+            status = 202,
+            headers = mapOf("Link" to "</monitor/123>;rel=related;title=monitor")
+        ), backOffDelay = 0).waitForResponse(object : TestExecutor {
+            override fun execute(request: HttpRequest): HttpResponse {
+                assertThat(request.path).isEqualTo("/monitor/123")
+                assertThat(request.method).isEqualTo("GET")
+                return HttpResponse(
+                    status = 200,
+                    body = JSONObjectValue(mapOf(
+                        "request" to postScenario.generateHttpRequest().updateHeader("EXTRA-HEADER", "Extra-Value").toJSON(),
+                        "response" to response
+                    ))
+                )
+            }
+        })
+
+        assertThat(result).isInstanceOf(HasValue::class.java); result as HasValue
+        assertThat(result.value.status).isEqualTo(201)
+        assertThat(result.value.headers).isEqualTo(mapOf(
+            "Content-Type" to "application/json",
+            "X-Extra" to "Extra-Value"
+        ))
+        assertThat(result.value.body).isEqualTo(response.jsonObject["body"])
     }
 }

--- a/core/src/test/kotlin/io/specmatic/test/ResponseMonitorTest.kt
+++ b/core/src/test/kotlin/io/specmatic/test/ResponseMonitorTest.kt
@@ -367,12 +367,18 @@ class ResponseMonitorTest {
             }
         })
 
-        assertThat(result).isInstanceOf(HasValue::class.java); result as HasValue
+        assertThatExtraHeaderWasAccepted(result)
+
+        result as HasValue
         assertThat(result.value.status).isEqualTo(201)
         assertThat(result.value.headers).isEqualTo(mapOf(
             "Content-Type" to "application/json",
             "X-Extra" to "Extra-Value"
         ))
         assertThat(result.value.body).isEqualTo(response.jsonObject["body"])
+    }
+
+    private fun assertThatExtraHeaderWasAccepted(result: ReturnValue<HttpResponse>) {
+        assertThat(result).isInstanceOf(HasValue::class.java)
     }
 }


### PR DESCRIPTION
**What**: Enable additional header validation in the validation module

**Why**: Any extra out-of-spec headers should not be permitted in the examples. If necessary, set `EXTENSIBLE_SCHEMA` to allow additional values in the example.

**Checklist**:
- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)