### PR TITLE
Add a branch check in GitRepo when loading contracts

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/git/GitCommand.kt
+++ b/core/src/main/kotlin/io/specmatic/core/git/GitCommand.kt
@@ -35,11 +35,8 @@ interface GitCommand {
     fun getFilesChangedInCurrentBranch(baseBranch: String): List<String>
     fun getFileInBranch(fileName: String, currentBranch: String, baseBranch: String): File?
     fun currentRemoteBranch(): String
+    fun getOriginDefaultBranchName(): String
     fun currentBranch(): String {
-        return ""
-    }
-
-    fun defaultBranch(): String {
         return ""
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/git/SystemGit.kt
+++ b/core/src/main/kotlin/io/specmatic/core/git/SystemGit.kt
@@ -183,7 +183,7 @@ class SystemGit(override val workingDirectory: String = ".", private val prefix:
     override fun getOriginDefaultBranchName(): String {
         val defaultBranchRef = execute(Configuration.gitCommand, "symbolic-ref", "refs/remotes/origin/HEAD", "--short")
 
-        val parts = defaultBranchRef.split("/").filterNot(String::isEmpty)
+        val parts = defaultBranchRef.split("/").map(String::trim).filterNot(String::isEmpty)
         if (parts.size < 2) {
             throw ContractException(errorMessage = "Could not parse symbolic-ref value '$defaultBranchRef'. Expected format: 'origin/branch'")
         }

--- a/core/src/main/kotlin/io/specmatic/core/utilities/GitRepo.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/GitRepo.kt
@@ -64,11 +64,15 @@ data class GitRepo(
                         logger.log("Contract repo does not exist.")
                         cloneRepoAndCheckoutBranch(reposBaseDir, this)
                     }
-                    contractsRepoDir.exists() && isBehind(contractsRepoDir) -> {
+                    isNotOnBranch(contractsRepoDir) -> {
+                        logger.log("Contract repo exists but is not on the correct branch.")
+                        cloneRepoAndCheckoutBranch(reposBaseDir, this)
+                    }
+                    isBehind(contractsRepoDir) -> {
                         logger.log("Contract repo exists but is behind the remote.")
                         cloneRepoAndCheckoutBranch(reposBaseDir, this)
                     }
-                    contractsRepoDir.exists() && isClean(contractsRepoDir) -> {
+                    isClean(contractsRepoDir) -> {
                         logger.log("Contract repo exists, is clean, and is up to date with remote.")
                         contractsRepoDir
                     }
@@ -101,6 +105,12 @@ data class GitRepo(
 
             directory to contractSourceEntry.path
         }
+    }
+
+    private fun isNotOnBranch(contractRepoDir: File): Boolean {
+        if (branchName == null) return false
+        val sourceGit = getSystemGit(contractRepoDir.path)
+        return sourceGit.currentBranch() != branchName
     }
 
     private fun isClean(contractsRepoDir: File): Boolean {

--- a/core/src/main/kotlin/io/specmatic/core/utilities/GitRepo.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/GitRepo.kt
@@ -108,9 +108,10 @@ data class GitRepo(
     }
 
     private fun isNotOnBranch(contractRepoDir: File): Boolean {
-        if (branchName == null) return false
         val sourceGit = getSystemGit(contractRepoDir.path)
-        return sourceGit.currentBranch() != branchName
+        val expectedBranch = branchName ?: sourceGit.getOriginDefaultBranchName()
+        val currentBranch = sourceGit.currentBranch()
+        return expectedBranch != currentBranch
     }
 
     private fun isClean(contractsRepoDir: File): Boolean {

--- a/core/src/test/kotlin/io/specmatic/core/utilities/GitRepoTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/utilities/GitRepoTest.kt
@@ -1,0 +1,83 @@
+package io.specmatic.core.utilities
+
+import io.mockk.*
+import io.specmatic.core.git.GitCommand
+import io.specmatic.core.git.SystemGit
+import io.specmatic.core.git.checkout
+import io.specmatic.core.git.clone
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class GitRepoTest {
+
+    companion object {
+        @JvmStatic
+        @BeforeAll
+        fun setup() {
+            mockkStatic("io.specmatic.core.git.GitOperations")
+            mockkStatic("io.specmatic.core.utilities.Utilities")
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun teardown() {
+            unmockkAll()
+        }
+    }
+
+    @AfterEach
+    fun clearMocks() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun `should reset the directory and checkout the correct branch if directory on the wrong branch`(@TempDir tempDir: File) {
+        tempDir.resolve("repos").resolve("specmatic").mkdirs()
+        val fakeGit = mockk<GitCommand>()
+        every { fakeGit.currentBranch() } returns "feature"
+
+        every { getSystemGit(any()) } returns fakeGit
+        every { clone(any(), any()) } returns tempDir
+        every { checkout(any(), any()) } returns Unit
+
+        val gitRepo = GitRepo(
+            gitRepositoryURL = "https://github.com/specmatic/specmatic.git",
+            branchName = "main",
+            testContracts = emptyList(),
+            stubContracts = emptyList(),
+            type = null
+        )
+        gitRepo.loadContracts(workingDirectory = tempDir.canonicalPath, configFilePath = "", selector = { it.stubContracts })
+
+        verify(exactly = 1) { clone(tempDir.resolve("repos"), gitRepo) }
+        verify(exactly = 1) { checkout(tempDir,"main") }
+    }
+
+    @Test
+    fun `should reset when branch does not match origin default while config branch is not set`(@TempDir tempDir: File) {
+        tempDir.resolve("repos").resolve("specmatic").mkdirs()
+        val fakeGit = mockk<GitCommand>()
+        every { fakeGit.currentBranch() } returns "feature"
+        every { fakeGit.getOriginDefaultBranchName() } returns "main"
+
+        every { getSystemGit(any()) } returns fakeGit
+        every { clone(any(), any()) } returns tempDir
+        every { checkout(any(), any()) } returns Unit
+
+        val gitRepo = GitRepo(
+            gitRepositoryURL = "https://github.com/specmatic/specmatic.git",
+            branchName = null,
+            testContracts = emptyList(),
+            stubContracts = emptyList(),
+            type = null
+        )
+        gitRepo.loadContracts(workingDirectory = tempDir.canonicalPath, configFilePath = "", selector = { it.stubContracts })
+
+        verify(exactly = 1) { clone(tempDir.resolve("repos"), gitRepo) }
+        verify(exactly = 0) { checkout(tempDir,"main") }
+    }
+}

--- a/core/src/test/kotlin/utilities/UtilitiesTest.kt
+++ b/core/src/test/kotlin/utilities/UtilitiesTest.kt
@@ -115,9 +115,13 @@ internal class UtilitiesTest {
         every { mockGitCommand.fetch() }.returns("")
         every { mockGitCommand.revisionsBehindCount() }.returns(0)
         every { mockGitCommand.statusPorcelain() }.returns("")
+        every { mockGitCommand.currentBranch() } returns "main"
+        every { mockGitCommand.getOriginDefaultBranchName() } returns "main"
+
         mockkStatic("io.specmatic.core.utilities.Utilities")
         every { loadSources("/configFilePath") }.returns(sources)
         every { getSystemGitWithAuth(any()) }.returns(mockGitCommand)
+        every { getSystemGit(any()) }.returns(mockGitCommand)
 
         val contractPaths = contractFilePathsFrom("/configFilePath", ".$CONTRACT_EXTENSION") { source -> source.stubContracts }
         val expectedContractPaths = listOf(
@@ -160,9 +164,13 @@ internal class UtilitiesTest {
         every { mockGitCommand.fetch() }.returns("")
         every { mockGitCommand.revisionsBehindCount() }.returns(0)
         every { mockGitCommand.statusPorcelain() }.returns("someDir/someFile")
+        every { mockGitCommand.currentBranch() } returns "main"
+        every { mockGitCommand.getOriginDefaultBranchName() } returns "main"
+
         mockkStatic("io.specmatic.core.utilities.Utilities")
         every { loadSources("/configFilePath") }.returns(sources)
         every { getSystemGitWithAuth(any()) }.returns(mockGitCommand)
+        every { getSystemGit(any()) }.returns(mockGitCommand)
 
         mockkStatic("io.specmatic.core.git.GitOperations")
         every { clone(File(".spec/repos"), any()) }.returns(File(".spec/repos/repo1"))
@@ -187,9 +195,13 @@ internal class UtilitiesTest {
         every { mockGitCommand.statusPorcelain() }.returns("")
         every { mockGitCommand.fetch() }.returns("changes")
         every { mockGitCommand.revisionsBehindCount() }.returns(1)
+        every { mockGitCommand.currentBranch() } returns "main"
+        every { mockGitCommand.getOriginDefaultBranchName() } returns "main"
+
         mockkStatic("io.specmatic.core.utilities.Utilities")
         every { loadSources("/configFilePath") }.returns(sources)
         every { getSystemGitWithAuth(any()) }.returns(mockGitCommand)
+        every { getSystemGit(any()) }.returns(mockGitCommand)
 
         mockkStatic("io.specmatic.core.git.GitOperations")
         every { clone(File(".spec/repos"), any()) }.returns(File(".spec/repos/repo1"))
@@ -558,6 +570,7 @@ internal class UtilitiesTest {
     @AfterEach
     fun tearDownAfterEach() {
         deleteGitIgnoreFile()
+        unmockkAll()
     }
 
     companion object {


### PR DESCRIPTION
**What**: Add a branch check in GitRepo when loading contracts

**Why**:  If switched to a different branch than the one specified in the config, it should reset to the current branch

**Checklist**:

- [ ] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
