### PR TITLE
Ability to disable hot-reload via config or command-line switch

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -22,6 +22,7 @@ import io.specmatic.core.SourceProvider.web
 import io.specmatic.core.azure.AzureAPI
 import io.specmatic.core.config.SpecmaticConfigVersion
 import io.specmatic.core.config.SpecmaticConfigVersion.VERSION_1
+import io.specmatic.core.config.Switch
 import io.specmatic.core.config.toSpecmaticConfig
 import io.specmatic.core.config.v3.Consumes
 import io.specmatic.core.config.v3.ConsumesDeserializer
@@ -107,7 +108,8 @@ data class StubConfiguration(
     private val delayInMilliseconds: Long? = null,
     private val dictionary: String? = null,
     private val includeMandatoryAndRequestedKeysInResponse: Boolean? = null,
-    private val startTimeoutInMilliseconds: Long? = null
+    private val startTimeoutInMilliseconds: Long? = null,
+    private val hotReload: Switch? = null
 ) {
     fun getGenerative(): Boolean? {
         return generative
@@ -127,6 +129,10 @@ data class StubConfiguration(
 
     fun getStartTimeoutInMilliseconds(): Long? {
         return startTimeoutInMilliseconds
+    }
+
+    fun getHotReload(): Switch? {
+        return hotReload
     }
 }
 
@@ -283,6 +289,11 @@ data class SpecmaticConfig(
         fun getEnvironments(specmaticConfig: SpecmaticConfig): Map<String, Environment>? {
             return specmaticConfig.environments
         }
+    }
+
+    @JsonIgnore
+    fun getHotReload(): Switch? {
+        return stub.getHotReload()
     }
 
     @JsonIgnore

--- a/core/src/main/kotlin/io/specmatic/core/config/Switch.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/Switch.kt
@@ -1,0 +1,5 @@
+package io.specmatic.core.config
+
+enum class Switch {
+    enabled, disabled
+}


### PR DESCRIPTION
**What**:

Specmatic stub's hot-reload can now be disabled, via the command line switch `--hot-reload=disabled`, or via the following config in specmatic.json:

```yaml
stub:
  hotReload: disabled
```

**Why**:

In some environments the number of files being watched may exceed the value of `/proc/sys/fs/inotify/max_user_watches`, and one may not have access to the environment's config/setup to change this value. The ability to disable hot-reload provides a pragmatic path forward as a temporary work-around until the reason for `/proc/sys/fs/inotify/max_user_watches` being exceeded is found and resolved.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [x] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)

<!-- feel free to add additional comments -->
