### PR TITLE
Ensure example dir and file ordering is backward compatible

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/examples/module/ExampleModule.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/module/ExampleModule.kt
@@ -40,8 +40,8 @@ class ExampleModule(private val specmaticConfig: SpecmaticConfig) {
     fun getExamplesDirPaths(contractFile: File): List<File> {
         val testDirs = specmaticConfig.getTestExampleDirs(contractFile).map(::File)
         val stubDirs = specmaticConfig.getStubExampleDirs(contractFile).map(::File)
-        val externalDir = listOf(defaultExternalExampleDirFrom(contractFile))
-        return listOf(testDirs, stubDirs, externalDir).flatten().distinctBy { it.normalizedPath() }
+        val implicitExamplesDir = listOf(defaultExternalExampleDirFrom(contractFile))
+        return listOf(implicitExamplesDir, testDirs, stubDirs).flatten().distinctBy { it.normalizedPath() }
     }
 
     fun getExamplesFor(contractFile: File, strictMode: Boolean = true): List<ExampleFromFile> {


### PR DESCRIPTION
**What**: Ensure that `ExampleModule` returns the implicit directory before the configured directories

**Checklist**:
- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)