### PR TITLE
Fix partial examples to respect metadata such as timeouts

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -872,15 +872,20 @@ data class Feature(
             )
 
         return HttpStubData(
-            requestTypeWithAncestors,
-            HttpResponse(),
-            matchingScenario.resolver,
+            requestType = requestTypeWithAncestors,
+            response = scenarioStub.response(),
+            resolver = matchingScenario.resolver,
             responsePattern = responseTypeWithAncestors,
             examplePath = scenarioStub.filePath,
             scenario = matchingScenario,
             data = scenarioStub.data,
             contractPath = this.path,
-            partial = scenarioStub.partial.copy(response = scenarioStub.partial.response)
+            partial = scenarioStub.partial,
+            originalRequest = scenarioStub.requestElsePartialRequest(),
+            delayInMilliseconds = scenarioStub.delayInMilliseconds,
+            requestBodyRegex = scenarioStub.requestBodyRegex?.let { Regex(it) },
+            stubToken = scenarioStub.stubToken,
+            feature = this,
         )
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/value/JSONObjectValue.kt
+++ b/core/src/main/kotlin/io/specmatic/core/value/JSONObjectValue.kt
@@ -128,6 +128,8 @@ data class JSONObjectValue(val jsonObject: Map<String, Value> = emptyMap()) : Va
     override fun specificity(): Int {
         return jsonObject.values.sumOf { it.specificity() }
     }
+
+    fun plus(other: JSONObjectValue): JSONObjectValue = JSONObjectValue(this.jsonObject.plus(other.jsonObject))
 }
 
 internal fun dictionaryToDeclarations(jsonObject: Map<String, Value>, types: Map<String, Pattern>, exampleDeclarations: ExampleDeclarations): Triple<Map<String, DeferredPattern>, Map<String, Pattern>, ExampleDeclarations> {

--- a/core/src/main/kotlin/io/specmatic/mock/ScenarioStub.kt
+++ b/core/src/main/kotlin/io/specmatic/mock/ScenarioStub.kt
@@ -381,10 +381,10 @@ fun validateMock(mockSpec: Map<String, Any?>) {
 fun mockFromJSON(mockSpec: Map<String, Value>): ScenarioStub {
     val data = JSONObjectValue(mockSpec.filterKeys { it !in (MOCK_HTTP_REQUEST_ALL_KEYS + MOCK_HTTP_RESPONSE_ALL_KEYS).plus(PARTIAL) })
 
-    if(PARTIAL in mockSpec) {
+    if (PARTIAL in mockSpec) {
         val template = mockSpec.getValue(PARTIAL) as? JSONObjectValue ?: throw ContractException("template key must be an object")
-
-        return ScenarioStub(data = data, partial = mockFromJSON(template.jsonObject))
+        val parsedPartial = mockFromJSON(template.plus(data).jsonObject)
+        return parsedPartial.copy(partial = parsedPartial, request = HttpRequest(), response = HttpResponse(0, emptyMap()))
     }
 
     val mockRequest: HttpRequest = requestFromJSON(getJSONObjectValue(MOCK_HTTP_REQUEST_ALL_KEYS, mockSpec))


### PR DESCRIPTION
**Why**:
- Metadata information, such as timeouts, should be extracted correctly
- It should not be a concern whether the metadata is specified inside or outside the partial object

**Checklist**:

- [x] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)