### PR TITLE
Show progress during the backward compatibility check

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/TestBackwardCompatibility.kt
+++ b/core/src/main/kotlin/io/specmatic/core/TestBackwardCompatibility.kt
@@ -1,15 +1,27 @@
 package io.specmatic.core
 
+import io.specmatic.core.log.logger
 import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.utilities.capitalizeFirstChar
 import io.specmatic.core.value.NullValue
 import io.specmatic.core.value.Value
 
 fun testBackwardCompatibility(older: Feature, newer: Feature): Results {
+    val cache = mutableSetOf<String>()
+
     return older.generateBackwardCompatibilityTestScenarios().filter { !it.ignoreFailure }.fold(Results()) { results, olderScenario ->
+        val olderScenarioDescription = olderScenario.testDescription()
+        if (olderScenarioDescription !in cache) {
+            logger.newLine()
+            logger.log("[Compatibility Check] ${olderScenarioDescription.trim()}")
+            cache.add(olderScenarioDescription)
+        }
+
         val scenarioResults: List<Result> = testBackwardCompatibility(olderScenario, newer)
         results.copy(results = results.results.plus(scenarioResults))
-    }.distinct()
+    }.distinct().also {
+        logger.newLine()
+    }
 }
 
 fun testBackwardCompatibility(


### PR DESCRIPTION
**What**:

Log each API being tested during the backward compatibility check.

**Why**:

Each API being tested gets printed, which should avoid giving the impression that Specmatic has hung when testing a complex specification with many APIs.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
