### PR TITLE
Fix validate command to ensure it validates all OAS within a specs directory

### DIFF
--- a/application/src/main/kotlin/application/ExamplesCommand.kt
+++ b/application/src/main/kotlin/application/ExamplesCommand.kt
@@ -211,9 +211,9 @@ For example, to filter by HTTP methods:
                 logger.boundary()
 
                 val associatedExamplesDir = examplesBaseDir.resolve(relativeSpecPath.substringBeforeLast(".").plus("_examples"))
-                val externalExampleValidationResult = when (associatedExamplesDir.exists()) {
-                    true -> validateExamplesDir(feature, associatedExamplesDir).second
-                    false -> ValidationResults.forNoExamples()
+                val externalExampleValidationResult = when {
+                    associatedExamplesDir.exists() -> validateExamplesDir(feature, associatedExamplesDir).second
+                    else -> ValidationResults.forNoExamples()
                 }
                 printValidationResult(externalExampleValidationResult.exampleValidationResults, "Example file")
                 logger.boundary()

--- a/application/src/main/kotlin/application/ExamplesCommand.kt
+++ b/application/src/main/kotlin/application/ExamplesCommand.kt
@@ -285,14 +285,6 @@ For example, to filter by HTTP methods:
         }
 
         private fun printValidationResult(validationResults: Map<String, Result>, tag: String) {
-            if (validationResults.isEmpty()) {
-                val message = "No associated ${tag}s found."
-                logger.log("=".repeat(message.length))
-                logger.log(message)
-                logger.log("=".repeat(message.length))
-                return
-            }
-
             val titleTag = tag.split(" ").joinToString(" ") { if (it.isBlank()) it else it.capitalizeFirstChar() }
 
             if (validationResults.containsFailuresOrPartialFailures()) {

--- a/application/src/main/kotlin/application/ExamplesCommand.kt
+++ b/application/src/main/kotlin/application/ExamplesCommand.kt
@@ -10,9 +10,11 @@ import io.specmatic.core.log.Verbose
 import io.specmatic.core.log.logger
 import io.specmatic.core.utilities.capitalizeFirstChar
 import io.specmatic.mock.ScenarioStub
+import io.specmatic.stub.isOpenAPI
 import picocli.CommandLine.*
 import java.io.File
 import java.util.concurrent.Callable
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.system.exitProcess
 
 private const val SUCCESS_EXIT_CODE = 0
@@ -195,26 +197,24 @@ For example, to filter by HTTP methods:
         }
 
         private fun validateAllExamplesAssociatedToEachSpecIn(specsDir: File, examplesBaseDir: File): List<ValidationResults> {
-            var ordinal = 1
+            val ordinal = AtomicInteger(1)
+            val allSpecFiles = specsDir.walk().filter(File::isFile).filter { isOpenAPI(it.canonicalPath) }
 
-            val validationResults = specsDir.walk().filter { it.isFile && it.extension in CONTRACT_EXTENSIONS }.map { specFile ->
+            val validationResults = allSpecFiles.map { specFile ->
                 val relativeSpecPath = specsDir.toPath().relativize(specFile.toPath()).toString()
-                val associatedExamplesDir =
-                    examplesBaseDir.resolve(relativeSpecPath.substringBeforeLast(".").plus("_examples"))
-
-                if (associatedExamplesDir.exists().not() || associatedExamplesDir.isDirectory.not()) {
-                    return@map ValidationResults.forNoExamples()
-                }
-
-                logger.log("$ordinal. Validating examples in '${associatedExamplesDir}' associated to '$relativeSpecPath'...${System.lineSeparator()}")
-                ordinal++
+                logger.log("${ordinal.getAndIncrement()}. Validating examples associated to '$relativeSpecPath'...")
+                logger.boundary()
 
                 val feature = parseContractFileWithNoMissingConfigWarning(specFile)
                 val inlineExampleValidationResults = validateInlineExamples(feature)
                 printValidationResult(inlineExampleValidationResults, "Inline example")
                 logger.boundary()
 
-                val externalExampleValidationResult = validateExamplesDir(feature, associatedExamplesDir).second
+                val associatedExamplesDir = examplesBaseDir.resolve(relativeSpecPath.substringBeforeLast(".").plus("_examples"))
+                val externalExampleValidationResult = when (associatedExamplesDir.exists()) {
+                    true -> validateExamplesDir(feature, associatedExamplesDir).second
+                    false -> ValidationResults.forNoExamples()
+                }
                 printValidationResult(externalExampleValidationResult.exampleValidationResults, "Example file")
                 logger.boundary()
 
@@ -223,7 +223,6 @@ For example, to filter by HTTP methods:
 
             logger.log("Summary:")
             printValidationResult(validationResults.ofAllExamples(), "Overall")
-
             return validationResults
         }
 
@@ -287,7 +286,7 @@ For example, to filter by HTTP methods:
 
         private fun printValidationResult(validationResults: Map<String, Result>, tag: String) {
             if (validationResults.isEmpty()) {
-                val message = "No associated examples found."
+                val message = "No associated ${tag}s found."
                 logger.log("=".repeat(message.length))
                 logger.log(message)
                 logger.log("=".repeat(message.length))
@@ -297,21 +296,20 @@ For example, to filter by HTTP methods:
             val titleTag = tag.split(" ").joinToString(" ") { if (it.isBlank()) it else it.capitalizeFirstChar() }
 
             if (validationResults.containsFailuresOrPartialFailures()) {
-                println()
+                logger.boundary()
                 logger.log("=============== $titleTag Validation Results ===============")
-
                 validationResults.forEach { (exampleFileName, result) ->
                     if (!result.isSuccess()) {
                         val errorPrefix = if (result.isPartialFailure()) "Warning" else "Error"
-
-                        logger.log("\n$errorPrefix(s) found in the example file - '$exampleFileName':")
+                        logger.boundary()
+                        logger.log("$errorPrefix(s) found in the $tag - '$exampleFileName':")
                         logger.log(result.reportString())
                     }
                 }
             }
 
-            println()
             val summaryTitle = "=============== $titleTag Validation Summary ==============="
+            logger.boundary()
             logger.log(summaryTitle)
             logger.log(Results(validationResults.values.toList()).summary())
             logger.log("=".repeat(summaryTitle.length))

--- a/application/src/test/kotlin/application/ExamplesCommandTest.kt
+++ b/application/src/test/kotlin/application/ExamplesCommandTest.kt
@@ -4,6 +4,7 @@ import io.specmatic.core.Result
 import io.specmatic.core.lifecycle.AfterLoadingStaticExamples
 import io.specmatic.core.lifecycle.LifecycleHooks
 import io.specmatic.core.log.logger
+import io.specmatic.core.utilities.Flags
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -399,7 +400,84 @@ paths:
             ==========================================================
             """.trimIndent())
         }
+
+        @Test
+        fun `should validate all oas files from --specs-dir even if no external examples exist for said oas`() {
+            val (stdOut, exitCode) = captureStandardOutput {
+                cli.execute("--specs-dir", "src/test/resources/examples/only_specs/products")
+            }
+
+            assertThat(exitCode).isEqualTo(0)
+            assertThat(stdOut).containsIgnoringWhitespaces("""
+            1. Validating examples associated to 'spec.yaml'...
+            """.trimIndent())
+            assertThat(stdOut).containsIgnoringWhitespaces("""
+            =============== Inline Example Validation Summary ===============
+            All 1 example(s) are valid.
+            =================================================================
+            """.trimIndent())
+            assertThat(stdOut).containsIgnoringWhitespaces("""
+            ==================================
+            No associated Example files found.
+            ==================================
+            """.trimIndent())
+            assertThat(stdOut).containsIgnoringWhitespaces("""
+            Summary:
+            =============== Overall Validation Summary ===============
+            All 1 example(s) are valid.
+            ==========================================================
+            """.trimIndent())
+        }
+
+        @Test
+        fun `should log inline and external examples errors and respective summaries with accurate tags`() {
+            val oasFile = File("src/test/resources/specifications/spec_invalid_examples/api.yaml")
+            val externalExample = oasFile.resolveSibling("api_examples").resolve("INVALID_EXTERNAL.json")
+            val (stdOut, exitCode) = captureStandardOutput {
+                cli.execute("--spec-file", oasFile.canonicalPath)
+            }
+
+            assertThat(exitCode).isEqualTo(1)
+            assertThat(stdOut).containsIgnoringWhitespaces("Error(s) found in the Inline example - 'INVALID_INLINE'")
+            assertThat(stdOut).containsIgnoringWhitespaces("Error(s) found in the Example file - '${externalExample.canonicalPath}'")
+            assertThat(stdOut).containsIgnoringWhitespaces("""
+            =============== Inline Example Validation Summary ===============
+            All 1 example(s) are invalid.
+            =================================================================
+            """.trimIndent())
+            assertThat(stdOut).containsIgnoringWhitespaces("""
+            =============== Example File Validation Summary ===============
+            All 1 example(s) are invalid.
+            ===============================================================
+            """.trimIndent())
+        }
+
+        @Test
+        fun `should log which associated inline or external examples were not found when no examples exist`() {
+            val emptyExamplesDir = File("src/test/resources/examples/only_specs/products/spec_examples")
+            try {
+                emptyExamplesDir.mkdirs()
+                val (stdOut, exitCode) = captureStandardOutput {
+                    Flags.using(Flags.IGNORE_INLINE_EXAMPLES to "true") {
+                        cli.execute("--spec-file", "src/test/resources/examples/only_specs/products/spec.yaml")
+                    }
+                }
+
+                assertThat(exitCode).isEqualTo(0)
+                assertThat(stdOut).containsIgnoringWhitespaces("""
+                ====================================
+                No associated Inline examples found.
+                ====================================
+                ==================================
+                No associated Example files found.
+                ==================================
+                """.trimIndent())
+            } finally {
+                emptyExamplesDir.deleteRecursively()
+            }
+        }
     }
+
     @Nested
     inner class ValidateLifeCycleTests {
         private val hook = AfterLoadingStaticExamples { examplesUsedFor, examples ->

--- a/application/src/test/kotlin/application/ExamplesCommandTest.kt
+++ b/application/src/test/kotlin/application/ExamplesCommandTest.kt
@@ -287,8 +287,10 @@ paths:
             All 1 example(s) are valid.
             =================================================================
             """.trimIndent())
-            assertThat(stdOut).doesNotContain("""
+            assertThat(stdOut).containsIgnoringWhitespaces("""
             =============== Example File Validation Summary ===============
+            No examples found
+            ===============================================================
             """.trimIndent())
         }
 
@@ -307,8 +309,10 @@ paths:
             All 1 example(s) are valid.
             ===============================================================
             """.trimIndent())
-            assertThat(stdOut).doesNotContain("""
-            =============== Inline Example Validation Summary =============
+            assertThat(stdOut).containsIgnoringWhitespaces("""
+            =============== Inline Example Validation Summary ===============
+            No examples found
+            =================================================================
             """.trimIndent())
         }
 
@@ -417,9 +421,9 @@ paths:
             =================================================================
             """.trimIndent())
             assertThat(stdOut).containsIgnoringWhitespaces("""
-            ==================================
-            No associated Example files found.
-            ==================================
+            =============== Example File Validation Summary ===============
+            No examples found
+            ===============================================================
             """.trimIndent())
             assertThat(stdOut).containsIgnoringWhitespaces("""
             Summary:
@@ -465,12 +469,12 @@ paths:
 
                 assertThat(exitCode).isEqualTo(0)
                 assertThat(stdOut).containsIgnoringWhitespaces("""
-                ====================================
-                No associated Inline examples found.
-                ====================================
-                ==================================
-                No associated Example files found.
-                ==================================
+                =============== Inline Example Validation Summary ===============
+                No examples found
+                =================================================================
+                =============== Example File Validation Summary ===============
+                No examples found
+                ===============================================================
                 """.trimIndent())
             } finally {
                 emptyExamplesDir.deleteRecursively()

--- a/application/src/test/resources/specifications/spec_invalid_examples/api.yaml
+++ b/application/src/test/resources/specifications/spec_invalid_examples/api.yaml
@@ -1,0 +1,44 @@
+openapi: 3.0.0
+info:
+  title: Simple API Specification
+  version: 1.0.0
+paths:
+  /test:
+    post:
+      summary: Test endpoint
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TestInput"
+            examples:
+              INVALID_INLINE:
+                value:
+                  name: john doe
+                  email: INVALID-EMAIL
+      responses:
+        "201":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TestResponse"
+              examples:
+                INVALID_INLINE:
+                  value:
+                    id: SHOULD-BE-AN-NUMBER
+components:
+  schemas:
+    TestInput:
+      type: object
+      properties:
+        name:
+          type: string
+        email:
+          type: string
+          format: email
+    TestResponse:
+      type: object
+      properties:
+        id:
+          type: integer

--- a/application/src/test/resources/specifications/spec_invalid_examples/api_examples/INVALID_EXTERNAL.json
+++ b/application/src/test/resources/specifications/spec_invalid_examples/api_examples/INVALID_EXTERNAL.json
@@ -1,0 +1,23 @@
+{
+  "http-request": {
+    "method": "POST",
+    "path": "/test",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "name": "john doe",
+      "email": "INVALID-EMAIL"
+    }
+  },
+  "http-response": {
+    "status": 201,
+    "status-text": "Created",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "id": "SHOULD-BE-AN-NUMBER"
+    }
+  }
+}

--- a/core/src/main/kotlin/io/specmatic/core/Results.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Results.kt
@@ -108,6 +108,8 @@ data class Results(val results: List<Result> = emptyList()) {
     }
 
     fun summary(): String {
+        if (results.isEmpty()) return "No examples found"
+
         val (successCount, failureCount, partialFailureCount) = getResultCounts()
         return when {
             successCount == results.size -> "All $successCount example(s) are valid."


### PR DESCRIPTION
**What**: 
- Fix validate command to ensure it validates all OAS within a specs directory
- Correct example tags when they are missing or invalid.

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)