### PR TITLE
Minor message change to the backward compatibility command

### DIFF
--- a/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckBaseCommand.kt
+++ b/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckBaseCommand.kt
@@ -169,7 +169,7 @@ abstract class BackwardCompatibilityCheckBaseCommand : Callable<Unit> {
         filesReferringToChangedFiles.printSummaryOfChangedSpecs("Specs referring to the changed specs")
         specificationsOfChangedExternalisedExamples
             .printSummaryOfChangedSpecs("Specs whose externalised examples were changed")
-        untrackedFiles.printSummaryOfChangedSpecs("Specs that will be skipped (untracked files that are not referred to in other specs)")
+        untrackedFiles.printSummaryOfChangedSpecs("Specs that will be skipped (untracked specs, or schema files that are not referred to in other specs)")
         logger.log("-".repeat(20))
         logger.log(newLine)
     }

--- a/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
+++ b/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
@@ -139,7 +139,7 @@ class BackwardCompatibilityCheckCommandV2Test {
 
             assertThat(exception.code).isEqualTo(0)
             assertThat(stdOut).containsIgnoringWhitespaces("""
-            - Specs that will be skipped (untracked files that are not referred to in other specs):
+            - Specs that will be skipped (untracked specs, or schema files that are not referred to in other specs):
             1. ${tempDir.resolve("contract.yaml").toPath().toRealPath()}
             """.trimIndent()).containsIgnoringWhitespaces("""
             Files checked: 0 (Passed: 0, Failed: 0)
@@ -167,7 +167,7 @@ class BackwardCompatibilityCheckCommandV2Test {
             assertThat(stdOut).containsIgnoringWhitespaces("""
             - Specs that have changed: 
             1. $gitApiFile
-            - Specs that will be skipped (untracked files that are not referred to in other specs):
+            - Specs that will be skipped (untracked specs, or schema files that are not referred to in other specs):
             1. ${tempDir.resolve("contract.yaml").canonicalFile.toPath().toRealPath()}
             """.trimIndent()).containsIgnoringWhitespaces("""
             Files checked: 1 (Passed: 1, Failed: 0)
@@ -192,7 +192,7 @@ class BackwardCompatibilityCheckCommandV2Test {
 
             assertThat(exception.code).isEqualTo(0)
             assertThat(stdOut).containsIgnoringWhitespaces("""
-            - Specs that will be skipped (untracked files that are not referred to in other specs):
+            - Specs that will be skipped (untracked specs, or schema files that are not referred to in other specs):
             1. ${tempDir.resolve("api.yaml").canonicalFile.toPath().toRealPath()}
             """.trimIndent()).containsIgnoringWhitespaces("""
             Files checked: 0 (Passed: 0, Failed: 0)
@@ -220,7 +220,7 @@ class BackwardCompatibilityCheckCommandV2Test {
 
             assertThat(exception.code).isEqualTo(0)
             assertThat(stdOut).containsIgnoringWhitespaces("""
-            - Specs that will be skipped (untracked files that are not referred to in other specs):
+            - Specs that will be skipped (untracked specs, or schema files that are not referred to in other specs):
             1. ${tempDir.resolve("api.yaml").canonicalFile.toPath().toRealPath()}
             """.trimIndent()).containsIgnoringWhitespaces("""
             Files checked: 0 (Passed: 0, Failed: 0)


### PR DESCRIPTION
A minor message change that better reflects which files are being ignored. There are two types, spec files, and schema files that are not being referred to, and this is made more explicit in this PR.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #123

<!-- feel free to add additional comments -->
