### PR TITLE
Change parameters to use allOrNothingCombination for test generation

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
@@ -597,9 +597,9 @@ data class HttpRequestPattern(
                         row,
                         resolver,
                         shouldGenerateMandatoryEntryIfMissing(resolver, status)
-                    )
-                }.map { pattern ->
-                    pattern.ifValue { HttpQueryParamPattern(pattern.value) }
+                    ).map { pattern ->
+                        pattern.ifValue { HttpQueryParamPattern(pattern.value) }
+                    }
                 }
             }
 
@@ -717,7 +717,7 @@ data class HttpRequestPattern(
                 newURLPathSegmentPatternsList.map { HttpPathPattern(it, httpPathPattern.path) }
             } ?: sequenceOf<HttpPathPattern?>(null)
 
-            val newQueryParamsPatterns = httpQueryParamPattern.newBasedOn(resolver).map { HttpQueryParamPattern(it) }
+            val newQueryParamsPatterns = httpQueryParamPattern.newBasedOn(resolver)
             val newBodies = attempt(breadCrumb = "BODY") {
                 resolver.withCyclePrevention(body) { cyclePreventedResolver ->
                     body.newBasedOn(cyclePreventedResolver)
@@ -768,8 +768,7 @@ data class HttpRequestPattern(
                         .map { it.ifValue { HttpPathPattern(it, httpPathPattern.path) } }
                 } ?: sequenceOf(null)
 
-            val newQueryParamsPatterns =
-                httpQueryParamPattern.negativeBasedOn(row, resolver).map { it.ifValue { HttpQueryParamPattern(it) } }
+            val newQueryParamsPatterns = httpQueryParamPattern.negativeBasedOn(row, resolver)
 
             val newBodies: Sequence<ReturnValue<out Pattern>> = returnValue(breadCrumb = "BODY") returnNewBodies@ {
                 val rawRequestBody = row.getFieldOrNull(REQUEST_BODY_FIELD) ?: return@returnNewBodies body.negativeBasedOn(row, resolver)

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiKtTest.kt
@@ -1317,9 +1317,8 @@ Background:
         printMap("Tests Executed", flags.mapValues { it.toString() })
 
         assertThat(flags["/pets POST executed"]).isEqualTo(1)
-        //assertThat(flags["/pets GET executed"]).isEqualTo(24)
-        assertThat(flags["/pets GET executed"]).isEqualTo(36)
-        assertThat(flags["/petIds GET executed"]).isEqualTo(4)
+        assertThat(flags["/pets GET executed"]).isEqualTo(5)
+        assertThat(flags["/petIds GET executed"]).isEqualTo(2)
         assertThat(flags["/pets/0 GET executed"]).isEqualTo(1)
         assertThat(flags.keys.filter { it.matches(Regex("""/pets/\d+ GET executed""")) }.size).isEqualTo(2)
         assertThat(flags.keys.any { it.matches(Regex("""/pets/\d+ DELETE executed""")) }).isNotNull

--- a/core/src/test/kotlin/io/specmatic/core/ContractAsTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ContractAsTest.kt
@@ -291,7 +291,7 @@ class ContractAsTest {
             override fun setServerState(serverState: Map<String, Value>) {}
         })
 
-        assertEquals(mutableListOf("without", "with"), flags)
+        assertThat(flags).containsExactlyInAnyOrder("with", "without")
         assertTrue(results.success(), results.report())
     }
 

--- a/core/src/test/kotlin/io/specmatic/core/HttpHeadersPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpHeadersPatternTest.kt
@@ -491,6 +491,22 @@ internal class HttpHeadersPatternTest {
             assertThat(newHeader.pattern).containsOnlyKeys("X-Existing")
             assertThat(newHeader.pattern["X-Existing"]).isInstanceOf(StringPattern::class.java)
         }
+
+        @Test
+        fun `should use allOrNothingCombination when generating patterns`() {
+            val headers = HttpHeadersPattern(1.until(11).associate { index ->
+                "Header${index}${"?".takeIf { index % 2 == 0 }}" to NumberPattern()
+            })
+            val newHeaders = headers.newBasedOn(Row(), Resolver()).toList()
+
+            assertThat(newHeaders).hasSize(2)
+            assertThat(newHeaders.first().value.pattern).hasSize(10).allSatisfy { key, _ ->
+                assertThat(isOptional(key)).isFalse()
+            }
+            assertThat(newHeaders.last().value.pattern).hasSize(5).allSatisfy { key, _ ->
+                assertThat(isOptional(key)).isFalse()
+            }
+        }
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/core/HttpQueryParamPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpQueryParamPatternTest.kt
@@ -124,7 +124,7 @@ class HttpQueryParamPatternTest {
         val row = Row(listOf("status", "type"), listOf("available", "dog"))
         val generatedPatterns = buildQueryPattern(URI("/pets?status=(string)&type=(string)")).newBasedOn(row, resolver).toList()
         assertEquals(1, generatedPatterns.size)
-        val values = HttpQueryParamPattern(generatedPatterns.first().value).generate(resolver)
+        val values = generatedPatterns.first().value.generate(resolver)
         assertThat(values.single{ it.first == "status"}.second).isEqualTo("available")
         assertThat(values.single{ it.first == "type"}.second).isEqualTo("dog")
     }
@@ -158,7 +158,7 @@ class HttpQueryParamPatternTest {
     @Tag(GENERATION)
     fun `should generate a path with a concrete value given a query param with newBasedOn`() {
         val matcher = buildQueryPattern(URI("/pets?available=(boolean)"))
-        val matchers = matcher.newBasedOn(Row(), Resolver()).toList().map { it.value }
+        val matchers = matcher.newBasedOn(Row(), Resolver()).toList().map { it.value.queryPatterns }
         assertThat(matchers).hasSize(2)
         assertThat(matchers).contains(emptyMap())
         assertThat(matchers).contains(mapOf("available" to BooleanPattern()))
@@ -178,7 +178,7 @@ class HttpQueryParamPatternTest {
     @Test
     fun `should generate negative values for a string`() {
         val urlMatchers =
-            buildQueryPattern(URI("/pets?name=(string)")).negativeBasedOn(Row(), Resolver()).toList().map { it.value }
+            buildQueryPattern(URI("/pets?name=(string)")).negativeBasedOn(Row(), Resolver()).toList().map { it.value.queryPatterns }
         assertThat(urlMatchers).containsExactly(emptyMap())
     }
 
@@ -186,11 +186,9 @@ class HttpQueryParamPatternTest {
     @Tag(GENERATION)
     fun `should create 2^n matchers on an empty Row`() {
         val patterns = buildQueryPattern(URI("/pets?status=(string)&type=(string)"))
-        val generatedPatterns = patterns.newBasedOn(Row(), Resolver()).toList().map { it.value }
+        val generatedPatterns = patterns.newBasedOn(Row(), Resolver()).toList().map { it.value.queryPatterns }
         assertThat(generatedPatterns).containsExactlyInAnyOrder(
             emptyMap(),
-            mapOf("status" to StringPattern()),
-            mapOf("type" to StringPattern()),
             mapOf("status" to StringPattern(), "type" to StringPattern()),
         )
     }
@@ -513,7 +511,7 @@ class HttpQueryParamPatternTest {
     fun `an additional query param should be added in a test`() {
         val queryPattern = HttpQueryParamPattern(mapOf("key" to QueryParameterScalarPattern(NumberPattern())), NumberPattern())
 
-        val generatedValue = queryPattern.newBasedOn(Row(), Resolver()).toList().map { it.value }
+        val generatedValue = queryPattern.newBasedOn(Row(), Resolver()).toList().map { it.value.queryPatterns }
 
         assertThat(generatedValue).hasSize(1)
         assertThat(generatedValue.first()).hasSize(2)

--- a/core/src/test/kotlin/io/specmatic/core/HttpQueryParamPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpQueryParamPatternTest.kt
@@ -184,7 +184,7 @@ class HttpQueryParamPatternTest {
 
     @Test
     @Tag(GENERATION)
-    fun `should create 2^n matchers on an empty Row`() {
+    fun `should not create 2^n matchers on an empty Row`() {
         val patterns = buildQueryPattern(URI("/pets?status=(string)&type=(string)"))
         val generatedPatterns = patterns.newBasedOn(Row(), Resolver()).toList().map { it.value.queryPatterns }
         assertThat(generatedPatterns).containsExactlyInAnyOrder(


### PR DESCRIPTION
**What**: Change parameters to use allOrNothingCombination for test generation

**Why**: Unlike `JSONObjectPattern`, `Query` and `Headers` do not currently utilize the `allOrNothingCombination` logic for generating test scenarios. This leads to a combinatorial explosion in tests when there are too many parameters, resulting in an excessive number of test executions

**Checklist**:

- [ ] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
