### PR TITLE
Fixes to example module loading and validation

### DIFF
--- a/application/src/main/kotlin/application/ExamplesCommand.kt
+++ b/application/src/main/kotlin/application/ExamplesCommand.kt
@@ -181,7 +181,7 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
         }
 
         private fun validateExamplesDir(contractFile: File, examplesDir: File): Pair<Int, ValidationResults> =
-            validateExamplesDir(parseContractFileWithNoMissingConfigWarning(contractFile, lenientMode = lenientMode), examplesDir)
+            validateExamplesDir(parseContractFileToFeature(contractFile, specmaticConfig = specmaticConfig, lenientMode = lenientMode), examplesDir)
 
         private fun validateExamplesDir(feature: Feature, examplesDir: File): Pair<Int, ValidationResults> {
             val (externalExampleDir, externalExamples) = ExampleModule(specmaticConfig).loadExternalExamples(examplesDir = examplesDir)
@@ -207,7 +207,7 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
                 logger.log("${ordinal.getAndIncrement()}. Validating examples associated to '$relativeSpecPath'...")
                 logger.boundary()
 
-                val feature = parseContractFileWithNoMissingConfigWarning(specFile, lenientMode = lenientMode)
+                val feature = parseContractFileToFeature(specFile, specmaticConfig = specmaticConfig, lenientMode = lenientMode)
                 val inlineExampleValidationResults = validateInlineExamples(feature)
                 printValidationResult(inlineExampleValidationResults, "Inline example")
                 logger.boundary()
@@ -229,7 +229,7 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
         }
 
         private fun validateImplicitAndConfigExamples(contractFile: File): Int {
-            val feature = parseContractFileWithNoMissingConfigWarning(contractFile, lenientMode = lenientMode)
+            val feature = parseContractFileToFeature(contractFile, specmaticConfig = specmaticConfig, lenientMode = lenientMode)
 
             val (validateInline, validateExternal) = getValidateInlineAndValidateExternalFlags()
 

--- a/application/src/main/kotlin/application/validate/OpenApiValidator.kt
+++ b/application/src/main/kotlin/application/validate/OpenApiValidator.kt
@@ -14,8 +14,6 @@ import io.specmatic.test.asserts.toFailure
 import java.io.File
 
 class OpenApiValidator: Validator<Feature> {
-    private val exampleValidationModule: ExampleValidationModule = ExampleValidationModule(specmaticConfig = SpecmaticConfig())
-
     override fun validateSpecification(specification: File, specmaticConfig: SpecmaticConfig): SpecValidationResult<Feature> {
         if (specification.extension in OPENAPI_FILE_EXTENSIONS) {
             val (feature, result) = OpenApiSpecification.fromFile(specification.canonicalPath, specmaticConfig).toFeatureLenient()
@@ -30,7 +28,7 @@ class OpenApiValidator: Validator<Feature> {
     }
 
     override fun validateInlineExamples(specification: File, feature: Feature, specmaticConfig: SpecmaticConfig): Map<String, ExampleValidationResult> {
-        return exampleValidationModule.validateInlineExamples(
+        return ExampleValidationModule(specmaticConfig = specmaticConfig).validateInlineExamples(
             feature = feature,
             examples = feature.stubsFromExamples.mapValues { (_, stub) ->
                 stub.map { (request, response) -> ScenarioStub(request, response) }
@@ -41,7 +39,7 @@ class OpenApiValidator: Validator<Feature> {
     }
 
     override fun validateExample(feature: Feature, file: File, specmaticConfig: SpecmaticConfig): ExampleValidationResult {
-        val result = exampleValidationModule.validateExample(feature, file)
+        val result = ExampleValidationModule(specmaticConfig = specmaticConfig).validateExample(feature, file)
         return when {
             result !is Result.Failure -> ExampleValidationResult.ValidationResult(file, result)
             result.hasReason(FailureReason.IdentifierMismatch) -> ExampleValidationResult.DoesNotBelong(file, result)
@@ -56,6 +54,6 @@ class OpenApiValidator: Validator<Feature> {
             )
         }
 
-        return exampleValidationModule.callLifecycleHook(feature, examples)
+        return ExampleValidationModule(specmaticConfig = specmaticConfig).callLifecycleHook(feature, examples)
     }
 }

--- a/application/src/main/kotlin/application/validate/OpenApiValidator.kt
+++ b/application/src/main/kotlin/application/validate/OpenApiValidator.kt
@@ -14,7 +14,7 @@ import io.specmatic.test.asserts.toFailure
 import java.io.File
 
 class OpenApiValidator: Validator<Feature> {
-    private val exampleValidationModule: ExampleValidationModule = ExampleValidationModule()
+    private val exampleValidationModule: ExampleValidationModule = ExampleValidationModule(specmaticConfig = SpecmaticConfig())
 
     override fun validateSpecification(specification: File, specmaticConfig: SpecmaticConfig): SpecValidationResult<Feature> {
         if (specification.extension in OPENAPI_FILE_EXTENSIONS) {

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -74,10 +74,6 @@ fun checkExists(file: File) = file.also {
         throw ContractException("File ${file.path} does not exist (absolute path ${file.canonicalPath})")
 }
 
-fun parseContractFileWithNoMissingConfigWarning(contractFile: File, lenientMode: Boolean = false): Feature {
-    return parseContractFileToFeature(contractFile, specmaticConfig = SpecmaticConfig(), lenientMode = lenientMode)
-}
-
 fun parseContractFileToFeature(
     file: File,
     hook: Hook = PassThroughHook(),

--- a/core/src/main/kotlin/io/specmatic/core/examples/module/ExampleModule.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/module/ExampleModule.kt
@@ -38,15 +38,8 @@ class ExampleModule(private val specmaticConfig: SpecmaticConfig) {
     }
 
     fun getExamplesDirPaths(contractFile: File): List<File> {
-        val contractParentDir = contractFile.canonicalFile.parentFile
-        val testDirs = specmaticConfig.getTestExampleDirs(contractFile).map { exampleDirPath ->
-            resolveConfiguredExampleDir(contractParentDir, exampleDirPath)
-        }
-
-        val stubDirs = specmaticConfig.getStubExampleDirs(contractFile).map { exampleDirPath ->
-            resolveConfiguredExampleDir(contractParentDir, exampleDirPath)
-        }
-
+        val testDirs = specmaticConfig.getTestExampleDirs(contractFile).map(::File)
+        val stubDirs = specmaticConfig.getStubExampleDirs(contractFile).map(::File)
         val externalDir = listOf(defaultExternalExampleDirFrom(contractFile))
         return listOf(testDirs, stubDirs, externalDir).flatten().distinctBy { it.normalizedPath() }
     }
@@ -121,11 +114,6 @@ class ExampleModule(private val specmaticConfig: SpecmaticConfig) {
                 orFailure = { null }
             )
         }
-    }
-
-    private fun resolveConfiguredExampleDir(contractParentDir: File, exampleDirPath: String): File {
-        val configuredDir = File(exampleDirPath)
-        return if (configuredDir.isAbsolute) configuredDir else contractParentDir.resolve(exampleDirPath)
     }
 
     private fun File.normalizedPath(): String {

--- a/core/src/main/kotlin/io/specmatic/core/examples/module/ExampleValidationModule.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/module/ExampleValidationModule.kt
@@ -57,7 +57,7 @@ class ExampleValidationModule(private val lenientMode: Boolean = false, private 
     }
 
     fun validateExample(contractFile: File, exampleFile: File): ValidationResult {
-        val feature = parseContractFileWithNoMissingConfigWarning(contractFile, lenientMode = lenientMode)
+        val feature = parseContractFileToFeature(contractFile, specmaticConfig = specmaticConfig, lenientMode = lenientMode)
         return ValidationResult(
             validateExample(feature, exampleFile),
             callLifecycleHook(feature, ExampleModule(specmaticConfig).getExamplesFromFiles(listOf(exampleFile)))

--- a/core/src/main/kotlin/io/specmatic/core/examples/module/ValidationResults.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/module/ValidationResults.kt
@@ -28,6 +28,11 @@ class ValidationResults(val exampleValidationResults: Map<String, Result>, priva
     fun plus(exampleValidationResults: Map<String, Result>) =
         ValidationResults(this.exampleValidationResults + exampleValidationResults, hookValidationResult)
 
+    fun merge(other: ValidationResults): ValidationResults = ValidationResults(
+        exampleValidationResults = this.exampleValidationResults + other.exampleValidationResults,                 // maps: later wins if same key
+        hookValidationResult = Result.fromResults(listOf(this.hookValidationResult, other.hookValidationResult))
+    )
+
     companion object {
         fun forNoExamples(): ValidationResults {
             return ValidationResults(emptyMap(), Result.Success())

--- a/core/src/main/kotlin/io/specmatic/stub/api.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/api.kt
@@ -694,16 +694,19 @@ private fun specPathToImplicitDataDirPaths(
             }
 
             val implicitExamplesPath = stubContractPath.substringBeforeLast(".").plus("_examples")
+            val stubContractFile = when {
+                File(stubContractPath).isAbsolute -> File(stubContractPath)
+                stubDirectory.isNotBlank() -> File(stubDirectory, stubContractPath)
+                else -> File(stubContractPath)
+            }
 
-            val stubContractPathWithDirectory =
-                if (stubDirectory.isNotBlank()) "$stubDirectory${File.separator}$stubContractPath" else stubContractPath
-            stubContractPathWithDirectory to
-                dataDirPaths.map { dataDirPath ->
-                    ImplicitOriginalDataDirPair(
-                        implicitDataDir = "$dataDirPath${File.separator}$implicitExamplesPath",
-                        dataDir = dataDirPath,
-                    )
+            stubContractFile.path to dataDirPaths.map { dataDirPath ->
+                val implicitDirFile = when {
+                    File(implicitExamplesPath).isAbsolute -> File(implicitExamplesPath)
+                    else -> File(dataDirPath, implicitExamplesPath)
                 }
+                ImplicitOriginalDataDirPair(implicitDataDir = implicitDirFile.path, dataDir = dataDirPath)
+            }
         }
 }
 

--- a/core/src/test/kotlin/io/specmatic/core/FeatureKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FeatureKtTest.kt
@@ -1180,15 +1180,6 @@ paths:
     }
 
     @Test
-    fun `should be able to parse a spec with no warning about missing config`() {
-        val (stdout, _) = captureStandardOutput {
-            parseContractFileWithNoMissingConfigWarning(File("src/test/resources/openapi/jsonAndYamlEquivalence/openapi.yaml"))
-        }
-
-        assertThat(stdout).doesNotContain("Could not find the Specmatic configuration at path")
-    }
-
-    @Test
     fun `should filter out scenario when 4xx definitions are missing from Feature but present in originalScenarios`() {
         val path = "/orders/(id:string)"
         val orderPostOk = Scenario(ScenarioInfo(

--- a/core/src/test/kotlin/io/specmatic/core/examples/module/ExampleModuleTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/examples/module/ExampleModuleTest.kt
@@ -142,8 +142,8 @@ class ExampleModuleTest {
         val dirPaths = module.getExamplesDirPaths(contractFile).map { it.canonicalFile.path }
         assertThat(dirPaths).containsExactlyInAnyOrder(
             absoluteExamplesDir.canonicalFile.path,
-            contractFile.parentFile.resolve("shared_examples").canonicalFile.path,
-            contractFile.parentFile.resolve("mock_examples").canonicalFile.path,
+            File(".").resolve("shared_examples").canonicalFile.path,
+            File(".").resolve("mock_examples").canonicalFile.path,
             contractFile.parentFile.resolve("api_examples").canonicalFile.path
         )
     }
@@ -174,7 +174,7 @@ class ExampleModuleTest {
         implicitDir.resolve("implicit.json").writeText(implicitExample)
 
         val specmaticConfig = mockk<SpecmaticConfig>(relaxed = true).apply {
-            every { getTestExampleDirs(contractFile) } returns listOf("configured_examples", "missing_examples")
+            every { getTestExampleDirs(contractFile) } returns listOf(configuredDir.absolutePath, "missing_examples")
             every { getStubExampleDirs(contractFile) } returns emptyList()
         }
 
@@ -194,7 +194,7 @@ class ExampleModuleTest {
         implicitDir.resolve("resource.customer.example.json").writeText("""{"id": 20}""")
 
         val specmaticConfig = mockk<SpecmaticConfig>(relaxed = true).apply {
-            every { getTestExampleDirs(contractFile) } returns listOf("configured_examples")
+            every { getTestExampleDirs(contractFile) } returns listOf(configuredDir.absolutePath)
             every { getStubExampleDirs(contractFile) } returns emptyList()
         }
 

--- a/core/src/test/kotlin/io/specmatic/core/examples/module/ExampleModuleTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/examples/module/ExampleModuleTest.kt
@@ -3,7 +3,10 @@ package io.specmatic.core.examples.module
 import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpResponse
+import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.value.JSONObjectValue
+import io.mockk.every
+import io.mockk.mockk
 import io.specmatic.mock.ScenarioStub
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -12,7 +15,7 @@ import java.io.File
 import java.util.UUID
 
 class ExampleModuleTest {
-    private val exampleModule = ExampleModule()
+    private val exampleModule = ExampleModule(SpecmaticConfig())
 
     @Test
     fun `get existing examples should be able to pick mutated and partial examples properly`(@TempDir tempDir: File) {
@@ -124,5 +127,81 @@ class ExampleModuleTest {
         val nonPartial = examplesDir.resolve("${UUID.randomUUID()}.json").apply { writeText(nonPartialExample.toStringLiteral()) }
         val partial = examplesDir.resolve("${UUID.randomUUID()}_partial.json").apply { writeText(partialExample.toStringLiteral()) }
         return listOf(nonPartial, partial)
+    }
+
+    @Test
+    fun `get examples dir paths should include test mock and implicit dirs with de-duplication`(@TempDir tempDir: File) {
+        val contractFile = tempDir.resolve("contracts").apply { mkdirs() }.resolve("api.yaml")
+        val absoluteExamplesDir = tempDir.resolve("absolute_examples").apply { mkdirs() }
+        val specmaticConfig = mockk<SpecmaticConfig>(relaxed = true).apply {
+            every { getTestExampleDirs(contractFile) } returns listOf("shared_examples", absoluteExamplesDir.path)
+            every { getStubExampleDirs(contractFile) } returns listOf("shared_examples", "mock_examples")
+        }
+
+        val module = ExampleModule(specmaticConfig)
+        val dirPaths = module.getExamplesDirPaths(contractFile).map { it.canonicalFile.path }
+        assertThat(dirPaths).containsExactlyInAnyOrder(
+            absoluteExamplesDir.canonicalFile.path,
+            contractFile.parentFile.resolve("shared_examples").canonicalFile.path,
+            contractFile.parentFile.resolve("mock_examples").canonicalFile.path,
+            contractFile.parentFile.resolve("api_examples").canonicalFile.path
+        )
+    }
+
+    @Test
+    fun `get examples dir paths should include implicit dir when config has no examples`(@TempDir tempDir: File) {
+        val contractFile = tempDir.resolve("service.yaml")
+        val specmaticConfig = mockk<SpecmaticConfig>(relaxed = true).apply {
+            every { getTestExampleDirs(contractFile) } returns emptyList()
+            every { getStubExampleDirs(contractFile) } returns emptyList()
+        }
+
+        val module = ExampleModule(specmaticConfig)
+        val dirPaths = module.getExamplesDirPaths(contractFile)
+        assertThat(dirPaths).containsExactly(contractFile.parentFile.resolve("service_examples"))
+    }
+
+    @Test
+    fun `get examples for should load from existing configured and implicit dirs and skip missing dirs`(@TempDir tempDir: File) {
+        val contractFile = tempDir.resolve("api.yaml")
+        val configuredDir = tempDir.resolve("configured_examples").apply { mkdirs() }
+        val implicitDir = tempDir.resolve("api_examples").apply { mkdirs() }
+
+        val configuredExample = ScenarioStub(request = HttpRequest("GET", "/orders/10"),response = HttpResponse(status = 200)).toJSON().toStringLiteral()
+        configuredDir.resolve("configured.json").writeText(configuredExample)
+
+        val implicitExample = ScenarioStub(request = HttpRequest("POST", "/orders"),response = HttpResponse(status = 201)).toJSON().toStringLiteral()
+        implicitDir.resolve("implicit.json").writeText(implicitExample)
+
+        val specmaticConfig = mockk<SpecmaticConfig>(relaxed = true).apply {
+            every { getTestExampleDirs(contractFile) } returns listOf("configured_examples", "missing_examples")
+            every { getStubExampleDirs(contractFile) } returns emptyList()
+        }
+
+        val module = ExampleModule(specmaticConfig)
+        val loadedExamples = module.getExamplesFor(contractFile).map { it.file.name }
+
+        assertThat(loadedExamples).containsExactlyInAnyOrder("configured.json", "implicit.json")
+    }
+
+    @Test
+    fun `get schema examples for should accumulate examples across configured and implicit dirs`(@TempDir tempDir: File) {
+        val contractFile = tempDir.resolve("api.yaml")
+        val configuredDir = tempDir.resolve("configured_examples").apply { mkdirs() }
+        val implicitDir = tempDir.resolve("api_examples").apply { mkdirs() }
+
+        configuredDir.resolve("resource.order.example.json").writeText("""{"id": 10}""")
+        implicitDir.resolve("resource.customer.example.json").writeText("""{"id": 20}""")
+
+        val specmaticConfig = mockk<SpecmaticConfig>(relaxed = true).apply {
+            every { getTestExampleDirs(contractFile) } returns listOf("configured_examples")
+            every { getStubExampleDirs(contractFile) } returns emptyList()
+        }
+
+        val module = ExampleModule(specmaticConfig)
+        val schemaExamples = module.getSchemaExamplesFor(contractFile)
+
+        assertThat(schemaExamples.map { it.file.name })
+            .containsExactlyInAnyOrder("resource.order.example.json", "resource.customer.example.json")
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/examples/module/ExampleValidationModuleTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/examples/module/ExampleValidationModuleTest.kt
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.io.TempDir
 import java.io.File
 
 class ExampleValidationModuleTest {
-    private val exampleValidationModule = ExampleValidationModule()
+    private val exampleValidationModule = ExampleValidationModule(specmaticConfig = SpecmaticConfig())
 
     @Test
     fun `should be able to match on pattern tokens instead of literal values`() {


### PR DESCRIPTION
**What**: Fixes to loading process of the example module, as well as fixes to the validation functionality of the example validation module

**Reason**:
- The example module should load examples from the dirs specified in the config, in addition to the implicit dirs
- The example validation module should create feature using a file-read SpecmaticConfig instance rather than the default one

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
