### PR TITLE
Bug fix: Stack overflow for string schema with maxLength 2147483647

### DIFF
--- a/application/src/test/kotlin/application/HTTPStubEngineTest.kt
+++ b/application/src/test/kotlin/application/HTTPStubEngineTest.kt
@@ -35,10 +35,15 @@ class HTTPStubEngineTest {
     @Test
     fun `should log sever startup messages for each base urls`() {
         val (stdOut, _) = captureStandardOutput {
-            runHttpStubEngineWithMockPaths("api.yaml", "bff.yaml", specToBaseUrlMap = mapOf(
-                "api.yaml" to "http://localhost:8000/api/v3",
-                "bff.yaml" to "http://localhost:9000"
-            ))
+            runHttpStubEngineWithMockPaths(
+                "api.yaml",
+                "bff.yaml",
+                specToBaseUrlMap =
+                    mapOf(
+                        "api.yaml" to "http://localhost:8000/api/v3",
+                        "bff.yaml" to "http://localhost:9000",
+                    ),
+            )
         }
 
         assertThat(stdOut).isEqualToNormalizingNewlines("""

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -42,6 +42,8 @@ import io.swagger.v3.parser.core.models.SwaggerParseResult
 import java.io.File
 
 private const val BEARER_SECURITY_SCHEME = "bearer"
+private const val REASONABLE_STRING_LENGTH = 4 * 1024 * 1024
+
 const val OBJECT_TYPE = "object"
 const val SERVICE_TYPE_HTTP = "HTTP"
 
@@ -1522,7 +1524,7 @@ class OpenApiSpecification(
                     example = schema.example?.toString(),
                     regex = schema.pattern,
                 ).also {
-                    if (schema.maxLength?.let { it > 4 * 1024 * 1024 } == true) {
+                    if (schema.maxLength?.let { maxLength -> maxLength > REASONABLE_STRING_LENGTH } == true) {
                         val warningMessage =
                             "WARNING: The maxLength of ${schema.maxLength} for ${if (patternName.isNotBlank()) "schema $patternName" else breadCrumb} is very large. It may have downstream results, such as tests do not covering the max length value of this field. Please reconsider the design of this field."
                         logger.log(warningMessage)

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -1724,7 +1724,7 @@ class OpenApiSpecification(
                 if (schema.nullable == true && schema.additionalProperties == null && schema.`$ref` == null) {
                     NullPattern
                 } else if (schema.additionalProperties is Schema<*> || schema.additionalProperties == true || schema.properties != null) {
-                    toJsonObjectPattern(schema, patternName, typeStack)
+                    toJsonObjectPattern(schema, patternName, typeStack, breadCrumb)
                 } else {
                     val schemaFragment = if(patternName.isNotBlank()) " in schema $patternName" else " in the schema"
 

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -1524,7 +1524,7 @@ class OpenApiSpecification(
                 ).also {
                     if (schema.maxLength?.let { it > 4 * 1024 * 1024 } == true) {
                         val warningMessage =
-                            "WARNING: The maxLength of ${schema.maxLength} for ${if (patternName.isNotBlank()) "schema $patternName" else breadCrumb} is very large. Tests do not run for values with size > 6MB. Please review the size of this field"
+                            "WARNING: The maxLength of ${schema.maxLength} for ${if (patternName.isNotBlank()) "schema $patternName" else breadCrumb} is very large. It may have downstream results, such as tests do not covering the max length value of this field. Please reconsider the design of this field."
                         logger.log(warningMessage)
                         logger.boundary()
                     }

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -42,7 +42,6 @@ import io.swagger.v3.parser.core.models.SwaggerParseResult
 import java.io.File
 
 private const val BEARER_SECURITY_SCHEME = "bearer"
-private const val REASONABLE_STRING_LENGTH = 4 * 1024 * 1024
 
 const val OBJECT_TYPE = "object"
 const val SERVICE_TYPE_HTTP = "HTTP"
@@ -1518,18 +1517,17 @@ class OpenApiSpecification(
             DeferredPattern("(${componentName})")
         } else when (schema) {
             is StringSchema -> when (schema.enum) {
-                null -> StringPattern(
-                    minLength = schema.minLength,
-                    maxLength = schema.maxLength,
-                    example = schema.example?.toString(),
-                    regex = schema.pattern,
-                ).also {
-                    if (schema.maxLength?.let { maxLength -> maxLength > REASONABLE_STRING_LENGTH } == true) {
-                        val warningMessage =
-                            "WARNING: The maxLength of ${schema.maxLength} for ${if (patternName.isNotBlank()) "schema $patternName" else breadCrumb} is very large. It may have downstream results, such as tests do not covering the max length value of this field. Please reconsider the design of this field."
-                        logger.log(warningMessage)
-                        logger.boundary()
-                    }
+                null -> {
+                    val stringConstraints = StringConstraints(schema, patternName, breadCrumb)
+
+                    StringPattern(
+                        minLength = stringConstraints.resolvedMinLength,
+                        maxLength = stringConstraints.resolvedMaxLength,
+                        example = schema.example?.toString(),
+                        regex = schema.pattern,
+                        downsampledMax = stringConstraints.downsampledMax,
+                        downsampledMin = stringConstraints.downsampledMin,
+                    )
                 }
                 else -> toEnum(schema, patternName) { enumValue -> StringValue(enumValue.toString()) }.withExample(
                     schema.example?.toString(),

--- a/core/src/main/kotlin/io/specmatic/conversions/StringConstraints.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/StringConstraints.kt
@@ -27,21 +27,21 @@ class StringConstraints(
             downsampledMin = it.second
         }
     }
+}
 
-    private fun rightSizedLength(
-        length: Int?,
-        paramName: String,
-        breadCrumb: String,
-    ): Pair<Int?, Boolean> {
-        length ?: return null to false
+internal fun rightSizedLength(
+    length: Int?,
+    paramName: String,
+    breadCrumb: String,
+): Pair<Int?, Boolean> {
+    length ?: return null to false
 
-        return if (length > REASONABLE_STRING_LENGTH) {
-            val warningMessage =
-                "WARNING: The $paramName of $length for $breadCrumb is very large. We will use a more reasonable $paramName of 4MB. Boundary testing will not be done for this parameter, and string lengths generated for test or stub will not exceed 4MB in length. Please review the $paramName of $length on this field."
-            logger.log(warningMessage)
-            REASONABLE_STRING_LENGTH to true
-        } else {
-            length to false
-        }
+    return if (length > REASONABLE_STRING_LENGTH) {
+        val warningMessage =
+            "WARNING: The $paramName of $length for $breadCrumb is very large. We will use a more reasonable $paramName of 4MB. Boundary testing will not be done for this parameter, and string lengths generated for test or stub will not exceed 4MB in length. Please review the $paramName of $length on this field."
+        logger.log(warningMessage)
+        REASONABLE_STRING_LENGTH to true
+    } else {
+        length to false
     }
 }

--- a/core/src/main/kotlin/io/specmatic/conversions/StringConstraints.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/StringConstraints.kt
@@ -1,0 +1,43 @@
+package io.specmatic.conversions
+
+import io.specmatic.core.log.logger
+import io.swagger.v3.oas.models.media.StringSchema
+
+private const val REASONABLE_STRING_LENGTH = 4 * 1024 * 1024
+
+class StringConstraints(schema: StringSchema, patternName: String, breadCrumb: String) {
+    val resolvedBreadCrumb = if (patternName.isNotBlank()) "schema $patternName" else breadCrumb
+    val resolvedMaxLength: Int?
+    val downsampledMax: Boolean
+    val resolvedMinLength: Int?
+    val downsampledMin: Boolean
+
+    init {
+        rightSizedLength(schema.maxLength, "maxLength", resolvedBreadCrumb).also {
+            resolvedMaxLength = it.first
+            downsampledMax = it.second
+        }
+
+        rightSizedLength(schema.minLength, "minLength", resolvedBreadCrumb).also {
+            resolvedMinLength = it.first
+            downsampledMin = it.second
+        }
+    }
+
+    private fun rightSizedLength(
+        length: Int?,
+        paramName: String,
+        breadCrumb: String,
+    ): Pair<Int?, Boolean> {
+        length ?: return null to false
+
+        return if (length > REASONABLE_STRING_LENGTH) {
+            val warningMessage =
+                "WARNING: The $paramName of $length for $breadCrumb is very large. It may have downstream impact, such as tests do not covering the max length value of this field. Please reconsider the design of this field."
+            logger.log(warningMessage)
+            REASONABLE_STRING_LENGTH to true
+        } else {
+            length to false
+        }
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/conversions/StringConstraints.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/StringConstraints.kt
@@ -5,8 +5,12 @@ import io.swagger.v3.oas.models.media.StringSchema
 
 private const val REASONABLE_STRING_LENGTH = 4 * 1024 * 1024
 
-class StringConstraints(schema: StringSchema, patternName: String, breadCrumb: String) {
-    val resolvedBreadCrumb = if (patternName.isNotBlank()) "schema $patternName" else breadCrumb
+class StringConstraints(
+    schema: StringSchema,
+    patternName: String,
+    breadCrumb: String,
+) {
+    private val resolvedBreadCrumb = if (patternName.isNotBlank()) "schema $patternName" else breadCrumb
     val resolvedMaxLength: Int?
     val downsampledMax: Boolean
     val resolvedMinLength: Int?
@@ -33,7 +37,7 @@ class StringConstraints(schema: StringSchema, patternName: String, breadCrumb: S
 
         return if (length > REASONABLE_STRING_LENGTH) {
             val warningMessage =
-                "WARNING: The $paramName of $length for $breadCrumb is very large. It may have downstream impact, such as tests do not covering the max length value of this field. Please reconsider the design of this field."
+                "WARNING: The $paramName of $length for $breadCrumb is very large. We will use a more reasonable $paramName of 4MB. Boundary testing will not be done for this parameter, and string lengths generated for test or stub will not exceed 4MB in length. Please review the $paramName of $length on this field."
             logger.log(warningMessage)
             REASONABLE_STRING_LENGTH to true
         } else {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/StringPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/StringPattern.kt
@@ -107,7 +107,6 @@ data class StringPattern (
                     try {
                         regExSpec.generateLongestStringOrRandom(maxLen)
                     } catch (_: Throwable) {
-                        logger.log("WARNING: Skipping generation of maximum length string example as the length is greater than 4MB")
                         return@let null
                     }
 

--- a/core/src/test/kotlin/io/specmatic/conversions/StringConstraintsTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/StringConstraintsTest.kt
@@ -1,0 +1,110 @@
+// filepath: /Users/joelrosario/Source/specmatic/specmatic/core/src/test/kotlin/io/specmatic/conversions/StringConstraintsTest.kt
+package io.specmatic.conversions
+
+import io.specmatic.stub.captureStandardOutput
+import io.swagger.v3.oas.models.media.StringSchema
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class StringConstraintsTest {
+    private val FOUR_MB = 4 * 1024 * 1024
+
+    @Test
+    fun `rightSizedLength returns null and false for null length and prints nothing`() {
+        val (output, result) = captureStandardOutput { rightSizedLength(null, "maxLength", "crumb") }
+        assertThat(result.first).isNull()
+        assertThat(result.second).isFalse()
+        assertThat(output).isBlank()
+    }
+
+    @Test
+    fun `rightSizedLength under or equal to limit returns unchanged with no warning`() {
+        val exactLimit = FOUR_MB
+        val under = 123
+
+        val (outUnder, resUnder) = captureStandardOutput { rightSizedLength(under, "minLength", "path.to.field") }
+        assertThat(resUnder.first).isEqualTo(under)
+        assertThat(resUnder.second).isFalse()
+        assertThat(outUnder).isBlank()
+
+        val (outExact, resExact) = captureStandardOutput { rightSizedLength(exactLimit, "maxLength", "path.to.field") }
+        assertThat(resExact.first).isEqualTo(exactLimit)
+        assertThat(resExact.second).isFalse()
+        assertThat(outExact).isBlank()
+    }
+
+    @Test
+    fun `rightSizedLength above limit returns 4MB and true and logs a warning`() {
+        val tooLarge = FOUR_MB + 1
+        val (output, result) = captureStandardOutput { rightSizedLength(tooLarge, "maxLength", "Example.Field") }
+
+        assertThat(result.first).isEqualTo(FOUR_MB)
+        assertThat(result.second).isTrue()
+        assertThat(output).contains("WARNING: The maxLength of $tooLarge for Example.Field is very large")
+        assertThat(output).contains("more reasonable maxLength of 4MB")
+        assertThat(output).contains("Boundary testing will not be done")
+    }
+
+    @Test
+    fun `StringConstraints downsamples too large min and max and logs warnings with breadcrumb`() {
+        val tooLarge = FOUR_MB + 100
+        val schema = StringSchema().apply {
+            maxLength = tooLarge
+            minLength = tooLarge
+        }
+
+        val (output, constraints) = captureStandardOutput { StringConstraints(schema, patternName = "", breadCrumb = "user.name") }
+
+        assertThat(constraints.resolvedMaxLength).isEqualTo(FOUR_MB)
+        assertThat(constraints.downsampledMax).isTrue()
+        assertThat(constraints.resolvedMinLength).isEqualTo(FOUR_MB)
+        assertThat(constraints.downsampledMin).isTrue()
+
+        assertThat(output).contains("maxLength of $tooLarge for user.name")
+        assertThat(output).contains("minLength of $tooLarge for user.name")
+        assertThat(output).contains("4MB")
+    }
+
+    @Test
+    fun `StringConstraints uses patternName in breadcrumb when provided`() {
+        val tooLarge = FOUR_MB + 42
+        val schema = StringSchema().apply { maxLength = tooLarge }
+
+        val (output, constraints) = captureStandardOutput { StringConstraints(schema, patternName = "MyPattern", breadCrumb = "ignored.breadcrumb") }
+
+        assertThat(constraints.resolvedMaxLength).isEqualTo(FOUR_MB)
+        assertThat(constraints.downsampledMax).isTrue()
+        assertThat(output).contains("for schema MyPattern")
+        assertThat(output).doesNotContain("ignored.breadcrumb")
+    }
+
+    @Test
+    fun `StringConstraints keeps reasonable values and prints nothing`() {
+        val schema = StringSchema().apply {
+            minLength = 1
+            maxLength = 100
+        }
+
+        val (output, constraints) = captureStandardOutput { StringConstraints(schema, patternName = "", breadCrumb = "account.id") }
+
+        assertThat(constraints.resolvedMinLength).isEqualTo(1)
+        assertThat(constraints.downsampledMin).isFalse()
+        assertThat(constraints.resolvedMaxLength).isEqualTo(100)
+        assertThat(constraints.downsampledMax).isFalse()
+        assertThat(output).isBlank()
+    }
+
+    @Test
+    fun `StringConstraints handles null min and max with no warnings`() {
+        val schema = StringSchema() // min and max default to null
+
+        val (output, constraints) = captureStandardOutput { StringConstraints(schema, patternName = "", breadCrumb = "any.path") }
+
+        assertThat(constraints.resolvedMinLength).isNull()
+        assertThat(constraints.downsampledMin).isFalse()
+        assertThat(constraints.resolvedMaxLength).isNull()
+        assertThat(constraints.downsampledMax).isFalse()
+        assertThat(output).isBlank()
+    }
+}
+

--- a/core/src/test/kotlin/io/specmatic/core/pattern/StringPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/StringPatternTest.kt
@@ -461,7 +461,7 @@ internal class StringPatternTest {
         ", 2147483647",
         useHeadersInDisplayName = true,
     )
-    fun `should gracefully fail to generate a pattern when the specified maxLength is too long`(regex: String?, maxLength: Int) {
+    fun `should gracefully fail to generate a pattern for test when the specified maxLength is too long`(regex: String?, maxLength: Int) {
         val pattern =
             StringPattern(
                 regex = regex,
@@ -478,5 +478,27 @@ internal class StringPatternTest {
         assertThat(values).allSatisfy {
             assertThat(it).hasSizeLessThan(Int.MAX_VALUE)
         }
+    }
+
+    @ParameterizedTest
+    @CsvSource (
+        "regex, maxLength",
+        "^.*$, 2147483647",
+        ", 2147483647",
+        useHeadersInDisplayName = true,
+    )
+    fun `should generate a pattern when the specified maxLength is too long`(regex: String?, maxLength: Int) {
+        val pattern =
+            StringPattern(
+                regex = regex,
+                minLength = 1,
+                maxLength = maxLength,
+            )
+
+        val value = assertDoesNotThrow {
+            pattern.generate(Resolver())
+        }
+
+        assertThat(value.toStringLiteral()).hasSizeLessThan(Int.MAX_VALUE)
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/pattern/StringPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/StringPatternTest.kt
@@ -469,12 +469,13 @@ internal class StringPatternTest {
                 maxLength = maxLength,
             )
 
-        assertDoesNotThrow {
-            pattern.newBasedOn(Row(), Resolver()).toList()
+        val patterns = assertDoesNotThrow {
+            pattern.newBasedOn(Row(), Resolver())
         }
 
-        val patterns = pattern.newBasedOn(Row(), Resolver()).toList().map { it.value.generate(Resolver()).toStringLiteral() }
-        assertThat(patterns).allSatisfy {
+        val values = patterns.toList().map { it.value.generate(Resolver()).toStringLiteral() }
+
+        assertThat(values).allSatisfy {
             assertThat(it).hasSizeLessThan(Int.MAX_VALUE)
         }
     }

--- a/core/src/test/kotlin/io/specmatic/core/pattern/StringPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/StringPatternTest.kt
@@ -452,4 +452,16 @@ internal class StringPatternTest {
             }
         }
     }
+
+    @Test
+    fun `should throw stackOverflowException`() {
+        val pattern = StringPattern(
+            regex = "^.*$",
+            minLength = 1,
+//            maxLength = 2147
+          maxLength = 2147483647
+        )
+
+        val newPatterns = pattern.newBasedOn(Row(), Resolver())
+    }
 }


### PR DESCRIPTION
**What**:

When the following schema is encountered:

```yaml
type: string
regex: ^.*$
maxLength: 2147483647 # Int.MAX_VALUE
```

- Show a warning at parse-time explaining that the maxLength has been downsampled.
- When generating negative tests, do not generate boundary tests for the downsampled lengths (though the other negative tests will be generated, namely mutation of string to number, null, boolean).

The same will be done for `minLength`.

**Why**:

`2147483647` is a 2GB-sized value. It makes little sense to generate strings which are that long.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
