### PR TITLE
Enable out-of-spec header validation for externalized examples on test

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
@@ -98,15 +98,14 @@ data class HttpRequestPattern(
     private fun matchSecurityScheme(parameters: Triple<HttpRequest, Resolver, List<Failure>>): MatchingResult<Triple<HttpRequest, Resolver, List<Failure>>> {
         val (httpRequest, resolver, failures) = parameters
 
-        val matchFailures = mutableListOf<Failure>()
-        val matchingSecurityScheme: OpenAPISecurityScheme = securitySchemes.firstOrNull {
-            when (val result = it.matches(httpRequest, resolver)) {
-                is Failure -> false.also { matchFailures.add(result) }
-                is Success -> true
-            }
-        } ?: return MatchSuccess(Triple(httpRequest, resolver, failures.plus(matchFailures)))
+        val (modifiedHttpRequest, results) = securitySchemes.fold(
+            initial = Pair(httpRequest, emptyList<Result>()))
+        { (request, results), securityScheme ->
+            securityScheme.removeParam(request) to results.plus(securityScheme.matches(request, resolver))
+        }
 
-        return MatchSuccess(Triple(matchingSecurityScheme.removeParam(httpRequest), resolver, failures))
+        val newFailures = results.filterIsInstance<Failure>()
+        return MatchSuccess(Triple(modifiedHttpRequest, resolver, failures.plus(newFailures)))
     }
 
     fun matchesSignature(other: HttpRequestPattern): Boolean =

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
@@ -98,13 +98,12 @@ data class HttpRequestPattern(
     private fun matchSecurityScheme(parameters: Triple<HttpRequest, Resolver, List<Failure>>): MatchingResult<Triple<HttpRequest, Resolver, List<Failure>>> {
         val (httpRequest, resolver, failures) = parameters
 
-        val (modifiedHttpRequest, results) = securitySchemes.fold(
-            initial = Pair(httpRequest, emptyList<Result>()))
-        { (request, results), securityScheme ->
+        val (modifiedHttpRequest, results) = securitySchemes.fold(Pair(httpRequest, emptyList<Result>())) { (request, results), securityScheme ->
             securityScheme.removeParam(request) to results.plus(securityScheme.matches(request, resolver))
         }
 
-        val newFailures = results.filterIsInstance<Failure>()
+        val hasSuccess = results.any { it is Success }
+        val newFailures = if (hasSuccess) emptyList() else results.filterIsInstance<Failure>()
         return MatchSuccess(Triple(modifiedHttpRequest, resolver, failures.plus(newFailures)))
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -512,7 +512,9 @@ data class Scenario(
         val rowsToValidate = examples.flatMap { it.rows }
 
         val errors = rowsToValidate.mapNotNull { row ->
-            val resolverForExample = flagsBased.update(resolverForValidation(resolver, row))
+            val resolverForExample = flagsBased.update(
+                resolver = resolverForValidation(resolver, row)
+            ).disableOverrideUnexpectedKeycheck()
 
             val requestError = nullOrExceptionString {
                 validateRequestExample(row, resolverForExample)

--- a/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
+++ b/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
@@ -441,6 +441,25 @@ class LoadTestsFromExternalisedFiles {
         assertThat(results.success()).withFailMessage(results.report()).isTrue()
     }
 
+    @Test
+    fun `should complain when example request-response contains out-of-spec headers`() {
+        val openApiFile = File("src/test/resources/openapi/apiKeyAuth.yaml")
+        val examplesDir = File("src/test/resources/openapi/apiKeyAuthExtraHeader_examples")
+
+        Flags.using(Flags.EXAMPLE_DIRECTORIES to examplesDir.canonicalPath) {
+            val feature = OpenApiSpecification.fromFile(openApiFile.canonicalPath).toFeature().loadExternalisedExamples()
+            val exception = assertThrows<ContractException> { feature.validateExamplesOrException() }
+
+            assertThat(exception.report()).isEqualToNormalizingWhitespace("""
+            Error loading example for GET /hello/(id:number) -> 200 from ${examplesDir.resolve("extra_header.json").canonicalPath}
+            >> REQUEST.HEADERS.X-Extra-Header  
+            The header X-Extra-Header was found in the example extra_header but was not in the specification.
+            >> RESPONSE.HEADERS.X-Extra-Header
+            The header X-Extra-Header was found in the example extra_header but was not in the specification.
+            """.trimIndent())
+        }
+    }
+
     @Nested
     inner class AttributeSelection {
         @BeforeEach

--- a/core/src/test/kotlin/io/specmatic/core/HttpRequestPatternKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpRequestPatternKtTest.kt
@@ -1,11 +1,12 @@
 package io.specmatic.core
 
+import io.specmatic.conversions.*
+import io.specmatic.core.pattern.*
+import org.apache.http.HttpHeaders.AUTHORIZATION
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import io.specmatic.core.pattern.AnyPattern
-import io.specmatic.core.pattern.NumberPattern
-import io.specmatic.core.pattern.Row
-import io.specmatic.core.pattern.StringPattern
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 
 internal class HttpRequestPatternKtTest {
     @Test
@@ -33,5 +34,29 @@ internal class HttpRequestPatternKtTest {
 
         assertThat(newTypes).contains(listOf(MultiPartContentPattern("data", StringPattern())))
         assertThat(newTypes).contains(emptyList())
+    }
+
+    @ParameterizedTest
+    @MethodSource("io.specmatic.core.ScenarioTest#securitySchemaProvider")
+    fun `should remove security schemes before header matching occurs even if value is invalid`(securitySchema: OpenAPISecurityScheme) {
+        val httpRequestPattern = HttpRequestPattern(
+            httpPathPattern = buildHttpPathPattern("/"), method = "POST", securitySchemes = listOf(securitySchema)
+        )
+        val httpRequest = invalidateSecuritySchemes(HttpRequest("POST", "/"), securitySchema)
+        val result = httpRequestPattern.matches(httpRequest, Resolver().disableOverrideUnexpectedKeycheck())
+
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
+        assertThat(result.reportString()).satisfiesAnyOf(
+            { assertThat(it).containsOnlyOnce(">> REQUEST.HEADERS.API-KEY") },
+            { assertThat(it).containsOnlyOnce(">> REQUEST.QUERY-PARAMS.API-KEY") },
+            { assertThat(it).containsOnlyOnce(">> REQUEST.HEADERS.Authorization") }
+        )
+    }
+
+    companion object {
+        private fun invalidateSecuritySchemes(request: HttpRequest, scheme: OpenAPISecurityScheme): HttpRequest {
+            if (scheme !is BasicAuthSecurityScheme && scheme !is BearerSecurityScheme) return request
+            return request.copy(headers = request.headers.plus(AUTHORIZATION to "INVALID"))
+        }
     }
 }

--- a/core/src/test/resources/openapi/apiKeyAuthExtraHeader_examples/extra_header.json
+++ b/core/src/test/resources/openapi/apiKeyAuthExtraHeader_examples/extra_header.json
@@ -1,0 +1,17 @@
+{
+  "http-request": {
+    "method": "GET",
+    "path": "/hello/10",
+    "headers": {
+      "X-API-KEY": "abc123",
+      "X-Extra-Header": "extraValue"
+    }
+  },
+  "http-response": {
+    "status": 200,
+    "headers": {
+      "X-Extra-Header": "extraValue"
+    },
+    "body": "Hello, World!"
+  }
+}


### PR DESCRIPTION
**What**: Enable out-of-spec header validation for externalized examples on test

Why: Any extra out-of-spec headers should not be permitted in the examples. If necessary, set EXTENSIBLE_SCHEMA to allow additional values in the example.

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
