### PR TITLE
Implement support for logical AND in security schemes

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/APIKeyInHeaderSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/APIKeyInHeaderSecurityScheme.kt
@@ -32,4 +32,8 @@ data class APIKeyInHeaderSecurityScheme(val name: String, private val apiKey:Str
     }
 
     override fun isInRow(row: Row): Boolean = row.containsField(name)
+
+    override fun isInRequest(request: HttpRequest): Boolean {
+        return request.headers.containsKey(name)
+    }
 }

--- a/core/src/main/kotlin/io/specmatic/conversions/APIKeyInHeaderSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/APIKeyInHeaderSecurityScheme.kt
@@ -34,6 +34,6 @@ data class APIKeyInHeaderSecurityScheme(val name: String, private val apiKey:Str
     override fun isInRow(row: Row): Boolean = row.containsField(name)
 
     override fun isInRequest(request: HttpRequest, complete: Boolean): Boolean {
-        return request.headers.containsKey(name)
+        return request.hasHeader(name)
     }
 }

--- a/core/src/main/kotlin/io/specmatic/conversions/APIKeyInHeaderSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/APIKeyInHeaderSecurityScheme.kt
@@ -33,7 +33,7 @@ data class APIKeyInHeaderSecurityScheme(val name: String, private val apiKey:Str
 
     override fun isInRow(row: Row): Boolean = row.containsField(name)
 
-    override fun isInRequest(request: HttpRequest): Boolean {
+    override fun isInRequest(request: HttpRequest, complete: Boolean): Boolean {
         return request.headers.containsKey(name)
     }
 }

--- a/core/src/main/kotlin/io/specmatic/conversions/APIKeyInQueryParamSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/APIKeyInQueryParamSecurityScheme.kt
@@ -48,6 +48,6 @@ data class APIKeyInQueryParamSecurityScheme(val name: String, private val apiKey
     override fun isInRow(row: Row): Boolean = row.containsField(name)
 
     override fun isInRequest(request: HttpRequest, complete: Boolean): Boolean {
-        return request.queryParams.containsKey(name)
+        return request.hasQueryParam(name)
     }
 }

--- a/core/src/main/kotlin/io/specmatic/conversions/APIKeyInQueryParamSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/APIKeyInQueryParamSecurityScheme.kt
@@ -47,7 +47,7 @@ data class APIKeyInQueryParamSecurityScheme(val name: String, private val apiKey
 
     override fun isInRow(row: Row): Boolean = row.containsField(name)
 
-    override fun isInRequest(request: HttpRequest): Boolean {
+    override fun isInRequest(request: HttpRequest, complete: Boolean): Boolean {
         return request.queryParams.containsKey(name)
     }
 }

--- a/core/src/main/kotlin/io/specmatic/conversions/APIKeyInQueryParamSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/APIKeyInQueryParamSecurityScheme.kt
@@ -46,4 +46,8 @@ data class APIKeyInQueryParamSecurityScheme(val name: String, private val apiKey
     }
 
     override fun isInRow(row: Row): Boolean = row.containsField(name)
+
+    override fun isInRequest(request: HttpRequest): Boolean {
+        return request.queryParams.containsKey(name)
+    }
 }

--- a/core/src/main/kotlin/io/specmatic/conversions/BasicAuthSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/BasicAuthSecurityScheme.kt
@@ -61,7 +61,7 @@ data class BasicAuthSecurityScheme(private val token: String? = null) : OpenAPIS
 
     override fun isInRow(row: Row): Boolean = row.containsField(AUTHORIZATION)
 
-    override fun isInRequest(request: HttpRequest): Boolean {
+    override fun isInRequest(request: HttpRequest, complete: Boolean): Boolean {
         return request.headers.containsKey(AUTHORIZATION)
     }
 

--- a/core/src/main/kotlin/io/specmatic/conversions/BasicAuthSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/BasicAuthSecurityScheme.kt
@@ -62,7 +62,7 @@ data class BasicAuthSecurityScheme(private val token: String? = null) : OpenAPIS
     override fun isInRow(row: Row): Boolean = row.containsField(AUTHORIZATION)
 
     override fun isInRequest(request: HttpRequest, complete: Boolean): Boolean {
-        return request.headers.containsKey(AUTHORIZATION)
+        return request.hasHeader(AUTHORIZATION)
     }
 
     private fun getAuthorizationHeaderValue(resolver: Resolver): String {

--- a/core/src/main/kotlin/io/specmatic/conversions/BasicAuthSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/BasicAuthSecurityScheme.kt
@@ -60,6 +60,11 @@ data class BasicAuthSecurityScheme(private val token: String? = null) : OpenAPIS
     }
 
     override fun isInRow(row: Row): Boolean = row.containsField(AUTHORIZATION)
+
+    override fun isInRequest(request: HttpRequest): Boolean {
+        return request.headers.containsKey(AUTHORIZATION)
+    }
+
     private fun getAuthorizationHeaderValue(resolver: Resolver): String {
         val validToken = when {
             token != null -> {

--- a/core/src/main/kotlin/io/specmatic/conversions/BearerSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/BearerSecurityScheme.kt
@@ -44,6 +44,10 @@ data class BearerSecurityScheme(private val configuredToken: String? = null) : O
         return row.columnNames.any { it.equals(AUTHORIZATION, ignoreCase = true) }
     }
 
+    override fun isInRequest(request: HttpRequest): Boolean {
+        return request.headers.containsKey(AUTHORIZATION)
+    }
+
     private fun getAuthorizationHeaderValue(resolver: Resolver): String {
         return "Bearer " + (configuredToken ?: resolver.generate("HEADERS", AUTHORIZATION, StringPattern()).toStringLiteral())
     }

--- a/core/src/main/kotlin/io/specmatic/conversions/BearerSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/BearerSecurityScheme.kt
@@ -44,7 +44,7 @@ data class BearerSecurityScheme(private val configuredToken: String? = null) : O
         return row.columnNames.any { it.equals(AUTHORIZATION, ignoreCase = true) }
     }
 
-    override fun isInRequest(request: HttpRequest): Boolean {
+    override fun isInRequest(request: HttpRequest, complete: Boolean): Boolean {
         return request.headers.containsKey(AUTHORIZATION)
     }
 

--- a/core/src/main/kotlin/io/specmatic/conversions/BearerSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/BearerSecurityScheme.kt
@@ -45,7 +45,7 @@ data class BearerSecurityScheme(private val configuredToken: String? = null) : O
     }
 
     override fun isInRequest(request: HttpRequest, complete: Boolean): Boolean {
-        return request.headers.containsKey(AUTHORIZATION)
+        return request.hasHeader(AUTHORIZATION)
     }
 
     private fun getAuthorizationHeaderValue(resolver: Resolver): String {

--- a/core/src/main/kotlin/io/specmatic/conversions/CompositeSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/CompositeSecurityScheme.kt
@@ -6,7 +6,7 @@ import io.specmatic.core.Resolver
 import io.specmatic.core.Result
 import io.specmatic.core.pattern.Row
 
-data class CompositeSecurityScheme(private val schemes: List<OpenAPISecurityScheme>): OpenAPISecurityScheme {
+data class CompositeSecurityScheme(val schemes: List<OpenAPISecurityScheme>): OpenAPISecurityScheme {
     override fun matches(httpRequest: HttpRequest, resolver: Resolver): Result {
         val results = schemes.map { it.matches(httpRequest, resolver) }
         return Result.fromResults(results)
@@ -38,5 +38,9 @@ data class CompositeSecurityScheme(private val schemes: List<OpenAPISecuritySche
 
     override fun isInRow(row: Row): Boolean {
         return schemes.all { it.isInRow(row) }
+    }
+
+    override fun isInRequest(request: HttpRequest): Boolean {
+        return schemes.all { it.isInRequest(request) }
     }
 }

--- a/core/src/main/kotlin/io/specmatic/conversions/CompositeSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/CompositeSecurityScheme.kt
@@ -40,7 +40,8 @@ data class CompositeSecurityScheme(val schemes: List<OpenAPISecurityScheme>): Op
         return schemes.all { it.isInRow(row) }
     }
 
-    override fun isInRequest(request: HttpRequest): Boolean {
-        return schemes.all { it.isInRequest(request) }
+    override fun isInRequest(request: HttpRequest, complete: Boolean): Boolean {
+        return if (!complete) schemes.any { it.isInRequest(request, false) }
+        else schemes.all { it.isInRequest(request, true) }
     }
 }

--- a/core/src/main/kotlin/io/specmatic/conversions/CompositeSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/CompositeSecurityScheme.kt
@@ -1,0 +1,42 @@
+package io.specmatic.conversions
+
+import io.specmatic.core.HttpRequest
+import io.specmatic.core.HttpRequestPattern
+import io.specmatic.core.Resolver
+import io.specmatic.core.Result
+import io.specmatic.core.pattern.Row
+
+data class CompositeSecurityScheme(private val schemes: List<OpenAPISecurityScheme>): OpenAPISecurityScheme {
+    override fun matches(httpRequest: HttpRequest, resolver: Resolver): Result {
+        val results = schemes.map { it.matches(httpRequest, resolver) }
+        return Result.fromResults(results)
+    }
+
+    override fun removeParam(httpRequest: HttpRequest): HttpRequest {
+        return schemes.fold(httpRequest) { request, scheme ->
+            scheme.removeParam(request)
+        }
+    }
+
+    override fun addTo(httpRequest: HttpRequest, resolver: Resolver): HttpRequest {
+        return schemes.fold(httpRequest) { request, scheme ->
+            scheme.addTo(request, resolver)
+        }
+    }
+
+    override fun addTo(requestPattern: HttpRequestPattern, row: Row): HttpRequestPattern {
+        return schemes.fold(requestPattern) { pattern, scheme ->
+            scheme.addTo(pattern, row)
+        }
+    }
+
+    override fun copyFromTo(originalRequest: HttpRequest, newHttpRequest: HttpRequest): HttpRequest {
+        return schemes.fold(newHttpRequest) { request, scheme ->
+            scheme.copyFromTo(originalRequest, request)
+        }
+    }
+
+    override fun isInRow(row: Row): Boolean {
+        return schemes.all { it.isInRow(row) }
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/conversions/ExampleRequestBuilder.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/ExampleRequestBuilder.kt
@@ -11,7 +11,7 @@ class ExampleRequestBuilder(
     exampleQueryParams: Map<String, Map<String, String>>,
     val httpPathPattern: HttpPathPattern,
     private val httpMethod: String,
-    val securitySchemes: Map<String, OpenAPISecurityScheme>
+    val securitySchemes: List<OpenAPISecurityScheme>
 ) {
     fun examplesWithRequestBodies(exampleBodies: Map<String, String?>, contentType: String): Map<String, List<HttpRequest>> {
         val examplesWithBodies: Map<String, List<HttpRequest>> = exampleBodies.mapValues { (exampleName, bodyValue) ->
@@ -30,7 +30,7 @@ class ExampleRequestBuilder(
                     body = parsedValue(bodyValue)
                 )
 
-                val requestsWithSecurityParams = securitySchemes.map { (_, securityScheme) ->
+                val requestsWithSecurityParams = securitySchemes.map { securityScheme ->
                     securityScheme.addTo(httpRequest)
                 }
 
@@ -60,7 +60,7 @@ class ExampleRequestBuilder(
         val httpRequest =
             HttpRequest(method = httpMethod, path = path, queryParametersMap = queryParams, headers = headerParams)
 
-        val requestsWithSecurityParams: List<HttpRequest> = securitySchemes.map { (_, securityScheme) ->
+        val requestsWithSecurityParams: List<HttpRequest> = securitySchemes.map { securityScheme ->
             securityScheme.addTo(httpRequest)
         }
 

--- a/core/src/main/kotlin/io/specmatic/conversions/NoSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/NoSecurityScheme.kt
@@ -39,7 +39,7 @@ class NoSecurityScheme : OpenAPISecurityScheme {
         return false
     }
 
-    override fun isInRequest(request: HttpRequest): Boolean {
+    override fun isInRequest(request: HttpRequest, complete: Boolean): Boolean {
         return false
     }
 }

--- a/core/src/main/kotlin/io/specmatic/conversions/NoSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/NoSecurityScheme.kt
@@ -38,4 +38,8 @@ class NoSecurityScheme : OpenAPISecurityScheme {
     override fun isInRow(row: Row): Boolean {
         return false
     }
+
+    override fun isInRequest(request: HttpRequest): Boolean {
+        return false
+    }
 }

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenAPISecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenAPISecurityScheme.kt
@@ -14,6 +14,7 @@ interface OpenAPISecurityScheme {
     fun addTo(requestPattern: HttpRequestPattern, row: Row): HttpRequestPattern
     fun copyFromTo(originalRequest: HttpRequest, newHttpRequest: HttpRequest): HttpRequest
     fun isInRow(row: Row): Boolean
+    fun isInRequest(request: HttpRequest): Boolean
 }
 
 fun addToHeaderType(

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenAPISecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenAPISecurityScheme.kt
@@ -14,7 +14,7 @@ interface OpenAPISecurityScheme {
     fun addTo(requestPattern: HttpRequestPattern, row: Row): HttpRequestPattern
     fun copyFromTo(originalRequest: HttpRequest, newHttpRequest: HttpRequest): HttpRequest
     fun isInRow(row: Row): Boolean
-    fun isInRequest(request: HttpRequest): Boolean
+    fun isInRequest(request: HttpRequest, complete: Boolean): Boolean
 }
 
 fun addToHeaderType(

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
@@ -409,6 +409,14 @@ data class HttpRequest(
         return headers[SPECMATIC_RESPONSE_CODE_HEADER]?.toIntOrNull()
     }
 
+    fun hasHeader(name: String): Boolean {
+        return headers.containsKey(name)
+    }
+
+    fun hasQueryParam(name: String): Boolean {
+        return queryParams.containsKey(name)
+    }
+
     val generality: Int by lazy {
         val pathScore: Int = path?.split(URL_PATH_DELIMITER)?.count { StringValue(it).isPatternToken() } ?: 0
         val headerScore: Int = headers.values.sumOf { if(isPatternToken(it)) 1 as Int else 0 }

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
@@ -115,11 +115,11 @@ data class HttpRequestPattern(
             securityScheme.removeParam(request) to results.plus(
                 SecurityMatch(
                     presence = when {
-                        securityScheme.isInRequest(request, complete = true) -> SchemePresence.FULL
-                        securityScheme.isInRequest(request, complete = false) -> SchemePresence.PARTIAL
+                        securityScheme.isInRequest(httpRequest, complete = true) -> SchemePresence.FULL
+                        securityScheme.isInRequest(httpRequest, complete = false) -> SchemePresence.PARTIAL
                         else -> SchemePresence.ABSENT
                     },
-                    result = securityScheme.matches(request, resolver)
+                    result = securityScheme.matches(httpRequest, resolver)
                 )
             )
         }

--- a/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
+++ b/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
@@ -569,9 +569,15 @@ class LoadTestsFromExternalisedFiles {
         Error loading example for POST /secure -> 200 from ${examplesDir.resolve("secure.json").canonicalPath} 
         >> REQUEST.HEADERS.Authorization
         Authorization header must be prefixed with "Bearer"
+
         Error loading example for POST /partial -> 200 from ${examplesDir.resolve("partial.json").canonicalPath} 
         >> REQUEST.HEADERS.Authorization
         Authorization header must be prefixed with "Bearer"
+        
+        Error loading example for POST /overlap -> 200 from ${examplesDir.resolve("overlap.json").canonicalPath}
+        >> REQUEST.HEADERS.Authorization
+        Authorization header must be prefixed with "Bearer"
+
         Error loading example for POST /insecure -> 200 from ${examplesDir.resolve("insecure.json").canonicalPath} 
         >> REQUEST.QUERY-PARAMS.apiKey
         The query param apiKey was found in the example insecure but was not in the specification. 
@@ -610,6 +616,19 @@ class LoadTestsFromExternalisedFiles {
                         assertAuthHeader(request, "Bearer API-SECRET")
                         assertThat(bodyString).isEqualTo("Hello to Secure")
                     }
+                    "/overlap" -> {
+                        assertThat(request).satisfiesAnyOf(
+                            {
+                                assertApiKey(it, "1234")
+                                assertAuthHeader(it, "Bearer API-SECRET")
+                            },
+                            {
+                                assertApiKey(it, null)
+                                assertAuthHeader(it, "Bearer API-SECRET")
+                            }
+                        )
+                        assertThat(bodyString).isEqualTo("Hello to Overlap")
+                    }
                     "/partial" -> {
                         assertThat(request).satisfiesAnyOf(
                             {
@@ -638,7 +657,7 @@ class LoadTestsFromExternalisedFiles {
         })
 
         assertThat(results.success()).withFailMessage(results.report()).isTrue()
-        assertThat(results.testCount).isEqualTo(4)
+        assertThat(results.testCount).isEqualTo(6)
     }
 
     @Nested

--- a/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
+++ b/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
@@ -560,7 +560,7 @@ class LoadTestsFromExternalisedFiles {
     fun `should complain when examples have invalid security-scheme values or unexpected keys in header and query`() {
         val openApiFile = File("src/test/resources/openapi/has_composite_security/api.yaml")
         val examplesDir = openApiFile.resolveSibling("invalid_examples")
-        val feature = Flags.using(EXAMPLE_DIRECTORIES to examplesDir.canonicalPath) {
+        val feature = Flags.using(EXAMPLE_DIRECTORIES to examplesDir.canonicalPath, IGNORE_INLINE_EXAMPLES to "true") {
             OpenApiSpecification.fromFile(openApiFile.canonicalPath).toFeature().loadExternalisedExamples()
         }
         val exception = assertThrows<ContractException> { feature.validateExamplesOrException() }

--- a/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
+++ b/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
@@ -14,6 +14,7 @@ import io.specmatic.core.utilities.Flags
 import io.specmatic.core.utilities.Flags.Companion.ADDITIONAL_EXAMPLE_PARAMS_FILE
 import io.specmatic.core.utilities.Flags.Companion.EXAMPLE_DIRECTORIES
 import io.specmatic.core.utilities.Flags.Companion.EXTENSIBLE_SCHEMA
+import io.specmatic.core.utilities.Flags.Companion.IGNORE_INLINE_EXAMPLES
 import io.specmatic.core.value.*
 import io.specmatic.test.ExampleProcessor
 import io.specmatic.test.TestExecutor
@@ -577,6 +578,67 @@ class LoadTestsFromExternalisedFiles {
         >> REQUEST.HEADERS.Authorization
         The header Authorization was found in the example insecure but was not in the specification.
         """.trimIndent())
+    }
+
+    @Test
+    fun `should use values provided in the example for security-schemes and fill-in missing values`() {
+        val openApiFile = File("src/test/resources/openapi/has_composite_security/api.yaml")
+        val examplesDir = openApiFile.resolveSibling("valid_examples")
+        val feature = Flags.using(
+            EXAMPLE_DIRECTORIES to examplesDir.canonicalPath,
+            IGNORE_INLINE_EXAMPLES to "true",
+            "bearerAuth" to "API-SECRET",
+            "apiKeyQuery" to "1234"
+        ) {
+            OpenApiSpecification.fromFile(openApiFile.canonicalPath).toFeature().loadExternalisedExamples()
+        }
+
+        val assertApiKey: (HttpRequest, String?) -> Unit = { request, expected ->
+            assertThat(request.queryParams.asMap()["apiKey"]).isEqualTo(expected)
+        }
+        val assertAuthHeader: (HttpRequest, String?) -> Unit = { request, expected ->
+            assertThat(request.headers["Authorization"]).isEqualTo(expected)
+        }
+
+        val results = feature.executeTests(object: TestExecutor {
+            override fun execute(request: HttpRequest): HttpResponse {
+                val requestBody = request.body as JSONObjectValue
+                val bodyString = requestBody.jsonObject["message"]!!.toStringLiteral()
+                when (request.path) {
+                    "/secure" -> {
+                        assertApiKey(request, "1234")
+                        assertAuthHeader(request, "Bearer API-SECRET")
+                        assertThat(bodyString).isEqualTo("Hello to Secure")
+                    }
+                    "/partial" -> {
+                        assertThat(request).satisfiesAnyOf(
+                            {
+                                assertApiKey(request, "1234")
+                                assertAuthHeader(request, null)
+                            },
+                            {
+                                assertApiKey(request, null)
+                                assertAuthHeader(request, "Bearer API-SECRET")
+                            }
+                        )
+                        assertThat(bodyString).isEqualTo("Hello to Partial")
+                    }
+                    else -> {
+                        assertApiKey(request, null)
+                        assertAuthHeader(request, null)
+                        assertThat(bodyString).isEqualTo("Hello to Insecure")
+                    }
+                }
+
+                return HttpResponse.ok(requestBody.addEntry("message", bodyString)).also {
+                    println(request.toLogString())
+                    println(it.toLogString())
+                }
+            }
+        })
+
+        assertThat(results.success()).withFailMessage(results.report()).isTrue()
+        assertThat(results.testCount).isEqualTo(4)
     }
 
     @Nested

--- a/core/src/test/kotlin/io/specmatic/conversions/CompositeSecuritySchemeTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/CompositeSecuritySchemeTest.kt
@@ -1,0 +1,68 @@
+package io.specmatic.conversions
+
+import io.specmatic.core.HttpRequest
+import io.specmatic.core.Resolver
+import io.specmatic.core.Result
+import org.apache.http.HttpHeaders.AUTHORIZATION
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class CompositeSecuritySchemeTest {
+
+    private val securityScheme = CompositeSecurityScheme(listOf(
+        BearerSecurityScheme(configuredToken = "API-SECRET"),
+        APIKeyInQueryParamSecurityScheme(name = "apiKey", apiKey = null)
+    ))
+
+    private val securitySchemeWithToken = CompositeSecurityScheme(listOf(
+        BearerSecurityScheme(configuredToken = "API-SECRET"),
+        APIKeyInQueryParamSecurityScheme(name = "apiKey", apiKey = "1234")
+    ))
+
+    @Test
+    fun `should return success when request matches all security schemes`() {
+        val httpRequest = HttpRequest(
+            method = "GET", path ="/",
+            headers = mapOf(AUTHORIZATION to "Bearer API-SECRET"), queryParametersMap = mapOf("apiKey" to "1234")
+        )
+        val result = securityScheme.matches(httpRequest, Resolver())
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+    }
+
+    @Test
+    fun `should return failure when request does not match at-least one security scheme`() {
+        val httpRequest = HttpRequest(method = "GET", path ="/")
+        val result = securityScheme.matches(httpRequest, Resolver())
+
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
+        assertThat(result.reportString()).isEqualToNormalizingWhitespace("""
+        >> HEADERS.$AUTHORIZATION
+        Expected header named "$AUTHORIZATION" was missing
+        >> QUERY-PARAMS.apiKey
+        Expected api-key named "apiKey" was missing
+        """.trimIndent())
+    }
+
+    @Test
+    fun `should add all security schemes into the request`() {
+        val httpRequest = HttpRequest(method = "GET", path ="/")
+        val newRequest = securitySchemeWithToken.addTo(httpRequest)
+
+        assertThat(newRequest.headers[AUTHORIZATION]).isEqualTo("Bearer API-SECRET")
+        assertThat(newRequest.queryParams.asMap()["apiKey"]).isEqualTo("1234")
+    }
+
+    @Test
+    fun `should be able to remove all security schemes from the request`() {
+        val httpRequest = HttpRequest(
+            method = "GET", path ="/",
+            headers = mapOf(AUTHORIZATION to "Bearer MY-TOKEN"),
+            queryParametersMap = mapOf("apiKey" to "ABC")
+        )
+        val newRequest = securityScheme.removeParam(httpRequest)
+
+        assertThat(newRequest.headers["API-SECRET"]).isNull()
+        assertThat(newRequest.queryParams.asMap()["apiKey"]).isNull()
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -10772,13 +10772,21 @@ paths:
         val feature = Flags.using("bearerAuth" to "API-SECRET", "apiKeyQuery" to "1234") {
             OpenApiSpecification.fromFile(oasFile.canonicalPath).toFeature()
         }
-        val (secure, partial, insecure) = feature.scenarios
+        val (secure, partial, overlap, insecure) = feature.scenarios
 
         assertThat(secure.httpRequestPattern.securitySchemes).isEqualTo(listOf(
             CompositeSecurityScheme(listOf(
                 BearerSecurityScheme(configuredToken = "API-SECRET"),
                 APIKeyInQueryParamSecurityScheme(name = "apiKey", apiKey = "1234")
             ))
+        ))
+
+        assertThat(overlap.httpRequestPattern.securitySchemes).isEqualTo(listOf(
+            CompositeSecurityScheme(listOf(
+                BearerSecurityScheme(configuredToken = "API-SECRET"),
+                APIKeyInQueryParamSecurityScheme(name = "apiKey", apiKey = "1234")
+            )),
+            BearerSecurityScheme(configuredToken = "API-SECRET"),
         ))
 
         assertThat(partial.httpRequestPattern.securitySchemes).isEqualTo(listOf(

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -10766,6 +10766,31 @@ paths:
         assertThat(results.report()).contains("""expected "application/json; charset=utf-8" but found value "application/json"""")
     }
 
+    @Test
+    fun `should be able to load OAS with security schemes defined in logical AND or OR combination`() {
+        val oasFile = File("src/test/resources/openapi/has_composite_security/api.yaml")
+        val feature = Flags.using("bearerAuth" to "API-SECRET", "apiKeyQuery" to "1234") {
+            OpenApiSpecification.fromFile(oasFile.canonicalPath).toFeature()
+        }
+        val (secure, partial, insecure) = feature.scenarios
+
+        assertThat(secure.httpRequestPattern.securitySchemes).isEqualTo(listOf(
+            CompositeSecurityScheme(listOf(
+                BearerSecurityScheme(configuredToken = "API-SECRET"),
+                APIKeyInQueryParamSecurityScheme(name = "apiKey", apiKey = "1234")
+            ))
+        ))
+
+        assertThat(partial.httpRequestPattern.securitySchemes).isEqualTo(listOf(
+            BearerSecurityScheme(configuredToken = "API-SECRET"),
+            APIKeyInQueryParamSecurityScheme(name = "apiKey", apiKey = "1234")
+        ))
+
+        assertThat(insecure.httpRequestPattern.securitySchemes).isEqualTo(listOf(
+            NoSecurityScheme()
+        ))
+    }
+
     private fun ignoreButLogException(function: () -> OpenApiSpecification) {
         try {
             function()

--- a/core/src/test/kotlin/io/specmatic/core/ContractTests.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ContractTests.kt
@@ -12,6 +12,7 @@ import io.ktor.util.*
 import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.core.pattern.NumberPattern
 import io.specmatic.core.pattern.parsedJSONObject
+import io.specmatic.core.utilities.Flags
 import io.specmatic.core.value.*
 import io.specmatic.osAgnosticPath
 import io.specmatic.test.LegacyHttpClient
@@ -21,6 +22,7 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.fail
+import java.io.File
 
 class ContractTests {
     @Test
@@ -1318,6 +1320,61 @@ Examples:
                 .loadExternalisedExamples()
 
         assertThat(feature.scenarios.filter { it.examples.singleOrNull()?.rows?.size?.let { it > 0 } == true }).hasSize(1)
+    }
+
+    @Test
+    fun `should be able to run tests from OAS with composite security schemes using inline examples`() {
+        val openApiFile = File("src/test/resources/openapi/has_composite_security/api.yaml")
+        val feature = Flags.using("bearerAuth" to "API-SECRET", "apiKeyQuery" to "1234") {
+            OpenApiSpecification.fromFile(openApiFile.canonicalPath).toFeature()
+        }
+
+        val assertApiKey: (HttpRequest, String?) -> Unit = { request, expected ->
+            assertThat(request.queryParams.asMap()["apiKey"]).isEqualTo(expected)
+        }
+        val assertAuthHeader: (HttpRequest, String?) -> Unit = { request, expected ->
+            assertThat(request.headers["Authorization"]).isEqualTo(expected)
+        }
+
+        val results = feature.executeTests(object : TestExecutor {
+            override fun execute(request: HttpRequest): HttpResponse {
+                val requestBody = request.body as JSONObjectValue
+                val bodyString = requestBody.jsonObject["message"]!!.toStringLiteral()
+                when (request.path) {
+                    "/secure" -> {
+                        assertApiKey(request, "1234")
+                        assertAuthHeader(request, "Bearer API-SECRET")
+                        assertThat(bodyString).isEqualTo("Hello to Secure")
+                    }
+                    "/partial" -> {
+                        assertThat(request).satisfiesAnyOf(
+                            {
+                                assertApiKey(request, "1234")
+                                assertAuthHeader(request, null)
+                            },
+                            {
+                                assertApiKey(request, null)
+                                assertAuthHeader(request, "Bearer API-SECRET")
+                            }
+                        )
+                        assertThat(bodyString).isEqualTo("Hello to Partial")
+                    }
+                    else -> {
+                        assertApiKey(request, null)
+                        assertAuthHeader(request, null)
+                        assertThat(bodyString).isEqualTo("Hello to Insecure")
+                    }
+                }
+
+                return HttpResponse.ok(requestBody.addEntry("message", bodyString)).also {
+                    println(request.toLogString())
+                    println(it.toLogString())
+                }
+            }}
+        )
+
+        assertThat(results.testCount).isEqualTo(3)
+        assertThat(results.success()).withFailMessage(results.report()).isTrue()
     }
 }
 

--- a/core/src/test/kotlin/io/specmatic/core/ContractTests.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ContractTests.kt
@@ -1359,6 +1359,19 @@ Examples:
                         )
                         assertThat(bodyString).isEqualTo("Hello to Partial")
                     }
+                    "/overlap" -> {
+                        assertThat(request).satisfiesAnyOf(
+                            {
+                                assertApiKey(it, "1234")
+                                assertAuthHeader(it, "Bearer API-SECRET")
+                            },
+                            {
+                                assertApiKey(it, null)
+                                assertAuthHeader(it, "Bearer API-SECRET")
+                            }
+                        )
+                        assertThat(bodyString).isEqualTo("Hello to Overlap")
+                    }
                     else -> {
                         assertApiKey(request, null)
                         assertAuthHeader(request, null)
@@ -1373,7 +1386,7 @@ Examples:
             }}
         )
 
-        assertThat(results.testCount).isEqualTo(3)
+        assertThat(results.testCount).isEqualTo(4)
         assertThat(results.success()).withFailMessage(results.report()).isTrue()
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/HttpRequestPatternKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpRequestPatternKtTest.kt
@@ -44,19 +44,28 @@ internal class HttpRequestPatternKtTest {
         )
         val httpRequest = invalidateSecuritySchemes(HttpRequest("POST", "/"), securitySchema)
         val result = httpRequestPattern.matches(httpRequest, Resolver().disableOverrideUnexpectedKeycheck())
+        val report = result.reportString()
 
         assertThat(result).isInstanceOf(Result.Failure::class.java)
-        assertThat(result.reportString()).satisfiesAnyOf(
-            { assertThat(it).containsOnlyOnce(">> REQUEST.HEADERS.API-KEY") },
-            { assertThat(it).containsOnlyOnce(">> REQUEST.QUERY-PARAMS.API-KEY") },
-            { assertThat(it).containsOnlyOnce(">> REQUEST.HEADERS.Authorization") }
-        )
+        when(securitySchema) {
+            is APIKeyInHeaderSecurityScheme -> assertThat(report).containsOnlyOnce(">> REQUEST.HEADERS.API-KEY")
+            is APIKeyInQueryParamSecurityScheme -> assertThat(report).containsOnlyOnce(">> REQUEST.QUERY-PARAMS.API-KEY")
+            is BasicAuthSecurityScheme, is BearerSecurityScheme -> assertThat(report).containsOnlyOnce(">> REQUEST.HEADERS.Authorization")
+            is CompositeSecurityScheme -> assertThat(report).satisfies(
+                { assertThat(it).containsOnlyOnce(">> REQUEST.HEADERS.Authorization") },
+                { assertThat(it).containsOnlyOnce(">> REQUEST.QUERY-PARAMS.API-KEY") },
+            )
+            else -> throw RuntimeException("Unknown security scheme ${securitySchema::javaClass.name}")
+        }
     }
 
     companion object {
         private fun invalidateSecuritySchemes(request: HttpRequest, scheme: OpenAPISecurityScheme): HttpRequest {
-            if (scheme !is BasicAuthSecurityScheme && scheme !is BearerSecurityScheme) return request
-            return request.copy(headers = request.headers.plus(AUTHORIZATION to "INVALID"))
+            return when (scheme) {
+                is CompositeSecurityScheme -> scheme.schemes.fold(request) { req, it -> invalidateSecuritySchemes(req, it) }
+                is BasicAuthSecurityScheme, is BearerSecurityScheme -> request.copy(headers = request.headers.plus(AUTHORIZATION to "INVALID"))
+                else -> request
+            }
         }
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/HttpStubTests.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpStubTests.kt
@@ -682,6 +682,21 @@ Scenario: JSON API to get account details with fact check
             Api-key named apiKey in the contract was not found in the request
             """.trimIndent())
 
+            val overlapInvalidRequest = HttpRequest("POST", "/overlap", body = validRequestBody)
+            val overlapResponse = it.client.execute(overlapInvalidRequest)
+
+            assertThat(overlapResponse.status).isEqualTo(400)
+            assertThat(overlapResponse.body.toStringLiteral()).isEqualToNormalizingWhitespace("""
+            In scenario "overlap endpoint requiring either Bearer token and query API key or Bearer token only. Response: Success"
+            API: POST /overlap -> 200
+            >> REQUEST.HEADERS.Authorization
+            Header named Authorization in the contract was not found in the request
+            >> REQUEST.QUERY-PARAMS.apiKey
+            Api-key named apiKey in the contract was not found in the request
+            >> REQUEST.HEADERS.Authorization
+            Header named Authorization in the contract was not found in the request
+            """.trimIndent())
+
             val insecureValidRequest = HttpRequest("POST", "/insecure", body = validRequestBody)
             val insecureResponse = it.client.execute(insecureValidRequest)
             assertThat(insecureResponse.status).isEqualTo(200)
@@ -705,6 +720,14 @@ Scenario: JSON API to get account details with fact check
             listOf(
                 HttpRequest("POST", "/partial", body = validRequestBody, headers = headersWithAuth),
                 HttpRequest("POST", "/partial", body = validRequestBody, queryParams = queryWithAuth)
+            ).forEach { request ->
+                val response = it.client.execute(request)
+                assertThat(response.status).isEqualTo(200)
+            }
+
+            listOf(
+                HttpRequest("POST", "/overlap", body = validRequestBody, headers = headersWithAuth),
+                HttpRequest("POST", "/overlap", body = validRequestBody, queryParams = queryWithAuth, headers = headersWithAuth)
             ).forEach { request ->
                 val response = it.client.execute(request)
                 assertThat(response.status).isEqualTo(200)

--- a/core/src/test/kotlin/io/specmatic/core/RunContractTestsUsingScenario.kt
+++ b/core/src/test/kotlin/io/specmatic/core/RunContractTestsUsingScenario.kt
@@ -1,16 +1,13 @@
 package io.specmatic.core
 
 import io.specmatic.DefaultStrategies
-import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.core.pattern.*
 import io.specmatic.core.value.*
 import io.specmatic.mock.ScenarioStub
 import io.specmatic.test.TestExecutor
 import io.mockk.every
 import io.mockk.mockk
-import io.specmatic.conversions.APIKeyInHeaderSecurityScheme
-import io.specmatic.conversions.APIKeyInQueryParamSecurityScheme
-import io.specmatic.conversions.OpenAPISecurityScheme
+import io.specmatic.conversions.*
 import io.specmatic.test.ScenarioAsTest
 import org.apache.http.HttpHeaders.AUTHORIZATION
 import org.assertj.core.api.Assertions.assertThat
@@ -768,9 +765,15 @@ paths:
                     val result = securitySchema.matches(request, Resolver())
                     assertThat(result).isInstanceOf(Result.Success::class.java)
 
-                    val actualValue = extractValue(request)
-                    val expectedValue = extractValue(request)
-                    assertThat(actualValue).isEqualTo(expectedValue)
+                    val schemesToCheck = when(securitySchema) {
+                        is CompositeSecurityScheme -> securitySchema.schemes
+                        else -> listOf(securitySchema)
+                    }
+                    assertThat(schemesToCheck).allSatisfy {
+                        val actualValue = extractValue(request)
+                        val expectedValue = extractValue(request)
+                        assertThat(actualValue).isEqualTo(expectedValue)
+                    }
                 }
             }
         })
@@ -797,25 +800,15 @@ paths:
         )
         val feature = Feature(name = "", scenarios = listOf(scenario))
 
-        val extractValue: (HttpRequest) -> String = { it ->
-            when(securitySchema) {
-                is APIKeyInHeaderSecurityScheme -> it.headers.getValue(securitySchema.name)
-                is APIKeyInQueryParamSecurityScheme -> it.queryParams.getValues(securitySchema.name).first()
-                else -> it.headers.getValue(AUTHORIZATION)
-            }
-        }
-
         val results = feature.executeTests(object : TestExecutor {
             override fun execute(request: HttpRequest): HttpResponse {
                 return HttpResponse.OK.also {
                     val logs = listOf(request.toLogString(), it.toLogString())
                     println(logs.joinToString(separator = "\n\n"))
-
                     val result = securitySchema.matches(request, Resolver())
-                    assertThat(result).isInstanceOf(Result.Success::class.java)
 
-                    val actualValue = extractValue(request)
-                    assertThat(actualValue).isNotEmpty()
+                    assertThat(result).isInstanceOf(Result.Success::class.java)
+                    assertThat(securitySchema.isInRequest(request)).isTrue()
                 }
             }
         })

--- a/core/src/test/kotlin/io/specmatic/core/RunContractTestsUsingScenario.kt
+++ b/core/src/test/kotlin/io/specmatic/core/RunContractTestsUsingScenario.kt
@@ -808,7 +808,7 @@ paths:
                     val result = securitySchema.matches(request, Resolver())
 
                     assertThat(result).isInstanceOf(Result.Success::class.java)
-                    assertThat(securitySchema.isInRequest(request)).isTrue()
+                    assertThat(securitySchema.isInRequest(request, complete = true)).isTrue()
                 }
             }
         })

--- a/core/src/test/kotlin/io/specmatic/core/RunContractTestsUsingScenario.kt
+++ b/core/src/test/kotlin/io/specmatic/core/RunContractTestsUsingScenario.kt
@@ -731,7 +731,7 @@ paths:
     @ParameterizedTest
     @MethodSource("io.specmatic.core.ScenarioTest#securitySchemaProvider")
     fun `should use security schema values from examples when provided`(securitySchema: OpenAPISecurityScheme) {
-        val request = securitySchema.addTo(HttpRequest("POST", "/"))
+        val exampleRequest = securitySchema.addTo(HttpRequest("POST", "/"))
         val scenario = Scenario(
             name = "SIMPLE POST",
             httpRequestPattern = HttpRequestPattern(
@@ -742,7 +742,7 @@ paths:
             examples = listOf(
                 Examples(
                     emptyList(),
-                    listOf(Row(requestExample = request))
+                    listOf(Row(requestExample = exampleRequest))
                 )
             )
         )
@@ -771,7 +771,7 @@ paths:
                     }
                     assertThat(schemesToCheck).allSatisfy {
                         val actualValue = extractValue(request)
-                        val expectedValue = extractValue(request)
+                        val expectedValue = extractValue(exampleRequest)
                         assertThat(actualValue).isEqualTo(expectedValue)
                     }
                 }

--- a/core/src/test/kotlin/io/specmatic/core/ScenarioTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ScenarioTest.kt
@@ -24,8 +24,12 @@ class ScenarioTest {
             return Stream.of(
                 APIKeyInHeaderSecurityScheme(name = "API-KEY", apiKey = "1234"),
                 APIKeyInQueryParamSecurityScheme(name = "API-KEY", apiKey = "1234"),
-                BasicAuthSecurityScheme(),
-                BearerSecurityScheme()
+                BasicAuthSecurityScheme("am9objoxMjM0"),
+                BearerSecurityScheme("1234"),
+                CompositeSecurityScheme(listOf(
+                    BearerSecurityScheme("1234"),
+                    APIKeyInQueryParamSecurityScheme(name = "API-KEY", apiKey = "1234"),
+                ))
             )
         }
     }

--- a/core/src/test/resources/openapi/has_composite_security/api.yaml
+++ b/core/src/test/resources/openapi/has_composite_security/api.yaml
@@ -54,6 +54,34 @@ paths:
       security:
         - bearerAuth: []
         - apiKeyQuery: []
+  /overlap:
+    post:
+      summary: overlap endpoint requiring either Bearer token and query API key or Bearer token only
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SimpleBody'
+            examples:
+              EITHER_SUCCESS:
+                value:
+                  message: Hello to Overlap
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleBody'
+              examples:
+                EITHER_SUCCESS:
+                  value:
+                    message: Hello from Overlap
+      security:
+        - bearerAuth: []
+          apiKeyQuery: []
+        - bearerAuth: []
   /insecure:
     post:
       summary: Insecure endpoint not requiring authentication

--- a/core/src/test/resources/openapi/has_composite_security/api.yaml
+++ b/core/src/test/resources/openapi/has_composite_security/api.yaml
@@ -4,26 +4,80 @@ info:
   version: 1.0.0
 paths:
   /secure:
-    get:
+    post:
       summary: Secure endpoint requiring Bearer token and query API key
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SimpleBody'
+            examples:
+              SECURE_SUCCESS:
+                value:
+                  message: Hello to Secure
       responses:
         '200':
           description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleBody'
+              examples:
+                SECURE_SUCCESS:
+                  value:
+                    message: Hello from Secure
   /partial:
-    get:
+    post:
       summary: Partially secure endpoint requiring either Bearer token or query API key
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SimpleBody'
+            examples:
+              PARTIAL_SUCCESS:
+                value:
+                  message: Hello to Partial
       responses:
         '200':
           description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleBody'
+              examples:
+                PARTIAL_SUCCESS:
+                  value:
+                    message: Hello from Partial
       security:
         - bearerAuth: []
         - apiKeyQuery: []
   /insecure:
-    get:
+    post:
       summary: Insecure endpoint not requiring authentication
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SimpleBody'
+            examples:
+              INSECURE_SUCCESS:
+                value:
+                  message: Hello to Insecure
       responses:
         '200':
           description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleBody'
+              examples:
+                INSECURE_SUCCESS:
+                  value:
+                    message: Hello from Insecure
       security: []
 components:
   securitySchemes:
@@ -34,6 +88,12 @@ components:
       type: apiKey
       in: query
       name: apiKey
+  schemas:
+    SimpleBody:
+      type: object
+      properties:
+        message:
+          type: string
 security:
   - bearerAuth: []
     apiKeyQuery: []

--- a/core/src/test/resources/openapi/has_composite_security/api.yaml
+++ b/core/src/test/resources/openapi/has_composite_security/api.yaml
@@ -1,0 +1,39 @@
+openapi: 3.0.0
+info:
+  title: Example API
+  version: 1.0.0
+paths:
+  /secure:
+    get:
+      summary: Secure endpoint requiring Bearer token and query API key
+      responses:
+        '200':
+          description: Success
+  /partial:
+    get:
+      summary: Partially secure endpoint requiring either Bearer token or query API key
+      responses:
+        '200':
+          description: Success
+      security:
+        - bearerAuth: []
+        - apiKeyQuery: []
+  /insecure:
+    get:
+      summary: Insecure endpoint not requiring authentication
+      responses:
+        '200':
+          description: Success
+      security: []
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+    apiKeyQuery:
+      type: apiKey
+      in: query
+      name: apiKey
+security:
+  - bearerAuth: []
+    apiKeyQuery: []

--- a/core/src/test/resources/openapi/has_composite_security/invalid_examples/insecure.json
+++ b/core/src/test/resources/openapi/has_composite_security/invalid_examples/insecure.json
@@ -1,0 +1,26 @@
+{
+    "http-request": {
+        "path": "/insecure",
+        "method": "POST",
+        "query": {
+            "apiKey": "1234"
+        },
+        "headers": {
+            "Authorization": "Bearer API-SECRET",
+            "Content-Type": "application/json"
+        },
+        "body": {
+            "message": "Hello to Insecure"
+        }
+    },
+    "http-response": {
+        "status": 200,
+        "body": {
+            "message": "Hello from Insecure"
+        },
+        "status-text": "OK",
+        "headers": {
+            "Content-Type": "application/json"
+        }
+    }
+}

--- a/core/src/test/resources/openapi/has_composite_security/invalid_examples/overlap.json
+++ b/core/src/test/resources/openapi/has_composite_security/invalid_examples/overlap.json
@@ -1,0 +1,23 @@
+{
+    "http-request": {
+        "path": "/overlap",
+        "method": "POST",
+        "headers": {
+            "Content-Type": "application/json",
+            "Authorization": "Should-Be-Bearer API-SECRET"
+        },
+        "body": {
+            "message": "Hello to Overlap"
+        }
+    },
+    "http-response": {
+        "status": 200,
+        "body": {
+            "message": "Hello from Overlap"
+        },
+        "status-text": "OK",
+        "headers": {
+            "Content-Type": "application/json"
+        }
+    }
+}

--- a/core/src/test/resources/openapi/has_composite_security/invalid_examples/partial.json
+++ b/core/src/test/resources/openapi/has_composite_security/invalid_examples/partial.json
@@ -1,0 +1,23 @@
+{
+    "http-request": {
+        "path": "/partial",
+        "method": "POST",
+        "headers": {
+            "Content-Type": "application/json",
+            "Authorization": "Should-Be-Bearer API-SECRET"
+        },
+        "body": {
+            "message": "Hello to Partial"
+        }
+    },
+    "http-response": {
+        "status": 200,
+        "body": {
+            "message": "Hello from Partial"
+        },
+        "status-text": "OK",
+        "headers": {
+            "Content-Type": "application/json"
+        }
+    }
+}

--- a/core/src/test/resources/openapi/has_composite_security/invalid_examples/secure.json
+++ b/core/src/test/resources/openapi/has_composite_security/invalid_examples/secure.json
@@ -1,0 +1,23 @@
+{
+    "http-request": {
+        "path": "/secure",
+        "method": "POST",
+        "headers": {
+            "Content-Type": "application/json",
+            "Authorization": "Should-Be-Bearer API-SECRET"
+        },
+        "body": {
+            "message": "Hello to Secure"
+        }
+    },
+    "http-response": {
+        "status": 200,
+        "body": {
+            "message": "Hello from Secure"
+        },
+        "status-text": "OK",
+        "headers": {
+            "Content-Type": "application/json"
+        }
+    }
+}

--- a/core/src/test/resources/openapi/has_composite_security/valid_examples/insecure.json
+++ b/core/src/test/resources/openapi/has_composite_security/valid_examples/insecure.json
@@ -1,0 +1,22 @@
+{
+    "http-request": {
+        "path": "/insecure",
+        "method": "POST",
+        "headers": {
+            "Content-Type": "application/json"
+        },
+        "body": {
+            "message": "Hello to Insecure"
+        }
+    },
+    "http-response": {
+        "status": 200,
+        "body": {
+            "message": "Hello from Insecure"
+        },
+        "status-text": "OK",
+        "headers": {
+            "Content-Type": "application/json"
+        }
+    }
+}

--- a/core/src/test/resources/openapi/has_composite_security/valid_examples/overlap.json
+++ b/core/src/test/resources/openapi/has_composite_security/valid_examples/overlap.json
@@ -1,0 +1,25 @@
+{
+    "http-request": {
+        "path": "/overlap",
+        "method": "POST",
+        "query": {
+            "apiKey": "1234"
+        },
+        "headers": {
+            "Content-Type": "application/json"
+        },
+        "body": {
+            "message": "Hello to Overlap"
+        }
+    },
+    "http-response": {
+        "status": 200,
+        "body": {
+            "message": "Hello from Overlap"
+        },
+        "status-text": "OK",
+        "headers": {
+            "Content-Type": "application/json"
+        }
+    }
+}

--- a/core/src/test/resources/openapi/has_composite_security/valid_examples/partial.json
+++ b/core/src/test/resources/openapi/has_composite_security/valid_examples/partial.json
@@ -1,0 +1,22 @@
+{
+    "http-request": {
+        "path": "/partial",
+        "method": "POST",
+        "headers": {
+            "Content-Type": "application/json"
+        },
+        "body": {
+            "message": "Hello to Partial"
+        }
+    },
+    "http-response": {
+        "status": 200,
+        "body": {
+            "message": "Hello from Partial"
+        },
+        "status-text": "OK",
+        "headers": {
+            "Content-Type": "application/json"
+        }
+    }
+}

--- a/core/src/test/resources/openapi/has_composite_security/valid_examples/secure.json
+++ b/core/src/test/resources/openapi/has_composite_security/valid_examples/secure.json
@@ -1,0 +1,25 @@
+{
+    "http-request": {
+        "path": "/secure",
+        "method": "POST",
+        "query": {
+            "apiKey": "123"
+        },
+        "headers": {
+            "Content-Type": "application/json"
+        },
+        "body": {
+            "message": "Hello to Secure"
+        }
+    },
+    "http-response": {
+        "status": 200,
+        "body": {
+            "message": "Hello from Secure"
+        },
+        "status-text": "OK",
+        "headers": {
+            "Content-Type": "application/json"
+        }
+    }
+}


### PR DESCRIPTION
**What**: Implement support for logical AND in security schemes

**Why**:
- Previously, we only supported `OR` between the security schemes defined in the `OAS`.
- However, a path can define multiple security schemes according to the OAS standards.

**Sources**:
- https://swagger.io/docs/specification/v3_0/authentication/#using-multiple-authentication-types
- https://spec.openapis.org/oas/v3.1.0.html#security-requirement-object

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmap updated (share link)
- [ ] Conference Talk (share link)

**Issue ID**:
Closes: #932
