### PR TITLE
fix(filter): improve handling of empty filters

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/filters/ExpressionStandardizer.kt
+++ b/core/src/main/kotlin/io/specmatic/core/filters/ExpressionStandardizer.kt
@@ -110,6 +110,9 @@ class ExpressionStandardizer {
 
     companion object {
         fun filterToEvalEx(filterExpression: String): Expression {
+            if (filterExpression.isBlank()) {
+                return Expression("true", ExpressionConfiguration.builder().build())
+            }
             val expressionStandardizer = ExpressionStandardizer()
             val evalExExpression = expressionStandardizer.tokenizeExpression(filterExpression)
             val functions = mapOf(

--- a/core/src/test/kotlin/io/specmatic/core/filters/ExpressionStandardizerTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/filters/ExpressionStandardizerTest.kt
@@ -2,11 +2,20 @@ package io.specmatic.core.filters
 
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatCode
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 
 class ExpressionStandardizerTest {
+
+
+    @Test
+    fun `filterToEvalx should return empty string for empty filter`() {
+        assertThat(ExpressionStandardizer.filterToEvalEx("").evaluate().booleanValue).isTrue
+        assertThat(ExpressionStandardizer.filterToEvalEx("\t").evaluate().booleanValue).isTrue
+        assertThat(ExpressionStandardizer.filterToEvalEx(" \r\n   \t").evaluate().booleanValue).isTrue
+    }
 
     @ParameterizedTest
     @MethodSource("validExpressionsProvider")
@@ -24,6 +33,7 @@ class ExpressionStandardizerTest {
         @JvmStatic
         private fun validExpressionsProvider(): List<Arguments> {
             return listOf(
+                Arguments.of("", ""),
                 Arguments.of("FOO='bar'", "includes('FOO', 'bar')"),
                 Arguments.of("FOO = 'one,two'", "includes('FOO', 'one', 'two')"),
                 Arguments.of("FOO = 'one, two, three'", "includes('FOO', 'one', 'two', 'three')"),


### PR DESCRIPTION
An empty filter is now evaluated to `true` to imply that it matches
everything
