### PR TITLE
Update breadCrumbs and dictionary paths for parameters

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/APIKeyInHeaderSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/APIKeyInHeaderSecurityScheme.kt
@@ -8,7 +8,7 @@ data class APIKeyInHeaderSecurityScheme(val name: String, private val apiKey:Str
     override fun matches(httpRequest: HttpRequest, resolver: Resolver): Result {
         return if (httpRequest.headers.containsKey(name) || resolver.mockMode) Result.Success()
         else Result.Failure(
-            breadCrumb = "HEADERS.$name",
+            breadCrumb = BreadCrumb.HEADER.with(name),
             message = resolver.mismatchMessages.expectedKeyWasMissing("API-Key", name)
         )
     }
@@ -18,7 +18,8 @@ data class APIKeyInHeaderSecurityScheme(val name: String, private val apiKey:Str
     }
 
     override fun addTo(httpRequest: HttpRequest, resolver: Resolver): HttpRequest {
-        val headerValue = apiKey ?: resolver.generate("HEADERS", name, StringPattern()).toStringLiteral()
+        val updatedResolver = resolver.updateLookupForParam(BreadCrumb.HEADER.value)
+        val headerValue = apiKey ?: updatedResolver.generate(null, name, StringPattern()).toStringLiteral()
         return httpRequest.addSecurityHeader(name, headerValue)
     }
 

--- a/core/src/main/kotlin/io/specmatic/conversions/BasicAuthSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/BasicAuthSecurityScheme.kt
@@ -12,14 +12,14 @@ data class BasicAuthSecurityScheme(private val token: String? = null) : OpenAPIS
         val authHeaderValue: String = httpRequest.headers[AUTHORIZATION] ?: return when(resolver.mockMode) {
             true -> Result.Success()
             else -> Result.Failure(
-                breadCrumb = "HEADERS.$AUTHORIZATION",
+                breadCrumb = BreadCrumb.HEADER.with(AUTHORIZATION),
                 message = resolver.mismatchMessages.expectedKeyWasMissing("Header", AUTHORIZATION)
             )
         }
 
         if (!authHeaderValue.lowercase().startsWith("basic")) {
             return Result.Failure(
-                breadCrumb = "HEADERS.$AUTHORIZATION",
+                breadCrumb = BreadCrumb.HEADER.with(AUTHORIZATION),
                 message = "$AUTHORIZATION header must be prefixed with \"Basic\""
             )
         }
@@ -81,6 +81,7 @@ data class BasicAuthSecurityScheme(private val token: String? = null) : OpenAPIS
         return "Basic $validToken"
     }
 
+    // TODO: Fix dictionary lookup to look into HEADER.AUTHORIZATION and provide feedback
     private fun dictionaryHasValidToken(resolver: Resolver) =
         resolver.hasDictionaryToken(AUTHORIZATION) && resolver.getDictionaryToken(AUTHORIZATION).toStringLiteral().let {
             it.lowercase()

--- a/core/src/main/kotlin/io/specmatic/conversions/BearerSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/BearerSecurityScheme.kt
@@ -12,14 +12,14 @@ data class BearerSecurityScheme(private val configuredToken: String? = null) : O
         } ?: return when(resolver.mockMode) {
             true -> Result.Success()
             else -> Result.Failure(
-                breadCrumb = "HEADERS.$AUTHORIZATION",
+                breadCrumb = BreadCrumb.HEADER.with(AUTHORIZATION),
                 message = resolver.mismatchMessages.expectedKeyWasMissing("Header", AUTHORIZATION)
             )
         }
 
         if (!authHeaderValue.value.lowercase().startsWith("bearer")) {
             return Result.Failure(
-                breadCrumb = "HEADERS.$AUTHORIZATION",
+                breadCrumb = BreadCrumb.HEADER.with(AUTHORIZATION),
                 message = "$AUTHORIZATION header must be prefixed with \"Bearer\""
             )
         }
@@ -49,7 +49,8 @@ data class BearerSecurityScheme(private val configuredToken: String? = null) : O
     }
 
     private fun getAuthorizationHeaderValue(resolver: Resolver): String {
-        return "Bearer " + (configuredToken ?: resolver.generate("HEADERS", AUTHORIZATION, StringPattern()).toStringLiteral())
+        val updatedResolver = resolver.updateLookupForParam(BreadCrumb.HEADER.value)
+        return "Bearer " + (configuredToken ?: updatedResolver.generate(null, AUTHORIZATION, StringPattern()).toStringLiteral())
     }
 
     override fun copyFromTo(originalRequest: HttpRequest, newHttpRequest: HttpRequest): HttpRequest {

--- a/core/src/main/kotlin/io/specmatic/core/BreadCrumbs.kt
+++ b/core/src/main/kotlin/io/specmatic/core/BreadCrumbs.kt
@@ -8,9 +8,11 @@ value class BreadCrumb(val value: String) {
     companion object {
         val REQUEST = BreadCrumb("REQUEST")
         val RESPONSE = BreadCrumb("RESPONSE")
+        val PATH = BreadCrumb("PATH")
         val HEADER = BreadCrumb("HEADER")
         val QUERY = BreadCrumb("QUERY")
         val PARAMETERS = BreadCrumb("PARAMETERS")
+        val PARAM_PATH = PARAMETERS.plus(PATH)
         val PARAM_HEADER = PARAMETERS.plus(HEADER)
         val PARAM_QUERY = PARAMETERS.plus(QUERY)
         val SOAP_ACTION = BreadCrumb("SOAPAction")

--- a/core/src/main/kotlin/io/specmatic/core/BreadCrumbs.kt
+++ b/core/src/main/kotlin/io/specmatic/core/BreadCrumbs.kt
@@ -9,8 +9,10 @@ value class BreadCrumb(val value: String) {
         val REQUEST = BreadCrumb("REQUEST")
         val RESPONSE = BreadCrumb("RESPONSE")
         val HEADER = BreadCrumb("HEADER")
+        val QUERY = BreadCrumb("QUERY")
         val PARAMETERS = BreadCrumb("PARAMETERS")
-        val PARAM_HEADER = PARAMETERS.plus("HEADER")
+        val PARAM_HEADER = PARAMETERS.plus(HEADER)
+        val PARAM_QUERY = PARAMETERS.plus(QUERY)
         val SOAP_ACTION = BreadCrumb("SOAPAction")
 
         private fun combine(vararg breadCrumbs: String): String {

--- a/core/src/main/kotlin/io/specmatic/core/BreadCrumbs.kt
+++ b/core/src/main/kotlin/io/specmatic/core/BreadCrumbs.kt
@@ -1,0 +1,30 @@
+package io.specmatic.core
+
+import io.specmatic.test.asserts.WILDCARD_INDEX
+
+@JvmInline
+value class BreadCrumb(val value: String) {
+
+    companion object {
+        val REQUEST = BreadCrumb("REQUEST")
+        val RESPONSE = BreadCrumb("RESPONSE")
+        val HEADER = BreadCrumb("HEADER")
+        val PARAMETERS = BreadCrumb("PARAMETERS")
+        val PARAM_HEADER = PARAMETERS.plus("HEADER")
+        val SOAP_ACTION = BreadCrumb("SOAPAction")
+
+        private fun combine(vararg breadCrumbs: String): String {
+            if (breadCrumbs.isEmpty()) return ""
+            return breadCrumbs.reduce { acc, breadCrumb ->
+                if (breadCrumb == WILDCARD_INDEX) "$acc$breadCrumb"
+                else "$acc.$breadCrumb"
+            }
+        }
+    }
+
+    fun with(key: String?): String = if (key == null) value else combine(value, key)
+
+    fun plus(key: String?): BreadCrumb = if (key == null) this else BreadCrumb(combine(value, key))
+
+    fun plus(other: BreadCrumb): BreadCrumb = BreadCrumb(combine(value, other.value))
+}

--- a/core/src/main/kotlin/io/specmatic/core/GenerationStrategies.kt
+++ b/core/src/main/kotlin/io/specmatic/core/GenerationStrategies.kt
@@ -4,7 +4,6 @@ import io.specmatic.core.pattern.Pattern
 import io.specmatic.core.pattern.ReturnValue
 import io.specmatic.core.pattern.Row
 import io.specmatic.core.pattern.withoutOptionality
-import io.specmatic.core.value.Value
 
 interface GenerationStrategies {
     fun generatedPatternsForGenerativeTests(resolver: Resolver, pattern: Pattern, key: String): Sequence<ReturnValue<Pattern>>
@@ -14,11 +13,12 @@ interface GenerationStrategies {
     fun generateKeySubLists(key: String, subList: List<String>): Sequence<List<String>>
 
     fun fillInTheMissingMapPatterns(
-        newQueryParamsList: Sequence<Map<String, Pattern>>,
-        queryPatterns: Map<String, Pattern>,
+        newParamsList: Sequence<Map<String, Pattern>>,
+        patterns: Map<String, Pattern>,
         additionalProperties: Pattern?,
         row: Row,
-        resolver: Resolver
+        resolver: Resolver,
+        breadCrumb: String
     ): Sequence<ReturnValue<Map<String, Pattern>>>
 }
 

--- a/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
@@ -355,13 +355,14 @@ data class HttpHeadersPattern(
         return Result.fromFailures(failures)
     }
 
-    fun addComplimentaryPatterns(basePatterns: Sequence<ReturnValue<HttpHeadersPattern>>, row: Row, resolver: Resolver): Sequence<ReturnValue<HttpHeadersPattern>> {
+    fun addComplimentaryPatterns(basePatterns: Sequence<ReturnValue<HttpHeadersPattern>>, row: Row, resolver: Resolver, breadCrumb: String): Sequence<ReturnValue<HttpHeadersPattern>> {
         return addComplimentaryPatterns(
             basePatterns.map { it.ifValue { it.pattern } },
             pattern,
             null,
             row,
             resolver,
+            breadCrumb
         ).map {
             it.ifValue {
                 HttpHeadersPattern(it, contentType = contentType)
@@ -377,8 +378,9 @@ data class HttpHeadersPattern(
         row: Row,
         resolver: Resolver,
         generateMandatoryEntryIfMissing: Boolean,
+        breadCrumb: String
     ): Sequence<ReturnValue<HttpHeadersPattern>> {
-        return attempt(breadCrumb = BreadCrumb.HEADER.value) {
+        return attempt(breadCrumb = breadCrumb) {
             readFrom(this.pattern, row, resolver, generateMandatoryEntryIfMissing)
         }.map {
             HasValue(HttpHeadersPattern(it, contentType = contentType))

--- a/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
@@ -9,8 +9,6 @@ import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.StringValue
 import io.specmatic.core.value.Value
 
-const val HEADERS_BREADCRUMB = "HEADERS"
-
 data class HttpHeadersPattern(
     val pattern: Map<String, Pattern> = emptyMap(),
     val ancestorHeaders: Map<String, Pattern>? = null,
@@ -36,7 +34,7 @@ data class HttpHeadersPattern(
                 ::returnResult
 
         return when (result) {
-            is Result.Failure -> result.breadCrumb("HEADERS")
+            is Result.Failure -> result.breadCrumb(BreadCrumb.HEADER.value)
             else -> result
         }
     }
@@ -84,7 +82,7 @@ data class HttpHeadersPattern(
                 return MatchFailure(
                     Result.Failure(
                         resolver.mismatchMessages.mismatchMessage(contentType, contentTypeHeaderValueFromRequest),
-                        breadCrumb = "Content-Type",
+                        breadCrumb = CONTENT_TYPE,
                         failureReason = FailureReason.ContentTypeMismatch
                     )
                 )
@@ -114,7 +112,7 @@ data class HttpHeadersPattern(
 
         keyErrors.find { it.name == "SOAPAction" }?.apply {
             return MatchFailure(
-                this.missingKeyToResult("header", resolver.mismatchMessages).breadCrumb("SOAPAction")
+                this.missingKeyToResult("header", resolver.mismatchMessages).breadCrumb(BreadCrumb.SOAP_ACTION.value)
                     .copy(failureReason = FailureReason.SOAPActionMismatch)
             )
         }
@@ -209,10 +207,12 @@ data class HttpHeadersPattern(
 
     fun generate(resolver: Resolver): Map<String, String> {
         val generatedHeaders = pattern.mapValues { (key, pattern) ->
-            attempt(breadCrumb = "HEADERS.$key") {
-                toStringLiteral(resolver.withCyclePrevention(pattern) {
-                    it.generate("HEADERS", key, pattern)
-                })
+            attempt(breadCrumb = BreadCrumb.HEADER.with(key)) {
+                toStringLiteral(
+                    resolver.updateLookupForParam(BreadCrumb.HEADER.value).withCyclePrevention(pattern) {
+                        it.generate(null, key, pattern)
+                    }
+                )
             }
         }.map { (key, value) -> withoutOptionality(key) to value }.toMap()
 
@@ -248,7 +248,7 @@ data class HttpHeadersPattern(
     }
 
     fun generateWithAll(resolver: Resolver): Map<String, String> {
-        return attempt(breadCrumb = "HEADERS") {
+        return attempt(breadCrumb = BreadCrumb.HEADER.value) {
             pattern.mapValues { (key, pattern) ->
                 attempt(breadCrumb = key) {
                     pattern.generateWithAll(resolver).toStringLiteral()
@@ -289,7 +289,7 @@ data class HttpHeadersPattern(
         "content-type"
     )
 
-    fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<HttpHeadersPattern>> = returnValue(breadCrumb = "HEADER") {
+    fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<HttpHeadersPattern>> = returnValue(breadCrumb = BreadCrumb.HEADER.value) {
         allOrNothingCombinationIn(pattern, row, null, null) { pattern ->
             NegativeNonStringlyPatterns().negativeBasedOn(pattern, row, resolver)
         }.plus(
@@ -339,7 +339,7 @@ data class HttpHeadersPattern(
 
         val results = listOf(missingHeaderResult).plus(valueResults)
 
-        return Result.fromResults(results).breadCrumb("HEADER")
+        return Result.fromResults(results).breadCrumb(BreadCrumb.HEADER.value)
     }
 
     private fun checkAllMissingHeaders(
@@ -378,7 +378,7 @@ data class HttpHeadersPattern(
         resolver: Resolver,
         generateMandatoryEntryIfMissing: Boolean,
     ): Sequence<ReturnValue<HttpHeadersPattern>> {
-        return attempt(breadCrumb = HEADERS_BREADCRUMB) {
+        return attempt(breadCrumb = BreadCrumb.HEADER.value) {
             readFrom(this.pattern, row, resolver, generateMandatoryEntryIfMissing)
         }.map {
             HasValue(HttpHeadersPattern(it, contentType = contentType))
@@ -398,8 +398,8 @@ data class HttpHeadersPattern(
 
         return fill(
             jsonPatternMap = pattern, jsonValueMap = headersValue,
-            resolver = resolver.withUnexpectedKeyCheck(IgnoreUnexpectedKeys),
-            typeAlias = "($HEADERS_BREADCRUMB)"
+            resolver = resolver.updateLookupForParam(BreadCrumb.HEADER.value).withUnexpectedKeyCheck(IgnoreUnexpectedKeys),
+            typeAlias = null
         ).realise(
             hasValue = { valuesMap, _ -> HasValue(valuesMap.mapValues { it.value.toStringLiteral() }) },
             orException = { e -> e.cast() }, orFailure = { f -> f.cast() }
@@ -414,13 +414,13 @@ data class HttpHeadersPattern(
         if (headersWithContentType.isEmpty() && pattern.isEmpty()) return emptyMap()
         val headersValue = headersWithContentType.mapValues { (key, value) ->
             val pattern = pattern[key] ?: pattern["$key?"] ?: return@mapValues StringValue(value)
-
             try { pattern.parse(value, resolver) } catch(e: Exception) { StringValue(value) }
         }
+
         val fixedHeaders = fix(
             jsonPatternMap = pattern, jsonValueMap = headersValue,
-            resolver = resolver.withUnexpectedKeyCheck(IgnoreUnexpectedKeys).withoutAllPatternsAsMandatory(),
-            jsonPattern = JSONObjectPattern(pattern, typeAlias = "($HEADERS_BREADCRUMB)")
+            resolver = resolver.updateLookupForParam(BreadCrumb.HEADER.value).withUnexpectedKeyCheck(IgnoreUnexpectedKeys).withoutAllPatternsAsMandatory(),
+            jsonPattern = JSONObjectPattern(pattern, typeAlias = null)
         )
 
         return fixedHeaders.mapValues { it.value.toStringLiteral() }

--- a/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
@@ -289,7 +289,7 @@ data class HttpHeadersPattern(
         "content-type"
     )
 
-    fun negativeBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<HttpHeadersPattern>> = returnValue(breadCrumb = BreadCrumb.HEADER.value) {
+    fun negativeBasedOn(row: Row, resolver: Resolver, breadCrumb: String): Sequence<ReturnValue<HttpHeadersPattern>> = returnValue(breadCrumb = breadCrumb) {
         allOrNothingCombinationIn(pattern, row, null, null) { pattern ->
             NegativeNonStringlyPatterns().negativeBasedOn(pattern, row, resolver)
         }.plus(

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
@@ -672,8 +672,8 @@ data class HttpRequestPattern(
             val newFormDataPartLists: Sequence<ReturnValue<List<MultiPartFormDataPattern>>> =
                 newMultiPartBasedOn(multiPartFormDataPattern, row, resolver).map { HasValue(it) }
 
-            newHttpPathPatterns.flatMap("PATH") { newPathParamPattern ->
-                newQueryParamsPatterns.flatMap("QUERY") { newQueryParamPattern ->
+            newHttpPathPatterns.flatMap(BreadCrumb.PARAM_PATH.value) { newPathParamPattern ->
+                newQueryParamsPatterns.flatMap(BreadCrumb.PARAM_QUERY.value) { newQueryParamPattern ->
                     newBodies.flatMap("BODY") { newBody ->
                         newHeadersPattern.flatMap(BreadCrumb.PARAM_HEADER.value) { newHeadersPattern ->
                             newFormFieldsPatterns.flatMap("FORM-FIELDS") { newFormFieldsPattern ->
@@ -907,7 +907,9 @@ data class HttpRequestPattern(
 
     fun fillInTheBlanks(request: HttpRequest, resolver: Resolver): HttpRequest {
         val sanitizedRequest = withoutSecuritySchemes(request)
-        val path = httpPathPattern?.fillInTheBlanks(sanitizedRequest.path, resolver)?.breadCrumb("PATH-PARAMS") ?: HasValue(null)
+        val path = httpPathPattern?.fillInTheBlanks(
+            path = sanitizedRequest.path, resolver = resolver
+        )?.breadCrumb(BreadCrumb.PARAM_PATH.value) ?: HasValue(null)
 
         val queryParams = httpQueryParamPattern.fillInTheBlanks(
             queryParams = sanitizedRequest.queryParams, resolver = resolver

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
@@ -98,7 +98,7 @@ data class HttpRequestPattern(
     fun matchesPathStructureMethodAndContentType(incomingHttpRequest: HttpRequest, resolver: Resolver): Result {
         val contentTypeMatches = headersPattern.matchContentType(incomingHttpRequest.headers to resolver)
         if (contentTypeMatches is MatchFailure<*>) {
-            return contentTypeMatches.error.breadCrumb("REQUEST.HEADERS")
+            return contentTypeMatches.error.breadCrumb(BreadCrumb.REQUEST.plus(BreadCrumb.PARAM_HEADER).value)
         }
 
         val pathAndMethodMatch = matchesPathAndMethod(incomingHttpRequest, resolver)
@@ -119,7 +119,7 @@ data class HttpRequestPattern(
                         securityScheme.isInRequest(httpRequest, complete = false) -> SchemePresence.PARTIAL
                         else -> SchemePresence.ABSENT
                     },
-                    result = securityScheme.matches(httpRequest, resolver)
+                    result = securityScheme.matches(httpRequest, resolver).breadCrumb(BreadCrumb.PARAMETERS.value)
                 )
             )
         }
@@ -225,17 +225,16 @@ data class HttpRequestPattern(
 
     private fun matchHeaders(parameters: HeaderMatchParams): MatchingResult<Triple<HttpRequest, Resolver, List<Failure>>> {
         val (httpRequest, headersResolver, defaultResolver, failures) = parameters
-        val headers = httpRequest.headers
-        return when (val result = this.headersPattern.matches(headers, headersResolver ?: defaultResolver)) {
+        return when (val result = this.headersPattern.matches(httpRequest.headers, headersResolver ?: defaultResolver)) {
             is Failure -> {
                 val failureReason = result.traverseFailureReason()
-                if(failureReason == FailureReason.ContentTypeMismatch)
-                    MatchFailure(result)
+                val breadCrumbResult = result.breadCrumb(BreadCrumb.PARAMETERS.value)
+                if (failureReason == FailureReason.ContentTypeMismatch)
+                    MatchFailure(breadCrumbResult)
                 else
-                    MatchSuccess(Triple(httpRequest, defaultResolver, failures.plus(result)))
+                    MatchSuccess(Triple(httpRequest, defaultResolver, failures.plus(breadCrumbResult)))
             }
-            else ->
-                MatchSuccess(Triple(httpRequest, defaultResolver, failures))
+            else -> MatchSuccess(Triple(httpRequest, defaultResolver, failures))
         }
     }
 
@@ -339,7 +338,7 @@ data class HttpRequestPattern(
                 requestPattern.copy(httpPathPattern = HttpPathPattern(pathTypes, path), httpQueryParamPattern = HttpQueryParamPattern(queryParamTypes))
             }
 
-            requestPattern = attempt(breadCrumb = "HEADERS") {
+            requestPattern = attempt(breadCrumb = BreadCrumb.PARAM_HEADER.value) {
                 val headersFromRequest = toTypeMap(
                     toLowerCaseKeys(request.headers),
                     toLowerCaseKeys(headersPattern.pattern),
@@ -555,7 +554,11 @@ data class HttpRequestPattern(
     }
 
     private fun HttpRequest.generateAndUpdateHeaders(resolver: Resolver): HttpRequest {
-        return this.copy(headers = headersPattern.generate(resolver))
+        return this.copy(
+            headers = headersPattern.generate(
+                resolver.updateLookupPath(BreadCrumb.PARAMETERS.value)
+            )
+        )
     }
 
     private fun HttpRequest.generateAndUpdateFormFieldsValues(resolver: Resolver): HttpRequest {
@@ -577,7 +580,7 @@ data class HttpRequestPattern(
 
     private fun HttpRequest.generateAndUpdateSecuritySchemes(resolver: Resolver): HttpRequest {
         return securitySchemes.fold(this) { request, securityScheme ->
-            securityScheme.addTo(request, resolver)
+            securityScheme.addTo(request, resolver.updateLookupPath(BreadCrumb.PARAMETERS.value))
         }
     }
 
@@ -626,7 +629,7 @@ data class HttpRequestPattern(
                 }
             }
 
-            val newHeadersPattern: Sequence<ReturnValue<HttpHeadersPattern>> = returnValue(breadCrumb = "HEADERS") {
+            val newHeadersPattern: Sequence<ReturnValue<HttpHeadersPattern>> = returnValue(breadCrumb = BreadCrumb.PARAM_HEADER.value) {
                 if (status.toString().startsWith("2")) {
                     headersPattern.addComplimentaryPatterns(
                         headersPattern.newBasedOn(row, resolver),
@@ -668,7 +671,7 @@ data class HttpRequestPattern(
             newHttpPathPatterns.flatMap("PATH") { newPathParamPattern ->
                 newQueryParamsPatterns.flatMap("QUERY") { newQueryParamPattern ->
                     newBodies.flatMap("BODY") { newBody ->
-                        newHeadersPattern.flatMap("HEADERS") { newHeadersPattern ->
+                        newHeadersPattern.flatMap(BreadCrumb.PARAM_HEADER.value) { newHeadersPattern ->
                             newFormFieldsPatterns.flatMap("FORM-FIELDS") { newFormFieldsPattern ->
                                 newFormDataPartLists.flatMap("FORM-DATA") { newFormDataPartList ->
                                     val newRequestPattern = HttpRequestPattern(
@@ -893,7 +896,7 @@ data class HttpRequestPattern(
             method = method,
             path = httpPathPattern?.fixValue(request.path, resolver),
             queryParams = httpQueryParamPattern.fixValue(request.queryParams, resolver),
-            headers = headersPattern.fixValue(request.headers, resolver),
+            headers = headersPattern.fixValue(request.headers, resolver.updateLookupPath(BreadCrumb.PARAMETERS.value)),
             body = body.fixValue(request.body, resolver)
         )
     }
@@ -902,8 +905,11 @@ data class HttpRequestPattern(
         val sanitizedRequest = withoutSecuritySchemes(request)
         val path = httpPathPattern?.fillInTheBlanks(sanitizedRequest.path, resolver)?.breadCrumb("PATH-PARAMS") ?: HasValue(null)
         val queryParams = httpQueryParamPattern.fillInTheBlanks(sanitizedRequest.queryParams, resolver).breadCrumb("QUERY-PARAMS")
-        val headers = headersPattern.fillInTheBlanks(sanitizedRequest.headers, resolver).breadCrumb("HEADERS")
         val body = body.fillInTheBlanks(sanitizedRequest.body, resolver).breadCrumb("BODY")
+
+        val headers = headersPattern.fillInTheBlanks(
+            headers = sanitizedRequest.headers, resolver = resolver.updateLookupPath(BreadCrumb.PARAMETERS.value)
+        ).breadCrumb(BreadCrumb.PARAM_HEADER.value)
 
         return HasValue(request)
             .combine(path) { req, it -> req.copy(path = it) }

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
@@ -807,7 +807,7 @@ data class HttpRequestPattern(
                 this.body.negativeBasedOn(row.noteRequestBody(), resolver)
             }
 
-            val newHeadersPattern = headersPattern.negativeBasedOn(row, resolver)
+            val newHeadersPattern = headersPattern.negativeBasedOn(row, resolver, BreadCrumb.PARAM_HEADER.value)
             val newFormFieldsPatterns = newMapBasedOn(formFieldsPattern, row, resolver).map { it.value }
             val newFormDataPartLists = newMultiPartBasedOn(multiPartFormDataPattern, row, resolver)
 

--- a/core/src/main/kotlin/io/specmatic/core/NonGenerativeTests.kt
+++ b/core/src/main/kotlin/io/specmatic/core/NonGenerativeTests.kt
@@ -1,7 +1,6 @@
 package io.specmatic.core
 
 import io.specmatic.core.pattern.*
-import io.specmatic.core.value.Value
 
 object NonGenerativeTests : GenerationStrategies {
 
@@ -41,10 +40,11 @@ object NonGenerativeTests : GenerationStrategies {
     }
 
     override fun fillInTheMissingMapPatterns(
-        newQueryParamsList: Sequence<Map<String, Pattern>>,
-        queryPatterns: Map<String, Pattern>,
+        newParamsList: Sequence<Map<String, Pattern>>,
+        patterns: Map<String, Pattern>,
         additionalProperties: Pattern?,
         row: Row,
-        resolver: Resolver
+        resolver: Resolver,
+        breadCrumb: String
     ): Sequence<ReturnValue<Map<String, Pattern>>> = emptySequence()
 }

--- a/core/src/main/kotlin/io/specmatic/core/Resolver.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Resolver.kt
@@ -280,6 +280,17 @@ data class Resolver(
         )
     }
 
+    fun updateLookupForParam(paramName: String): Resolver {
+        val lookupPath = lookupPath(null, paramName).takeIf(String::isNotBlank) ?: return this
+        val paramFocused = dictionary.focusIntoProperty(AnyValuePattern, paramName, this)
+
+        return copy(
+            dictionaryLookupPath = lookupPath,
+            lookupPathsSeenSoFar = lookupPathsSeenSoFar.plus(lookupPath),
+            dictionary = paramFocused
+        )
+    }
+
     private fun lookupPath(typeAlias: String?, lookupKey: String): String {
         val base = typeAlias?.trim()?.let(::withoutPatternDelimiters)?.takeIf(String::isNotBlank) ?: dictionaryLookupPath
         return when (lookupKey) {

--- a/core/src/main/kotlin/io/specmatic/core/URLPathSegmentPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/URLPathSegmentPattern.kt
@@ -50,12 +50,13 @@ data class URLPathSegmentPattern(override val pattern: Pattern, override val key
             return emptySequence()
 
         return resolver.withCyclePrevention(pattern) { cyclePreventedResolver ->
-            pattern.negativeBasedOn(row, cyclePreventedResolver).map { it.breadCrumb(key).breadCrumb("PATH") }
-                .filterValueIsNot {
-                    it is NullPattern
-                }.map {
-                    it.ifValue {  URLPathSegmentPattern(it, key) }
-                }
+            pattern.negativeBasedOn(row, cyclePreventedResolver).map {
+                it.breadCrumb(BreadCrumb.PARAM_PATH.with(key))
+            }.filterValueIsNot {
+                it is NullPattern
+            }.map {
+                it.ifValue {  URLPathSegmentPattern(it, key) }
+            }
         }
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/examples/module/ExampleModule.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/module/ExampleModule.kt
@@ -29,7 +29,7 @@ class ExampleModule {
                     val isFailureRelatedToScenario = matchResult.getFailureBreadCrumbs("").none { breadCrumb ->
                         breadCrumb.contains(PATH_BREAD_CRUMB)
                                 || breadCrumb.contains(METHOD_BREAD_CRUMB)
-                                || breadCrumb.contains("REQUEST.HEADERS.Content-Type")
+                                || breadCrumb.contains(BreadCrumb.REQUEST.plus(BreadCrumb.PARAM_HEADER).with(CONTENT_TYPE))
                                 || breadCrumb.contains("STATUS")
                     } || matchResult.hasReason(FailureReason.URLPathParamMismatchButSameStructure)
                     if (isFailureRelatedToScenario) { example to matchResult } else null

--- a/core/src/main/kotlin/io/specmatic/core/examples/module/ExampleModule.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/module/ExampleModule.kt
@@ -27,7 +27,7 @@ class ExampleModule {
                 is Result.Success -> example to matchResult
                 is Result.Failure -> {
                     val isFailureRelatedToScenario = matchResult.getFailureBreadCrumbs("").none { breadCrumb ->
-                        breadCrumb.contains(BreadCrumb.PARAM_PATH.value)
+                        breadCrumb.contains(BreadCrumb.PATH.value)
                                 || breadCrumb.contains(METHOD_BREAD_CRUMB)
                                 || breadCrumb.contains(BreadCrumb.REQUEST.plus(BreadCrumb.PARAM_HEADER).with(CONTENT_TYPE))
                                 || breadCrumb.contains("STATUS")

--- a/core/src/main/kotlin/io/specmatic/core/examples/module/ExampleModule.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/module/ExampleModule.kt
@@ -27,7 +27,7 @@ class ExampleModule {
                 is Result.Success -> example to matchResult
                 is Result.Failure -> {
                     val isFailureRelatedToScenario = matchResult.getFailureBreadCrumbs("").none { breadCrumb ->
-                        breadCrumb.contains(PATH_BREAD_CRUMB)
+                        breadCrumb.contains(BreadCrumb.PARAM_PATH.value)
                                 || breadCrumb.contains(METHOD_BREAD_CRUMB)
                                 || breadCrumb.contains(BreadCrumb.REQUEST.plus(BreadCrumb.PARAM_HEADER).with(CONTENT_TYPE))
                                 || breadCrumb.contains("STATUS")

--- a/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
@@ -279,15 +279,13 @@ data class JSONObjectPattern(
     }
 
     override fun generateWithAll(resolver: Resolver): Value {
-        return attempt(breadCrumb = "HEADERS") {
-            JSONObjectValue(pattern.filterNot { it.key == "..." }.mapKeys {
-                attempt(breadCrumb = it.key) {
-                    withoutOptionality(it.key)
-                }
-            }.mapValues {
-                it.value.generateWithAll(resolver)
-            })
-        }
+        return JSONObjectValue(pattern.filterNot { it.key == "..." }.mapKeys {
+            attempt(breadCrumb = it.key) {
+                withoutOptionality(it.key)
+            }
+        }.mapValues {
+            it.value.generateWithAll(resolver)
+        })
     }
 
     override fun listOf(valueList: List<Value>, resolver: Resolver): Value {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/TabularPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/TabularPattern.kt
@@ -71,15 +71,13 @@ data class TabularPattern(
     }
 
     override fun generateWithAll(resolver: Resolver): Value {
-        return attempt(breadCrumb = "HEADERS") {
-            JSONObjectValue(pattern.filterNot { it.key == "..." }.mapKeys {
-                attempt(breadCrumb = it.key) {
-                    withoutOptionality(it.key)
-                }
-            }.mapValues {
-                it.value.generateWithAll(resolver)
-            })
-        }
+        return JSONObjectValue(pattern.filterNot { it.key == "..." }.mapKeys {
+            attempt(breadCrumb = it.key) {
+                withoutOptionality(it.key)
+            }
+        }.mapValues {
+            it.value.generateWithAll(resolver)
+        })
     }
 
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {

--- a/core/src/test/kotlin/integration_tests/DictionaryTest.kt
+++ b/core/src/test/kotlin/integration_tests/DictionaryTest.kt
@@ -479,7 +479,7 @@ class DictionaryTest {
 
         @Test
         fun `negative based path parameters should still be generated when dictionary contains substitutions`() {
-            val dictionary = mapOf("PATH-PARAMS.id" to NumberValue(123)).let(Dictionary::from)
+            val dictionary = "PARAMETERS: { PATH: { id: 123 } }".let(Dictionary::fromYaml)
             val scenario = Scenario(ScenarioInfo(
                 httpRequestPattern = HttpRequestPattern(httpPathPattern = buildHttpPathPattern("/orders/(id:number)"), method = "GET"),
                 httpResponsePattern = HttpResponsePattern(status = 200)
@@ -502,6 +502,7 @@ class DictionaryTest {
             })
 
             assertThat(result.results).hasSize(3)
+            assertThat(result.successCount).isEqualTo(1)
         }
 
         @Test

--- a/core/src/test/kotlin/integration_tests/DictionaryTest.kt
+++ b/core/src/test/kotlin/integration_tests/DictionaryTest.kt
@@ -538,7 +538,7 @@ class DictionaryTest {
 
         @Test
         fun `negative based headers should still be generated when dictionary contains substitutions`() {
-            val dictionary = mapOf("HEADERS.ID" to NumberValue(123)).let(Dictionary::from)
+            val dictionary = "PARAMETERS: { HEADER: { ID: 123 } }".let(Dictionary::fromYaml)
             val scenario = Scenario(ScenarioInfo(
                 httpRequestPattern = HttpRequestPattern(
                     httpPathPattern = buildHttpPathPattern("/orders"), method = "GET",
@@ -566,6 +566,7 @@ class DictionaryTest {
             })
 
             assertThat(result.results).hasSize(4)
+            assertThat(result.successCount).isEqualTo(1)
         }
 
         @Test

--- a/core/src/test/kotlin/integration_tests/DictionaryTest.kt
+++ b/core/src/test/kotlin/integration_tests/DictionaryTest.kt
@@ -506,7 +506,7 @@ class DictionaryTest {
 
         @Test
         fun `negative based query parameters should still be generated when dictionary contains substitutions`() {
-            val dictionary = mapOf("QUERY-PARAMS.id" to NumberValue(123)).let(Dictionary::from)
+            val dictionary = "PARAMETERS: { QUERY: { id: 123 } }".let(Dictionary::fromYaml)
             val scenario = Scenario(ScenarioInfo(
                 httpRequestPattern = HttpRequestPattern(
                     httpPathPattern = buildHttpPathPattern("/orders"), method = "GET",
@@ -534,6 +534,7 @@ class DictionaryTest {
             })
 
             assertThat(result.results).hasSize(4)
+            assertThat(result.successCount).isEqualTo(1)
         }
 
         @Test

--- a/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
+++ b/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
@@ -453,9 +453,9 @@ class LoadTestsFromExternalisedFiles {
 
             assertThat(exception.report()).isEqualToNormalizingWhitespace("""
             Error loading example for GET /hello/(id:number) -> 200 from ${examplesDir.resolve("extra_header.json").canonicalPath}
-            >> REQUEST.HEADERS.X-Extra-Header  
+            >> REQUEST.PARAMETERS.HEADER.X-Extra-Header  
             The header X-Extra-Header was found in the example extra_header but was not in the specification.
-            >> RESPONSE.HEADERS.X-Extra-Header
+            >> RESPONSE.HEADER.X-Extra-Header
             The header X-Extra-Header was found in the example extra_header but was not in the specification.
             """.trimIndent())
         }
@@ -567,21 +567,21 @@ class LoadTestsFromExternalisedFiles {
 
         assertThat(exception.report()).isEqualToNormalizingWhitespace("""
         Error loading example for POST /secure -> 200 from ${examplesDir.resolve("secure.json").canonicalPath} 
-        >> REQUEST.HEADERS.Authorization
+        >> REQUEST.PARAMETERS.HEADER.Authorization
         Authorization header must be prefixed with "Bearer"
 
         Error loading example for POST /partial -> 200 from ${examplesDir.resolve("partial.json").canonicalPath} 
-        >> REQUEST.HEADERS.Authorization
+        >> REQUEST.PARAMETERS.HEADER.Authorization
         Authorization header must be prefixed with "Bearer"
         
         Error loading example for POST /overlap -> 200 from ${examplesDir.resolve("overlap.json").canonicalPath}
-        >> REQUEST.HEADERS.Authorization
+        >> REQUEST.PARAMETERS.HEADER.Authorization
         Authorization header must be prefixed with "Bearer"
 
         Error loading example for POST /insecure -> 200 from ${examplesDir.resolve("insecure.json").canonicalPath} 
         >> REQUEST.QUERY-PARAMS.apiKey
         The query param apiKey was found in the example insecure but was not in the specification. 
-        >> REQUEST.HEADERS.Authorization
+        >> REQUEST.PARAMETERS.HEADER.Authorization
         The header Authorization was found in the example insecure but was not in the specification.
         """.trimIndent())
     }
@@ -1111,9 +1111,9 @@ class LoadTestsFromExternalisedFiles {
             >> REQUEST.QUERY-PARAMS.petId
             Expected number as per the specification, but the example pets_post had string.
 
-            >> REQUEST.HEADERS.CREATOR-ID
+            >> REQUEST.PARAMETERS.HEADER.CREATOR-ID
             Expected number as per the specification, but the example pets_post had "abc".
-            >> REQUEST.HEADERS.PET-ID  
+            >> REQUEST.PARAMETERS.HEADER.PET-ID  
             Expected number as per the specification, but the example pets_post had string.
 
             >> REQUEST.BODY.creatorId  

--- a/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
+++ b/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
@@ -579,7 +579,7 @@ class LoadTestsFromExternalisedFiles {
         Authorization header must be prefixed with "Bearer"
 
         Error loading example for POST /insecure -> 200 from ${examplesDir.resolve("insecure.json").canonicalPath} 
-        >> REQUEST.QUERY-PARAMS.apiKey
+        >> REQUEST.PARAMETERS.QUERY.apiKey
         The query param apiKey was found in the example insecure but was not in the specification. 
         >> REQUEST.PARAMETERS.HEADER.Authorization
         The header Authorization was found in the example insecure but was not in the specification.
@@ -1106,9 +1106,9 @@ class LoadTestsFromExternalisedFiles {
             >> REQUEST.PATH.petId  
             Expected number as per the specification, but the example pets_post had string.
             
-            >> REQUEST.QUERY-PARAMS.creatorId
+            >> REQUEST.PARAMETERS.QUERY.creatorId
             Expected number as per the specification, but the example pets_post had "abc".
-            >> REQUEST.QUERY-PARAMS.petId
+            >> REQUEST.PARAMETERS.QUERY.petId
             Expected number as per the specification, but the example pets_post had string.
 
             >> REQUEST.PARAMETERS.HEADER.CREATOR-ID

--- a/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
+++ b/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
@@ -1101,9 +1101,9 @@ class LoadTestsFromExternalisedFiles {
             assertThat(exception.report()).isEqualToNormalizingWhitespace("""
             Error loading example for PATCH /creators/(creatorId:number)/pets/(petId:number) -> 201 from ${invalidExamplesDir.resolve("pets_post.json").canonicalPath}
 
-            >> REQUEST.PATH.creatorId  
+            >> REQUEST.PARAMETERS.PATH.creatorId  
             Expected number as per the specification, but the example pets_post had "abc".
-            >> REQUEST.PATH.petId  
+            >> REQUEST.PARAMETERS.PATH.petId  
             Expected number as per the specification, but the example pets_post had string.
             
             >> REQUEST.PARAMETERS.QUERY.creatorId

--- a/core/src/test/kotlin/integration_tests/PartialExampleTest.kt
+++ b/core/src/test/kotlin/integration_tests/PartialExampleTest.kt
@@ -97,7 +97,7 @@ class PartialExampleTest {
             val response = stub.client.execute(request)
 
             assertThat(response.status).isEqualTo(400)
-            assertThat(response.body.toStringLiteral()).contains(">> REQUEST.QUERY-PARAMS.words")
+            assertThat(response.body.toStringLiteral()).contains(">> REQUEST.PARAMETERS.QUERY.words")
         }
     }
 
@@ -158,7 +158,7 @@ class PartialExampleTest {
         assertThat(output).contains(">> REQUEST.BODY.department")
         assertThat(output).contains(">> REQUEST.PATH.personId")
         assertThat(output).contains(">> REQUEST.PARAMETERS.HEADER.id")
-        assertThat(output).contains(">> REQUEST.QUERY-PARAMS.data")
+        assertThat(output).contains(">> REQUEST.PARAMETERS.QUERY.data")
         assertThat(output).contains(">> RESPONSE.HEADER.data")
         assertThat(output).contains(">> RESPONSE.BODY.location")
     }

--- a/core/src/test/kotlin/integration_tests/PartialExampleTest.kt
+++ b/core/src/test/kotlin/integration_tests/PartialExampleTest.kt
@@ -123,7 +123,7 @@ class PartialExampleTest {
             val response = stub.client.execute(request)
 
             assertThat(response.status).isEqualTo(400)
-            assertThat(response.body.toStringLiteral()).contains(">> REQUEST.HEADERS.words")
+            assertThat(response.body.toStringLiteral()).contains(">> REQUEST.PARAMETERS.HEADER.words")
         }
     }
 
@@ -157,9 +157,9 @@ class PartialExampleTest {
 
         assertThat(output).contains(">> REQUEST.BODY.department")
         assertThat(output).contains(">> REQUEST.PATH.personId")
-        assertThat(output).contains(">> REQUEST.HEADERS.id")
+        assertThat(output).contains(">> REQUEST.PARAMETERS.HEADER.id")
         assertThat(output).contains(">> REQUEST.QUERY-PARAMS.data")
-        assertThat(output).contains(">> RESPONSE.HEADERS.data")
+        assertThat(output).contains(">> RESPONSE.HEADER.data")
         assertThat(output).contains(">> RESPONSE.BODY.location")
     }
 

--- a/core/src/test/kotlin/integration_tests/PartialExampleTest.kt
+++ b/core/src/test/kotlin/integration_tests/PartialExampleTest.kt
@@ -156,7 +156,7 @@ class PartialExampleTest {
         println(output)
 
         assertThat(output).contains(">> REQUEST.BODY.department")
-        assertThat(output).contains(">> REQUEST.PATH.personId")
+        assertThat(output).contains(">> REQUEST.PARAMETERS.PATH.personId")
         assertThat(output).contains(">> REQUEST.PARAMETERS.HEADER.id")
         assertThat(output).contains(">> REQUEST.PARAMETERS.QUERY.data")
         assertThat(output).contains(">> RESPONSE.HEADER.data")

--- a/core/src/test/kotlin/integration_tests/StubSubstitutionTest.kt
+++ b/core/src/test/kotlin/integration_tests/StubSubstitutionTest.kt
@@ -382,7 +382,7 @@ class StubSubstitutionTest {
             val response = stub.client.execute(exampleRequest)
 
             assertThat(response.status).isEqualTo(400)
-            assertThat(response.body.toStringLiteral()).contains("RESPONSE.HEADERS.X-Id")
+            assertThat(response.body.toStringLiteral()).contains("RESPONSE.HEADER.X-Id")
         }
     }
 

--- a/core/src/test/kotlin/integration_tests/ValidateResponseSchemaTest.kt
+++ b/core/src/test/kotlin/integration_tests/ValidateResponseSchemaTest.kt
@@ -367,7 +367,7 @@ paths:
         println(results.report())
 
         assertThat(results.report())
-            .contains("RESPONSE.HEADERS.X-Rate-Limit-Remaining")
+            .contains("RESPONSE.HEADER.X-Rate-Limit-Remaining")
             .contains("Expected \"100\", got value \"200\"")
     }
 }

--- a/core/src/test/kotlin/integration_tests/ValueAssertionsTest.kt
+++ b/core/src/test/kotlin/integration_tests/ValueAssertionsTest.kt
@@ -382,7 +382,7 @@ paths:
                 return HttpResponse(200, "Product added successfully")
             }
         }).let { results ->
-            assertThat(results.report()).contains(">> RESPONSE.HEADERS.Header1")
+            assertThat(results.report()).contains(">> RESPONSE.HEADER.Header1")
         }
     }
 }

--- a/core/src/test/kotlin/io/specmatic/conversions/APIKeyInHeaderSecuritySchemeTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/APIKeyInHeaderSecuritySchemeTest.kt
@@ -15,7 +15,7 @@ class APIKeyInHeaderSecuritySchemeTest {
 
         assertThat(result).isInstanceOf(Result.Failure::class.java)
         assertThat(result.reportString()).isEqualToNormalizingWhitespace("""
-        >> HEADERS.API-KEY
+        >> HEADER.API-KEY
         Expected api-key named "API-KEY" was missing
         """.trimIndent())
     }

--- a/core/src/test/kotlin/io/specmatic/conversions/APIKeyInQueryParamSecuritySchemeTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/APIKeyInQueryParamSecuritySchemeTest.kt
@@ -16,7 +16,7 @@ class APIKeyInQueryParamSecuritySchemeTest {
 
         assertThat(result).isInstanceOf(Result.Failure::class.java)
         assertThat(result.reportString()).isEqualToNormalizingWhitespace("""
-        >> QUERY-PARAMS.API-KEY
+        >> QUERY.API-KEY
         Expected api-key named "API-KEY" was missing
         """.trimIndent())
     }

--- a/core/src/test/kotlin/io/specmatic/conversions/BearerSecuritySchemeTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/BearerSecuritySchemeTest.kt
@@ -36,7 +36,7 @@ class BearerSecuritySchemeTest {
         with(scheme.matches(requestWithoutHeader, Resolver())) {
             assertThat(isSuccess()).isFalse
             assertThat(this.reportString())
-                .contains(">> HEADERS.Authorization")
+                .contains(">> HEADER.Authorization")
                 .contains("Expected header named \"Authorization\" was missing")
         }
     }

--- a/core/src/test/kotlin/io/specmatic/conversions/CompositeSecuritySchemeTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/CompositeSecuritySchemeTest.kt
@@ -39,7 +39,7 @@ class CompositeSecuritySchemeTest {
         assertThat(result.reportString()).isEqualToNormalizingWhitespace("""
         >> HEADER.$AUTHORIZATION
         Expected header named "$AUTHORIZATION" was missing
-        >> QUERY-PARAMS.apiKey
+        >> QUERY.apiKey
         Expected api-key named "apiKey" was missing
         """.trimIndent())
     }

--- a/core/src/test/kotlin/io/specmatic/conversions/CompositeSecuritySchemeTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/CompositeSecuritySchemeTest.kt
@@ -37,7 +37,7 @@ class CompositeSecuritySchemeTest {
 
         assertThat(result).isInstanceOf(Result.Failure::class.java)
         assertThat(result.reportString()).isEqualToNormalizingWhitespace("""
-        >> HEADERS.$AUTHORIZATION
+        >> HEADER.$AUTHORIZATION
         Expected header named "$AUTHORIZATION" was missing
         >> QUERY-PARAMS.apiKey
         Expected api-key named "apiKey" was missing

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiIntegrationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiIntegrationTest.kt
@@ -185,7 +185,7 @@ Examples:
                 val result = feature.scenarios.first().httpRequestPattern.matches(httpRequest, Resolver())
                 assertThat(result).isInstanceOf(Result.Failure::class.java)
                 assertThat(result.reportString())
-                    .contains(">> REQUEST.HEADERS.Authorization")
+                    .contains(">> REQUEST.PARAMETERS.HEADER.Authorization")
                     .contains("Expected header named \"Authorization\" was missing")
             }
 
@@ -560,7 +560,7 @@ Background:
             val result = feature.scenarios.first().httpRequestPattern.matches(httpRequest, Resolver())
             assertThat(result).isInstanceOf(Result.Failure::class.java)
             assertThat(result.reportString())
-                .contains(">> REQUEST.HEADERS.Authorization")
+                .contains(">> REQUEST.PARAMETERS.HEADER.Authorization")
                 .contains("Expected header named \"Authorization\" was missing")
         }
 

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -7057,9 +7057,9 @@ components:
 
         val testDescriptionList = tests.map { it.testDescription() }
         assertThat(testDescriptionList).containsExactlyInAnyOrder(
-            " Scenario: GET /items -> 200 [REQUEST.HEADERS.X-region selected FIRST from enum]",
-            " Scenario: GET /items -> 200 [REQUEST.HEADERS.X-region selected SECOND from enum]",
-            " Scenario: GET /items -> 200 [REQUEST.HEADERS.X-region selected THIRD from enum]"
+            " Scenario: GET /items -> 200 [REQUEST.PARAMETERS.HEADER.X-region selected FIRST from enum]",
+            " Scenario: GET /items -> 200 [REQUEST.PARAMETERS.HEADER.X-region selected SECOND from enum]",
+            " Scenario: GET /items -> 200 [REQUEST.PARAMETERS.HEADER.X-region selected THIRD from enum]"
         )
     }
 

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -9001,8 +9001,8 @@ paths:
                 }
             })
 
-            assertThat(firstScenario.testDescription()).isEqualTo(" Scenario: GET /persons -> 4xx [REQUEST.HEADER.X-Required-Header mandatory header not sent]")
-            assertThat(secondScenario.testDescription()).isEqualTo(" Scenario: GET /persons -> 4xx [REQUEST.HEADER.X-Another-Required-Header mandatory header not sent]")
+            assertThat(firstScenario.testDescription()).isEqualTo(" Scenario: GET /persons -> 4xx [REQUEST.PARAMETERS.HEADER.X-Required-Header mandatory header not sent]")
+            assertThat(secondScenario.testDescription()).isEqualTo(" Scenario: GET /persons -> 4xx [REQUEST.PARAMETERS.HEADER.X-Another-Required-Header mandatory header not sent]")
         }
 
         @Test
@@ -9091,8 +9091,8 @@ paths:
                     return HttpResponse.OK
                 }
             })
-            assertThat(firstScenario.testDescription()).isEqualTo(" Scenario: GET /persons -> 4xx [REQUEST.HEADER.X-Required-Header mandatory header not sent]")
-            assertThat(secondScenario.testDescription()).isEqualTo(" Scenario: GET /persons -> 4xx [REQUEST.HEADER.X-Another-Required-Header mandatory header not sent]")
+            assertThat(firstScenario.testDescription()).isEqualTo(" Scenario: GET /persons -> 4xx [REQUEST.PARAMETERS.HEADER.X-Required-Header mandatory header not sent]")
+            assertThat(secondScenario.testDescription()).isEqualTo(" Scenario: GET /persons -> 4xx [REQUEST.PARAMETERS.HEADER.X-Another-Required-Header mandatory header not sent]")
         }
     }
 

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -8782,8 +8782,8 @@ paths:
                 }
             })
 
-            assertThat(firstScenario.testDescription()).isEqualTo(" Scenario: GET /persons -> 4xx [REQUEST.QUERY-PARAM.id mandatory query param not sent]")
-            assertThat(secondScenario.testDescription()).isEqualTo(" Scenario: GET /persons -> 4xx [REQUEST.QUERY-PARAM.age mandatory query param not sent]")
+            assertThat(firstScenario.testDescription()).isEqualTo(" Scenario: GET /persons -> 4xx [REQUEST.PARAMETERS.QUERY.id mandatory query param not sent]")
+            assertThat(secondScenario.testDescription()).isEqualTo(" Scenario: GET /persons -> 4xx [REQUEST.PARAMETERS.QUERY.age mandatory query param not sent]")
         }
 
         @Test
@@ -8837,7 +8837,7 @@ paths:
                 }
             })
 
-            assertThat(firstScenario.testDescription()).isEqualTo(" Scenario: GET /items -> 4xx [REQUEST.QUERY-PARAM.ids mandatory query param not sent]")
+            assertThat(firstScenario.testDescription()).isEqualTo(" Scenario: GET /items -> 4xx [REQUEST.PARAMETERS.QUERY.ids mandatory query param not sent]")
         }
 
         @Test
@@ -8920,8 +8920,8 @@ paths:
                 }
             })
 
-            assertThat(firstScenario.testDescription()).isEqualTo(" Scenario: GET /persons -> 4xx [REQUEST.QUERY-PARAM.id mandatory query param not sent] | EX:EXAMPLE")
-            assertThat(secondScenario.testDescription()).isEqualTo(" Scenario: GET /persons -> 4xx [REQUEST.QUERY-PARAM.age mandatory query param not sent] | EX:EXAMPLE")
+            assertThat(firstScenario.testDescription()).isEqualTo(" Scenario: GET /persons -> 4xx [REQUEST.PARAMETERS.QUERY.id mandatory query param not sent] | EX:EXAMPLE")
+            assertThat(secondScenario.testDescription()).isEqualTo(" Scenario: GET /persons -> 4xx [REQUEST.PARAMETERS.QUERY.age mandatory query param not sent] | EX:EXAMPLE")
         }
 
     }

--- a/core/src/test/kotlin/io/specmatic/core/ContractAsTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ContractAsTest.kt
@@ -87,7 +87,7 @@ class ContractAsTest {
             In scenario "Get balance"
             API: GET /balance -> 200
             
-              >> RESPONSE.HEADERS.length
+              >> RESPONSE.HEADER.length
               
                  ${ContractAndResponseMismatch.mismatchMessage("number", "\"abc\"")}
             """.trimIndent().trimmedLinesString()

--- a/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
@@ -320,7 +320,7 @@ paths:
             In scenario "Get balance info"
             API: GET /balance -> 200
             
-              >> REQUEST.HEADERS.x-loginId
+              >> REQUEST.PARAMETERS.HEADER.x-loginId
               
                  Expected header named "x-loginId" was missing
               """.trimIndent().trimmedLinesList())
@@ -1849,7 +1849,7 @@ paths:
         ).toFeature()
 
         assertThatThrownBy { feature.validateExamplesOrException() }.satisfies(Consumer { exception ->
-            assertThat(exceptionCauseMessage(exception)).contains("REQUEST.HEADERS.X-Test-Header")
+            assertThat(exceptionCauseMessage(exception)).contains("REQUEST.PARAMETERS.HEADER.X-Test-Header")
         })
     }
 
@@ -1902,8 +1902,8 @@ paths:
         ).toFeature()
 
         assertThatThrownBy { feature.validateExamplesOrException() }.satisfies(Consumer { exception ->
-            assertThat(exceptionCauseMessage(exception)).contains("REQUEST.HEADERS.X-Test-Header")
-            assertThat(exceptionCauseMessage(exception)).doesNotContain("REQUEST.HEADERS.X-Test-Header?")
+            assertThat(exceptionCauseMessage(exception)).contains("REQUEST.PARAMETERS.HEADER.X-Test-Header")
+            assertThat(exceptionCauseMessage(exception)).doesNotContain("REQUEST.PARAMETERS.HEADER.X-Test-Header?")
         })
     }
 
@@ -2064,7 +2064,7 @@ paths:
         ).toFeature()
 
         assertThatThrownBy { feature.validateExamplesOrException() }.satisfies(Consumer { exception ->
-            assertThat(exceptionCauseMessage(exception)).contains("RESPONSE.HEADERS.X-Value")
+            assertThat(exceptionCauseMessage(exception)).contains("RESPONSE.HEADER.X-Value")
         })
     }
 
@@ -2170,8 +2170,8 @@ paths:
         ).toFeature()
 
         assertThatThrownBy { feature.validateExamplesOrException() }.satisfies(Consumer { exception ->
-            assertThat(exceptionCauseMessage(exception)).contains("RESPONSE.HEADERS.X-Value")
-            assertThat(exceptionCauseMessage(exception)).doesNotContain("RESPONSE.HEADERS.X-Value?")
+            assertThat(exceptionCauseMessage(exception)).contains("RESPONSE.HEADER.X-Value")
+            assertThat(exceptionCauseMessage(exception)).doesNotContain("RESPONSE.HEADER.X-Value?")
         })
     }
 
@@ -2229,7 +2229,7 @@ paths:
         assertThatThrownBy { feature.validateExamplesOrException() }.satisfies(Consumer { exception ->
             assertThat(exceptionCauseMessage(exception)).contains(">> REQUEST.BODY.data")
             assertThat(exceptionCauseMessage(exception)).contains(">> REQUEST.BODY.info")
-            assertThat(exceptionCauseMessage(exception)).contains("RESPONSE.HEADERS.X-Value")
+            assertThat(exceptionCauseMessage(exception)).contains("RESPONSE.HEADER.X-Value")
             assertThat(exceptionCauseMessage(exception)).contains("RESPONSE.BODY")
         })
     }
@@ -2303,8 +2303,8 @@ components:
         assertThatThrownBy { feature.validateExamplesOrException() }.satisfies(Consumer { exception ->
             assertThat(exceptionCauseMessage(exception)).contains("REQUEST.PATH.id")
             assertThat(exceptionCauseMessage(exception)).contains("REQUEST.QUERY-PARAMS.enabled")
-            assertThat(exceptionCauseMessage(exception)).contains("REQUEST.HEADERS.X-Token")
-            assertThat(exceptionCauseMessage(exception)).contains("RESPONSE.HEADERS.X-Value")
+            assertThat(exceptionCauseMessage(exception)).contains("REQUEST.PARAMETERS.HEADER.X-Token")
+            assertThat(exceptionCauseMessage(exception)).contains("RESPONSE.HEADER.X-Value")
             assertThat(exceptionCauseMessage(exception)).contains("RESPONSE.BODY")
         })
     }

--- a/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
@@ -466,7 +466,7 @@ paths:
             In scenario "Get account balance"
             API: GET /balance -> 200
             
-              >> REQUEST.QUERY-PARAMS.account-id
+              >> REQUEST.PARAMETERS.QUERY.account-id
               
                  Expected number, actual was "abc"
             """.trimIndent().trimmedLinesList())
@@ -1957,7 +1957,7 @@ paths:
         ).toFeature()
 
         assertThatThrownBy { feature.validateExamplesOrException() }.satisfies(Consumer { exception ->
-            assertThat(exceptionCauseMessage(exception)).contains("REQUEST.QUERY-PARAMS.enabled")
+            assertThat(exceptionCauseMessage(exception)).contains("REQUEST.PARAMETERS.QUERY.enabled")
         })
     }
 
@@ -2010,7 +2010,7 @@ paths:
         ).toFeature()
 
         assertThatThrownBy { feature.validateExamplesOrException() }.satisfies(Consumer { exception ->
-            assertThat(exceptionCauseMessage(exception)).contains("REQUEST.QUERY-PARAMS.enabled")
+            assertThat(exceptionCauseMessage(exception)).contains("REQUEST.PARAMETERS.QUERY.enabled")
         })
     }
 
@@ -2302,7 +2302,7 @@ components:
 
         assertThatThrownBy { feature.validateExamplesOrException() }.satisfies(Consumer { exception ->
             assertThat(exceptionCauseMessage(exception)).contains("REQUEST.PATH.id")
-            assertThat(exceptionCauseMessage(exception)).contains("REQUEST.QUERY-PARAMS.enabled")
+            assertThat(exceptionCauseMessage(exception)).contains("REQUEST.PARAMETERS.QUERY.enabled")
             assertThat(exceptionCauseMessage(exception)).contains("REQUEST.PARAMETERS.HEADER.X-Token")
             assertThat(exceptionCauseMessage(exception)).contains("RESPONSE.HEADER.X-Value")
             assertThat(exceptionCauseMessage(exception)).contains("RESPONSE.BODY")
@@ -2470,7 +2470,7 @@ paths:
 
         assertThatThrownBy {
             feature.validateExamplesOrException()
-        }.hasMessageContaining("REQUEST.QUERY-PARAMS.enabled")
+        }.hasMessageContaining("REQUEST.PARAMETERS.QUERY.enabled")
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
@@ -2117,7 +2117,7 @@ paths:
         ).toFeature()
 
         assertThatThrownBy { feature.validateExamplesOrException() }.satisfies(Consumer { exception ->
-            assertThat(exceptionCauseMessage(exception)).contains("REQUEST.PATH.id")
+            assertThat(exceptionCauseMessage(exception)).contains("REQUEST.PARAMETERS.PATH.id")
         })
     }
 
@@ -2301,7 +2301,7 @@ components:
         ).toFeature()
 
         assertThatThrownBy { feature.validateExamplesOrException() }.satisfies(Consumer { exception ->
-            assertThat(exceptionCauseMessage(exception)).contains("REQUEST.PATH.id")
+            assertThat(exceptionCauseMessage(exception)).contains("REQUEST.PARAMETERS.PATH.id")
             assertThat(exceptionCauseMessage(exception)).contains("REQUEST.PARAMETERS.QUERY.enabled")
             assertThat(exceptionCauseMessage(exception)).contains("REQUEST.PARAMETERS.HEADER.X-Token")
             assertThat(exceptionCauseMessage(exception)).contains("RESPONSE.HEADER.X-Value")

--- a/core/src/test/kotlin/io/specmatic/core/HttpHeadersPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpHeadersPatternTest.kt
@@ -228,7 +228,7 @@ internal class HttpHeadersPatternTest {
     @Test
     fun `should generate negative values for a string`() {
         val headers = HttpHeadersPattern(mapOf("X-TraceID" to StringPattern()))
-        val newHeaders = headers.negativeBasedOn(Row(), Resolver()).map { it.value }.toList()
+        val newHeaders = headers.negativeBasedOn(Row(), Resolver(), BreadCrumb.PARAM_HEADER.value).map { it.value }.toList()
 
         assertThat(newHeaders).containsExactlyInAnyOrder(
             HttpHeadersPattern(mapOf())
@@ -239,7 +239,7 @@ internal class HttpHeadersPatternTest {
     @Test
     fun `should generate negative values for a number`() {
         val headers = HttpHeadersPattern(mapOf("X-TraceID" to NumberPattern()))
-        val newHeaders = headers.negativeBasedOn(Row(), Resolver()).map { it.value }.toList()
+        val newHeaders = headers.negativeBasedOn(Row(), Resolver(), BreadCrumb.PARAM_HEADER.value).map { it.value }.toList()
 
         assertThat(newHeaders).containsExactlyInAnyOrder(
             HttpHeadersPattern(mapOf("X-TraceID" to StringPattern())),

--- a/core/src/test/kotlin/io/specmatic/core/HttpHeadersPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpHeadersPatternTest.kt
@@ -97,7 +97,9 @@ internal class HttpHeadersPatternTest {
         headers["key"] = "abc"
         httpHeaders.matches(headers, Resolver()).let {
             assertThat(it is Result.Failure).isTrue()
-            assertThat((it as Result.Failure).toMatchFailureDetails()).isEqualTo(MatchFailureDetails(listOf("HEADERS", "key"), listOf("Expected number, actual was \"abc\"")))
+            assertThat((it as Result.Failure).toMatchFailureDetails()).isEqualTo(MatchFailureDetails(
+                listOf("HEADER", "key"), listOf("Expected number, actual was \"abc\""))
+            )
         }
     }
 
@@ -108,8 +110,9 @@ internal class HttpHeadersPatternTest {
         headers["anotherKey"] = "123"
         httpHeaders.matches(headers, Resolver()).let {
             assertThat(it is Result.Failure).isTrue()
-            assertThat((it as Result.Failure).toMatchFailureDetails())
-                    .isEqualTo(MatchFailureDetails(listOf("HEADERS", "key"), listOf("Expected header named \"key\" was missing")))
+            assertThat((it as Result.Failure).toMatchFailureDetails()).isEqualTo(MatchFailureDetails(
+                listOf("HEADER", "key"), listOf("Expected header named \"key\" was missing"))
+            )
         }
     }
 
@@ -355,8 +358,8 @@ internal class HttpHeadersPatternTest {
         fun `errors should mention the name of header`() {
             result as Result.Failure
 
-            assertThat(result.toFailureReport().toText()).contains(">> HEADERS.X-Data")
-            assertThat(result.toFailureReport().toText()).contains(">> HEADERS.Y-Data")
+            assertThat(result.toFailureReport().toText()).contains(">> HEADER.X-Data")
+            assertThat(result.toFailureReport().toText()).contains(">> HEADER.Y-Data")
 
             println(result.toFailureReport().toText())
         }
@@ -367,7 +370,7 @@ internal class HttpHeadersPatternTest {
 
             val resultText = result.toFailureReport().toText()
 
-            assertThat(resultText.indexOf(">> HEADERS.X-Data")).isLessThan(resultText.indexOf(">> HEADERS.Y-Data"))
+            assertThat(resultText.indexOf(">> HEADER.X-Data")).isLessThan(resultText.indexOf(">> HEADER.Y-Data"))
 
             println(result.toFailureReport().toText())
         }
@@ -587,8 +590,10 @@ internal class HttpHeadersPatternTest {
             ))
             val invalidValue = mapOf("key" to "value", "type" to  "Invalid", "age" to "invalid")
 
-            val dictionary = "HEADERS: { age: 999 }".let(Dictionary::fromYaml)
-            val fixedValue = httpHeaders.fixValue(invalidValue, Resolver(dictionary = dictionary))
+            val dictionary = "PARAMETERS: { HEADER: { age: 999 } }".let(Dictionary::fromYaml)
+            val fixedValue = httpHeaders.fixValue(
+                invalidValue, Resolver(dictionary = dictionary).updateLookupPath(BreadCrumb.PARAMETERS.value)
+            )
             println(fixedValue)
 
             assertThat(fixedValue).isNotEmpty
@@ -800,8 +805,10 @@ internal class HttpHeadersPatternTest {
         fun `should generate values for missing mandatory keys and pattern tokens`() {
             val httpHeaders = HttpHeadersPattern(mapOf("number" to NumberPattern(), "boolean" to BooleanPattern()))
             val headers = mapOf("number" to "(number)")
-            val dictionary = "HEADERS: { number: 999, boolean: true }".let(Dictionary::fromYaml)
-            val filledHeaders = httpHeaders.fillInTheBlanks(headers, Resolver(dictionary = dictionary)).value
+            val dictionary = "PARAMETERS: { HEADER: { number: 999, boolean: true } }".let(Dictionary::fromYaml)
+            val filledHeaders = httpHeaders.fillInTheBlanks(
+                headers, Resolver(dictionary = dictionary).updateLookupPath(BreadCrumb.PARAMETERS.value)
+            ).value
 
             assertThat(filledHeaders).isEqualTo(mapOf("number" to "999", "boolean" to "true"))
         }
@@ -810,8 +817,7 @@ internal class HttpHeadersPatternTest {
         fun `should not generate missing optional keys`() {
             val httpHeaders = HttpHeadersPattern(mapOf("number" to NumberPattern(), "boolean?" to BooleanPattern()))
             val headers = mapOf("number" to "999")
-            val dictionary = mapOf("HEADERS.boolean" to BooleanValue(true)).let(Dictionary::from)
-            val filledHeaders = httpHeaders.fillInTheBlanks(headers, Resolver(dictionary = dictionary)).value
+            val filledHeaders = httpHeaders.fillInTheBlanks(headers, Resolver()).value
 
             assertThat(filledHeaders).isEqualTo(mapOf("number" to "999"))
         }
@@ -820,8 +826,10 @@ internal class HttpHeadersPatternTest {
         fun `should handle any-value pattern token as a special case`() {
             val httpHeaders = HttpHeadersPattern(mapOf("number" to NumberPattern(), "boolean" to BooleanPattern()))
             val headers = mapOf("number" to "(anyvalue)")
-            val dictionary = "HEADERS: { number: 999, boolean: true }".let(Dictionary::fromYaml)
-            val filledHeaders = httpHeaders.fillInTheBlanks(headers, Resolver(dictionary = dictionary)).value
+            val dictionary = "RESPONSE: { HEADER: { number: 999, boolean: true } }".let(Dictionary::fromYaml)
+            val filledHeaders = httpHeaders.fillInTheBlanks(
+                headers, Resolver(dictionary = dictionary).updateLookupPath(BreadCrumb.RESPONSE.value)
+            ).value
 
             assertThat(filledHeaders).isEqualTo(mapOf("number" to "999", "boolean" to "true"))
         }
@@ -843,10 +851,10 @@ internal class HttpHeadersPatternTest {
         @Test
         fun `should generate missing optional keys when allPatternsMandatory is set`() {
             val httpHeaders = HttpHeadersPattern(mapOf("number" to NumberPattern(), "boolean?" to BooleanPattern()))
-            val dictionary = "HEADERS: { boolean: true }".let(Dictionary::fromYaml)
+            val dictionary = "RESPONSE: { HEADER: { boolean: true } }".let(Dictionary::fromYaml)
             val headers = mapOf("number" to "999")
             val filledHeaders = httpHeaders.fillInTheBlanks(
-                headers, Resolver(dictionary = dictionary).withAllPatternsAsMandatory()
+                headers, Resolver(dictionary = dictionary).withAllPatternsAsMandatory().updateLookupPath(BreadCrumb.RESPONSE.value)
             ).value
 
             assertThat(filledHeaders).isEqualTo(mapOf("number" to "999", "boolean" to "true"))
@@ -866,13 +874,13 @@ internal class HttpHeadersPatternTest {
             val httpHeaders = HttpHeadersPattern(mapOf("number" to NumberPattern()))
             val headers = mapOf("number" to "(number)", "extraKey" to "(string)")
             val dictionary = """
-            HEADERS: { number: 999 }
+            PARAMETERS: { HEADER: { number: 999 } }
             (string): ExtraValue
             """.trimIndent().let(Dictionary::fromYaml)
             val resolvers = listOf(
                 Resolver(dictionary = dictionary, isNegative = true),
                 Resolver(dictionary = dictionary).withUnexpectedKeyCheck(IgnoreUnexpectedKeys)
-            )
+            ).map { it.updateLookupPath(BreadCrumb.PARAMETERS.value) }
 
             assertThat(resolvers).allSatisfy {
                 val filledJsonObject = httpHeaders.fillInTheBlanks(headers, it).value

--- a/core/src/test/kotlin/io/specmatic/core/HttpPathPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpPathPatternTest.kt
@@ -358,7 +358,7 @@ internal class HttpPathPatternTest {
     @Test
     fun `should generate negative values for a number`() {
         val headers = HttpHeadersPattern(mapOf("X-TraceID" to NumberPattern()))
-        val newHeaders = headers.negativeBasedOn(Row(), Resolver()).map { it.value }.toList()
+        val newHeaders = headers.negativeBasedOn(Row(), Resolver(), BreadCrumb.PARAM_HEADER.value).map { it.value }.toList()
 
         assertThat(newHeaders).containsExactlyInAnyOrder(
             HttpHeadersPattern(mapOf("X-TraceID" to StringPattern())),

--- a/core/src/test/kotlin/io/specmatic/core/HttpQueryParamPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpQueryParamPatternTest.kt
@@ -694,8 +694,7 @@ class HttpQueryParamPatternTest {
         fun `should not generate missing optional keys`() {
             val queryParams = HttpQueryParamPattern(mapOf("number" to NumberPattern(), "boolean?" to BooleanPattern()))
             val params = QueryParameters(mapOf("number" to "999"))
-            val dictionary = mapOf("QUERY-PARAMS.boolean" to BooleanValue(true)).let(Dictionary::from)
-            val filledParams = queryParams.fillInTheBlanks(params, Resolver(dictionary = dictionary)).value
+            val filledParams = queryParams.fillInTheBlanks(params, Resolver()).value
 
             assertThat(filledParams.asMap()).isEqualTo(mapOf("number" to "999"))
         }
@@ -726,7 +725,7 @@ class HttpQueryParamPatternTest {
         fun `should generate missing optional keys when allPatternsMandatory is set`() {
             val queryParams = HttpQueryParamPattern(mapOf("number" to NumberPattern(), "boolean?" to BooleanPattern()))
             val params = QueryParameters(mapOf("number" to "999"))
-            val dictionary = "QUERY-PARAMS: { boolean: true }".let(Dictionary::fromYaml)
+            val dictionary = "PARAMETERS: { QUERY: { boolean: true } }".let(Dictionary::fromYaml)
             val filledParams = queryParams.fillInTheBlanks(
                 params, Resolver(dictionary = dictionary).withAllPatternsAsMandatory()
             ).value

--- a/core/src/test/kotlin/io/specmatic/core/HttpRequestPatternKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpRequestPatternKtTest.kt
@@ -48,12 +48,12 @@ internal class HttpRequestPatternKtTest {
 
         assertThat(result).isInstanceOf(Result.Failure::class.java)
         when(securitySchema) {
-            is APIKeyInHeaderSecurityScheme -> assertThat(report).containsOnlyOnce(">> REQUEST.HEADERS.API-KEY")
-            is APIKeyInQueryParamSecurityScheme -> assertThat(report).containsOnlyOnce(">> REQUEST.QUERY-PARAMS.API-KEY")
-            is BasicAuthSecurityScheme, is BearerSecurityScheme -> assertThat(report).containsOnlyOnce(">> REQUEST.HEADERS.Authorization")
+            is APIKeyInHeaderSecurityScheme -> assertThat(report).containsOnlyOnce(">> REQUEST.PARAMETERS.HEADER.API-KEY")
+            is APIKeyInQueryParamSecurityScheme -> assertThat(report).containsOnlyOnce(">> REQUEST.PARAMETERS.QUERY-PARAMS.API-KEY")
+            is BasicAuthSecurityScheme, is BearerSecurityScheme -> assertThat(report).containsOnlyOnce(">> REQUEST.PARAMETERS.HEADER.Authorization")
             is CompositeSecurityScheme -> assertThat(report).satisfies(
-                { assertThat(it).containsOnlyOnce(">> REQUEST.HEADERS.Authorization") },
-                { assertThat(it).containsOnlyOnce(">> REQUEST.QUERY-PARAMS.API-KEY") },
+                { assertThat(it).containsOnlyOnce(">> REQUEST.PARAMETERS.HEADER.Authorization") },
+                { assertThat(it).containsOnlyOnce(">> REQUEST.PARAMETERS.QUERY-PARAMS.API-KEY") },
             )
             else -> throw RuntimeException("Unknown security scheme ${securitySchema::javaClass.name}")
         }

--- a/core/src/test/kotlin/io/specmatic/core/HttpRequestPatternKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpRequestPatternKtTest.kt
@@ -49,11 +49,11 @@ internal class HttpRequestPatternKtTest {
         assertThat(result).isInstanceOf(Result.Failure::class.java)
         when(securitySchema) {
             is APIKeyInHeaderSecurityScheme -> assertThat(report).containsOnlyOnce(">> REQUEST.PARAMETERS.HEADER.API-KEY")
-            is APIKeyInQueryParamSecurityScheme -> assertThat(report).containsOnlyOnce(">> REQUEST.PARAMETERS.QUERY-PARAMS.API-KEY")
+            is APIKeyInQueryParamSecurityScheme -> assertThat(report).containsOnlyOnce(">> REQUEST.PARAMETERS.QUERY.API-KEY")
             is BasicAuthSecurityScheme, is BearerSecurityScheme -> assertThat(report).containsOnlyOnce(">> REQUEST.PARAMETERS.HEADER.Authorization")
             is CompositeSecurityScheme -> assertThat(report).satisfies(
                 { assertThat(it).containsOnlyOnce(">> REQUEST.PARAMETERS.HEADER.Authorization") },
-                { assertThat(it).containsOnlyOnce(">> REQUEST.PARAMETERS.QUERY-PARAMS.API-KEY") },
+                { assertThat(it).containsOnlyOnce(">> REQUEST.PARAMETERS.QUERY.API-KEY") },
             )
             else -> throw RuntimeException("Unknown security scheme ${securitySchema::javaClass.name}")
         }

--- a/core/src/test/kotlin/io/specmatic/core/HttpRequestPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpRequestPatternTest.kt
@@ -647,7 +647,7 @@ internal class HttpRequestPatternTest {
 
         val testDescriptions = negativeTestScenarios.map { it.second }.filterIsInstance<HasValue<*>>().map { it.value as Scenario }.map { it.testDescription() }
 
-        assertThat(testDescriptions.count { it.matches(Regex("^.*QUERY-PARAM.*enum.*$")) }).isEqualTo(4)
+        assertThat(testDescriptions.count { it.matches(Regex("^.*PARAMETERS.QUERY.*enum.*$")) }).isEqualTo(4)
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/core/HttpRequestPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpRequestPatternTest.kt
@@ -22,7 +22,9 @@ internal class HttpRequestPatternTest {
         val httpRequest = HttpRequest().updateWith(URI("/unmatched_path"))
         httpRequestPattern.matches(httpRequest, Resolver()).let {
             assertThat(it).isInstanceOf(Failure::class.java)
-            assertThat((it as Failure).toMatchFailureDetails()).isEqualTo(MatchFailureDetails(listOf("REQUEST", "PATH (/unmatched_path)"), listOf("""Expected "matching_path", actual was "unmatched_path"""")))
+            assertThat((it as Failure).toMatchFailureDetails()).isEqualTo(MatchFailureDetails(
+                listOf("REQUEST", "PARAMETERS.PATH (/unmatched_path)"), listOf("""Expected "matching_path", actual was "unmatched_path""""))
+            )
         }
     }
 

--- a/core/src/test/kotlin/io/specmatic/core/HttpRequestPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpRequestPatternTest.kt
@@ -460,7 +460,7 @@ internal class HttpRequestPatternTest {
 
         val result = type.matches(request, Resolver())
         val reportText = result.reportString()
-        assertThat(reportText).contains(">> REQUEST.HEADERS.X-Data")
+        assertThat(reportText).contains(">> REQUEST.PARAMETERS.HEADER.X-Data")
         assertThat(reportText).contains(">> REQUEST.BODY.id")
     }
 

--- a/core/src/test/kotlin/io/specmatic/core/HttpResponsePatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpResponsePatternTest.kt
@@ -44,7 +44,7 @@ internal class HttpResponsePatternTest {
         assertThat(result.toMatchFailureDetailList()).hasSize(2)
 
         val resultText = result.reportString()
-        assertThat(resultText).contains(">> RESPONSE.HEADERS.X-Data")
+        assertThat(resultText).contains(">> RESPONSE.HEADER.X-Data")
         assertThat(resultText).contains(">> RESPONSE.BODY")
     }
 

--- a/core/src/test/kotlin/io/specmatic/core/HttpStubTests.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpStubTests.kt
@@ -665,7 +665,7 @@ Scenario: JSON API to get account details with fact check
             assertThat(secureResponse.body.toStringLiteral()).isEqualToNormalizingWhitespace("""
             In scenario "Secure endpoint requiring Bearer token and query API key. Response: Success"
             API: POST /secure -> 200
-            >> REQUEST.QUERY-PARAMS.apiKey
+            >> REQUEST.PARAMETERS.QUERY-PARAMS.apiKey
             Api-key named apiKey in the contract was not found in the request
             """.trimIndent())
 
@@ -676,9 +676,9 @@ Scenario: JSON API to get account details with fact check
             assertThat(partialResponse.body.toStringLiteral()).isEqualToNormalizingWhitespace("""
             In scenario "Partially secure endpoint requiring either Bearer token or query API key. Response: Success"
             API: POST /partial -> 200
-            >> REQUEST.HEADERS.Authorization
+            >> REQUEST.PARAMETERS.HEADER.Authorization
             Header named Authorization in the contract was not found in the request
-            >> REQUEST.QUERY-PARAMS.apiKey
+            >> REQUEST.PARAMETERS.QUERY-PARAMS.apiKey
             Api-key named apiKey in the contract was not found in the request
             """.trimIndent())
 
@@ -689,11 +689,11 @@ Scenario: JSON API to get account details with fact check
             assertThat(overlapResponse.body.toStringLiteral()).isEqualToNormalizingWhitespace("""
             In scenario "overlap endpoint requiring either Bearer token and query API key or Bearer token only. Response: Success"
             API: POST /overlap -> 200
-            >> REQUEST.HEADERS.Authorization
+            >> REQUEST.PARAMETERS.HEADER.Authorization
             Header named Authorization in the contract was not found in the request
-            >> REQUEST.QUERY-PARAMS.apiKey
+            >> REQUEST.PARAMETERS.QUERY-PARAMS.apiKey
             Api-key named apiKey in the contract was not found in the request
-            >> REQUEST.HEADERS.Authorization
+            >> REQUEST.PARAMETERS.HEADER.Authorization
             Header named Authorization in the contract was not found in the request
             """.trimIndent())
 

--- a/core/src/test/kotlin/io/specmatic/core/HttpStubTests.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpStubTests.kt
@@ -665,7 +665,7 @@ Scenario: JSON API to get account details with fact check
             assertThat(secureResponse.body.toStringLiteral()).isEqualToNormalizingWhitespace("""
             In scenario "Secure endpoint requiring Bearer token and query API key. Response: Success"
             API: POST /secure -> 200
-            >> REQUEST.PARAMETERS.QUERY-PARAMS.apiKey
+            >> REQUEST.PARAMETERS.QUERY.apiKey
             Api-key named apiKey in the contract was not found in the request
             """.trimIndent())
 
@@ -678,7 +678,7 @@ Scenario: JSON API to get account details with fact check
             API: POST /partial -> 200
             >> REQUEST.PARAMETERS.HEADER.Authorization
             Header named Authorization in the contract was not found in the request
-            >> REQUEST.PARAMETERS.QUERY-PARAMS.apiKey
+            >> REQUEST.PARAMETERS.QUERY.apiKey
             Api-key named apiKey in the contract was not found in the request
             """.trimIndent())
 
@@ -691,7 +691,7 @@ Scenario: JSON API to get account details with fact check
             API: POST /overlap -> 200
             >> REQUEST.PARAMETERS.HEADER.Authorization
             Header named Authorization in the contract was not found in the request
-            >> REQUEST.PARAMETERS.QUERY-PARAMS.apiKey
+            >> REQUEST.PARAMETERS.QUERY.apiKey
             Api-key named apiKey in the contract was not found in the request
             >> REQUEST.PARAMETERS.HEADER.Authorization
             Header named Authorization in the contract was not found in the request

--- a/core/src/test/kotlin/io/specmatic/core/ScenarioTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ScenarioTest.kt
@@ -378,7 +378,7 @@ class ScenarioTest {
         assertThat(exception.report()).isEqualToNormalizingWhitespace(
             """
         Error loading example named  for POST / -> 200
-        >> REQUEST.HEADERS.Authorization
+        >> REQUEST.PARAMETERS.HEADER.Authorization
         Authorization header must be prefixed with "Basic"
         """.trimIndent()
         )
@@ -426,9 +426,9 @@ class ScenarioTest {
         assertThat(exception.report()).isEqualToNormalizingWhitespace(
             """
         Error loading example named example.json for POST / -> 200
-        >> REQUEST.HEADERS.X-EXTRA-HEADERS
+        >> REQUEST.PARAMETERS.HEADER.X-EXTRA-HEADERS
         The header X-EXTRA-HEADERS was found in the example example.json but was not in the specification.
-        >> RESPONSE.HEADERS.X-EXTRA-HEADERS
+        >> RESPONSE.HEADER.X-EXTRA-HEADERS
         The header X-EXTRA-HEADERS was found in the example example.json but was not in the specification.
         """.trimIndent()
         )
@@ -477,9 +477,9 @@ class ScenarioTest {
         assertThat(exception.report()).isEqualToNormalizingWhitespace(
             """
         Error loading example named partial-example.json for POST / -> 200
-        >> REQUEST.HEADERS.X-EXTRA-HEADERS
+        >> REQUEST.PARAMETERS.HEADER.X-EXTRA-HEADERS
         The header X-EXTRA-HEADERS was found in the example partial-example.json but was not in the specification.
-        >> RESPONSE.HEADERS.X-EXTRA-HEADERS
+        >> RESPONSE.HEADER.X-EXTRA-HEADERS
         The header X-EXTRA-HEADERS was found in the example partial-example.json but was not in the specification.
         """.trimIndent()
         )

--- a/core/src/test/kotlin/io/specmatic/core/examples/module/ExampleValidationModuleTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/examples/module/ExampleValidationModuleTest.kt
@@ -140,7 +140,7 @@ class ExampleValidationModuleTest {
         assertThat(result.reportString()).isEqualToNormalizingWhitespace("""
         In scenario ""
         API: GET /test/(id:number)/name/(name:string) -> 200
-        >> REQUEST.PATH.id
+        >> REQUEST.PARAMETERS.PATH.id
         Specification expected number but example contained "abc"
         """.trimIndent())
     }

--- a/core/src/test/kotlin/io/specmatic/core/examples/module/ExampleValidationModuleTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/examples/module/ExampleValidationModuleTest.kt
@@ -423,9 +423,9 @@ class ExampleValidationModuleTest {
 
         assertThat(result).isInstanceOf(Result.Failure::class.java)
         assertThat(result.reportString()).isEqualToNormalizingWhitespace("""
-        >> REQUEST.HEADERS.EXTRA-HEADER
+        >> REQUEST.PARAMETERS.HEADER.EXTRA-HEADER
         Header EXTRA-HEADER in the example is not in the specification
-        >> RESPONSE.HEADERS.EXTRA-HEADER
+        >> RESPONSE.HEADER.EXTRA-HEADER
         Header EXTRA-HEADER in the example is not in the specification
         """.trimIndent())
     }
@@ -452,9 +452,9 @@ class ExampleValidationModuleTest {
 
         assertThat(result).isInstanceOf(Result.Failure::class.java)
         assertThat(result.reportString()).isEqualToNormalizingWhitespace("""
-        >> REQUEST.HEADERS.EXTRA-HEADER
+        >> REQUEST.PARAMETERS.HEADER.EXTRA-HEADER
         Header EXTRA-HEADER in the example is not in the specification
-        >> RESPONSE.HEADERS.EXTRA-HEADER
+        >> RESPONSE.HEADER.EXTRA-HEADER
         Header EXTRA-HEADER in the example is not in the specification
         """.trimIndent())
     }

--- a/core/src/test/kotlin/io/specmatic/core/pattern/QueryParameterScalarPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/QueryParameterScalarPatternTest.kt
@@ -11,7 +11,7 @@ class QueryParameterScalarPatternTest {
     @Test
     fun `should be able to fix invalid values`() {
         val pattern = HttpQueryParamPattern(mapOf("email" to QueryParameterScalarPattern(EmailPattern())))
-        val dictionary = "QUERY-PARAMS: { email: SomeDude@example.com }".let(Dictionary::fromYaml)
+        val dictionary = "PARAMETERS: { QUERY: { email: SomeDude@example.com } }".let(Dictionary::fromYaml)
         val resolver = Resolver(dictionary = dictionary)
         val invalidValues = listOf(
             "Unknown",

--- a/core/src/test/kotlin/io/specmatic/mock/ScenarioStubKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/mock/ScenarioStubKtTest.kt
@@ -909,7 +909,7 @@ paths:
                 In scenario "hello world. Response: Says hello"
                 API: GET /hello/(id:number) -> 200
 
-                  >> REQUEST.HEADERS.X-Value
+                  >> REQUEST.PARAMETERS.HEADER.X-Value
                   
                      ${ContractAndStubMismatchMessages.mismatchMessage("number", """"data" """.trim())}
                 """.trimIndent().trimmedLinesList())

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubKtTest.kt
@@ -459,7 +459,7 @@ Scenario: Square of a number
         val strictResponse = stubResponse(request, listOf(feature), listOf(stubData), true)
         assertResponseFailure(strictResponse, """STRICT MODE ON
 
->> REQUEST.QUERY-PARAMS.status
+>> REQUEST.PARAMETERS.QUERY.status
 
    ${StubAndRequestMismatchMessages.expectedKeyWasMissing("query param", "status")}""")
     }

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
@@ -746,7 +746,7 @@ components:
             }
         }
 
-        assertThat(output).contains(">> REQUEST.PATH.userId")
+        assertThat(output).contains(">> REQUEST.PARAMETERS.PATH.userId")
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubWithArrayQueryParameterTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubWithArrayQueryParameterTest.kt
@@ -289,11 +289,11 @@ class HttpStubWithArrayQueryParameterTest {
             In scenario "get products. Response: OK"
             API: GET /products -> 200
             
-              >> REQUEST.QUERY-PARAMS.brand_ids
+              >> REQUEST.PARAMETERS.QUERY.brand_ids
               
                  Query param named brand_ids in the contract was not found in the request
               
-              >> REQUEST.QUERY-PARAMS.category_id
+              >> REQUEST.PARAMETERS.QUERY.category_id
               
                  Query param named category_id in the request was not in the contract
             """.trimIndent().trimmedLinesList())
@@ -362,11 +362,11 @@ class HttpStubWithArrayQueryParameterTest {
                   In scenario "get orders. Response: OK"
                   API: GET /orders -> 200
                   
-                    >> REQUEST.QUERY-PARAMS.status
+                    >> REQUEST.PARAMETERS.QUERY.status
                   
                        Contract expected ("pending" or "complete") but stub contained "cancelled"
                   
-                    >> REQUEST.QUERY-PARAMS.status
+                    >> REQUEST.PARAMETERS.QUERY.status
                   
                        Contract expected ("pending" or "complete") but stub contained "suspended"
             """.trimIndent())

--- a/core/src/test/kotlin/io/specmatic/test/ResponseMonitorTest.kt
+++ b/core/src/test/kotlin/io/specmatic/test/ResponseMonitorTest.kt
@@ -81,7 +81,7 @@ class ResponseMonitorTest {
         assertThat(result.failure.reportString()).isEqualToNormalizingWhitespace("""
         In scenario ""
         API: POST / -> 202
-        >> RESPONSE.HEADERS.Link
+        >> RESPONSE.HEADER.Link
         Expected header named "Link" was missing
         """.trimIndent())
     }

--- a/core/src/test/resources/openapi/partial_example_tests/simple_dictionary.json
+++ b/core/src/test/resources/openapi/partial_example_tests/simple_dictionary.json
@@ -1,11 +1,13 @@
 {
+  "PARAMETERS": {
+    "HEADER": {
+      "CREATOR-ID": 123,
+      "PET-ID": 999
+    }
+  },
   "PATH-PARAMS": {
     "creatorId": 123,
     "petId": 999
-  },
-  "HEADERS": {
-    "CREATOR-ID": 123,
-    "PET-ID": 999
   },
   "QUERY-PARAMS": {
     "creatorId": 123,

--- a/core/src/test/resources/openapi/partial_example_tests/simple_dictionary.json
+++ b/core/src/test/resources/openapi/partial_example_tests/simple_dictionary.json
@@ -1,5 +1,9 @@
 {
   "PARAMETERS": {
+    "PATH": {
+      "creatorId": 123,
+      "petId": 999
+    },
     "HEADER": {
       "CREATOR-ID": 123,
       "PET-ID": 999
@@ -8,10 +12,6 @@
       "creatorId": 123,
       "petId": 999
     }
-  },
-  "PATH-PARAMS": {
-    "creatorId": 123,
-    "petId": 999
   },
   "NewPet": {
     "creatorId": 123,

--- a/core/src/test/resources/openapi/partial_example_tests/simple_dictionary.json
+++ b/core/src/test/resources/openapi/partial_example_tests/simple_dictionary.json
@@ -3,13 +3,13 @@
     "HEADER": {
       "CREATOR-ID": 123,
       "PET-ID": 999
+    },
+    "QUERY": {
+      "creatorId": 123,
+      "petId": 999
     }
   },
   "PATH-PARAMS": {
-    "creatorId": 123,
-    "petId": 999
-  },
-  "QUERY-PARAMS": {
     "creatorId": 123,
     "petId": 999
   },

--- a/core/src/test/resources/openapi/simple_partial_non_partial_examples_with_dictionary/simple_pets_dictionary.json
+++ b/core/src/test/resources/openapi/simple_partial_non_partial_examples_with_dictionary/simple_pets_dictionary.json
@@ -1,12 +1,14 @@
 {
+  "PARAMETERS": {
+    "HEADER": {
+      "CREATOR-ID": "John"
+    }
+  },
   "PATH-PARAMS": {
     "id": 1
   },
   "QUERY-PARAMS": {
     "tag": "cat"
-  },
-  "HEADERS": {
-    "CREATOR-ID": "John"
   },
   "NewPet": {
     "name": "Tom",

--- a/core/src/test/resources/openapi/simple_partial_non_partial_examples_with_dictionary/simple_pets_dictionary.json
+++ b/core/src/test/resources/openapi/simple_partial_non_partial_examples_with_dictionary/simple_pets_dictionary.json
@@ -1,14 +1,14 @@
 {
   "PARAMETERS": {
+    "PATH": {
+      "id": 1
+    },
     "HEADER": {
       "CREATOR-ID": "John"
     },
     "QUERY": {
       "tag": "cat"
     }
-  },
-  "PATH-PARAMS": {
-    "id": 1
   },
   "NewPet": {
     "name": "Tom",

--- a/core/src/test/resources/openapi/simple_partial_non_partial_examples_with_dictionary/simple_pets_dictionary.json
+++ b/core/src/test/resources/openapi/simple_partial_non_partial_examples_with_dictionary/simple_pets_dictionary.json
@@ -2,13 +2,13 @@
   "PARAMETERS": {
     "HEADER": {
       "CREATOR-ID": "John"
+    },
+    "QUERY": {
+      "tag": "cat"
     }
   },
   "PATH-PARAMS": {
     "id": 1
-  },
-  "QUERY-PARAMS": {
-    "tag": "cat"
   },
   "NewPet": {
     "name": "Tom",

--- a/core/src/test/resources/openapi/spec_with_dictionary_and_query_params/spec_dictionary.json
+++ b/core/src/test/resources/openapi/spec_with_dictionary_and_query_params/spec_dictionary.json
@@ -1,6 +1,8 @@
 {
-  "QUERY-PARAMS": {
-    "name": "input123"
+  "PARAMETERS": {
+    "QUERY": {
+      "name": "input123"
+    }
   },
   "OutputData": {
     "data": "output123"

--- a/core/src/test/resources/openapi/spec_with_dictionary_and_request_headers/spec_dictionary.json
+++ b/core/src/test/resources/openapi/spec_with_dictionary_and_request_headers/spec_dictionary.json
@@ -1,6 +1,8 @@
 {
-  "HEADERS": {
-    "X-LoginID": "abc123"
+  "PARAMETERS": {
+    "HEADER": {
+      "X-LoginID": "abc123"
+    }
   },
   "OutputData": {
     "data": "output123"

--- a/core/src/test/resources/openapi/spec_with_dictionary_and_response_headers/spec_dictionary.json
+++ b/core/src/test/resources/openapi/spec_with_dictionary_and_response_headers/spec_dictionary.json
@@ -1,5 +1,7 @@
 {
-  "HEADERS": {
-    "X-Trace-ID": "trace123"
+  "RESPONSE": {
+    "HEADER": {
+      "X-Trace-ID": "trace123"
+    }
   }
 }

--- a/core/src/test/resources/openapi/spec_with_multi_value_dict/api_dictionary.yaml
+++ b/core/src/test/resources/openapi/spec_with_multi_value_dict/api_dictionary.yaml
@@ -6,13 +6,14 @@ PATH-PARAMS:
     - 123
     - 456
 
-HEADERS:
-  CREATOR-ID:
-    - 123
-    - 456
-  PET-ID:
-    - 123
-    - 456
+PARAMETERS:
+  HEADER:
+    CREATOR-ID:
+      - 123
+      - 456
+    PET-ID:
+      - 123
+      - 456
 
 QUERY-PARAMS:
   creatorId:

--- a/core/src/test/resources/openapi/spec_with_multi_value_dict/api_dictionary.yaml
+++ b/core/src/test/resources/openapi/spec_with_multi_value_dict/api_dictionary.yaml
@@ -1,12 +1,12 @@
-PATH-PARAMS:
-  creatorId:
-    - 123
-    - 456
-  petId:
-    - 123
-    - 456
-
 PARAMETERS:
+  PATH:
+    creatorId:
+      - 123
+      - 456
+    petId:
+      - 123
+      - 456
+
   HEADER:
     CREATOR-ID:
       - 123

--- a/core/src/test/resources/openapi/spec_with_multi_value_dict/api_dictionary.yaml
+++ b/core/src/test/resources/openapi/spec_with_multi_value_dict/api_dictionary.yaml
@@ -15,13 +15,13 @@ PARAMETERS:
       - 123
       - 456
 
-QUERY-PARAMS:
-  creatorId:
-    - 123
-    - 456
-  petId:
-    - 123
-    - 456
+  QUERY:
+    creatorId:
+      - 123
+      - 456
+    petId:
+      - 123
+      - 456
 
 NewPet:
   creatorId:

--- a/core/src/test/resources/openapi/substitutions/dictionary.json
+++ b/core/src/test/resources/openapi/substitutions/dictionary.json
@@ -5,8 +5,10 @@
       "X-Data-Token": "pqr"
     }
   },
-  "QUERY-PARAMS": {
-    "id": 10
+  "PARAMETERS": {
+    "QUERY": {
+      "id": 10
+    }
   },
   "*": {
     "id": 10,

--- a/core/src/test/resources/openapi/substitutions/dictionary.json
+++ b/core/src/test/resources/openapi/substitutions/dictionary.json
@@ -1,10 +1,12 @@
 {
+  "RESPONSE": {
+    "HEADER": {
+      "X-Region": "Asia",
+      "X-Data-Token": "pqr"
+    }
+  },
   "QUERY-PARAMS": {
     "id": 10
-  },
-  "HEADERS": {
-    "X-Region": "Asia",
-    "X-Data-Token": "pqr"
   },
   "*": {
     "id": 10,


### PR DESCRIPTION
**What**: Update breadCrumbs and dictionary paths for parameters

**Why**: Rather than utilizing arbitrary breadcrumbs and dictionary paths like `QUERY-PARAMS`, replicate the structure of the OpenAPI specification
- Rename `QUERY-PARAMS` to `PARAMETERS.QUERY`
- Rename `PATH-PARAMS` to `PARAMETERS.PATH`
- Rename `HEADERS` to `PARAMETERS.HEADER` for requests and `RESPONSE.HEADER` for responses
- Updated the `BreadCrumb`  in the Failures and modified the dictionary lookup paths for all parameters

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)