### PR TITLE
Fix dictionary usage for positive mutated object patterns

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/Dictionary.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Dictionary.kt
@@ -70,7 +70,7 @@ data class Dictionary(private val data: Map<String, Value>, private val focusedD
     private fun getReturnValueFor(lookup: String, value: Value, pattern: Pattern, resolver: Resolver): ReturnValue<Value>? {
         val valueToMatch = getValueToMatch(value, pattern, resolver) ?: return null
         return runCatching {
-            val result = pattern.fillInTheBlanks(valueToMatch, resolver.copy(isNegative = false))
+            val result = pattern.fillInTheBlanks(valueToMatch, resolver.copy(isNegative = false), removeExtraKeys = true)
             if (result is ReturnFailure && resolver.isNegative) return null
             result.addDetails("Invalid Dictionary value at \"$lookup\"", breadCrumb = "")
         }.getOrElse(::HasException)

--- a/core/src/main/kotlin/io/specmatic/core/NoBodyPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/NoBodyPattern.kt
@@ -41,7 +41,7 @@ object NoBodyPattern : Pattern {
         return Result.Failure("Expected no body, but found ${otherPattern.typeName}")
     }
 
-    override fun fillInTheBlanks(value: Value, resolver: Resolver): ReturnValue<Value> {
+    override fun fillInTheBlanks(value: Value, resolver: Resolver, removeExtraKeys: Boolean): ReturnValue<Value> {
         return runCatching { parse(value.toStringLiteral(), resolver) }.map(::HasValue).getOrElse(::HasException)
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/AnyNonNullJSONValue.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/AnyNonNullJSONValue.kt
@@ -25,7 +25,7 @@ data class AnyNonNullJSONValue(override val pattern: Pattern = AnythingPattern):
         }
     }
 
-    override fun fillInTheBlanks(value: Value, resolver: Resolver): ReturnValue<Value> {
+    override fun fillInTheBlanks(value: Value, resolver: Resolver, removeExtraKeys: Boolean): ReturnValue<Value> {
         return fillInTheBlanksWithPattern(value, resolver, this)
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
@@ -101,7 +101,7 @@ data class AnyPattern(
         return matchingPattern.addTypeAliasesToConcretePattern(concretePattern, resolver, this.typeAlias ?: typeAlias)
     }
 
-    override fun fillInTheBlanks(value: Value, resolver: Resolver): ReturnValue<Value> {
+    override fun fillInTheBlanks(value: Value, resolver: Resolver, removeExtraKeys: Boolean): ReturnValue<Value> {
         val patternToConsider = when (val resolvedPattern = resolveToPattern(value, resolver, this)) {
             is ReturnFailure -> return resolvedPattern.cast()
             else -> resolvedPattern.value
@@ -112,7 +112,7 @@ data class AnyPattern(
         val newPatterns = updatedPatterns.filter { it.typeAlias != null }.associateBy { it.typeAlias.orEmpty() }
         val updatedResolver = resolver.copy(newPatterns = resolver.newPatterns.plus(newPatterns) ).updateLookupPath(this.typeAlias)
 
-        val results = updatedPatterns.asSequence().map { it.fillInTheBlanks(value, updatedResolver) }
+        val results = updatedPatterns.asSequence().map { it.fillInTheBlanks(value, updatedResolver, removeExtraKeys) }
         val successfulGeneration = results.firstOrNull { it is HasValue }
         if(successfulGeneration != null) return successfulGeneration
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/DeferredPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/DeferredPattern.kt
@@ -24,8 +24,8 @@ data class DeferredPattern(
         return resolvePattern(resolver).addTypeAliasesToConcretePattern(concretePattern, resolver, null)
     }
 
-    override fun fillInTheBlanks(value: Value, resolver: Resolver): ReturnValue<Value> {
-        return resolvePattern(resolver).fillInTheBlanks(value, resolver)
+    override fun fillInTheBlanks(value: Value, resolver: Resolver, removeExtraKeys: Boolean): ReturnValue<Value> {
+        return resolvePattern(resolver).fillInTheBlanks(value, resolver, removeExtraKeys)
     }
 
     override fun removeKeysNotPresentIn(keys: Set<String>, resolver: Resolver): Pattern {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/DictionaryPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/DictionaryPattern.kt
@@ -13,16 +13,11 @@ data class DictionaryPattern(val keyPattern: Pattern, val valuePattern: Pattern,
         return JSONObjectValue()
     }
 
-    override fun fillInTheBlanks(value: Value, resolver: Resolver): ReturnValue<Value> {
+    override fun fillInTheBlanks(value: Value, resolver: Resolver, removeExtraKeys: Boolean): ReturnValue<Value> {
         val jsonObject = value as? JSONObjectValue ?: return HasFailure("Can't generate object value from type ${value.displayableType()}")
 
-        val returnValue = jsonObject.jsonObject.mapValues { (key, value) ->
-            val matchResult = valuePattern.matches(value, resolver)
-
-            if(matchResult is Result.Failure)
-                HasFailure(matchResult)
-            else
-                HasValue(value)
+        val returnValue = jsonObject.jsonObject.mapValues { (_, value) ->
+            valuePattern.fillInTheBlanks(value, resolver, removeExtraKeys)
         }.mapFold()
 
         return returnValue.ifValue { jsonObject.copy(jsonObject = it) }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/EmailPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/EmailPattern.kt
@@ -35,7 +35,7 @@ class EmailPattern (private val stringPatternDelegate: StringPattern) :
         }
     }
 
-    override fun fillInTheBlanks(value: Value, resolver: Resolver): ReturnValue<Value> {
+    override fun fillInTheBlanks(value: Value, resolver: Resolver, removeExtraKeys: Boolean): ReturnValue<Value> {
         return fillInTheBlanksWithPattern(value, resolver, this)
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/EnumPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/EnumPattern.kt
@@ -70,14 +70,14 @@ data class EnumPattern(
         }
     }
 
-    override fun fillInTheBlanks(value: Value, resolver: Resolver): ReturnValue<Value> {
+    override fun fillInTheBlanks(value: Value, resolver: Resolver, removeExtraKeys: Boolean): ReturnValue<Value> {
         val patternToConsider = when (val resolvedPattern = resolveToPattern(value, resolver, this)) {
             is ReturnFailure -> return resolvedPattern.cast()
             else -> resolvedPattern.value
         }
 
         return if (isPatternToken(value) && patternToConsider == this) HasValue(resolver.generate(this))
-        else pattern.fillInTheBlanks(value, resolver)
+        else pattern.fillInTheBlanks(value, resolver, removeExtraKeys)
     }
 
     override fun fixValue(value: Value, resolver: Resolver): Value {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
@@ -126,7 +126,7 @@ data class JSONObjectPattern(
         )
     }
 
-    override fun fillInTheBlanks(value: Value, resolver: Resolver): ReturnValue<Value> {
+    override fun fillInTheBlanks(value: Value, resolver: Resolver, removeExtraKeys: Boolean): ReturnValue<Value> {
         val patternToConsider = when (val resolvedPattern = resolveToPattern(value, resolver, this)) {
             is ReturnFailure -> return resolvedPattern.cast()
             else -> (resolvedPattern.value as? JSONObjectPattern) ?: return when(resolver.isNegative) {
@@ -146,7 +146,8 @@ data class JSONObjectPattern(
 
         return fill(
             jsonPatternMap = patternToConsider.pattern, jsonValueMap = valueToConsider,
-            typeAlias = patternToConsider.typeAlias, resolver = resolver
+            typeAlias = patternToConsider.typeAlias, resolver = resolver,
+            removeExtraKeys = removeExtraKeys
         ).realise(
             hasValue = { valuesMap, _ -> HasValue(JSONObjectValue(valuesMap)) },
             orException = { e -> e.cast() }, orFailure = { f -> f.cast() }
@@ -562,8 +563,13 @@ fun fix(jsonPatternMap: Map<String, Pattern>, jsonValueMap: Map<String, Value>, 
     .mapValues { (_, opt) -> opt.get() }
 }
 
-fun fill(jsonPatternMap: Map<String, Pattern>, jsonValueMap: Map<String, Value>, resolver: Resolver, typeAlias: String?): ReturnValue<Map<String, Value>> {
-    val resolvedValuesMap = jsonValueMap.mapValues { (key, value) ->
+fun fill(jsonPatternMap: Map<String, Pattern>, jsonValueMap: Map<String, Value>, resolver: Resolver, typeAlias: String?, removeExtraKeys: Boolean = false): ReturnValue<Map<String, Value>> {
+    val adjustedValue = if (removeExtraKeys) {
+        val keysToRetain = jsonPatternMap.keys.map(::withoutOptionality)
+        jsonValueMap.filterKeys { it in keysToRetain }
+    } else jsonValueMap
+
+    val resolvedValuesMap = adjustedValue.mapValues { (key, value) ->
         val pattern = jsonPatternMap[key] ?: jsonPatternMap["$key?"] ?: return@mapValues when {
             resolver.findKeyErrorCheck.unexpectedKeyCheck is IgnoreUnexpectedKeys -> generateIfPatternToken(typeAlias, key, value, resolver)
             resolver.isNegative -> generateIfPatternToken(typeAlias, key, value, resolver)

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
@@ -46,7 +46,7 @@ data class ListPattern(
         )
     }
 
-    override fun fillInTheBlanks(value: Value, resolver: Resolver): ReturnValue<Value> {
+    override fun fillInTheBlanks(value: Value, resolver: Resolver, removeExtraKeys: Boolean): ReturnValue<Value> {
         val patternToConsider = when (val resolvedPattern = resolveToPattern(value, resolver, this)) {
             is ReturnFailure -> return resolvedPattern.cast()
             else -> (resolvedPattern.value as? ListPattern) ?: return when(resolver.isNegative) {
@@ -65,7 +65,7 @@ data class ListPattern(
 
         return valueToConsider.mapIndexed { index, item ->
             val updatedResolver = resolver.updateLookupPath(this, this.pattern)
-            patternToConsider.fillInTheBlanks(item, updatedResolver).breadCrumb("[$index]")
+            patternToConsider.fillInTheBlanks(item, updatedResolver, removeExtraKeys).breadCrumb("[$index]")
         }.listFold().ifValue(::JSONArrayValue)
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/Pattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/Pattern.kt
@@ -78,7 +78,7 @@ interface Pattern {
             HasValue(emptyMap())
     }
 
-    fun fillInTheBlanks(value: Value, resolver: Resolver): ReturnValue<Value> {
+    fun fillInTheBlanks(value: Value, resolver: Resolver, removeExtraKeys: Boolean = false): ReturnValue<Value> {
         return fillInTheBlanksWithPattern(value, resolver, this)
     }
 


### PR DESCRIPTION
**What**: Fix dictionary usage for positive mutated object patterns

**Why**: Positive mutated patterns can remove optional keys; however, if the dictionary value includes these optional keys, it can lead to issues when generating test scenarios

**How**: Remove optional keys if the object's structure has been positively altered to exclude them

**Checklist**:

- [ ] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)