### PR TITLE
Minor updates to drop directive, primitive scalar and pattern interfaces

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/Substitution.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Substitution.kt
@@ -239,13 +239,20 @@ class Substitution(
 
     fun isDropDirective(value: Value): Boolean {
         val strValue = (value as? StringValue)?.nativeValue ?: return false
-        return try {
-            val resolved = if (!isDataLookup(strValue)) strValue else substituteDataLookupExpression(strValue)
-            resolved == DROP_DIRECTIVE
-        } catch (e: Throwable) {
-            logger.debug(e, "Failed to check for drop directive")
-            false
-        }
+
+        val resolved =
+            if (!isDataLookup(strValue)) {
+                strValue
+            } else {
+                try {
+                    substituteDataLookupExpression(strValue)
+                } catch (e: Throwable) {
+                    logger.debug(e, "Failed to check for drop directive")
+                    strValue
+                }
+            }
+
+        return resolved == DROP_DIRECTIVE
     }
 }
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
@@ -79,8 +79,9 @@ data class ListPattern(
         val resolved = runCatching { substitution.resolveIfLookup(value, this) }.getOrElse { e -> return HasException(e) }
         val resolvedValue = resolved as? JSONArrayValue ?: return HasValue(resolved)
 
-        val updatedList = resolvedValue.list.mapIndexed { index, listItem ->
-            pattern.resolveSubstitutions(substitution, listItem, resolver).breadCrumb("[$index]")
+        val updatedList = resolvedValue.list.withIndex().mapNotNull { item ->
+            if (substitution.isDropDirective(item.value)) return@mapNotNull null
+            pattern.resolveSubstitutions(substitution, item.value, resolver).breadCrumb("[${item.index}]")
         }.listFoldException()
 
         return updatedList.ifValue(resolvedValue::copy)

--- a/core/src/main/kotlin/io/specmatic/core/pattern/QueryParameterScalarPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/QueryParameterScalarPattern.kt
@@ -6,7 +6,7 @@ import io.specmatic.core.Substitution
 import io.specmatic.core.utilities.exceptionCauseMessage
 import io.specmatic.core.value.*
 
-data class QueryParameterScalarPattern(override val pattern: Pattern): Pattern by pattern {
+data class QueryParameterScalarPattern(override val pattern: Pattern): Pattern by pattern, ScalarType {
     override fun resolveSubstitutions(
         substitution: Substitution,
         value: Value,

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ScalarType.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ScalarType.kt
@@ -1,6 +1,6 @@
 package io.specmatic.core.pattern
 
-interface ScalarType
+interface ScalarType: Pattern
 
 fun scalarAnnotation(pattern: Pattern, negativePatterns: Sequence<Pattern>): Sequence<ReturnValue<Pattern>> {
     return negativePatterns.map {

--- a/core/src/main/kotlin/io/specmatic/core/value/ScalarValue.kt
+++ b/core/src/main/kotlin/io/specmatic/core/value/ScalarValue.kt
@@ -1,5 +1,5 @@
 package io.specmatic.core.value
 
-interface ScalarValue {
+interface ScalarValue: Value {
     val nativeValue: Any?
 }

--- a/core/src/test/kotlin/integration_tests/StubSubstitutionTest.kt
+++ b/core/src/test/kotlin/integration_tests/StubSubstitutionTest.kt
@@ -1054,7 +1054,7 @@ class StubSubstitutionTest {
             "lookup": {
                 "data": {
                     "123": {
-                        "names": "(drop)"
+                        "names": "$(drop)"
                     }
                 }
             }
@@ -1120,7 +1120,7 @@ class StubSubstitutionTest {
             "lookup": {
                 "data": {
                     "123": {
-                        "names": "(drop)"
+                        "names": "$(drop)"
                     }
                 }
             }


### PR DESCRIPTION
**What**: Minor updates to drop directive, primitive scalar and pattern interfaces

**How**:
- Change drop directive to `$(drop)` from `(drop)`
- Make `ScalarType `a subclass of `Pattern`, and `ScalarValue `a subclass of `Value`

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
