### PR TITLE
Fix contentType being dropped during the request to pattern conversion

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
@@ -323,7 +323,11 @@ data class HttpRequestPattern(
                     resolver
                 )
 
-                requestPattern.copy(headersPattern = HttpHeadersPattern(headersFromRequest, ancestorHeaders = this.headersPattern.pattern))
+                requestPattern.copy(
+                    headersPattern = headersPattern.copy(
+                        pattern = headersFromRequest, ancestorHeaders = this.headersPattern.pattern
+                    )
+                )
             }
 
             requestPattern = attempt(breadCrumb = "BODY") {

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -6639,6 +6639,9 @@ paths:
             val stubbedRequest = HttpRequest(
                 method = "POST",
                 path = "/data",
+                headers = mapOf(
+                    "Content-Type" to "application/octet-stream"
+                ),
                 body = StringValue(base64EncodedRequestBody)
             )
 


### PR DESCRIPTION
**What**: Fix contentType being dropped during the request to pattern conversion

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)