### PR TITLE
Less verbose stub logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ gen-kt/
 gen-resources/
 .vscode
 .kotlin/
+settings.local.json

--- a/application/src/main/kotlin/application/StubCommand.kt
+++ b/application/src/main/kotlin/application/StubCommand.kt
@@ -222,7 +222,6 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
         listOf(TextFilePrinter(LogDirectory(it, logPrefix, ".log")))
     } ?: emptyList()
 
-
     private fun startServer() {
         val workingDirectory = WorkingDirectory()
         if(strictMode) throwExceptionIfDirectoriesAreInvalid(exampleDirs, "example directories")
@@ -230,16 +229,16 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
             contractPathDataList = contractSources,
             dataDirs = exampleDirs,
             specmaticConfigPath = specmaticConfigPath,
-            strictMode = strictMode
+            strictMode = strictMode,
         )
-        
+
         logStubLoadingSummary(stubData)
-        
+
         val filteredStubData = stubData.mapNotNull { (feature, scenarioStubs) ->
             val metadataFilter = ScenarioMetadataFilter.from(filter)
             val filteredScenarios = ScenarioMetadataFilter.filterUsing(
                 feature.scenarios.asSequence(),
-                metadataFilter
+                metadataFilter,
             ).toList()
             val stubFilterExpression = ExpressionStandardizer.filterToEvalEx(filter)
             val filteredStubScenario = scenarioStubs.filter { it ->
@@ -319,12 +318,12 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
             }
         })
     }
-    
+
     private fun logStubLoadingSummary(stubData: List<Pair<Feature, List<ScenarioStub>>>) {
         val totalStubs = stubData.sumOf { it.second.size }
-        
+
         if (verbose) {
-            logger.newLine()
+            logger.boundary()
             consoleLog(StringLog("Loaded stubs:"))
             stubData.forEach { (feature, stubs) ->
                 val featureName = feature.specification ?: feature.path
@@ -333,11 +332,10 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
                     consoleLog(StringLog("  - $featureName: $stubDescription"))
                 }
             }
-            consoleLog(StringLog("Total: $totalStubs stubs loaded"))
-        } else {
-            consoleLog(StringLog("$totalStubs stubs loaded"))
+            consoleLog(StringLog("Total: $totalStubs example(s) loaded"))
         }
-        logger.newLine()
+
+        logger.boundary()
     }
     
     private fun buildStubDescription(stub: ScenarioStub): String {

--- a/core/src/main/kotlin/io/specmatic/stub/api.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/api.kt
@@ -18,6 +18,7 @@ import io.specmatic.core.git.SystemGit
 import io.specmatic.core.isContractFile
 import io.specmatic.core.loadSpecmaticConfigOrDefault
 import io.specmatic.core.log.StringLog
+import io.specmatic.core.log.Verbose
 import io.specmatic.core.log.consoleDebug
 import io.specmatic.core.log.consoleLog
 import io.specmatic.core.log.logger
@@ -807,7 +808,9 @@ fun loadContractStubsAsResults(
             if (matchResult.feature == null) {
                 null
             } else {
-                logger.debug("Successfully loaded the stub expectation from '${stub.filePath.orEmpty()}".prependIndent(" "))
+                if (logger is Verbose) {
+                    logger.debug("Successfully loaded the stub expectation from '${stub.filePath.orEmpty()}".prependIndent(" "))
+                }
                 FeatureStubsResult.Success(matchResult.feature, listOf(stub))
             }
         }


### PR DESCRIPTION
**What**:

- Print only the count of stub loaded by default, and the full list of stubs loaded when `--debug` is set to true.

**Why**:

- The logs get too verbose when there are a large number of stub files. It makes looking through the errors hard. We don't care to see the files loaded unless we want to debug.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)

