### PR TITLE
Fixed exit status handling in example validation for specFile and examplesDir combination

### DIFF
--- a/application/src/main/kotlin/application/ExamplesCommand.kt
+++ b/application/src/main/kotlin/application/ExamplesCommand.kt
@@ -15,7 +15,6 @@ import picocli.CommandLine.*
 import java.io.File
 import java.util.concurrent.Callable
 import java.util.concurrent.atomic.AtomicInteger
-import kotlin.system.exitProcess
 
 private const val SUCCESS_EXIT_CODE = 0
 private const val FAILURE_EXIT_CODE = 1
@@ -127,7 +126,7 @@ For example, to filter by HTTP methods:
                 val (exitCode, validationResults) = validateExamplesDir(contractFile!!, examplesDir)
 
                 printValidationResult(validationResults.exampleValidationResults, "Example directory")
-                return exitCode
+                return if (exitCode == FAILURE_EXIT_CODE) FAILURE_EXIT_CODE else validationResults.exitCode
             }
 
             if (contractFile != null) return validateImplicitExamplesFrom(contractFile!!)
@@ -243,7 +242,7 @@ For example, to filter by HTTP methods:
                 else {
                     val (exitCode, validationResults)
                             = validateExamplesDir(feature, ExampleModule().defaultExternalExampleDirFrom(contractFile))
-                    if(exitCode == 1) exitProcess(exitCode)
+                    if(exitCode == 1) return exitCode
                     validationResults
                 }
 


### PR DESCRIPTION
**What**:

In examples validate command, now for each of the five parameter combinations (to accept spec and/or examples), the hook result is also honoured in overall exit status of the process. 

**Checklist**:
- [/] Unit Tests
- [/] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
