### PR TITLE
feat: store extensions specified in the OpenAPI schema in PossibleJsonObjectPatternContainer

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/OptionalBodyPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OptionalBodyPattern.kt
@@ -5,12 +5,17 @@ import io.specmatic.core.Resolver
 import io.specmatic.core.Result
 import io.specmatic.core.pattern.AnyPattern
 import io.specmatic.core.pattern.Pattern
+import io.specmatic.core.pattern.extractCombinedExtensions
 import io.specmatic.core.value.Value
 
 data class OptionalBodyPattern(override val pattern: AnyPattern, private val bodyPattern: Pattern) : Pattern by pattern {
     companion object {
         fun fromPattern(bodyPattern: Pattern): OptionalBodyPattern {
-            return OptionalBodyPattern(AnyPattern(listOf(bodyPattern, NoBodyPattern)), bodyPattern)
+            val anyPatternPatterns = listOf(bodyPattern, NoBodyPattern)
+            return OptionalBodyPattern(
+                AnyPattern(anyPatternPatterns, extensions = anyPatternPatterns.extractCombinedExtensions()),
+                bodyPattern
+            )
         }
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -1542,10 +1542,11 @@ data class Feature(
                         val descriptor = if (isEmptyOrNull(type1)) type2Descriptor else type1Descriptor
                         val withoutBrackets = withoutPatternDelimiters(descriptor)
                         val newPattern = withoutBrackets.removeSuffix("?").let { "($it)" }
-
-                        AnyPattern(listOf(NullPattern, type.copy(pattern = newPattern)))
+                        val patterns = listOf(NullPattern, type.copy(pattern = newPattern))
+                        AnyPattern(patterns, extensions = patterns.extractCombinedExtensions())
                     } else {
-                        AnyPattern(listOf(NullPattern, type))
+                        val patterns = listOf(NullPattern, type)
+                        AnyPattern(patterns, extensions = patterns.extractCombinedExtensions())
                     }
                 } else if (cleanedUpDescriptors.first() == cleanedUpDescriptors.second()) {
                     entry.value
@@ -2257,7 +2258,10 @@ fun parseEnum(step: StepInfo): Pair<String, Pattern> {
             }
         )
     }
-    return Pair("($enumName)", AnyPattern(exactValuePatterns))
+    return Pair(
+        "($enumName)",
+        AnyPattern(exactValuePatterns, extensions = exactValuePatterns.extractCombinedExtensions())
+    )
 }
 
 private fun scenarioInfoWithExamples(

--- a/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
@@ -8,12 +8,20 @@ import io.specmatic.core.discriminator.DiscriminatorMetadata
 import io.specmatic.core.pattern.config.NegativePatternConfiguration
 import io.specmatic.core.value.*
 
+fun List<Pattern>.extractCombinedExtensions(): Map<String, Any> {
+    return this.flatMap {
+        if (it is PossibleJsonObjectPatternContainer) it.extensions.entries
+        else emptyList()
+    }.associate { it.toPair() }
+}
+
 data class AnyPattern(
     override val pattern: List<Pattern>,
     val key: String? = null,
     override val typeAlias: String? = null,
     override val example: String? = null,
-    val discriminator: Discriminator? = null
+    val discriminator: Discriminator? = null,
+    override val extensions: Map<String, Any> = pattern.extractCombinedExtensions()
 ) : Pattern, HasDefaultExample, PossibleJsonObjectPatternContainer {
     constructor(
         pattern: List<Pattern>,
@@ -26,7 +34,7 @@ data class AnyPattern(
         discriminatorProperty,
         discriminatorValues,
         emptyMap()
-    ))
+    ), pattern.extractCombinedExtensions())
 
     data class AnyPatternMatch(val pattern: Pattern, val result: Result)
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/DeferredPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/DeferredPattern.kt
@@ -9,7 +9,8 @@ import io.specmatic.core.value.Value
 
 data class DeferredPattern(
     override val pattern: String,
-    val key: String? = null
+    val key: String? = null,
+    override val extensions: Map<String, Any> = emptyMap()
 ) : Pattern, PossibleJsonObjectPatternContainer {
 
     override fun fixValue(value: Value, resolver: Resolver): Value {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/EnumPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/EnumPattern.kt
@@ -9,7 +9,14 @@ import io.specmatic.core.value.Value
 
 private fun validEnumValues(values: List<Value>, key: String?, typeAlias: String?, example: String?, nullable: Boolean): AnyPattern {
     assertThatAllValuesHaveTheSameType(values, nullable)
-    return AnyPattern(values.map { ExactValuePattern(it) }, key, typeAlias, example)
+    val patterns = values.map { ExactValuePattern(it) }
+    return AnyPattern(
+        patterns,
+        key,
+        typeAlias,
+        example,
+        extensions = patterns.extractCombinedExtensions()
+    )
 }
 
 fun not(boolean: Boolean) = !boolean

--- a/core/src/main/kotlin/io/specmatic/core/pattern/Grammar.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/Grammar.kt
@@ -233,12 +233,13 @@ fun parsedPattern(rawContent: String, key: String? = null, typeAlias: String? = 
                     LookupRowPattern(parsedPattern(pattern, typeAlias = typeAlias), lookupKey)
                 }
 
-                isOptionalValuePattern(it) -> AnyPattern(
-                    listOf(
+                isOptionalValuePattern(it) -> {
+                    val patterns = listOf(
                         DeferredPattern("(empty)", key),
                         parsedPattern(withoutNullToken(it), typeAlias = typeAlias)
                     )
-                )
+                    AnyPattern(patterns, extensions = patterns.extractCombinedExtensions())
+                }
 
                 isRestPattern(it) -> RestPattern(parsedPattern(withoutRestToken(it), typeAlias = typeAlias))
                 isRepeatingPattern(it) -> ListPattern(parsedPattern(withoutListToken(it), typeAlias = typeAlias))

--- a/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
@@ -83,7 +83,8 @@ data class JSONObjectPattern(
     override val typeAlias: String? = null,
     val minProperties: Int? = null,
     val maxProperties: Int? = null,
-    val additionalProperties: AdditionalProperties = AdditionalProperties.NoAdditionalProperties
+    val additionalProperties: AdditionalProperties = AdditionalProperties.NoAdditionalProperties,
+    override val extensions: Map<String, Any> = emptyMap()
 ) : Pattern, PossibleJsonObjectPatternContainer {
 
     override fun fixValue(value: Value, resolver: Resolver): Value {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
@@ -9,7 +9,8 @@ const val LIST_BREAD_CRUMB = "[]"
 data class ListPattern(
     override val pattern: Pattern,
     override val typeAlias: String? = null,
-    override val example: List<String?>? = null
+    override val example: List<String?>? = null,
+    override val extensions: Map<String, Any>  = emptyMap()
 ) : Pattern, SequenceType, HasDefaultExample, PossibleJsonObjectPatternContainer {
     override val memberList: MemberList
         get() = MemberList(emptyList(), pattern)

--- a/core/src/main/kotlin/io/specmatic/core/pattern/Pattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/Pattern.kt
@@ -64,7 +64,8 @@ interface Pattern {
     fun listOf(valueList: List<Value>, resolver: Resolver): Value
 
     fun toNullable(defaultValue: String?): Pattern {
-        return AnyPattern(listOf(NullPattern, this), example = defaultValue)
+        val patterns = listOf(NullPattern, this)
+        return AnyPattern(patterns, example = defaultValue, extensions = patterns.extractCombinedExtensions())
     }
 
     fun resolveSubstitutions(substitution: Substitution, value: Value, resolver: Resolver, key: String? = null): ReturnValue<Value> {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/PossibleJsonObjectPatternContainer.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/PossibleJsonObjectPatternContainer.kt
@@ -5,4 +5,6 @@ import io.specmatic.core.Resolver
 interface PossibleJsonObjectPatternContainer {
     fun removeKeysNotPresentIn(keys: Set<String>, resolver: Resolver): Pattern
     fun jsonObjectPattern(resolver: Resolver): JSONObjectPattern?
+
+    val extensions: Map<String, Any>
 }

--- a/core/src/test/kotlin/io/specmatic/OpenAPIExtensionsTest.kt
+++ b/core/src/test/kotlin/io/specmatic/OpenAPIExtensionsTest.kt
@@ -1,0 +1,51 @@
+package io.specmatic
+
+import io.specmatic.conversions.OpenApiSpecification
+import io.specmatic.core.pattern.JSONObjectPattern
+import io.specmatic.core.pattern.resolvedHop
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class OpenAPIExtensionsTest {
+
+    @Test
+    fun `should store extensions for a JSONObjectPattern`() {
+        val specContent = """
+            openapi: 3.0.3
+            info:
+              title: Product API
+              version: 1.0.0
+            paths:
+              /product:
+                get:
+                  responses:
+                    '200':
+                      description: Product retrieved successfully
+                      content:
+                        application/json:
+                          schema:
+                            ${'$'}ref: '#/components/schemas/Product'
+            components:
+              schemas:
+                Product:
+                  type: object
+                  x-id-field: productId
+                  properties:
+                    productId:
+                      type: string
+                    price:
+                      type: number
+                    category:
+                      type: string
+        """.trimIndent()
+
+
+        val feature = OpenApiSpecification.fromYAML(specContent, "").toFeature()
+        val scenario = feature.scenarios.first { it.path == "/product" }
+
+        val responseBodyPattern = scenario.httpResponsePattern.body
+        val resolvedResponseBodyPattern = resolvedHop(responseBodyPattern, scenario.resolver) as JSONObjectPattern
+
+        assertThat(resolvedResponseBodyPattern.extensions["x-id-field"]).isEqualTo("productId")
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/TestUtilities.kt
+++ b/core/src/test/kotlin/io/specmatic/TestUtilities.kt
@@ -35,7 +35,10 @@ object Utils {
         ).readText()
 }
 
-fun optionalPattern(pattern: Pattern): AnyPattern = AnyPattern(listOf(DeferredPattern("(empty)"), pattern))
+fun optionalPattern(pattern: Pattern): AnyPattern {
+    val patterns = listOf(DeferredPattern("(empty)"), pattern)
+    return AnyPattern(patterns, extensions = patterns.extractCombinedExtensions())
+}
 
 infix fun Value.shouldMatch(pattern: Pattern) {
     val result = pattern.matches(this, Resolver())

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -10049,12 +10049,16 @@ paths:
         val additionalProperties = responseBodyPattern.additionalProperties
         assertThat(additionalProperties).isInstanceOf(AdditionalProperties.PatternConstrained::class.java)
         additionalProperties as AdditionalProperties.PatternConstrained
-        assertThat(resolvedHop(additionalProperties.pattern, scenario.resolver)).isEqualTo(AnyPattern(
-            pattern = listOf(
-                parsedPattern("{ \"property1?\": \"(string)\" }"),
-                parsedPattern("{ \"property2?\": \"(string)\" }")
-            ), typeAlias = "(ComplexSchema)"
-        ))
+
+        val patterns = listOf(
+            parsedPattern("{ \"property1?\": \"(string)\" }"),
+            parsedPattern("{ \"property2?\": \"(string)\" }")
+        )
+        assertThat(resolvedHop(additionalProperties.pattern, scenario.resolver)).isEqualTo(
+            AnyPattern(
+                pattern = patterns, typeAlias = "(ComplexSchema)", extensions = patterns.extractCombinedExtensions()
+            )
+        )
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/core/CalculatePathTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/CalculatePathTest.kt
@@ -16,7 +16,7 @@ internal class CalculatePathTest {
         val pattern = JSONObjectPattern(
             pattern = mapOf(
                 "id" to StringPattern(),
-                "data" to AnyPattern(listOf(StringPattern(), NumberPattern()))
+                "data" to AnyPattern(listOf(StringPattern(), NumberPattern()), extensions = emptyMap())
             ),
             typeAlias = "(User)"
         )
@@ -37,7 +37,7 @@ internal class CalculatePathTest {
         val pattern = JSONObjectPattern(
             pattern = mapOf(
                 "id" to StringPattern(),
-                "value" to AnyPattern(listOf(StringPattern(), NumberPattern()))
+                "value" to AnyPattern(listOf(StringPattern(), NumberPattern()), extensions = emptyMap())
             )
         )
 
@@ -55,7 +55,7 @@ internal class CalculatePathTest {
     fun `calculatePath should find AnyPattern at top level`() {
         // For this test, create a scenario and test through Scenario.calculatePath
         val httpRequestPattern = HttpRequestPattern(
-            body = AnyPattern(listOf(StringPattern(), NumberPattern()))
+            body = AnyPattern(listOf(StringPattern(), NumberPattern()), extensions = emptyMap())
         )
         val httpResponsePattern = HttpResponsePattern(
             headersPattern = HttpHeadersPattern(),
@@ -89,7 +89,7 @@ internal class CalculatePathTest {
             name = "test",
             httpRequestPattern = HttpRequestPattern(
                 body = ListPattern(
-                    pattern = AnyPattern(listOf(StringPattern(), NumberPattern()))
+                    pattern = AnyPattern(listOf(StringPattern(), NumberPattern()), extensions = emptyMap())
                 )
             ),
             httpResponsePattern = HttpResponsePattern(
@@ -136,7 +136,7 @@ internal class CalculatePathTest {
     fun `calculatePath should handle non-JSON object value`() {
         val pattern = JSONObjectPattern(
             pattern = mapOf(
-                "data" to AnyPattern(listOf(StringPattern(), NumberPattern()))
+                "data" to AnyPattern(listOf(StringPattern(), NumberPattern()), extensions = emptyMap())
             )
         )
 
@@ -149,7 +149,7 @@ internal class CalculatePathTest {
     fun `calculatePath should find nested AnyPatterns`() {
         val nestedPattern = JSONObjectPattern(
             pattern = mapOf(
-                "nestedData" to AnyPattern(listOf(StringPattern(), NumberPattern()))
+                "nestedData" to AnyPattern(listOf(StringPattern(), NumberPattern()), extensions = emptyMap())
             ),
             typeAlias = "(NestedObject)"
         )
@@ -178,8 +178,8 @@ internal class CalculatePathTest {
     fun `calculatePath should handle multiple AnyPatterns in same object`() {
         val pattern = JSONObjectPattern(
             pattern = mapOf(
-                "data1" to AnyPattern(listOf(StringPattern(), NumberPattern())),
-                "data2" to AnyPattern(listOf(StringPattern(), NumberPattern())),
+                "data1" to AnyPattern(listOf(StringPattern(), NumberPattern()), extensions = emptyMap()),
+                "data2" to AnyPattern(listOf(StringPattern(), NumberPattern()), extensions = emptyMap()),
                 "regularField" to StringPattern()
             ),
             typeAlias = "(MultiAnyObject)"
@@ -203,7 +203,7 @@ internal class CalculatePathTest {
             httpPathPattern = buildHttpPathPattern("/test"),
             body = JSONObjectPattern(
                 pattern = mapOf(
-                    "field1" to AnyPattern(listOf(StringPattern(), NumberPattern()))
+                    "field1" to AnyPattern(listOf(StringPattern(), NumberPattern()), extensions = emptyMap())
                 ),
                 typeAlias = "(Request1)"
             )
@@ -225,7 +225,7 @@ internal class CalculatePathTest {
             httpPathPattern = buildHttpPathPattern("/test"),
             body = JSONObjectPattern(
                 pattern = mapOf(
-                    "field2" to AnyPattern(listOf(StringPattern(), NumberPattern()))
+                    "field2" to AnyPattern(listOf(StringPattern(), NumberPattern()), extensions = emptyMap())
                 ),
                 typeAlias = "(Request2)"
             )
@@ -265,7 +265,7 @@ internal class CalculatePathTest {
         val pattern = JSONObjectPattern(
             pattern = mapOf(
                 "items" to ListPattern(
-                    pattern = AnyPattern(listOf(StringPattern(), NumberPattern()))
+                    pattern = AnyPattern(listOf(StringPattern(), NumberPattern()), extensions = emptyMap())
                 )
             ),
             typeAlias = "(ArrayContainer)"
@@ -292,7 +292,7 @@ internal class CalculatePathTest {
     fun `calculatePath should find nested AnyPatterns in array objects`() {
         val arrayItemPattern = JSONObjectPattern(
             pattern = mapOf(
-                "data" to AnyPattern(listOf(StringPattern(), NumberPattern()))
+                "data" to AnyPattern(listOf(StringPattern(), NumberPattern()), extensions = emptyMap())
             ),
             typeAlias = "(ArrayItem)"
         )
@@ -326,7 +326,7 @@ internal class CalculatePathTest {
         val pattern = JSONObjectPattern(
             pattern = mapOf(
                 "items" to ListPattern(
-                    pattern = AnyPattern(listOf(StringPattern(), NumberPattern()))
+                    pattern = AnyPattern(listOf(StringPattern(), NumberPattern()), extensions = emptyMap())
                 )
             ),
             typeAlias = "(ListContainer)"
@@ -352,7 +352,7 @@ internal class CalculatePathTest {
         val pattern = JSONObjectPattern(
             pattern = mapOf(
                 "items" to ListPattern(
-                    pattern = AnyPattern(listOf(StringPattern(), NumberPattern()))
+                    pattern = AnyPattern(listOf(StringPattern(), NumberPattern()), extensions = emptyMap())
                 )
             ),
             typeAlias = "(EmptyArrayContainer)"
@@ -372,7 +372,7 @@ internal class CalculatePathTest {
         val pattern = JSONObjectPattern(
             pattern = mapOf(
                 "requiredField" to StringPattern(),
-                "optionalField?" to AnyPattern(listOf(StringPattern(), NumberPattern()))
+                "optionalField?" to AnyPattern(listOf(StringPattern(), NumberPattern()), extensions = emptyMap())
             ),
             typeAlias = "(OptionalFieldObject)"
         )
@@ -406,7 +406,8 @@ internal class CalculatePathTest {
                         DeferredPattern(pattern = "(Address)"),
                         DeferredPattern(pattern = "(AddressRef)")
                     ),
-                    typeAlias = "(AddressOrRef)"
+                    typeAlias = "(AddressOrRef)",
+                    extensions = emptyMap()
                 )
             ),
             httpResponsePattern = HttpResponsePattern(
@@ -446,7 +447,8 @@ internal class CalculatePathTest {
                     pattern = listOf(
                         DeferredPattern(pattern = "(Address)"),
                         DeferredPattern(pattern = "(AddressRef)")
-                    )
+                    ),
+                    extensions = emptyMap()
                     // No typeAlias for the AnyPattern itself
                 )
             ),
@@ -484,7 +486,8 @@ internal class CalculatePathTest {
                     pattern = listOf(
                         DeferredPattern(pattern = "(Address)"),
                         JSONObjectPattern(pattern = mapOf("address_id" to NumberPattern()))
-                    )
+                    ),
+                    extensions = emptyMap()
                 )
             ),
             httpResponsePattern = HttpResponsePattern(
@@ -528,7 +531,8 @@ internal class CalculatePathTest {
                                 pattern = listOf(
                                     DeferredPattern(pattern = "(Address)"),
                                     DeferredPattern(pattern = "(AddressRef)")
-                                )
+                                ),
+                                extensions = emptyMap()
                             )
                         )
                     ),
@@ -579,7 +583,8 @@ internal class CalculatePathTest {
                         pattern = listOf(
                             DeferredPattern(pattern = "(Address)"),
                             DeferredPattern(pattern = "(AddressRef)")
-                        )
+                        ),
+                        extensions = emptyMap()
                     ),
                     typeAlias = "(AddressList)"
                 )
@@ -635,7 +640,8 @@ internal class CalculatePathTest {
                                 pattern = listOf(
                                     DeferredPattern("(Address)"),
                                     DeferredPattern("(AddressRef)")
-                                )
+                                ),
+                                extensions = emptyMap()
                             )
                         )
                     ),
@@ -687,7 +693,8 @@ internal class CalculatePathTest {
                 pattern = listOf(
                     DeferredPattern("(Address)"),
                     DeferredPattern("(AddressRef)")
-                )
+                ),
+                extensions = emptyMap()
             )
         )
         
@@ -731,7 +738,7 @@ internal class CalculatePathTest {
         // Test case 1: Nested structure with typeAlias at multiple levels
         val level3Pattern = JSONObjectPattern(
             pattern = mapOf(
-                "data" to AnyPattern(listOf(StringPattern(), NumberPattern()))
+                "data" to AnyPattern(listOf(StringPattern(), NumberPattern()), extensions = emptyMap())
             ),
             typeAlias = "(Level3Object)"
         )
@@ -768,7 +775,7 @@ internal class CalculatePathTest {
         // Test case 1: Nested structure with typeAlias at multiple levels
         val level3Pattern = JSONObjectPattern(
             pattern = mapOf(
-                "keyAppears" to AnyPattern(listOf(StringPattern(), NumberPattern())),
+                "keyAppears" to AnyPattern(listOf(StringPattern(), NumberPattern()), extensions = emptyMap()),
                 "keyDoesNotAppear" to StringPattern()
             ),
             typeAlias = "(Level3Object)"
@@ -819,10 +826,12 @@ internal class CalculatePathTest {
         
         val pattern = JSONObjectPattern(
             pattern = mapOf(
-                "field" to AnyPattern(listOf(
-                    innerObjectPattern,
-                    StringPattern()
-                ))
+                "field" to AnyPattern(
+                    listOf(
+                        innerObjectPattern,
+                        StringPattern()
+                    ), extensions = emptyMap()
+                )
             ),
             typeAlias = "(OuterObject)"
         )
@@ -853,10 +862,12 @@ internal class CalculatePathTest {
             pattern = mapOf(
                 "level1" to JSONObjectPattern(
                     pattern = mapOf(
-                        "level2" to AnyPattern(listOf(
-                            DeferredPattern("(NestedData)"),
-                            NumberPattern()
-                        ))
+                        "level2" to AnyPattern(
+                            listOf(
+                                DeferredPattern("(NestedData)"),
+                                NumberPattern()
+                            ), extensions = emptyMap()
+                        )
                     ),
                     typeAlias = "(MiddleLevel)"
                 )
@@ -886,7 +897,10 @@ internal class CalculatePathTest {
                     pattern = mapOf(
                         "level2" to JSONObjectPattern(
                             pattern = mapOf(
-                                "level3" to AnyPattern(listOf(StringPattern(), NumberPattern()))
+                                "level3" to AnyPattern(
+                                    listOf(StringPattern(), NumberPattern()),
+                                    extensions = emptyMap()
+                                )
                             )
                         )
                     )
@@ -913,17 +927,19 @@ internal class CalculatePathTest {
         // This tests whether we can properly find nested AnyPatterns inside matched JSONObjectPatterns
         val nestedObjectWithAnyPattern = JSONObjectPattern(
             pattern = mapOf(
-                "nestedField" to AnyPattern(listOf(StringPattern(), NumberPattern()))
+                "nestedField" to AnyPattern(listOf(StringPattern(), NumberPattern()), extensions = emptyMap())
             ),
             typeAlias = "(NestedObjectWithAny)"
         )
         
         val pattern = JSONObjectPattern(
             pattern = mapOf(
-                "container" to AnyPattern(listOf(
-                    nestedObjectWithAnyPattern,
-                    StringPattern()
-                ))
+                "container" to AnyPattern(
+                    listOf(
+                        nestedObjectWithAnyPattern,
+                        StringPattern()
+                    ), extensions = emptyMap()
+                )
             ),
             typeAlias = "(Container)"
         )
@@ -950,7 +966,10 @@ internal class CalculatePathTest {
                     pattern = mapOf(
                         "level2" to JSONObjectPattern(
                             pattern = mapOf(
-                                "level3" to AnyPattern(listOf(StringPattern(), NumberPattern()))
+                                "level3" to AnyPattern(
+                                    listOf(StringPattern(), NumberPattern()),
+                                    extensions = emptyMap()
+                                )
                             )
                         )
                     )

--- a/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
@@ -1490,7 +1490,7 @@ paths:
             assertThat(it).contains("-> 4xx")
         }
 
-        negativeTestScenarios.zip((1..negativeTestScenarios.size).toList()).forEach { (scenario, index) ->
+        negativeTestScenarios.zip((1..negativeTestScenarios.size).toList()).forEach { (scenario, _) ->
             assertThat(scenario.testDescription()).contains("4xx [REQUEST.BODY.name string mutated to")
         }
     }
@@ -2999,7 +2999,7 @@ paths:
                     method = "POST",
                     httpPathPattern = buildHttpPathPattern("/test"),
                     body = JSONObjectPattern(
-                        mapOf("field1" to AnyPattern(listOf(StringPattern()))),
+                        mapOf("field1" to AnyPattern(listOf(StringPattern()), extensions = emptyMap())),
                         typeAlias = "(Request1)"
                     )
                 ),
@@ -3015,7 +3015,7 @@ paths:
                     method = "POST",
                     httpPathPattern = buildHttpPathPattern("/test"),
                     body = JSONObjectPattern(
-                        mapOf("field2" to AnyPattern(listOf(NumberPattern()))),
+                        mapOf("field2" to AnyPattern(listOf(NumberPattern()), extensions = emptyMap())),
                         typeAlias = "(Request2)"
                     )
                 ),
@@ -3045,7 +3045,7 @@ paths:
                     method = "POST",
                     httpPathPattern = buildHttpPathPattern("/test/(id:number)"),
                     body = JSONObjectPattern(
-                        mapOf("data" to AnyPattern(listOf(StringPattern()))),
+                        mapOf("data" to AnyPattern(listOf(StringPattern()), extensions = emptyMap())),
                         typeAlias = "(BadRequest)"
                     )
                 ),
@@ -3092,7 +3092,7 @@ paths:
                     body = JSONObjectPattern(
                         mapOf(
                             "type" to ExactValuePattern(StringValue("type2")),
-                            "data" to AnyPattern(listOf(StringPattern()))
+                            "data" to AnyPattern(listOf(StringPattern()), extensions = emptyMap())
                         ),
                         typeAlias = "(Type2Request)"
                     )

--- a/core/src/test/kotlin/io/specmatic/core/HttpRequestPatternKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpRequestPatternKtTest.kt
@@ -13,7 +13,7 @@ internal class HttpRequestPatternKtTest {
     fun `when generating new content part types with two value options there should be two types generated`() {
         val multiPartTypes = listOf(MultiPartContentPattern(
             "data",
-            AnyPattern(listOf(StringPattern(), NumberPattern())),
+            AnyPattern(listOf(StringPattern(), NumberPattern()), extensions = emptyMap()),
         ))
 
         val newTypes = newMultiPartBasedOn(multiPartTypes, Row(), Resolver()).toList()

--- a/core/src/test/kotlin/io/specmatic/core/HttpResponsePatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpResponsePatternTest.kt
@@ -17,8 +17,23 @@ internal class HttpResponsePatternTest {
 
     @Test
     fun `it should encompass another smaller response pattern`() {
-        val bigger = HttpResponsePattern(status = 200, headersPattern = HttpHeadersPattern(mapOf("X-Required" to StringPattern())), body = toTabularPattern(mapOf("data" to AnyPattern(listOf(StringPattern(), NullPattern)))))
-        val smaller = HttpResponsePattern(status = 200, headersPattern = HttpHeadersPattern(mapOf("X-Required" to StringPattern(), "X-Extra" to StringPattern())), body = toTabularPattern(mapOf("data" to StringPattern())))
+        val bigger = HttpResponsePattern(
+            status = 200,
+            headersPattern = HttpHeadersPattern(mapOf("X-Required" to StringPattern())),
+            body = toTabularPattern(
+                mapOf(
+                    "data" to AnyPattern(
+                        listOf(StringPattern(), NullPattern),
+                        extensions = emptyMap()
+                    )
+                )
+            )
+        )
+        val smaller = HttpResponsePattern(
+            status = 200,
+            headersPattern = HttpHeadersPattern(mapOf("X-Required" to StringPattern(), "X-Extra" to StringPattern())),
+            body = toTabularPattern(mapOf("data" to StringPattern()))
+        )
         assertThat(bigger.encompasses(smaller, Resolver(), Resolver())).isInstanceOf(Result.Success::class.java)
     }
 

--- a/core/src/test/kotlin/io/specmatic/core/ScenarioTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ScenarioTest.kt
@@ -671,7 +671,7 @@ class ScenarioTest {
                 name = "test",
                 httpRequestPattern = HttpRequestPattern(
                     body = JSONObjectPattern(
-                        mapOf("data" to AnyPattern(listOf(StringPattern()))),
+                        mapOf("data" to AnyPattern(listOf(StringPattern()), extensions = emptyMap())),
                         typeAlias = "(TestRequest)"
                     )
                 ),
@@ -697,7 +697,7 @@ class ScenarioTest {
             val scenario = Scenario(
                 name = "test",
                 httpRequestPattern = HttpRequestPattern(
-                    body = AnyPattern(listOf(StringPattern(), NumberPattern()))
+                    body = AnyPattern(listOf(StringPattern(), NumberPattern()), extensions = emptyMap())
                 ),
                 httpResponsePattern = HttpResponsePattern(
                     headersPattern = HttpHeadersPattern(),
@@ -725,7 +725,7 @@ class ScenarioTest {
             val scenario = Scenario(
                 name = "test",
                 httpRequestPattern = HttpRequestPattern(
-                    body = AnyPattern(listOf(objectPattern))
+                    body = AnyPattern(listOf(objectPattern), extensions = emptyMap())
                 ),
                 httpResponsePattern = HttpResponsePattern(
                     headersPattern = HttpHeadersPattern(),
@@ -749,7 +749,7 @@ class ScenarioTest {
             val scenario = Scenario(
                 name = "test",
                 httpRequestPattern = HttpRequestPattern(
-                    body = ListPattern(AnyPattern(listOf(StringPattern(), NumberPattern())))
+                    body = ListPattern(AnyPattern(listOf(StringPattern(), NumberPattern()), extensions = emptyMap()))
                 ),
                 httpResponsePattern = HttpResponsePattern(
                     headersPattern = HttpHeadersPattern(),
@@ -773,7 +773,7 @@ class ScenarioTest {
             val scenario = Scenario(
                 name = "test",
                 httpRequestPattern = HttpRequestPattern(
-                    body = JSONArrayPattern(listOf(AnyPattern(listOf(StringPattern()))))
+                    body = JSONArrayPattern(listOf(AnyPattern(listOf(StringPattern()), extensions = emptyMap())))
                 ),
                 httpResponsePattern = HttpResponsePattern(
                     headersPattern = HttpHeadersPattern(),
@@ -824,7 +824,12 @@ class ScenarioTest {
                 mapOf(
                     "items" to ListPattern(
                         JSONObjectPattern(
-                            mapOf("value" to AnyPattern(listOf(StringPattern(), NumberPattern()))),
+                            mapOf(
+                                "value" to AnyPattern(
+                                    listOf(StringPattern(), NumberPattern()),
+                                    extensions = emptyMap()
+                                )
+                            ),
                             typeAlias = "(Item)"
                         )
                     )
@@ -863,7 +868,7 @@ class ScenarioTest {
         fun `calculatePath should handle DeferredPattern in resolver`() {
             val patterns = mapOf(
                 "(CustomType)" to JSONObjectPattern(
-                    mapOf("data" to AnyPattern(listOf(StringPattern()))),
+                    mapOf("data" to AnyPattern(listOf(StringPattern()), extensions = emptyMap())),
                     typeAlias = "(CustomType)"
                 )
             )

--- a/core/src/test/kotlin/io/specmatic/core/pattern/JSONArrayPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/JSONArrayPatternTest.kt
@@ -382,7 +382,7 @@ paths:
 
         @Test
         fun `calculatePath should return empty set for empty array`() {
-            val pattern = JSONArrayPattern(listOf(AnyPattern(listOf(StringPattern()))))
+            val pattern = JSONArrayPattern(listOf(AnyPattern(listOf(StringPattern()), extensions = emptyMap())))
             val value = JSONArrayValue(emptyList())
             val resolver = Resolver()
 
@@ -393,7 +393,7 @@ paths:
 
         @Test
         fun `calculatePath should handle single pattern with AnyPattern`() {
-            val pattern = JSONArrayPattern(listOf(AnyPattern(listOf(StringPattern(), NumberPattern()))))
+            val pattern = JSONArrayPattern(listOf(AnyPattern(listOf(StringPattern(), NumberPattern()), extensions = emptyMap())))
             val value = JSONArrayValue(listOf(StringValue("test"), NumberValue(42)))
             val resolver = Resolver()
 
@@ -405,7 +405,7 @@ paths:
         @Test
         fun `calculatePath should handle single pattern with JSONObjectPattern`() {
             val objectPattern = JSONObjectPattern(
-                mapOf("data" to AnyPattern(listOf(StringPattern()))),
+                mapOf("data" to AnyPattern(listOf(StringPattern()), extensions = emptyMap())),
                 typeAlias = "(Item)"
             )
             val pattern = JSONArrayPattern(listOf(objectPattern))
@@ -426,9 +426,9 @@ paths:
         @Test
         fun `calculatePath should handle multiple patterns with different types`() {
             val pattern = JSONArrayPattern(listOf(
-                AnyPattern(listOf(StringPattern())),
-                AnyPattern(listOf(NumberPattern())),
-                AnyPattern(listOf(BooleanPattern()))
+                AnyPattern(listOf(StringPattern()), extensions = emptyMap()),
+                AnyPattern(listOf(NumberPattern()), extensions = emptyMap()),
+                AnyPattern(listOf(BooleanPattern()), extensions = emptyMap())
             ))
             val value = JSONArrayValue(listOf(
                 StringValue("test"),
@@ -444,7 +444,7 @@ paths:
 
         @Test
         fun `calculatePath should handle array with more elements than patterns`() {
-            val pattern = JSONArrayPattern(listOf(AnyPattern(listOf(StringPattern()))))
+            val pattern = JSONArrayPattern(listOf(AnyPattern(listOf(StringPattern()), extensions = emptyMap())))
             val value = JSONArrayValue(listOf(
                 StringValue("item1"),
                 StringValue("item2"),
@@ -460,9 +460,9 @@ paths:
         @Test
         fun `calculatePath should handle multiple patterns with some elements missing`() {
             val pattern = JSONArrayPattern(listOf(
-                AnyPattern(listOf(StringPattern())),
-                AnyPattern(listOf(NumberPattern())),
-                AnyPattern(listOf(BooleanPattern()))
+                AnyPattern(listOf(StringPattern()), extensions = emptyMap()),
+                AnyPattern(listOf(NumberPattern()), extensions = emptyMap()),
+                AnyPattern(listOf(BooleanPattern()), extensions = emptyMap())
             ))
             val value = JSONArrayValue(listOf(
                 StringValue("test"),
@@ -481,7 +481,7 @@ paths:
             val nestedObjectPattern = JSONObjectPattern(
                 mapOf(
                     "id" to StringPattern(),
-                    "value" to AnyPattern(listOf(StringPattern(), NumberPattern()))
+                    "value" to AnyPattern(listOf(StringPattern(), NumberPattern()), extensions = emptyMap())
                 ),
                 typeAlias = "(NestedItem)"
             )
@@ -502,7 +502,8 @@ paths:
 
         @Test
         fun `calculatePath should wrap scalar types in braces`() {
-            val pattern = JSONArrayPattern(listOf(AnyPattern(listOf(StringPattern(), NumberPattern()))))
+            val pattern =
+                JSONArrayPattern(listOf(AnyPattern(listOf(StringPattern(), NumberPattern()), extensions = emptyMap())))
             val value = JSONArrayValue(listOf(StringValue("test")))
             val resolver = Resolver()
 

--- a/core/src/test/kotlin/io/specmatic/core/pattern/JSONObjectPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/JSONObjectPatternTest.kt
@@ -461,7 +461,7 @@ internal class JSONObjectPatternTest {
                 newPatterns = (1..6).associate { paramIndex ->
                     "(enum${paramIndex})" to AnyPattern((0..9).map { possibleValueIndex ->
                         ExactValuePattern(StringValue("${paramIndex}${possibleValueIndex}"))
-                    }.toList())
+                    }.toList(), extensions = emptyMap())
                 }
             )
 
@@ -1780,10 +1780,12 @@ components:
         @Test
         fun `should validate against pattern when additionalProperties is PatternConstrained with complex`() {
             val additionalProperties = AdditionalProperties.PatternConstrained(
-                AnyPattern(pattern = listOf(
-                    JSONObjectPattern(mapOf("values" to StringPattern())),
-                    ListPattern(StringPattern())
-                ))
+                AnyPattern(
+                    pattern = listOf(
+                        JSONObjectPattern(mapOf("values" to StringPattern())),
+                        ListPattern(StringPattern())
+                    ), extensions = emptyMap()
+                )
             )
             val pattern = JSONObjectPattern(mapOf("name" to StringPattern()), additionalProperties = additionalProperties)
             val validValues = listOf(
@@ -2293,7 +2295,8 @@ components:
                 AnyPattern(pattern = listOf(
                     JSONObjectPattern(mapOf("values" to NumberPattern())),
                     ListPattern(NumberPattern())
-                ))
+                ), extensions = emptyMap()
+                )
             )
             val pattern = JSONObjectPattern(
                 mapOf("name" to StringPattern(), "age" to NumberPattern()),
@@ -2573,7 +2576,7 @@ components:
         @Test
         fun `calculatePath should find AnyPattern in object field`() {
             val pattern = JSONObjectPattern(
-                mapOf("data" to AnyPattern(listOf(StringPattern()))),
+                mapOf("data" to AnyPattern(listOf(StringPattern()), extensions = emptyMap())),
                 typeAlias = "(TestObject)"
             )
             val value = JSONObjectValue(mapOf("data" to StringValue("test")))
@@ -2587,7 +2590,7 @@ components:
         @Test
         fun `calculatePath should handle nested JSONObjectPattern`() {
             val nestedPattern = JSONObjectPattern(
-                mapOf("nested" to AnyPattern(listOf(NumberPattern()))),
+                mapOf("nested" to AnyPattern(listOf(NumberPattern()), extensions = emptyMap())),
                 typeAlias = "(NestedObject)"
             )
             val pattern = JSONObjectPattern(
@@ -2607,7 +2610,7 @@ components:
         @Test
         fun `calculatePath should handle array patterns`() {
             val pattern = JSONObjectPattern(
-                mapOf("items" to ListPattern(AnyPattern(listOf(StringPattern())))),
+                mapOf("items" to ListPattern(AnyPattern(listOf(StringPattern()), extensions = emptyMap()))),
                 typeAlias = "(ArrayContainer)"
             )
             val value = JSONObjectValue(mapOf(
@@ -2626,7 +2629,7 @@ components:
         @Test
         fun `calculatePath should handle JSONArrayPattern`() {
             val pattern = JSONObjectPattern(
-                mapOf("array" to JSONArrayPattern(listOf(AnyPattern(listOf(NumberPattern()))))),
+                mapOf("array" to JSONArrayPattern(listOf(AnyPattern(listOf(NumberPattern()), extensions = emptyMap())))),
                 typeAlias = "(JsonArrayContainer)"
             )
             val value = JSONObjectValue(mapOf(
@@ -2644,7 +2647,7 @@ components:
 
         @Test
         fun `calculatePath should handle object without typeAlias`() {
-            val pattern = JSONObjectPattern(mapOf("data" to AnyPattern(listOf(StringPattern()))))
+            val pattern = JSONObjectPattern(mapOf("data" to AnyPattern(listOf(StringPattern()), extensions = emptyMap())))
             val value = JSONObjectValue(mapOf("data" to StringValue("test")))
             val resolver = Resolver()
 
@@ -2657,8 +2660,8 @@ components:
         fun `calculatePath should handle multiple AnyPattern fields`() {
             val pattern = JSONObjectPattern(
                 mapOf(
-                    "field1" to AnyPattern(listOf(StringPattern())),
-                    "field2" to AnyPattern(listOf(NumberPattern())),
+                    "field1" to AnyPattern(listOf(StringPattern()), extensions = emptyMap()),
+                    "field2" to AnyPattern(listOf(NumberPattern()), extensions = emptyMap()),
                     "field3" to StringPattern()
                 ),
                 typeAlias = "(MultiFieldObject)"
@@ -2681,7 +2684,7 @@ components:
         @Test
         fun `calculatePath should handle deeply nested structures`() {
             val level3Pattern = JSONObjectPattern(
-                mapOf("level3" to AnyPattern(listOf(BooleanPattern()))),
+                mapOf("level3" to AnyPattern(listOf(BooleanPattern()), extensions = emptyMap())),
                 typeAlias = "(Level3)"
             )
             val level2Pattern = JSONObjectPattern(
@@ -2708,7 +2711,8 @@ components:
 
         @Test
         fun `calculatePath should handle empty object`() {
-            val pattern = JSONObjectPattern(mapOf("data" to AnyPattern(listOf(StringPattern()))))
+            val pattern =
+                JSONObjectPattern(mapOf("data" to AnyPattern(listOf(StringPattern()), extensions = emptyMap())))
             val value = JSONObjectValue(emptyMap())
             val resolver = Resolver()
 

--- a/core/src/test/kotlin/io/specmatic/core/pattern/ListPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/ListPatternTest.kt
@@ -95,7 +95,7 @@ internal class ListPatternTest {
 
     @Test
     fun `a list should encompass a json array with items matching the list`() {
-        val bigger = ListPattern(AnyPattern(listOf(NumberPattern(), NullPattern)))
+        val bigger = ListPattern(AnyPattern(listOf(NumberPattern(), NullPattern), extensions = emptyMap()))
         val smaller1Element = parsedPattern("""["(number)"]""")
         val smaller1ElementAndRest = parsedPattern("""["(number)", "(number...)"]""")
 
@@ -823,7 +823,7 @@ Feature: Recursive test
 
         @Test
         fun `calculatePath should return empty set for empty array`() {
-            val pattern = ListPattern(AnyPattern(listOf(StringPattern())))
+            val pattern = ListPattern(AnyPattern(listOf(StringPattern()), extensions = emptyMap()))
             val value = JSONArrayValue(emptyList())
             val resolver = Resolver()
 
@@ -834,7 +834,7 @@ Feature: Recursive test
 
         @Test
         fun `calculatePath should handle AnyPattern elements`() {
-            val pattern = ListPattern(AnyPattern(listOf(StringPattern(), NumberPattern())))
+            val pattern = ListPattern(AnyPattern(listOf(StringPattern(), NumberPattern()), extensions = emptyMap()))
             val value = JSONArrayValue(listOf(StringValue("test"), NumberValue(42), StringValue("test2")))
             val resolver = Resolver()
 
@@ -846,7 +846,7 @@ Feature: Recursive test
         @Test
         fun `calculatePath should handle JSONObjectPattern elements`() {
             val objectPattern = JSONObjectPattern(
-                mapOf("data" to AnyPattern(listOf(StringPattern()))),
+                mapOf("data" to AnyPattern(listOf(StringPattern()), extensions = emptyMap())),
                 typeAlias = "(ListItem)"
             )
             val pattern = ListPattern(objectPattern)
@@ -869,7 +869,7 @@ Feature: Recursive test
             val nestedObjectPattern = JSONObjectPattern(
                 mapOf(
                     "id" to StringPattern(),
-                    "value" to AnyPattern(listOf(StringPattern(), NumberPattern()))
+                    "value" to AnyPattern(listOf(StringPattern(), NumberPattern()), extensions = emptyMap())
                 ),
                 typeAlias = "(NestedListItem)"
             )
@@ -890,7 +890,8 @@ Feature: Recursive test
 
         @Test
         fun `calculatePath should handle patterns without typeAlias`() {
-            val objectPattern = JSONObjectPattern(mapOf("data" to AnyPattern(listOf(StringPattern()))))
+            val objectPattern =
+                JSONObjectPattern(mapOf("data" to AnyPattern(listOf(StringPattern()), extensions = emptyMap())))
             val pattern = ListPattern(objectPattern)
             val value = JSONArrayValue(listOf(
                 JSONObjectValue(mapOf("data" to StringValue("item1")))
@@ -915,7 +916,9 @@ Feature: Recursive test
 
         @Test
         fun `calculatePath should handle DeferredPattern in AnyPattern`() {
-            val pattern = ListPattern(AnyPattern(listOf(DeferredPattern("(TestType)"))))
+            val pattern = ListPattern(
+                AnyPattern(listOf(DeferredPattern("(TestType)")), extensions = emptyMap())
+            )
             val resolver = Resolver(newPatterns = mapOf("(TestType)" to StringPattern()))
             val value = JSONArrayValue(listOf(StringValue("test")))
 
@@ -926,7 +929,7 @@ Feature: Recursive test
 
         @Test
         fun `calculatePath should handle large arrays efficiently`() {
-            val pattern = ListPattern(AnyPattern(listOf(StringPattern())))
+            val pattern = ListPattern(AnyPattern(listOf(StringPattern()), extensions = emptyMap()))
             val largeArray = JSONArrayValue((1..100).map { StringValue("item$it") })
             val resolver = Resolver()
 

--- a/core/src/test/kotlin/io/specmatic/core/pattern/LookupRowPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/LookupRowPatternTest.kt
@@ -48,7 +48,7 @@ internal class LookupRowPatternTest {
 
     @Test
     fun `should be encompassed by wider non lookup type`() {
-        val anyType = AnyPattern(listOf(StringPattern(), NumberPattern()))
+        val anyType = AnyPattern(listOf(StringPattern(), NumberPattern()), extensions = emptyMap())
         val lookupRowType = LookupRowPattern(StringPattern(), "name")
         assertThat(anyType.encompasses(lookupRowType, Resolver(), Resolver())).isInstanceOf(Result.Success::class.java)
     }

--- a/core/src/test/kotlin/io/specmatic/core/pattern/StringPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/StringPatternTest.kt
@@ -174,7 +174,8 @@ internal class StringPatternTest {
                 listOf(
                     ExactValuePattern(StringValue("01")),
                     ExactValuePattern(StringValue("02"))
-                )
+                ),
+                extensions = emptyMap()
             ), Resolver(), Resolver()
         )
 
@@ -187,7 +188,8 @@ internal class StringPatternTest {
             listOf(
                 ExactValuePattern(StringValue("01")),
                 ExactValuePattern(StringValue("02"))
-            )
+            ),
+            extensions = emptyMap()
         ).encompasses(
             StringPattern(), Resolver(), Resolver()
         )


### PR DESCRIPTION
This PR stores any extensions specified in the OpenAPI schema in PossibleJsonObjectPatternContainer.
e.g. 
```yaml
    Order:
      type: object
      x-random-extension: random_value
      x-another-random-extension: another_random_value
      properties:
        orderId:
          type: string
        userId:
          type: string
        product:
          type: string
```

In this case, the pattern generated for schema "Order" will have hold of the extensions `x-random-extension` and `x-another-random-extension` in a map.
