### PR TITLE
Preprocess non-object additionalProperties before OpenAPI parsing

### DIFF
--- a/application/src/test/kotlin/application/HTTPStubEngineTest.kt
+++ b/application/src/test/kotlin/application/HTTPStubEngineTest.kt
@@ -46,7 +46,7 @@ class HTTPStubEngineTest {
             )
         }
 
-        assertThat(stdOut).isEqualToNormalizingNewlines("""
+        assertThat(stdOut).containsIgnoringNewLines("""
         |Stub server is running on the following URLs:
         |- http://localhost:8000/api/v3 serving endpoints from specs:
         |\t1. api.yaml

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import io.cucumber.messages.types.Step
 import io.ktor.util.reflect.*
 import io.specmatic.core.*
@@ -302,9 +303,8 @@ class OpenApiSpecification(
         private val yamlPreprocessorMapper: ObjectMapper by lazy {
             ObjectMapper(
                 YAMLFactory()
-                    .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER)
-                    .enable(YAMLGenerator.Feature.MINIMIZE_QUOTES)
-            )
+                    .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER),
+            ).registerKotlinModule()
         }
 
         private fun preprocessYamlForAdditionalProperties(yaml: String): String {

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -334,7 +334,7 @@ class OpenApiSpecification(
                                 else -> typeNode.toString()
                             }
                         } ?: "unspecified"
-                        logger.debug("Removed 'additionalProperties' from $logPath where type was $typeDescription, instead of 'object'")
+                        logger.debug("Ignoring 'additionalProperties' from $logPath (additionalProperties only applies to 'type: object', but found 'type: $typeDescription')")
                         node.remove("additionalProperties")
                     }
 

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -1,7 +1,11 @@
 package io.specmatic.conversions
 
+import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator
 import io.cucumber.messages.types.Step
 import io.ktor.util.reflect.*
 import io.specmatic.core.*
@@ -219,10 +223,12 @@ class OpenApiSpecification(
             strictMode: Boolean = false
         ): OpenApiSpecification {
             val implicitOverlayFile = getImplicitOverlayContent(openApiFilePath)
+            val mergedYaml = yamlContent.applyOverlay(overlayContent).applyOverlay(implicitOverlayFile)
+            val preprocessedYaml = preprocessYamlForAdditionalProperties(mergedYaml)
 
             val parseResult: SwaggerParseResult =
                 OpenAPIV3Parser().readContents(
-                    yamlContent.applyOverlay(overlayContent).applyOverlay(implicitOverlayFile),
+                    preprocessedYaml,
                     null,
                     resolveExternalReferences(),
                     openApiFilePath
@@ -230,7 +236,7 @@ class OpenApiSpecification(
             val parsedOpenApi: OpenAPI? = parseResult.openAPI
 
             if (parsedOpenApi == null) {
-                logger.log("FATAL: Failed to parse OpenAPI from file $openApiFilePath\n\n$yamlContent")
+                logger.log("FATAL: Failed to parse OpenAPI from file $openApiFilePath after preprocessing additionalProperties\n\n$preprocessedYaml")
 
                 printMessages(parseResult, loggerForErrors)
 
@@ -288,6 +294,65 @@ class OpenApiSpecification(
                 it.isResolveRequestBody = true
                 it.isResolveResponses = true
             }
+        }
+
+        private val yamlPreprocessorMapper: ObjectMapper by lazy {
+            ObjectMapper(
+                YAMLFactory()
+                    .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER)
+                    .enable(YAMLGenerator.Feature.MINIMIZE_QUOTES)
+            )
+        }
+
+        private fun preprocessYamlForAdditionalProperties(yaml: String): String {
+            if (yaml.isBlank()) return yaml
+
+            return try {
+                val root = yamlPreprocessorMapper.readTree(yaml) ?: return yaml
+                removeInvalidAdditionalProperties(root)
+                yamlPreprocessorMapper.writeValueAsString(root)
+            } catch (exception: Exception) {
+                logger.debug("Skipping additionalProperties preprocessing due to error: ${exception.message}")
+                yaml
+            }
+        }
+
+        private fun removeInvalidAdditionalProperties(node: JsonNode?, skipProcessing: Boolean = false) {
+            if (node == null || skipProcessing) return
+
+            when (node) {
+                is ObjectNode -> {
+                    if (node.has("additionalProperties") && shouldRemoveAdditionalProperties(node.get("type"))) {
+                        node.remove("additionalProperties")
+                    }
+
+                    val iterator = node.fields()
+                    while (iterator.hasNext()) {
+                        val entry = iterator.next()
+                        val fieldName = entry.key
+                        val value = entry.value
+                        val shouldSkipChild = fieldName == "example" || fieldName == "examples"
+
+                        removeInvalidAdditionalProperties(value, shouldSkipChild)
+                    }
+                }
+
+                is ArrayNode -> node.forEach { removeInvalidAdditionalProperties(it, skipProcessing) }
+            }
+        }
+
+        private fun shouldRemoveAdditionalProperties(typeNode: JsonNode?): Boolean {
+            if (typeNode == null) return false
+
+            if (typeNode.isTextual) {
+                return !typeNode.asText().equals(OBJECT_TYPE, ignoreCase = true)
+            }
+
+            if (typeNode is ArrayNode) {
+                return typeNode.none { it.isTextual && it.asText().equals(OBJECT_TYPE, ignoreCase = true) }
+            }
+
+            return true
         }
 
         fun String.applyOverlay(overlayContent: String): String {

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -381,7 +381,7 @@ components:
 
         val originalLogger = logger
         val mockLogger = mockk<LogStrategy>(relaxed = true)
-        val expectedLog = "Removed 'additionalProperties' from components.schemas.Person.name where type was string, instead of 'object'"
+  val expectedLog = "Ignoring 'additionalProperties' from components.schemas.Person.name (additionalProperties only applies to 'type: object', but found 'type: string')"
 
         try {
             logger = mockLogger


### PR DESCRIPTION
**What**:
- Preprocess OpenAPI YAML to strip `additionalProperties` from schemas whose type isn’t `object`
- Improve the debug message to report the path and offending type when a field is cleaned up
- Add focused tests covering preprocessing behaviour and the emitted log trail

**Why**:
- Some partner specs ship `additionalProperties` alongside non-object types, which is invalid OpenAPI and caused noisy parsing behaviour
- Normalizing those inputs before handing them to the parser keeps ingestion resilient and surfaces actionable diagnostics

**How**:
- Added a Jackson-backed YAML preprocessor that traverses the tree, removing invalid `additionalProperties` while skipping example payloads
- Logged each removal with a dot-path and human-readable type description
- Extended `OpenApiSpecificationTest` with parameterized coverage for removal/retention scenarios plus a logger-verification test

**Checklist**:
- [x] Unit Tests (`./gradlew :specmatic-core:test --tests io.specmatic.conversions.OpenApiSpecificationTest`)
- [x] Build passing locally (`./gradlew clean assemble`)
- [ ] Sonar Quality Gate N/A
- [ ] Security scans don't report any vulnerabilities N/A
- [ ] Documentation added/updated (share link) N/A
- [ ] Sample Project added/updated (share link) N/A
- [ ] Demo video (share link) N/A
- [ ] Article on Website (share link) N/A
- [ ] Roadmpap updated (share link) N/A
- [ ] Conference Talk (share link) N/A