### PR TITLE
Restart mock only for changes to interesting file

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -50,6 +50,7 @@ dependencies {
     testImplementation("org.assertj:assertj-core:3.27.3")
     testImplementation("io.ktor:ktor-client-mock-jvm:2.3.13")
     implementation("org.thymeleaf:thymeleaf:3.1.3.RELEASE")
+    testImplementation(kotlin("test"))
 }
 
 configurations.implementation.configure {

--- a/core/src/main/kotlin/io/specmatic/core/utilities/FileSystemChanges.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/FileSystemChanges.kt
@@ -1,0 +1,37 @@
+package io.specmatic.core.utilities
+
+import io.specmatic.core.CONTRACT_EXTENSIONS
+import io.specmatic.core.EXAMPLES_DIR_SUFFIX
+import io.specmatic.core.JSON
+import java.io.File
+import java.nio.file.WatchKey
+
+class FileSystemChanges(
+    key: WatchKey,
+) {
+    private val rawEvents = key.pollEvents()
+    private val events =
+        rawEvents
+            .map {
+                it.context()?.toString().orEmpty()
+            }.filter { it.isNotBlank() }
+
+    val hasNoEvents: Boolean
+        get() = events.isEmpty()
+
+    val filesWithEvents = events.joinToString(", ")
+
+    val interestingEvents: List<String> = events.filter { event -> interesting(event) }
+
+    private fun interesting(event: String): Boolean {
+        try {
+            val file = File(event)
+            val extension = file.extension.lowercase()
+            return extension in CONTRACT_EXTENSIONS || extension == JSON || file.nameWithoutExtension.endsWith(
+                EXAMPLES_DIR_SUFFIX
+            )
+        } catch (e: Throwable) {
+            return false
+        }
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/core/utilities/FileSystemChanges.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/FileSystemChanges.kt
@@ -3,11 +3,13 @@ package io.specmatic.core.utilities
 import io.specmatic.core.CONTRACT_EXTENSIONS
 import io.specmatic.core.EXAMPLES_DIR_SUFFIX
 import io.specmatic.core.JSON
+import io.specmatic.core.log.logger
 import java.io.File
+import java.nio.file.Path
 import java.nio.file.WatchKey
 
 class FileSystemChanges(
-    key: WatchKey,
+    private val key: WatchKey,
 ) {
     private val rawEvents = key.pollEvents()
     private val events =
@@ -27,11 +29,22 @@ class FileSystemChanges(
         try {
             val file = File(event)
             val extension = file.extension.lowercase()
-            return extension in CONTRACT_EXTENSIONS || extension == JSON || file.nameWithoutExtension.endsWith(
-                EXAMPLES_DIR_SUFFIX
-            )
+
+            return extension in CONTRACT_EXTENSIONS ||
+                extension == JSON ||
+                file.nameWithoutExtension.endsWith(EXAMPLES_DIR_SUFFIX) ||
+                parentDirectoryIsExamplesDir(key.watchable() as? Path)
         } catch (e: Throwable) {
             return false
         }
+    }
+
+    private fun parentDirectoryIsExamplesDir(path: Path?): Boolean {
+        if (path == null) return false
+
+        logger.debug("Checking if $path is or is in an examples directory")
+
+        return path.toString().endsWith(EXAMPLES_DIR_SUFFIX) ||
+            path.toString().contains(EXAMPLES_DIR_SUFFIX + File.separator)
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/utilities/FileSystemChangesTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/utilities/FileSystemChangesTest.kt
@@ -1,0 +1,113 @@
+package io.specmatic.core.utilities
+
+import io.mockk.every
+import io.mockk.mockk
+import io.specmatic.core.CONTRACT_EXTENSIONS
+import io.specmatic.core.EXAMPLES_DIR_SUFFIX
+import io.specmatic.core.JSON
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.io.File
+import java.nio.file.Path
+import java.nio.file.WatchEvent
+import java.nio.file.WatchKey
+
+class FileSystemChangesTest {
+    private lateinit var key: WatchKey
+
+    @BeforeEach
+    fun setUp() {
+        key = mockk()
+    }
+
+    private fun eventMock(filename: String): WatchEvent<Any> {
+        val event = mockk<WatchEvent<Any>>()
+        every { event.context() } returns filename
+        return event
+    }
+
+    @Test
+    fun `hasNoEvents is true when there are no events`() {
+        every { key.pollEvents() } returns emptyList()
+        val changes = FileSystemChanges(key)
+        assertTrue(changes.hasNoEvents)
+        assertEquals("", changes.filesWithEvents)
+        assertTrue(changes.interestingEvents.isEmpty())
+    }
+
+    @Test
+    fun `filesWithEvents joins event names`() {
+        every { key.pollEvents() } returns listOf(eventMock("foo.txt"), eventMock("bar.json"))
+        val changes = FileSystemChanges(key)
+        assertEquals("foo.txt, bar.json", changes.filesWithEvents)
+    }
+
+    @Test
+    fun `interestingEvents filters for contract extension`() {
+        val contractFile = "api.${CONTRACT_EXTENSIONS.first()}"
+        every { key.pollEvents() } returns listOf(eventMock(contractFile), eventMock("readme.md"))
+        every { key.watchable() } returns null
+        val changes = FileSystemChanges(key)
+        assertEquals(listOf(contractFile), changes.interestingEvents)
+    }
+
+    @Test
+    fun `interestingEvents filters for json file`() {
+        val jsonFile = "data.$JSON"
+        every { key.pollEvents() } returns listOf(eventMock(jsonFile), eventMock("notes.txt"))
+        every { key.watchable() } returns null
+        val changes = FileSystemChanges(key)
+        assertEquals(listOf(jsonFile), changes.interestingEvents)
+    }
+
+    @Test
+    fun `interestingEvents filters for file name ending with examples dir suffix`() {
+        val examplesFile = "contract$EXAMPLES_DIR_SUFFIX"
+        every { key.pollEvents() } returns listOf(eventMock(examplesFile), eventMock("other.txt"))
+        every { key.watchable() } returns null
+        val changes = FileSystemChanges(key)
+        assertEquals(listOf(examplesFile), changes.interestingEvents)
+    }
+
+    @Test
+    fun `interestingEvents filters for parent directory ending with examples dir suffix`() {
+        val file = "foo.txt"
+        val path = mockk<Path>()
+        every { path.toString() } returns "some/path$EXAMPLES_DIR_SUFFIX"
+        every { key.pollEvents() } returns listOf(eventMock(file))
+        every { key.watchable() } returns path
+        val changes = FileSystemChanges(key)
+        assertEquals(listOf(file), changes.interestingEvents)
+    }
+
+    @Test
+    fun `interestingEvents filters for parent directory containing examples dir suffix with separator`() {
+        val file = "foo.txt"
+        val path = mockk<Path>()
+        every { path.toString() } returns "some${File.separator}spec_examples${File.separator}dir"
+        every { key.pollEvents() } returns listOf(eventMock(file))
+        every { key.watchable() } returns path
+        val changes = FileSystemChanges(key)
+        assertEquals(listOf(file), changes.interestingEvents)
+    }
+
+    @Test
+    fun `ignores blank filenames`() {
+        every { key.pollEvents() } returns listOf(eventMock(""), eventMock("   "))
+        val changes = FileSystemChanges(key)
+        assertTrue(changes.hasNoEvents)
+        assertEquals("", changes.filesWithEvents)
+        assertTrue(changes.interestingEvents.isEmpty())
+    }
+
+    @Test
+    fun `interesting handles exception gracefully`() {
+        val badEvent = mockk<WatchEvent<Any>>()
+        every { badEvent.context() } returns null
+        every { key.pollEvents() } returns listOf(badEvent)
+        val changes = FileSystemChanges(key)
+        assertTrue(changes.interestingEvents.isEmpty())
+    }
+}


### PR DESCRIPTION
**What**:

The stub will restart only when interesting files have changed.

Interesting files here refers to files whose extensions are spec file extensions (yaml, yml, etc), example file extensions (json), or directories with _examples in the name.

**Why**:

There are various circumstances in which restarting for every little change is painful (E.g. when Kafka is running in the same directory and creates kafka-logs)

**How**:

Modified the file watcher to filter out uninteresting events.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
