### PR TITLE
Support for extra field for integers indicating that Specmatic should do boundary testing

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -46,6 +46,10 @@ private const val BEARER_SECURITY_SCHEME = "bearer"
 const val OBJECT_TYPE = "object"
 const val SERVICE_TYPE_HTTP = "HTTP"
 
+private const val X_SPECMATIC_HINT = "x-specmatic-hint"
+private const val HINT_BOUNDARY_TESTING_ENABLED = "boundary_testing_enabled"
+private val HINT_VALUE_DELIMITERS = charArrayOf(',')
+
 const val testDirectoryEnvironmentVariable = "SPECMATIC_TESTS_DIRECTORY"
 const val testDirectoryProperty = "specmaticTestsDirectory"
 
@@ -1758,8 +1762,26 @@ class OpenApiSpecification(
         exclusiveMinimum = schema.exclusiveMinimum ?: false,
         exclusiveMaximum = schema.exclusiveMaximum ?: false,
         isDoubleFormat = isDoubleFormat,
-        example = schema.example?.toString()
+        example = schema.example?.toString(),
+        boundaryTestingEnabled = isBoundaryTestingEnabled(schema)
     )
+
+    private fun isBoundaryTestingEnabled(schema: Schema<*>): Boolean {
+        val extensions = schema.extensions.orEmpty()
+        if (extensions.isEmpty()) return false
+
+        val raw = extensions[X_SPECMATIC_HINT] ?: return false
+
+        fun normalizeHintString(s: String): String = s.trim().lowercase()
+
+        return when (raw) {
+            is String -> raw
+                .split(*HINT_VALUE_DELIMITERS)
+                .map(::normalizeHintString)
+                .any { it == HINT_BOUNDARY_TESTING_ENABLED }
+            else -> false
+        }
+    }
 
     private fun toListExample(example: Any?): List<String?>? {
         if (example == null)

--- a/core/src/main/kotlin/io/specmatic/core/pattern/NumberPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/NumberPattern.kt
@@ -19,7 +19,8 @@ data class NumberPattern(
     val maximum: BigDecimal? = null,
     val exclusiveMaximum: Boolean = false,
     override val example: String? = null,
-    val isDoubleFormat: Boolean = false
+    val isDoubleFormat: Boolean = false,
+    internal val boundaryTestingEnabled: Boolean = false
 ) : Pattern, ScalarType, HasDefaultExample {
     private fun minValueIsSet() = minimum != null
     private fun maxValueIsSet() = maximum != null
@@ -115,30 +116,35 @@ data class NumberPattern(
         val values = mutableListOf<HasValue<Pattern>>()
 
         val messageForTestFromThisObject =
-            if (minAndMaxValuesNotSet())
+            if (minAndMaxValuesNotSet()) {
                 ""
-            else
+            } else {
                 "value within bounds"
+            }
 
         values.add(HasValue(this, messageForTestFromThisObject))
 
-        val minimumValueAnnotation =
-            if (minValueIsSet()) {
-                if (exclusiveMinimum) "value just within exclusive minimum $effectiveMin" else "minimum value $effectiveMin"
-            } else {
-                "lowest possible value when no minimum is set"
-            }
+        if (minValueIsSet() || boundaryTestingEnabled) {
+            val minimumValueAnnotation =
+                if (minValueIsSet()) {
+                    if (exclusiveMinimum) "value just within exclusive minimum $effectiveMin" else "minimum value $effectiveMin"
+                } else {
+                    "lowest possible value when no minimum is set"
+                }
 
-        values.add(HasValue(ExactValuePattern(NumberValue(effectiveMin)), minimumValueAnnotation))
+            values.add(HasValue(ExactValuePattern(NumberValue(effectiveMin)), minimumValueAnnotation))
+        }
 
-        val maximumValueAnnotation =
-            if (maxValueIsSet()) {
-                if (exclusiveMaximum) "value just within exclusive maximum $effectiveMax" else "maximum value $effectiveMax"
-            } else {
-                "highest possible value when no maximum is set"
-            }
+        if (maxValueIsSet() || boundaryTestingEnabled) {
+            val maximumValueAnnotation =
+                if (maxValueIsSet()) {
+                    if (exclusiveMaximum) "value just within exclusive maximum $effectiveMax" else "maximum value $effectiveMax"
+                } else {
+                    "highest possible value when no maximum is set"
+                }
 
-        values.add(HasValue(ExactValuePattern(NumberValue(effectiveMax)), maximumValueAnnotation))
+            values.add(HasValue(ExactValuePattern(NumberValue(effectiveMax)), maximumValueAnnotation))
+        }
 
         return values.asSequence().distinct()
     }

--- a/core/src/test/kotlin/integration_tests/AllOfDiscriminatorTest.kt
+++ b/core/src/test/kotlin/integration_tests/AllOfDiscriminatorTest.kt
@@ -860,7 +860,7 @@ class AllOfDiscriminatorTest {
         })
 
         assertThat(vehicleTypes).containsAll(listOf("car", "bike"))
-        assertThat(results.testCount).isEqualTo(6)
+        assertThat(results.testCount).isEqualTo(2)
     }
 
     @Test
@@ -1073,7 +1073,7 @@ class AllOfDiscriminatorTest {
         })
 
         assertThat(vehicleTypes).containsAll(listOf("car", "bike"))
-        assertThat(results.testCount).isEqualTo(6)
+        assertThat(results.testCount).isEqualTo(2)
         assertThat(results.success()).withFailMessage(results.report()).isTrue()
     }
 }

--- a/core/src/test/kotlin/integration_tests/DefaultValuesInOpenapiSpecification.kt
+++ b/core/src/test/kotlin/integration_tests/DefaultValuesInOpenapiSpecification.kt
@@ -296,7 +296,7 @@ class DefaultValuesInOpenapiSpecification {
             "salary mutated to boolean",
             "salary mutated to string",
         )
-        assertThat(results.results).hasSize(36)
+        assertThat(results.results).hasSize(16)
     }
 
     @Test
@@ -361,7 +361,7 @@ class DefaultValuesInOpenapiSpecification {
                 }
             })
 
-            assertThat(results.successCount).isEqualTo(3)
+            assertThat(results.successCount).isEqualTo(1)
             assertThat(results.failureCount).isEqualTo(0)
             assertThat(priceSeen).isTrue()
         } finally {

--- a/core/src/test/kotlin/integration_tests/DictionaryTest.kt
+++ b/core/src/test/kotlin/integration_tests/DictionaryTest.kt
@@ -505,8 +505,8 @@ class DictionaryTest {
                 }
             })
 
-            assertThat(result.results).hasSize(5)
-            assertThat(result.successCount).withFailMessage(result.report()).isEqualTo(5)
+            assertThat(result.results).hasSize(3)
+            assertThat(result.successCount).withFailMessage(result.report()).isEqualTo(3)
         }
 
         @Test
@@ -543,8 +543,8 @@ class DictionaryTest {
                 }
             })
 
-            assertThat(result.results).hasSize(6)
-            assertThat(result.successCount).withFailMessage(result.report()).isEqualTo(6)
+            assertThat(result.results).hasSize(4)
+            assertThat(result.successCount).withFailMessage(result.report()).isEqualTo(4)
         }
 
         @Test
@@ -580,8 +580,8 @@ class DictionaryTest {
                 }
             })
 
-            assertThat(result.results).hasSize(6)
-            assertThat(result.successCount).withFailMessage(result.report()).isEqualTo(6)
+            assertThat(result.results).hasSize(4)
+            assertThat(result.successCount).withFailMessage(result.report()).isEqualTo(4)
         }
 
         @Test
@@ -619,8 +619,8 @@ class DictionaryTest {
                 }
             })
 
-            assertThat(result.results).hasSize(6)
-            assertThat(result.successCount).withFailMessage(result.report()).isEqualTo(6)
+            assertThat(result.results).hasSize(4)
+            assertThat(result.successCount).withFailMessage(result.report()).isEqualTo(4)
         }
 
         private fun Scenario.withBadRequest(): List<Scenario> {

--- a/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
+++ b/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
@@ -1251,7 +1251,7 @@ class LoadTestsFromExternalisedFiles {
                 assertThat(evidences.distinct()).containsExactlyInAnyOrder(
                     "bad request",
                 )
-                assertThat(results).hasOnlyElementsOfTypes(Result.Success::class.java).hasSize(131)
+                assertThat(results).hasOnlyElementsOfTypes(Result.Success::class.java).hasSize(23)
             }
         }
 

--- a/core/src/test/kotlin/integration_tests/OneOfDiscriminatorTest.kt
+++ b/core/src/test/kotlin/integration_tests/OneOfDiscriminatorTest.kt
@@ -495,7 +495,7 @@ components:
 
         assertThat(results.success()).withFailMessage(results.report()).isTrue()
         assertThat(petTypesSeen).containsOnly("dog", "cat")
-        assertThat(results.testCount).isEqualTo(18)
+        assertThat(results.testCount).isEqualTo(2)
     }
 
     @Test
@@ -830,7 +830,7 @@ components:
         })
 
         assertThat(petTypesSeen).containsAll(listOf("dog", "cat"))
-        assertThat(results.testCount).isEqualTo(18)
+        assertThat(results.testCount).isEqualTo(2)
         assertThat(results.success()).withFailMessage(results.report()).isTrue()
     }
 

--- a/core/src/test/kotlin/integration_tests/ResiliencyTests.kt
+++ b/core/src/test/kotlin/integration_tests/ResiliencyTests.kt
@@ -250,7 +250,7 @@ class GenerativeTests {
 
         try {
             val results = runGenerativeTests(feature)
-            assertThat(results.results).hasSize(9)
+            assertThat(results.results).hasSize(7)
         } catch (e: ContractException) {
             println(e.report())
             throw e
@@ -313,7 +313,7 @@ class GenerativeTests {
 
         try {
             val results = runGenerativeTests(feature)
-            assertThat(results.results).hasSize(9)
+            assertThat(results.results).hasSize(7)
         } catch (e: ContractException) {
             println(e.report())
             throw e
@@ -443,7 +443,7 @@ class GenerativeTests {
 
         try {
             val results = runGenerativeTests(feature)
-            assertThat(results.results).hasSize(6)
+            assertThat(results.results).hasSize(4)
         } catch (e: ContractException) {
             println(e.report())
             throw e
@@ -489,7 +489,7 @@ class GenerativeTests {
 
         try {
             val results = runGenerativeTests(feature)
-            assertThat(results.results).hasSize(6)
+            assertThat(results.results).hasSize(4)
         } catch (e: ContractException) {
             println(e.report())
             throw e
@@ -535,7 +535,7 @@ class GenerativeTests {
 
         try {
             val results = runGenerativeTests(feature)
-            assertThat(results.results).hasSize(6)
+            assertThat(results.results).hasSize(4)
         } catch (e: ContractException) {
             println(e.report())
             throw e
@@ -586,7 +586,7 @@ class GenerativeTests {
 
         try {
             val results = runGenerativeTests(feature)
-            assertThat(results.results).hasSize(27)
+            assertThat(results.results).hasSize(9)
         } catch (e: ContractException) {
             println(e.report())
             throw e
@@ -645,7 +645,7 @@ class GenerativeTests {
 
         try {
             val results = runGenerativeTests(feature)
-            assertThat(results.results).hasSize(27)
+            assertThat(results.results).hasSize(9)
         } catch (e: ContractException) {
             println(e.report())
             throw e
@@ -705,7 +705,7 @@ class GenerativeTests {
 
         try {
             val results = runGenerativeTests(feature)
-            assertThat(results.results).hasSize(27)
+            assertThat(results.results).hasSize(9)
         } catch (e: ContractException) {
             println(e.report())
             throw e
@@ -1017,8 +1017,6 @@ class GenerativeTests {
                 "null in company.address.building",
                 "Value type number in company.address.building",
                 "Value type boolean in company.address.building",
-                "Value -2147483648 in person.address.building",
-                "Value 2147483647 in person.address.building",
             )
         } catch (e: ContractException) {
             Assertions.fail("Should not have got this error:\n${e.report()}")
@@ -1355,8 +1353,6 @@ class GenerativeTests {
 
             assertThat(testType).containsExactlyInAnyOrder(
                 "price is present",
-                "price is present",
-                "price is present",
                 "price is absent",
             )
 
@@ -1530,20 +1526,8 @@ class GenerativeTests {
                 "address.building.flat mutated to string",
                 "address.building.name mutated to boolean",
                 "address.building.name mutated to boolean",
-                "address.building.name mutated to boolean",
-                "address.building.name mutated to boolean",
-                "address.building.name mutated to boolean",
-                "address.building.name mutated to boolean",
                 "address.building.name mutated to null",
                 "address.building.name mutated to null",
-                "address.building.name mutated to null",
-                "address.building.name mutated to null",
-                "address.building.name mutated to null",
-                "address.building.name mutated to null",
-                "address.building.name mutated to number",
-                "address.building.name mutated to number",
-                "address.building.name mutated to number",
-                "address.building.name mutated to number",
                 "address.building.name mutated to number",
                 "address.building.name mutated to number",
                 "address.propertyType is commercial",
@@ -1573,23 +1557,11 @@ class GenerativeTests {
                 "name mutated to boolean",
                 "name mutated to boolean",
                 "name mutated to boolean",
-                "name mutated to boolean",
-                "name mutated to boolean",
-                "name mutated to boolean",
-                "name mutated to boolean",
                 "name mutated to null",
                 "name mutated to null",
                 "name mutated to null",
                 "name mutated to null",
                 "name mutated to null",
-                "name mutated to null",
-                "name mutated to null",
-                "name mutated to null",
-                "name mutated to null",
-                "name mutated to number",
-                "name mutated to number",
-                "name mutated to number",
-                "name mutated to number",
                 "name mutated to number",
                 "name mutated to number",
                 "name mutated to number",
@@ -1885,7 +1857,7 @@ class GenerativeTests {
             }
         })
 
-        assertThat(results.testCount).isEqualTo(8)
+        assertThat(results.testCount).isEqualTo(6)
         assertThat(testsSeen).doesNotContain("-ve" to "BAD_REQUEST")
         assertThat(testsSeen).doesNotContain("-ve" to "SERVER_ERROR")
     }
@@ -2137,7 +2109,7 @@ class GenerativeTests {
             }
         })
 
-        assertThat(results.testCount).isEqualTo(7)
+        assertThat(results.testCount).isEqualTo(5)
         assertThat(testsSeen).doesNotContain("-ve" to "BAD_REQUEST")
         assertThat(testsSeen).doesNotContain("-ve" to "SERVER_ERROR")
     }
@@ -2352,12 +2324,6 @@ class GenerativeTests {
             "POST /items -> 4xx [REQUEST.BODY.[].quantity number mutated to boolean]",
             "POST /items -> 4xx [REQUEST.BODY.[].quantity number mutated to null]",
             "POST /items -> 4xx [REQUEST.BODY.[].quantity number mutated to string]",
-            "POST /items -> 4xx [REQUEST.BODY.[].name string mutated to boolean, REQUEST.BODY.[].quantity highest possible value when no maximum is set]",
-            "POST /items -> 4xx [REQUEST.BODY.[].name string mutated to boolean, REQUEST.BODY.[].quantity lowest possible value when no minimum is set]",
-            "POST /items -> 4xx [REQUEST.BODY.[].name string mutated to null, REQUEST.BODY.[].quantity highest possible value when no maximum is set]",
-            "POST /items -> 4xx [REQUEST.BODY.[].name string mutated to null, REQUEST.BODY.[].quantity lowest possible value when no minimum is set]",
-            "POST /items -> 4xx [REQUEST.BODY.[].name string mutated to number, REQUEST.BODY.[].quantity highest possible value when no maximum is set]",
-            "POST /items -> 4xx [REQUEST.BODY.[].name string mutated to number, REQUEST.BODY.[].quantity lowest possible value when no minimum is set]",
         )
     }
 

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiBoundaryHintTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiBoundaryHintTest.kt
@@ -1,0 +1,43 @@
+package io.specmatic.conversions
+
+import io.specmatic.core.pattern.JSONObjectPattern
+import io.specmatic.core.pattern.NumberPattern
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class OpenApiBoundaryHintTest {
+    @Test
+    fun `x-specmatic-hint enables boundary testing only where present`() {
+        val spec = OpenApiSpecification.fromYAML(
+            """
+                openapi: 3.0.1
+                info:
+                  title: Test
+                  version: 1
+                components:
+                  schemas:
+                    Person:
+                      type: object
+                      required: [id, age]
+                      properties:
+                        id:
+                          type: integer
+                        age:
+                          type: integer
+                          x-specmatic-hint: boundary_testing_enabled
+                paths: {}
+            """.trimIndent(),
+            ""
+        )
+
+        val schemas = spec.parseUnreferencedSchemas()
+        val person = schemas["(Person)"] as JSONObjectPattern
+
+        val idPattern = person.pattern.getValue("id") as NumberPattern
+        val agePattern = person.pattern.getValue("age") as NumberPattern
+
+        assertThat(idPattern.boundaryTestingEnabled).isFalse()
+        assertThat(agePattern.boundaryTestingEnabled).isTrue()
+    }
+}
+

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiKtTest.kt
@@ -138,7 +138,7 @@ Scenario: zero should return not found
         )
 
         assertThat(flags["/hello/0 executed"]).isTrue
-        assertThat(flags.size).isEqualTo(4)
+        assertThat(flags.size).isEqualTo(2)
         assertThat(results.report()).isEqualTo("""Match not found""".trimIndent())
     }
 
@@ -447,9 +447,9 @@ Background:
             }
         )
 
-        assertThat(results.results.size).isEqualTo(31)
-        assertThat(results.results.filterIsInstance<Result.Success>().size).isEqualTo(8)
-        assertThat(results.results.filterIsInstance<Result.Failure>().size).isEqualTo(23)
+        assertThat(results.results.size).isEqualTo(17)
+        assertThat(results.results.filterIsInstance<Result.Success>().size).isEqualTo(4)
+        assertThat(results.results.filterIsInstance<Result.Failure>().size).isEqualTo(13)
     }
 
     @Test
@@ -539,7 +539,7 @@ Background:
         })
 
         assertThat(results.success()).withFailMessage(results.report()).isTrue()
-        assertThat(results.successCount).isEqualTo(4)
+        assertThat(results.successCount).isEqualTo(2)
         assertThat(pathsSeen).contains("/v1/users/me")
     }
 

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -7686,15 +7686,10 @@ paths:
             }
         })
 
-        val exclusiveMin = minAge + smallInc
-        val exclusiveMax = maxAge - smallInc
-
-        val minOutsideBounds = exclusiveMin - smallInc
-        val maxOutsideBounds = exclusiveMax + smallInc
+        val minOutsideBounds = minAge
+        val maxOutsideBounds = maxAge
 
         assertThat(actualAges).contains(
-            exclusiveMin,
-            exclusiveMax,
             minOutsideBounds,
             maxOutsideBounds
         )

--- a/core/src/test/kotlin/io/specmatic/conversions/WsdlKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/WsdlKtTest.kt
@@ -405,7 +405,7 @@ Scenario: test spec with mandatory attributes without examples
             }
         )
         assertTrue(results.success(), results.report())
-        assertThat(countOfTestsWithAgeAttributeSetToRandomValue).isEqualTo(12)
+        assertThat(countOfTestsWithAgeAttributeSetToRandomValue).isEqualTo(2)
     }
 
     @Test
@@ -721,7 +721,7 @@ Scenario: test spec with mandatory attributes without examples
         }
 
         assertTrue(results.success(), results.report())
-        assertThat(countWithEscapedAction).isEqualTo(18)
+        assertThat(countWithEscapedAction).isEqualTo(2)
     }
 
     @AfterEach

--- a/core/src/test/kotlin/io/specmatic/core/ContractAsTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ContractAsTest.kt
@@ -290,7 +290,7 @@ class ContractAsTest {
             override fun setServerState(serverState: Map<String, Value>) {}
         })
 
-        assertThat(flags).containsExactlyInAnyOrder("with", "with", "with", "without")
+        assertThat(flags).containsExactlyInAnyOrder("with", "without")
         assertTrue(results.success(), results.report())
     }
 

--- a/core/src/test/kotlin/io/specmatic/core/ContractTests.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ContractTests.kt
@@ -59,8 +59,8 @@ Then status 200
             }
         })
 
-        assertEquals(9, flags["with"])
-        assertEquals(3, flags["without"])
+        assertEquals(1, flags["with"])
+        assertEquals(1, flags["without"])
         assertTrue(results.success(), results.report())
     }
 
@@ -100,7 +100,7 @@ Examples:
         })
 
         assertThat(optionals).contains(10)
-        assertThat(optionals).hasSize(3)
+        assertThat(optionals).hasSize(1)
         assertTrue(results.success(), results.report())
     }
 
@@ -477,7 +477,7 @@ Then status 200
             }
         })
 
-        assertEquals(3, invocationCount)
+        assertEquals(1, invocationCount)
         assertFalse(results.hasFailures(), results.report())
     }
 
@@ -606,7 +606,7 @@ Then status 200
             }
         })
 
-        assertThat(flags).isEqualTo(mutableListOf("executed", "executed", "executed"))
+        assertThat(flags).isEqualTo(mutableListOf("executed"))
         assertFalse(results.hasFailures(), results.report())
     }
 

--- a/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
@@ -1429,7 +1429,7 @@ paths:
             contract.enableGenerativeTesting().generateContractTestScenarios(emptyList()).toList()
                 .map { it.second.value }
         val negativeTestScenarios = scenarios.filter { it.testDescription().contains("-ve") }
-        assertThat(negativeTestScenarios.count()).isEqualTo(20)
+        assertThat(negativeTestScenarios.count()).isEqualTo(12)
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/core/HttpQueryParamPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpQueryParamPatternTest.kt
@@ -520,7 +520,7 @@ class HttpQueryParamPatternTest {
 
         val generatedValue = queryPattern.newBasedOn(Row(), Resolver()).toList().map { it.value.queryPatterns }
 
-        assertThat(generatedValue).hasSize(9)
+        assertThat(generatedValue).hasSize(1)
         assertThat(generatedValue.first()).hasSize(2)
         assertThat(generatedValue.first().keys).contains("key")
         assertThat(generatedValue.first().keys.filter { it != "key" }).hasSize(1)

--- a/core/src/test/kotlin/io/specmatic/core/HttpRequestPatternKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpRequestPatternKtTest.kt
@@ -18,7 +18,7 @@ internal class HttpRequestPatternKtTest {
 
         val newTypes = newMultiPartBasedOn(multiPartTypes, Row(), Resolver()).toList()
 
-        assertThat(newTypes).hasSize(4)
+        assertThat(newTypes).hasSize(2)
 
         assertThat(newTypes).contains(listOf(MultiPartContentPattern("data", NumberPattern())))
         assertThat(newTypes).contains(listOf(MultiPartContentPattern("data", StringPattern())))

--- a/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
@@ -741,7 +741,7 @@ And response-body
         val results: Results = testBackwardCompatibility(behaviour, behaviour)
 
         println(results.report())
-        assertEquals(3, results.successCount)
+        assertEquals(1, results.successCount)
         assertEquals(0, results.failureCount)
     }
 

--- a/core/src/test/kotlin/io/specmatic/core/pattern/AllNegativePatternsTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/AllNegativePatternsTest.kt
@@ -39,12 +39,6 @@ class AllNegativePatternsTest {
             mapOf("key1" to NumberPattern(), "key2" to BooleanPattern()),
             mapOf("key1" to NumberPattern(), "key2" to NumberPattern()),
             mapOf("key1" to NumberPattern(), "key2" to NullPattern),
-            mapOf("key1" to ExactValuePattern(NumberValue(BigDecimal(Int.MIN_VALUE))), "key2" to NumberPattern()),
-            mapOf("key1" to ExactValuePattern(NumberValue(BigDecimal(Int.MAX_VALUE))), "key2" to BooleanPattern()),
-            mapOf("key1" to ExactValuePattern(NumberValue(BigDecimal(Int.MIN_VALUE))), "key2" to NullPattern),
-            mapOf("key1" to ExactValuePattern(NumberValue(BigDecimal(Int.MIN_VALUE))), "key2" to BooleanPattern()),
-            mapOf("key1" to ExactValuePattern(NumberValue(BigDecimal(Int.MAX_VALUE))), "key2" to NullPattern),
-            mapOf("key1" to ExactValuePattern(NumberValue(BigDecimal(Int.MAX_VALUE))), "key2" to NumberPattern()),
         )
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/pattern/AnyPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/AnyPatternTest.kt
@@ -184,7 +184,7 @@ internal class AnyPatternTest {
             ),
             extensions = emptyMap()
         ).newBasedOn(Row(), Resolver()).map { it.value }.toList().let { patterns ->
-            patterns.map { it.typeName } shouldContainInAnyOrder listOf("number", "\"one\"", "\"two\"", "-2147483648", "2147483647")
+            patterns.map { it.typeName } shouldContainInAnyOrder listOf("number", "\"one\"", "\"two\"")
         }
     }
 

--- a/core/src/test/kotlin/io/specmatic/core/pattern/CsvPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/CsvPatternTest.kt
@@ -143,8 +143,8 @@ paths:
         println(count)
         println(params)
 
-        assertThat(params).isEqualTo(listOf("data", "data", "data"))
-        assertThat(count).isEqualTo(4)
+        assertThat(params).isEqualTo(listOf("data"))
+        assertThat(count).isEqualTo(2)
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/core/pattern/JSONArrayPatternKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/JSONArrayPatternKtTest.kt
@@ -13,7 +13,7 @@ internal class JSONArrayPatternKtTest {
         val arrayType = parsedPattern("""["(number?)", "(number)"]""")
 
         val patterns = arrayType.newBasedOn(Row(), Resolver()).toList().map { it.value as JSONArrayPattern }
-        assertThat(patterns).hasSize(12)
+        assertThat(patterns).hasSize(2)
         assertThat(patterns).contains(JSONArrayPattern(listOf<Pattern>(NullPattern, NumberPattern())))
         assertThat(patterns).contains(JSONArrayPattern(listOf<Pattern>(NullPattern, NumberPattern())))
 

--- a/core/src/test/kotlin/io/specmatic/core/pattern/LookupRowPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/LookupRowPatternTest.kt
@@ -25,8 +25,6 @@ internal class LookupRowPatternTest {
         val newPattern = pattern.newBasedOn(row, Resolver()).map { it.value }
         assertThat(newPattern.toList()).containsExactlyInAnyOrder(
             NumberPattern(),
-            ExactValuePattern(NumberValue(BigDecimal(Int.MAX_VALUE))),
-            ExactValuePattern(NumberValue(BigDecimal(Int.MIN_VALUE))),
         )
     }
 

--- a/core/src/test/kotlin/io/specmatic/core/pattern/PatternInStringPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/PatternInStringPatternTest.kt
@@ -40,7 +40,7 @@ internal class PatternInStringPatternTest {
     fun `should generate a list of patterns based on a Row`() {
         val patterns = PatternInStringPattern(NumberPattern()).newBasedOn(Row(), Resolver()).map { it.value }.toList()
 
-        assertThat(patterns).hasSize(3)
+        assertThat(patterns).hasSize(1)
 
         val pattern = patterns.first()
 

--- a/core/src/test/kotlin/io/specmatic/core/pattern/XMLPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/XMLPatternTest.kt
@@ -594,7 +594,7 @@ internal class XMLPatternTest {
             val type = XMLPattern("""<number val$XML_ATTR_OPTIONAL_SUFFIX="(number)"></number>""")
 
             val newTypes = type.newBasedOn(Row(), Resolver()).map { it.value as XMLPattern }.toList()
-            assertThat(newTypes.size).isEqualTo(4)
+            assertThat(newTypes.size).isEqualTo(2)
 
             val flags = mutableListOf<String>()
 
@@ -605,7 +605,7 @@ internal class XMLPatternTest {
                 }
             }
 
-            assertThat(flags).hasSize(4)
+            assertThat(flags).hasSize(2)
             assertThat(flags).contains("with")
             assertThat(flags).contains("without")
         }
@@ -616,7 +616,7 @@ internal class XMLPatternTest {
                 XMLPattern("""<number val$XML_ATTR_OPTIONAL_SUFFIX$XML_ATTR_OPTIONAL_SUFFIX="(number)"></number>""")
 
             val newTypes = type.newBasedOn(Row(), Resolver()).map { it.value as XMLPattern }.toList()
-            assertThat(newTypes).hasSize(4)
+            assertThat(newTypes).hasSize(2)
 
             val flags = mutableListOf<String>()
 
@@ -627,7 +627,7 @@ internal class XMLPatternTest {
                 }
             }
 
-            assertThat(flags).hasSize(4)
+            assertThat(flags).hasSize(2)
             assertThat(flags).contains("with")
             assertThat(flags).contains("without")
         }
@@ -742,7 +742,7 @@ internal class XMLPatternTest {
             val nameType = XMLPattern("<name><nameid $isOptional>(number)</nameid></name>")
             val newTypes = nameType.newBasedOn(Row(), Resolver()).map { it.value as XMLPattern }.toList()
 
-            assertThat(newTypes).hasSize(4)
+            assertThat(newTypes).hasSize(2)
 
             val newValues = newTypes.map {
                 it.generate(Resolver())
@@ -859,7 +859,7 @@ internal class XMLPatternTest {
             val nameType = XMLPattern("<name><title $occursMultipleTimes>(number)</title></name>")
             val newTypes = nameType.newBasedOn(Row(), Resolver()).map { it.value as XMLPattern }.toList()
 
-            assertThat(newTypes).hasSize(3)
+            assertThat(newTypes).hasSize(1)
         }
 
         @Test

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=io.specmatic
-version=2.21.3-SNAPSHOT
+version=2.22.0-SNAPSHOT
 specmaticGradlePluginVersion=0.13.2
 kotlin.daemon.jvmargs=-Xmx768m
 org.gradle.jvmargs=-Xmx768m


### PR DESCRIPTION
**What**:

Added support for x-specmatic-hint: boundary_testing_enabled in a schema to switch on boundary testing on a single field

**Why**:

Boundary testing of numbers is useful for highlighting constraints that are missing from the spec. But this becomes tricky with numerical ids, where we cannot just expect applications to always be able to generate random ids. And it may make test setup more complex.

**How**:

- `NumberPattern` has been modified with a field based on which it knows whether to do boundary testing in the absence of the `minimum` and `maximum` keywords.
- `OpenApiSpecification` now looks for the `x-specmatic-hint: boundary_testing_enabled` when parsing a number type.

**Checklist**:

- [x] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
