### PR TITLE
Fix Path-matching logic for ExampleValidationModule

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -344,7 +344,9 @@ data class Scenario(
         val updatedScenario = newBasedOnAttributeSelectionFields(httpRequest.queryParams)
         val requestMatch = when(httpResponse.status in invalidRequestStatuses) {
             false -> updatedScenario.matches(httpRequest, mismatchMessages, updatedResolver.findKeyErrorCheck.unexpectedKeyCheck, updatedResolver)
-            else -> updatedScenario.httpRequestPattern.withWildcardPathPattern().matchesPathAndMethod(httpRequest, updatedResolver)
+            else -> updatedScenario.httpRequestPattern.matchesPathAndMethod(httpRequest, updatedResolver).let {
+                it.takeUnless { it is Result.Failure && it.hasReason(FailureReason.URLPathParamMismatchButSameStructure) } ?: Result.Success()
+            }
         }
 
         val fieldsSelected = fieldsToBeMadeMandatoryBasedOnAttributeSelection(httpRequest.queryParams)


### PR DESCRIPTION
**What**:

Don't use wildcard matches for 4xx examples. Instead, look for a Result.Failure reason saying that this structure of the URL was right but the types didn't match.

**Why**:

This becomes causes an issue when validation an inline 4xx example.


**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
