### PR TITLE
feat(security): show warning on conflicting header and query param

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/APIKeyInHeaderSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/APIKeyInHeaderSecurityScheme.kt
@@ -3,6 +3,8 @@ package io.specmatic.conversions
 import io.specmatic.core.*
 import io.specmatic.core.pattern.Row
 import io.specmatic.core.pattern.StringPattern
+import io.swagger.v3.oas.models.parameters.HeaderParameter
+import io.swagger.v3.oas.models.parameters.Parameter
 
 
 data class APIKeyInHeaderSecurityScheme(val name: String, private val apiKey:String?) : OpenAPISecurityScheme {
@@ -37,6 +39,22 @@ data class APIKeyInHeaderSecurityScheme(val name: String, private val apiKey:Str
 
     override fun isInRequest(request: HttpRequest, complete: Boolean): Boolean {
         return request.hasHeader(name)
+    }
+
+    override fun warnIfExistsInParameters(parameters: List<Parameter>, method: String, path: String) {
+        val matchingHeaders = parameters.filterIsInstance<HeaderParameter>().filter {
+            it.name.equals(name, ignoreCase = true)
+        }
+
+        if(matchingHeaders.isNotEmpty()) {
+            printWarningsForOverriddenSecurityParameters(
+                matchingParameters = matchingHeaders,
+                securitySchemeDescription = "API key with header $name",
+                httpParameterType = "header",
+                method = method,
+                path = path
+            )
+        }
     }
 
     override fun getHeaderKey(): String? {

--- a/core/src/main/kotlin/io/specmatic/conversions/APIKeyInHeaderSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/APIKeyInHeaderSecurityScheme.kt
@@ -4,12 +4,13 @@ import io.specmatic.core.*
 import io.specmatic.core.pattern.Row
 import io.specmatic.core.pattern.StringPattern
 
+
 data class APIKeyInHeaderSecurityScheme(val name: String, private val apiKey:String?) : OpenAPISecurityScheme {
     override fun matches(httpRequest: HttpRequest, resolver: Resolver): Result {
         return if (httpRequest.headers.containsKey(name) || resolver.mockMode) Result.Success()
         else Result.Failure(
             breadCrumb = BreadCrumb.HEADER.with(name),
-            message = resolver.mismatchMessages.expectedKeyWasMissing("API-Key", name)
+            message = resolver.mismatchMessages.expectedKeyWasMissing(apiKeyParamName, name)
         )
     }
 
@@ -36,5 +37,9 @@ data class APIKeyInHeaderSecurityScheme(val name: String, private val apiKey:Str
 
     override fun isInRequest(request: HttpRequest, complete: Boolean): Boolean {
         return request.hasHeader(name)
+    }
+
+    override fun getHeaderKey(): String? {
+        return apiKeyParamName
     }
 }

--- a/core/src/main/kotlin/io/specmatic/conversions/APIKeyInQueryParamSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/APIKeyInQueryParamSecurityScheme.kt
@@ -3,6 +3,9 @@ package io.specmatic.conversions
 import io.specmatic.core.*
 import io.specmatic.core.pattern.*
 import io.specmatic.core.value.StringValue
+import io.swagger.v3.oas.models.parameters.Parameter
+import io.swagger.v3.oas.models.parameters.QueryParameter
+import org.apache.http.HttpHeaders.AUTHORIZATION
 
 const val apiKeyParamName = "API-Key"
 
@@ -54,5 +57,21 @@ data class APIKeyInQueryParamSecurityScheme(val name: String, private val apiKey
 
     override fun getHeaderKey(): String? {
         return apiKeyParamName
+    }
+
+    override fun warnIfExistsInParameters(parameters: List<Parameter>, method: String, path: String) {
+        val matchingQueryParams = parameters.filterIsInstance<QueryParameter>().filter {
+            it.name.equals(name, ignoreCase = true)
+        }
+
+        if(matchingQueryParams.isNotEmpty()) {
+            printWarningsForOverriddenSecurityParameters(
+                matchingParameters = matchingQueryParams,
+                securitySchemeDescription = "API key with query parameter $name",
+                httpParameterType = "query",
+                method = method,
+                path = path
+            )
+        }
     }
 }

--- a/core/src/main/kotlin/io/specmatic/conversions/APIKeyInQueryParamSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/APIKeyInQueryParamSecurityScheme.kt
@@ -4,12 +4,14 @@ import io.specmatic.core.*
 import io.specmatic.core.pattern.*
 import io.specmatic.core.value.StringValue
 
+const val apiKeyParamName = "API-Key"
+
 data class APIKeyInQueryParamSecurityScheme(val name: String, private val apiKey:String?) : OpenAPISecurityScheme {
     override fun matches(httpRequest: HttpRequest, resolver: Resolver): Result {
         return if (httpRequest.queryParams.containsKey(name) || resolver.mockMode) Result.Success()
         else Result.Failure(
             breadCrumb = BreadCrumb.QUERY.with(name),
-            message = resolver.mismatchMessages.expectedKeyWasMissing("API-Key", name)
+            message = resolver.mismatchMessages.expectedKeyWasMissing(apiKeyParamName, name)
         )
     }
 
@@ -48,5 +50,9 @@ data class APIKeyInQueryParamSecurityScheme(val name: String, private val apiKey
 
     override fun isInRequest(request: HttpRequest, complete: Boolean): Boolean {
         return request.hasQueryParam(name)
+    }
+
+    override fun getHeaderKey(): String? {
+        return apiKeyParamName
     }
 }

--- a/core/src/main/kotlin/io/specmatic/conversions/BasicAuthSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/BasicAuthSecurityScheme.kt
@@ -3,6 +3,8 @@ package io.specmatic.conversions
 import io.specmatic.core.*
 import io.specmatic.core.pattern.*
 import io.specmatic.core.value.StringValue
+import io.swagger.v3.oas.models.parameters.HeaderParameter
+import io.swagger.v3.oas.models.parameters.Parameter
 import org.apache.http.HttpHeaders.AUTHORIZATION
 import java.util.Base64
 
@@ -127,5 +129,22 @@ data class BasicAuthSecurityScheme(private val token: String? = null) : OpenAPIS
 
     override fun getHeaderKey(): String? {
         return AUTHORIZATION
+    }
+
+    override fun warnIfExistsInParameters(parameters: List<Parameter>, method: String, path: String) {
+        val matchingHeaders = parameters.filterIsInstance<HeaderParameter>().filter {
+            it.name.equals(AUTHORIZATION, ignoreCase = true)
+        }
+
+        if(matchingHeaders.isNotEmpty()) {
+            printWarningsForOverriddenSecurityParameters(
+                matchingParameters = matchingHeaders,
+                securitySchemeDescription = "Basic Auth",
+                httpParameterType = "header",
+                method = method,
+                path = path
+            )
+
+        }
     }
 }

--- a/core/src/main/kotlin/io/specmatic/conversions/BasicAuthSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/BasicAuthSecurityScheme.kt
@@ -124,4 +124,8 @@ data class BasicAuthSecurityScheme(private val token: String? = null) : OpenAPIS
 
         return Base64.getEncoder().encodeToString("$randomUsername:$randomPassword".toByteArray())
     }
+
+    override fun getHeaderKey(): String? {
+        return AUTHORIZATION
+    }
 }

--- a/core/src/main/kotlin/io/specmatic/conversions/BearerSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/BearerSecurityScheme.kt
@@ -3,6 +3,8 @@ package io.specmatic.conversions
 import io.specmatic.core.*
 import io.specmatic.core.pattern.Row
 import io.specmatic.core.pattern.StringPattern
+import io.swagger.v3.oas.models.parameters.HeaderParameter
+import io.swagger.v3.oas.models.parameters.Parameter
 import org.apache.http.HttpHeaders.AUTHORIZATION
 
 data class BearerSecurityScheme(private val configuredToken: String? = null) : OpenAPISecurityScheme {
@@ -60,5 +62,22 @@ data class BearerSecurityScheme(private val configuredToken: String? = null) : O
 
     override fun getHeaderKey(): String? {
         return AUTHORIZATION
+    }
+
+    override fun warnIfExistsInParameters(parameters: List<Parameter>, method: String, path: String) {
+        val matchingHeaders = parameters.filterIsInstance<HeaderParameter>().filter {
+            it.name.equals(AUTHORIZATION, ignoreCase = true)
+        }
+
+        if(matchingHeaders.isNotEmpty()) {
+            printWarningsForOverriddenSecurityParameters(
+                matchingParameters = matchingHeaders,
+                securitySchemeDescription = "Bearer Authorization",
+                httpParameterType = "header",
+                method = method,
+                path = path
+            )
+
+        }
     }
 }

--- a/core/src/main/kotlin/io/specmatic/conversions/BearerSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/BearerSecurityScheme.kt
@@ -57,4 +57,8 @@ data class BearerSecurityScheme(private val configuredToken: String? = null) : O
         if (!originalRequest.headers.containsKey(AUTHORIZATION)) return newHttpRequest
         return newHttpRequest.addSecurityHeader(AUTHORIZATION, originalRequest.headers.getValue(AUTHORIZATION))
     }
+
+    override fun getHeaderKey(): String? {
+        return AUTHORIZATION
+    }
 }

--- a/core/src/main/kotlin/io/specmatic/conversions/CompositeSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/CompositeSecurityScheme.kt
@@ -5,6 +5,7 @@ import io.specmatic.core.HttpRequestPattern
 import io.specmatic.core.Resolver
 import io.specmatic.core.Result
 import io.specmatic.core.pattern.Row
+import io.swagger.v3.oas.models.parameters.Parameter
 
 data class CompositeSecurityScheme(val schemes: List<OpenAPISecurityScheme>): OpenAPISecurityScheme {
     override fun matches(httpRequest: HttpRequest, resolver: Resolver): Result {
@@ -43,5 +44,11 @@ data class CompositeSecurityScheme(val schemes: List<OpenAPISecurityScheme>): Op
     override fun isInRequest(request: HttpRequest, complete: Boolean): Boolean {
         return if (!complete) schemes.any { it.isInRequest(request, false) }
         else schemes.all { it.isInRequest(request, true) }
+    }
+
+    override fun warnIfExistsInParameters(parameters: List<Parameter>, method: String, path: String) {
+        schemes.forEach { securityScheme ->
+            securityScheme.warnIfExistsInParameters(parameters, method, path)
+        }
     }
 }

--- a/core/src/main/kotlin/io/specmatic/conversions/NoSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/NoSecurityScheme.kt
@@ -5,6 +5,7 @@ import io.specmatic.core.HttpRequestPattern
 import io.specmatic.core.Resolver
 import io.specmatic.core.Result
 import io.specmatic.core.pattern.Row
+import io.swagger.v3.oas.models.parameters.Parameter
 
 class NoSecurityScheme : OpenAPISecurityScheme {
     override fun matches(httpRequest: HttpRequest, resolver: Resolver): Result {
@@ -41,5 +42,9 @@ class NoSecurityScheme : OpenAPISecurityScheme {
 
     override fun isInRequest(request: HttpRequest, complete: Boolean): Boolean {
         return false
+    }
+
+    override fun warnIfExistsInParameters(parameters: List<Parameter>, method: String, path: String) {
+        return
     }
 }

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenAPISecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenAPISecurityScheme.kt
@@ -15,6 +15,7 @@ interface OpenAPISecurityScheme {
     fun copyFromTo(originalRequest: HttpRequest, newHttpRequest: HttpRequest): HttpRequest
     fun isInRow(row: Row): Boolean
     fun isInRequest(request: HttpRequest, complete: Boolean): Boolean
+    fun getHeaderKey(): String? = null
 }
 
 fun addToHeaderType(

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenAPISecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenAPISecurityScheme.kt
@@ -39,33 +39,6 @@ fun addToHeaderType(
     )
 }
 
-internal fun headerPatternFromRequest(
-    request: HttpRequest,
-    headerName: String
-): Map<String, Pattern> {
-    val headerValue = request.headers[headerName]
-
-    if (headerValue != null) {
-        return mapOf(headerName to ExactValuePattern(StringValue(headerValue)))
-    }
-
-    return emptyMap()
-}
-
-internal fun queryPatternFromRequest(
-    request: HttpRequest,
-    queryParamName: String
-): Map<String, Pattern> {
-    val queryParamValue = request.queryParams.getValues(queryParamName)
-
-    if(queryParamValue.isEmpty())
-        return emptyMap()
-
-    return mapOf(
-        queryParamName to ExactValuePattern(StringValue(queryParamValue.first()))
-    )
-}
-
 internal fun printWarningsForOverriddenSecurityParameters(
     matchingParameters: List<Parameter>,
     securitySchemeDescription: String,

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenAPISecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenAPISecurityScheme.kt
@@ -6,6 +6,7 @@ import io.specmatic.core.Resolver
 import io.specmatic.core.Result
 import io.specmatic.core.pattern.*
 import io.specmatic.core.value.StringValue
+import io.swagger.v3.oas.models.parameters.Parameter
 
 interface OpenAPISecurityScheme {
     fun matches(httpRequest: HttpRequest, resolver: Resolver): Result
@@ -16,6 +17,7 @@ interface OpenAPISecurityScheme {
     fun isInRow(row: Row): Boolean
     fun isInRequest(request: HttpRequest, complete: Boolean): Boolean
     fun getHeaderKey(): String? = null
+    fun warnIfExistsInParameters(parameters: List<Parameter>, method: String, path: String)
 }
 
 fun addToHeaderType(
@@ -62,4 +64,18 @@ internal fun queryPatternFromRequest(
     return mapOf(
         queryParamName to ExactValuePattern(StringValue(queryParamValue.first()))
     )
+}
+
+internal fun printWarningsForOverriddenSecurityParameters(
+    matchingParameters: List<Parameter>,
+    securitySchemeDescription: String,
+    httpParameterType: String,
+    method: String,
+    path: String
+) {
+    val parameterNames = matchingParameters.joinToString(", ") { it.name }
+    val message =
+        "Security scheme $securitySchemeDescription is defined in the OpenAPI specification, but conflicting $httpParameterType parameter(s) have been defined in the $method operation for path '$path'. This may lead to confusion or conflicts."
+    println("Warning: $message")
+    println("Conflicting $httpParameterType parameter(s): $parameterNames")
 }

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -1029,6 +1029,16 @@ class OpenApiSpecification(
 
         val parameters = operation.parameters
 
+        operation.responses?.forEach { (status, _) ->
+            validateSecuritySchemeParameterDuplication(
+                securitySchemesForRequestPattern,
+                parameters,
+                httpMethod,
+                httpPathPattern.path,
+                status
+            )
+        }
+
         val headersMap = parameters.orEmpty().filterIsInstance<HeaderParameter>().associate {
             logger.debug("Processing request header ${it.name}")
 
@@ -2099,5 +2109,35 @@ class OpenApiSpecification(
             "PUT" to pathItem.put,
             "DELETE" to pathItem.delete
         ).filter { (_, value) -> value != null }.map { (key, value) -> key to OpenApiOperation(value!!) }.toMap()
+    }
+
+    private fun validateSecuritySchemeParameterDuplication(
+        securitySchemes: List<OpenAPISecurityScheme>,
+        parameters: List<Parameter>?,
+        method: String,
+        path: String,
+        status: String
+    ) {
+        val securityHeaderNames = securitySchemes.mapNotNull { it.getHeaderKey() }.toSet()
+
+        val headerParamNames = parameters.orEmpty()
+            .filterIsInstance<HeaderParameter>()
+            .map { it.name }
+            .toSet()
+
+        val duplicateHeaders = securityHeaderNames.intersect(headerParamNames)
+        if (duplicateHeaders.isNotEmpty()) {
+            logger.log("WARNING: $method $path - $status: Duplicate header definition found. Header(s) ${duplicateHeaders.joinToString()} is/are already defined in security scheme")
+        }
+
+        val queryParamNames = parameters.orEmpty()
+            .filterIsInstance<QueryParameter>()
+            .map { it.name }
+            .toSet()
+
+        val duplicateQueryParams = securityHeaderNames.intersect(queryParamNames)
+        if (duplicateQueryParams.isNotEmpty()) {
+            logger.log("WARNING: $method $path - $status: Duplicate query parameter definition found. Parameter(s) ${duplicateQueryParams.joinToString()} is/are already defined in security scheme")
+        }
     }
 }

--- a/core/src/test/kotlin/io/specmatic/conversions/SecuritySchemeWarnIfExistsInParametersTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/SecuritySchemeWarnIfExistsInParametersTest.kt
@@ -1,0 +1,117 @@
+package io.specmatic.conversions
+
+import io.specmatic.stub.captureStandardOutput
+import io.swagger.v3.oas.models.parameters.HeaderParameter
+import io.swagger.v3.oas.models.parameters.Parameter
+import io.swagger.v3.oas.models.parameters.QueryParameter
+import org.apache.http.HttpHeaders.AUTHORIZATION
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class SecuritySchemeWarnIfExistsInParametersTest {
+    @Test
+    fun `APIKeyInHeaderSecurityScheme should print warning if header param exists`() {
+        val scheme = APIKeyInHeaderSecurityScheme("X-API-KEY", null)
+        val parameters = listOf(HeaderParameter().apply { name = "X-API-KEY" })
+        val (output, _) = captureStandardOutput {
+            scheme.warnIfExistsInParameters(parameters, "GET", "/path")
+        }
+        assertTrue(output.contains("API key with header X-API-KEY"))
+    }
+
+    @Test
+    fun `APIKeyInQueryParamSecurityScheme should print warning if query param exists`() {
+        val scheme = APIKeyInQueryParamSecurityScheme("api_key", null)
+        val parameters = listOf(QueryParameter().apply { name = "api_key" })
+        val (output, _) = captureStandardOutput {
+            scheme.warnIfExistsInParameters(parameters, "POST", "/path")
+        }
+        assertTrue(output.contains("API key with query parameter api_key"))
+    }
+
+    @Test
+    fun `BasicAuthSecurityScheme should print warning if Authorization header param exists`() {
+        val scheme = BasicAuthSecurityScheme()
+        val parameters = listOf(HeaderParameter().apply { name = AUTHORIZATION })
+        val (output, _) = captureStandardOutput {
+            scheme.warnIfExistsInParameters(parameters, "PUT", "/path")
+        }
+        assertTrue(output.contains("Basic Auth"))
+    }
+
+    @Test
+    fun `BearerSecurityScheme should print warning if Authorization header param exists`() {
+        val scheme = BearerSecurityScheme()
+        val parameters = listOf(HeaderParameter().apply { name = AUTHORIZATION })
+        val (output, _) = captureStandardOutput {
+            scheme.warnIfExistsInParameters(parameters, "DELETE", "/path")
+        }
+        assertTrue(output.contains("Bearer Authorization"))
+    }
+
+    @Test
+    fun `CompositeSecurityScheme should print warnings for all child schemes`() {
+        val headerScheme = APIKeyInHeaderSecurityScheme("X-API-KEY", null)
+        val bearerScheme = BearerSecurityScheme()
+        val composite = CompositeSecurityScheme(listOf(headerScheme, bearerScheme))
+        val parameters = listOf(HeaderParameter().apply { name = "X-API-KEY" }, HeaderParameter().apply { name = AUTHORIZATION })
+        val (output, _) = captureStandardOutput {
+            composite.warnIfExistsInParameters(parameters, "PATCH", "/path")
+        }
+        assertTrue(output.contains("API key with header X-API-KEY"))
+        assertTrue(output.contains("Bearer Authorization"))
+    }
+
+    @Test
+    fun `no warning if header security scheme and query param have same name`() {
+        val scheme = APIKeyInHeaderSecurityScheme("X-API-KEY", null)
+        val parameters = listOf(QueryParameter().apply { name = "X-API-KEY" })
+        val (output, _) = captureStandardOutput {
+            scheme.warnIfExistsInParameters(parameters, "GET", "/path")
+        }
+        assertTrue(output.isBlank(), "Expected no warning, but got: $output")
+    }
+
+    @Test
+    fun `no warning if there are no security schemes`() {
+        val composite = NoSecurityScheme()
+        val parameters = listOf(HeaderParameter().apply { name = "X-API-KEY" })
+        val (output, _) = captureStandardOutput {
+            composite.warnIfExistsInParameters(parameters, "GET", "/path")
+        }
+        assertTrue(output.isBlank(), "Expected no warning, but got: $output")
+    }
+
+    @Test
+    fun `no warning if there are security schemes and no parameters`() {
+        val composite = CompositeSecurityScheme(listOf(
+            APIKeyInHeaderSecurityScheme("X-API-KEY", null),
+            APIKeyInQueryParamSecurityScheme("api_key", null),
+            BearerSecurityScheme(),
+            BasicAuthSecurityScheme()
+        ))
+        val parameters = emptyList<Parameter>()
+        val (output, _) = captureStandardOutput {
+            composite.warnIfExistsInParameters(parameters, "GET", "/path")
+        }
+        assertTrue(output.isBlank(), "Expected no warning, but got: $output")
+    }
+
+    @Test
+    fun `no warning if there are security schemes and parameters but no naming collisions`() {
+        val composite = CompositeSecurityScheme(listOf(
+            APIKeyInHeaderSecurityScheme("X-API-KEY", null),
+            APIKeyInQueryParamSecurityScheme("api_key", null),
+            BearerSecurityScheme(),
+            BasicAuthSecurityScheme()
+        ))
+        val parameters = listOf(
+            HeaderParameter().apply { name = "SOME-OTHER-HEADER" },
+            QueryParameter().apply { name = "some_other_query" }
+        )
+        val (output, _) = captureStandardOutput {
+            composite.warnIfExistsInParameters(parameters, "GET", "/path")
+        }
+        assertTrue(output.isBlank(), "Expected no warning, but got: $output")
+    }
+}


### PR DESCRIPTION
Added a validation check that will show a warning whenever there is a header or query parameter conflicting with security scheme.