### PR TITLE
Fix content-type matching logic for ExampleValidationModule

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
@@ -52,7 +52,7 @@ data class HttpHeadersPattern(
         }
     }
 
-    private fun matchContentType(parameters: Pair<Map<String, String>, Resolver>):  MatchingResult<Pair<Map<String, String>, Resolver>> {
+    fun matchContentType(parameters: Pair<Map<String, String>, Resolver>):  MatchingResult<Pair<Map<String, String>, Resolver>> {
 
         val (headers, resolver) = parameters
 

--- a/core/src/main/kotlin/io/specmatic/core/HttpPathPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpPathPattern.kt
@@ -207,15 +207,6 @@ data class HttpPathPattern(
         return pathSegmentPatterns.filter { !it.pattern.instanceOf(ExactValuePattern::class) }
     }
 
-    fun withWildcardPathSegments(): HttpPathPattern {
-        return this.copy(
-            pathSegmentPatterns = this.pathSegmentPatterns.map {
-                if (it.pattern is ExactValuePattern) it
-                else it.copy(pattern = AnythingPattern)
-            }
-        )
-    }
-
     private fun negatively(
         patterns: List<URLPathSegmentPattern>,
         row: Row,

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
@@ -872,12 +872,6 @@ data class HttpRequestPattern(
         )
     }
 
-    fun withWildcardPathPattern(): HttpRequestPattern {
-        return this.copy(
-            httpPathPattern = this.httpPathPattern?.withWildcardPathSegments()
-        )
-    }
-
     fun fillInTheBlanks(request: HttpRequest, resolver: Resolver): HttpRequest {
         val sanitizedRequest = withoutSecuritySchemes(request)
         val path = httpPathPattern?.fillInTheBlanks(sanitizedRequest.path, resolver)?.breadCrumb("PATH-PARAMS") ?: HasValue(null)

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
@@ -71,7 +71,7 @@ data class HttpRequestPattern(
         }
     }
 
-    fun matchesPathAndMethod(
+    private fun matchesPathAndMethod(
         incomingHttpRequest: HttpRequest,
         resolver: Resolver
     ): Result {
@@ -93,6 +93,18 @@ data class HttpRequestPattern(
             ).breadCrumb("REQUEST")
             else -> result
         }
+    }
+
+    fun matchesPathStructureMethodAndContentType(incomingHttpRequest: HttpRequest, resolver: Resolver): Result {
+        val contentTypeMatches = headersPattern.matchContentType(incomingHttpRequest.headers to resolver)
+        if (contentTypeMatches is MatchFailure<*>) {
+            return contentTypeMatches.error.breadCrumb("REQUEST.HEADERS")
+        }
+
+        val pathAndMethodMatch = matchesPathAndMethod(incomingHttpRequest, resolver)
+        return pathAndMethodMatch.takeUnless {
+            it is Failure && it.hasReason(FailureReason.URLPathParamMismatchButSameStructure)
+        } ?: Success()
     }
 
     private fun matchSecurityScheme(parameters: Triple<HttpRequest, Resolver, List<Failure>>): MatchingResult<Triple<HttpRequest, Resolver, List<Failure>>> {

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -344,9 +344,7 @@ data class Scenario(
         val updatedScenario = newBasedOnAttributeSelectionFields(httpRequest.queryParams)
         val requestMatch = when(httpResponse.status in invalidRequestStatuses) {
             false -> updatedScenario.matches(httpRequest, mismatchMessages, updatedResolver.findKeyErrorCheck.unexpectedKeyCheck, updatedResolver)
-            else -> updatedScenario.httpRequestPattern.matchesPathAndMethod(httpRequest, updatedResolver).let {
-                it.takeUnless { it is Result.Failure && it.hasReason(FailureReason.URLPathParamMismatchButSameStructure) } ?: Result.Success()
-            }
+            else -> updatedScenario.httpRequestPattern.matchesPathStructureMethodAndContentType(httpRequest, updatedResolver)
         }
 
         val fieldsSelected = fieldsToBeMadeMandatoryBasedOnAttributeSelection(httpRequest.queryParams)
@@ -699,9 +697,7 @@ data class Scenario(
 
             val requestMatchResult = attempt(breadCrumb = "REQUEST") {
                 if (response.status !in invalidRequestStatuses) return@attempt httpRequestPattern.matches(request, resolver)
-                httpRequestPattern.matchesPathAndMethod(request, resolver).takeUnless {
-                    it is Result.Failure && it.hasReason(FailureReason.URLPathParamMismatchButSameStructure)
-                } ?: Result.Success()
+                httpRequestPattern.matchesPathStructureMethodAndContentType(request, resolver)
             }
 
             if (requestMatchResult is Result.Failure)
@@ -851,9 +847,7 @@ data class Scenario(
             if (template.response.status !in invalidRequestStatuses) {
                 return@attempt httpRequestPattern.matches(template.request, updatedResolver, updatedResolver)
             }
-            httpRequestPattern.matchesPathAndMethod(template.request, updatedResolver).takeUnless {
-                it is Result.Failure && it.hasReason(FailureReason.URLPathParamMismatchButSameStructure)
-            } ?: Result.Success()
+            httpRequestPattern.matchesPathStructureMethodAndContentType(template.request, updatedResolver)
         }
 
         val responseMatch = attempt(breadCrumb = "RESPONSE") {

--- a/core/src/test/kotlin/io/specmatic/core/examples/module/ExampleValidationModuleTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/examples/module/ExampleValidationModuleTest.kt
@@ -482,6 +482,26 @@ class ExampleValidationModuleTest {
         }
     }
 
+    @Test
+    fun `should validate request content-type for 4xx examples along with path structure and method`(@TempDir tempDir: File) {
+        val scenario = Scenario(ScenarioInfo(
+            httpRequestPattern = HttpRequestPattern(
+                method = "GET",
+                httpPathPattern = buildHttpPathPattern("/test"),
+                headersPattern = HttpHeadersPattern(contentType = "application/json-patch-query+json")
+            ),
+            httpResponsePattern = HttpResponsePattern(status = 400)
+        ))
+        val example = ScenarioStub(
+            request = HttpRequest("GET", "/test", headers = mapOf("Content-Type" to "application/json")),
+            response = HttpResponse(status = 400, headers = mapOf("Content-Type" to "application/json"))
+        ).toExample(tempDir)
+        val feature = Feature(listOf(scenario), name = "")
+        val result = exampleValidationModule.validateExample(feature, example)
+
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
+    }
+
     private fun ScenarioStub.toPartialExample(tempDir: File): File {
         val example = JSONObjectValue(mapOf("partial" to this.toJSON()))
         val exampleFile = tempDir.resolve("example.json")


### PR DESCRIPTION
**What**: Fix content-type matching logic for `ExampleValidationModule`

**Why**: 4xx Example must match path structure, method and request content-type, and response

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
