### PR TITLE
Fix serialization and deserialization for floating point values

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/pattern/Grammar.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/Grammar.kt
@@ -371,7 +371,6 @@ fun parsedScalarValue(content: String?): Value {
     return when {
         trimmed.toIntOrNull() != null -> NumberValue(trimmed.toInt())
         trimmed.toLongOrNull() != null -> NumberValue(trimmed.toLong())
-        trimmed.toFloatOrNull() != null -> NumberValue(trimmed.toFloat())
         trimmed.toDoubleOrNull() != null -> NumberValue(trimmed.toDouble())
         trimmed.lowercase() in setOf("true", "false") -> BooleanValue(trimmed.toBoolean())
         else -> StringValue(trimmed)

--- a/core/src/main/kotlin/io/specmatic/core/pattern/TabularPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/TabularPattern.kt
@@ -454,7 +454,7 @@ fun isNumber(value: StringValue): Boolean {
 }
 
 fun convertToNumber(value: String): Number = value.trim().let {
-    stringToInt(it) ?: stringToLong(it) ?: stringToFloat(it) ?: stringToDouble(it)
+    stringToInt(it) ?: stringToLong(it) ?: stringToDouble(it)
     ?: throw ContractException("""Expected number, actual was "$value"""")
 }
 
@@ -466,12 +466,6 @@ internal fun stringToInt(value: String): Int? = try {
 
 internal fun stringToLong(value: String): Long? = try {
     value.toLong()
-} catch (e: Throwable) {
-    null
-}
-
-internal fun stringToFloat(value: String): Float? = try {
-    value.toFloat()
 } catch (e: Throwable) {
     null
 }

--- a/core/src/main/kotlin/io/specmatic/core/utilities/JSONSerialisation.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/JSONSerialisation.kt
@@ -57,7 +57,6 @@ fun toPattern(jsonElement: JsonElement): Pattern {
         is JsonObject -> toJSONObjectPattern(jsonElement.toMap().mapValues { toPattern(it.value) })
         is JsonArray -> JSONArrayPattern(jsonElement.toList().map { toPattern(it) })
         is JsonPrimitive -> toLiteralPattern(jsonElement)
-        else -> throw ContractException("Unknown value type: ${jsonElement.javaClass.name}")
     }
 }
 
@@ -67,7 +66,7 @@ fun toLiteralPattern(jsonElement: JsonPrimitive): Pattern =
         jsonElement.booleanOrNull != null -> ExactValuePattern(BooleanValue(jsonElement.boolean))
         jsonElement.intOrNull != null -> ExactValuePattern(NumberValue(jsonElement.int))
         jsonElement.longOrNull != null -> ExactValuePattern(NumberValue(jsonElement.long))
-        jsonElement.floatOrNull != null -> ExactValuePattern(NumberValue(jsonElement.float))
+        jsonElement.doubleOrNull != null -> ExactValuePattern(NumberValue(jsonElement.double))
         else -> throw ContractException("Can't recognise the type of $jsonElement")
     }
 
@@ -77,7 +76,6 @@ private fun toValue(jsonElement: JsonElement): Value =
         is JsonObject -> JSONObjectValue(jsonElement.toMap().mapValues { toValue(it.value) })
         is JsonArray -> JSONArrayValue(jsonElement.toList().map { toValue(it) })
         is JsonPrimitive -> toLiteralValue(jsonElement)
-        else -> throw ContractException("Unknown value type: ${jsonElement.javaClass.name}")
     }
 
 fun toLiteralValue(jsonElement: JsonPrimitive): Value =
@@ -86,8 +84,8 @@ fun toLiteralValue(jsonElement: JsonPrimitive): Value =
         jsonElement.booleanOrNull != null -> BooleanValue(jsonElement.boolean)
         jsonElement.intOrNull != null -> NumberValue(jsonElement.int)
         jsonElement.longOrNull != null -> NumberValue(jsonElement.long)
-        jsonElement.floatOrNull != null -> NumberValue(jsonElement.float)
-        else -> NumberValue(jsonElement.double)
+        jsonElement.doubleOrNull != null -> NumberValue(jsonElement.double)
+        else -> throw ContractException("Can't recognise the type of $jsonElement")
     }
 
 fun convertToArrayValue(data: List<JsonElement>): List<Value> =

--- a/core/src/test/kotlin/io/specmatic/core/utilities/JSONSerialisationKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/utilities/JSONSerialisationKtTest.kt
@@ -1,13 +1,48 @@
 package io.specmatic.core.utilities
 
 import io.specmatic.core.pattern.parsedJSONObject
+import io.specmatic.core.value.NumberValue
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import java.math.BigDecimal
 
 class JSONSerialisationKtTest {
     @Test
     fun `should parse a JSON string with a UTF-8 BOM`() {
         val jsonContent = "\uFEFF{\"greeting\":\"hello\"}"
         assertDoesNotThrow { parsedJSONObject(jsonContent) }
+    }
+
+    @ParameterizedTest
+    @MethodSource("floatingPointValues")
+    fun `should be able to de-serialise floating point values from json to number value`(value: Number) {
+        val jsonString = """{"value": $value}"""
+        val valueMap = jsonStringToValueMap(jsonString)
+        val parsedValue = (valueMap["value"] as NumberValue).nativeValue
+
+        assertThat(
+            BigDecimal(parsedValue.toString())
+        ).isEqualTo(
+            BigDecimal(value.toString())
+        )
+    }
+
+    @ParameterizedTest
+    @MethodSource("floatingPointValues")
+    fun `should be able to serialise floating point values from json to number value`(value: Number) {
+        val valueMap = mapOf("value" to NumberValue(value))
+        val jsonContent = valueMapToUnindentedJsonString(valueMap)
+
+        assertThat(jsonContent).isEqualTo("""{"value":$value}""")
+    }
+
+    companion object {
+        @JvmStatic
+        fun floatingPointValues(): List<Number> {
+            return listOf(Float.MIN_VALUE, Float.MAX_VALUE, Double.MIN_VALUE, Double.MAX_VALUE)
+        }
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/utilities/JSONSerialisationKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/utilities/JSONSerialisationKtTest.kt
@@ -32,7 +32,7 @@ class JSONSerialisationKtTest {
 
     @ParameterizedTest
     @MethodSource("floatingPointValues")
-    fun `should be able to serialise floating point values from json to number value`(value: Number) {
+    fun `should be able to serialise floating point values from number value to json`(value: Number) {
         val valueMap = mapOf("value" to NumberValue(value))
         val jsonContent = valueMapToUnindentedJsonString(valueMap)
 

--- a/core/src/test/kotlin/io/specmatic/core/utilities/JSONSerialisationKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/utilities/JSONSerialisationKtTest.kt
@@ -17,8 +17,8 @@ class JSONSerialisationKtTest {
     }
 
     @ParameterizedTest
-    @MethodSource("floatingPointValues")
-    fun `should be able to de-serialise floating point values from json to number value`(value: Number) {
+    @MethodSource("numberValuesProvider")
+    fun `should be able to de-serialise numbers from json to number value`(value: Number) {
         val jsonString = """{"value": $value}"""
         val valueMap = jsonStringToValueMap(jsonString)
         val parsedValue = (valueMap["value"] as NumberValue).nativeValue
@@ -31,8 +31,8 @@ class JSONSerialisationKtTest {
     }
 
     @ParameterizedTest
-    @MethodSource("floatingPointValues")
-    fun `should be able to serialise floating point values from number value to json`(value: Number) {
+    @MethodSource("numberValuesProvider")
+    fun `should be able to serialise from number value to json`(value: Number) {
         val valueMap = mapOf("value" to NumberValue(value))
         val jsonContent = valueMapToUnindentedJsonString(valueMap)
 
@@ -41,8 +41,13 @@ class JSONSerialisationKtTest {
 
     companion object {
         @JvmStatic
-        fun floatingPointValues(): List<Number> {
-            return listOf(Float.MIN_VALUE, Float.MAX_VALUE, Double.MIN_VALUE, Double.MAX_VALUE)
+        fun numberValuesProvider(): List<Number> {
+            return listOf(
+                Int.MIN_VALUE, Int.MAX_VALUE,
+                Long.MIN_VALUE, Long.MAX_VALUE,
+                Float.MIN_VALUE, Float.MAX_VALUE,
+                Double.MIN_VALUE, Double.MAX_VALUE
+            )
         }
     }
 }


### PR DESCRIPTION
**What**: Fix serialization and deserialization for floating point values

**Why**: Having floating point values outside the range of `Floats` results in the occurrence of `Infinity` and `-Infinity`

**How**: Use `Double` instead of `Float` whenever possible

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
