### PR TITLE
update: pass resolved specmatic config

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/config/VersionAwareConfigParser.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/VersionAwareConfigParser.kt
@@ -48,7 +48,7 @@ private fun JsonNode.getVersion(): SpecmaticConfigVersion? {
     return SpecmaticConfigVersion.getByValue(version)
 }
 
-private fun resolveTemplates(node: JsonNode): JsonNode {
+fun resolveTemplates(node: JsonNode): JsonNode {
     return when {
         node.isObject ->
             node.fields().asSequence().fold(objectMapper.nodeFactory.objectNode()) { acc, entry ->

--- a/core/src/main/kotlin/io/specmatic/core/report/ReportGenerator.kt
+++ b/core/src/main/kotlin/io/specmatic/core/report/ReportGenerator.kt
@@ -1,9 +1,6 @@
 package io.specmatic.core.report
 
-import com.fasterxml.jackson.core.type.TypeReference
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
-import io.specmatic.core.config.resolveTemplates
+import io.specmatic.core.config.toResolvedSpecmaticConfigMap
 import io.specmatic.core.getConfigFilePath
 import io.specmatic.core.log.consoleLog
 import io.specmatic.reporter.ctrf.CtrfReportGenerator
@@ -49,15 +46,10 @@ object ReportGenerator {
     }
 
     internal fun specmaticConfigAsMap(): Map<String, Any> {
-        val specmaticConfigAsString = File(getConfigFilePath()).readText()
-        if(specmaticConfigAsString.isEmpty()) return emptyMap()
-        try {
-            val objectMapper = ObjectMapper(YAMLFactory())
-            val specmaticConfigAsJsonNode = objectMapper.readTree(specmaticConfigAsString)
-            val resolvedSpecmaticConfig = resolveTemplates(specmaticConfigAsJsonNode)
-            return objectMapper.treeToValue(resolvedSpecmaticConfig, object : TypeReference<Map<String, Any>>() {})
+        return try {
+            File(getConfigFilePath()).toResolvedSpecmaticConfigMap()
         } catch(_: Throwable) {
-            return emptyMap()
+            emptyMap()
         }
     }
 

--- a/core/src/test/kotlin/io/specmatic/core/report/ReportGeneratorTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/report/ReportGeneratorTest.kt
@@ -5,7 +5,11 @@ import io.specmatic.core.utilities.Flags.Companion.using
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 import java.io.File
+import java.util.stream.Stream
 
 class ReportGeneratorTest {
     @Test
@@ -44,17 +48,14 @@ class ReportGeneratorTest {
         assertThat((configAsMap["stub"] as Map<*, *>)["delayInMilliseconds"]).isEqualTo(123)
     }
 
-    @Test
-    fun `specmaticConfigAsMap resolves templates in config values`(@TempDir tempDir: File) {
-        val configFile = tempDir.resolve("specmatic.yaml").apply {
-            writeText(
-                """
-                version: 2
-                pipeline:
-                  organization: "${'{'}PIPELINE_ORG:default-org}"
-                """.trimIndent()
-            )
-        }
+    @ParameterizedTest
+    @MethodSource("templateConfigs")
+    fun `specmaticConfigAsMap resolves templates in yaml and json config values`(
+        fileName: String,
+        fileContent: String,
+        @TempDir tempDir: File
+    ) {
+        val configFile = tempDir.resolve(fileName).apply { writeText(fileContent) }
 
         val configAsMap = using(
             CONFIG_FILE_PATH to configFile.canonicalPath,
@@ -76,5 +77,30 @@ class ReportGeneratorTest {
         }
 
         assertThat(configAsMap).isEmpty()
+    }
+
+    companion object {
+        @JvmStatic
+        fun templateConfigs(): Stream<Arguments> {
+            val yamlConfig = """
+                version: 2
+                pipeline:
+                  organization: "${'{'}PIPELINE_ORG:default-org}"
+            """.trimIndent()
+
+            val jsonConfig = """
+                {
+                  "version": 2,
+                  "pipeline": {
+                    "organization": "${'$'}{PIPELINE_ORG:default-org}"
+                  }
+                }
+            """.trimIndent()
+
+            return Stream.of(
+                Arguments.of("specmatic.yaml", yamlConfig),
+                Arguments.of("specmatic.json", jsonConfig)
+            )
+        }
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/report/ReportGeneratorTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/report/ReportGeneratorTest.kt
@@ -1,0 +1,80 @@
+package io.specmatic.core.report
+
+import io.specmatic.core.utilities.Flags.Companion.CONFIG_FILE_PATH
+import io.specmatic.core.utilities.Flags.Companion.using
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class ReportGeneratorTest {
+    @Test
+    fun `specmaticConfigAsMap returns empty map when config file is empty`(@TempDir tempDir: File) {
+        val configFile = tempDir.resolve("specmatic.yaml").apply { writeText("") }
+
+        val configAsMap = using(CONFIG_FILE_PATH to configFile.canonicalPath) {
+            ReportGenerator.specmaticConfigAsMap()
+        }
+
+        assertThat(configAsMap).isEmpty()
+    }
+
+    @Test
+    fun `specmaticConfigAsMap returns map for valid yaml config`(@TempDir tempDir: File) {
+        val configFile = tempDir.resolve("specmatic.yaml").apply {
+            writeText(
+                """
+                version: 2
+                test:
+                  generativeTests: true
+                stub:
+                  delayInMilliseconds: 123
+                """.trimIndent()
+            )
+        }
+
+        val configAsMap = using(CONFIG_FILE_PATH to configFile.canonicalPath) {
+            ReportGenerator.specmaticConfigAsMap()
+        }
+
+        assertThat(configAsMap["version"]).isEqualTo(2)
+        assertThat(configAsMap["test"]).isInstanceOf(Map::class.java)
+        assertThat((configAsMap["test"] as Map<*, *>)["generativeTests"]).isEqualTo(true)
+        assertThat(configAsMap["stub"]).isInstanceOf(Map::class.java)
+        assertThat((configAsMap["stub"] as Map<*, *>)["delayInMilliseconds"]).isEqualTo(123)
+    }
+
+    @Test
+    fun `specmaticConfigAsMap resolves templates in config values`(@TempDir tempDir: File) {
+        val configFile = tempDir.resolve("specmatic.yaml").apply {
+            writeText(
+                """
+                version: 2
+                pipeline:
+                  organization: "${'{'}PIPELINE_ORG:default-org}"
+                """.trimIndent()
+            )
+        }
+
+        val configAsMap = using(
+            CONFIG_FILE_PATH to configFile.canonicalPath,
+            "PIPELINE_ORG" to "acme"
+        ) {
+            ReportGenerator.specmaticConfigAsMap()
+        }
+
+        assertThat(configAsMap["pipeline"]).isInstanceOf(Map::class.java)
+        assertThat((configAsMap["pipeline"] as Map<*, *>)["organization"]).isEqualTo("acme")
+    }
+
+    @Test
+    fun `specmaticConfigAsMap returns empty map when config is invalid`(@TempDir tempDir: File) {
+        val configFile = tempDir.resolve("specmatic.yaml").apply { writeText(": : :") }
+
+        val configAsMap = using(CONFIG_FILE_PATH to configFile.canonicalPath) {
+            ReportGenerator.specmaticConfigAsMap()
+        }
+
+        assertThat(configAsMap).isEmpty()
+    }
+}


### PR DESCRIPTION
ReportGenerator should pass a resolved specmatic.yaml config (with templates expanded) instead of raw template strings when generating reports.

- [x] Unit Tests
- [x] Build passing locally