### PR TITLE
Fix fill-in-the-blanks for the object pattern with additional properties

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
@@ -144,8 +144,12 @@ data class JSONObjectPattern(
             else -> return HasFailure("Can't generate object value from type ${value.displayableType()}")
         }
 
+        val adjustedPattern = patternToConsider.additionalProperties.updatePatternMap(
+            patternMap = patternToConsider.pattern, valueMap = valueToConsider
+        )
+
         return fill(
-            jsonPatternMap = patternToConsider.pattern, jsonValueMap = valueToConsider,
+            jsonPatternMap = adjustedPattern, jsonValueMap = valueToConsider,
             typeAlias = patternToConsider.typeAlias, resolver = resolver,
             removeExtraKeys = removeExtraKeys
         ).realise(

--- a/core/src/test/kotlin/io/specmatic/core/pattern/JSONObjectPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/JSONObjectPatternTest.kt
@@ -2512,7 +2512,7 @@ components:
         @Test
         fun `should work with additional patterns`() {
             val jsonObjectPattern = JSONObjectPattern(
-                pattern = emptyMap(),
+                pattern = mapOf("key-in-pattern" to ExactValuePattern(StringValue("some string value"))),
                 additionalProperties = AdditionalProperties.FreeForm,
                 typeAlias = "(Test)"
             )
@@ -2526,10 +2526,12 @@ components:
                 "field7": "bar"
             }
             }""".trimIndent())
-            val filledInValue = jsonObjectPattern.fillInTheBlanks(validValue, Resolver()).value
-            filledInValue as JSONObjectValue
+            val actualFilledInValue =
+                jsonObjectPattern.fillInTheBlanks(validValue, Resolver()).value as JSONObjectValue
 
-            assertThat(validValue).isEqualTo(filledInValue)
+            val expectedFilledInValue = validValue.addEntry("key-in-pattern", "some string value")
+
+            assertThat(actualFilledInValue).isEqualTo(expectedFilledInValue)
         }
     }
 

--- a/core/src/test/kotlin/io/specmatic/core/pattern/JSONObjectPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/JSONObjectPatternTest.kt
@@ -2508,6 +2508,29 @@ components:
                 println(result.value)
             }
         }
+
+        @Test
+        fun `should work with additional patterns`() {
+            val jsonObjectPattern = JSONObjectPattern(
+                pattern = emptyMap(),
+                additionalProperties = AdditionalProperties.FreeForm,
+                typeAlias = "(Test)"
+            )
+            val validValue = parsedJSONObject("""{
+            "field1": "foo",
+            "field2": 123,
+            "field3": true,
+            "field4": null,
+            "field5": [1, 2, 3],
+            "field6": {
+                "field7": "bar"
+            }
+            }""".trimIndent())
+            val filledInValue = jsonObjectPattern.fillInTheBlanks(validValue, Resolver()).value
+            filledInValue as JSONObjectValue
+
+            assertThat(validValue).isEqualTo(filledInValue)
+        }
     }
 
     companion object {


### PR DESCRIPTION

**What**: Fix fill-in-the-blanks for the object pattern with additional properties

**Why**:  Due to a missing call to update additional properties, any extra keys in the payload were being treated as out of spec, even when `additionalProperties` were defined in the `OpenAPI` schema.

**How**:
- Ensure that we update the pattern map before calling fill to account for additional properties.
- Add test to ensure the behavior

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)

**Issue ID**:
Closes Issue: #1796