### PR TITLE
Add HEAD readiness response for HttpStub

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/route/modules/HealthCheckModule.kt
+++ b/core/src/main/kotlin/io/specmatic/core/route/modules/HealthCheckModule.kt
@@ -10,6 +10,9 @@ import io.specmatic.stub.respondToKtorHttpResponse
 class HealthCheckModule {
     companion object {
         private const val HEALTH_ENDPOINT = "/actuator/health"
+        private const val ROOT_ENDPOINT = "/"
+        private const val SPECMATIC_STATUS_HEADER = "X-Specmatic-Status"
+        private const val SPECMATIC_STATUS_UP = "up"
 
         fun Application.configureHealthCheckModule() {
             routing {
@@ -24,11 +27,22 @@ class HealthCheckModule {
                         )
                     )
                 }
+
+                head(ROOT_ENDPOINT) {
+                    respondToKtorHttpResponse(
+                        call,
+                        HttpResponse(
+                            status = 200,
+                            headers = mapOf(SPECMATIC_STATUS_HEADER to SPECMATIC_STATUS_UP)
+                        )
+                    )
+                }
             }
         }
 
         fun HttpRequest.isHealthCheckRequest(): Boolean {
-            return (this.path == HEALTH_ENDPOINT) && (this.method == "GET")
+            return ((this.path == HEALTH_ENDPOINT) && (this.method == "GET")) ||
+                ((this.path == ROOT_ENDPOINT) && (this.method == "HEAD"))
         }
     }
 }

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
@@ -666,6 +666,22 @@ paths:
     }
 
     @Test
+    fun `should return up status header when root HEAD endpoint is hit`() {
+        val specification =
+            OpenApiSpecification.fromFile("src/test/resources/openapi/spec_with_space_in_path.yaml").toFeature()
+
+        HttpStub(specification).use { stub ->
+            val request = HttpRequest("HEAD", "/")
+
+            val response = stub.client.execute(request)
+
+            assertThat(response.status).isEqualTo(200)
+            assertThat(response.headers["X-Specmatic-Status"]).isEqualTo("up")
+            assertThat(response.headers[SPECMATIC_RESULT_HEADER]).isNotEqualTo("failure")
+        }
+    }
+
+    @Test
     fun `should be able to set expectations for an API with a security scheme`() {
         val feature = OpenApiSpecification.fromYAML(
             """


### PR DESCRIPTION
#### Summary
- add dedicated HEAD `/` route so `HttpStub` can report readiness with a `200` status and `X-Specmatic-Status: up`
- treat `HEAD /` as a health-check request so it bypasses stub matching while existing `/actuator/health` behavior stays unchanged
- add regression test verifying the new header, status, and bypass behavior
