### PR TITLE
Remove value check from the pattern resolveSubstitution

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/Dictionary.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Dictionary.kt
@@ -45,9 +45,10 @@ data class Dictionary(private val data: Map<String, Value>, private val focusedD
     }
 
     fun getDefaultValueFor(pattern: Pattern, resolver: Resolver): Value? {
-        val lookupKey = withPatternDelimiters(pattern.typeName)
+        val resolved = resolvedHop(pattern, resolver)
+        val lookupKey = withPatternDelimiters(resolved.typeName)
         val defaultValue = defaultData[lookupKey] ?: return null
-        return getReturnValueFor(lookupKey, defaultValue, pattern, resolver)?.withDefault(null) { it }
+        return getReturnValueFor(lookupKey, defaultValue, resolved, resolver)?.withDefault(null) { it }
     }
 
     fun getValueFor(lookup: String, pattern: Pattern, resolver: Resolver): ReturnValue<Value>? {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/DictionaryPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/DictionaryPattern.kt
@@ -30,7 +30,7 @@ data class DictionaryPattern(val keyPattern: Pattern, val valuePattern: Pattern,
         key: String?
     ): ReturnValue<Value> {
         val resolved = runCatching { substitution.resolveIfLookup(value, this) }.getOrElse { e -> return HasException(e) }
-        val resolvedValue = resolved as? JSONObjectValue ?: return HasFailure(Result.Failure("Cannot resolve substitutions, expected object but got ${value.displayableType()}"))
+        val resolvedValue = resolved as? JSONObjectValue ?: return HasValue(resolved)
 
         val updatedMap = resolvedValue.jsonObject.mapValues { (key, value) ->
             valuePattern.resolveSubstitutions(substitution, value, resolver, key)

--- a/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
@@ -194,7 +194,7 @@ data class JSONObjectPattern(
         key: String?
     ): ReturnValue<Value> {
         val resolved = runCatching { substitution.resolveIfLookup(value, this) }.getOrElse { e -> return HasException(e) }
-        val resolvedValue = resolved as? JSONObjectValue ?: return HasFailure(Result.Failure("Cannot resolve substitutions, expected object but got ${value.displayableType()}"))
+        val resolvedValue = resolved as? JSONObjectValue ?: return HasValue(resolved)
 
         if(pattern.isEmpty()) return HasValue(value)
         val updatedMap = resolvedValue.jsonObject.mapNotNull { (key, value) ->

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
@@ -77,7 +77,7 @@ data class ListPattern(
         key: String?
     ): ReturnValue<Value> {
         val resolved = runCatching { substitution.resolveIfLookup(value, this) }.getOrElse { e -> return HasException(e) }
-        val resolvedValue = resolved as? JSONArrayValue ?: return HasFailure(Result.Failure("Cannot resolve substitutions, expected list but got ${value.displayableType()}"))
+        val resolvedValue = resolved as? JSONArrayValue ?: return HasValue(resolved)
 
         val updatedList = resolvedValue.list.mapIndexed { index, listItem ->
             pattern.resolveSubstitutions(substitution, listItem, resolver).breadCrumb("[$index]")

--- a/core/src/main/kotlin/io/specmatic/stub/ThreadSafeListOfStubs.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/ThreadSafeListOfStubs.kt
@@ -163,7 +163,6 @@ class ThreadSafeListOfStubs(
         return runCatching {
             val substituted = stubResponse.resolveSubstitutions(httpRequest, originalRequest ?: httpRequest, stubData.data)
             val substitutedResponse = stubData.copy(response = substituted.response)
-            if (stubData.partial == null) return@runCatching substitutedResponse
             stubData.copy(response = stubData.responsePattern.fillInTheBlanks(substitutedResponse.response, stubData.resolver))
         }.map { Result.Success() to it }.getOrElse { e ->
             when {

--- a/core/src/test/kotlin/integration_tests/StubSubstitutionTest.kt
+++ b/core/src/test/kotlin/integration_tests/StubSubstitutionTest.kt
@@ -1204,7 +1204,7 @@ class StubSubstitutionTest {
             assertThat(response.status).isEqualTo(400)
             assertThat(response.body.toStringLiteral()).isEqualToNormalizingWhitespace("""
              >> RESPONSE.BODY.names[0]
-            Cannot resolve substitutions, expected string but got number
+            Expected string, actual was number
             """.trimIndent())
         }
     }

--- a/core/src/test/kotlin/io/specmatic/stub/HttpExpectationsTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpExpectationsTest.kt
@@ -17,7 +17,7 @@ class HttpExpectationsTest {
     private val staticStubData = HttpStubData(
         requestType = request.toPattern(),
         response = HttpResponse.ok(parsedJSONObject("{\"id\": 10}")),
-        responsePattern = HttpResponsePattern(HttpResponse.OK),
+        responsePattern = HttpResponsePattern(HttpResponse.ok(parsedJSONObject("{\"id\": 10}"))),
         resolver = Resolver(),
         contractPath = "test.yaml",
         originalRequest = request
@@ -44,7 +44,7 @@ class HttpExpectationsTest {
         val dynamicStubData = HttpStubData(
             requestType = request.toPattern(),
             response = response,
-            responsePattern = HttpResponsePattern(HttpResponse.OK),
+            responsePattern = HttpResponsePattern(response),
             resolver = Resolver(),
             originalRequest = request
         )
@@ -69,7 +69,7 @@ class HttpExpectationsTest {
         val dynamicStubData = HttpStubData(
             requestType = request.toPattern(),
             response = dynamicStubResponse,
-            responsePattern = HttpResponsePattern(HttpResponse.OK),
+            responsePattern = HttpResponsePattern(dynamicStubResponse),
             resolver = Resolver(),
             originalRequest = request
         )
@@ -85,7 +85,7 @@ class HttpExpectationsTest {
         val transientStubData = HttpStubData(
             requestType = request.toPattern(),
             response = transientStubResponse,
-            responsePattern = HttpResponsePattern(HttpResponse.OK),
+            responsePattern = HttpResponsePattern(transientStubResponse),
             resolver = Resolver(),
             originalRequest = request
         )

--- a/core/src/test/kotlin/io/specmatic/stub/ThreadSafeListOfStubsTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/ThreadSafeListOfStubsTest.kt
@@ -157,7 +157,7 @@ class ThreadSafeListOfStubsTest {
         private val specificExpectation = HttpStubData(
             requestType = specificRequest.toPattern(),
             response = HttpResponse.ok(parsedJSONObject("{\"id\": 10}")),
-            responsePattern = HttpResponsePattern(HttpResponse.OK),
+            responsePattern = HttpResponsePattern(HttpResponse.ok(parsedJSONObject("{\"id\": 10}"))),
             resolver = Resolver(),
             originalRequest = specificRequest
         )
@@ -165,7 +165,7 @@ class ThreadSafeListOfStubsTest {
         private val generalExpectation = HttpStubData(
             requestType = generalRequest.toPattern(),
             response = HttpResponse.ok(parsedJSONObject("{\"id\": 20}")),
-            responsePattern = HttpResponsePattern(HttpResponse.OK),
+            responsePattern = HttpResponsePattern(HttpResponse.ok(parsedJSONObject("{\"id\": 20}"))),
             resolver = Resolver(),
             originalRequest = generalRequest
         )

--- a/core/src/test/resources/openapi/partial_example_tests/substitute_examples/pets_post.json
+++ b/core/src/test/resources/openapi/partial_example_tests/substitute_examples/pets_post.json
@@ -1,0 +1,29 @@
+{
+  "partial": {
+    "http-request": {
+      "path": "/creators/(creatorId:number)/pets/(petId:number)",
+      "method": "PATCH",
+      "body": {
+        "creatorId": "(CREATOR_ID:number)",
+        "petId": "(PET_ID:number)"
+      }
+    },
+    "http-response": {
+      "status": 201,
+      "body": {
+        "id": "$(dataLookup.CREATOR_ID[CREATOR_ID].id)"
+      },
+      "status-text": "Created",
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  "dataLookup": {
+    "CREATOR_ID": {
+      "*": {
+        "id": 123
+      }
+    }
+  }
+}

--- a/core/src/test/resources/openapi/partial_example_tests/substitute_examples/pets_post_another.json
+++ b/core/src/test/resources/openapi/partial_example_tests/substitute_examples/pets_post_another.json
@@ -1,0 +1,17 @@
+{
+  "partial": {
+    "http-request": {
+      "path": "/creators/123/pets/123",
+      "method": "PATCH",
+      "body": {}
+    },
+    "http-response": {
+      "status": 201,
+      "body": "(anyvalue)",
+      "status-text": "Created",
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  }
+}


### PR DESCRIPTION
**What**: Remove value check from the pattern resolveSubstitution

**Why**: This resolves issues when the example contains a pattern token instead of a composite value. The `fillInTheBlanks` function should then replace the pattern token with the appropriate value.

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)