### PR TITLE
fix(http-client): fix issue with leaving too many open connections

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/Postman.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/Postman.kt
@@ -8,7 +8,7 @@ import io.specmatic.core.utilities.parseXML
 import io.specmatic.core.value.*
 import io.specmatic.mock.ScenarioStub
 import io.specmatic.core.log.dontPrintToConsole
-import io.specmatic.test.HttpClient
+import io.specmatic.test.LegacyHttpClient
 import java.net.URI
 import java.net.URL
 
@@ -37,7 +37,7 @@ fun runTests(contract: ImportedPostmanContracts) {
     logger.log("Testing contract \"$name\" with base URL ${baseURLInfo.originalBaseURL}")
     try {
         val feature = parseGherkinStringToFeature(gherkin)
-        val results = feature.executeTests(HttpClient(baseURL = baseURLInfo.originalBaseURL))
+        val results = feature.executeTests(LegacyHttpClient(baseURL = baseURLInfo.originalBaseURL))
 
         logger.log("Test result for contract \"$name\" ###")
         val resultReport = "${results.report(PATH_NOT_RECOGNIZED_ERROR).trim()}\n\n".trim()
@@ -102,7 +102,7 @@ private fun baseNamedStub(request: JSONObjectValue, scenarioName: String): List<
         val (baseURL, httpRequest) = postmanItemRequest(request)
 
         logger.log("  Using base url $baseURL")
-        val response = HttpClient(baseURL, log = dontPrintToConsole).execute(httpRequest)
+        val response = LegacyHttpClient(baseURL, log = dontPrintToConsole).execute(httpRequest)
 
         listOf(Pair(hostAndPort(baseURL), NamedStub(scenarioName, ScenarioStub(
             httpRequest,

--- a/core/src/main/kotlin/io/specmatic/core/ContractFileWithExports.kt
+++ b/core/src/main/kotlin/io/specmatic/core/ContractFileWithExports.kt
@@ -1,7 +1,7 @@
 package io.specmatic.core
 
 import io.specmatic.core.pattern.ContractException
-import io.specmatic.test.HttpClient
+import io.specmatic.test.LegacyHttpClient
 import java.io.File
 
 data class ContractFileWithExports(val path: String, val relativeTo: RelativeTo = NoAnchor) {
@@ -22,7 +22,7 @@ data class ContractFileWithExports(val path: String, val relativeTo: RelativeTo 
         val feature = readFeatureForValue(valueName)
             .copy(testVariables = variables, testBaseURLs = baseURLs)
 
-        val client = HttpClient(
+        val client = LegacyHttpClient(
             baseURLs[path] ?: throw ContractException("Base URL for spec file $path was not supplied.")
         )
 

--- a/core/src/main/kotlin/io/specmatic/core/azure/AzureAPI.kt
+++ b/core/src/main/kotlin/io/specmatic/core/azure/AzureAPI.kt
@@ -7,7 +7,7 @@ import io.specmatic.core.pattern.parsedJSON
 import io.specmatic.core.value.JSONArrayValue
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.Value
-import io.specmatic.test.HttpClient
+import io.specmatic.test.LegacyHttpClient
 import java.net.URI
 
 private fun unDefault(jsonObject: JSONObjectValue, defaultCollectionName: String) =
@@ -45,7 +45,7 @@ class AzureAPI(private val azureAuthToken: AzureAuthToken, private val azureBase
     }
 
     private fun codeAdvancedSearch(searchString: String): JSONObjectValue {
-        val client = HttpClient(azureBaseURL, log = { })
+        val client = LegacyHttpClient(azureBaseURL, log = { })
         val request = HttpRequest(
             "POST",
             URI("/$collection/_apis/search/codeAdvancedQueryResults?api-version=5.1-preview.1")

--- a/core/src/main/kotlin/io/specmatic/proxy/Proxy.kt
+++ b/core/src/main/kotlin/io/specmatic/proxy/Proxy.kt
@@ -25,7 +25,7 @@ import io.specmatic.stub.httpRequestLog
 import io.specmatic.stub.httpResponseLog
 import io.specmatic.stub.ktorHttpRequestToHttpRequest
 import io.specmatic.stub.respondToKtorHttpResponse
-import io.specmatic.test.HttpClient
+import io.specmatic.test.LegacyHttpClient
 import io.swagger.v3.core.util.Yaml
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
@@ -69,7 +69,7 @@ class Proxy(host: String, port: Int, baseURL: String, private val outputDirector
                         }
 
                         else -> try {
-                            val client = HttpClient(proxyURL(httpRequest, baseURL), timeoutInMilliseconds = timeoutInMilliseconds)
+                            val client = LegacyHttpClient(proxyURL(httpRequest, baseURL), timeoutInMilliseconds = timeoutInMilliseconds)
 
                             val requestToSend = targetHost?.let {
                                 httpRequest.withHost(targetHost)

--- a/core/src/main/kotlin/io/specmatic/stub/ContractStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/ContractStub.kt
@@ -1,10 +1,10 @@
 package io.specmatic.stub
 
-import io.specmatic.test.HttpClient
+import io.specmatic.test.LegacyHttpClient
 import java.io.Closeable
 
 interface ContractStub : Closeable {
-    val client: HttpClient
+    val client: LegacyHttpClient
 
     // Java helper
     fun setExpectation(json: String)

--- a/core/src/main/kotlin/io/specmatic/stub/HttpClientFactory.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpClientFactory.kt
@@ -1,8 +1,8 @@
 package io.specmatic.stub
 
 import io.specmatic.core.log.ignoreLog
-import io.specmatic.test.HttpClient
+import io.specmatic.test.LegacyHttpClient
 
 class HttpClientFactory {
-    fun client(baseURL: String): HttpClient = HttpClient(baseURL, log = ignoreLog)
+    fun client(baseURL: String): LegacyHttpClient = LegacyHttpClient(baseURL, log = ignoreLog)
 }

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -35,7 +35,7 @@ import io.specmatic.mock.validateMock
 import io.specmatic.stub.report.StubEndpoint
 import io.specmatic.stub.report.StubUsageReport
 import io.specmatic.stub.report.StubUsageReportJson
-import io.specmatic.test.HttpClient
+import io.specmatic.test.LegacyHttpClient
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.BroadcastChannel
 import kotlinx.coroutines.channels.BufferOverflow
@@ -233,7 +233,7 @@ class HttpStub(
 
     val endPoint = endPointFromHostAndPort(host, port, keyData)
 
-    override val client = HttpClient(this.endPoint)
+    override val client = LegacyHttpClient(this.endPoint)
 
     private val sseBuffer: SSEBuffer = SSEBuffer()
 

--- a/core/src/main/kotlin/io/specmatic/stub/stateful/StatefulHttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/stateful/StatefulHttpStub.kt
@@ -5,9 +5,7 @@ import io.ktor.server.application.*
 import io.ktor.server.engine.*
 import io.ktor.server.http.content.*
 import io.ktor.server.netty.*
-import io.ktor.server.plugins.cors.*
 import io.ktor.server.plugins.cors.CORS
-import io.ktor.server.plugins.cors.routing.*
 import io.ktor.server.plugins.doublereceive.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
@@ -44,7 +42,7 @@ import io.specmatic.mock.ScenarioStub
 import io.specmatic.stub.*
 import io.specmatic.stub.stateful.StubCache.Companion.idValueFor
 import io.specmatic.test.ExampleProcessor
-import io.specmatic.test.HttpClient
+import io.specmatic.test.LegacyHttpClient
 import java.io.File
 
 const val DEFAULT_ACCEPTED_RESPONSE_QUERY_ENDPOINT = "/monitor"
@@ -149,7 +147,7 @@ class StatefulHttpStub(
         server.start()
     }
 
-    override val client = HttpClient(endPointFromHostAndPort(host, port, null))
+    override val client = LegacyHttpClient(endPointFromHostAndPort(host, port, null))
 
     override fun setExpectation(json: String) {
         return

--- a/core/src/main/kotlin/io/specmatic/test/HttpClient.kt
+++ b/core/src/main/kotlin/io/specmatic/test/HttpClient.kt
@@ -1,20 +1,5 @@
 package io.specmatic.test
 
-import io.specmatic.core.*
-import io.specmatic.core.HttpRequest
-import io.specmatic.core.HttpResponse
-import io.specmatic.core.log.HttpLogMessage
-import io.specmatic.core.log.LogMessage
-import io.specmatic.core.log.consoleLog
-import io.specmatic.core.log.logger
-import io.specmatic.core.pattern.ContractException
-import io.specmatic.core.startLinesWith
-import io.specmatic.core.utilities.valueMapToPlainJsonString
-import io.specmatic.core.value.EmptyString
-import io.specmatic.core.value.JSONObjectValue
-import io.specmatic.core.value.StringValue
-import io.specmatic.core.value.Value
-import io.specmatic.stub.toParams
 import io.ktor.client.plugins.*
 import io.ktor.client.request.*
 import io.ktor.client.request.forms.*
@@ -24,22 +9,38 @@ import io.ktor.http.*
 import io.ktor.http.content.*
 import io.ktor.util.*
 import io.ktor.utils.io.charsets.*
+import io.specmatic.core.*
+import io.specmatic.core.HttpRequest
+import io.specmatic.core.HttpResponse
+import io.specmatic.core.log.HttpLogMessage
+import io.specmatic.core.log.LogMessage
+import io.specmatic.core.log.consoleLog
+import io.specmatic.core.log.logger
+import io.specmatic.core.pattern.ContractException
+import io.specmatic.core.utilities.valueMapToPlainJsonString
+import io.specmatic.core.value.EmptyString
+import io.specmatic.core.value.JSONObjectValue
+import io.specmatic.core.value.StringValue
+import io.specmatic.core.value.Value
+import io.specmatic.stub.toParams
 import kotlinx.coroutines.runBlocking
 import java.net.URL
 import java.util.*
 import java.util.zip.GZIPInputStream
 
 // API for non-Kotlin invokers
-fun createHttpClient(baseURL: String, timeoutInMilliseconds: Long) = HttpClient(baseURL, timeoutInMilliseconds)
+fun createHttpClient(baseURL: String, timeoutInMilliseconds: Long) = LegacyHttpClient(baseURL, timeoutInMilliseconds)
+
+private const val SERVER_STATE_URL = "/_$APPLICATION_NAME_LOWER_CASE/state"
 
 data class HttpClient(
-    val baseURL: String,
-    private val timeoutInMilliseconds: Long = 6000,
+    private val baseURL: String,
+    val timeoutInMilliseconds: Long = 6000,
     private val log: (event: LogMessage) -> Unit = ::consoleLog,
-    private val httpClientFactory: HttpClientFactory = ApacheHttpClientFactory(timeoutInMilliseconds)
-) : TestExecutor {
-    private val serverStateURL = "/_$APPLICATION_NAME_LOWER_CASE/state"
-    private var httpLogMessage: HttpLogMessage = HttpLogMessage(targetServer = baseURL)
+    private var httpLogMessage: HttpLogMessage = HttpLogMessage(targetServer = baseURL),
+    private val httpClientFactory: Lazy<ApacheHttpClientFactory> = lazy { ApacheHttpClientFactory(timeoutInMilliseconds) },
+    private val httpClient: Lazy<io.ktor.client.HttpClient> = lazy { httpClientFactory.value.create() },
+) : TestExecutor, AutoCloseable {
 
     override fun execute(request: HttpRequest): HttpResponse {
         val url = URL(request.getURL(baseURL))
@@ -51,20 +52,17 @@ data class HttpClient(
 
         return try {
             runBlocking {
-                httpClientFactory.create().use { ktorClient ->
-                    val ktorResponse: io.ktor.client.statement.HttpResponse = ktorClient.request(url) {
-                        requestWithFileContent.buildKTORRequest(this, url)
-                    }
+                val ktorResponse: io.ktor.client.statement.HttpResponse = httpClient.value.request(url) {
+                    requestWithFileContent.buildKTORRequest(this, url)
+                }
 
-                    val outboundRequest: HttpRequest =
-                        ktorHttpRequestToHttpRequestForLogging(ktorResponse.request, requestWithFileContent)
-                    httpLogMessage.addRequest(outboundRequest)
+                val outboundRequest: HttpRequest =
+                    ktorHttpRequestToHttpRequestForLogging(ktorResponse.request, requestWithFileContent)
+                httpLogMessage.addRequest(outboundRequest)
 
-                    ktorResponseToHttpResponse(ktorResponse).also {
-                        httpLogMessage.addResponse(it)
-                        log(httpLogMessage)
-                        ktorClient.close()
-                    }
+                ktorResponseToHttpResponse(ktorResponse).also {
+                    httpLogMessage.addResponse(it)
+                    log(httpLogMessage)
                 }
             }
         } catch (e: Exception) {
@@ -76,56 +74,54 @@ data class HttpClient(
     override fun setServerState(serverState: Map<String, Value>) {
         if (serverState.isEmpty()) return
 
-        val url = URL(baseURL + serverStateURL)
+        val url = URL(baseURL + SERVER_STATE_URL)
 
         val startTime = Date()
 
         runBlocking {
-            httpClientFactory.create().use { ktorClient ->
-                var endTime: Date? = null
-                var response: HttpResponse? = null
+            var endTime: Date? = null
+            var response: HttpResponse? = null
 
-                try {
-                    val ktorResponse: io.ktor.client.statement.HttpResponse = ktorClient.request(url) {
-                        this.method = HttpMethod.Post
-                        this.contentType(ContentType.Application.Json)
-                        this.setBody(valueMapToPlainJsonString(serverState))
-                    }
+            try {
+                val ktorResponse: io.ktor.client.statement.HttpResponse = httpClient.value.request(url) {
+                    this.method = HttpMethod.Post
+                    this.contentType(ContentType.Application.Json)
+                    this.setBody(valueMapToPlainJsonString(serverState))
+                }
 
-                    endTime = Date()
+                endTime = Date()
 
-                    response = ktorResponseToHttpResponse(ktorResponse)
+                response = ktorResponseToHttpResponse(ktorResponse)
 
-                    if (ktorResponse.status != HttpStatusCode.OK)
-                        throw Exception("API responded with ${ktorResponse.status}")
-                } finally {
-                    val serverStateLog = object : LogMessage {
-                        override fun toJSONObject(): JSONObjectValue {
-                            val data: MutableMap<String, String> = mutableMapOf(
-                                "requestTime" to startTime.toString(),
-                                "serverState" to valueMapToPlainJsonString(serverState)
-                            )
+                if (ktorResponse.status != HttpStatusCode.OK)
+                    throw Exception("API responded with ${ktorResponse.status}")
+            } finally {
+                val serverStateLog = object : LogMessage {
+                    override fun toJSONObject(): JSONObjectValue {
+                        val data: MutableMap<String, String> = mutableMapOf(
+                            "requestTime" to startTime.toString(),
+                            "serverState" to valueMapToPlainJsonString(serverState)
+                        )
 
-                            if (endTime != null && response != null) {
-                                data["endTime"] = endTime.toString()
-                                data["response"] = response.toLogString()
-                            }
-
-                            return JSONObjectValue(data.mapValues { StringValue(it.value) }.toMap())
+                        if (endTime != null && response != null) {
+                            data["endTime"] = endTime.toString()
+                            data["response"] = response.toLogString()
                         }
 
-                        override fun toLogString(): String {
+                        return JSONObjectValue(data.mapValues { StringValue(it.value) }.toMap())
+                    }
 
-                            return """
+                    override fun toLogString(): String {
+
+                        return """
                         # >> Request Sent At $startTime
                         ${startLinesWith(valueMapToPlainJsonString(serverState), "# ")}
                         "# << Complete At $endTime"
                         """.trimIndent()
-                        }
                     }
-
-                    log(serverStateLog)
                 }
+
+                log(serverStateLog)
             }
         }
     }
@@ -133,6 +129,35 @@ data class HttpClient(
     override fun preExecuteScenario(scenario: Scenario, request: HttpRequest) {
         httpLogMessage = httpLogMessage.copy(scenario = scenario, request = request)
         TestInteractionsLog.addHttpLog(httpLogMessage)
+    }
+
+    override fun close() {
+        httpClient.value.close()
+    }
+
+    fun withLogger(log: (LogMessage) -> Unit): TestExecutor {
+        return this.copy(log = log)
+    }
+}
+
+
+@Deprecated("Use GoodHttpClient instead")
+data class LegacyHttpClient(
+    val baseURL: String,
+    val timeoutInMilliseconds: Long = 6000,
+    val log: (event: LogMessage) -> Unit = ::consoleLog,
+) : TestExecutor {
+
+    override fun execute(request: HttpRequest): HttpResponse {
+        return HttpClient(baseURL, timeoutInMilliseconds, log).use { it.execute(request) }
+    }
+
+    override fun setServerState(serverState: Map<String, Value>) {
+        HttpClient(baseURL, timeoutInMilliseconds, log).use { it.setServerState(serverState) }
+    }
+
+    override fun preExecuteScenario(scenario: Scenario, request: HttpRequest) {
+        HttpClient(baseURL, timeoutInMilliseconds, log).preExecuteScenario(scenario, request)
     }
 }
 
@@ -151,6 +176,7 @@ private fun ktorHttpRequestToHttpRequestForLogging(
 
                 Triple(bodyValue, emptyMap(), emptyList())
             }
+
             is MultiPartFormDataContent -> Triple(EmptyString, emptyMap(), specmaticRequest.multiPartFormData)
             is EmptyContent -> Triple(EmptyString, emptyMap(), emptyList())
             else -> throw ContractException("Unknown type of body content sent in the request")

--- a/core/src/main/kotlin/io/specmatic/test/ScenarioTestGenerationException.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ScenarioTestGenerationException.kt
@@ -52,7 +52,7 @@ class ScenarioTestGenerationException(
 
     override fun runTest(testBaseURL: String, timeoutInMilliseconds: Long): Pair<Result, HttpResponse?> {
         val log: (LogMessage) -> Unit = { logMessage -> logger.log(logMessage) }
-        val httpClient = HttpClient(testBaseURL, log = log, timeoutInMilliseconds = timeoutInMilliseconds)
+        val httpClient = LegacyHttpClient(testBaseURL, log = log, timeoutInMilliseconds = timeoutInMilliseconds)
         return runTest(httpClient)
     }
 
@@ -74,4 +74,3 @@ class ScenarioTestGenerationException(
         return Pair(result, null)
     }
 }
-

--- a/core/src/main/kotlin/io/specmatic/test/ScenarioTestGenerationFailure.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ScenarioTestGenerationFailure.kt
@@ -49,7 +49,7 @@ class ScenarioTestGenerationFailure(
 
     override fun runTest(testBaseURL: String, timeoutInMilliseconds: Long): Pair<Result, HttpResponse?> {
         val log: (LogMessage) -> Unit = { logMessage -> logger.log(logMessage) }
-        val httpClient = HttpClient(testBaseURL, log = log, timeoutInMilliseconds = timeoutInMilliseconds)
+        val httpClient = LegacyHttpClient(testBaseURL, log = log, timeoutInMilliseconds = timeoutInMilliseconds)
         return runTest(httpClient)
     }
 

--- a/core/src/test/kotlin/io/specmatic/core/ContractIntegrationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ContractIntegrationTest.kt
@@ -1,7 +1,7 @@
 package io.specmatic.core
 
 import io.specmatic.core.pattern.parsedJSONObject
-import io.specmatic.test.HttpClient
+import io.specmatic.test.LegacyHttpClient
 import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
@@ -50,7 +50,7 @@ class ContractIntegrationTest {
             server.start(wait = false)
 
             val contractBehaviour = parseGherkinStringToFeature(contractGherkin)
-            val results = contractBehaviour.executeTests(HttpClient("http://localhost:8080"))
+            val results = contractBehaviour.executeTests(LegacyHttpClient("http://localhost:8080"))
             assertThat(results.success()).withFailMessage(results.report()).isTrue()
         } finally {
             server.stop()

--- a/core/src/test/kotlin/io/specmatic/core/ContractTests.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ContractTests.kt
@@ -14,7 +14,7 @@ import io.specmatic.core.pattern.NumberPattern
 import io.specmatic.core.pattern.parsedJSONObject
 import io.specmatic.core.value.*
 import io.specmatic.osAgnosticPath
-import io.specmatic.test.HttpClient
+import io.specmatic.test.LegacyHttpClient
 import io.specmatic.test.TestExecutor
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.*
@@ -784,7 +784,7 @@ Examples:
         try {
             server.start(wait = false)
 
-            val results = spec.executeTests(HttpClient("http://localhost:8080"))
+            val results = spec.executeTests(LegacyHttpClient("http://localhost:8080"))
             assertThat(results.success()).withFailMessage(results.report()).isTrue()
             assertThat(results.successCount).isPositive()
         } finally {
@@ -825,7 +825,7 @@ Examples:
         try {
             server.start(wait = false)
 
-            val results = spec.executeTests(HttpClient("http://localhost:8080"))
+            val results = spec.executeTests(LegacyHttpClient("http://localhost:8080"))
             assertThat(results.success()).withFailMessage(results.report()).isTrue()
             assertThat(results.successCount).isPositive()
         } finally {
@@ -879,7 +879,7 @@ Examples:
 
         val results = try {
             server.start(wait = false)
-            specification.executeTests(HttpClient("http://localhost:9001"))
+            specification.executeTests(LegacyHttpClient("http://localhost:9001"))
         } finally {
             server.stop()
         }
@@ -940,7 +940,7 @@ Examples:
 
         val results = try {
             server.start(wait = false)
-            specification.executeTests(HttpClient("http://localhost:9001"))
+            specification.executeTests(LegacyHttpClient("http://localhost:9001"))
         } finally {
             server.stop()
         }
@@ -1011,7 +1011,7 @@ Examples:
 
         val results = try {
             server.start(wait = false)
-            specification.executeTests(HttpClient("http://localhost:9001"))
+            specification.executeTests(LegacyHttpClient("http://localhost:9001"))
         } finally {
             server.stop()
         }
@@ -1090,7 +1090,7 @@ Examples:
 
         val results = try {
             server.start(wait = false)
-            specification.enableGenerativeTesting().executeTests(HttpClient("http://localhost:9001"))
+            specification.enableGenerativeTesting().executeTests(LegacyHttpClient("http://localhost:9001"))
         } finally {
             server.stop()
         }

--- a/core/src/test/kotlin/io/specmatic/core/HttpClientTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpClientTest.kt
@@ -7,7 +7,7 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.specmatic.core.value.StringValue
 import io.specmatic.stub.HttpStub
-import io.specmatic.test.HttpClient
+import io.specmatic.test.LegacyHttpClient
 import org.json.JSONObject
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
@@ -32,7 +32,7 @@ class HttpClientTest {
             server.start(wait = false)
 
             val request = HttpRequest().updateMethod("GET").updatePath("/some/redirect")
-            val response = HttpClient("http://localhost:8080").execute(request)
+            val response = LegacyHttpClient("http://localhost:8080").execute(request)
             Assertions.assertEquals(302, response.status)
             Assertions.assertEquals("/newUrl", response.headers["Location"])
         } finally {
@@ -54,7 +54,7 @@ class HttpClientTest {
         val host = "localhost"
         val port = 8080
         val url = "http://localhost:$port"
-        val client = HttpClient(url)
+        val client = LegacyHttpClient(url)
         HttpStub(contractGherkin, emptyList(), host, port).use {
             val response = client.execute(request)
             Assertions.assertNotNull(response)
@@ -79,7 +79,7 @@ class HttpClientTest {
         val host = "localhost"
         val port = 8080
         val url = "http://localhost:$port"
-        val client = HttpClient(url)
+        val client = LegacyHttpClient(url)
 
         HttpStub(contractGherkin, emptyList(), host, port).use {
             client.setServerState(mapOf("server" to StringValue("state")))

--- a/core/src/test/kotlin/io/specmatic/core/ReferencesTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ReferencesTest.kt
@@ -6,7 +6,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import io.specmatic.core.pattern.ContractException
-import io.specmatic.test.HttpClient
+import io.specmatic.test.LegacyHttpClient
 import io.mockk.verify
 
 internal class ReferencesTest {
@@ -107,7 +107,7 @@ internal class ReferencesTest {
     private fun mockFeature(results: Results): Feature {
         val mockFeature = mockk<Feature>()
         every {
-            mockFeature.executeTests(match { (it as HttpClient).baseURL == baseURL }, any())
+            mockFeature.executeTests(match { (it as LegacyHttpClient).baseURL == baseURL }, any())
         }.returns(results)
         every {
             mockFeature.copy(testVariables = any(), testBaseURLs = any())

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubKtTest.kt
@@ -25,7 +25,7 @@ import io.specmatic.core.value.XMLValue
 import io.specmatic.core.value.toXMLNode
 import io.specmatic.mock.ScenarioStub
 import io.specmatic.stubResponse
-import io.specmatic.test.HttpClient
+import io.specmatic.test.LegacyHttpClient
 import io.specmatic.trimmedLinesList
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.OkHttpClient
@@ -33,11 +33,7 @@ import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.json.JSONObject
-import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Disabled
-import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.DisabledOnOs
 import org.junit.jupiter.api.condition.OS
@@ -645,7 +641,7 @@ Feature: POST API
 
     private fun invokeStub(i: Int, stub: HttpStub): HttpResponse {
         val request = HttpRequest(method = "POST", path = "/", formFields = mapOf("Data" to """{"number": $i}"""))
-        val client = HttpClient(stub.endPoint)
+        val client = LegacyHttpClient(stub.endPoint)
         return client.execute(request)
     }
 
@@ -666,7 +662,7 @@ Feature: POST API
     }
     """.trimIndent()
 
-        val client = HttpClient(stub.endPoint, log = ::consoleLog)
+        val client = LegacyHttpClient(stub.endPoint, log = ::consoleLog)
         val request = HttpRequest("POST", path = "/_specmatic/expectations", body = parsedValue(stubInfo))
         val response = client.execute(request)
 

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
@@ -16,7 +16,7 @@ import io.specmatic.mock.DELAY_IN_SECONDS
 import io.specmatic.mock.ScenarioStub
 import io.specmatic.osAgnosticPath
 import io.specmatic.shouldMatch
-import io.specmatic.test.HttpClient
+import io.specmatic.test.LegacyHttpClient
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -55,7 +55,7 @@ internal class HttpStubTest {
         val request = HttpRequest(method = "GET", path = "/")
 
         HttpStub(gherkin).use { stub ->
-            val response = HttpClient(stub.endPoint).execute(request)
+            val response = LegacyHttpClient(stub.endPoint).execute(request)
             assertThat(response.headers[SPECMATIC_TYPE_HEADER]).isEqualTo("random")
         }
     }
@@ -387,7 +387,7 @@ Scenario: Square of a number
         )
 
         HttpStub(listOf(feature, feature)).use { stub ->
-            val client = HttpClient(stub.endPoint)
+            val client = LegacyHttpClient(stub.endPoint)
             val request = HttpRequest(method = "POST", path = "/wrong_path", body = NumberValue(10))
             val squareResponse = client.execute(request)
             assertThat(squareResponse.status).isEqualTo(400)
@@ -409,7 +409,7 @@ Scenario: Square of a number
 """.trim()
         )
 
-        val httpClient = mockk<HttpClient>()
+        val httpClient = mockk<LegacyHttpClient>()
         every { httpClient.execute(any()) } returns (HttpResponse.ok("it worked"))
 
         val httpClientFactory = mockk<HttpClientFactory>()
@@ -420,7 +420,7 @@ Scenario: Square of a number
             passThroughTargetBase = "http://example.com",
             httpClientFactory = httpClientFactory
         ).use { stub ->
-            val client = HttpClient(stub.endPoint)
+            val client = LegacyHttpClient(stub.endPoint)
             val response = client.execute(HttpRequest(method = "POST", path = "/", body = NumberValue(10)))
 
             assertThat(response.status).isEqualTo(200)
@@ -443,7 +443,7 @@ Scenario: Square of a number
 """.trim()
         )
 
-        val httpClient = mockk<HttpClient>()
+        val httpClient = mockk<LegacyHttpClient>()
         every { httpClient.execute(any()) } returns (HttpResponse.ok("it worked"))
 
         val httpClientFactory = mockk<HttpClientFactory>()
@@ -454,7 +454,7 @@ Scenario: Square of a number
             passThroughTargetBase = "http://example.com",
             httpClientFactory = httpClientFactory
         ).use { stub ->
-            val client = HttpClient(stub.endPoint)
+            val client = LegacyHttpClient(stub.endPoint)
             val response = client.execute(HttpRequest(method = "POST", path = "/", body = NumberValue(10)))
 
             assertThat(response.headers[SPECMATIC_SOURCE_HEADER]).isEqualTo("proxy")
@@ -475,7 +475,7 @@ Scenario: Square of a number
 """.trim()
         )
 
-        val httpClient = mockk<HttpClient>()
+        val httpClient = mockk<LegacyHttpClient>()
         every { httpClient.execute(any()) } returns (HttpResponse.ok("should not get here"))
 
         val httpClientFactory = mockk<HttpClientFactory>()
@@ -492,7 +492,7 @@ Scenario: Square of a number
                     HttpResponse.ok("success")
                 )
             )
-            val client = HttpClient(stub.endPoint)
+            val client = LegacyHttpClient(stub.endPoint)
             val response = client.execute(HttpRequest(method = "POST", path = "/", body = NumberValue(10)))
 
             assertThat(response.status).isEqualTo(200)
@@ -2290,7 +2290,7 @@ Then status 200
                     path = "/products",
                     body = parsedJSONObject("""{"name": "Xiaomi", "category": "Mobile"}""")
                 )
-                val importedProductResponse = HttpClient(
+                val importedProductResponse = LegacyHttpClient(
                     endPointFromHostAndPort("localhost", 9001, null)
                 ).execute(request)
                 assertThat(
@@ -2298,7 +2298,7 @@ Then status 200
                 ).isEqualTo("100")
 
 
-                val exportedProductResponse = HttpClient(
+                val exportedProductResponse = LegacyHttpClient(
                     endPointFromHostAndPort("localhost", 9002, null)
                 ).execute(request)
                 assertThat(
@@ -2306,7 +2306,7 @@ Then status 200
                 ).isEqualTo("200")
 
 
-                val anotherExportedProductResponse = HttpClient(
+                val anotherExportedProductResponse = LegacyHttpClient(
                     endPointFromHostAndPort("localhost", 9003, null)
                 ).execute(request)
                 assertThat(
@@ -2333,7 +2333,7 @@ Then status 200
                     path = "/products",
                     body = parsedJSONObject("""{"name": "Xiaomi", "category": "Mobile"}""")
                 )
-                val importedProductResponse = HttpClient(
+                val importedProductResponse = LegacyHttpClient(
                     endPointFromHostAndPort("localhost", 9001, null)
                 ).execute(request.copy(path = "/base/products"))
                 assertThat(
@@ -2341,7 +2341,7 @@ Then status 200
                 ).isEqualTo("100")
 
 
-                val exportedProductResponse = HttpClient(
+                val exportedProductResponse = LegacyHttpClient(
                     endPointFromHostAndPort("localhost", 9002, null)
                 ).execute(request.copy(path = "/random/products"))
                 assertThat(
@@ -2349,7 +2349,7 @@ Then status 200
                 ).isEqualTo("200")
 
 
-                val anotherExportedProductResponse = HttpClient(
+                val anotherExportedProductResponse = LegacyHttpClient(
                     endPointFromHostAndPort("localhost", 9003, null)
                 ).execute(request.copy(path = "/random/base/products"))
                 assertThat(
@@ -2371,7 +2371,7 @@ Then status 200
                 specmaticConfigPath = specmaticConfigFile.canonicalPath,
                 specToStubBaseUrlMap = contractPathData.specToBaseUrlMap()
             ).use {
-                val productWithoutCategoryResponse = HttpClient(
+                val productWithoutCategoryResponse = LegacyHttpClient(
                     endPointFromHostAndPort("localhost", 9000, null)
                 ).execute(
                     HttpRequest(
@@ -2384,7 +2384,7 @@ Then status 200
                 assertThat(productWithoutCategoryResponse.jsonObject).doesNotContainKey("category")
 
 
-                val productWithCategoryResponse = HttpClient(
+                val productWithCategoryResponse = LegacyHttpClient(
                     endPointFromHostAndPort("localhost", 9001, null)
                 ).execute(
                     HttpRequest(
@@ -2418,7 +2418,7 @@ Then status 200
                 )
 
                 assertThrows<ConnectException> {
-                    HttpClient(endPointFromHostAndPort(
+                    LegacyHttpClient(endPointFromHostAndPort(
                         "localhost", Configuration.DEFAULT_HTTP_STUB_PORT.toInt(), null
                     )).execute(request)
                 }
@@ -2444,7 +2444,7 @@ Then status 200
                     path = "/products",
                     body = parsedJSONObject("""{"name": "Widget", "price": 9.99}""")
                 )
-                val productWithCategoryResponse = HttpClient(
+                val productWithCategoryResponse = LegacyHttpClient(
                     endPointFromHostAndPort("localhost", 9001, null)
                 ).execute(productWithoutCategoryExampleBasedRequest)
 
@@ -2456,7 +2456,7 @@ Then status 200
                     path = "/products",
                     body = parsedJSONObject("""{"name": "Nokia", "price": 100.0, "category": "Electronics"}""")
                 )
-                val productWithoutCategoryResponse = HttpClient(
+                val productWithoutCategoryResponse = LegacyHttpClient(
                     endPointFromHostAndPort("localhost", 9000, null)
                 ).execute(productWithCategoryBasedRequest)
 
@@ -2483,7 +2483,7 @@ Then status 200
                     body = parsedJSONObject("""{"name": "Xiaomi", "category": "Mobile"}""")
                 )
 
-                val importedProductResponse = HttpClient(
+                val importedProductResponse = LegacyHttpClient(
                     endPointFromHostAndPort("localhost", 9000, null)
                 ).execute(exportedProductStubbedRequest)
 
@@ -2491,7 +2491,7 @@ Then status 200
                     (importedProductResponse.body as JSONObjectValue).findFirstChildByPath("name")?.toStringLiteral()
                 ).isNotEqualTo("Xiaomi").isNotEmpty()
 
-                val exportedProductResponse = HttpClient(
+                val exportedProductResponse = LegacyHttpClient(
                     endPointFromHostAndPort("localhost", 9001, null)
                 ).execute(exportedProductStubbedRequest)
 
@@ -2514,7 +2514,7 @@ Then status 200
                 specmaticConfigPath = specmaticConfigFile.canonicalPath,
                 specToStubBaseUrlMap = contractPathData.specToBaseUrlMap()
             ).use {
-                val productsResponse = HttpClient(
+                val productsResponse = LegacyHttpClient(
                     endPointFromHostAndPort("localhost", 9000, null)
                 ).execute(
                     HttpRequest(
@@ -2529,7 +2529,7 @@ Then status 200
                     (productsResponse.body as JSONObjectValue).findFirstChildByPath("name")?.toStringLiteral()
                 ).isNotEqualTo("Xiaomi").isNotEmpty()
 
-                val ordersResponse = HttpClient(
+                val ordersResponse = LegacyHttpClient(
                     endPointFromHostAndPort("localhost", 9000, null)
                 ).execute(
                     HttpRequest(
@@ -2562,7 +2562,7 @@ Then status 200
                 specmaticConfigPath = specmaticConfigFile.canonicalPath,
                 specToStubBaseUrlMap = contractPathData.specToBaseUrlMap()
             ).use {
-                val productsResponse = HttpClient(
+                val productsResponse = LegacyHttpClient(
                     endPointFromHostAndPort("localhost", 9000, null)
                 ).execute(
                     HttpRequest(
@@ -2578,7 +2578,7 @@ Then status 200
                 ).isNotEqualTo("Xiaomi").isNotEmpty()
 
 
-                val exportedProductsResponse = HttpClient(
+                val exportedProductsResponse = LegacyHttpClient(
                     endPointFromHostAndPort("localhost", 9001, null)
                 ).execute(
                     HttpRequest(
@@ -2593,7 +2593,7 @@ Then status 200
                     (exportedProductsResponse.body as JSONObjectValue).findFirstChildByPath("id")?.toStringLiteral()
                 ).isEqualTo("200")
 
-                val ordersResponse = HttpClient(
+                val ordersResponse = LegacyHttpClient(
                     endPointFromHostAndPort("localhost", 9001, null)
                 ).execute(
                     HttpRequest(
@@ -2626,7 +2626,7 @@ Then status 200
                 specmaticConfigPath = specmaticConfigFile.canonicalPath,
                 specToStubBaseUrlMap = contractPathData.specToBaseUrlMap()
             ).use {
-                val postProductResponse = HttpClient(
+                val postProductResponse = LegacyHttpClient(
                     endPointFromHostAndPort("localhost", 9000, null)
                 ).execute(
                     HttpRequest(
@@ -2642,7 +2642,7 @@ Then status 200
                 ).isEqualTo("100")
 
 
-                val postOrderResponse = HttpClient(
+                val postOrderResponse = LegacyHttpClient(
                     endPointFromHostAndPort("localhost", 9000, null)
                 ).execute(
                     HttpRequest(
@@ -2695,7 +2695,7 @@ Then status 200
                     path = "/products",
                     body = parsedJSONObject("""{"name": "Xiaomi", "category": "Mobile"}""")
                 )
-                val importedProductResponse = HttpClient(
+                val importedProductResponse = LegacyHttpClient(
                     endPointFromHostAndPort("localhost", 9001, null)
                 ).execute(request)
                 assertThat(
@@ -2703,7 +2703,7 @@ Then status 200
                 ).isEqualTo("100")
 
 
-                val exportedProductResponse = HttpClient(
+                val exportedProductResponse = LegacyHttpClient(
                     endPointFromHostAndPort("localhost", 9002, null)
                 ).execute(request)
                 assertThat(
@@ -2711,7 +2711,7 @@ Then status 200
                 ).isEqualTo("200")
 
 
-                val anotherExportedProductResponse = HttpClient(
+                val anotherExportedProductResponse = LegacyHttpClient(
                     endPointFromHostAndPort("localhost", 9003, null)
                 ).execute(request)
                 assertThat(
@@ -2740,13 +2740,13 @@ Then status 200
                     body = parsedJSONObject("""{"name": "Xiaomi", "category": "Mobile"}""")
                 )
 
-                val exportedProductResponse = HttpClient(endPointFromHostAndPort("localhost", 9002, null)).execute(request)
+                val exportedProductResponse = LegacyHttpClient(endPointFromHostAndPort("localhost", 9002, null)).execute(request)
                 assertThat(exportedProductResponse.body).isEqualTo(
                     parsedJSONObject("""{"id": "999", "name": "Nokia", "category": "Mobile"}""")
                 )
 
 
-                val importedProductResponse = HttpClient(endPointFromHostAndPort("localhost", 9001, null)).execute(request)
+                val importedProductResponse = LegacyHttpClient(endPointFromHostAndPort("localhost", 9001, null)).execute(request)
                 assertThat(importedProductResponse.body).isEqualTo(
                     parsedJSONObject("""{"id": "999", "name": "Nokia", "category": "Mobile", "senderName": "Payne"}""")
                 )
@@ -2777,7 +2777,7 @@ Then status 200
                         method = "POST", path = "/products",
                         body = parsedJSONObject("""{"name": "Xiaomi", "category": "Mobile"}""")
                     )
-                    val client = HttpClient(endPointFromHostAndPort(host, port, null))
+                    val client = LegacyHttpClient(endPointFromHostAndPort(host, port, null))
                     val response = client.execute(request)
                     val actualId = (response.body as JSONObjectValue).findFirstChildByPath("id")?.toStringLiteral()
 
@@ -3068,8 +3068,8 @@ Then status 200
             port = 9000,
             dataDirPaths = emptyList<String>()
         ) { stub ->
-            val client8080 = HttpClient("http://localhost:8080")
-            val client9000 = HttpClient("http://localhost:9000")
+            val client8080 = LegacyHttpClient("http://localhost:8080")
+            val client9000 = LegacyHttpClient("http://localhost:9000")
 
             val dynamicExpectationRequest = HttpRequest(
                 method = "POST",
@@ -3140,7 +3140,7 @@ Then status 200
                     - ${simpleProductIdSpec.path}
                 """.trimIndent()
             ) {
-                val client = HttpClient("http://localhost:8080/api/v2")
+                val client = LegacyHttpClient("http://localhost:8080/api/v2")
                 assertGetProductResponse(client)
             }
         }
@@ -3157,7 +3157,7 @@ Then status 200
                     - ${simpleProductIdSpec.path}
                 """.trimIndent()
             ) {
-                val client = HttpClient("http://0.0.0.0:9000")
+                val client = LegacyHttpClient("http://0.0.0.0:9000")
                 assertGetProductResponse(client)
             }
         }
@@ -3174,7 +3174,7 @@ Then status 200
                     - ${simpleProductIdSpec.path}
                 """.trimIndent()
             ) {
-                val client = HttpClient("http://0.0.0.0:5000")
+                val client = LegacyHttpClient("http://0.0.0.0:5000")
                 assertGetProductResponse(client)
             }
         }
@@ -3191,7 +3191,7 @@ Then status 200
                     - ${simpleProductIdSpec.path}
                 """.trimIndent()
             ) {
-                val client = HttpClient("http://0.0.0.0:9000/api/v2")
+                val client = LegacyHttpClient("http://0.0.0.0:9000/api/v2")
                 assertGetProductResponse(client)
             }
         }
@@ -3210,12 +3210,12 @@ Then status 200
                     - ${simpleProductIdSpec.path}
                 """.trimIndent()
             ) {
-                val client = HttpClient("http://0.0.0.0:20000/api/v2")
+                val client = LegacyHttpClient("http://0.0.0.0:20000/api/v2")
                 assertGetProductResponse(client)
             }
         }
 
-        private fun assertGetProductResponse(client: HttpClient) {
+        private fun assertGetProductResponse(client: LegacyHttpClient) {
             val request = HttpRequest(method = "GET", path = "/products/123")
             val response = client.execute(request)
 

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -6,9 +6,13 @@ import io.specmatic.core.*
 import io.specmatic.core.SpecmaticConfig.Companion.getSecurityConfiguration
 import io.specmatic.core.filters.ScenarioMetadataFilter
 import io.specmatic.core.filters.ScenarioMetadataFilter.Companion.filterUsing
+import io.specmatic.core.log.LogMessage
 import io.specmatic.core.log.ignoreLog
 import io.specmatic.core.log.logger
-import io.specmatic.core.pattern.*
+import io.specmatic.core.pattern.ContractException
+import io.specmatic.core.pattern.Examples
+import io.specmatic.core.pattern.Row
+import io.specmatic.core.pattern.parsedValue
 import io.specmatic.core.utilities.*
 import io.specmatic.core.utilities.Flags.Companion.SPECMATIC_TEST_TIMEOUT
 import io.specmatic.core.utilities.Flags.Companion.getLongValue
@@ -111,7 +115,7 @@ open class SpecmaticJUnitSupport {
 
         fun actuatorFromSwagger(testBaseURL: String, client: TestExecutor? = null): ActuatorSetupResult {
             val baseURL = Flags.getStringValue(SWAGGER_UI_BASEURL) ?: testBaseURL
-            val httpClient = client ?: HttpClient(baseURL, log = ignoreLog)
+            val httpClient = client ?: LegacyHttpClient(baseURL, log = ignoreLog)
 
             val request = HttpRequest(path = "/swagger/v1/swagger.yaml", method = "GET")
             val response = httpClient.execute(request)
@@ -135,7 +139,7 @@ open class SpecmaticJUnitSupport {
         fun queryActuator(): ActuatorSetupResult {
             val endpointsAPI: String = Flags.getStringValue(ENDPOINTS_API) ?: return ActuatorSetupResult.Failure
             val request = HttpRequest("GET")
-            val response = HttpClient(endpointsAPI, log = ignoreLog).execute(request)
+            val response = LegacyHttpClient(endpointsAPI, log = ignoreLog).execute(request)
 
             if (response.status != 200) {
                 logger.log("Failed to query actuator, status code: ${response.status}")
@@ -340,6 +344,12 @@ open class SpecmaticJUnitSupport {
 
         logger.newLine()
 
+        val log: (LogMessage) -> Unit = { logMessage ->
+            logger.log(logMessage)
+        }
+
+        val httpClient = HttpClient(testBaseURL, log = log, timeoutInMilliseconds = timeoutInMilliseconds)
+
         return testScenarios.map { contractTest ->
             DynamicTest.dynamicTest(contractTest.testDescription()) {
                 threads.add(Thread.currentThread().name)
@@ -347,7 +357,7 @@ open class SpecmaticJUnitSupport {
                 var testResult: Pair<Result, HttpResponse?>? = null
 
                 try {
-                    testResult = contractTest.runTest(testBaseURL, timeoutInMilliseconds)
+                    testResult = contractTest.runTest(httpClient)
                     val (result) = testResult
 
                     if (result is Result.Success && result.isPartialSuccess()) {
@@ -375,7 +385,7 @@ open class SpecmaticJUnitSupport {
                     }
                 }
             }
-        }.asStream()
+        }.asStream().onClose { httpClient.close() }
     }
 
     fun constructTestBaseURL(): String {
@@ -611,4 +621,3 @@ fun <T> selectTestsToRun(
 
     return filteredByNotName
 }
-

--- a/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
@@ -9,7 +9,6 @@ import io.specmatic.test.SpecmaticJUnitSupport.Companion.PROTOCOL
 import io.specmatic.test.SpecmaticJUnitSupport.Companion.TEST_BASE_URL
 import io.specmatic.test.listeners.ContractExecutionListener
 import io.specmatic.test.reports.coverage.Endpoint
-import io.specmatic.test.reports.coverage.OpenApiCoverageReportInput
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatCode
 import org.junit.jupiter.api.AfterEach


### PR DESCRIPTION
When running a close loop test, too many connections remain in
`TIME_WAIT` state. This is a side-effect of how tcp works. TCP
connections go into this state, in anticipation of any delayed packets
still on the network after the connection is closed.

Earlier implementation created a new httpclient (and connection) for
each HTTP request/response cycle, thereby making the situation worse.

Using a longer lived http-client tends to reuse the same TCP connection
for more than one HTTP call and significantly reduces (near zero) the
number of connections in `TIME_WAIT` state.

`HttpClient` is renamed to `Legacy` and the new `HttpClient` expects
the consumer to call `close` or use with `.use`