### PR TITLE
Fix headers and media-type conversion from stubs to Gherkin and OpenAPI

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/Postman.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/Postman.kt
@@ -105,8 +105,8 @@ private fun baseNamedStub(request: JSONObjectValue, scenarioName: String): List<
         val response = LegacyHttpClient(baseURL, log = dontPrintToConsole).execute(httpRequest)
 
         listOf(Pair(hostAndPort(baseURL), NamedStub(scenarioName, ScenarioStub(
-            httpRequest.withoutTransportHeaders().withoutSpecmaticHeaders(),
-            response.withoutTransportHeaders().withoutSpecmaticHeaders()
+            httpRequest.dropIrrelevantHeaders(),
+            response.dropIrrelevantHeaders()
         ))))
     } catch (e: Throwable) {
         logger.log(e,"  Failed to generate a response for the Postman request")
@@ -125,8 +125,8 @@ fun namedStubsFromPostmanResponses(responses: List<Value>): List<Pair<BaseURLInf
         val innerHttpResponse: HttpResponse = postmanItemResponse(responseItem)
 
         Pair(hostAndPort(baseURL), NamedStub(scenarioName, ScenarioStub(
-            innerHttpRequest.withoutTransportHeaders().withoutSpecmaticHeaders(),
-            innerHttpResponse.withoutTransportHeaders().withoutSpecmaticHeaders()
+            innerHttpRequest.dropIrrelevantHeaders(),
+            innerHttpResponse.dropIrrelevantHeaders()
         )))
     }
 }

--- a/core/src/main/kotlin/io/specmatic/conversions/Postman.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/Postman.kt
@@ -105,8 +105,8 @@ private fun baseNamedStub(request: JSONObjectValue, scenarioName: String): List<
         val response = LegacyHttpClient(baseURL, log = dontPrintToConsole).execute(httpRequest)
 
         listOf(Pair(hostAndPort(baseURL), NamedStub(scenarioName, ScenarioStub(
-            httpRequest,
-            response.withoutSpecmaticHeaders()
+            httpRequest.withoutTransportHeaders().withoutSpecmaticHeaders(),
+            response.withoutTransportHeaders().withoutSpecmaticHeaders()
         ))))
     } catch (e: Throwable) {
         logger.log(e,"  Failed to generate a response for the Postman request")
@@ -124,7 +124,10 @@ fun namedStubsFromPostmanResponses(responses: List<Value>): List<Pair<BaseURLInf
         val (baseURL, innerHttpRequest) = postmanItemRequest(innerRequest)
         val innerHttpResponse: HttpResponse = postmanItemResponse(responseItem)
 
-        Pair(hostAndPort(baseURL), NamedStub(scenarioName, ScenarioStub(innerHttpRequest, innerHttpResponse)))
+        Pair(hostAndPort(baseURL), NamedStub(scenarioName, ScenarioStub(
+            innerHttpRequest.withoutTransportHeaders().withoutSpecmaticHeaders(),
+            innerHttpResponse.withoutTransportHeaders().withoutSpecmaticHeaders()
+        )))
     }
 }
 

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -1195,11 +1195,11 @@ data class Feature(
 
             var scenario = rawScenario
 
-            if (scenario.httpRequestPattern.body.let {
-                    it is DeferredPattern && it.pattern == "(RequestBody)" && isJSONPayload(
-                        it.resolvePattern(scenario.resolver)
-                    )
-                }) {
+            if (
+                scenario.httpRequestPattern.body.let {
+                    it is DeferredPattern && it.pattern == "(RequestBody)" && isJSONPayload(it.resolvePattern(scenario.resolver))
+                }
+            ) {
                 val requestBody = scenario.httpRequestPattern.body as DeferredPattern
                 val oldTypeName = requestBody.pattern
                 val newTypeName = "(${prefix}_${withoutPatternDelimiters(oldTypeName)})"
@@ -1217,11 +1217,11 @@ data class Feature(
                 )
             }
 
-            if (scenario.httpResponsePattern.body.let {
-                    it is DeferredPattern && it.pattern == "(ResponseBody)" && isJSONPayload(
-                        it.resolvePattern(scenario.resolver)
-                    )
-                }) {
+            if (
+                scenario.httpResponsePattern.body.let {
+                    it is DeferredPattern && it.pattern == "(ResponseBody)" && isJSONPayload(it.resolvePattern(scenario.resolver))
+                }
+            ) {
                 val responseBody = scenario.httpResponsePattern.body as DeferredPattern
                 val oldTypeName = responseBody.pattern
                 val newTypeName = "(${prefix}_${withoutPatternDelimiters(oldTypeName)})"
@@ -1239,25 +1239,7 @@ data class Feature(
                 )
             }
 
-            val (contentTypePattern, rawResponseHeadersWithoutContentType) = scenario.httpResponsePattern.headersPattern.pattern.entries.find {
-                it.key.equals(CONTENT_TYPE, ignoreCase = true)
-            }?.let {
-                it.value to scenario.httpResponsePattern.headersPattern.pattern.minus(it.key)
-            } ?: (null to scenario.httpResponsePattern.headersPattern.pattern)
-
-            val responseContentType: String? = if(contentTypePattern is ExactValuePattern)
-                contentTypePattern.pattern.toStringLiteral()
-            else null
-
-            val updatedResponseHeaders = HttpHeadersPattern(rawResponseHeadersWithoutContentType, contentType = responseContentType)
-
-            scenario = scenario.copy(
-                httpResponsePattern = scenario.httpResponsePattern.copy(
-                    headersPattern = updatedResponseHeaders
-                )
-            )
-
-            scenario
+            updateScenarioContentTypeFromPattern(scenario)
         }
 
         val rawCombinedScenarios = payloadAdjustedScenarios.fold(emptyList<Scenario>()) { acc, payloadAdjustedScenario ->
@@ -1421,6 +1403,27 @@ data class Feature(
         }
 
         return openAPI
+    }
+
+    private fun updateScenarioContentTypeFromPattern(scenario: Scenario): Scenario {
+        val (reqContentTypeEntry, otherReqHeaders) = partitionOnContentType(scenario.httpRequestPattern.headersPattern.pattern)
+        val requestContentType = (reqContentTypeEntry?.value as? ExactValuePattern)?.pattern?.toStringLiteral()
+
+        val (resContentTypeEntry, otherResHeaders) = partitionOnContentType(scenario.httpResponsePattern.headersPattern.pattern)
+        val responseContentType = (resContentTypeEntry?.value as? ExactValuePattern)?.pattern?.toStringLiteral()
+
+        return scenario.copy(
+            httpRequestPattern = scenario.httpRequestPattern.copy(
+                headersPattern = scenario.httpRequestPattern.headersPattern.copy(
+                    pattern = otherReqHeaders, contentType = requestContentType
+                )
+            ),
+            httpResponsePattern = scenario.httpResponsePattern.copy(
+                headersPattern = scenario.httpResponsePattern.headersPattern.copy(
+                    pattern = otherResHeaders, contentType = responseContentType
+                )
+            )
+        )
     }
 
     private fun withoutQueryParams(name: String): String {
@@ -2564,15 +2567,20 @@ private fun scenarios(featureChildren: List<FeatureChild>) = featureChildren.fil
 fun toGherkinFeature(stub: NamedStub): String = toGherkinFeature("New Feature", listOf(stub))
 
 private fun stubToClauses(namedStub: NamedStub): Pair<List<GherkinClause>, ExampleDeclarations> {
-        val (requestClauses, typesFromRequest, examples) = toGherkinClauses(namedStub.stub.request)
+    val (requestClauses, typesFromRequest, examples) = toGherkinClauses(
+        namedStub.stub.request.copy(headers = dropConversionExcludedHeaders(namedStub.stub.request.headers))
+    )
 
-        for (message in examples.messages) {
-            logger.log(message)
-        }
+    for (message in examples.messages) {
+        logger.log(message)
+    }
 
-        val (responseClauses, allTypes, _) = toGherkinClauses(namedStub.stub.response, typesFromRequest)
-        val typeClauses = toGherkinClauses(allTypes)
-        return Pair(typeClauses.plus(requestClauses).plus(responseClauses), examples)
+    val (responseClauses, allTypes, _) = toGherkinClauses(
+        namedStub.stub.response.copy(headers = dropConversionExcludedHeaders(namedStub.stub.response.headers)),
+        typesFromRequest
+    )
+    val typeClauses = toGherkinClauses(allTypes)
+    return Pair(typeClauses.plus(requestClauses).plus(responseClauses), examples)
 }
 
 data class GherkinScenario(val scenarioName: String, val clauses: List<GherkinClause>)

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -1197,9 +1197,10 @@ data class Feature(
 
             if (
                 scenario.httpRequestPattern.body.let {
-                    it is DeferredPattern && it.pattern == "(RequestBody)" && isJSONPayload(it.resolvePattern(scenario.resolver))
-                }
-            ) {
+                    it is DeferredPattern && it.pattern == "(RequestBody)" && isJSONPayload(
+                        it.resolvePattern(scenario.resolver)
+                    )
+                }) {
                 val requestBody = scenario.httpRequestPattern.body as DeferredPattern
                 val oldTypeName = requestBody.pattern
                 val newTypeName = "(${prefix}_${withoutPatternDelimiters(oldTypeName)})"
@@ -1219,9 +1220,10 @@ data class Feature(
 
             if (
                 scenario.httpResponsePattern.body.let {
-                    it is DeferredPattern && it.pattern == "(ResponseBody)" && isJSONPayload(it.resolvePattern(scenario.resolver))
-                }
-            ) {
+                    it is DeferredPattern && it.pattern == "(ResponseBody)" && isJSONPayload(
+                        it.resolvePattern(scenario.resolver)
+                    )
+                }) {
                 val responseBody = scenario.httpResponsePattern.body as DeferredPattern
                 val oldTypeName = responseBody.pattern
                 val newTypeName = "(${prefix}_${withoutPatternDelimiters(oldTypeName)})"
@@ -2567,18 +2569,13 @@ private fun scenarios(featureChildren: List<FeatureChild>) = featureChildren.fil
 fun toGherkinFeature(stub: NamedStub): String = toGherkinFeature("New Feature", listOf(stub))
 
 private fun stubToClauses(namedStub: NamedStub): Pair<List<GherkinClause>, ExampleDeclarations> {
-    val (requestClauses, typesFromRequest, examples) = toGherkinClauses(
-        namedStub.stub.request.copy(headers = dropConversionExcludedHeaders(namedStub.stub.request.headers))
-    )
+    val (requestClauses, typesFromRequest, examples) = toGherkinClauses(namedStub.stub.request)
 
     for (message in examples.messages) {
         logger.log(message)
     }
 
-    val (responseClauses, allTypes, _) = toGherkinClauses(
-        namedStub.stub.response.copy(headers = dropConversionExcludedHeaders(namedStub.stub.response.headers)),
-        typesFromRequest
-    )
+    val (responseClauses, allTypes, _) = toGherkinClauses(namedStub.stub.response, typesFromRequest)
     val typeClauses = toGherkinClauses(allTypes)
     return Pair(typeClauses.plus(requestClauses).plus(responseClauses), examples)
 }

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
@@ -388,9 +388,13 @@ data class HttpRequest(
         return requestNotRecognized(StrictRequestNotRecognizedMessages())
     }
 
+    fun dropIrrelevantHeaders(): HttpRequest = withoutTransportHeaders().withoutConversionHeaders().withoutSpecmaticHeaders()
+
     fun withoutTransportHeaders(): HttpRequest = copy(headers = headers.withoutTransportHeaders())
 
     fun withoutSpecmaticHeaders(): HttpRequest = copy(headers = dropSpecmaticHeaders(headers))
+
+    fun withoutConversionHeaders(): HttpRequest = copy(headers = dropConversionExcludedHeaders(headers))
 
     fun addSecurityHeader(headerName: String, headerValue: String): HttpRequest {
         val updatedMetadata = metadata.copy(securityHeaderNames = metadata.securityHeaderNames.plus(headerName))

--- a/core/src/main/kotlin/io/specmatic/core/HttpResponse.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpResponse.kt
@@ -117,14 +117,6 @@ data class HttpResponse(
         return this.copy(headers = this.headers.plus(SPECMATIC_TYPE_HEADER to "random"))
     }
 
-    fun withoutSpecmaticHeaders(): HttpResponse {
-        val withoutSpecmaticHeaders = this.headers.filterNot {
-            it.key.startsWith(SPECMATIC_HEADER_PREFIX)
-        }
-
-        return this.copy(headers = withoutSpecmaticHeaders)
-    }
-
     fun withoutSpecmaticResultHeader(): HttpResponse {
         return this.copy(headers = this.headers.minus(SPECMATIC_RESULT_HEADER))
     }
@@ -177,6 +169,8 @@ data class HttpResponse(
 
     fun withoutTransportHeaders(): HttpResponse = copy(headers = headers.withoutTransportHeaders())
 
+    fun withoutSpecmaticHeaders(): HttpResponse = copy(headers = dropSpecmaticHeaders(headers))
+
     fun isNotEmpty(): Boolean {
         val bodyIsEmpty = body == NoBodyValue
         val headersIsEmpty = headers.isEmpty() ||  headersHasOnlyTextPlainContentTypeHeader()
@@ -224,44 +218,38 @@ fun nativeInteger(json: Map<String, Value>, key: String): Int? {
     }
 }
 
-
-val responseHeadersToExcludeFromConversion = listOf("Vary", SPECMATIC_RESULT_HEADER)
-
 fun toGherkinClauses(
     response: HttpResponse,
     types: Map<String, Pattern> = emptyMap()
 ): Triple<List<GherkinClause>, Map<String, Pattern>, ExampleDeclarations> {
     return try {
-        val cleanedUpResponse = dropContentAndCORSResponseHeaders(response)
-
         return Triple(
             emptyList<GherkinClause>(),
             types,
             DiscardExampleDeclarations()
         ).let { (clauses, types, examples) ->
             val status = when {
-                cleanedUpResponse.status > 0 -> cleanedUpResponse.status
+                response.status > 0 -> response.status
                 else -> throw ContractException("Can't generate a contract without a response status")
             }
             Triple(clauses.plus(GherkinClause("status $status", Then)), types, examples)
         }.let { (clauses, types, _) ->
-            val contentTypeHeader: List<GherkinClause> = response.headers.entries.find {
-                it.key.equals(CONTENT_TYPE, ignoreCase = true)
-            }?.let {
-                val contentType = it.value.split(";")[0]
-                listOf(GherkinClause("response-header ${it.key} $contentType", Then))
-            } ?: emptyList()
+            val (contentTypeEntry, restHeaders) = partitionOnContentType(response.headers)
+            val contentTypHeaderClause = contentTypeEntry?.let { (key, value) ->
+                val contentType = value.split(";").first()
+                listOf(GherkinClause("response-header $key $contentType", Then))
+            }.orEmpty()
 
             val (newClauses, newTypes, _) = headersToGherkin(
-                cleanedUpResponse.headers,
+                restHeaders,
                 "response-header",
                 types,
                 DiscardExampleDeclarations(),
                 Then
             )
-            Triple(clauses.plus(newClauses).plus(contentTypeHeader), newTypes, DiscardExampleDeclarations())
+            Triple(clauses.plus(newClauses).plus(contentTypHeaderClause), newTypes, DiscardExampleDeclarations())
         }.let { (clauses, types, examples) ->
-            when (val result = responseBodyToGherkinClauses("ResponseBody", guessType(cleanedUpResponse.body), types)) {
+            when (val result = responseBodyToGherkinClauses("ResponseBody", guessType(response.body), types)) {
                 null -> Triple(clauses, types, examples)
                 else -> {
                     val (newClauses, newTypes, _) = result
@@ -274,7 +262,22 @@ fun toGherkinClauses(
     }
 }
 
-fun dropContentAndCORSResponseHeaders(response: HttpResponse) =
-    response.copy(headers = response.headers.filterNot {
-        it.key in responseHeadersToExcludeFromConversion || it.key.lowercase() in listOf("content-type", "content-encoding", "content-length", "content-disposition") || it.key.startsWith("Access-Control-")
-    })
+fun dropConversionExcludedHeaders(headers: Map<String, String>): Map<String, String> {
+    val headersToExcludeFromConversion = listOf(HttpHeaders.ContentDisposition, HttpHeaders.ContentEncoding)
+    return headers.minusIgnoringCase(headersToExcludeFromConversion).filterKeys { !it.startsWith("Access-Control-") }
+}
+
+fun dropSpecmaticHeaders(headers: Map<String, String>): Map<String, String> {
+    return headers.filterKeys { !it.contains(APPLICATION_NAME, ignoreCase = true) }
+}
+
+fun <T> partitionOnContentType(headers: Map<String, T>): Pair<Map.Entry<String, T>?, Map<String, T>> {
+    val contentTypeEntry = headers.entries.find { it.key.equals(CONTENT_TYPE, ignoreCase = true) }
+    if (contentTypeEntry == null) return null to headers
+    return contentTypeEntry to headers.minus(contentTypeEntry.key)
+}
+
+fun <T> Map<String, T>.minusIgnoringCase(keys: Iterable<String>): Map<String, T> {
+    val caseInsensitiveKeys = keys.map(String::lowercase).toSet()
+    return this.filterKeys { it.lowercase() !in caseInsensitiveKeys }
+}

--- a/core/src/main/kotlin/io/specmatic/core/HttpResponse.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpResponse.kt
@@ -167,9 +167,13 @@ data class HttpResponse(
         }
     }
 
+    fun dropIrrelevantHeaders(): HttpResponse = withoutTransportHeaders().withoutConversionHeaders().withoutSpecmaticHeaders()
+
     fun withoutTransportHeaders(): HttpResponse = copy(headers = headers.withoutTransportHeaders())
 
     fun withoutSpecmaticHeaders(): HttpResponse = copy(headers = dropSpecmaticHeaders(headers))
+
+    fun withoutConversionHeaders(): HttpResponse = copy(headers = dropConversionExcludedHeaders(headers))
 
     fun isNotEmpty(): Boolean {
         val bodyIsEmpty = body == NoBodyValue

--- a/core/src/main/kotlin/io/specmatic/proxy/Proxy.kt
+++ b/core/src/main/kotlin/io/specmatic/proxy/Proxy.kt
@@ -127,8 +127,8 @@ class Proxy(
                                             name,
                                             uniqueNameForApiOperation(httpRequest, baseURL, httpResponse.status),
                                             ScenarioStub(
-                                                httpRequest.withoutTransportHeaders(),
-                                                httpResponse.withoutTransportHeaders(),
+                                                httpRequest.withoutTransportHeaders().withoutSpecmaticHeaders(),
+                                                httpResponse.withoutTransportHeaders().withoutSpecmaticHeaders(),
                                             ),
                                         ),
                                     )

--- a/core/src/main/kotlin/io/specmatic/proxy/Proxy.kt
+++ b/core/src/main/kotlin/io/specmatic/proxy/Proxy.kt
@@ -127,8 +127,8 @@ class Proxy(
                                             name,
                                             uniqueNameForApiOperation(httpRequest, baseURL, httpResponse.status),
                                             ScenarioStub(
-                                                httpRequest.withoutTransportHeaders().withoutSpecmaticHeaders(),
-                                                httpResponse.withoutTransportHeaders().withoutSpecmaticHeaders(),
+                                                httpRequest.dropIrrelevantHeaders(),
+                                                httpResponse.dropIrrelevantHeaders(),
                                             ),
                                         ),
                                     )

--- a/core/src/test/kotlin/io/specmatic/core/PostmanKtTests.kt
+++ b/core/src/test/kotlin/io/specmatic/core/PostmanKtTests.kt
@@ -622,7 +622,14 @@ class PostmanKtTests {
 
     private fun validate(gherkinString: String, stubs: List<NamedStub>, additionalHeaders: Map<String, String> = emptyMap()) {
         val behaviour = parseGherkinStringToFeature(gherkinString)
-        val cleanedUpStubs = stubs.map { it.stub }.map { it.copy(response = dropContentAndCORSResponseHeaders(it.response).let { it.copy(headers = it.headers + additionalHeaders)} ) }
+        val cleanedUpStubs = stubs.map { it.stub }.map {
+            it.copy(
+                response = it.response.copy(
+                    headers = dropConversionExcludedHeaders(it.response.headers) + additionalHeaders
+                )
+            )
+        }
+
         for(stub in cleanedUpStubs) {
             behaviour.matchingStub(stub)
         }
@@ -858,7 +865,7 @@ class PostmanKtTests {
         val stub2 = postmanCollection.stubs[1]
         assertThat(stub2.second.name).isEqualTo("Square Of A Number 2")
         assertThat(stub2.second.stub.request.method).isEqualTo("POST")
-        assertThat(stub2.second.stub.response.headers).hasSize(5)
+        assertThat(stub2.second.stub.response.headers).hasSize(2)
     }
 
     companion object {

--- a/core/src/test/kotlin/io/specmatic/mock/ScenarioStubKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/mock/ScenarioStubKtTest.kt
@@ -216,6 +216,7 @@ internal class ScenarioStubKtTest {
     When POST /customer
     And request-body (RequestBody)
     Then status 200
+    And response-header Content-Type application/json
     And response-body (ResponseBody)
   
     Examples:
@@ -264,6 +265,7 @@ internal class ScenarioStubKtTest {
     When POST /customer
     And form-field X-FormData1 (string)
     Then status 200
+    And response-header Content-Type application/json
     And response-body (ResponseBody)
   
     Examples:
@@ -283,6 +285,7 @@ internal class ScenarioStubKtTest {
     When POST /customer
     And request-part name (string)
     Then status 200
+    And response-header Content-Type application/json
     And response-body (ResponseBody)
   
     Examples:
@@ -302,6 +305,7 @@ internal class ScenarioStubKtTest {
     When POST /customer
     And request-part customer_csv @(string) text/csv identity
     Then status 200
+    And response-header Content-Type application/json
     And response-body (ResponseBody)
   
     Examples:
@@ -1076,7 +1080,7 @@ paths:
 
 fun validateStubAndSpec(request: HttpRequest, response: HttpResponse, expectedGherkin: String? = null) {
     try {
-        val cleanedUpResponse = dropContentAndCORSResponseHeaders(response)
+        val cleanedUpResponse = response.copy(headers = dropConversionExcludedHeaders(response.headers))
         val gherkin = toGherkinFeature(NamedStub("New scenario", ScenarioStub(request, cleanedUpResponse))).also { println(it) }
 
         if(expectedGherkin != null) {

--- a/core/src/test/kotlin/io/specmatic/proxy/ProxyTest.kt
+++ b/core/src/test/kotlin/io/specmatic/proxy/ProxyTest.kt
@@ -9,13 +9,10 @@ import io.specmatic.core.pattern.parsedJSON
 import io.specmatic.core.pattern.parsedJSONObject
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.stub.HttpStub
-import io.ktor.http.*
 import io.ktor.util.*
-import io.specmatic.Waiter
 import io.specmatic.mock.DELAY_IN_MILLISECONDS
 import io.specmatic.stub.SPECMATIC_RESPONSE_CODE_HEADER
 import io.specmatic.test.HttpClient
-import io.specmatic.stub.HttpStub
 import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -421,6 +418,30 @@ internal class ProxyTest {
         }
 
         assertThat(fakeFileWriter.receivedContract).doesNotContainIgnoringCase("Specmatic", "Content-Type")
+        assertThat(fakeFileWriter.receivedStub).doesNotContainIgnoringCase("Specmatic").containsIgnoringCase("Content-Type")
+    }
+
+    @Test
+    fun `dumped specification headers should be in-sync with dumped examples`() {
+        val openApiFile = File("src/test/resources/openapi/partial_with_discriminator/openapi.yaml")
+        val feature = OpenApiSpecification.fromFile(openApiFile.canonicalPath).toFeature()
+
+        HttpStub(feature).use {
+            Proxy(host = "localhost", port = 9001, "http://localhost:9000", fakeFileWriter).use {
+                val request = feature.scenarios.first().generateHttpRequest()
+                    .addHeaderIfMissing(SPECMATIC_RESPONSE_CODE_HEADER, "201")
+                    .addHeaderIfMissing(HttpHeaders.AccessControlAllowOrigin, "*")
+                    .addHeaderIfMissing(HttpHeaders.ContentDisposition, "*")
+
+                val response = HttpClient(baseURL = "http://localhost:9001").use { it.execute(request) }
+                assertThat(response.status).isEqualTo(201)
+                assertThat(response.headers.keys.map(String::toLowerCasePreservingASCIIRules)).contains(
+                    "x-specmatic-result", "x-specmatic-type", "content-type"
+                )
+            }
+        }
+
+        assertThat(fakeFileWriter.receivedContract).doesNotContainIgnoringCase("Specmatic", "Content-Type", HttpHeaders.AccessControlAllowOrigin, HttpHeaders.ContentDisposition)
         assertThat(fakeFileWriter.receivedStub).doesNotContainIgnoringCase("Specmatic").containsIgnoringCase("Content-Type")
     }
 }

--- a/core/src/test/kotlin/io/specmatic/proxy/ProxyTest.kt
+++ b/core/src/test/kotlin/io/specmatic/proxy/ProxyTest.kt
@@ -8,7 +8,13 @@ import io.specmatic.core.parseGherkinStringToFeature
 import io.specmatic.core.pattern.parsedJSON
 import io.specmatic.core.pattern.parsedJSONObject
 import io.specmatic.core.value.JSONObjectValue
+import io.specmatic.stub.HttpStub
+import io.ktor.http.*
+import io.ktor.util.*
+import io.specmatic.Waiter
 import io.specmatic.mock.DELAY_IN_MILLISECONDS
+import io.specmatic.stub.SPECMATIC_RESPONSE_CODE_HEADER
+import io.specmatic.test.HttpClient
 import io.specmatic.stub.HttpStub
 import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
@@ -262,7 +268,7 @@ internal class ProxyTest {
         }
 
         assertThat(fakeFileWriter.receivedStub).withFailMessage(fakeFileWriter.receivedStub).contains("text/html")
-        assertThat(fakeFileWriter.receivedContract).withFailMessage(fakeFileWriter.receivedStub).contains("text/html")
+        assertThat(fakeFileWriter.receivedContract).withFailMessage(fakeFileWriter.receivedContract).contains("text/html")
 
         HttpStub(OpenApiSpecification.fromYAML(fakeFileWriter.receivedContract!!, "").toFeature()).use { stub ->
         }
@@ -395,6 +401,27 @@ internal class ProxyTest {
                 }
             }
         }
+    }
+
+    @Test
+    fun `should not include any specmatic headers in the final stubs and api specification`() {
+        val openApiFile = File("src/test/resources/openapi/partial_with_discriminator/openapi.yaml")
+        val feature = OpenApiSpecification.fromFile(openApiFile.canonicalPath).toFeature()
+
+        HttpStub(feature).use {
+            Proxy(host = "localhost", port = 9001, "http://localhost:9000", fakeFileWriter).use {
+                val request = feature.scenarios.first().generateHttpRequest().addHeaderIfMissing(SPECMATIC_RESPONSE_CODE_HEADER, "201")
+                val response = HttpClient(baseURL = "http://localhost:9001").use { it.execute(request) }
+
+                assertThat(response.status).isEqualTo(201)
+                assertThat(response.headers.keys.map(String::toLowerCasePreservingASCIIRules)).contains(
+                    "x-specmatic-result", "x-specmatic-type", "content-type"
+                )
+            }
+        }
+
+        assertThat(fakeFileWriter.receivedContract).doesNotContainIgnoringCase("Specmatic", "Content-Type")
+        assertThat(fakeFileWriter.receivedStub).doesNotContainIgnoringCase("Specmatic").containsIgnoringCase("Content-Type")
     }
 }
 


### PR DESCRIPTION
**What**: Fix headers and media-type conversion from stubs to Gherkin and OpenAPI

**How**:
- Ensure Transport and Specmatic Headers are removed
- Remove additional Headers on stub-to-clause conversion
- Fix contentType in request and response headers on openAPI conversion

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)