### PR TITLE
Fix proxy recording of integers

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -1694,6 +1694,9 @@ data class Feature(
                 }
             }
             pattern is NumberPattern || (pattern is DeferredPattern && pattern.pattern == "(number)") -> NumberSchema()
+            pattern is NumberPattern || (pattern is DeferredPattern && pattern.pattern == "(integer)") -> IntegerSchema().apply {
+                format = null
+            }
             pattern is BooleanPattern || (pattern is DeferredPattern && pattern.pattern == "(boolean)") -> BooleanSchema()
             pattern is DateTimePattern || (pattern is DeferredPattern && pattern.pattern == "(datetime)") -> StringSchema()
             pattern is StringPattern || pattern is EmptyStringPattern || (pattern is DeferredPattern && pattern.pattern == "(string)") || (pattern is DeferredPattern && pattern.pattern == "(emptystring)") -> StringSchema()

--- a/core/src/main/kotlin/io/specmatic/core/pattern/Grammar.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/Grammar.kt
@@ -37,6 +37,7 @@ internal fun containsKey(jsonObject: Map<String, Any?>, key: String) =
 
 internal val builtInPatterns = mapOf(
     "(number)" to NumberPattern(),
+    "(integer)" to NumberPattern(),
     "(string)" to StringPattern(),
     "(email)" to EmailPattern(),
     "(boolean)" to BooleanPattern(),

--- a/core/src/main/kotlin/io/specmatic/core/value/NumberValue.kt
+++ b/core/src/main/kotlin/io/specmatic/core/value/NumberValue.kt
@@ -14,15 +14,35 @@ data class NumberValue(val number: Number) : Value, ScalarValue {
     override fun exactMatchElseType(): Pattern = ExactValuePattern(this)
     override fun type(): Pattern = NumberPattern()
 
-    override fun typeDeclarationWithKey(key: String, types: Map<String, Pattern>, exampleDeclarations: ExampleDeclarations): Pair<TypeDeclaration, ExampleDeclarations> =
-            primitiveTypeDeclarationWithKey(key, types, exampleDeclarations, displayableType(), number.toString())
+    override fun typeDeclarationWithKey(key: String, types: Map<String, Pattern>, exampleDeclarations: ExampleDeclarations): Pair<TypeDeclaration, ExampleDeclarations> {
+        val displayableType = if(number is Int || number is Long) {
+            "integer"
+        } else {
+            displayableType()
+        }
+        
+        return primitiveTypeDeclarationWithKey(key, types, exampleDeclarations, displayableType, number.toString())
+    }
 
     override fun listOf(valueList: List<Value>): Value {
         return JSONArrayValue(valueList)
     }
 
-    override fun typeDeclarationWithoutKey(exampleKey: String, types: Map<String, Pattern>, exampleDeclarations: ExampleDeclarations): Pair<TypeDeclaration, ExampleDeclarations> =
-            primitiveTypeDeclarationWithoutKey(exampleKey, types, exampleDeclarations, displayableType(), number.toString())
+    override fun typeDeclarationWithoutKey(exampleKey: String, types: Map<String, Pattern>, exampleDeclarations: ExampleDeclarations): Pair<TypeDeclaration, ExampleDeclarations> {
+        val displayableType = if(number is Int || number is Long) {
+            "integer"
+        } else {
+            displayableType()
+        }
+
+        return primitiveTypeDeclarationWithoutKey(
+            exampleKey,
+            types,
+            exampleDeclarations,
+            displayableType,
+            number.toString(),
+        )
+    }
 
     override val nativeValue: Number
         get() = number

--- a/core/src/test/kotlin/io/specmatic/core/FeatureKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FeatureKtTest.kt
@@ -397,7 +397,7 @@ class FeatureKtTest {
                     - name: id
                       in: query
                       schema:
-                        type: number
+                        type: integer
                     requestBody:
                       content:
                         application/json:
@@ -470,7 +470,7 @@ class FeatureKtTest {
     Given type Entries
       | name | (string) |
     And type Entries_
-      | id | (number) |
+      | id | (integer) |
     And type Data
       | entries | (Entries_*) |
     And type ResponseBody
@@ -520,14 +520,14 @@ class FeatureKtTest {
     Given type Entries
       | name | (string) |
     And type Entries_
-      | id | (number) |
+      | id | (integer) |
     And type Data
       | entries | (Entries_*) |
     And type RequestBody
       | entries | (Entries*) |
       | data | (Data) |
     And type ResponseBody
-      | operationId | (number) |
+      | operationId | (integer) |
     When POST /data
     And request-body (RequestBody)
     Then status 200

--- a/core/src/test/kotlin/io/specmatic/core/HttpRequestKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpRequestKtTest.kt
@@ -57,7 +57,7 @@ internal class HttpRequestKtTest {
         assertThat(clauses).hasSize(1)
 
         assertThat(clauses.first().section).isEqualTo(When)
-        assertThat(clauses.first().content).isEqualTo("GET /data?count=(number)")
+        assertThat(clauses.first().content).isEqualTo("GET /data?count=(integer)")
     }
 
     @Test
@@ -85,7 +85,7 @@ internal class HttpRequestKtTest {
         assertThat(clauses.first().content).isEqualTo("POST /data")
 
         assertThat(clauses[1].section).isEqualTo(When)
-        assertThat(clauses[1].content).isEqualTo("form-field field (number)")
+        assertThat(clauses[1].content).isEqualTo("form-field field (integer)")
     }
 
     @Test
@@ -99,7 +99,7 @@ internal class HttpRequestKtTest {
         assertThat(clauses.first().content).isEqualTo("POST /data")
 
         assertThat(clauses[1].section).isEqualTo(When)
-        assertThat(clauses[1].content).isEqualTo("request-part field (number)")
+        assertThat(clauses[1].content).isEqualTo("request-part field (integer)")
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/core/HttpResponseTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpResponseTest.kt
@@ -62,7 +62,7 @@ internal class HttpResponseTest {
         assertThat(clauses.first.first().content).isEqualTo("status 200")
 
         assertThat(clauses.first[1].section).isEqualTo(Then)
-        assertThat(clauses.first[1].content).isEqualTo("response-header X-Value (number)")
+        assertThat(clauses.first[1].content).isEqualTo("response-header X-Value (integer)")
     }
 
     @Test
@@ -86,7 +86,7 @@ internal class HttpResponseTest {
         assertThat(clauses.first.first().content).isEqualTo("status 200")
 
         assertThat(clauses.first[1].section).isEqualTo(Then)
-        assertThat(clauses.first[1].content).isEqualTo("response-body (number)")
+        assertThat(clauses.first[1].content).isEqualTo("response-body (integer)")
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/core/PostmanKtTests.kt
+++ b/core/src/test/kotlin/io/specmatic/core/PostmanKtTests.kt
@@ -468,7 +468,7 @@ class PostmanKtTests {
     Then status 200
     And response-header Connection (string)
     And response-header Content-Type text/plain
-    And response-body (number)
+    And response-body (integer)
   
   Scenario: With JSON body
     Given type RequestBody
@@ -478,18 +478,18 @@ class PostmanKtTests {
     Then status 200
     And response-header Connection (string)
     And response-header Content-Type text/plain
-    And response-body (number)
+    And response-body (integer)
   
     Examples:
     | data |
     | value |
   
   Scenario: With query
-    When GET /stuff?one=(number)
+    When GET /stuff?one=(integer)
     Then status 200
     And response-header Connection (string)
     And response-header Content-Type text/plain
-    And response-body (number)
+    And response-body (integer)
   
     Examples:
     | one |
@@ -497,11 +497,11 @@ class PostmanKtTests {
   
   Scenario: Square Of A Number 2
     When POST /square
-    And request-body (RequestBody: number)
+    And request-body (RequestBody: integer)
     Then status 200
-    And response-header Connection (number)
+    And response-header Connection (integer)
     And response-header Content-Type text/plain
-    And response-body (number)
+    And response-body (integer)
   
     Examples:
     | RequestBody |
@@ -509,11 +509,11 @@ class PostmanKtTests {
   
   Scenario: With form fields
     When POST /stuff
-    And form-field field1 (number)
+    And form-field field1 (integer)
     Then status 200
     And response-header Connection (string)
     And response-header Content-Type text/plain
-    And response-body (number)
+    And response-body (integer)
   
     Examples:
     | field1 |
@@ -521,11 +521,11 @@ class PostmanKtTests {
   
   Scenario: With form data
     When POST /stuff
-    And request-part part1 (number)
+    And request-part part1 (integer)
     Then status 200
     And response-header Connection (string)
     And response-header Content-Type text/plain
-    And response-body (number)
+    And response-body (integer)
   
     Examples:
     | part1 |

--- a/core/src/test/kotlin/io/specmatic/core/value/TypeDeclarationKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/value/TypeDeclarationKtTest.kt
@@ -19,8 +19,8 @@ internal class TypeDeclarationKtTest {
         val convergedOneWay = convergeTypeDeclarations(emptyDeclaration, oneElementDeclaration)
         val convergedTheOtherWay = convergeTypeDeclarations(oneElementDeclaration, emptyDeclaration)
 
-        assertThat((convergedOneWay.types.getValue("List") as TabularPattern).pattern.getValue("list")).isEqualTo(DeferredPattern("(number*)"))
-        assertThat((convergedTheOtherWay.types.getValue("List") as TabularPattern).pattern.getValue("list")).isEqualTo(DeferredPattern("(number*)"))
+        assertThat((convergedOneWay.types.getValue("List") as TabularPattern).pattern.getValue("list")).isEqualTo(DeferredPattern("(integer*)"))
+        assertThat((convergedTheOtherWay.types.getValue("List") as TabularPattern).pattern.getValue("list")).isEqualTo(DeferredPattern("(integer*)"))
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/mock/ScenarioStubKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/mock/ScenarioStubKtTest.kt
@@ -211,7 +211,7 @@ internal class ScenarioStubKtTest {
       | name | (string) |
       | address | (Address) |
     And type ResponseBody
-      | id | (number) |
+      | id | (integer) |
     When POST /customer
     And request-body (RequestBody)
     Then status 200
@@ -236,7 +236,7 @@ internal class ScenarioStubKtTest {
       | name | (string) |
       | address | (Address) |
     And type ResponseBody
-      | id | (number) |
+      | id | (integer) |
     When POST /customer
     And request-header X-Header1 (string)
     And request-header X-Header2 (string)
@@ -259,7 +259,7 @@ internal class ScenarioStubKtTest {
         validateStubAndSpec(request, response, """Feature: New Feature
   Scenario: New scenario
     Given type ResponseBody
-      | id | (number) |
+      | id | (integer) |
     When POST /customer
     And form-field X-FormData1 (string)
     Then status 200
@@ -278,7 +278,7 @@ internal class ScenarioStubKtTest {
         validateStubAndSpec(request, response, """Feature: New Feature
   Scenario: New scenario
     Given type ResponseBody
-      | id | (number) |
+      | id | (integer) |
     When POST /customer
     And request-part name (string)
     Then status 200
@@ -297,7 +297,7 @@ internal class ScenarioStubKtTest {
         validateStubAndSpec(request, response, """Feature: New Feature
   Scenario: New scenario
     Given type ResponseBody
-      | id | (number) |
+      | id | (integer) |
     When POST /customer
     And request-part customer_csv @(string) text/csv identity
     Then status 200
@@ -338,7 +338,7 @@ internal class ScenarioStubKtTest {
     When POST /square
     And request-part employees @(string) text/csv gzip
     Then status 200
-    And response-body (number)
+    And response-body (integer)
   
     Examples:
     | employees_filename |
@@ -369,7 +369,7 @@ internal class ScenarioStubKtTest {
     When POST /square
     And request-body (string*)
     Then status 200
-    And response-body (number)""")
+    And response-body (integer)""")
     }
 
     @Test
@@ -404,7 +404,7 @@ internal class ScenarioStubKtTest {
     When POST /square
     And request-body (RequestBody*)
     Then status 200
-    And response-body (number)
+    And response-body (integer)
   
     Examples:
     | name |
@@ -445,7 +445,7 @@ internal class ScenarioStubKtTest {
     When POST /square
     And request-body (RequestBody*)
     Then status 200
-    And response-body (number)
+    And response-body (integer)
   
     Examples:
     | name | address |
@@ -486,7 +486,7 @@ internal class ScenarioStubKtTest {
     When POST /square
     And request-body (RequestBody*)
     Then status 200
-    And response-body (number)
+    And response-body (integer)
   
     Examples:
     | name |
@@ -527,7 +527,7 @@ internal class ScenarioStubKtTest {
     When POST /square
     And request-body (RequestBody*)
     Then status 200
-    And response-body (number)
+    And response-body (integer)
   
     Examples:
     | name | address |
@@ -572,7 +572,7 @@ internal class ScenarioStubKtTest {
     When POST /square
     And request-body (RequestBody*)
     Then status 200
-    And response-body (number)
+    And response-body (integer)
   
     Examples:
     | name |
@@ -617,7 +617,7 @@ internal class ScenarioStubKtTest {
     When POST /square
     And request-body (RequestBody*)
     Then status 200
-    And response-body (number)
+    And response-body (integer)
   
     Examples:
     | name |
@@ -658,7 +658,7 @@ internal class ScenarioStubKtTest {
     When POST /square
     And request-body (RequestBody*)
     Then status 200
-    And response-body (number)
+    And response-body (integer)
   
     Examples:
     | name |
@@ -699,7 +699,7 @@ internal class ScenarioStubKtTest {
     When POST /square
     And request-body (RequestBody*)
     Then status 200
-    And response-body (number)
+    And response-body (integer)
   
     Examples:
     | name |
@@ -729,7 +729,7 @@ internal class ScenarioStubKtTest {
     When POST /square
     And request-body []
     Then status 200
-    And response-body (number)""")
+    And response-body (integer)""")
     }
 
     @Test


### PR DESCRIPTION
Updated the proxy record to intelligently use integer or number when converting examples to spec


**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
