### PR TITLE
fix: Put the right test specification path in the CTRF report

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -44,7 +44,7 @@ data class SpecificationSourceEntry(
     val exampleDirs: List<String>?,
 ) {
     fun toContractSourceEntry(): ContractSourceEntry {
-        return ContractSourceEntry(specFile.canonicalPath, baseUrl, resiliencyTestSuite, exampleDirs)
+        return ContractSourceEntry(specPathInConfig, baseUrl, resiliencyTestSuite, exampleDirs)
     }
 
     constructor(source: Source, specFile: File, specPathInConfig: String, baseUrl: String?, port: Int?, resiliencyTestSuite: ResiliencyTestSuite?) : this(

--- a/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigKtTest.kt
@@ -34,6 +34,33 @@ import java.util.stream.Stream
 
 internal class SpecmaticConfigKtTest {
 
+    @Test
+    fun `toContractSourceEntry should preserve the path from config`() {
+        val specFile = File("./contracts/../contracts/petstore.yaml")
+        val sourceEntry = SpecificationSourceEntry(
+            specFile = specFile,
+            specPathInConfig = "contracts/petstore.yaml",
+            port = null,
+            baseUrl = "http://localhost:9000",
+            resiliencyTestSuite = ResiliencyTestSuite.positiveOnly,
+            type = SourceProvider.filesystem,
+            repository = null,
+            directory = "./contracts",
+            branch = null,
+            matchBranch = null,
+            exampleDirs = listOf("examples")
+        )
+
+        assertThat(sourceEntry.toContractSourceEntry()).isEqualTo(
+            ContractSourceEntry(
+                path = "contracts/petstore.yaml",
+                baseUrl = "http://localhost:9000",
+                generative = ResiliencyTestSuite.positiveOnly,
+                exampleDirPaths = listOf("examples")
+            )
+        )
+    }
+
     @CsvSource(
         "./src/test/resources/specmaticConfigFiles/specmatic.yaml",
         "./src/test/resources/specmaticConfigFiles/specmatic.yml",

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3ImplTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3ImplTest.kt
@@ -49,11 +49,10 @@ class SpecmaticConfigV3ImplTest {
                 val v2Value = extract(v2Config)
                 val v3Value = extract(v3Config)
 
-                // TODO: Investigate the Contract sources returning .path instead of .canonicalPath on loadSources
                 // ALl except GitMonoRepo returns .path instead of .canonicalPath
                 assertThat(v2Value)
                     .usingRecursiveComparison()
-                    .ignoringFieldsMatchingRegexes(".*specmaticConfig", ".*path")
+                    .ignoringFieldsMatchingRegexes(".*specmaticConfig")
                     .isEqualTo(v3Value)
             }
 


### PR DESCRIPTION
**What**:

This change puts the relative path in the CTRF report. Previously, the canonical path used to go into the CTRF report.

**Why**:

The canonical path doesn't make sense when the path in the config is relative. Either it's relative to the current working directory, or it is relative to the root of a central specification repository. In either case, the canonical path is an implementation detail of the system on which the test runs, and should not make it into the report, Unless of course the canonical / absolute path is in fact what's in the config file.

**How**:

ContractSourceEntry was updated to use specPathInConfig instead of canonicalPath.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #123

<!-- feel free to add additional comments -->
