### PR TITLE
Implement StringProviders to provide string values on generation

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -78,6 +78,7 @@ class OpenApiSpecification(
     private val strictMode: Boolean = false
 ) : IncludedSpecification, ApiSpecification {
     init {
+        StringProviders // Trigger early initialization of StringProviders to ensure all providers are loaded at startup
         logger.log(openApiSpecificationInfo(openApiFilePath, parsedOpenApi))
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
@@ -144,7 +144,7 @@ data class HttpRequest(
     fun toJSON(): JSONObjectValue {
         val requestMap = mutableMapOf<String, Value>()
 
-        requestMap["path"] = path?.let { StringValue(it) } ?: StringValue("/")
+        requestMap["path"] = path?.encodeURLPath()?.let { StringValue(it) } ?: StringValue("/")
         method?.let { requestMap["method"] = StringValue(it) }
             ?: throw ContractException("Can't serialise the request without a method.")
 

--- a/core/src/main/kotlin/io/specmatic/core/Resolver.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Resolver.kt
@@ -439,6 +439,12 @@ data class Resolver(
         return findKeyErrorCheck.toPartialKeyCheck()
     }
 
+    fun provideString(pattern: Pattern): StringValue? {
+        val path = dictionaryLookupPath.split(".").filter(String::isNotBlank)
+        val value = StringProviders.getFor(path) { pattern.matches(StringValue(it),this).isSuccess() }
+        return value?.let(::StringValue)
+    }
+
     private fun lastLookupKey(): String? = dictionaryLookupPath.substringAfterLast(".").takeIf(String::isNotBlank)
 }
 

--- a/core/src/main/kotlin/io/specmatic/core/Resolver.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Resolver.kt
@@ -440,8 +440,12 @@ data class Resolver(
     }
 
     fun provideString(pattern: ScalarType): StringValue? {
-        val values = StringProviders.getFor(pattern, this)
+        val path = dictionaryLookupPath.replace(WILDCARD_INDEX, "|$WILDCARD_INDEX|").split(".", "|")
+        val values = StringProviders.getFor(pattern, this, path)
+        val isForParameter = path.contains(BreadCrumb.PARAMETERS.value)
+
         return values.filterNot { value ->
+            if (!isForParameter) return@filterNot false
             this.isNegative && (value.toIntOrNull() != null || value.lowercase() in setOf("true", "false"))
         }.map(::StringValue).firstNotNullOfOrNull { value ->
             val result = pattern.matches(value, this)

--- a/core/src/main/kotlin/io/specmatic/core/Resolver.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Resolver.kt
@@ -439,9 +439,8 @@ data class Resolver(
         return findKeyErrorCheck.toPartialKeyCheck()
     }
 
-    fun provideString(pattern: Pattern): StringValue? {
-        val path = dictionaryLookupPath.replace(WILDCARD_INDEX, "|$WILDCARD_INDEX|").split(".", "|").filter(String::isNotEmpty)
-        val values = StringProviders.getFor(path.reversed())
+    fun provideString(pattern: ScalarType): StringValue? {
+        val values = StringProviders.getFor(pattern, this)
         return values.map(::StringValue).firstNotNullOfOrNull { value ->
             val result = pattern.matches(value, this)
             value.takeIf { result.isSuccess() }

--- a/core/src/main/kotlin/io/specmatic/core/Resolver.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Resolver.kt
@@ -441,7 +441,9 @@ data class Resolver(
 
     fun provideString(pattern: ScalarType): StringValue? {
         val values = StringProviders.getFor(pattern, this)
-        return values.map(::StringValue).firstNotNullOfOrNull { value ->
+        return values.filterNot { value ->
+            this.isNegative && (value.toIntOrNull() != null || value.lowercase() in setOf("true", "false"))
+        }.map(::StringValue).firstNotNullOfOrNull { value ->
             val result = pattern.matches(value, this)
             value.takeIf { result.isSuccess() }
         }

--- a/core/src/main/kotlin/io/specmatic/core/Resolver.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Resolver.kt
@@ -440,14 +440,14 @@ data class Resolver(
     }
 
     fun provideString(pattern: ScalarType): StringValue? {
+        if (this.isNegative) {
+            return null
+        }
+
         val path = dictionaryLookupPath.replace(WILDCARD_INDEX, "|$WILDCARD_INDEX|").split(".", "|")
         val values = StringProviders.getFor(pattern, this, path)
-        val isForParameter = path.contains(BreadCrumb.PARAMETERS.value)
 
-        return values.filterNot { value ->
-            if (!isForParameter) return@filterNot false
-            this.isNegative && (value.toIntOrNull() != null || value.lowercase() in setOf("true", "false"))
-        }.map(::StringValue).firstNotNullOfOrNull { value ->
+        return values.map(::StringValue).firstNotNullOfOrNull { value ->
             val result = pattern.matches(value, this)
             value.takeIf { result.isSuccess() }
         }

--- a/core/src/main/kotlin/io/specmatic/core/StringProviders.kt
+++ b/core/src/main/kotlin/io/specmatic/core/StringProviders.kt
@@ -1,5 +1,6 @@
 package io.specmatic.core
 
+import java.util.*
 import java.util.concurrent.CopyOnWriteArrayList
 
 interface StringProvider {
@@ -9,17 +10,19 @@ interface StringProvider {
 object StringProviders {
     private val providers = CopyOnWriteArrayList<StringProvider>()
 
+    init {
+        ServiceLoader.load(StringProvider::class.java).forEach {
+            providers.add(it)
+        }
+    }
+
     fun add(provider: StringProvider) {
         providers.add(provider)
     }
 
-    fun getFor(path: List<String>, match: (String) -> Boolean): String? {
-        for (provider in providers) {
-            val value = provider.getFor(path)
-            if (value != null && match(value)) {
-                return value
-            }
+    fun getFor(path: List<String>): Sequence<String> {
+        return providers.asSequence().mapNotNull {
+            runCatching { it.getFor(path) }.getOrNull()
         }
-        return null
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/StringProviders.kt
+++ b/core/src/main/kotlin/io/specmatic/core/StringProviders.kt
@@ -1,0 +1,25 @@
+package io.specmatic.core
+
+import java.util.concurrent.CopyOnWriteArrayList
+
+interface StringProvider {
+    fun getFor(path: List<String>): String?
+}
+
+object StringProviders {
+    private val providers = CopyOnWriteArrayList<StringProvider>()
+
+    fun add(provider: StringProvider) {
+        providers.add(provider)
+    }
+
+    fun getFor(path: List<String>, match: (String) -> Boolean): String? {
+        for (provider in providers) {
+            val value = provider.getFor(path)
+            if (value != null && match(value)) {
+                return value
+            }
+        }
+        return null
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/core/StringProviders.kt
+++ b/core/src/main/kotlin/io/specmatic/core/StringProviders.kt
@@ -1,10 +1,12 @@
 package io.specmatic.core
 
+import io.specmatic.core.pattern.ScalarType
+import io.specmatic.test.asserts.WILDCARD_INDEX
 import java.util.*
 import java.util.concurrent.CopyOnWriteArrayList
 
 interface StringProvider {
-    fun getFor(path: List<String>): String?
+    fun getFor(pattern: ScalarType, resolver: Resolver, path: List<String>): String?
 }
 
 object StringProviders {
@@ -20,9 +22,20 @@ object StringProviders {
         providers.add(provider)
     }
 
-    fun getFor(path: List<String>): Sequence<String> {
+    fun getFor(pattern: ScalarType, resolver: Resolver): Sequence<String> {
+        val path = resolver.dictionaryLookupPath.replace(WILDCARD_INDEX, "|$WILDCARD_INDEX|").split(".", "|")
+        val reversedPath = path.filter(String::isNotEmpty).reversed()
         return providers.asSequence().mapNotNull {
-            runCatching { it.getFor(path) }.getOrNull()
+            runCatching { it.getFor(pattern, resolver, reversedPath) }.getOrNull()
+        }
+    }
+
+    fun with(provider: StringProvider, block: () -> Unit) {
+        providers.add(provider)
+        try {
+            block()
+        } finally {
+            providers.remove(provider)
         }
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/EmailPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/EmailPattern.kt
@@ -55,7 +55,7 @@ class EmailPattern (private val stringPatternDelegate: StringPattern) :
     override fun generate(resolver: Resolver): Value {
         val localPart = randomString(5).lowercase(Locale.getDefault())
         val domain = randomString(5).lowercase(Locale.getDefault())
-        return StringValue("$localPart@$domain.com")
+        return resolver.provideString(this) ?: StringValue("$localPart@$domain.com")
     }
 
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/StringPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/StringPattern.kt
@@ -89,7 +89,7 @@ data class StringPattern (
             return it
         }
 
-        return regExSpec.generateRandomString(effectiveMinLength, maxLength)
+        return resolver.provideString(this) ?: regExSpec.generateRandomString(effectiveMinLength, maxLength)
     }
 
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/URLPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/URLPattern.kt
@@ -8,7 +8,7 @@ import io.specmatic.core.value.StringValue
 import io.specmatic.core.value.Value
 import java.net.URI
 
-data class URLPattern(val scheme: URLScheme = URLScheme.HTTPS, override val typeAlias: String? = null): Pattern {
+data class URLPattern(val scheme: URLScheme = URLScheme.HTTPS, override val typeAlias: String? = null): Pattern, ScalarType {
     override val pattern: String = "(url)"
 
     override fun matches(sampleData: Value?, resolver: Resolver): Result {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/URLPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/URLPattern.kt
@@ -22,8 +22,10 @@ data class URLPattern(val scheme: URLScheme = URLScheme.HTTPS, override val type
         }
     }
 
-    override fun generate(resolver: Resolver): StringValue =
-            StringValue("${scheme.prefix}${randomString().lowercase()}.com/${randomString().lowercase()}")
+    override fun generate(resolver: Resolver): StringValue {
+        val providedString = resolver.provideString(this)
+        return providedString ?: StringValue("${scheme.prefix}${randomString().lowercase()}.com/${randomString().lowercase()}")
+    }
 
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> = sequenceOf(HasValue(this))
 

--- a/core/src/main/kotlin/io/specmatic/core/utilities/Utilities.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/Utilities.kt
@@ -380,17 +380,21 @@ fun nullOrExceptionString(fn: () -> Result): String? {
     }
 }
 
+private fun sanitizeFilename(input: String): String {
+    return input.replace(Regex("""[\\/:*?"'<>| ]"""), "_")
+}
+
 fun uniqueNameForApiOperation(httpRequest: HttpRequest, baseURL: String, responseStatus: Int): String {
     val (method, path, headers) = httpRequest
     val contentType = if(method == "PATCH")
         "_" + headers[CONTENT_TYPE].orEmpty().replace("/", "_")
     else ""
-    val formattedPath = path?.replace(baseURL, "")
-        ?.replace("/", "_")
-        ?.drop(1)
-        .orEmpty()
+
+    val formattedPath = path?.replace(baseURL, "")?.drop(1).orEmpty()
     if (formattedPath.isEmpty()) return "${method}_${responseStatus}"
-    return "${formattedPath}_${method}_${responseStatus}$contentType"
+
+    val rawName = "${formattedPath}_${method}_${responseStatus}$contentType"
+    return sanitizeFilename(rawName)
 }
 
 fun consolePrintableURL(host: String, port: Int, keyStoreData: KeyData? = null): String {

--- a/core/src/test/kotlin/io/specmatic/core/HttpPathPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpPathPatternTest.kt
@@ -406,6 +406,20 @@ internal class HttpPathPatternTest {
         assertThat(result).isInstanceOf(Result.Success::class.java)
     }
 
+    @Test
+    fun `should replace any non-encodable characters from values provided by StringProviders`() {
+        val pattern = HttpPathPattern.from("/test/(userName:string)")
+        val resolver = Resolver()
+        val provider = object: StringProvider {
+            override fun getFor(pattern: ScalarType, resolver: Resolver, path: List<String>): String = "specmatic test"
+        }
+
+        StringProviders.with(provider) {
+            val generated = pattern.generate(resolver)
+            assertThat(generated).isEqualTo("/test/specmatic_test")
+        }
+    }
+
     @Nested
     inner class FixValueTests {
         @Test

--- a/core/src/test/kotlin/io/specmatic/core/HttpQueryParamPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpQueryParamPatternTest.kt
@@ -524,7 +524,21 @@ class HttpQueryParamPatternTest {
         assertThat(generatedValue.first()).hasSize(2)
         assertThat(generatedValue.first().keys).contains("key")
         assertThat(generatedValue.first().keys.filter { it != "key" }).hasSize(1)
- }
+    }
+
+    @Test
+    fun `should replace any non-encodable characters from values provided by StringProviders`() {
+        val pattern = HttpQueryParamPattern(mapOf("userName" to QueryParameterScalarPattern(StringPattern())))
+        val resolver = Resolver()
+        val provider = object: StringProvider {
+            override fun getFor(pattern: ScalarType, resolver: Resolver, path: List<String>): String = "specmatic test"
+        }
+
+        StringProviders.with(provider) {
+            val generated = pattern.generate(resolver).toMap()
+            assertThat(generated["userName"]).isEqualTo("specmatic_test")
+        }
+    }
 
     @Nested
     inner class FixValueTests {

--- a/core/src/test/kotlin/io/specmatic/core/pattern/StringPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/StringPatternTest.kt
@@ -452,18 +452,4 @@ internal class StringPatternTest {
             }
         }
     }
-
-    @Test
-    fun `should allow number or boolean like values from string providers for non parameter requests`() {
-        val pattern = StringPattern()
-        val resolver = Resolver(isNegative = true, dictionaryLookupPath = "SomeSchema.nestedObject.thisKey")
-        val provider = object: StringProvider {
-            override fun getFor(pattern: ScalarType, resolver: Resolver, path: List<String>): String = "123"
-        }
-
-        StringProviders.with(provider) {
-            val generated = pattern.generate(resolver)
-            assertThat(generated.toStringLiteral()).isEqualTo("123")
-        }
-    }
 }

--- a/core/src/test/kotlin/io/specmatic/core/pattern/StringPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/StringPatternTest.kt
@@ -437,9 +437,9 @@ internal class StringPatternTest {
     }
 
     @Test
-    fun `should not use provider provided value if pattern is mutated from number to string and value is all digits`() {
+    fun `should not allow number or boolean like values from string providers for parameter requests`() {
         val pattern = NumberPattern()
-        val resolver = Resolver(isNegative = true)
+        val resolver = Resolver(isNegative = true, dictionaryLookupPath = BreadCrumb.PARAMETERS.value)
         val provider = object: StringProvider {
             override fun getFor(pattern: ScalarType, resolver: Resolver, path: List<String>): String = "123"
         }
@@ -450,6 +450,20 @@ internal class StringPatternTest {
                 val generated = mutation.value.parse(mutation.value.generate(resolver).toStringLiteral(), resolver)
                 assertThat(pattern.matches(generated, resolver).isSuccess()).isFalse()
             }
+        }
+    }
+
+    @Test
+    fun `should allow number or boolean like values from string providers for non parameter requests`() {
+        val pattern = StringPattern()
+        val resolver = Resolver(isNegative = true, dictionaryLookupPath = "SomeSchema.nestedObject.thisKey")
+        val provider = object: StringProvider {
+            override fun getFor(pattern: ScalarType, resolver: Resolver, path: List<String>): String = "123"
+        }
+
+        StringProviders.with(provider) {
+            val generated = pattern.generate(resolver)
+            assertThat(generated.toStringLiteral()).isEqualTo("123")
         }
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/pattern/URLPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/URLPatternTest.kt
@@ -3,9 +3,12 @@ package io.specmatic.core.pattern
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.fail
 import io.specmatic.core.Resolver
+import io.specmatic.core.StringProvider
+import io.specmatic.core.StringProviders
 import io.specmatic.core.value.StringValue
 import io.specmatic.shouldMatch
 import io.specmatic.shouldNotMatch
+import org.assertj.core.api.Assertions.assertThat
 import java.net.URI
 import org.junit.jupiter.api.Assertions.assertEquals
 
@@ -41,5 +44,48 @@ internal class URLPatternTest {
 
         assertEquals(pattern, newPatterns.first())
         assertEquals(1, newPatterns.size)
+    }
+
+    @Test
+    fun `should be able to use values provided by StringProviders when one is registered`() {
+        val pattern = URLPattern()
+        val resolver = Resolver()
+        val provider = object: StringProvider {
+            override fun getFor(pattern: ScalarType, resolver: Resolver, path: List<String>): String = "https://specmatic.io"
+        }
+
+        StringProviders.with(provider) {
+            val generated = pattern.generate(resolver)
+            assertThat(generated).isEqualTo(StringValue("https://specmatic.io"))
+        }
+    }
+
+    @Test
+    fun `should generate a random string if no provider exists or can't provide a value`() {
+        val pattern = URLPattern()
+        val resolver = Resolver()
+        val provider = object: StringProvider {
+            override fun getFor(pattern: ScalarType, resolver: Resolver, path: List<String>): String? = null
+        }
+
+        StringProviders.with(provider) {
+            val generated = pattern.generate(resolver)
+            assertThat(generated).isInstanceOf(StringValue::class.java)
+        }
+    }
+
+    @Test
+    fun `invalid value provided by any StringProviders should be halted by resolver and result in random generation`() {
+        val pattern = URLPattern(scheme = URLScheme.HTTPS)
+        val resolver = Resolver()
+        val provider = object: StringProvider {
+            override fun getFor(pattern: ScalarType, resolver: Resolver, path: List<String>): String = "http://specmatic.io"
+        }
+
+        StringProviders.with(provider) {
+            val generated = pattern.generate(resolver)
+            assertThat(generated.toStringLiteral()).isNotEqualTo("http://specmatic.io")
+            assertThat(generated).isInstanceOf(StringValue::class.java)
+        }
     }
 }

--- a/core/src/test/kotlin/utilities/UtilitiesTest.kt
+++ b/core/src/test/kotlin/utilities/UtilitiesTest.kt
@@ -23,12 +23,10 @@ import io.ktor.server.routing.*
 import io.mockk.*
 import io.specmatic.toContractSourceEntries
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Nested
-import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.*
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.MethodSource
 import java.io.File
 import java.net.ServerSocket
@@ -557,6 +555,19 @@ internal class UtilitiesTest {
     fun `validateURI should return error for invalid URLs`(url: String, expectedResult: URIValidationResult) {
         val result = validateTestOrStubUri(url)
         assertThat(result).isEqualTo(expectedResult)
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        "http://example.com/api/v1/user, http://example.com/api/v1, GET, 200, user_GET_200",
+        "http://localhost:8080/users/Specmatic Test/details, http://localhost:8080, GET, 200, users_Specmatic_Test_details_GET_200",
+    )
+    fun `unique names from operation information names should be path valid`(path: String?, baseURL: String, method: String, status: Int, expected: String) {
+        val request = HttpRequest(method, path, emptyMap())
+        val actual = uniqueNameForApiOperation(request, baseURL, status)
+
+        assertThat(actual).isEqualTo(expected)
+        assertDoesNotThrow { File(actual).canonicalPath }
     }
 
     private fun deleteGitIgnoreFile(){


### PR DESCRIPTION
**What**: Implement `StringProviders` to provide string values on generation instead of random string generation

**Why**: Offers a method to implement and register provider services that generate meaningful values instead of random text

**How**:
- Invoke services before random generation with required context, enabling the generation of contextually appropriate value
- Dictionary values are prioritized over providers and will be favored.

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
