### PR TITLE
Add VersionProvider for commands that currently lack it

### DIFF
--- a/application/src/main/kotlin/application/SpecmaticCommand.kt
+++ b/application/src/main/kotlin/application/SpecmaticCommand.kt
@@ -2,6 +2,7 @@ package application
 
 import application.backwardCompatibility.BackwardCompatibilityCheckCommandV2
 import picocli.AutoComplete.GenerateCompletion
+import picocli.CommandLine
 import picocli.CommandLine.Command
 import java.util.concurrent.Callable
 
@@ -9,6 +10,7 @@ import java.util.concurrent.Callable
         name = "specmatic",
         mixinStandardHelpOptions = true,
         versionProvider = VersionProvider::class,
+        scope = CommandLine.ScopeType.INHERIT,
         subcommands = [
             BackwardCompatibilityCheckCommandV2::class,
             CompareCommand::class,

--- a/application/src/test/kotlin/application/SpecmaticApplicationTest.kt
+++ b/application/src/test/kotlin/application/SpecmaticApplicationTest.kt
@@ -1,0 +1,40 @@
+package application
+
+import io.specmatic.core.utilities.SystemExit
+import io.specmatic.core.utilities.SystemExitException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class SpecmaticApplicationTest {
+
+    @Test
+    fun `should print version info on each invocation that isn't version check`() {
+        val args = arrayOf("test", "--help")
+        val (stdOut, exception) = captureStandardOutput {
+            assertThrows<SystemExitException> {
+                SystemExit.throwOnExit {
+                    SpecmaticApplication.main(args)
+                }
+            }
+        }
+
+        assertThat(exception.code).isEqualTo(0)
+        assertThat(stdOut).containsPattern("Specmatic Version: v\\d+\\.\\d+\\.\\d+")
+    }
+
+    @Test
+    fun `should print version info when invoking version check on any command or sub-command`() {
+        val args = arrayOf("examples", "validate", "-V")
+        val (stdOut, exception) = captureStandardOutput {
+            assertThrows<SystemExitException> {
+                SystemExit.throwOnExit {
+                    SpecmaticApplication.main(args)
+                }
+            }
+        }
+
+        assertThat(exception.code).isEqualTo(0)
+        assertThat(stdOut).containsPattern("v\\d+\\.\\d+\\.\\d+")
+    }
+}


### PR DESCRIPTION
**What**:
- Add VersionProvider into commands that currently do not include it
- Simplify  the check for displaying version information.

**Why**: Commands executed with `command -V` or `command --version` do not output version information as expected

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
