### PR TITLE
Include path parameters in HttpRequest generality calculation

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
@@ -22,6 +22,7 @@ import java.nio.charset.StandardCharsets
 
 const val FORM_FIELDS_JSON_KEY = "form-fields"
 const val MULTIPART_FORMDATA_JSON_KEY = "multipart-formdata"
+const val URL_PATH_DELIMITER = "/"
 
 fun urlToQueryParams(uri: URI): Map<String, String> {
     if (uri.query == null)
@@ -409,11 +410,12 @@ data class HttpRequest(
     }
 
     val generality: Int by lazy {
+        val pathScore: Int = path?.split(URL_PATH_DELIMITER)?.count { StringValue(it).isPatternToken() } ?: 0
         val headerScore: Int = headers.values.sumOf { if(isPatternToken(it)) 1 as Int else 0 }
         val queryScore: Int = queryParams.paramPairs.sumOf { if(isPatternToken(it.second)) 1 as Int else 0 }
         val bodyScore: Int = body.generality()
 
-        headerScore + queryScore + bodyScore
+        pathScore + headerScore + queryScore + bodyScore
     }
 }
 

--- a/core/src/test/kotlin/io/specmatic/core/HttpRequestTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpRequestTest.kt
@@ -204,6 +204,21 @@ internal class HttpRequestTest {
                 Arguments.of("http://localhost/test", ""),
                 Arguments.of(null, "http://localhost/test"),
             ).stream()
+
+        @JvmStatic
+        fun urlPathToExpectedPathGenerality(): List<Pair<String?, Int>> =
+            listOf(
+                Pair(null, 0),
+                Pair("", 0),
+                Pair("/", 0),
+                Pair("/persons", 0),
+                Pair("/persons/1", 0),
+                Pair("/(string)", 1),
+                Pair("/persons/(string)", 1),
+                Pair("/persons/(string)/1", 1),
+                Pair("/persons/(string)/1/(string)", 2),
+                Pair("/persons/group/(string)/1/(string)", 2),
+            )
     }
 
     @ParameterizedTest
@@ -393,5 +408,12 @@ internal class HttpRequestTest {
     fun `should calculate precision score based on the number of patterns seen`(id: String, count: String, generality: Int) {
         val request = HttpRequest("POST", "/", body = parsedJSONObject("""{"id": "$id", "count": "$count"}"""))
         assertThat(request.generality).isEqualTo(generality)
+    }
+
+    @ParameterizedTest
+    @MethodSource("urlPathToExpectedPathGenerality")
+    fun `should include path params to calculate generality`(pathToExpectedGenerality: Pair<String?, Int>) {
+        val request = HttpRequest(path = pathToExpectedGenerality.first)
+        assertThat(request.generality).isEqualTo(pathToExpectedGenerality.second)
     }
 }


### PR DESCRIPTION
**What**:

Generality calculation in HttpRequest is being used to disambiguate among competing examples during `stub` and `validate` commands. Currently it considers headres, query params and body to calculate generality. Now path parameters are also added in the mix.

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally

