### PR TITLE
Added support for `anyOf`

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -473,7 +473,7 @@ data class Feature(
             else Result.Failure(e.message ?: "Invalid Pattern \"$discriminatorPatternName.$patternName\"")
         }
 
-        return if (pattern is AnyPattern && !discriminatorPatternName.isNullOrEmpty()) {
+        return if (pattern is SubSchemaCompositePattern && !discriminatorPatternName.isNullOrEmpty()) {
             pattern.matchesValue(value, updatedResolver, patternName, breadCrumbIfDiscriminatorMismatch)
         } else pattern.matches(value, updatedResolver)
     }
@@ -485,7 +485,7 @@ data class Feature(
         }.getOrElse { return emptySet() }
 
         return when (pattern) {
-            is AnyPattern -> pattern.discriminator?.values.orEmpty()
+            is SubSchemaCompositePattern -> pattern.discriminator?.values.orEmpty()
             else -> emptySet()
         }
     }
@@ -494,7 +494,7 @@ data class Feature(
         val updatedResolver = flagsBased.update(scenarios.last().resolver)
 
        return when (val pattern = getSchemaPattern(discriminatorPatternName, patternName, updatedResolver)) {
-           is AnyPattern -> pattern.generateValue(updatedResolver, patternName)
+           is SubSchemaCompositePattern -> pattern.generateValue(updatedResolver, patternName)
            else -> pattern.generate(updatedResolver)
        }
     }

--- a/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
@@ -448,7 +448,7 @@ data class HttpHeadersPattern(
         } ?: return this
 
         val resolvedPattern = resolvedHop(soapActionPattern, resolver)
-        if (resolvedPattern !is AnyPattern) return this
+        if (resolvedPattern !is SubSchemaCompositePattern) return this
 
         val preferEscaped = Flags.getBooleanValue(Flags.SPECMATIC_ESCAPE_SOAP_ACTION)
         val updatedSoapActionPattern = resolvedPattern.pattern.filterIsInstance<ExactValuePattern>().firstOrNull {

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -801,14 +801,14 @@ data class Scenario(
         val bodyPattern = resolvedHop(this.httpRequestPattern.body, this.resolver)
         val paths = when (bodyPattern) {
             is JSONObjectPattern -> bodyPattern.calculatePath(httpRequest.body, this.resolver)
-            is AnyPattern -> bodyPattern.calculatePath(httpRequest.body, this.resolver)
+            is SubSchemaCompositePattern -> bodyPattern.calculatePath(httpRequest.body, this.resolver)
             is ListPattern -> bodyPattern.calculatePath(httpRequest.body, this.resolver)
             is JSONArrayPattern -> bodyPattern.calculatePath(httpRequest.body, this.resolver)
             else -> emptySet()
         }
 
         // For top-level AnyPattern that returns scalar type names, wrap them in braces
-        return if (bodyPattern is AnyPattern) {
+        return if (bodyPattern is SubSchemaCompositePattern) {
             paths.map { path ->
                 // If it's a simple scalar type name (string, number, boolean), wrap in braces
                 if (path in setOf("string", "number", "boolean")) {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/AnyOfPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/AnyOfPattern.kt
@@ -13,7 +13,7 @@ class AnyOfPattern(
     private val key: String? = null,
     override val typeAlias: String? = null,
     override val example: String? = null,
-    private val discriminator: Discriminator? = null,
+    override val discriminator: Discriminator? = null,
     override val extensions: Map<String, Any> = pattern.extractCombinedExtensions(),
     private val delegate: AnyPattern =
         AnyPattern(
@@ -26,7 +26,8 @@ class AnyOfPattern(
         ),
 ) : Pattern by delegate,
     HasDefaultExample by delegate,
-    PossibleJsonObjectPatternContainer by delegate {
+    PossibleJsonObjectPatternContainer by delegate,
+    SubSchemaCompositePattern by delegate {
     override fun matches(
         sampleData: Value?,
         resolver: Resolver,
@@ -146,8 +147,7 @@ class AnyOfPattern(
                     .map(::withoutOptionality)
                     .toSet()
 
-            is AnyPattern -> resolved.pattern.flatMap { it.extractObjectKeys(resolver, nextVisited) }.toSet()
-            is AnyOfPattern -> resolved.pattern.flatMap { it.extractObjectKeys(resolver, nextVisited) }.toSet()
+            is SubSchemaCompositePattern -> resolved.pattern.flatMap { it.extractObjectKeys(resolver, nextVisited) }.toSet()
 
             is PossibleJsonObjectPatternContainer ->
                 resolved

--- a/core/src/main/kotlin/io/specmatic/core/pattern/AnyOfPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/AnyOfPattern.kt
@@ -130,7 +130,8 @@ class AnyOfPattern(
 
         val resolvedPatterns = pattern.map { resolvedHop(it, resolver) }
         if (resolvedPatterns.all { it is JSONObjectPattern } && discriminator == null) {
-            return newPatterns.plus(HasValue(combineJSONPatterns(pattern.filterIsInstance<JSONObjectPattern>())))
+            val combinedPattern = combineJSONPatterns(pattern.filterIsInstance<JSONObjectPattern>())
+            return newPatterns.plus(combinedPattern.newBasedOn(row, resolver))
         }
 
         return newPatterns

--- a/core/src/main/kotlin/io/specmatic/core/pattern/AnyOfPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/AnyOfPattern.kt
@@ -33,7 +33,6 @@ class AnyOfPattern(
         resolver: Resolver,
     ): Result {
         if (discriminator != null) {
-            // Discriminator-driven resolution behaves the same as oneOf
             return delegate.matches(sampleData, resolver)
         }
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/AnyOfPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/AnyOfPattern.kt
@@ -1,0 +1,138 @@
+package io.specmatic.core.pattern
+
+import io.specmatic.core.Resolver
+import io.specmatic.core.Result
+import io.specmatic.core.Result.Failure
+import io.specmatic.core.mismatchResult
+import io.specmatic.core.value.EmptyString
+import io.specmatic.core.value.JSONObjectValue
+import io.specmatic.core.value.Value
+
+class AnyOfPattern(
+    override val pattern: List<Pattern>,
+    private val key: String? = null,
+    override val typeAlias: String? = null,
+    override val example: String? = null,
+    private val discriminator: Discriminator? = null,
+    override val extensions: Map<String, Any> = pattern.extractCombinedExtensions(),
+    private val delegate: AnyPattern = AnyPattern(
+        pattern = pattern,
+        key = key,
+        typeAlias = typeAlias,
+        example = example,
+        discriminator = discriminator,
+        extensions = extensions,
+    )
+) : Pattern by delegate, HasDefaultExample by delegate, PossibleJsonObjectPatternContainer by delegate {
+
+    override fun matches(sampleData: Value?, resolver: Resolver): Result {
+        if (discriminator != null) {
+            // Discriminator-driven resolution behaves the same as oneOf
+            return delegate.matches(sampleData, resolver)
+        }
+
+        val updatedPatterns = delegate.getUpdatedPattern(resolver)
+        val unknownKeys = if (sampleData is JSONObjectValue)
+            findKeysNotDeclaredInAnySchema(sampleData, updatedPatterns, resolver)
+        else
+            emptyList()
+
+        val matchResults = updatedPatterns.map { innerPattern ->
+            resolver.matchesPattern(key, innerPattern, sampleData ?: EmptyString)
+        }
+
+        if (unknownKeys.isEmpty() && matchResults.any { it.isSuccess() }) {
+            return Result.Success()
+        }
+
+        val delegateResult = delegate.matches(sampleData, resolver)
+
+        val failures = mutableListOf<Failure>()
+        if (unknownKeys.isNotEmpty()) {
+            failures.add(Failure("Key(s) ${unknownKeys.joinToString(", ")} are not declared in any anyOf option"))
+        }
+
+        if (delegateResult is Failure) {
+            failures.add(delegateResult)
+        }
+
+        return when (failures.size) {
+            0 -> delegateResult
+            1 -> failures.first()
+            else -> Failure.fromFailures(failures)
+        }
+    }
+
+    override fun generate(resolver: Resolver): Value {
+        return delegate.generate(resolver)
+    }
+
+    override fun fixValue(value: Value, resolver: Resolver): Value {
+        val updatedPatterns = delegate.getUpdatedPattern(resolver)
+        val firstPattern = updatedPatterns.firstOrNull { it !is NullPattern }
+            ?: updatedPatterns.firstOrNull()
+            ?: throw ContractException("Cannot fix value: anyOf has no subschemas")
+
+        val updatedResolver = resolver.updateLookupPath(typeAlias)
+        return firstPattern.fixValue(value, updatedResolver)
+    }
+
+    override fun encompasses(
+        otherPattern: Pattern,
+        thisResolver: Resolver,
+        otherResolver: Resolver,
+        typeStack: TypeStack
+    ): Result {
+        if (otherPattern !is AnyOfPattern) {
+            return mismatchResult(this, otherPattern, thisResolver.mismatchMessages)
+        }
+
+        val myPatterns = patternSet(thisResolver)
+
+        val encompassResults = otherPattern.pattern.map { legacyPattern ->
+            val results = myPatterns.asSequence().map { candidate ->
+                biggerEncompassesSmaller(candidate, legacyPattern, thisResolver, otherResolver, typeStack)
+            }
+
+            results.find { it is Result.Success } ?: results.firstOrNull()?.let {
+                when (it) {
+                    is Failure -> it
+                    else -> Result.Success()
+                }
+            } ?: Failure("Could not find matching subschema in anyOf pattern")
+        }
+
+        return Result.fromResults(encompassResults)
+    }
+
+    override fun equals(other: Any?): Boolean = other is AnyOfPattern && other.pattern == this.pattern
+
+    override fun hashCode(): Int = pattern.hashCode()
+
+    private fun findKeysNotDeclaredInAnySchema(
+        value: JSONObjectValue,
+        patterns: List<Pattern>,
+        resolver: Resolver
+    ): List<String> {
+        val declaredKeys = patterns.flatMap { it.extractObjectKeys(resolver) }.toSet()
+        val presentKeys = value.jsonObject.keys
+        return presentKeys.filter { key -> key !in declaredKeys }
+    }
+
+    private fun Pattern.extractObjectKeys(resolver: Resolver, visited: Set<Pattern> = emptySet()): Set<String> {
+        val resolved = resolvedHop(this, resolver)
+        if (resolved in visited) return emptySet()
+
+        val nextVisited = visited + resolved
+
+        return when (resolved) {
+            is JSONObjectPattern -> resolved.pattern.keys.map(::withoutOptionality).toSet()
+            is PossibleJsonObjectPatternContainer -> resolved.jsonObjectPattern(resolver)?.pattern?.keys
+                ?.map(::withoutOptionality)
+                ?.toSet() ?: emptySet()
+            is AnyPattern -> resolved.pattern.flatMap { it.extractObjectKeys(resolver, nextVisited) }.toSet()
+            is AnyOfPattern -> resolved.pattern.flatMap { it.extractObjectKeys(resolver, nextVisited) }.toSet()
+            else -> emptySet()
+        }
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/core/pattern/AnyOfPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/AnyOfPattern.kt
@@ -122,6 +122,13 @@ class AnyOfPattern(
 
     override fun hashCode(): Int = pattern.hashCode()
 
+    override val typeName: String
+        get() =
+            when {
+                pattern.isEmpty() -> "(anyOf)"
+                else -> pattern.joinToString(prefix = "(anyOf ", postfix = ")", separator = " or ") { withoutPatternDelimiters(it.typeName) }
+            }
+
     private fun findKeysNotDeclaredInAnySchema(
         value: JSONObjectValue,
         patterns: List<Pattern>,

--- a/core/src/main/kotlin/io/specmatic/core/pattern/JSONArrayPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/JSONArrayPattern.kt
@@ -137,7 +137,7 @@ data class JSONArrayPattern(override val pattern: List<Pattern> = emptyList(), o
             if (pattern.size == 1) {
                 val resolvedPattern = resolvedHop(pattern[0], resolver)
                 when (resolvedPattern) {
-                    is AnyPattern -> {
+                    is SubSchemaCompositePattern -> {
                         // For AnyPattern, get the path and add array index prefix
                         val anyPatternPaths = resolvedPattern.calculatePath(arrayItem, resolver)
                         anyPatternPaths.map { path ->
@@ -166,7 +166,7 @@ data class JSONArrayPattern(override val pattern: List<Pattern> = emptyList(), o
                 if (index < pattern.size) {
                     val resolvedPattern = resolvedHop(pattern[index], resolver)
                     when (resolvedPattern) {
-                        is AnyPattern -> {
+                        is SubSchemaCompositePattern -> {
                             val anyPatternPaths = resolvedPattern.calculatePath(arrayItem, resolver)
                             anyPatternPaths.map { path ->
                                 if (path in setOf("string", "number", "boolean")) {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
@@ -314,7 +314,7 @@ data class JSONObjectPattern(
         return when (pattern) {
             is DeferredPattern -> getPatternsToCheck(resolvedHop(pattern, resolver), resolver)
             is ListPattern -> getPatternsToCheck(pattern.pattern, resolver)
-            is AnyPattern -> pattern.pattern.flatMap { getPatternsToCheck(it, resolver) }
+            is SubSchemaCompositePattern -> pattern.pattern.flatMap { getPatternsToCheck(it, resolver) }
             else -> listOf(pattern.takeIf { it.typeAlias != null } ?: this)
         }
     }
@@ -511,7 +511,7 @@ data class JSONObjectPattern(
         val resolvedPattern = resolvedHop(childPattern, resolver)
         
         return when (resolvedPattern) {
-            is AnyPattern -> calculatePathForAnyPattern(key, childValue, resolvedPattern, resolver)
+            is SubSchemaCompositePattern -> calculatePathForAnyPattern(key, childValue, resolvedPattern, resolver)
             is JSONObjectPattern -> calculatePathForJSONObjectPattern(key, childValue, resolvedPattern, resolver)
             is JSONArrayPattern, is ListPattern -> calculatePathForArrayPattern(key, childValue, resolvedPattern, resolver)
             else -> emptyList()
@@ -519,7 +519,7 @@ data class JSONObjectPattern(
     }
     
 
-    private fun calculatePathForAnyPattern(key: String, childValue: Value, anyPattern: AnyPattern, resolver: Resolver): List<String> {
+    private fun calculatePathForAnyPattern(key: String, childValue: Value, anyPattern: SubSchemaCompositePattern, resolver: Resolver): List<String> {
         val anyPatternPaths = anyPattern.calculatePath(childValue, resolver)
         val pathPrefix = if (!typeAlias.isNullOrBlank()) {
             val cleanTypeAlias = withoutPatternDelimiters(typeAlias)
@@ -582,13 +582,13 @@ data class JSONObjectPattern(
         val resolvedElementPattern = resolvedHop(elementPattern, resolver)
         
         return when (resolvedElementPattern) {
-            is AnyPattern -> calculatePathForArrayAnyPattern(key, index, arrayItem, resolvedElementPattern, resolver)
+            is SubSchemaCompositePattern -> calculatePathForArrayAnyPattern(key, index, arrayItem, resolvedElementPattern, resolver)
             is JSONObjectPattern -> calculatePathForArrayJSONObjectPattern(key, index, arrayItem, resolvedElementPattern, resolver)
             else -> emptyList()
         }
     }
     
-    private fun calculatePathForArrayAnyPattern(key: String, index: Int, arrayItem: Value, anyPattern: AnyPattern, resolver: Resolver): List<String> {
+    private fun calculatePathForArrayAnyPattern(key: String, index: Int, arrayItem: Value, anyPattern: SubSchemaCompositePattern, resolver: Resolver): List<String> {
         val anyPatternPaths = anyPattern.calculatePath(arrayItem, resolver)
         
         return if (anyPatternPaths.isNotEmpty()) {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
@@ -251,7 +251,7 @@ data class ListPattern(
         return value.list.flatMapIndexed { index, arrayItem ->
             val resolvedPattern = resolvedHop(pattern, resolver)
             when (resolvedPattern) {
-                is AnyPattern -> {
+                is SubSchemaCompositePattern -> {
                     // For AnyPattern, get the path and add array index prefix
                     val anyPatternPaths = resolvedPattern.calculatePath(arrayItem, resolver)
                     anyPatternPaths.map { path ->

--- a/core/src/main/kotlin/io/specmatic/core/pattern/NumberPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/NumberPattern.kt
@@ -213,7 +213,7 @@ fun encompasses(
             typeStack
         )
 
-        otherPattern is AnyPattern -> {
+        otherPattern is SubSchemaCompositePattern -> {
             val failures: List<Result.Failure> = otherPattern.patternSet(otherResolver).map {
                 thisPattern.encompasses(it, thisResolver, otherResolver)
             }.filterIsInstance<Result.Failure>()

--- a/core/src/main/kotlin/io/specmatic/core/pattern/SubSchemaCompositePattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/SubSchemaCompositePattern.kt
@@ -1,0 +1,37 @@
+package io.specmatic.core.pattern
+
+import io.specmatic.core.Resolver
+import io.specmatic.core.Result
+import io.specmatic.core.discriminator.DiscriminatorBasedItem
+import io.specmatic.core.value.Value
+
+interface SubSchemaCompositePattern {
+    val pattern: List<Pattern>
+    val discriminator: Discriminator?
+
+    fun isDiscriminatorPresent(): Boolean
+
+    fun generateForEveryDiscriminatorValue(resolver: Resolver): List<DiscriminatorBasedItem<Value>>
+
+    fun calculatePath(
+        value: Value,
+        resolver: Resolver,
+    ): Set<String>
+
+    fun getDiscriminatorBasedPattern(
+        updatedPatterns: List<Pattern>,
+        discriminatorValue: String,
+        resolver: Resolver,
+    ): JSONObjectPattern?
+
+    fun fixValue(
+        value: Value,
+        resolver: Resolver,
+        discriminatorValue: String,
+        onValidDiscValue: () -> Value?,
+        onInvalidDiscValue: (Result.Failure) -> Value?,
+    ): Value?
+
+    fun generateValue(resolver: Resolver, discriminatorValue: String = ""): Value
+    fun matchesValue(sampleData: Value?, resolver: Resolver, discriminatorValue: String, discMisMatchBreadCrumb: String? = null): Result
+}

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -10208,7 +10208,7 @@ paths:
     }
 
     @Test
-    fun `should run 1 contract test per anyOf example`() {
+    fun `should run the right count of contract test per anyOf example`() {
         val spec =
             """
             openapi: '3.0.3'
@@ -10259,8 +10259,6 @@ paths:
                   properties:
                     type:
                       type: string
-                      enum:
-                        - alpha
                     message:
                       type: string
                 Count:
@@ -10271,12 +10269,10 @@ paths:
                   properties:
                     type:
                       type: string
-                      enum:
-                        - beta
                     count:
                       type: integer
                 Choice:
-                  anyOf:
+                  oneOf:
                     - ${"$"}ref: '#/components/schemas/Message'
                     - ${"$"}ref: '#/components/schemas/Count'
             """.trimIndent()
@@ -10293,10 +10289,17 @@ paths:
                     override fun execute(request: HttpRequest): HttpResponse {
                         return HttpResponse.ok(parsedJSONObject("""{"status":"ok"}"""))
                     }
+
+                    override fun preExecuteScenario(scenario: Scenario, request: HttpRequest) {
+                        println("Executing scenario: ${scenario.testDescription()}")
+                        println(request.toLogString())
+                        println()
+                    }
                 },
             )
 
         assertThat(results.success()).withFailMessage(results.report()).isTrue()
+        assertThat(results.results).hasSize(4)
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/core/pattern/AnyOfPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/AnyOfPatternTest.kt
@@ -4,8 +4,8 @@ import io.specmatic.core.Resolver
 import io.specmatic.core.Result
 import io.specmatic.core.pattern.AdditionalProperties
 import io.specmatic.core.value.BooleanValue
-import io.specmatic.core.value.NumberValue
 import io.specmatic.core.value.JSONObjectValue
+import io.specmatic.core.value.NumberValue
 import io.specmatic.core.value.StringValue
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -61,18 +61,19 @@ internal class AnyOfPatternTest {
 
     @Test
     fun `matches fails when object contains keys missing from all schemas`() {
-        val pattern = AnyOfPattern(
-            listOf(
-                JSONObjectPattern(
-                    pattern = mapOf("id" to StringPattern()),
-                    additionalProperties = AdditionalProperties.FreeForm
+        val pattern =
+            AnyOfPattern(
+                listOf(
+                    JSONObjectPattern(
+                        pattern = mapOf("id" to StringPattern()),
+                        additionalProperties = AdditionalProperties.FreeForm,
+                    ),
+                    JSONObjectPattern(
+                        pattern = mapOf("code" to NumberPattern()),
+                        additionalProperties = AdditionalProperties.FreeForm,
+                    ),
                 ),
-                JSONObjectPattern(
-                    pattern = mapOf("code" to NumberPattern()),
-                    additionalProperties = AdditionalProperties.FreeForm
-                )
             )
-        )
 
         val value = JSONObjectValue(mapOf("id" to StringValue("123"), "extra" to StringValue("value")))
 

--- a/core/src/test/kotlin/io/specmatic/core/pattern/AnyOfPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/AnyOfPatternTest.kt
@@ -125,25 +125,28 @@ internal class AnyOfPatternTest {
 
     @Test
     fun `discriminator based anyOf matches respective subschema`() {
-        val alphaPattern = JSONObjectPattern(
-            mapOf(
-                "type" to ExactValuePattern(StringValue("alpha"), discriminator = true),
-                "message" to StringPattern(),
-            ),
-            typeAlias = "(Alpha)",
-        )
-        val betaPattern = JSONObjectPattern(
-            mapOf(
-                "type" to ExactValuePattern(StringValue("beta"), discriminator = true),
-                "count" to NumberPattern(),
-            ),
-            typeAlias = "(Beta)",
-        )
+        val alphaPattern =
+            JSONObjectPattern(
+                mapOf(
+                    "type" to ExactValuePattern(StringValue("alpha"), discriminator = true),
+                    "message" to StringPattern(),
+                ),
+                typeAlias = "(Alpha)",
+            )
+        val betaPattern =
+            JSONObjectPattern(
+                mapOf(
+                    "type" to ExactValuePattern(StringValue("beta"), discriminator = true),
+                    "count" to NumberPattern(),
+                ),
+                typeAlias = "(Beta)",
+            )
 
-        val anyOf = AnyOfPattern(
-            listOf(alphaPattern, betaPattern),
-            discriminator = Discriminator.create("type", setOf("alpha", "beta"), emptyMap()),
-        )
+        val anyOf =
+            AnyOfPattern(
+                listOf(alphaPattern, betaPattern),
+                discriminator = Discriminator.create("type", setOf("alpha", "beta"), emptyMap()),
+            )
 
         val alphaValue = JSONObjectValue(mapOf("type" to StringValue("alpha"), "message" to StringValue("hello")))
         val betaValue = JSONObjectValue(mapOf("type" to StringValue("beta"), "count" to NumberValue(5)))
@@ -154,25 +157,28 @@ internal class AnyOfPatternTest {
 
     @Test
     fun `discriminator based anyOf generate produces matching value`() {
-        val alphaPattern = JSONObjectPattern(
-            mapOf(
-                "type" to ExactValuePattern(StringValue("alpha"), discriminator = true),
-                "message" to StringPattern(),
-            ),
-            typeAlias = "(Alpha)",
-        )
-        val betaPattern = JSONObjectPattern(
-            mapOf(
-                "type" to ExactValuePattern(StringValue("beta"), discriminator = true),
-                "count" to NumberPattern(),
-            ),
-            typeAlias = "(Beta)",
-        )
+        val alphaPattern =
+            JSONObjectPattern(
+                mapOf(
+                    "type" to ExactValuePattern(StringValue("alpha"), discriminator = true),
+                    "message" to StringPattern(),
+                ),
+                typeAlias = "(Alpha)",
+            )
+        val betaPattern =
+            JSONObjectPattern(
+                mapOf(
+                    "type" to ExactValuePattern(StringValue("beta"), discriminator = true),
+                    "count" to NumberPattern(),
+                ),
+                typeAlias = "(Beta)",
+            )
 
-        val anyOf = AnyOfPattern(
-            listOf(alphaPattern, betaPattern),
-            discriminator = Discriminator.create("type", setOf("alpha", "beta"), emptyMap()),
-        )
+        val anyOf =
+            AnyOfPattern(
+                listOf(alphaPattern, betaPattern),
+                discriminator = Discriminator.create("type", setOf("alpha", "beta"), emptyMap()),
+            )
 
         val generated = anyOf.generate(resolver)
 
@@ -184,25 +190,28 @@ internal class AnyOfPatternTest {
 
     @Test
     fun `discriminator based anyOf newBasedOn derives both subschemas`() {
-        val alphaPattern = JSONObjectPattern(
-            mapOf(
-                "type" to ExactValuePattern(StringValue("alpha"), discriminator = true),
-                "message" to StringPattern(),
-            ),
-            typeAlias = "(Alpha)",
-        )
-        val betaPattern = JSONObjectPattern(
-            mapOf(
-                "type" to ExactValuePattern(StringValue("beta"), discriminator = true),
-                "count" to NumberPattern(),
-            ),
-            typeAlias = "(Beta)",
-        )
+        val alphaPattern =
+            JSONObjectPattern(
+                mapOf(
+                    "type" to ExactValuePattern(StringValue("alpha"), discriminator = true),
+                    "message" to StringPattern(),
+                ),
+                typeAlias = "(Alpha)",
+            )
+        val betaPattern =
+            JSONObjectPattern(
+                mapOf(
+                    "type" to ExactValuePattern(StringValue("beta"), discriminator = true),
+                    "count" to NumberPattern(),
+                ),
+                typeAlias = "(Beta)",
+            )
 
-        val anyOf = AnyOfPattern(
-            listOf(alphaPattern, betaPattern),
-            discriminator = Discriminator.create("type", setOf("alpha", "beta"), emptyMap()),
-        )
+        val anyOf =
+            AnyOfPattern(
+                listOf(alphaPattern, betaPattern),
+                discriminator = Discriminator.create("type", setOf("alpha", "beta"), emptyMap()),
+            )
 
         val derivedPatterns = anyOf.newBasedOn(Row(), resolver).map { it.value }.toList()
 

--- a/core/src/test/kotlin/io/specmatic/core/pattern/AnyOfPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/AnyOfPatternTest.kt
@@ -1,0 +1,84 @@
+package io.specmatic.core.pattern
+
+import io.specmatic.core.Resolver
+import io.specmatic.core.Result
+import io.specmatic.core.pattern.AdditionalProperties
+import io.specmatic.core.value.BooleanValue
+import io.specmatic.core.value.NumberValue
+import io.specmatic.core.value.JSONObjectValue
+import io.specmatic.core.value.StringValue
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class AnyOfPatternTest {
+    private val resolver = Resolver()
+
+    @Test
+    fun `matches succeeds when one subschema matches`() {
+        val pattern = AnyOfPattern(listOf(StringPattern(), NumberPattern()))
+
+        val result = pattern.matches(StringValue("hello"), resolver)
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+    }
+
+    @Test
+    fun `matches fails when none of the subschemas match`() {
+        val pattern = AnyOfPattern(listOf(StringPattern(), NumberPattern()))
+
+        val result = pattern.matches(BooleanValue(true), resolver)
+
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
+    }
+
+    @Test
+    fun `fixValue delegates to the first subschema`() {
+        val pattern = AnyOfPattern(listOf(StringPattern(), NumberPattern()))
+
+        val fixed = pattern.fixValue(NumberValue(10), resolver)
+
+        assertThat(fixed).isInstanceOf(StringValue::class.java)
+    }
+
+    @Test
+    fun `encompasses ensures old subschemas are covered`() {
+        val newPattern = AnyOfPattern(listOf(StringPattern(), NumberPattern()))
+        val oldPattern = AnyOfPattern(listOf(StringPattern()))
+
+        val result = newPattern.encompasses(oldPattern, resolver, resolver, emptySet())
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+    }
+
+    @Test
+    fun `encompasses fails when other pattern is not anyOf`() {
+        val pattern = AnyOfPattern(listOf(StringPattern()))
+
+        val result = pattern.encompasses(StringPattern(), resolver, resolver, emptySet())
+
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
+    }
+
+    @Test
+    fun `matches fails when object contains keys missing from all schemas`() {
+        val pattern = AnyOfPattern(
+            listOf(
+                JSONObjectPattern(
+                    pattern = mapOf("id" to StringPattern()),
+                    additionalProperties = AdditionalProperties.FreeForm
+                ),
+                JSONObjectPattern(
+                    pattern = mapOf("code" to NumberPattern()),
+                    additionalProperties = AdditionalProperties.FreeForm
+                )
+            )
+        )
+
+        val value = JSONObjectValue(mapOf("id" to StringValue("123"), "extra" to StringValue("value")))
+
+        val result = pattern.matches(value, resolver)
+
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
+        assertThat(result.toReport().toText()).contains("Key(s) extra")
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/pattern/AnyOfPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/AnyOfPatternTest.kt
@@ -210,4 +210,18 @@ internal class AnyOfPatternTest {
         val derivedAliases = derivedPatterns.filterIsInstance<JSONObjectPattern>().mapNotNull { it.typeAlias }
         assertThat(derivedAliases).contains("(Alpha)", "(Beta)")
     }
+
+    @Test
+    fun `typeName describes constituent patterns`() {
+        val pattern = AnyOfPattern(listOf(StringPattern(), NumberPattern()))
+
+        assertThat(pattern.typeName).isEqualTo("(anyOf string or number)")
+    }
+
+    @Test
+    fun `typeName for empty anyOf`() {
+        val pattern = AnyOfPattern(emptyList())
+
+        assertThat(pattern.typeName).isEqualTo("(anyOf)")
+    }
 }


### PR DESCRIPTION
**What**:

The `anyOf` keyword is now supported by Specmatic.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)

