### PR TITLE
Handle Swagger spec requests without OpenAPI mocks

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/filters/ExpressionStandardizer.kt
+++ b/core/src/main/kotlin/io/specmatic/core/filters/ExpressionStandardizer.kt
@@ -109,6 +109,146 @@ class ExpressionStandardizer {
     }
 
     companion object {
+        private sealed class FilterExpr {
+            abstract fun projectUnsupportedKeys(isSupportedKey: (String) -> Boolean): FilterExpr?
+
+            data class Condition(val key: String, val operator: Operator, val value: String) : FilterExpr() {
+                override fun projectUnsupportedKeys(isSupportedKey: (String) -> Boolean): FilterExpr? {
+                    return takeIf { isSupportedKey(key) }
+                }
+            }
+
+            data class Not(val expr: FilterExpr) : FilterExpr() {
+                override fun projectUnsupportedKeys(isSupportedKey: (String) -> Boolean): FilterExpr? {
+                    return expr.projectUnsupportedKeys(isSupportedKey)?.let { Not(it) }
+                }
+            }
+
+            data class And(val left: FilterExpr, val right: FilterExpr) : FilterExpr() {
+                override fun projectUnsupportedKeys(isSupportedKey: (String) -> Boolean): FilterExpr? {
+                    val projectedLeft = left.projectUnsupportedKeys(isSupportedKey)
+                    val projectedRight = right.projectUnsupportedKeys(isSupportedKey)
+
+                    return when {
+                        projectedLeft == null && projectedRight == null -> null
+                        projectedLeft == null -> projectedRight
+                        projectedRight == null -> projectedLeft
+                        else -> And(projectedLeft, projectedRight)
+                    }
+                }
+            }
+
+            data class Or(val left: FilterExpr, val right: FilterExpr) : FilterExpr() {
+                override fun projectUnsupportedKeys(isSupportedKey: (String) -> Boolean): FilterExpr? {
+                    val projectedLeft = left.projectUnsupportedKeys(isSupportedKey)
+                    val projectedRight = right.projectUnsupportedKeys(isSupportedKey)
+
+                    return when {
+                        projectedLeft == null && projectedRight == null -> null
+                        projectedLeft == null -> projectedRight
+                        projectedRight == null -> projectedLeft
+                        else -> Or(projectedLeft, projectedRight)
+                    }
+                }
+            }
+        }
+
+        private class FilterExprParser(private val tokens: List<Token>) {
+            private var index = 0
+
+            fun parse(): FilterExpr? {
+                if (tokens.isEmpty()) return null
+                val expr = parseOr()
+                if (index != tokens.size) {
+                    throw IllegalArgumentException("Unexpected token in filter expression")
+                }
+                return expr
+            }
+
+            private fun parseOr(): FilterExpr {
+                var expr = parseAnd()
+                while (match<Token.Or>()) {
+                    expr = FilterExpr.Or(expr, parseAnd())
+                }
+                return expr
+            }
+
+            private fun parseAnd(): FilterExpr {
+                var expr = parseUnary()
+                while (match<Token.And>()) {
+                    expr = FilterExpr.And(expr, parseUnary())
+                }
+                return expr
+            }
+
+            private fun parseUnary(): FilterExpr {
+                return if (match<Token.Not>()) {
+                    FilterExpr.Not(parseUnary())
+                } else {
+                    parsePrimary()
+                }
+            }
+
+            private fun parsePrimary(): FilterExpr {
+                if (match<Token.LParen>()) {
+                    val expr = parseOr()
+                    if (!match<Token.RParen>()) {
+                        throw IllegalArgumentException("Mismatched parentheses in filter expression")
+                    }
+                    return expr
+                }
+
+                return when (val token = tokens.getOrNull(index++)) {
+                    is Token.Operation -> FilterExpr.Condition(token.key, token.operator, token.value)
+                    else -> throw IllegalArgumentException("Unexpected token in filter expression")
+                }
+            }
+
+            private inline fun <reified T : Token> match(): Boolean {
+                if (index >= tokens.size || tokens[index] !is T) return false
+                index++
+                return true
+            }
+        }
+
+        private fun renderToEvalEx(expr: FilterExpr?): String {
+            if (expr == null) return "true"
+
+            fun precedence(node: FilterExpr): Int = when (node) {
+                is FilterExpr.Or -> 1
+                is FilterExpr.And -> 2
+                is FilterExpr.Not -> 3
+                is FilterExpr.Condition -> 4
+            }
+
+            fun render(node: FilterExpr): String {
+                return when (node) {
+                    is FilterExpr.Condition -> node.operator.operate(node.key, node.value)
+                    is FilterExpr.Not -> {
+                        val child = render(node.expr)
+                        val wrapped = if (precedence(node.expr) < precedence(node)) "( $child )" else child
+                        "!$wrapped"
+                    }
+                    is FilterExpr.And -> {
+                        val left = render(node.left)
+                        val right = render(node.right)
+                        val leftWrapped = if (precedence(node.left) < precedence(node)) "( $left )" else left
+                        val rightWrapped = if (precedence(node.right) < precedence(node)) "( $right )" else right
+                        "$leftWrapped && $rightWrapped"
+                    }
+                    is FilterExpr.Or -> {
+                        val left = render(node.left)
+                        val right = render(node.right)
+                        val leftWrapped = if (precedence(node.left) < precedence(node)) "( $left )" else left
+                        val rightWrapped = if (precedence(node.right) < precedence(node)) "( $right )" else right
+                        "$leftWrapped || $rightWrapped"
+                    }
+                }
+            }
+
+            return render(expr)
+        }
+
         fun filterToEvalEx(filterExpression: String): Expression {
             if (filterExpression.isBlank()) {
                 return Expression("true", expressionConfiguration())
@@ -117,6 +257,21 @@ class ExpressionStandardizer {
             val evalExExpression = expressionStandardizer.tokenizeExpression(filterExpression)
 
             return Expression(evalExExpression, expressionConfiguration())
+        }
+
+        fun filterToEvalExForSupportedKeys(
+            filterExpression: String,
+            isSupportedKey: (String) -> Boolean
+        ): Expression {
+            if (filterExpression.isBlank()) {
+                return Expression("true", expressionConfiguration())
+            }
+
+            val expressionStandardizer = ExpressionStandardizer()
+            val tokens = expressionStandardizer.tokenize(filterExpression)
+            val parsedExpression = FilterExprParser(tokens).parse()
+            val projectedExpression = parsedExpression?.projectUnsupportedKeys(isSupportedKey)
+            return Expression(renderToEvalEx(projectedExpression), expressionConfiguration())
         }
 
         private fun expressionConfiguration(): ExpressionConfiguration? {

--- a/core/src/main/kotlin/io/specmatic/core/filters/TestRecordFilter.kt
+++ b/core/src/main/kotlin/io/specmatic/core/filters/TestRecordFilter.kt
@@ -4,14 +4,14 @@ import io.specmatic.test.TestResultRecord
 
 class TestRecordFilter(private val eachTestResult: TestResultRecord) : FilterContext {
     override fun includes(key: String, values: List<String>): Boolean {
-        return when (key) {
-            "PATH" -> {
+        return when (SupportedKey.from(key)) {
+            SupportedKey.PATH -> {
                 values.any(eachTestResult.path::contains)
             }
-            "METHOD" -> {
+            SupportedKey.METHOD -> {
                 values.any { it.equals(eachTestResult.method, ignoreCase = true) }
             }
-            "STATUS" -> {
+            SupportedKey.STATUS -> {
                 values.any { it.toIntOrNull() == eachTestResult.responseStatus }
             }
             else -> true
@@ -22,8 +22,8 @@ class TestRecordFilter(private val eachTestResult: TestResultRecord) : FilterCon
         filterKey: String,
         operator: String,
         filterValue: String
-    ): Boolean = when (filterKey) {
-        "STATUS" -> {
+    ): Boolean = when (SupportedKey.from(filterKey)) {
+        SupportedKey.STATUS -> {
             evaluateCondition(
                 eachTestResult.responseStatus,
                 operator,
@@ -33,5 +33,20 @@ class TestRecordFilter(private val eachTestResult: TestResultRecord) : FilterCon
         else -> {
             true
         }
+    }
+
+    companion object {
+        private enum class SupportedKey {
+            PATH,
+            METHOD,
+            STATUS;
+
+            companion object {
+                fun from(key: String): SupportedKey? =
+                    runCatching { enumValueOf<SupportedKey>(key) }.getOrNull()
+            }
+        }
+
+        fun supportsFilterKey(key: String): Boolean = SupportedKey.from(key) != null
     }
 }

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -429,7 +429,7 @@ class HttpStub(
                         // Add the original response (before encoding) to the log message
                         val stubResponseToLog = if (shouldRedactSwaggerSpecResponseInLogs) {
                             val summary = swaggerSpecSummary ?: "returned spec"
-                            httpStubResponse.copy(response = redactedSwaggerSpecResponse(summary))
+                            httpStubResponse.copy(response = redactedSwaggerSpecResponse(httpStubResponse.response, summary))
                         } else {
                             httpStubResponse
                         }
@@ -793,8 +793,12 @@ class HttpStub(
         }.orEmpty()
     }
 
-    private fun redactedSwaggerSpecResponse(summary: String): HttpResponse =
-        HttpResponse(status = 200, body = StringValue(summary))
+    private fun redactedSwaggerSpecResponse(originalResponse: HttpResponse, summary: String): HttpResponse =
+        HttpResponse(
+            status = originalResponse.status,
+            headers = mapOf(HttpHeaders.ContentType to (originalResponse.contentType() ?: "text/plain")),
+            body = StringValue(summary)
+        )
 
     private fun handleFetchLogRequest(): HttpStubResponse =
         HttpStubResponse(HttpResponse.ok(StringValue(LogTail.getString())))

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -1,5 +1,6 @@
 package io.specmatic.stub
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.ktor.http.*
 import io.ktor.http.content.*
@@ -12,7 +13,9 @@ import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.util.*
 import io.ktor.util.pipeline.*
+import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.conversions.convertPathParameterStyle
+import io.swagger.v3.core.util.Yaml
 import io.specmatic.core.APPLICATION_NAME
 import io.specmatic.core.APPLICATION_NAME_LOWER_CASE
 import io.specmatic.core.Feature
@@ -112,6 +115,9 @@ import kotlin.text.toCharArray
 const val SPECMATIC_RESPONSE_CODE_HEADER = "Specmatic-Response-Code"
 const val HTTP_PORT = 80
 const val HTTPS_PORT = 443
+const val JSON_REPORT_PATH = "./build/reports/specmatic"
+const val JSON_REPORT_FILE_NAME = "stub_usage_report.json"
+private const val SWAGGER_SPEC_NOT_AVAILABLE_MESSAGE = "No OpenAPI specifications are loaded in this mock server"
 
 class HttpStub(
     private val features: List<Feature>,
@@ -134,6 +140,15 @@ class HttpStub(
     private val startTime: Instant = Instant.now(),
     private val requestHandlers: MutableList<RequestHandler> = mutableListOf()
 ) : ContractStub {
+    private enum class SwaggerSpecResponseFormat {
+        YAML,
+        JSON
+    }
+    private data class MockedOpenApiSpec(
+        val resolvedSpecPath: String,
+        val displaySpecId: String
+    )
+
     constructor(
         feature: Feature,
         scenarioStubs: List<ScenarioStub> = emptyList(),
@@ -172,9 +187,6 @@ class HttpStub(
     )
 
     companion object {
-        const val JSON_REPORT_PATH = "./build/reports/specmatic"
-        const val JSON_REPORT_FILE_NAME = "stub_usage_report.json"
-
         fun setExpectation(
             stub: ScenarioStub,
             feature: Feature,
@@ -225,6 +237,19 @@ class HttpStub(
         transient = rawHttpStubs.filter { it.stubToken != null }.reversed().toMutableList(),
         specToBaseUrlMap = specToBaseUrlMap
     )
+    private val firstMockedOpenApiSpec: MockedOpenApiSpec? by lazy {
+        features.asSequence()
+            .filter { it.path.isNotBlank() }
+            .firstOrNull { isOpenAPI(it.path, logFailure = false) }
+            ?.let { feature ->
+                val resolvedSpecPath = feature.path
+                val displaySpecId = File(resolvedSpecPath).name.ifBlank { feature.name }
+                MockedOpenApiSpec(
+                    resolvedSpecPath = resolvedSpecPath,
+                    displaySpecId = displaySpecId
+                )
+            }
+    }
 
     // used by graphql/plugins
     fun ctrfTestResultRecords() = ctrfTestResultRecords.toList()
@@ -303,6 +328,8 @@ class HttpStub(
                 )
                 var transformedResponse: HttpResponse? = null
                 var responseErrors: List<InterceptorError> = emptyList()
+                var swaggerSpecSummary: String? = null
+                var shouldRedactSwaggerSpecResponseInLogs = false
 
                 try {
                     val rawHttpRequest = ktorHttpRequestToHttpRequest(call).also {
@@ -347,6 +374,18 @@ class HttpStub(
                         isFetchLogRequest(httpRequest) -> handleFetchLogRequest().copy(isInternalStubPath = true)
                         isFetchLoadLogRequest(httpRequest) -> handleFetchLoadLogRequest().copy(isInternalStubPath = true)
                         isFetchContractsRequest(httpRequest) -> handleFetchContractsRequest().copy(isInternalStubPath = true)
+                        isSwaggerSpecRequest(httpRequest) -> {
+                            shouldRedactSwaggerSpecResponseInLogs = true
+                            handleFetchSwaggerSpecRequest(httpRequest).also {
+                                swaggerSpecSummary = if (it.response.status == 429) {
+                                    SWAGGER_SPEC_NOT_AVAILABLE_MESSAGE
+                                } else {
+                                    val specId = it.contractPath.takeIf(String::isNotBlank)?.let { path -> File(path).name }
+                                        ?: "unknown-openapi-spec"
+                                    "returned spec for $specId"
+                                }
+                            }.copy(isInternalStubPath = true)
+                        }
                         responseFromRequestHandler != null -> responseFromRequestHandler
                         isExpectationCreation(httpRequest) -> handleExpectationCreationRequest(httpRequest).copy(isInternalStubPath = true)
                         isSseExpectationCreation(httpRequest) -> handleSseExpectationCreationRequest(httpRequest).copy(isInternalStubPath = true)
@@ -388,7 +427,13 @@ class HttpStub(
                             updatedHttpStubResponse.contractPath
                         )
                         // Add the original response (before encoding) to the log message
-                        httpLogMessage.addResponse(httpStubResponse)
+                        val stubResponseToLog = if (shouldRedactSwaggerSpecResponseInLogs) {
+                            val summary = swaggerSpecSummary ?: "returned spec"
+                            httpStubResponse.copy(response = redactedSwaggerSpecResponse(summary))
+                        } else {
+                            httpStubResponse
+                        }
+                        httpLogMessage.addResponse(stubResponseToLog)
                     }
 
                     if (httpStubResponse.isInternalStubPath.not()) {
@@ -413,10 +458,11 @@ class HttpStub(
                     respondToKtorHttpResponse(call, response)
                 }
 
+                swaggerSpecSummary?.let { log(StringLog(it)) }
                 log(httpLogMessage)
 
                 // Log the response after hook processing if it was transformed
-                transformedResponse?.let {
+                if (!shouldRedactSwaggerSpecResponseInLogs) transformedResponse?.let {
                     logger.log("")
                     logger.log("--------------------")
                     logger.log("Response after hook processing:")
@@ -689,6 +735,66 @@ class HttpStub(
 
     private fun handleFetchContractsRequest(): HttpStubResponse =
         HttpStubResponse(HttpResponse.ok(StringValue(features.joinToString("\n") { it.name })))
+
+    private fun handleFetchSwaggerSpecRequest(httpRequest: HttpRequest): HttpStubResponse {
+        val openApiSpec = firstMockedOpenApiSpec ?: return HttpStubResponse(
+            HttpResponse(status = 429, body = SWAGGER_SPEC_NOT_AVAILABLE_MESSAGE)
+        )
+        val resolvedSpec = File(openApiSpec.resolvedSpecPath)
+        if (!resolvedSpec.exists()) {
+            throw ContractException("Could not find mocked OpenAPI specification: ${resolvedSpec.canonicalPath}")
+        }
+
+        val overlayContent = stubOverlayContent(resolvedSpec)
+        val parsedOpenApi = OpenApiSpecification.fromYAML(
+            yamlContent = resolvedSpec.readText(),
+            openApiFilePath = resolvedSpec.canonicalPath,
+            specificationPath = openApiSpec.displaySpecId,
+            specmaticConfig = specmaticConfigInstance,
+            overlayContent = overlayContent,
+            strictMode = specmaticConfigInstance.getStubStrictMode(null) ?: false
+        ).parsedOpenApi
+
+        val format = swaggerSpecResponseFormat(httpRequest)
+            ?: throw ContractException("Unsupported swagger specification path: ${httpRequest.path.orEmpty()}")
+        val response = when (format) {
+            SwaggerSpecResponseFormat.YAML -> {
+                val openApiYaml = Yaml.pretty(parsedOpenApi)
+                HttpResponse(status = 200, headers = mapOf(HttpHeaders.ContentType to "application/yaml"), body = StringValue(openApiYaml))
+            }
+            SwaggerSpecResponseFormat.JSON -> {
+                val openApiJson = ObjectMapper()
+                    .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+                    .writeValueAsString(parsedOpenApi)
+                HttpResponse.jsonResponse(openApiJson)
+            }
+        }
+
+        return HttpStubResponse(
+            response = response,
+            contractPath = resolvedSpec.canonicalPath
+        )
+    }
+
+    private fun swaggerSpecResponseFormat(httpRequest: HttpRequest): SwaggerSpecResponseFormat? =
+        when (httpRequest.path) {
+            SWAGGER_SPEC_YAML_PATH -> SwaggerSpecResponseFormat.YAML
+            SWAGGER_SPEC_JSON_PATH -> SwaggerSpecResponseFormat.JSON
+            else -> null
+        }
+
+    private fun stubOverlayContent(specFile: File): String {
+        val configuredOverlay = specmaticConfigInstance.getStubOverlayFilePath(specFile, SpecType.OPENAPI)?.let(::File)
+        return configuredOverlay?.let {
+            if (!it.exists()) {
+                throw ContractException("Specified Overlay file does not exist ${it.canonicalPath}")
+            }
+            it.readText()
+        }.orEmpty()
+    }
+
+    private fun redactedSwaggerSpecResponse(summary: String): HttpResponse =
+        HttpResponse(status = 200, body = StringValue(summary))
 
     private fun handleFetchLogRequest(): HttpStubResponse =
         HttpStubResponse(HttpResponse.ok(StringValue(LogTail.getString())))
@@ -1635,6 +1741,12 @@ internal fun isFetchContractsRequest(httpRequest: HttpRequest): Boolean =
 
 internal fun isFetchLoadLogRequest(httpRequest: HttpRequest): Boolean =
     isPath(httpRequest.path, "load_log") && httpRequest.method == "GET"
+
+private const val SWAGGER_SPEC_YAML_PATH = "/swagger/v1/swagger.yaml"
+private const val SWAGGER_SPEC_JSON_PATH = "/swagger/v1/swagger.json"
+
+internal fun isSwaggerSpecRequest(httpRequest: HttpRequest): Boolean =
+    httpRequest.method == "GET" && (httpRequest.path == SWAGGER_SPEC_YAML_PATH || httpRequest.path == SWAGGER_SPEC_JSON_PATH)
 
 internal fun isExpectationCreation(httpRequest: HttpRequest) =
     isPath(httpRequest.path, "expectations") && httpRequest.method == "POST"

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -386,12 +386,11 @@ class HttpStub(
                         isSwaggerSpecRequest(httpRequest) -> {
                             shouldRedactSwaggerSpecResponseInLogs = true
                             handleFetchSwaggerSpecRequest(httpRequest).also {
-                                swaggerSpecSummary = if (it.response.status == 429) {
+                                swaggerSpecSummary = if (it.response.status == HttpStatusCode.Conflict.value) {
                                     SWAGGER_SPEC_NOT_AVAILABLE_MESSAGE
                                 } else {
-                                    val specId = it.contractPath.takeIf(String::isNotBlank)?.let { path -> File(path).name }
-                                        ?: "unknown-openapi-spec"
-                                    "returned spec for $specId"
+                                    val specPath = it.contractPath.takeIf(String::isNotBlank) ?: "unknown-openapi-spec"
+                                    "(specification in $specPath was returned)"
                                 }
                             }.copy(isInternalStubPath = true)
                         }
@@ -760,7 +759,7 @@ class HttpStub(
 
     private fun handleFetchSwaggerSpecRequest(httpRequest: HttpRequest): HttpStubResponse {
         val openApiSpec = firstMockedOpenApiSpec ?: return HttpStubResponse(
-            HttpResponse(status = 429, body = SWAGGER_SPEC_NOT_AVAILABLE_MESSAGE)
+            HttpResponse(status = HttpStatusCode.Conflict.value, body = SWAGGER_SPEC_NOT_AVAILABLE_MESSAGE)
         )
         val resolvedSpec = File(openApiSpec.resolvedSpecPath)
         if (!resolvedSpec.exists()) {

--- a/core/src/test/kotlin/io/specmatic/core/filters/ExpressionStandardizerTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/filters/ExpressionStandardizerTest.kt
@@ -29,6 +29,43 @@ class ExpressionStandardizerTest {
         assertThatCode { ExpressionStandardizer().tokenizeExpression(expression) }.isInstanceOf(IllegalArgumentException::class.java)
     }
 
+    @Test
+    fun `unsupported keys should be dropped when projecting filter for a limited context`() {
+        val expression = ExpressionStandardizer.filterToEvalExForSupportedKeys(
+            "EXAMPLE-NAME!='SUCCESS'",
+            TestRecordFilter::supportsFilterKey
+        )
+
+        assertThat(expression.evaluate().booleanValue).isTrue
+    }
+
+    @ParameterizedTest
+    @MethodSource("projectionCasesProvider")
+    fun `projection should keep supported-key behavior`(
+        filterExpression: String,
+        matchingValuesByKey: Map<String, Set<String>>
+    ) {
+        val expression = ExpressionStandardizer.filterToEvalExForSupportedKeys(
+            filterExpression,
+            TestRecordFilter::supportsFilterKey
+        )
+
+        val contextWithSupportedKeyMatch = object : FilterContext {
+            override fun includes(key: String, values: List<String>): Boolean =
+                matchingValuesByKey[key]?.intersect(values.toSet())?.isNotEmpty() == true
+
+            override fun compare(filterKey: String, operator: String, filterValue: String): Boolean = true
+        }
+
+        val contextWithNoSupportedKeyMatches = object : FilterContext {
+            override fun includes(key: String, values: List<String>): Boolean = false
+            override fun compare(filterKey: String, operator: String, filterValue: String): Boolean = true
+        }
+
+        assertThat(expression.with("context", contextWithSupportedKeyMatch).evaluate().booleanValue).isTrue
+        assertThat(expression.with("context", contextWithNoSupportedKeyMatches).evaluate().booleanValue).isFalse
+    }
+
     companion object {
         @JvmStatic
         private fun validExpressionsProvider(): List<Arguments> {
@@ -67,6 +104,28 @@ class ExpressionStandardizerTest {
                         <
                     '1,2'
                 """.trimIndent(),
+            )
+        }
+
+        @JvmStatic
+        private fun projectionCasesProvider(): List<Arguments> {
+            return listOf(
+                Arguments.of(
+                    "PATH='/orders' && EXAMPLE-NAME!='SUCCESS'",
+                    mapOf("PATH" to setOf("/orders"))
+                ),
+                Arguments.of(
+                    "METHOD='POST' || EXAMPLE-NAME='SUCCESS'",
+                    mapOf("METHOD" to setOf("POST"))
+                ),
+                Arguments.of(
+                    "!(EXAMPLE-NAME='SUCCESS') && METHOD='POST'",
+                    mapOf("METHOD" to setOf("POST"))
+                ),
+                Arguments.of(
+                    "(METHOD='POST' || PATH='/orders') && EXAMPLE-NAME!='SUCCESS'",
+                    mapOf("METHOD" to setOf("POST"), "PATH" to setOf("/orders"))
+                )
             )
         }
     }

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubKtTest.kt
@@ -797,6 +797,18 @@ Feature: POST API
         assertThat(isStateSetupRequest(HttpRequest("POST", "/_$APPLICATION_NAME_LOWER_CASE/state"))).isTrue()
     }
 
+    @Test
+    fun `swagger specification route should match expected path and method`() {
+        assertThat(isSwaggerSpecRequest(HttpRequest("GET", "/swagger/v1/swagger.yaml"))).isTrue()
+    }
+
+    @Test
+    fun `swagger specification route should not match other requests`() {
+        assertThat(isSwaggerSpecRequest(HttpRequest("POST", "/swagger/v1/swagger.yaml"))).isFalse()
+        assertThat(isSwaggerSpecRequest(HttpRequest("GET", "/swagger/v1/swagger.json"))).isTrue()
+        assertThat(isSwaggerSpecRequest(HttpRequest("GET", "/swagger/v1/swagger.xml"))).isFalse()
+    }
+
     private fun waitFor(threads: List<Thread>) = threads.forEach { it.join() }
 
     private fun start(threads: List<Thread>) = threads.forEach { it.start() }

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
@@ -100,7 +100,7 @@ internal class HttpStubTest {
             HttpStub(features = listOf(feature)).use { stub ->
                 val response = RestTemplate().getForEntity<String>(stub.endPoint + "/swagger/v1/swagger.yaml")
 
-                assertThat(response.statusCodeValue).isEqualTo(200)
+                assertThat(response.statusCode.value()).isEqualTo(200)
                 assertThat(response.headers.contentType?.toString()).contains("application/yaml")
                 assertThat(response.body).contains("openapi: 3.0.0")
                 assertThat(response.body).contains("title: Title from overlay")
@@ -120,7 +120,7 @@ internal class HttpStubTest {
             HttpStub(features = listOf(feature)).use { stub ->
                 val response = RestTemplate().getForEntity<String>(stub.endPoint + "/swagger/v1/swagger.json")
 
-                assertThat(response.statusCodeValue).isEqualTo(200)
+                assertThat(response.statusCode.value()).isEqualTo(200)
                 assertThat(response.headers.contentType?.toString()).contains("application/json")
                 assertThat(response.body).contains("\"openapi\"")
                 assertThat(response.body).contains("\"title\": \"Title from overlay\"")
@@ -226,7 +226,7 @@ Scenario: Get a number
             headers.contentType = MediaType.APPLICATION_JSON
             val stubRequest = RequestEntity(mockData, headers, HttpMethod.POST, URI.create(stubSetupURL))
             val stubResponse = RestTemplate().postForEntity<String>(stubSetupURL, stubRequest)
-            assertThat(stubResponse.statusCodeValue).isEqualTo(200)
+            assertThat(stubResponse.statusCode.value()).isEqualTo(200)
 
             val postResponse = RestTemplate().getForEntity<String>(fake.endPoint + "/number")
             assertThat(postResponse.body).isEqualTo("10")
@@ -255,7 +255,7 @@ Scenario: Multiply a number by 3
             headers.contentType = MediaType.APPLICATION_JSON
             val stubRequest = RequestEntity(mockData, headers, HttpMethod.POST, URI.create(stubSetupURL))
             val stubResponse = RestTemplate().postForEntity<String>(stubSetupURL, stubRequest)
-            assertThat(stubResponse.statusCodeValue).isEqualTo(200)
+            assertThat(stubResponse.statusCode.value()).isEqualTo(200)
 
             val postResponse = RestTemplate().getForEntity<String>(fake.endPoint + "/multiply/5")
             assertThat(postResponse.body).isEqualTo("15")
@@ -294,7 +294,7 @@ Scenario: Get a number
 
         val stubRequest = RequestEntity(mockData, headers, HttpMethod.POST, URI.create(stubSetupURL))
         val stubResponse = RestTemplate().postForEntity<String>(stubSetupURL, stubRequest)
-        assertThat(stubResponse.statusCodeValue).isEqualTo(200)
+        assertThat(stubResponse.statusCode.value()).isEqualTo(200)
 
         val postResponse = RestTemplate().getForEntity<String>(fake.endPoint + "/number")
         assertThat(postResponse.body).isEqualTo(output)

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
@@ -144,46 +144,46 @@ internal class HttpStubTest {
                     RestTemplate().getForEntity<String>(stub.endPoint + "/swagger/v1/swagger.yaml")
 
                     val logResponse = RestTemplate().getForEntity<String>(stub.endPoint + "/_specmatic/log")
-                    assertThat(logResponse.body).contains("returned spec for ${openApiSpec.name}")
+                    assertThat(logResponse.body).contains("(specification in ${openApiSpec.canonicalPath} was returned)")
                     assertThat(logResponse.body).doesNotContain("\"openapi\"")
                 }
             }
 
-            assertThat(consoleOutput).contains("returned spec for ${openApiSpec.name}")
+            assertThat(consoleOutput).contains("(specification in ${openApiSpec.canonicalPath} was returned)")
         } finally {
             tempDir.deleteRecursively()
         }
     }
 
     @Test
-    fun `should return plain text 429 from swagger endpoints when only wsdl is mocked`() {
+    fun `should return plain text 409 from swagger endpoints when only wsdl is mocked`() {
         LogTail.clear()
         val wsdlFeature = parseContractFileToFeature("src/test/resources/wsdl/hello.wsdl")
 
         val (consoleOutput, _) = captureStandardOutput(trim = false) {
             HttpStub(features = listOf(wsdlFeature), log = ::consoleLog).use { stub ->
-                val yamlException = Assertions.assertThrows(HttpClientErrorException.TooManyRequests::class.java) {
+                val yamlException = Assertions.assertThrows(HttpClientErrorException.Conflict::class.java) {
                     RestTemplate().getForEntity<String>(stub.endPoint + "/swagger/v1/swagger.yaml")
                 }
 
-                assertThat(yamlException.statusCode.value()).isEqualTo(429)
+                assertThat(yamlException.statusCode.value()).isEqualTo(409)
                 assertThat(yamlException.responseHeaders?.contentType?.toString()).contains("text/plain")
                 assertThat(yamlException.responseBodyAsString).contains("No OpenAPI specifications are loaded in this mock server")
 
-                val jsonException = Assertions.assertThrows(HttpClientErrorException.TooManyRequests::class.java) {
+                val jsonException = Assertions.assertThrows(HttpClientErrorException.Conflict::class.java) {
                     RestTemplate().getForEntity<String>(stub.endPoint + "/swagger/v1/swagger.json")
                 }
 
-                assertThat(jsonException.statusCode.value()).isEqualTo(429)
+                assertThat(jsonException.statusCode.value()).isEqualTo(409)
                 assertThat(jsonException.responseHeaders?.contentType?.toString()).contains("text/plain")
                 assertThat(jsonException.responseBodyAsString).contains("No OpenAPI specifications are loaded in this mock server")
 
                 val logResponse = RestTemplate().getForEntity<String>(stub.endPoint + "/_specmatic/log")
-                assertThat(logResponse.body).contains("429 Too Many Requests")
+                assertThat(logResponse.body).contains("409 Conflict")
             }
         }
 
-        assertThat(consoleOutput).contains("429 Too Many Requests")
+        assertThat(consoleOutput).contains("409 Conflict")
     }
 
     @Test

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
@@ -291,11 +291,15 @@ class OpenApiCoverageReportInput(
         }
 
 
-        val filterExpression = ExpressionStandardizer.filterToEvalEx(filterExpression)
-
-        return (testResults + testResultsForMissingAPIs).filter { eachTestResult ->
-            filterExpression.with("context", TestRecordFilter(eachTestResult)).evaluate().booleanValue
+        val projectedFilterExpression = ExpressionStandardizer.filterToEvalExForSupportedKeys(filterExpression) {
+            TestRecordFilter.supportsFilterKey(it)
         }
+
+        val filteredMissingApiResults = testResultsForMissingAPIs.filter { missingTestResult ->
+            projectedFilterExpression.with("context", TestRecordFilter(missingTestResult)).evaluate().booleanValue
+        }
+
+        return testResults + filteredMissingApiResults
     }
 
     private fun calculateTotalCoveragePercentage(methodMap: Map<String, Map<String?, Map<String, List<TestResultRecord>>>>): Int {


### PR DESCRIPTION
## Summary
- add `/swagger/v1/swagger.yaml` and `/swagger/v1/swagger.json` handlers that return the first mocked OpenAPI spec or a 429/plain-text message when none exists
- redact the detailed Swagger payload from logs while logging a concise summary, and extend tests to cover YAML/JSON responses and the 429 WS-DL case
- improve routing helpers and introduce spec-format detection for Swagger endpoints
