### PR TITLE
Add --use-current-branch-for-central-repo flag for branch-based contract testing

### DIFF
--- a/application/src/main/kotlin/application/SpecmaticConfig.kt
+++ b/application/src/main/kotlin/application/SpecmaticConfig.kt
@@ -10,26 +10,23 @@ class SpecmaticConfig {
         return contractFilePathsFrom(
             Configuration.configFilePath, 
             DEFAULT_WORKING_DIRECTORY,
-            { source -> source.stubContracts },
             useCurrentBranchForCentralRepo
-        ).map { it.path }
+        ) { source -> source.stubContracts }.map { it.path }
     }
 
     fun contractTestPaths(useCurrentBranchForCentralRepo: Boolean = false): List<String> {
         return contractFilePathsFrom(
             Configuration.configFilePath,
             DEFAULT_WORKING_DIRECTORY,
-            { source -> source.testContracts },
             useCurrentBranchForCentralRepo
-        ).map { it.path }
+        ) { source -> source.testContracts }.map { it.path }
     }
 
     fun contractStubPathData(useCurrentBranchForCentralRepo: Boolean = false): List<ContractPathData> {
         return contractFilePathsFrom(
             Configuration.configFilePath,
             DEFAULT_WORKING_DIRECTORY,
-            { source -> source.stubContracts },
             useCurrentBranchForCentralRepo
-        )
+        ) { source -> source.stubContracts }
     }
 }

--- a/application/src/main/kotlin/application/SpecmaticConfig.kt
+++ b/application/src/main/kotlin/application/SpecmaticConfig.kt
@@ -6,15 +6,30 @@ import io.specmatic.core.utilities.ContractPathData
 import io.specmatic.core.utilities.contractFilePathsFrom
 
 class SpecmaticConfig {
-    fun contractStubPaths(): List<String> {
-        return contractFilePathsFrom(Configuration.configFilePath, DEFAULT_WORKING_DIRECTORY) { source -> source.stubContracts }.map { it.path }
+    fun contractStubPaths(useCurrentBranchForCentralRepo: Boolean = false): List<String> {
+        return contractFilePathsFrom(
+            Configuration.configFilePath, 
+            DEFAULT_WORKING_DIRECTORY,
+            { source -> source.stubContracts },
+            useCurrentBranchForCentralRepo
+        ).map { it.path }
     }
 
-    fun contractTestPaths(): List<String> {
-        return contractFilePathsFrom(Configuration.configFilePath, DEFAULT_WORKING_DIRECTORY) { source -> source.testContracts }.map { it.path }
+    fun contractTestPaths(useCurrentBranchForCentralRepo: Boolean = false): List<String> {
+        return contractFilePathsFrom(
+            Configuration.configFilePath,
+            DEFAULT_WORKING_DIRECTORY,
+            { source -> source.testContracts },
+            useCurrentBranchForCentralRepo
+        ).map { it.path }
     }
 
-    fun contractStubPathData(): List<ContractPathData> {
-        return contractFilePathsFrom(Configuration.configFilePath, DEFAULT_WORKING_DIRECTORY) { source -> source.stubContracts }
+    fun contractStubPathData(useCurrentBranchForCentralRepo: Boolean = false): List<ContractPathData> {
+        return contractFilePathsFrom(
+            Configuration.configFilePath,
+            DEFAULT_WORKING_DIRECTORY,
+            { source -> source.stubContracts },
+            useCurrentBranchForCentralRepo
+        )
     }
 }

--- a/application/src/main/kotlin/application/StubCommand.kt
+++ b/application/src/main/kotlin/application/StubCommand.kt
@@ -123,7 +123,7 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
     var hotReload: Switch? = null
 
     @Option(
-        names = ["--use-current-branch-for-central-repo"],
+        names = ["--match-branch"],
         description = ["Use the current branch name for contract source branch when not on default branch"],
         required = false
     )

--- a/application/src/main/kotlin/application/StubCommand.kt
+++ b/application/src/main/kotlin/application/StubCommand.kt
@@ -13,6 +13,7 @@ import io.specmatic.core.utilities.ContractPathData.Companion.specToBaseUrlMap
 import io.specmatic.core.utilities.Flags
 import io.specmatic.core.utilities.Flags.Companion.SPECMATIC_BASE_URL
 import io.specmatic.core.utilities.Flags.Companion.SPECMATIC_STUB_DELAY
+import io.specmatic.core.utilities.Flags.Companion.MATCH_BRANCH
 import io.specmatic.core.utilities.Flags.Companion.USE_CURRENT_BRANCH_FOR_CENTRAL_REPO
 import io.specmatic.core.utilities.exitIfAnyDoNotExist
 import io.specmatic.core.utilities.exitWithMessage
@@ -162,12 +163,14 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
         System.setProperty(SPECMATIC_BASE_URL, baseUrl)
 
         try {
+            val matchBranchEnabled = useCurrentBranchForCentralRepo || Flags.getBooleanValue(MATCH_BRANCH, false)
+            
             contractSources = when (contractPaths.isEmpty()) {
                 true -> {
                     specmaticConfigPath = File(Configuration.configFilePath).canonicalPath
 
                     logger.debug("Using the spec paths configured for stubs in the configuration file '$specmaticConfigPath'")
-                    specmaticConfig.contractStubPathData(useCurrentBranchForCentralRepo)
+                    specmaticConfig.contractStubPathData(matchBranchEnabled)
                 }
                 else -> contractPaths.map {
                     ContractPathData("", it)

--- a/application/src/main/kotlin/application/StubCommand.kt
+++ b/application/src/main/kotlin/application/StubCommand.kt
@@ -10,8 +10,10 @@ import io.specmatic.core.filters.ScenarioMetadataFilter
 import io.specmatic.core.log.*
 import io.specmatic.core.utilities.ContractPathData
 import io.specmatic.core.utilities.ContractPathData.Companion.specToBaseUrlMap
+import io.specmatic.core.utilities.Flags
 import io.specmatic.core.utilities.Flags.Companion.SPECMATIC_BASE_URL
 import io.specmatic.core.utilities.Flags.Companion.SPECMATIC_STUB_DELAY
+import io.specmatic.core.utilities.Flags.Companion.USE_CURRENT_BRANCH_FOR_CENTRAL_REPO
 import io.specmatic.core.utilities.exitIfAnyDoNotExist
 import io.specmatic.core.utilities.exitWithMessage
 import io.specmatic.core.utilities.throwExceptionIfDirectoriesAreInvalid
@@ -120,6 +122,13 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
     @Option(names = ["--hot-reload"], description = ["Time to wait for the server to stop before starting it again"])
     var hotReload: Switch? = null
 
+    @Option(
+        names = ["--use-current-branch-for-central-repo"],
+        description = ["Use the current branch name for contract source branch when not on default branch"],
+        required = false
+    )
+    var useCurrentBranchForCentralRepo: Boolean = false
+
     private var contractSources: List<ContractPathData> = emptyList()
 
     var specmaticConfigPath: String? = null
@@ -151,6 +160,7 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
         }
         val baseUrl = endPointFromHostAndPort(host, port, keyData = certInfo.getHttpsCert())
         System.setProperty(SPECMATIC_BASE_URL, baseUrl)
+        System.setProperty(USE_CURRENT_BRANCH_FOR_CENTRAL_REPO, useCurrentBranchForCentralRepo.toString())
 
         try {
             contractSources = when (contractPaths.isEmpty()) {

--- a/application/src/main/kotlin/application/StubCommand.kt
+++ b/application/src/main/kotlin/application/StubCommand.kt
@@ -160,7 +160,6 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
         }
         val baseUrl = endPointFromHostAndPort(host, port, keyData = certInfo.getHttpsCert())
         System.setProperty(SPECMATIC_BASE_URL, baseUrl)
-        System.setProperty(USE_CURRENT_BRANCH_FOR_CENTRAL_REPO, useCurrentBranchForCentralRepo.toString())
 
         try {
             contractSources = when (contractPaths.isEmpty()) {
@@ -168,7 +167,7 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
                     specmaticConfigPath = File(Configuration.configFilePath).canonicalPath
 
                     logger.debug("Using the spec paths configured for stubs in the configuration file '$specmaticConfigPath'")
-                    specmaticConfig.contractStubPathData()
+                    specmaticConfig.contractStubPathData(useCurrentBranchForCentralRepo)
                 }
                 else -> contractPaths.map {
                     ContractPathData("", it)

--- a/application/src/main/kotlin/application/TestCommand.kt
+++ b/application/src/main/kotlin/application/TestCommand.kt
@@ -12,6 +12,7 @@ import io.specmatic.core.utilities.Flags.Companion.EXAMPLE_DIRECTORIES
 import io.specmatic.core.utilities.Flags.Companion.SPECMATIC_TEST_PARALLELISM
 import io.specmatic.core.utilities.Flags.Companion.SPECMATIC_TEST_TIMEOUT
 import io.specmatic.core.utilities.Flags.Companion.USE_CURRENT_BRANCH_FOR_CENTRAL_REPO
+import io.specmatic.core.utilities.Flags.Companion.MATCH_BRANCH
 import io.specmatic.core.utilities.Flags.Companion.getStringValue
 import io.specmatic.core.utilities.exitWithMessage
 import io.specmatic.core.utilities.newXMLBuilder
@@ -181,8 +182,10 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
         System.setProperty(FILTER, filter)
         System.setProperty(OVERLAY_FILE_PATH, overlayFilePath.orEmpty())
         System.setProperty(STRICT_MODE, strictMode.toString())
-        if(useCurrentBranchForCentralRepo) {
-            System.setProperty(USE_CURRENT_BRANCH_FOR_CENTRAL_REPO, useCurrentBranchForCentralRepo.toString())
+        
+        val matchBranchEnabled = useCurrentBranchForCentralRepo || Flags.getBooleanValue(MATCH_BRANCH, false)
+        if(matchBranchEnabled) {
+            System.setProperty(USE_CURRENT_BRANCH_FOR_CENTRAL_REPO, matchBranchEnabled.toString())
         }
 
         if(exampleDirs.isNotEmpty()) {

--- a/application/src/main/kotlin/application/TestCommand.kt
+++ b/application/src/main/kotlin/application/TestCommand.kt
@@ -6,10 +6,12 @@ import io.specmatic.core.DEFAULT_TIMEOUT_IN_MILLISECONDS
 import io.specmatic.core.log.Verbose
 import io.specmatic.core.log.logger
 import io.specmatic.core.pattern.ContractException
+import io.specmatic.core.utilities.Flags
 import io.specmatic.core.utilities.Flags.Companion.CONFIG_FILE_PATH
 import io.specmatic.core.utilities.Flags.Companion.EXAMPLE_DIRECTORIES
 import io.specmatic.core.utilities.Flags.Companion.SPECMATIC_TEST_PARALLELISM
 import io.specmatic.core.utilities.Flags.Companion.SPECMATIC_TEST_TIMEOUT
+import io.specmatic.core.utilities.Flags.Companion.USE_CURRENT_BRANCH_FOR_CENTRAL_REPO
 import io.specmatic.core.utilities.Flags.Companion.getStringValue
 import io.specmatic.core.utilities.exitWithMessage
 import io.specmatic.core.utilities.newXMLBuilder
@@ -135,6 +137,13 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
     )
     var strictMode: Boolean = false
 
+    @Option(
+        names = ["--use-current-branch-for-central-repo"],
+        description = ["Use the current branch name for contract source branch when not on default branch"],
+        required = false
+    )
+    var useCurrentBranchForCentralRepo: Boolean = false
+
     override fun call() = try {
         setParallelism()
 
@@ -172,6 +181,7 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
         System.setProperty(FILTER, filter)
         System.setProperty(OVERLAY_FILE_PATH, overlayFilePath.orEmpty())
         System.setProperty(STRICT_MODE, strictMode.toString())
+        System.setProperty(USE_CURRENT_BRANCH_FOR_CENTRAL_REPO, useCurrentBranchForCentralRepo.toString())
 
         if(exampleDirs.isNotEmpty()) {
             System.setProperty(EXAMPLE_DIRECTORIES, exampleDirs.joinToString(","))

--- a/application/src/main/kotlin/application/TestCommand.kt
+++ b/application/src/main/kotlin/application/TestCommand.kt
@@ -138,7 +138,7 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
     var strictMode: Boolean = false
 
     @Option(
-        names = ["--use-current-branch-for-central-repo"],
+        names = ["--match-branch"],
         description = ["Use the current branch name for contract source branch when not on default branch"],
         required = false
     )

--- a/application/src/main/kotlin/application/TestCommand.kt
+++ b/application/src/main/kotlin/application/TestCommand.kt
@@ -181,7 +181,9 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
         System.setProperty(FILTER, filter)
         System.setProperty(OVERLAY_FILE_PATH, overlayFilePath.orEmpty())
         System.setProperty(STRICT_MODE, strictMode.toString())
-        System.setProperty(USE_CURRENT_BRANCH_FOR_CENTRAL_REPO, useCurrentBranchForCentralRepo.toString())
+        if(useCurrentBranchForCentralRepo) {
+            System.setProperty(USE_CURRENT_BRANCH_FOR_CENTRAL_REPO, useCurrentBranchForCentralRepo.toString())
+        }
 
         if(exampleDirs.isNotEmpty()) {
             System.setProperty(EXAMPLE_DIRECTORIES, exampleDirs.joinToString(","))

--- a/application/src/test/kotlin/application/SpecmaticConfigTest.kt
+++ b/application/src/test/kotlin/application/SpecmaticConfigTest.kt
@@ -14,7 +14,7 @@ internal class SpecmaticConfigTest {
         val contractPathData = ContractPathData("baseDir", "invalidPath")
         mockkStatic("io.specmatic.core.utilities.Utilities")
         every {
-            contractFilePathsFrom(any(), any(), any())
+            contractFilePathsFrom(any(), any(), any(), any())
         }.returns(listOf(contractPathData))
 
         val paths = SpecmaticConfig().contractStubPathData()

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -422,11 +422,14 @@ data class SpecmaticConfig(
             val currentBranch = git.getCurrentBranchForMatchBranch()
             logger.debug("Current branch: $currentBranch")
 
-            logger.log("Using branch '$currentBranch' in central repo")
+            logger.log("Central repo branch: '$currentBranch'")
             currentBranch
         } catch (e: Throwable) {
+            val fallbackBranchToLog = configuredBranch?.let { "configured branch: $configuredBranch" } ?: "default"
+
             logger.log("Could not determine current branch for --match-branch flag: ${e.message}")
-            logger.debug("Falling back to configured branch: ${configuredBranch ?: "default"}")
+            logger.log("Falling back to $fallbackBranchToLog")
+
             configuredBranch
         }
     }

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -416,7 +416,7 @@ data class SpecmaticConfig(
 
         return try {
             val git = SystemGit()
-            val currentBranch = git.currentBranch()
+            val currentBranch = git.getCurrentBranchForMatchBranch()
             logger.debug("Current branch: $currentBranch")
             
             val defaultBranch = git.getOriginDefaultBranchName()

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -426,6 +426,9 @@ data class SpecmaticConfig(
                 logger.log("Using default branch on central repo")
                 configuredBranch
             } else {
+                // Note: We don't check if the branch exists in the remote here because
+                // we don't have access to the cloned repo yet. The actual creation happens
+                // in GitOperations.checkout() which will log the appropriate message.
                 logger.log("Using branch '$currentBranch' in central repo")
                 currentBranch
             }

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -417,16 +417,21 @@ data class SpecmaticConfig(
         return try {
             val git = SystemGit()
             val currentBranch = git.currentBranch()
+            logger.debug("Current branch: $currentBranch")
+            
             val defaultBranch = git.getOriginDefaultBranchName()
+            logger.debug("Default branch: $defaultBranch")
             
             if (currentBranch == defaultBranch) {
+                logger.log("On default branch '$defaultBranch', using configured branch: ${configuredBranch ?: "default"}")
                 configuredBranch
             } else {
-                logger.log("Using current branch '$currentBranch' for contract source instead of configured branch")
+                logger.log("Using current branch '$currentBranch' for contract source (not on default branch '$defaultBranch')")
                 currentBranch
             }
         } catch (e: Throwable) {
-            logger.log("Could not determine current branch, using configured branch: ${e.message}")
+            logger.log("Could not determine current branch for --match-branch flag: ${e.message}")
+            logger.debug("Falling back to configured branch: ${configuredBranch ?: "default"}")
             configuredBranch
         }
     }

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -426,7 +426,7 @@ data class SpecmaticConfig(
                 logger.log("Using default branch on central repo")
                 configuredBranch
             } else {
-                logger.log("Using current branch '$currentBranch' in central repo")
+                logger.log("Using branch '$currentBranch' in central repo")
                 currentBranch
             }
         } catch (e: Throwable) {

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -409,7 +409,10 @@ data class SpecmaticConfig(
         }
     }
 
-    private fun getEffectiveBranchForSource(configuredBranch: String?, useCurrentBranchForCentralRepo: Boolean): String? {
+    private fun getEffectiveBranchForSource(
+        configuredBranch: String?,
+        useCurrentBranchForCentralRepo: Boolean,
+    ): String? {
         if (!useCurrentBranchForCentralRepo) {
             return configuredBranch
         }
@@ -418,20 +421,9 @@ data class SpecmaticConfig(
             val git = SystemGit()
             val currentBranch = git.getCurrentBranchForMatchBranch()
             logger.debug("Current branch: $currentBranch")
-            
-            val defaultBranch = git.getOriginDefaultBranchName()
-            logger.debug("Default branch: $defaultBranch")
-            
-            if (currentBranch == defaultBranch) {
-                logger.log("Using default branch on central repo")
-                configuredBranch
-            } else {
-                // Note: We don't check if the branch exists in the remote here because
-                // we don't have access to the cloned repo yet. The actual creation happens
-                // in GitOperations.checkout() which will log the appropriate message.
-                logger.log("Using branch '$currentBranch' in central repo")
-                currentBranch
-            }
+
+            logger.log("Using branch '$currentBranch' in central repo")
+            currentBranch
         } catch (e: Throwable) {
             logger.log("Could not determine current branch for --match-branch flag: ${e.message}")
             logger.debug("Falling back to configured branch: ${configuredBranch ?: "default"}")

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -423,10 +423,10 @@ data class SpecmaticConfig(
             logger.debug("Default branch: $defaultBranch")
             
             if (currentBranch == defaultBranch) {
-                logger.log("On default branch '$defaultBranch', using configured branch: ${configuredBranch ?: "default"}")
+                logger.log("Using default branch on central repo")
                 configuredBranch
             } else {
-                logger.log("Using current branch '$currentBranch' for contract source (not on default branch '$defaultBranch')")
+                logger.log("Using current branch '$currentBranch' in central repo")
                 currentBranch
             }
         } catch (e: Throwable) {

--- a/core/src/main/kotlin/io/specmatic/core/git/GitCommand.kt
+++ b/core/src/main/kotlin/io/specmatic/core/git/GitCommand.kt
@@ -15,6 +15,7 @@ interface GitCommand {
     fun resetMixed(): SystemGit
     fun mergeAbort(): SystemGit
     fun checkout(branchName: String): SystemGit
+    fun checkoutWithCreate(branchName: String): SystemGit
     fun merge(branchName: String): SystemGit
     fun clone(gitRepositoryURI: String, cloneDirectory: File): SystemGit
     fun gitRoot(): String

--- a/core/src/main/kotlin/io/specmatic/core/git/GitCommand.kt
+++ b/core/src/main/kotlin/io/specmatic/core/git/GitCommand.kt
@@ -37,6 +37,7 @@ interface GitCommand {
     fun getFileInBranch(fileName: String, currentBranch: String, baseBranch: String): File?
     fun currentRemoteBranch(): String
     fun getOriginDefaultBranchName(): String
+    fun remoteBranchExists(branchName: String): Boolean
     fun currentBranch(): String {
         return ""
     }

--- a/core/src/main/kotlin/io/specmatic/core/git/GitOperations.kt
+++ b/core/src/main/kotlin/io/specmatic/core/git/GitOperations.kt
@@ -50,7 +50,7 @@ fun checkout(workingDirectory: File, branchName: String, useCurrentBranchForCent
                 logger.debug("Branch $branchName exists in origin, using regular checkout")
                 git.checkout(branchName)
             } else {
-                logger.log("Branch $branchName does not exist in origin, creating it with -B flag")
+                logger.log("Creating branch '$branchName' in the local checkout of the central repo")
                 git.checkoutWithCreate(branchName)
             }
         } else {

--- a/core/src/main/kotlin/io/specmatic/core/git/GitOperations.kt
+++ b/core/src/main/kotlin/io/specmatic/core/git/GitOperations.kt
@@ -40,7 +40,18 @@ fun clone(workingDirectory: File, gitRepo: GitRepo): File {
 fun checkout(workingDirectory: File, branchName: String) {
     logger.log("Checking out branch: $branchName")
     try {
-        SystemGit(workingDirectory.path).checkout(branchName)
+        val git = SystemGit(workingDirectory.path)
+        val useCurrentBranch = io.specmatic.core.utilities.Flags.getBooleanValue(
+            io.specmatic.core.utilities.Flags.USE_CURRENT_BRANCH_FOR_CENTRAL_REPO,
+            false
+        )
+        
+        if (useCurrentBranch) {
+            // Use -B flag to create/reset branch if needed
+            git.checkoutWithCreate(branchName)
+        } else {
+            git.checkout(branchName)
+        }
     } catch(exception: Exception) {
         logger.debug("Could not checkout branch $branchName")
         logger.debug(exception.localizedMessage ?: exception.message ?: "")

--- a/core/src/main/kotlin/io/specmatic/core/git/GitOperations.kt
+++ b/core/src/main/kotlin/io/specmatic/core/git/GitOperations.kt
@@ -43,8 +43,16 @@ fun checkout(workingDirectory: File, branchName: String, useCurrentBranchForCent
         val git = SystemGit(workingDirectory.path)
         
         if (useCurrentBranchForCentralRepo) {
-            // Use -B flag to create/reset branch if needed
-            git.checkoutWithCreate(branchName)
+            // Check if the branch exists in origin
+            val branchExists = git.remoteBranchExists(branchName)
+            
+            if (branchExists) {
+                logger.debug("Branch $branchName exists in origin, using regular checkout")
+                git.checkout(branchName)
+            } else {
+                logger.log("Branch $branchName does not exist in origin, creating it with -B flag")
+                git.checkoutWithCreate(branchName)
+            }
         } else {
             git.checkout(branchName)
         }

--- a/core/src/main/kotlin/io/specmatic/core/git/GitOperations.kt
+++ b/core/src/main/kotlin/io/specmatic/core/git/GitOperations.kt
@@ -37,16 +37,12 @@ fun clone(workingDirectory: File, gitRepo: GitRepo): File {
     return cloneDirectory
 }
 
-fun checkout(workingDirectory: File, branchName: String) {
+fun checkout(workingDirectory: File, branchName: String, useCurrentBranchForCentralRepo: Boolean = false) {
     logger.log("Checking out branch: $branchName")
     try {
         val git = SystemGit(workingDirectory.path)
-        val useCurrentBranch = io.specmatic.core.utilities.Flags.getBooleanValue(
-            io.specmatic.core.utilities.Flags.USE_CURRENT_BRANCH_FOR_CENTRAL_REPO,
-            false
-        )
         
-        if (useCurrentBranch) {
+        if (useCurrentBranchForCentralRepo) {
             // Use -B flag to create/reset branch if needed
             git.checkoutWithCreate(branchName)
         } else {

--- a/core/src/main/kotlin/io/specmatic/core/git/SystemGit.kt
+++ b/core/src/main/kotlin/io/specmatic/core/git/SystemGit.kt
@@ -172,6 +172,15 @@ class SystemGit(override val workingDirectory: String = ".", private val prefix:
         return execute(Configuration.gitCommand, "rev-parse", "--abbrev-ref", "HEAD").trim()
     }
 
+    override fun remoteBranchExists(branchName: String): Boolean {
+        return try {
+            execute(Configuration.gitCommand, "rev-parse", "--verify", "origin/$branchName")
+            true
+        } catch (e: NonZeroExitError) {
+            false
+        }
+    }
+
     override fun currentRemoteBranch(): String {
         val branchStatus = execute(Configuration.gitCommand, "status", "-b", "--porcelain=2").trim()
         val hasUpstream = branchStatus.lines().any { it.startsWith("# branch.upstream") }

--- a/core/src/main/kotlin/io/specmatic/core/git/SystemGit.kt
+++ b/core/src/main/kotlin/io/specmatic/core/git/SystemGit.kt
@@ -211,7 +211,7 @@ class SystemGit(override val workingDirectory: String = ".", private val prefix:
     }
 
     override fun getOriginDefaultBranchName(): String {
-        return try {
+//        return try {
             val defaultBranchRef = execute(Configuration.gitCommand, "symbolic-ref", "refs/remotes/origin/HEAD", "--short")
 
             val parts = defaultBranchRef.split("/").map(String::trim).filterNot(String::isEmpty)
@@ -219,40 +219,40 @@ class SystemGit(override val workingDirectory: String = ".", private val prefix:
                 throw ContractException(errorMessage = "Could not parse symbolic-ref value '$defaultBranchRef'. Expected format: 'origin/branch'")
             }
 
-            parts[1]
-        } catch (e: NonZeroExitError) {
-            // If symbolic-ref fails, try to determine default branch from remote
-            logger.debug("symbolic-ref failed, attempting to determine default branch from remote")
-            try {
-                // Try git remote show origin to get default branch
-                val remoteInfo = execute(Configuration.gitCommand, "remote", "show", "origin")
-                val headBranchLine = remoteInfo.lines().find { it.trim().startsWith("HEAD branch:") }
-                if (headBranchLine != null) {
-                    val branchName = headBranchLine.substringAfter("HEAD branch:").trim()
-                    logger.debug("Default branch from remote: $branchName")
-                    return branchName
-                }
-            } catch (remoteError: Throwable) {
-                logger.debug("Failed to get default branch from remote: ${remoteError.message}")
-            }
-            
-            // Fallback to common default branch names
-            logger.debug("Falling back to common default branch names")
-            val commonDefaults = listOf("main", "master", "develop")
-            for (branchName in commonDefaults) {
-                try {
-                    execute(Configuration.gitCommand, "rev-parse", "--verify", "origin/$branchName")
-                    logger.debug("Using fallback default branch: $branchName")
-                    return branchName
-                } catch (verifyError: Throwable) {
-                    // Branch doesn't exist, try next
-                }
-            }
-            
-            // If all else fails, return "main" as final fallback
-            logger.debug("Using final fallback: main")
-            "main"
-        }
+            return parts[1]
+//        } catch (e: NonZeroExitError) {
+//            // If symbolic-ref fails, try to determine default branch from remote
+//            logger.debug("symbolic-ref failed, attempting to determine default branch from remote")
+//            try {
+//                // Try git remote show origin to get default branch
+//                val remoteInfo = execute(Configuration.gitCommand, "remote", "show", "origin")
+//                val headBranchLine = remoteInfo.lines().find { it.trim().startsWith("HEAD branch:") }
+//                if (headBranchLine != null) {
+//                    val branchName = headBranchLine.substringAfter("HEAD branch:").trim()
+//                    logger.debug("Default branch from remote: $branchName")
+//                    return branchName
+//                }
+//            } catch (remoteError: Throwable) {
+//                logger.debug("Failed to get default branch from remote: ${remoteError.message}")
+//            }
+//
+//            // Fallback to common default branch names
+//            logger.debug("Falling back to common default branch names")
+//            val commonDefaults = listOf("main", "master", "develop")
+//            for (branchName in commonDefaults) {
+//                try {
+//                    execute(Configuration.gitCommand, "rev-parse", "--verify", "origin/$branchName")
+//                    logger.debug("Using fallback default branch: $branchName")
+//                    return branchName
+//                } catch (verifyError: Throwable) {
+//                    // Branch doesn't exist, try next
+//                }
+//            }
+//
+//            // If all else fails, return "main" as final fallback
+//            logger.debug("Using final fallback: main")
+//            "main"
+//        }
     }
 
     private fun getStashListSize(): Int {

--- a/core/src/main/kotlin/io/specmatic/core/git/SystemGit.kt
+++ b/core/src/main/kotlin/io/specmatic/core/git/SystemGit.kt
@@ -48,6 +48,7 @@ class SystemGit(override val workingDirectory: String = ".", private val prefix:
     override fun resetMixed(): SystemGit = this.also { execute(Configuration.gitCommand, "reset", "--mixed", "HEAD") }
     override fun mergeAbort(): SystemGit = this.also { execute(Configuration.gitCommand, "merge", "--aborg") }
     override fun checkout(branchName: String): SystemGit = this.also { execute(Configuration.gitCommand, "checkout", branchName) }
+    override fun checkoutWithCreate(branchName: String): SystemGit = this.also { execute(Configuration.gitCommand, "checkout", "-B", branchName) }
     override fun merge(branchName: String): SystemGit = this.also { execute(Configuration.gitCommand, "merge", branchName) }
     override fun clone(gitRepositoryURI: String, cloneDirectory: File): SystemGit =
         this.also { executeWithAuth("clone", evaluateEnvVariablesInGitRepoURI(gitRepositoryURI, System.getenv()), cloneDirectory.absolutePath) }

--- a/core/src/main/kotlin/io/specmatic/core/utilities/Flags.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/Flags.kt
@@ -27,6 +27,7 @@ class Flags {
         const val ADDITIONAL_EXAMPLE_PARAMS_FILE = "ADDITIONAL_EXAMPLE_PARAMS_FILE"
 
         const val MAX_TEST_COUNT = "MAX_TEST_COUNT"
+        const val USE_CURRENT_BRANCH_FOR_CENTRAL_REPO = "USE_CURRENT_BRANCH_FOR_CENTRAL_REPO"
 
         fun getStringValue(flagName: String): String? = System.getenv(flagName) ?: System.getProperty(flagName)
 

--- a/core/src/main/kotlin/io/specmatic/core/utilities/Flags.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/Flags.kt
@@ -28,6 +28,7 @@ class Flags {
 
         const val MAX_TEST_COUNT = "MAX_TEST_COUNT"
         const val USE_CURRENT_BRANCH_FOR_CENTRAL_REPO = "USE_CURRENT_BRANCH_FOR_CENTRAL_REPO"
+        const val MATCH_BRANCH = "MATCH_BRANCH"
 
         fun getStringValue(flagName: String): String? = System.getenv(flagName) ?: System.getProperty(flagName)
 

--- a/core/src/main/kotlin/io/specmatic/core/utilities/GitRepo.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/GitRepo.kt
@@ -15,7 +15,8 @@ data class GitRepo(
     val branchName: String?,
     override val testContracts: List<ContractSourceEntry>,
     override val stubContracts: List<ContractSourceEntry>,
-    override val type: String?
+    override val type: String?,
+    val useCurrentBranchForCentralRepo: Boolean = false
 ) : ContractSource, GitSource {
     private val repoName = gitRepositoryURL.split("/").last().removeSuffix(".git")
     override fun pathDescriptor(path: String): String {
@@ -132,7 +133,7 @@ data class GitRepo(
         val repositoryDirectory = clone(reposBaseDir, gitRepo)
         when (branchName) {
             null -> logger.log("No branch specified, using default branch")
-            else -> checkout(repositoryDirectory, branchName)
+            else -> checkout(repositoryDirectory, branchName, useCurrentBranchForCentralRepo)
         }
         return repositoryDirectory
     }

--- a/core/src/main/kotlin/io/specmatic/core/utilities/GitRepo.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/GitRepo.kt
@@ -62,7 +62,7 @@ data class GitRepo(
                 logger.log("Looking for a contract repo checkout at: ${contractsRepoDir.canonicalPath}")
                 when {
                     !contractsRepoDir.exists() -> {
-                        logger.log("Contract repo does not exist.")
+                        logger.log("Contract repo dir does not exist.")
                         cloneRepoAndCheckoutBranch(reposBaseDir, this)
                     }
                     isNotOnBranch(contractsRepoDir) -> {

--- a/core/src/main/kotlin/io/specmatic/core/utilities/Utilities.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/Utilities.kt
@@ -275,7 +275,7 @@ fun exitIfAnyDoNotExist(label: String, filePaths: List<String>) {
 
 // Used by SpecmaticJUnitSupport users for loading contracts to stub or mock
 fun contractStubPaths(configFileName: String, useCurrentBranchForCentralRepo: Boolean = false): List<ContractPathData> {
-    return contractFilePathsFrom(configFileName, DEFAULT_WORKING_DIRECTORY, { source -> source.stubContracts }, useCurrentBranchForCentralRepo)
+    return contractFilePathsFrom(configFileName, DEFAULT_WORKING_DIRECTORY, useCurrentBranchForCentralRepo) { source -> source.stubContracts }
 }
 
 fun interface ContractsSelectorPredicate {
@@ -283,7 +283,7 @@ fun interface ContractsSelectorPredicate {
 }
 
 fun contractTestPathsFrom(configFilePath: String, workingDirectory: String, useCurrentBranchForCentralRepo: Boolean = false): List<ContractPathData> {
-    return contractFilePathsFrom(configFilePath, workingDirectory, { source -> source.testContracts }, useCurrentBranchForCentralRepo)
+    return contractFilePathsFrom(configFilePath, workingDirectory, useCurrentBranchForCentralRepo) { source -> source.testContracts }
 }
 
 fun gitRootDir(): String {
@@ -312,8 +312,8 @@ data class ContractPathData(
 fun contractFilePathsFrom(
     configFilePath: String, 
     workingDirectory: String, 
-    selector: ContractsSelectorPredicate,
-    useCurrentBranchForCentralRepo: Boolean = false
+    useCurrentBranchForCentralRepo: Boolean = false,
+    selector: ContractsSelectorPredicate
 ): List<ContractPathData> {
     logger.log("Loading config file $configFilePath")
     val sources = loadSources(configFilePath, useCurrentBranchForCentralRepo)

--- a/core/src/main/kotlin/io/specmatic/core/utilities/Utilities.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/Utilities.kt
@@ -174,7 +174,8 @@ fun strings(list: List<Value>): List<String> {
     }
 }
 
-fun loadSources(configFilePath: String): List<ContractSource> = loadSpecmaticConfig(configFilePath).loadSources()
+fun loadSources(configFilePath: String, useCurrentBranchForCentralRepo: Boolean = false): List<ContractSource> = 
+    loadSpecmaticConfig(configFilePath).loadSources(useCurrentBranchForCentralRepo)
 
 fun loadConfigJSON(configFile: File): JSONObjectValue {
     val configJson = try {
@@ -273,16 +274,16 @@ fun exitIfAnyDoNotExist(label: String, filePaths: List<String>) {
 }
 
 // Used by SpecmaticJUnitSupport users for loading contracts to stub or mock
-fun contractStubPaths(configFileName: String): List<ContractPathData> {
-    return contractFilePathsFrom(configFileName, DEFAULT_WORKING_DIRECTORY) { source -> source.stubContracts }
+fun contractStubPaths(configFileName: String, useCurrentBranchForCentralRepo: Boolean = false): List<ContractPathData> {
+    return contractFilePathsFrom(configFileName, DEFAULT_WORKING_DIRECTORY, { source -> source.stubContracts }, useCurrentBranchForCentralRepo)
 }
 
 fun interface ContractsSelectorPredicate {
     fun select(source: ContractSource): List<ContractSourceEntry>
 }
 
-fun contractTestPathsFrom(configFilePath: String, workingDirectory: String): List<ContractPathData> {
-    return contractFilePathsFrom(configFilePath, workingDirectory) { source -> source.testContracts }
+fun contractTestPathsFrom(configFilePath: String, workingDirectory: String, useCurrentBranchForCentralRepo: Boolean = false): List<ContractPathData> {
+    return contractFilePathsFrom(configFilePath, workingDirectory, { source -> source.testContracts }, useCurrentBranchForCentralRepo)
 }
 
 fun gitRootDir(): String {
@@ -308,9 +309,14 @@ data class ContractPathData(
     }
 }
 
-fun contractFilePathsFrom(configFilePath: String, workingDirectory: String, selector: ContractsSelectorPredicate): List<ContractPathData> {
+fun contractFilePathsFrom(
+    configFilePath: String, 
+    workingDirectory: String, 
+    selector: ContractsSelectorPredicate,
+    useCurrentBranchForCentralRepo: Boolean = false
+): List<ContractPathData> {
     logger.log("Loading config file $configFilePath")
-    val sources = loadSources(configFilePath)
+    val sources = loadSources(configFilePath, useCurrentBranchForCentralRepo)
 
     val contractPathData = sources.flatMap {
         it.loadContracts(selector, workingDirectory, configFilePath)

--- a/core/src/test/kotlin/utilities/UtilitiesTest.kt
+++ b/core/src/test/kotlin/utilities/UtilitiesTest.kt
@@ -60,7 +60,7 @@ internal class UtilitiesTest {
         every { clone(File(".spec/repos"), any()) }.returns(File(".spec/repos/repo1"))
 
 
-        val contractPaths = contractFilePathsFrom("/configFilePath", ".$CONTRACT_EXTENSION") { source -> source.stubContracts }
+        val contractPaths = contractFilePathsFrom("/configFilePath", ".$CONTRACT_EXTENSION", { source -> source.stubContracts })
         val expectedContractPaths = listOf(
             ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/a/1.$CONTRACT_EXTENSION", "git", "https://repo1",  specificationPath = "a/1.spec"),
             ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/b/1.$CONTRACT_EXTENSION", "git", "https://repo1",  specificationPath = "b/1.spec"),
@@ -85,7 +85,7 @@ internal class UtilitiesTest {
         every { clone(File(".spec/repos"), any()) }.returns(repositoryDirectory)
         every { checkout(repositoryDirectory, branchName) }.returns(Unit)
 
-        val contractPaths = contractFilePathsFrom("/configFilePath", ".$CONTRACT_EXTENSION") { source -> source.stubContracts }
+        val contractPaths = contractFilePathsFrom("/configFilePath", ".$CONTRACT_EXTENSION", { source -> source.stubContracts })
         val expectedContractPaths = listOf(
             ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/a/1.$CONTRACT_EXTENSION", "git", "https://repo1", "featureBranch", "a/1.spec"),
             ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/b/1.$CONTRACT_EXTENSION", "git", "https://repo1", "featureBranch", "b/1.spec"),
@@ -121,7 +121,7 @@ internal class UtilitiesTest {
         every { getSystemGitWithAuth(any()) }.returns(mockGitCommand)
         every { getSystemGit(any()) }.returns(mockGitCommand)
 
-        val contractPaths = contractFilePathsFrom("/configFilePath", ".$CONTRACT_EXTENSION") { source -> source.stubContracts }
+        val contractPaths = contractFilePathsFrom("/configFilePath", ".$CONTRACT_EXTENSION", { source -> source.stubContracts })
         val expectedContractPaths = listOf(
                 ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/a/1.$CONTRACT_EXTENSION", "git", "https://repo1",  specificationPath = "a/1.spec"),
                 ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/b/1.$CONTRACT_EXTENSION", "git", "https://repo1",  specificationPath = "b/1.spec"),
@@ -174,7 +174,7 @@ internal class UtilitiesTest {
         every { clone(File(".spec/repos"), any()) }.returns(File(".spec/repos/repo1"))
 
 
-        val contractPaths = contractFilePathsFrom("/configFilePath", ".$CONTRACT_EXTENSION") { source -> source.stubContracts }
+        val contractPaths = contractFilePathsFrom("/configFilePath", ".$CONTRACT_EXTENSION", { source -> source.stubContracts })
         val expectedContractPaths = listOf(
             ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/a/1.$CONTRACT_EXTENSION", "git", "https://repo1",  specificationPath = "a/1.spec"),
             ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/b/1.$CONTRACT_EXTENSION", "git", "https://repo1",  specificationPath = "b/1.spec"),
@@ -205,7 +205,7 @@ internal class UtilitiesTest {
         every { clone(File(".spec/repos"), any()) }.returns(File(".spec/repos/repo1"))
 
 
-        val contractPaths = contractFilePathsFrom("/configFilePath", ".$CONTRACT_EXTENSION") { source -> source.stubContracts }
+        val contractPaths = contractFilePathsFrom("/configFilePath", ".$CONTRACT_EXTENSION", { source -> source.stubContracts })
         val expectedContractPaths = listOf(
             ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/a/1.$CONTRACT_EXTENSION", "git", "https://repo1",  specificationPath = "a/1.spec"),
             ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/b/1.$CONTRACT_EXTENSION", "git", "https://repo1",  specificationPath = "b/1.spec"),
@@ -238,8 +238,8 @@ internal class UtilitiesTest {
         every { anyConstructed<SystemGit>().gitRoot() }.returns("/path/to/monorepo")
 
         val currentPath = File(".").canonicalPath
-        val testPaths = contractFilePathsFrom(configFilePath, ".$CONTRACT_EXTENSION") { source -> source.testContracts }
-        val stubPaths = contractFilePathsFrom(configFilePath, ".$CONTRACT_EXTENSION") { source -> source.stubContracts }
+        val testPaths = contractFilePathsFrom(configFilePath, ".$CONTRACT_EXTENSION", { source -> source.testContracts })
+        val stubPaths = contractFilePathsFrom(configFilePath, ".$CONTRACT_EXTENSION", { source -> source.stubContracts })
         val expectedStubPaths = listOf(
             ContractPathData("/path/to/monorepo", "$currentPath/monorepo/a/1.$CONTRACT_EXTENSION", provider = SourceProvider.git.toString(), specificationPath = "../a/1.spec"),
             ContractPathData("/path/to/monorepo", "$currentPath/monorepo/b/1.$CONTRACT_EXTENSION", provider = SourceProvider.git.toString(), specificationPath = "../b/1.spec")

--- a/core/src/test/kotlin/utilities/UtilitiesTest.kt
+++ b/core/src/test/kotlin/utilities/UtilitiesTest.kt
@@ -60,7 +60,7 @@ internal class UtilitiesTest {
         every { clone(File(".spec/repos"), any()) }.returns(File(".spec/repos/repo1"))
 
 
-        val contractPaths = contractFilePathsFrom("/configFilePath", ".$CONTRACT_EXTENSION", { source -> source.stubContracts })
+        val contractPaths = contractFilePathsFrom("/configFilePath", ".$CONTRACT_EXTENSION") { source -> source.stubContracts }
         val expectedContractPaths = listOf(
             ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/a/1.$CONTRACT_EXTENSION", "git", "https://repo1",  specificationPath = "a/1.spec"),
             ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/b/1.$CONTRACT_EXTENSION", "git", "https://repo1",  specificationPath = "b/1.spec"),
@@ -85,7 +85,7 @@ internal class UtilitiesTest {
         every { clone(File(".spec/repos"), any()) }.returns(repositoryDirectory)
         every { checkout(repositoryDirectory, branchName) }.returns(Unit)
 
-        val contractPaths = contractFilePathsFrom("/configFilePath", ".$CONTRACT_EXTENSION", { source -> source.stubContracts })
+        val contractPaths = contractFilePathsFrom("/configFilePath", ".$CONTRACT_EXTENSION") { source -> source.stubContracts }
         val expectedContractPaths = listOf(
             ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/a/1.$CONTRACT_EXTENSION", "git", "https://repo1", "featureBranch", "a/1.spec"),
             ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/b/1.$CONTRACT_EXTENSION", "git", "https://repo1", "featureBranch", "b/1.spec"),
@@ -121,7 +121,7 @@ internal class UtilitiesTest {
         every { getSystemGitWithAuth(any()) }.returns(mockGitCommand)
         every { getSystemGit(any()) }.returns(mockGitCommand)
 
-        val contractPaths = contractFilePathsFrom("/configFilePath", ".$CONTRACT_EXTENSION", { source -> source.stubContracts })
+        val contractPaths = contractFilePathsFrom("/configFilePath", ".$CONTRACT_EXTENSION") { source -> source.stubContracts }
         val expectedContractPaths = listOf(
                 ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/a/1.$CONTRACT_EXTENSION", "git", "https://repo1",  specificationPath = "a/1.spec"),
                 ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/b/1.$CONTRACT_EXTENSION", "git", "https://repo1",  specificationPath = "b/1.spec"),
@@ -174,7 +174,7 @@ internal class UtilitiesTest {
         every { clone(File(".spec/repos"), any()) }.returns(File(".spec/repos/repo1"))
 
 
-        val contractPaths = contractFilePathsFrom("/configFilePath", ".$CONTRACT_EXTENSION", { source -> source.stubContracts })
+        val contractPaths = contractFilePathsFrom("/configFilePath", ".$CONTRACT_EXTENSION") { source -> source.stubContracts }
         val expectedContractPaths = listOf(
             ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/a/1.$CONTRACT_EXTENSION", "git", "https://repo1",  specificationPath = "a/1.spec"),
             ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/b/1.$CONTRACT_EXTENSION", "git", "https://repo1",  specificationPath = "b/1.spec"),
@@ -205,7 +205,7 @@ internal class UtilitiesTest {
         every { clone(File(".spec/repos"), any()) }.returns(File(".spec/repos/repo1"))
 
 
-        val contractPaths = contractFilePathsFrom("/configFilePath", ".$CONTRACT_EXTENSION", { source -> source.stubContracts })
+        val contractPaths = contractFilePathsFrom("/configFilePath", ".$CONTRACT_EXTENSION") { source -> source.stubContracts }
         val expectedContractPaths = listOf(
             ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/a/1.$CONTRACT_EXTENSION", "git", "https://repo1",  specificationPath = "a/1.spec"),
             ContractPathData(".spec/repos/repo1", ".spec/repos/repo1/b/1.$CONTRACT_EXTENSION", "git", "https://repo1",  specificationPath = "b/1.spec"),
@@ -238,8 +238,8 @@ internal class UtilitiesTest {
         every { anyConstructed<SystemGit>().gitRoot() }.returns("/path/to/monorepo")
 
         val currentPath = File(".").canonicalPath
-        val testPaths = contractFilePathsFrom(configFilePath, ".$CONTRACT_EXTENSION", { source -> source.testContracts })
-        val stubPaths = contractFilePathsFrom(configFilePath, ".$CONTRACT_EXTENSION", { source -> source.stubContracts })
+        val testPaths = contractFilePathsFrom(configFilePath, ".$CONTRACT_EXTENSION") { source -> source.testContracts }
+        val stubPaths = contractFilePathsFrom(configFilePath, ".$CONTRACT_EXTENSION") { source -> source.stubContracts }
         val expectedStubPaths = listOf(
             ContractPathData("/path/to/monorepo", "$currentPath/monorepo/a/1.$CONTRACT_EXTENSION", provider = SourceProvider.git.toString(), specificationPath = "../a/1.spec"),
             ContractPathData("/path/to/monorepo", "$currentPath/monorepo/b/1.$CONTRACT_EXTENSION", provider = SourceProvider.git.toString(), specificationPath = "../b/1.spec")

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -15,6 +15,7 @@ import io.specmatic.core.pattern.Examples
 import io.specmatic.core.pattern.Row
 import io.specmatic.core.pattern.parsedValue
 import io.specmatic.core.utilities.*
+import io.specmatic.core.utilities.Flags
 import io.specmatic.core.utilities.Flags.Companion.SPECMATIC_TEST_TIMEOUT
 import io.specmatic.core.utilities.Flags.Companion.getLongValue
 import io.specmatic.core.value.JSONArrayValue
@@ -230,6 +231,7 @@ open class SpecmaticJUnitSupport {
         val filterNotName: String? = System.getProperty(FILTER_NOT_NAME_PROPERTY) ?: System.getenv(FILTER_NOT_NAME_ENVIRONMENT_VARIABLE)
         val overlayFilePath: String? = System.getProperty(OVERLAY_FILE_PATH) ?: System.getenv(OVERLAY_FILE_PATH)
         val overlayContent = if(overlayFilePath.isNullOrBlank()) "" else readFrom(overlayFilePath, "overlay")
+        val useCurrentBranchForCentralRepo = System.getProperty(Flags.USE_CURRENT_BRANCH_FOR_CENTRAL_REPO)?.toBoolean() ?: false
 
         openApiCoverageReportInput = OpenApiCoverageReportInput(getConfigFileWithAbsolutePath(), filterExpression = settings.filter, coverageHooks = settings.coverageHooks, httpInteractionsLog = httpInteractionsLog)
 
@@ -284,7 +286,7 @@ open class SpecmaticJUnitSupport {
 
                     createIfDoesNotExist(workingDirectory.path)
 
-                    val contractFilePaths = contractTestPathsFrom(settings.configFile, workingDirectory.path)
+                    val contractFilePaths = contractTestPathsFrom(settings.configFile, workingDirectory.path, useCurrentBranchForCentralRepo)
 
                     exitIfAnyDoNotExist("The following specifications do not exist", contractFilePaths.map { it.path })
 


### PR DESCRIPTION
**What**:
Added a new `--use-current-branch-for-central-repo` flag to both `StubCommand` and `TestCommand` that automatically uses the current git branch name for loading contracts from a central repository when not on the default branch.

**Why**:
This feature enables developers working on feature branches to automatically pull contracts from the same branch name in the central contract repository, making it easier to test contract changes alongside application changes. The implementation avoids using global system properties to ensure compatibility with multi-tenanted systems.

**How**:
- Added new `USE_CURRENT_BRANCH_FOR_CENTRAL_REPO` flag constant to the Flags class
- Added `--use-current-branch-for-central-repo` command-line option to TestCommand and StubCommand
- Modified contract loading logic to detect current branch and override configured branch when flag is enabled and current branch differs from default branch
- Enhanced git checkout operations to use `-B` flag (create/reset branch) when the feature is active
- Refactored method signatures to pass the flag as a parameter through the call chain instead of using system properties
- Moved `selector` parameter to the end of method signatures and updated all callers to use idiomatic Kotlin trailing lambda syntax
- Added `checkoutWithCreate()` method to GitCommand interface and SystemGit class

**Checklist**:
- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate - N/A
- [ ] Security scans don't report any vulnerabilities - N/A (existing vulnerability in docker image unrelated to changes)
- [ ] Documentation added/updated - N/A
- [ ] Sample Project added/updated - N/A
- [ ] Demo video - N/A
- [ ] Article on Website - N/A
- [ ] Roadmap updated - N/A
- [ ] Conference Talk - N/A