### PR TITLE
Migrate to a new external dictionary structure

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -1800,7 +1800,7 @@ class OpenApiSpecification(
         val schemaProperties = toSchemaProperties(schema, requiredFields, patternName, typeStack)
         val minProperties: Int? = schema.minProperties
         val maxProperties: Int? = schema.maxProperties
-        val jsonObjectPattern = toJSONObjectPattern(schemaProperties, if(patternName.isNotBlank()) "(${patternName})" else "").copy(
+        val jsonObjectPattern = toJSONObjectPattern(schemaProperties, if(patternName.isNotBlank()) "(${patternName})" else null).copy(
             minProperties = minProperties,
             maxProperties = maxProperties,
             additionalProperties = additionalPropertiesFrom(schema, patternName, typeStack)

--- a/core/src/main/kotlin/io/specmatic/core/DataRepresentation.kt
+++ b/core/src/main/kotlin/io/specmatic/core/DataRepresentation.kt
@@ -1,0 +1,64 @@
+package io.specmatic.core
+
+import io.specmatic.core.value.JSONObjectValue
+import io.specmatic.core.value.Value
+
+sealed interface DataRepresentation {
+    fun insert(segments: List<String>, value: Value): DataRepresentation
+    fun toValue(): Value
+
+    data class NodeData(val data: Map<String, DataRepresentation> = emptyMap()): DataRepresentation {
+
+        override fun insert(segments: List<String>, value: Value): NodeData {
+            require(segments.isNotEmpty()) { "Cannot insert into MapData with empty path" }
+            val currentSegment = segments.first()
+            val remaining = segments.drop(1)
+
+            if (remaining.isEmpty()) {
+                return copy(data = data + (currentSegment to from(value)))
+            }
+
+            val child = data[currentSegment] ?: NodeData()
+            val updatedChild = child.insert(remaining, value)
+            return copy(data = data + (currentSegment to updatedChild))
+        }
+
+        override fun toValue(): JSONObjectValue {
+            return JSONObjectValue(data.mapValues { it.value.toValue() })
+        }
+    }
+
+    class LeafData(val data: Value) : DataRepresentation {
+        override fun insert(segments: List<String>, value: Value): LeafData {
+            throw UnsupportedOperationException("LeafData does not support inserts")
+        }
+
+        override fun toValue(): Value {
+            return data
+        }
+    }
+
+    fun insert(key: String, value: Value): DataRepresentation {
+        val segments = key.toSegments()
+        return insert(segments, value)
+    }
+
+    fun String.toSegments(): List<String> {
+        return this.split(".").filterNot(String::isEmpty)
+    }
+
+    companion object {
+        fun from(value: Value): DataRepresentation {
+            return when (value) {
+                is JSONObjectValue -> from(value.jsonObject)
+                else -> LeafData(value)
+            }
+        }
+
+        fun from(map: Map<String, Value>): DataRepresentation {
+            return map.entries.fold(NodeData() as DataRepresentation) { acc, data ->
+                acc.insert(data.key, data.value)
+            }
+        }
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/core/DataRepresentation.kt
+++ b/core/src/main/kotlin/io/specmatic/core/DataRepresentation.kt
@@ -44,7 +44,7 @@ sealed interface DataRepresentation {
     }
 
     fun String.toSegments(): List<String> {
-        return this.split(".").filterNot(String::isEmpty)
+        return this.split(".").map { it.takeIf(String::isNotEmpty) ?: "*" }
     }
 
     companion object {
@@ -55,9 +55,9 @@ sealed interface DataRepresentation {
             }
         }
 
-        fun from(map: Map<String, Value>): DataRepresentation {
-            return map.entries.fold(NodeData() as DataRepresentation) { acc, data ->
-                acc.insert(data.key, data.value)
+        fun from(map: Map<String, Value>): NodeData {
+            return map.entries.fold(NodeData()) { acc, data ->
+                acc.insert(data.key, data.value) as NodeData
             }
         }
     }

--- a/core/src/main/kotlin/io/specmatic/core/HttpPathPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpPathPattern.kt
@@ -306,7 +306,7 @@ data class HttpPathPattern(
         return pathSegmentPatterns.zip(pathSegments).map { (urlPathPattern, token) ->
             val tokenWithoutParameter = removeKeyFromParameterToken(token)
             val (key, keyPattern) = urlPathPattern.let { it.key.orEmpty() to it.pattern }
-            val updatedResolver = resolver.updateLookupPath("PATH-PARAMS", key, keyPattern)
+            val updatedResolver = resolver.updateLookupPath("PATH-PARAMS", KeyWithPattern(key, keyPattern))
             val result = urlPathPattern.fixValue(urlPathPattern.tryParse(tokenWithoutParameter, updatedResolver), updatedResolver)
             token.takeIf { isPatternToken(tokenWithoutParameter) && isPatternToken(result) } ?: result
         }.joinToString("/", prefix = "/".takeIf { pathHadPrefix }.orEmpty() )
@@ -323,7 +323,7 @@ data class HttpPathPattern(
         val pathHadPrefix = path.startsWith("/")
         val generatedSegments = pathSegmentPatterns.zip(pathSegments).map { (urlPathPattern, token) ->
             val (key, keyPattern) = urlPathPattern.let { it.key.orEmpty() to it.pattern }
-            val updatedResolver = resolver.updateLookupPath("PATH-PARAMS", key, keyPattern)
+            val updatedResolver = resolver.updateLookupPath("PATH-PARAMS", KeyWithPattern(key, keyPattern))
             urlPathPattern.fillInTheBlanks(urlPathPattern.tryParse(token, updatedResolver), updatedResolver).breadCrumb(urlPathPattern.key)
         }.listFold()
 

--- a/core/src/main/kotlin/io/specmatic/core/HttpPathPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpPathPattern.kt
@@ -305,7 +305,8 @@ data class HttpPathPattern(
         val pathHadPrefix = path.startsWith("/")
         return pathSegmentPatterns.zip(pathSegments).map { (urlPathPattern, token) ->
             val tokenWithoutParameter = removeKeyFromParameterToken(token)
-            val updatedResolver = resolver.updateLookupPath("PATH-PARAMS", urlPathPattern.key.orEmpty())
+            val (key, keyPattern) = urlPathPattern.let { it.key.orEmpty() to it.pattern }
+            val updatedResolver = resolver.updateLookupPath("PATH-PARAMS", key, keyPattern)
             val result = urlPathPattern.fixValue(urlPathPattern.tryParse(tokenWithoutParameter, updatedResolver), updatedResolver)
             token.takeIf { isPatternToken(tokenWithoutParameter) && isPatternToken(result) } ?: result
         }.joinToString("/", prefix = "/".takeIf { pathHadPrefix }.orEmpty() )
@@ -321,7 +322,8 @@ data class HttpPathPattern(
 
         val pathHadPrefix = path.startsWith("/")
         val generatedSegments = pathSegmentPatterns.zip(pathSegments).map { (urlPathPattern, token) ->
-            val updatedResolver = resolver.updateLookupPath("PATH-PARAMS", urlPathPattern.key.orEmpty())
+            val (key, keyPattern) = urlPathPattern.let { it.key.orEmpty() to it.pattern }
+            val updatedResolver = resolver.updateLookupPath("PATH-PARAMS", key, keyPattern)
             urlPathPattern.fillInTheBlanks(urlPathPattern.tryParse(token, updatedResolver), updatedResolver).breadCrumb(urlPathPattern.key)
         }.listFold()
 

--- a/core/src/main/kotlin/io/specmatic/core/Resolver.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Resolver.kt
@@ -226,7 +226,7 @@ data class Resolver(
 
     fun generate(typeAlias: String?, rawLookupKey: String, pattern: Pattern): Value {
         val resolvedPattern = resolvedHop(pattern, this)
-        if(resolvedPattern is ExactValuePattern && !resolvedPattern.hasPatternToken())
+        if((resolvedPattern is ExactValuePattern && !resolvedPattern.hasPatternToken()) || resolvedPattern is JSONArrayPattern)
             return pattern.generate(this)
 
         val lookupKey = withoutOptionality(rawLookupKey)

--- a/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
@@ -64,7 +64,7 @@ data class AnyPattern(
         }
 
         val matchingPatternNew = patternMatches.minBy { (it.result as? Failure)?.failureCount() ?: 0 }
-        val updatedResolver = resolver.updateLookupPath(this.typeAlias, "")
+        val updatedResolver = resolver.updateLookupPath(this.typeAlias, "", matchingPatternNew.pattern)
         return matchingPatternNew.pattern.fixValue(value, updatedResolver)
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
@@ -64,7 +64,7 @@ data class AnyPattern(
         }
 
         val matchingPatternNew = patternMatches.minBy { (it.result as? Failure)?.failureCount() ?: 0 }
-        val updatedResolver = resolver.updateLookupPath(this.typeAlias, "", matchingPatternNew.pattern)
+        val updatedResolver = resolver.updateLookupPath(this.typeAlias)
         return matchingPatternNew.pattern.fixValue(value, updatedResolver)
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
@@ -110,7 +110,7 @@ data class AnyPattern(
 
         val updatedPatterns = getUpdatedPattern(resolver)
         val newPatterns = updatedPatterns.filter { it.typeAlias != null }.associateBy { it.typeAlias.orEmpty() }
-        val updatedResolver = resolver.copy(newPatterns = resolver.newPatterns.plus(newPatterns) )
+        val updatedResolver = resolver.copy(newPatterns = resolver.newPatterns.plus(newPatterns) ).updateLookupPath(this.typeAlias)
 
         val results = updatedPatterns.asSequence().map { it.fillInTheBlanks(value, updatedResolver) }
         val successfulGeneration = results.firstOrNull { it is HasValue }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
@@ -146,7 +146,7 @@ data class JSONObjectPattern(
 
         return fill(
             jsonPatternMap = patternToConsider.pattern, jsonValueMap = valueToConsider,
-            typeAlias = patternToConsider.typeAlias.orEmpty(), resolver = resolver
+            typeAlias = patternToConsider.typeAlias, resolver = resolver
         ).realise(
             hasValue = { valuesMap, _ -> HasValue(JSONObjectValue(valuesMap)) },
             orException = { e -> e.cast() }, orFailure = { f -> f.cast() }
@@ -562,14 +562,14 @@ fun fix(jsonPatternMap: Map<String, Pattern>, jsonValueMap: Map<String, Value>, 
     .mapValues { (_, opt) -> opt.get() }
 }
 
-fun fill(jsonPatternMap: Map<String, Pattern>, jsonValueMap: Map<String, Value>, resolver: Resolver, typeAlias: String): ReturnValue<Map<String, Value>> {
+fun fill(jsonPatternMap: Map<String, Pattern>, jsonValueMap: Map<String, Value>, resolver: Resolver, typeAlias: String?): ReturnValue<Map<String, Value>> {
     val resolvedValuesMap = jsonValueMap.mapValues { (key, value) ->
-        val updatedResolver = resolver.updateLookupPath(typeAlias, key)
         val pattern = jsonPatternMap[key] ?: jsonPatternMap["$key?"] ?: return@mapValues when {
-            resolver.findKeyErrorCheck.unexpectedKeyCheck is IgnoreUnexpectedKeys -> generateIfPatternToken(value, updatedResolver)
-            resolver.isNegative -> generateIfPatternToken(value, updatedResolver)
+            resolver.findKeyErrorCheck.unexpectedKeyCheck is IgnoreUnexpectedKeys -> generateIfPatternToken(typeAlias, key, value, resolver)
+            resolver.isNegative -> generateIfPatternToken(typeAlias, key, value, resolver)
             else -> HasFailure<Value>(Result.Failure(resolver.mismatchMessages.unexpectedKey("key", key)))
         }.breadCrumb(key)
+        val updatedResolver = resolver.updateLookupPath(typeAlias, key, pattern)
         pattern.fillInTheBlanks(value, updatedResolver).breadCrumb(key)
     }.mapFold()
 
@@ -589,12 +589,11 @@ fun fill(jsonPatternMap: Map<String, Pattern>, jsonValueMap: Map<String, Value>,
     }
 }
 
-private fun generateIfPatternToken(value: Value, resolver: Resolver): ReturnValue<Value> {
+private fun generateIfPatternToken(typeAlias: String?, key: String, value: Value, resolver: Resolver): ReturnValue<Value> {
     if (value !is StringValue || !value.isPatternToken()) return HasValue(value)
     return runCatching {
-        val pattern = resolver.getPattern(value.string)
-        if (pattern is AnyValuePattern) return@runCatching resolver.generate(StringPattern())
-        resolver.generate(pattern)
+        val keyPattern = resolver.getPattern(value.string).takeUnless { it is AnyValuePattern } ?: StringPattern()
+        resolver.updateLookupPath(typeAlias, key, keyPattern).generate(keyPattern)
     }.map(::HasValue).getOrElse(::HasException)
 }
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
@@ -569,7 +569,7 @@ fun fill(jsonPatternMap: Map<String, Pattern>, jsonValueMap: Map<String, Value>,
             resolver.isNegative -> generateIfPatternToken(typeAlias, key, value, resolver)
             else -> HasFailure<Value>(Result.Failure(resolver.mismatchMessages.unexpectedKey("key", key)))
         }.breadCrumb(key)
-        val updatedResolver = resolver.updateLookupPath(typeAlias, key, pattern)
+        val updatedResolver = resolver.updateLookupPath(typeAlias, KeyWithPattern(key, pattern))
         pattern.fillInTheBlanks(value, updatedResolver).breadCrumb(key)
     }.mapFold()
 
@@ -593,7 +593,7 @@ private fun generateIfPatternToken(typeAlias: String?, key: String, value: Value
     if (value !is StringValue || !value.isPatternToken()) return HasValue(value)
     return runCatching {
         val keyPattern = resolver.getPattern(value.string).takeUnless { it is AnyValuePattern } ?: StringPattern()
-        resolver.updateLookupPath(typeAlias, key, keyPattern).generate(keyPattern)
+        resolver.updateLookupPath(typeAlias, KeyWithPattern(key, keyPattern)).generate(keyPattern)
     }.map(::HasValue).getOrElse(::HasException)
 }
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
@@ -63,7 +63,7 @@ data class ListPattern(
             else -> return HasFailure("Cannot generate a list from type ${value.displayableType()}")
         }
 
-        val updatedResolver = resolver.updateLookupPath(this.typeAlias, "[*]", this.pattern)
+        val updatedResolver = resolver.updateLookupPath(this.typeAlias, KeyWithPattern("[*]", this.pattern))
         return valueToConsider.mapIndexed { index, item ->
             patternToConsider.fillInTheBlanks(item, updatedResolver).breadCrumb("[$index]")
         }.listFold().ifValue(::JSONArrayValue)

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
@@ -63,8 +63,8 @@ data class ListPattern(
             else -> return HasFailure("Cannot generate a list from type ${value.displayableType()}")
         }
 
-        val updatedResolver = resolver.updateLookupPath(this, this.pattern)
         return valueToConsider.mapIndexed { index, item ->
+            val updatedResolver = resolver.updateLookupPath(this, this.pattern)
             patternToConsider.fillInTheBlanks(item, updatedResolver).breadCrumb("[$index]")
         }.listFold().ifValue(::JSONArrayValue)
     }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
@@ -63,7 +63,7 @@ data class ListPattern(
             else -> return HasFailure("Cannot generate a list from type ${value.displayableType()}")
         }
 
-        val updatedResolver = resolver.updateLookupPath(this.typeAlias, KeyWithPattern("[*]", this.pattern))
+        val updatedResolver = resolver.updateLookupPath(this, this.pattern)
         return valueToConsider.mapIndexed { index, item ->
             patternToConsider.fillInTheBlanks(item, updatedResolver).breadCrumb("[$index]")
         }.listFold().ifValue(::JSONArrayValue)

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
@@ -63,7 +63,7 @@ data class ListPattern(
             else -> return HasFailure("Cannot generate a list from type ${value.displayableType()}")
         }
 
-        val updatedResolver = resolver.plusDictionaryLookupDetails(null, "[*]")
+        val updatedResolver = resolver.updateLookupPath(this.typeAlias, "[*]", this.pattern)
         return valueToConsider.mapIndexed { index, item ->
             patternToConsider.fillInTheBlanks(item, updatedResolver).breadCrumb("[$index]")
         }.listFold().ifValue(::JSONArrayValue)

--- a/core/src/main/kotlin/io/specmatic/core/pattern/MemberList.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/MemberList.kt
@@ -39,4 +39,6 @@ data class MemberList(private val finiteList: List<Pattern>, private val rest: P
     }
 
     fun isEndless(): Boolean = rest != null
+
+    fun patternList(): List<Pattern> = rest?.let { finiteList.plus(it) } ?: finiteList
 }

--- a/core/src/test/kotlin/integration_tests/DictionaryTest.kt
+++ b/core/src/test/kotlin/integration_tests/DictionaryTest.kt
@@ -569,32 +569,13 @@ class DictionaryTest {
 
         @Test
         fun `should use the array value as is when pattern is an array and dictionary contains array level key`() {
-            val dictionary = jsonStringToValueMap("""{
-            "Schema.array": [10, 20, 30],
-            "Schema.array[*]": [1, 2, 3]
-            }""".trimIndent()).let(Dictionary::from)
+            val dictionary = jsonStringToValueMap("""{ "Schema.array": [10, 20, 30] }""".trimIndent()).let(Dictionary::from)
             val pattern = JSONObjectPattern(mapOf("array" to ListPattern(NumberPattern())), typeAlias = "(Schema)")
             val resolver = Resolver(dictionary = dictionary)
             val value = pattern.generate(resolver)
 
             assertThat(value.jsonObject["array"]).isInstanceOf(JSONArrayValue::class.java)
             assertThat((value.jsonObject["array"])).isEqualTo(listOf(10, 20, 30).map(::NumberValue).let(::JSONArrayValue))
-        }
-
-        @Test
-        fun `should use wildcard index key if exists in dictionary when array key is missing and pattern is an array`() {
-            val dictionary = jsonStringToValueMap("""{
-            "Schema.array[*]": [1, 2, 3]
-            }""".trimIndent()).let(Dictionary::from)
-            val pattern = JSONObjectPattern(mapOf("array" to ListPattern(NumberPattern())), typeAlias = "(Schema)")
-            val resolver = Resolver(dictionary = dictionary)
-            val value = pattern.generate(resolver)
-
-            assertThat(value.jsonObject["array"]).isInstanceOf(JSONArrayValue::class.java)
-            assertThat((value.jsonObject["array"] as JSONArrayValue).list).hasSizeGreaterThanOrEqualTo(1).hasSizeLessThanOrEqualTo(3)
-            assertThat((value.jsonObject["array"] as JSONArrayValue).list).allSatisfy {
-                assertThat(it).isIn(listOf(1, 2, 3).map(::NumberValue))
-            }
         }
 
         @Test

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationInfoTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationInfoTest.kt
@@ -109,7 +109,6 @@ class OpenApiSpecificationInfoTest {
         Schema.booleanKey: true
         Schema.nullKey: null
         Schema.nested.key: value
-        Schema.array[*]: value
         Schema.array: 
         - value
         """.trimIndent()
@@ -124,7 +123,6 @@ class OpenApiSpecificationInfoTest {
         "nested": {
             "key": "value"
         },
-        "array[*]": "value",
         "array": [
             "value"
         ]

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationInfoTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationInfoTest.kt
@@ -1,9 +1,6 @@
 package io.specmatic.conversions
 
-import io.specmatic.core.value.BooleanValue
-import io.specmatic.core.value.NullValue
-import io.specmatic.core.value.NumberValue
-import io.specmatic.core.value.StringValue
+import io.specmatic.core.pattern.parsedJSONObject
 import io.swagger.v3.oas.models.*
 import io.swagger.v3.oas.models.info.Info
 import io.swagger.v3.oas.models.media.Schema
@@ -113,23 +110,27 @@ class OpenApiSpecificationInfoTest {
         Schema.nullKey: null
         Schema.nested.key: value
         Schema.array[*]: value
-        Schema.array[0].key: value
+        Schema.array: 
+        - value
         """.trimIndent()
         tempDir.resolve("api_dictionary.yaml").writeText(yamlDictionary)
         val dictionary = OpenApiSpecification.loadDictionary(apiFile.canonicalPath, null)
-        val expectedEntries = mapOf(
-            "Schema.stringKey" to StringValue("stringValue"),
-            "Schema.numberKey" to NumberValue(123),
-            "Schema.booleanKey" to BooleanValue(true),
-            "Schema.nullKey" to NullValue,
-            "Schema.nested.key" to StringValue("value"),
-            "Schema.array[*]" to StringValue("value"),
-            "Schema.array[0].key" to StringValue("value"),
-        ).entries
 
-        assertThat(expectedEntries).allSatisfy { (key, value) ->
-            assertThat(dictionary.containsKey(key))
-            assertThat(dictionary.getRawValue(key)).isEqualTo(value)
-        }
+        val expectedSchemaEntry = parsedJSONObject("""{
+        "stringKey": "stringValue",
+        "numberKey": 123,
+        "booleanKey": true,
+        "nullKey": null,
+        "nested": {
+            "key": "value"
+        },
+        "array[*]": "value",
+        "array": [
+            "value"
+        ]
+        }""".trimIndent())
+        val actualEntry = dictionary.getRawValue("Schema")
+
+        assertThat(actualEntry).isEqualTo(expectedSchemaEntry)
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/DataRepresentationTests.kt
+++ b/core/src/test/kotlin/io/specmatic/core/DataRepresentationTests.kt
@@ -1,0 +1,36 @@
+package io.specmatic.core
+
+import io.specmatic.core.value.JSONArrayValue
+import io.specmatic.core.value.NumberValue
+import io.specmatic.core.value.StringValue
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class DataRepresentationTests {
+
+    @Test
+    fun `should be able to convert flattened map to a nested structure`() {
+        val initialMap = mapOf(
+            "Schema.name" to StringValue("<NAME>"),
+            "Schema.age" to NumberValue(10),
+            "Schema.details[*].address" to JSONArrayValue(listOf("<ADDRESS1>", "<ADDRESS2>").map(::StringValue))
+        )
+        val dataRepresentation = DataRepresentation.from(initialMap)
+        val finalValue = dataRepresentation.toValue()
+
+        assertThat(finalValue.toStringLiteral()).isEqualToNormalizingWhitespace("""
+        {
+            "Schema": {
+                "name": "<NAME>",
+                "age": 10,
+                "details[*]": {
+                    "address": [
+                        "<ADDRESS1>",
+                        "<ADDRESS2>"
+                    ]
+                }
+            }
+        }
+        """.trimIndent())
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/DataRepresentationTests.kt
+++ b/core/src/test/kotlin/io/specmatic/core/DataRepresentationTests.kt
@@ -13,7 +13,7 @@ class DataRepresentationTests {
         val initialMap = mapOf(
             "Schema.name" to StringValue("<NAME>"),
             "Schema.age" to NumberValue(10),
-            "Schema.details[*].address" to JSONArrayValue(listOf("<ADDRESS1>", "<ADDRESS2>").map(::StringValue))
+            "Schema.details.address" to JSONArrayValue(listOf("<ADDRESS1>", "<ADDRESS2>").map(::StringValue))
         )
         val dataRepresentation = DataRepresentation.from(initialMap)
         val finalValue = dataRepresentation.toValue()
@@ -23,7 +23,7 @@ class DataRepresentationTests {
             "Schema": {
                 "name": "<NAME>",
                 "age": 10,
-                "details[*]": {
+                "details": {
                     "address": [
                         "<ADDRESS1>",
                         "<ADDRESS2>"

--- a/core/src/test/kotlin/io/specmatic/core/ResolverKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ResolverKtTest.kt
@@ -1,5 +1,6 @@
 package io.specmatic.core
 
+import io.specmatic.core.pattern.AnyValuePattern
 import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.Test
 import io.specmatic.core.pattern.ContractException
@@ -17,7 +18,7 @@ internal class ResolverKtTest {
     @ParameterizedTest
     @MethodSource("typeAliasToLookupKeyProvider")
     fun `should be able to combine typeAlias and lookupKey to a lookupPath`(typeAlias: String?, lookupKey: String, expectedLookupPath: String) {
-        val resolver = Resolver().updateLookupPath(typeAlias, lookupKey)
+        val resolver = Resolver().updateLookupPath(typeAlias, lookupKey, AnyValuePattern)
         assertThat(resolver.dictionaryLookupPath).isEqualTo(expectedLookupPath)
     }
 

--- a/core/src/test/kotlin/io/specmatic/core/ResolverKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ResolverKtTest.kt
@@ -18,7 +18,7 @@ internal class ResolverKtTest {
     @ParameterizedTest
     @MethodSource("typeAliasToLookupKeyProvider")
     fun `should be able to combine typeAlias and lookupKey to a lookupPath`(typeAlias: String?, lookupKey: String, expectedLookupPath: String) {
-        val resolver = Resolver().updateLookupPath(typeAlias, lookupKey, AnyValuePattern)
+        val resolver = Resolver().updateLookupPath(typeAlias, KeyWithPattern(lookupKey, AnyValuePattern))
         assertThat(resolver.dictionaryLookupPath).isEqualTo(expectedLookupPath)
     }
 

--- a/core/src/test/kotlin/io/specmatic/core/pattern/JSONObjectPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/JSONObjectPatternTest.kt
@@ -1002,10 +1002,7 @@ internal class JSONObjectPatternTest {
         )
 
         val street = StringValue("Baker Street")
-
-        val dictionary = mapOf("Person.address" to JSONObjectValue(
-            mapOf("street" to street)
-        ))
+        val dictionary = mapOf("Address.street" to street)
 
         val resolver = Resolver(
             newPatterns = mapOf(personTypeAlias to personPattern, addressTypeAlias to addressPattern),

--- a/core/src/test/kotlin/io/specmatic/core/pattern/JSONObjectPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/JSONObjectPatternTest.kt
@@ -760,8 +760,7 @@ internal class JSONObjectPatternTest {
         )
 
         val expectedAddress = StringValue("22B Baker Street")
-
-        val dictionary = mapOf("Address.addresses[*]" to expectedAddress)
+        val dictionary = mapOf("Address.addresses" to JSONArrayValue(listOf(expectedAddress)))
 
         val resolver = Resolver(
             newPatterns = mapOf(addressTypeAlias to addressPattern),
@@ -849,8 +848,7 @@ internal class JSONObjectPatternTest {
         )
 
         val streetAsNumber = NumberValue(10)
-
-        val dictionary = mapOf("Person.addresses[*]" to streetAsNumber)
+        val dictionary = mapOf("Person.addresses" to JSONArrayValue(listOf(streetAsNumber)))
 
         val resolver = Resolver(
             newPatterns = mapOf(personTypeAlias to personPattern),
@@ -862,8 +860,8 @@ internal class JSONObjectPatternTest {
         }
 
         assertThat(exception.report()).isEqualToNormalizingWhitespace("""
-        >> addresses[0 (random)]
-        Invalid Dictionary value at "Person.addresses[*]"
+        >> addresses[0]
+        Invalid Dictionary value at "Person.addresses"
         Expected string, actual was 10 (number)
         """.trimIndent())
     }

--- a/core/src/test/resources/openapi/spec_with_dictionary_with_multilevel_schema_and_dictionary_array_objects/spec_dictionary.json
+++ b/core/src/test/resources/openapi/spec_with_dictionary_with_multilevel_schema_and_dictionary_array_objects/spec_dictionary.json
@@ -1,3 +1,11 @@
 {
-  "Person.details.addresses[*].street": "22B Baker Street"
+  "Person": {
+    "details": {
+      "addresses": [
+        {
+          "street": "22B Baker Street"
+        }
+      ]
+    }
+  }
 }

--- a/core/src/test/resources/openapi/spec_with_dictionary_with_multilevel_schema_and_dictionary_array_objects_with_example/spec_dictionary.json
+++ b/core/src/test/resources/openapi/spec_with_dictionary_with_multilevel_schema_and_dictionary_array_objects_with_example/spec_dictionary.json
@@ -1,3 +1,11 @@
 {
-  "Person.details.addresses[*].street": "22B Baker Street"
+  "Person": {
+    "details": {
+      "addresses": [
+        {
+          "street": "22B Baker Street"
+        }
+      ]
+    }
+  }
 }

--- a/core/src/test/resources/openapi/substitutions/complicated_dictionary.json
+++ b/core/src/test/resources/openapi/substitutions/complicated_dictionary.json
@@ -1,5 +1,17 @@
 {
-  "PersonDetails.person.addresses[*].street": "Baker Street",
-  "PersonDetails.person.past_companies[*].name": "Acme Inc",
+  "PersonDetails": {
+    "person": {
+      "addresses": [
+        {
+          "street": "Baker Street"
+        }
+      ],
+      "past_companies": [
+        {
+          "name": "Acme Inc"
+        }
+      ]
+    }
+  },
   "PersonDetails.person.name": "Jackie"
 }

--- a/core/src/test/resources/openapi/substitutions/dictionary.json
+++ b/core/src/test/resources/openapi/substitutions/dictionary.json
@@ -5,7 +5,10 @@
   ".name": "George",
   "HEADERS.X-Data-Token": "pqr",
   ".street": "Baker Street",
-  ".addresses[*].street": "Baker Street",
+  ".addresses": [
+    {
+      "street":  "Baker Street"
+    }
+  ],
   ".address.street": "Baker Street"
-
 }

--- a/core/src/test/resources/openapi/substitutions/spec_with_no_substitutions.yaml
+++ b/core/src/test/resources/openapi/substitutions/spec_with_no_substitutions.yaml
@@ -23,8 +23,7 @@ paths:
           headers:
             X-Region:
               schema:
-                X-Region:
-                  type: string
+                type: string
           content:
             application/json:
               schema:


### PR DESCRIPTION
The dictionary now supports a nested structure instead of flattened keys, For example, instead of using the format
```yaml
Schema.nested.key: value
```
you now need to provide it as follows:
```yaml
Schema:
    nested:
        key: value
```
**Note:** This depends on https://github.com/znsio/specmatic/pull/1803 Pull Request

**Checklist**:

- [ ] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
