### PR TITLE
Ensure additional query parameters are included in the test request

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/APIKeyInHeaderSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/APIKeyInHeaderSecurityScheme.kt
@@ -17,7 +17,7 @@ data class APIKeyInHeaderSecurityScheme(val name: String, private val apiKey:Str
     }
 
     override fun removeParam(httpRequest: HttpRequest): HttpRequest {
-        return httpRequest.copy(headers = httpRequest.headers.minus(name))
+        return httpRequest.removeSecurityHeader(name)
     }
 
     override fun addTo(httpRequest: HttpRequest, resolver: Resolver): HttpRequest {

--- a/core/src/main/kotlin/io/specmatic/conversions/APIKeyInQueryParamSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/APIKeyInQueryParamSecurityScheme.kt
@@ -5,7 +5,6 @@ import io.specmatic.core.pattern.*
 import io.specmatic.core.value.StringValue
 import io.swagger.v3.oas.models.parameters.Parameter
 import io.swagger.v3.oas.models.parameters.QueryParameter
-import org.apache.http.HttpHeaders.AUTHORIZATION
 
 const val apiKeyParamName = "API-Key"
 
@@ -19,13 +18,13 @@ data class APIKeyInQueryParamSecurityScheme(val name: String, private val apiKey
     }
 
     override fun removeParam(httpRequest: HttpRequest): HttpRequest {
-        return httpRequest.copy(queryParams = httpRequest.queryParams.minus(name))
+        return httpRequest.removeSecurityQueryParam(name)
     }
 
     override fun addTo(httpRequest: HttpRequest, resolver: Resolver): HttpRequest {
         val updatedResolver = resolver.updateLookupForParam(BreadCrumb.QUERY.value)
         val apiKeyValue = apiKey ?: updatedResolver.generate(null, name, StringPattern()).toStringLiteral()
-        return httpRequest.copy(queryParams = httpRequest.queryParams.plus(name to apiKeyValue))
+        return httpRequest.addSecurityQueryParam(name, apiKeyValue)
     }
 
     override fun addTo(requestPattern: HttpRequestPattern, row: Row): HttpRequestPattern {
@@ -46,7 +45,7 @@ data class APIKeyInQueryParamSecurityScheme(val name: String, private val apiKey
     override fun copyFromTo(originalRequest: HttpRequest, newHttpRequest: HttpRequest): HttpRequest {
         if (!originalRequest.queryParams.containsKey(name)) return newHttpRequest
         val apiKeyValue = originalRequest.queryParams.getValues(name).first()
-        return newHttpRequest.copy(queryParams = newHttpRequest.queryParams.plus(name to apiKeyValue))
+        return newHttpRequest.addSecurityQueryParam(name, apiKeyValue)
     }
 
     override fun isInRow(row: Row): Boolean = row.containsField(name)

--- a/core/src/main/kotlin/io/specmatic/conversions/BasicAuthSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/BasicAuthSecurityScheme.kt
@@ -49,7 +49,7 @@ data class BasicAuthSecurityScheme(private val token: String? = null) : OpenAPIS
     }
 
     override fun removeParam(httpRequest: HttpRequest): HttpRequest {
-        return httpRequest.copy(headers = httpRequest.headers.minus(AUTHORIZATION))
+        return httpRequest.removeSecurityHeader(AUTHORIZATION)
     }
 
     override fun addTo(httpRequest: HttpRequest, resolver: Resolver): HttpRequest {

--- a/core/src/main/kotlin/io/specmatic/conversions/BearerSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/BearerSecurityScheme.kt
@@ -30,8 +30,7 @@ data class BearerSecurityScheme(private val configuredToken: String? = null) : O
     }
 
     override fun removeParam(httpRequest: HttpRequest): HttpRequest {
-        val headersWithoutAuthorization = httpRequest.headers.filterKeys { !it.equals(AUTHORIZATION, ignoreCase = true) }
-        return httpRequest.copy(headers = headersWithoutAuthorization)
+        return httpRequest.removeSecurityHeader(AUTHORIZATION)
     }
 
     override fun addTo(httpRequest: HttpRequest, resolver: Resolver): HttpRequest {

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
@@ -21,6 +21,8 @@ import java.io.File
 import java.io.UnsupportedEncodingException
 import java.net.*
 import java.nio.charset.StandardCharsets
+import kotlin.collections.plus
+import kotlin.to
 
 const val FORM_FIELDS_JSON_KEY = "form-fields"
 const val MULTIPART_FORMDATA_JSON_KEY = "multipart-formdata"
@@ -36,7 +38,7 @@ fun urlToQueryParams(uri: URI): Map<String, String> {
     }
 }
 
-data class HttpRequestMetadata(val securityHeaderNames: Set<String> = emptySet())
+data class HttpRequestMetadata(val securityHeaderNames: Set<String> = emptySet(), val securityQueryNames: Set<String> = emptySet())
 
 data class HttpRequest(
     val method: String? = null,
@@ -399,18 +401,28 @@ data class HttpRequest(
 
     fun addSecurityHeader(headerName: String, headerValue: String): HttpRequest {
         val updatedMetadata = metadata.copy(securityHeaderNames = metadata.securityHeaderNames.plus(headerName))
-
         val updatedHeaders = headers.filterKeys { key ->
-            !key.equals(
-                headerName,
-                ignoreCase = true
-            )
+            !key.equals(headerName, ignoreCase = true)
         } + (headerName to headerValue)
+        return this.copy(headers = updatedHeaders, metadata = updatedMetadata)
+    }
 
-        return this.copy(
-            headers = updatedHeaders,
-            metadata = updatedMetadata
-        )
+    fun removeSecurityHeader(headerName: String): HttpRequest {
+        val updatedMetadata = metadata.copy(securityHeaderNames = metadata.securityHeaderNames.minus(headerName))
+        val updatedHeaders = headers.filterKeys { key -> !key.equals(headerName, ignoreCase = true) }
+        return this.copy(headers = updatedHeaders, metadata = updatedMetadata)
+    }
+
+    fun addSecurityQueryParam(queryParamName: String, paramValue: String): HttpRequest {
+        val updatedMetadata = metadata.copy(securityQueryNames = metadata.securityQueryNames.plus(queryParamName))
+        val updatedQueryParameters = queryParams.plus(queryParamName to paramValue)
+        return this.copy(queryParams = updatedQueryParameters, metadata = updatedMetadata)
+    }
+
+    fun removeSecurityQueryParam(queryParamName: String): HttpRequest {
+        val updatedMetadata = metadata.copy(securityQueryNames = metadata.securityQueryNames.minus(queryParamName))
+        val updatedQueryParameters = queryParams.minus(queryParamName)
+        return this.copy(queryParams = updatedQueryParameters, metadata = updatedMetadata)
     }
 
     fun expectedResponseCode(): Int? {

--- a/core/src/test/kotlin/io/specmatic/core/RunContractTestsUsingScenario.kt
+++ b/core/src/test/kotlin/io/specmatic/core/RunContractTestsUsingScenario.kt
@@ -10,6 +10,7 @@ import io.specmatic.test.TestExecutor
 import io.mockk.every
 import io.mockk.mockk
 import io.specmatic.conversions.*
+import io.specmatic.core.utilities.Flags
 import io.specmatic.test.ScenarioAsTest
 import org.apache.http.HttpHeaders.AUTHORIZATION
 import org.assertj.core.api.Assertions.assertThat
@@ -21,6 +22,57 @@ import java.util.*
 import java.util.function.Consumer
 
 internal class RunContractTestsUsingScenario {
+    @Test
+    fun `should send additional request query-params if defined in example with extensible-query-params enabled`() {
+        val scenario = Scenario(ScenarioInfo(
+            httpRequestPattern = HttpRequestPattern(
+                httpPathPattern = HttpPathPattern.from("/test"), method = "GET",
+                httpQueryParamPattern = HttpQueryParamPattern(mapOf("key" to StringPattern())),
+            ),
+            httpResponsePattern = HttpResponsePattern(status = 200)
+        ))
+        val httpRequest = HttpRequest(
+            path = "/test", method = "GET",
+            queryParams = QueryParameters(mapOf("key" to "value", "extensibleKey" to "extensibleValue"))
+        )
+
+        val newBasedOnScenarios = Flags.using(Flags.Companion.EXTENSIBLE_QUERY_PARAMS to "true") {
+            scenario.newBasedOn(
+                row = Row().updateRequest(httpRequest, scenario.httpRequestPattern, scenario.resolver),
+                flagsBased = DefaultStrategies,
+            ).toList().listFold().value
+        }
+
+        assertThat(newBasedOnScenarios).hasSize(1)
+        assertThat(
+            newBasedOnScenarios.single().httpRequestPattern.httpQueryParamPattern.queryPatterns
+        ).isEqualTo(
+            mapOf("key" to ExactValuePattern(StringValue("value")), "extensibleKey" to ExactValuePattern(StringValue("extensibleValue")))
+        )
+    }
+
+    @Test
+    fun `should return failure on additional request query-params if defined in example without extensible-query-params enabled`() {
+        val scenario = Scenario(ScenarioInfo(
+            httpRequestPattern = HttpRequestPattern(
+                httpPathPattern = HttpPathPattern.from("/test"), method = "GET",
+                httpQueryParamPattern = HttpQueryParamPattern(mapOf("key" to StringPattern())),
+            ),
+            httpResponsePattern = HttpResponsePattern(status = 200)
+        ))
+        val httpRequest = HttpRequest(
+            path = "/test", method = "GET",
+            queryParams = QueryParameters(mapOf("key" to "value", "extensibleKey" to "extensibleValue"))
+        )
+
+        val newBasedOnScenarios = scenario.newBasedOn(
+            row = Row().updateRequest(httpRequest, scenario.httpRequestPattern, scenario.resolver),
+            flagsBased = DefaultStrategies,
+        ).toList().listFold()
+
+        assertThat(newBasedOnScenarios).isInstanceOf(HasFailure::class.java)
+    }
+
     @Test
     fun `should generate one test scenario when there are no examples`() {
         val scenario = Scenario(

--- a/core/src/test/resources/openapi/has_composite_security/valid_examples/secure.json
+++ b/core/src/test/resources/openapi/has_composite_security/valid_examples/secure.json
@@ -3,10 +3,11 @@
         "path": "/secure",
         "method": "POST",
         "query": {
-            "apiKey": "123"
+            "apiKey": "1234"
         },
         "headers": {
-            "Content-Type": "application/json"
+            "Content-Type": "application/json",
+            "Authorization": "Bearer API-SECRET"
         },
         "body": {
             "message": "Hello to Secure"


### PR DESCRIPTION
**What**: Ensure additional query parameters are included in the test request when  `EXTENSIBLE_QUERY_PARAMS` is enabled

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
