### PR TITLE
Update Parameter assertions to utilize the new parameter paths

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/BreadCrumbs.kt
+++ b/core/src/main/kotlin/io/specmatic/core/BreadCrumbs.kt
@@ -8,6 +8,7 @@ value class BreadCrumb(val value: String) {
     companion object {
         val REQUEST = BreadCrumb("REQUEST")
         val RESPONSE = BreadCrumb("RESPONSE")
+        val BODY = BreadCrumb("BODY")
         val PATH = BreadCrumb("PATH")
         val HEADER = BreadCrumb("HEADER")
         val QUERY = BreadCrumb("QUERY")

--- a/core/src/main/kotlin/io/specmatic/test/ContractTest.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ContractTest.kt
@@ -11,7 +11,7 @@ interface ResponseValidator {
         return null
     }
 
-    fun postValidate(scenario: Scenario, httpRequest: HttpRequest, httpResponse: HttpResponse): Result? {
+    fun postValidate(scenario: Scenario, originalScenario: Scenario, httpRequest: HttpRequest, httpResponse: HttpResponse): Result? {
         return null
     }
 }

--- a/core/src/main/kotlin/io/specmatic/test/ExamplePostValidator.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ExamplePostValidator.kt
@@ -1,19 +1,19 @@
 package io.specmatic.test
 
 import io.specmatic.core.*
+import io.specmatic.core.pattern.Pattern
 import io.specmatic.core.pattern.Row
 import io.specmatic.core.value.*
 import io.specmatic.test.asserts.Assert
 import io.specmatic.test.asserts.parsedAssert
 
 object ExamplePostValidator: ResponseValidator {
-
-    override fun postValidate(scenario: Scenario, httpRequest: HttpRequest, httpResponse: HttpResponse): Result? {
+    override fun postValidate(scenario: Scenario, originalScenario: Scenario, httpRequest: HttpRequest, httpResponse: HttpResponse): Result? {
         if (scenario.isNegative) return null
-        val asserts  = scenario.exampleRow?.toAsserts(scenario)?.takeIf { it.isNotEmpty() } ?: return null
+        val asserts = scenario.exampleRow?.toAsserts(scenario.resolver)?.takeIf(List<*>::isNotEmpty) ?: return null
 
-        val actualFactStore = httpRequest.toFactStore(scenario) + ExampleProcessor.getFactStore()
-        val currentFactStore = httpResponse.toFactStore()
+        val actualFactStore = httpRequest.toFactStore(originalScenario) + ExampleProcessor.getFactStore()
+        val currentFactStore = httpResponse.toFactStore(originalScenario)
 
         val results = asserts.map { it.assert(currentFactStore, actualFactStore) }
 
@@ -21,41 +21,86 @@ object ExamplePostValidator: ResponseValidator {
         return Result.fromFailures(finalResults)
     }
 
-    private fun Row.toAsserts(scenario: Scenario): List<Assert> {
+    private fun Row.toAsserts(resolver: Resolver): List<Assert> {
         val responseExampleBody = this.responseExampleForAssertion ?: return emptyList()
 
+        val responseHeaderPrefix = BreadCrumb.RESPONSE.plus(BreadCrumb.HEADER).value
         val headerAsserts = responseExampleBody.headers.map {
-            parsedAssert("RESPONSE.HEADERS", it.key, StringValue(it.value), scenario.resolver)
+            parsedAssert(responseHeaderPrefix, it.key, StringValue(it.value), resolver)
         }.filterNotNull()
 
+        val responseBodyPrefix = BreadCrumb.RESPONSE.plus(BreadCrumb.BODY).value
         return responseExampleBody.body.traverse(
-            onScalar = { value, key -> mapOf(key to parsedAssert("RESPONSE.BODY", key, value, scenario.resolver)) },
-            onAssert = { value, key -> mapOf(key to parsedAssert("RESPONSE.BODY", key, value, scenario.resolver)) }
+            onScalar = { value, key -> mapOf(key to parsedAssert(responseBodyPrefix, key, value, resolver)) },
+            onAssert = { value, key -> mapOf(key to parsedAssert(responseBodyPrefix, key, value, resolver)) }
         ).values.filterNotNull() + headerAsserts
     }
 
     private fun HttpRequest.toFactStore(scenario: Scenario): Map<String, Value> {
-        val pathParams = if(scenario.httpRequestPattern.httpPathPattern != null && this.path != null) {
-            scenario.httpRequestPattern.httpPathPattern.extractPathParams(this.path, scenario.resolver).toFactStore("REQUEST.PATH-PARAMS")
+        val pathParams = if (scenario.httpRequestPattern.httpPathPattern != null && this.path != null) {
+            val paramsMap = scenario.httpRequestPattern.httpPathPattern.extractPathParams(this.path, scenario.resolver)
+            val patternMap = scenario.httpRequestPattern.httpPathPattern.pathParameters().associate { it.key.orEmpty() to it.pattern }
+            paramsMap.toFactStore(
+                prefix = BreadCrumb.REQUEST.plus(BreadCrumb.PARAM_PATH).value,
+                patternMap = patternMap,
+                resolver = scenario.resolver,
+            )
         } else emptyMap()
 
-        val queryParams = queryParams.asMap().toFactStore("REQUEST.QUERY-PARAMS")
-        val headers = headers.toFactStore("REQUEST.HEADERS")
+        val queryParams = queryParams.asValueMap().mapValues { it.value.toStringLiteral() }.toFactStore(
+            prefix = BreadCrumb.REQUEST.plus(BreadCrumb.PARAM_QUERY).value,
+            patternMap = scenario.httpRequestPattern.httpQueryParamPattern.queryPatterns,
+            resolver = scenario.resolver,
+        )
 
-        return body.traverse(
-            prefix = "REQUEST.BODY", onScalar = ::toFactEntry, onComposite = ::toFactEntry
-        ) + pathParams + queryParams + headers + mapOf("REQUEST" to this.toJSON())
+        val headers = headers.toFactStore(
+            prefix = BreadCrumb.REQUEST.plus(BreadCrumb.PARAM_HEADER).value,
+            patternMap = scenario.httpRequestPattern.headersPattern.pattern,
+            resolver = scenario.resolver,
+        )
+
+        val body = body.traverse(
+            prefix = BreadCrumb.REQUEST.plus(BreadCrumb.BODY).value, onScalar = ::toFactEntry, onComposite = ::toFactEntry
+        )
+
+        return buildMap {
+            this.putAll(pathParams)
+            this.putAll(queryParams)
+            this.putAll(headers)
+            this.putAll(body)
+            // Empty entries to satisfy dynamic path creation
+            this[BreadCrumb.PARAMETERS.value] = JSONObjectValue()
+            this[BreadCrumb.REQUEST.value] = JSONObjectValue()
+        }
     }
 
-    private fun HttpResponse.toFactStore(): Map<String, Value> {
-        val headers = headers.toFactStore("RESPONSE.HEADERS")
+    private fun HttpResponse.toFactStore(scenario: Scenario): Map<String, Value> {
+        val headers = headers.toFactStore(
+            prefix = BreadCrumb.RESPONSE.plus(BreadCrumb.PARAM_HEADER).value,
+            patternMap = scenario.httpResponsePattern.headersPattern.pattern,
+            resolver = scenario.resolver
+        )
 
-        return body.traverse(
-            prefix = "RESPONSE.BODY", onScalar = ::toFactEntry, onComposite = ::toFactEntry
-        ) + headers + mapOf("RESPONSE" to this.toJSON())
+        val body = body.traverse(
+            prefix = BreadCrumb.RESPONSE.plus(BreadCrumb.BODY).value, onScalar = ::toFactEntry, onComposite = ::toFactEntry
+        )
+
+        return buildMap {
+            this.putAll(headers)
+            this.putAll(body)
+            // Empty entries to satisfy dynamic path creation
+            this[BreadCrumb.RESPONSE.value] = JSONObjectValue()
+        }
     }
 
-    private fun Map<String, String>.toFactStore(prefix: String) = mapKeys { "$prefix.${it.key}" }.mapValues { StringValue(it.value) }
+    private fun Map<String, String>.toFactStore(prefix: String, patternMap: Map<String, Pattern>, resolver: Resolver): Map<String, Value> {
+        return mapValues {
+            runCatching {
+                val pattern = patternMap[it.key] ?: patternMap["${it.key}?"] ?: return@runCatching StringValue(it.value)
+                pattern.parse(it.value, resolver)
+            }.getOrDefault(StringValue(it.value))
+        }.mapKeys { "$prefix.${it.key}" }
+    }
 
     private fun toFactEntry(value: Value, prefix: String): Map<String, Value> = mapOf(prefix to value)
 }

--- a/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
@@ -142,7 +142,7 @@ data class ScenarioAsTest(
             }
 
             val result = validators.asSequence().mapNotNull {
-                it.postValidate(testScenario, request, responseToCheckAndStore)
+                it.postValidate(testScenario, originalScenario, request, responseToCheckAndStore)
             }.firstOrNull() ?: Result.Success()
 
             testScenario.exampleRow?.let { ExampleProcessor.store(it, request, responseToCheckAndStore) }

--- a/core/src/test/resources/openapi/partial_example_tests/assert_example/pets_post.json
+++ b/core/src/test/resources/openapi/partial_example_tests/assert_example/pets_post.json
@@ -1,0 +1,32 @@
+{
+  "http-request": {
+    "path": "/creators/123/pets/456",
+    "method": "PATCH",
+    "query": {
+      "creatorId": "123",
+      "petId": "456"
+    },
+    "headers": {
+      "CREATOR-ID": "123",
+      "PET-ID": "456",
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "creatorId": 123,
+      "petId": 456
+    }
+  },
+  "http-response": {
+    "status": 201,
+    "body": {
+      "id": "$eq(REQUEST.PARAMETERS.PATH.creatorId)",
+      "traceId": "(string)",
+      "creatorId": "$eq(REQUEST.PARAMETERS.HEADER.CREATOR-ID)",
+      "petId": "$eq(REQUEST.PARAMETERS.QUERY.petId)"
+    },
+    "status-text": "Created",
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}


### PR DESCRIPTION
**What**:

* Update Parameter assertions to utilize the new parameter paths
* When collecting parameters into the fact store for assertion, parse the values to the correct type so that validation succeeds when the assertions are evaluated


For additional information, please refer to the following PR: https://github.com/specmatic/specmatic/pull/1862
Dependent On and Based Off: https://github.com/specmatic/specmatic/pull/1862

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link
