### PR TITLE
Fix examples validate command trying all files when ran with specs-dir

### DIFF
--- a/application/src/main/kotlin/application/ExamplesCommand.kt
+++ b/application/src/main/kotlin/application/ExamplesCommand.kt
@@ -197,9 +197,7 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
 
         private fun validateAllExamplesAssociatedToEachSpecIn(specsDir: File, examplesBaseDir: File): List<ValidationResults> {
             val ordinal = AtomicInteger(1)
-            val allSpecFiles = specsDir.walk().filter(File::isFile).filter { isOpenAPI(it.canonicalPath) }.onEach {
-                OpenApiSpecification.checkSpecValidity(it.canonicalPath, lenientMode)
-            }
+            val allSpecFiles = specsDir.walk().filter(::isFileAndOpenApi)
 
             val validationResults = allSpecFiles.map { specFile ->
                 val relativeSpecPath = specsDir.toPath().relativize(specFile.toPath()).toString()
@@ -315,6 +313,12 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
             return this.any { it.value is Result.Failure }
         }
 
+        private fun isFileAndOpenApi(file: File): Boolean {
+            if (!file.isFile || file.extension.lowercase() !in OPENAPI_FILE_EXTENSIONS) return false
+            if (!isOpenAPI(file.canonicalPath, logFailure = false)) return false
+            OpenApiSpecification.checkSpecValidity(file.canonicalPath, lenientMode)
+            return true
+        }
     }
 
 }

--- a/application/src/test/kotlin/application/ExamplesCommandTest.kt
+++ b/application/src/test/kotlin/application/ExamplesCommandTest.kt
@@ -565,6 +565,23 @@ paths:
                 emptyExamplesDir.deleteRecursively()
             }
         }
+
+        @Test
+        fun `should not log unable to parse when the extension is not valid openapi extension when validating specs-dir`(@TempDir tempDir: File) {
+            File("src/test/resources/examples/only_specs/products/spec.yaml").copyTo(tempDir.resolve("api.yaml"))
+            tempDir.resolve("config.toml").createNewFile()
+            tempDir.resolve("package.json").createNewFile()
+            tempDir.resolve("dictionary.yaml").createNewFile()
+
+            val (stdOut, exitCode) = captureStandardOutput {
+                cli.execute("--specs-dir", tempDir.canonicalPath)
+            }
+
+            println(stdOut)
+            assertThat(exitCode).isEqualTo(0)
+            assertThat(stdOut).contains("1. Validating examples associated to 'api.yaml'")
+            assertThat(stdOut).doesNotContain("Could not parse", "config.toml", "package.json", "dictionary.yaml")
+        }
     }
 
     @Nested


### PR DESCRIPTION
**What**: Fix examples validate command trying all files when ran with `--specs-dir`

**Why**: We should only attempt to process files that conform to the standard OpenAPI extensions and content to avoid overwhelming the console with unnecessary log entries

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)