### PR TITLE
Print parser warnings with a clear warning message

### DIFF
--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -7907,7 +7907,7 @@ paths:
     }
 
     @Test
-    fun `check that a console warning is printed when a named request example has no corresponding named responsee example`() {
+    fun `check that a console warning is printed when a named request example has no corresponding named response example`() {
         val (stdout, _) = captureStandardOutput {
             OpenApiSpecification.fromYAML(
                 """
@@ -11200,5 +11200,34 @@ paths:
         } catch (e: Throwable) {
             println(exceptionCauseMessage(e))
         }
+    }
+
+    @Test
+    fun `parser errors should be printed as a WARNING statement on the console`() {
+        val yaml =
+            """
+            openapi: 3.0.3
+            info:
+              title: Simple API
+              version: 1.0.0
+            paths:
+              /data:
+                post:
+                  requestBody:
+                    required: true
+                    content:
+                      application/json:
+                        schema:
+                          type: object
+                          additionalProperties: []
+                  responses:
+                    '200':
+                      description: Success
+            """.trimIndent()
+
+        val (output, _) = captureStandardOutput { OpenApiSpecification.fromYAML(yaml, "spec.yaml") }
+
+        assertThat(output).contains("WARNING: The OpenAPI file spec.yaml was read successfully but with some issues")
+        assertThat(output).contains("additionalProperties is not of type")
     }
 }


### PR DESCRIPTION
**What**:

Parser errors were always printed to the console, but without any demarcations. So the message did not stand out and was easy to miss.

This PR fixes the problem. Parser errors are printed as a WARNING message. A bit of whitespace has also been added before and after the warning. This way the WARNING message stands out more easily.

**How**:

The `OpenApiSpecification` class has been updated with this change.

The warning message will hence-forth look like this:

```

WARNING: The OpenAPI file invalidAdditionalProperties.yaml was read successfully but with some issues
  - attribute paths.'/data'(post).requestBody.content.'application/json'.schema.additionalProperties is not of type `object`

```

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)

