### PR TITLE
feat: add request before interception and response after interception in HttpLogMessage in stub

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/log/HttpLogMessage.kt
+++ b/core/src/main/kotlin/io/specmatic/core/log/HttpLogMessage.kt
@@ -7,13 +7,18 @@ import io.specmatic.core.value.StringValue
 import io.specmatic.core.value.Value
 import io.specmatic.reporter.model.TestResult
 import io.specmatic.stub.HttpStubResponse
+import io.specmatic.stub.InterceptorResult
 import java.io.File
 
 data class HttpLogMessage(
+    var preHookRequestTime: CurrentDate? = null,
+    var preHookRequest: InterceptorResult<HttpRequest>? = null,
     var requestTime: CurrentDate = CurrentDate(),
     var request: HttpRequest = HttpRequest(),
     var responseTime: CurrentDate? = null,
     var response: HttpResponse? = null,
+    var postHookResponseTime: CurrentDate? = null,
+    var postHookResponse: InterceptorResult<HttpResponse>? = null,
     var contractPath: String = "",
     var examplePath: String? = null,
     val targetServer: String = "",
@@ -42,6 +47,16 @@ data class HttpLogMessage(
     fun addResponseWithCurrentTime(httpResponse: HttpResponse) {
         responseTime = CurrentDate()
         this.response = httpResponse
+    }
+
+    fun addPreHookRequestWithCurrentTime(interceptorResultForRequest: InterceptorResult<HttpRequest>) {
+        this.preHookRequestTime = CurrentDate()
+        this.preHookRequest = interceptorResultForRequest
+    }
+
+    fun addPostHookResponseWithCurrentTime(interceptorResultForResponse: InterceptorResult<HttpResponse>) {
+        this.postHookResponseTime = CurrentDate()
+        this.postHookResponse = interceptorResultForResponse
     }
 
     fun addException(exception: Exception) {

--- a/core/src/main/kotlin/io/specmatic/proxy/Proxy.kt
+++ b/core/src/main/kotlin/io/specmatic/proxy/Proxy.kt
@@ -172,7 +172,7 @@ class Proxy(
                                         httpRequest to emptyList<InterceptorError>()
                                     ) { (request, errors), requestInterceptor ->
                                         val result = requestInterceptor.interceptRequestAndReturnErrors(request)
-                                        (result.value ?: request) to (errors + result.errors)
+                                        (result.processedValue ?: request) to (errors + result.errors)
                                     }
 
                                     // Log the transformed request if it was changed by hooks
@@ -238,7 +238,7 @@ class Proxy(
                                         httpResponse to emptyList<InterceptorError>()
                                     ) { (response, errors), responseInterceptor ->
                                         val result = responseInterceptor.interceptResponseAndReturnErrors(recordedRequest, response)
-                                        (result.value ?: response) to (errors + result.errors)
+                                        (result.processedValue ?: response) to (errors + result.errors)
                                     }
 
                                     // Log the transformed response if it was changed by hooks

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -338,7 +338,7 @@ class HttpStub(
                     if (requestInterceptorErrors.isNotEmpty()) {
                         logger.boundary()
                         logger.log("--------------------")
-                        logger.log("Request hook responseInterceptorErrors:")
+                        logger.log("Request adapter errors:")
                         logger.log(InterceptorErrors(requestInterceptorErrors).toString().prependIndent("  "))
                     }
 
@@ -432,7 +432,7 @@ class HttpStub(
                 transformedResponse?.let {
                     logger.log("")
                     logger.log("--------------------")
-                    logger.log("Response after hook processing:")
+                    logger.log("Response after adapter processing:")
                     logger.log(it.toLogString(prettyPrint = prettyPrint).prependIndent("  "))
                 }
 
@@ -440,7 +440,7 @@ class HttpStub(
                 if (responseErrors.isNotEmpty()) {
                     logger.boundary()
                     logger.log("--------------------")
-                    logger.log("Response hook errors:")
+                    logger.log("Response adapter errors:")
                     logger.log(InterceptorErrors(responseErrors).toString().prependIndent("  "))
                 }
 

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -302,19 +302,20 @@ class HttpStub(
                     prettyPrint = prettyPrint,
                 )
                 var transformedResponse: HttpResponse? = null
-                var responseErrors: List<InterceptorError> = emptyList()
+                var responseInterceptorResults: List<InterceptorResult<HttpResponse>> = emptyList()
 
                 try {
                     val rawHttpRequest = ktorHttpRequestToHttpRequest(call).also {
                         if (it.isHealthCheckRequest()) return@intercept
                     }
 
-                    val (httpRequest, requestInterceptorErrors) = requestInterceptors.fold(
-                        rawHttpRequest to emptyList<InterceptorError>()
-                    ) { (request, errors), requestInterceptor ->
-                        val result = requestInterceptor.interceptRequestAndReturnErrors(request)
-                        (result.value ?: request) to (errors + result.errors)
+                    val (httpRequest, requestInterceptorResults) = requestInterceptors.fold(
+                        rawHttpRequest to emptyList<InterceptorResult<HttpRequest>>()
+                    ) { (request, results), interceptor ->
+                        val result = interceptor.interceptRequestAndReturnErrors(request)
+                        (result.processedValue ?: request) to results + result
                     }
+                    val requestInterceptorErrors = requestInterceptorResults.flatMap { it.errors }
 
                     LicenseResolver.utilize(
                         product = LicensedProduct.OPEN_SOURCE,
@@ -333,12 +334,20 @@ class HttpStub(
                         logger.log(rawHttpRequest.toLogString(prettyPrint = prettyPrint).prependIndent("  "))
                     }
 
-                    // Log request hook responseInterceeptorErrors if any occurred
+                    // Log request hook responseInterceptorErrors if any occurred
                     if (requestInterceptorErrors.isNotEmpty()) {
                         logger.boundary()
                         logger.log("--------------------")
-                        logger.log("Request hook responseInterceeptorErrors:")
+                        logger.log("Request hook responseInterceptorErrors:")
                         logger.log(InterceptorErrors(requestInterceptorErrors).toString().prependIndent("  "))
+                    }
+
+                    if(requestInterceptorResults.isNotEmpty()) {
+                        httpLogMessage.addPreHookRequestWithCurrentTime(
+                            requestInterceptorResults.first().copy(
+                                errors = requestInterceptorErrors
+                            )
+                        )
                     }
 
                     val responseFromRequestHandler =
@@ -364,13 +373,15 @@ class HttpStub(
                         }
                     }
 
-                    val (httpResponse, responseInterceptorErrors) = responseInterceptors.fold(
-                        httpStubResponse.response to emptyList<InterceptorError>()
-                    ) { (response, errors), responseInterceptor ->
-                        val result = responseInterceptor.interceptResponseAndReturnErrors(httpRequest, response)
-                        (result.value ?: response) to (errors + result.errors)
+
+                    val (httpResponse, responseInterceptorResultsList) = responseInterceptors.fold(
+                        httpStubResponse.response to emptyList<InterceptorResult<HttpResponse>>()
+                    ) { (response, results), interceptor ->
+                        val result = interceptor.interceptResponseAndReturnErrors(httpRequest, response)
+                        (result.processedValue ?: response) to results + result
                     }
-                    responseErrors = responseInterceptorErrors
+
+                    responseInterceptorResults = responseInterceptorResultsList
 
                     // Store encoded response for later logging if different
                     transformedResponse =
@@ -415,6 +426,8 @@ class HttpStub(
 
                 log(httpLogMessage)
 
+                val responseErrors = responseInterceptorResults.flatMap { it.errors }
+
                 // Log the response after hook processing if it was transformed
                 transformedResponse?.let {
                     logger.log("")
@@ -429,6 +442,15 @@ class HttpStub(
                     logger.log("--------------------")
                     logger.log("Response hook errors:")
                     logger.log(InterceptorErrors(responseErrors).toString().prependIndent("  "))
+                }
+
+                if (responseInterceptorResults.isNotEmpty()) {
+                    httpLogMessage.addPostHookResponseWithCurrentTime(
+                        responseInterceptorResults.last().copy(
+                            processedValue = transformedResponse,
+                            errors = responseErrors
+                        )
+                    )
                 }
 
                 MockEvent(httpLogMessage).let { event -> listeners.forEach { it.onRespond(event) } }

--- a/core/src/main/kotlin/io/specmatic/stub/InterceptorResult.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/InterceptorResult.kt
@@ -1,20 +1,35 @@
 package io.specmatic.stub
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.specmatic.core.pattern.parsedJSON
+import io.specmatic.core.value.Value
+
 data class InterceptorResult<T>(
-    val value: T?,
+    val name: String,
+    val originalValue: T?,
+    val processedValue: T?,
     val errors: List<InterceptorError> = emptyList()
 ) {
+
+    fun toLogString(): String {
+        return ObjectMapper().writeValueAsString(this)
+    }
+
+    fun toValue(): Value {
+        return parsedJSON(toLogString())
+    }
+
     companion object {
-        fun <T> success(value: T): InterceptorResult<T> {
-            return InterceptorResult(value, emptyList())
+        fun <T> success(name: String, originalValue: T, processedValue: T): InterceptorResult<T> {
+            return InterceptorResult(name, originalValue,processedValue, emptyList())
         }
 
-        fun <T> failure(error: InterceptorError): InterceptorResult<T> {
-            return InterceptorResult(null, listOf(error))
+        fun <T> failure(name: String, originalValue: T, error: InterceptorError): InterceptorResult<T> {
+            return InterceptorResult(name, originalValue, null,listOf(error))
         }
 
-        fun <T> passthrough(): InterceptorResult<T> {
-            return InterceptorResult(null, emptyList())
+        fun <T> passthrough(name: String): InterceptorResult<T> {
+            return InterceptorResult(name,null, null, emptyList())
         }
     }
 }

--- a/core/src/main/kotlin/io/specmatic/stub/RequestInterceptor.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/RequestInterceptor.kt
@@ -3,14 +3,16 @@ package io.specmatic.stub
 import io.specmatic.core.HttpRequest
 
 interface RequestInterceptor {
+    val name: String
+
     fun interceptRequest(httpRequest: HttpRequest): HttpRequest?
 
     fun interceptRequestAndReturnErrors(httpRequest: HttpRequest): InterceptorResult<HttpRequest> {
         val result = interceptRequest(httpRequest)
         return if (result != null) {
-            InterceptorResult.success(result)
+            InterceptorResult.success(name, httpRequest,result)
         } else {
-            InterceptorResult.passthrough()
+            InterceptorResult.passthrough(name)
         }
     }
 }

--- a/core/src/main/kotlin/io/specmatic/stub/ResponseInterceptor.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/ResponseInterceptor.kt
@@ -4,14 +4,16 @@ import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpResponse
 
 interface ResponseInterceptor {
+    val name: String
+
     fun interceptResponse(httpRequest: HttpRequest, httpResponse: HttpResponse): HttpResponse?
 
     fun interceptResponseAndReturnErrors(httpRequest: HttpRequest, httpResponse: HttpResponse): InterceptorResult<HttpResponse> {
         val result = interceptResponse(httpRequest, httpResponse)
         return if (result != null) {
-            InterceptorResult.success(result)
+            InterceptorResult.success(name, httpResponse,result)
         } else {
-            InterceptorResult.passthrough()
+            InterceptorResult.passthrough(name)
         }
     }
 }

--- a/core/src/main/kotlin/io/specmatic/stub/listener/MockEventListener.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/listener/MockEventListener.kt
@@ -6,6 +6,7 @@ import io.specmatic.core.Result
 import io.specmatic.core.Scenario
 import io.specmatic.core.log.HttpLogMessage
 import io.specmatic.reporter.model.TestResult
+import io.specmatic.stub.InterceptorResult
 
 interface MockEventListener {
     fun onRespond(data: MockEvent)
@@ -15,10 +16,14 @@ data class MockEvent (
     val name: String,
     val details: String,
     val result: Result,
+    val preHookRequestTime: Long? = null,
+    val preHookRequest: InterceptorResult<HttpRequest>? = null,
     val request: HttpRequest,
     val requestTime: Long,
     val response: HttpResponse?,
     val responseTime: Long?,
+    val postHookResponse: InterceptorResult<HttpResponse>? = null,
+    val postHookResponseTime: Long? = null,
     val scenario: Scenario?,
     val stubResult: TestResult,
 ) {
@@ -30,10 +35,14 @@ data class MockEvent (
         } else {
             Result.Failure("No failure details found for this stub event")
         },
+        preHookRequestTime = logMessage.preHookRequestTime?.toEpochMillis(),
+        preHookRequest = logMessage.preHookRequest,
         request = logMessage.request,
         requestTime = logMessage.requestTime.toEpochMillis(),
         response = logMessage.response,
         responseTime = logMessage.responseTime?.toEpochMillis(),
+        postHookResponse = logMessage.postHookResponse,
+        postHookResponseTime = logMessage.postHookResponseTime?.toEpochMillis(),
         scenario = logMessage.scenario,
         stubResult = logMessage.toResult()
     )

--- a/core/src/test/kotlin/HttpLogMessageTest.kt
+++ b/core/src/test/kotlin/HttpLogMessageTest.kt
@@ -10,7 +10,13 @@ import org.junit.jupiter.api.Test
 
 internal class HttpLogMessageTest {
     private val dateTime: CurrentDate = CurrentDate()
-    private val httpLog = HttpLogMessage(dateTime, HttpRequest("GET", "/"), dateTime, HttpResponse.OK, "/path/to/file")
+    private val httpLog = HttpLogMessage(
+        requestTime =dateTime,
+        request = HttpRequest("GET", "/"),
+        responseTime = dateTime,
+        response = HttpResponse.OK,
+        contractPath = "/path/to/file"
+    )
 
     @Test
     fun `render an http log message as JSON`() {

--- a/core/src/test/kotlin/io/specmatic/core/wsdl/WSDLTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/wsdl/WSDLTest.kt
@@ -3,18 +3,12 @@ package io.specmatic.core.wsdl
 import io.specmatic.Utils.readTextResource
 import io.specmatic.conversions.wsdlContentToFeature
 import io.specmatic.core.*
-import io.specmatic.core.utilities.contractStubPaths
-import io.specmatic.core.utilities.contractTestPathsFrom
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.api.Test
 import io.specmatic.core.value.toXMLNode
 import io.specmatic.core.wsdl.parser.WSDL
 import io.specmatic.mock.ScenarioStub
-import io.specmatic.stub.FeatureStubsResult
 import io.specmatic.stub.HttpStub
-import io.specmatic.stub.loadContractStubsFromFilesAsResults
-import io.specmatic.stub.loadIfSupportedAPISpecification
 import io.specmatic.test.TestExecutor
 import org.junit.jupiter.api.assertDoesNotThrow
 import java.io.File
@@ -85,90 +79,6 @@ class WSDLTest {
 
         assertThat(result.success()).withFailMessage(result.report()).isTrue()
         assertThat(result.successCount).isEqualTo(1)
-    }
-
-    @Test
-    fun `wsdl loop should load v3 configured non underscore examples for sut and mock and traffic should contain example values`(@TempDir tempDir: File) {
-        val wsdlSource = File("src/test/resources/wsdl/with_examples/order_api.wsdl")
-        val wsdlFile = tempDir.resolve("order_api.wsdl").apply { writeText(wsdlSource.readText()) }
-
-        val exampleSource = File("src/test/resources/wsdl/with_examples/order_api_examples/create_product.json")
-        val sutExamplesDir = tempDir.resolve("sut-example-data").apply { mkdirs() }
-        val mockExamplesDir = tempDir.resolve("mock-example-data").apply { mkdirs() }
-        exampleSource.copyTo(sutExamplesDir.resolve("create_product.json"))
-        exampleSource.copyTo(mockExamplesDir.resolve("create_product.json"))
-
-        val configFile = tempDir.resolve("specmatic.yaml")
-        configFile.writeText(
-            """
-            version: 3
-            systemUnderTest:
-              service:
-                definitions:
-                  - definition:
-                      source:
-                        filesystem:
-                          directory: ${tempDir.canonicalPath}
-                      specs:
-                        - ${wsdlFile.name}
-                data:
-                  examples:
-                    - directories:
-                        - ${sutExamplesDir.canonicalPath}
-            dependencies:
-              services:
-                - service:
-                    definitions:
-                      - definition:
-                          source:
-                            filesystem:
-                              directory: ${tempDir.canonicalPath}
-                          specs:
-                            - ${wsdlFile.name}
-                    data:
-                      examples:
-                        - directories:
-                            - ${mockExamplesDir.canonicalPath}
-            """.trimIndent()
-        )
-
-        val config = loadSpecmaticConfig(configFile.canonicalPath)
-        val stubContractPathData = contractStubPaths(configFile.canonicalPath)
-        val testContractPathData = contractTestPathsFrom(configFile.canonicalPath, ".")
-
-        assertThat(stubContractPathData.single().exampleDirPaths).containsExactly(mockExamplesDir.canonicalPath)
-        assertThat(testContractPathData.single().exampleDirPaths).containsExactly(sutExamplesDir.canonicalPath)
-
-        val stubLoadResults = loadContractStubsFromFilesAsResults(
-            contractPathDataList = stubContractPathData,
-            dataDirPaths = emptyList(),
-            specmaticConfig = config,
-            withImplicitStubs = false
-        )
-        val stubConfig = stubLoadResults.filterIsInstance<FeatureStubsResult.Success>().single()
-
-        val testFeature = loadIfSupportedAPISpecification(testContractPathData.single(), config)?.second
-            ?: throw AssertionError("Could not load test feature from v3 config")
-
-        val requestTraffic = mutableListOf<String>()
-        val responseTraffic = mutableListOf<String>()
-        val result = HttpStub(stubConfig.feature, stubConfig.scenarioStubs).use { stub ->
-            testFeature.executeTests(object : TestExecutor {
-                override fun execute(request: HttpRequest): HttpResponse {
-                    val response = stub.client.execute(request)
-                    requestTraffic.add(request.toLogString(prettyPrint = false))
-                    responseTraffic.add(response.toLogString(prettyPrint = false))
-                    return response
-                }
-            })
-        }
-
-        assertThat(result.success()).withFailMessage(result.report()).isTrue()
-        assertThat(requestTraffic.joinToString("\n"))
-            .contains("Phone")
-            .contains("Gadget")
-        assertThat(responseTraffic.joinToString("\n"))
-            .contains("123")
     }
 
     private fun readContracts(filename: String): Pair<String, String> {

--- a/core/src/test/kotlin/io/specmatic/core/wsdl/WSDLTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/wsdl/WSDLTest.kt
@@ -3,12 +3,18 @@ package io.specmatic.core.wsdl
 import io.specmatic.Utils.readTextResource
 import io.specmatic.conversions.wsdlContentToFeature
 import io.specmatic.core.*
+import io.specmatic.core.utilities.contractStubPaths
+import io.specmatic.core.utilities.contractTestPathsFrom
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.api.Test
 import io.specmatic.core.value.toXMLNode
 import io.specmatic.core.wsdl.parser.WSDL
 import io.specmatic.mock.ScenarioStub
+import io.specmatic.stub.FeatureStubsResult
 import io.specmatic.stub.HttpStub
+import io.specmatic.stub.loadContractStubsFromFilesAsResults
+import io.specmatic.stub.loadIfSupportedAPISpecification
 import io.specmatic.test.TestExecutor
 import org.junit.jupiter.api.assertDoesNotThrow
 import java.io.File
@@ -79,6 +85,90 @@ class WSDLTest {
 
         assertThat(result.success()).withFailMessage(result.report()).isTrue()
         assertThat(result.successCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `wsdl loop should load v3 configured non underscore examples for sut and mock and traffic should contain example values`(@TempDir tempDir: File) {
+        val wsdlSource = File("src/test/resources/wsdl/with_examples/order_api.wsdl")
+        val wsdlFile = tempDir.resolve("order_api.wsdl").apply { writeText(wsdlSource.readText()) }
+
+        val exampleSource = File("src/test/resources/wsdl/with_examples/order_api_examples/create_product.json")
+        val sutExamplesDir = tempDir.resolve("sut-example-data").apply { mkdirs() }
+        val mockExamplesDir = tempDir.resolve("mock-example-data").apply { mkdirs() }
+        exampleSource.copyTo(sutExamplesDir.resolve("create_product.json"))
+        exampleSource.copyTo(mockExamplesDir.resolve("create_product.json"))
+
+        val configFile = tempDir.resolve("specmatic.yaml")
+        configFile.writeText(
+            """
+            version: 3
+            systemUnderTest:
+              service:
+                definitions:
+                  - definition:
+                      source:
+                        filesystem:
+                          directory: ${tempDir.canonicalPath}
+                      specs:
+                        - ${wsdlFile.name}
+                data:
+                  examples:
+                    - directories:
+                        - ${sutExamplesDir.canonicalPath}
+            dependencies:
+              services:
+                - service:
+                    definitions:
+                      - definition:
+                          source:
+                            filesystem:
+                              directory: ${tempDir.canonicalPath}
+                          specs:
+                            - ${wsdlFile.name}
+                    data:
+                      examples:
+                        - directories:
+                            - ${mockExamplesDir.canonicalPath}
+            """.trimIndent()
+        )
+
+        val config = loadSpecmaticConfig(configFile.canonicalPath)
+        val stubContractPathData = contractStubPaths(configFile.canonicalPath)
+        val testContractPathData = contractTestPathsFrom(configFile.canonicalPath, ".")
+
+        assertThat(stubContractPathData.single().exampleDirPaths).containsExactly(mockExamplesDir.canonicalPath)
+        assertThat(testContractPathData.single().exampleDirPaths).containsExactly(sutExamplesDir.canonicalPath)
+
+        val stubLoadResults = loadContractStubsFromFilesAsResults(
+            contractPathDataList = stubContractPathData,
+            dataDirPaths = emptyList(),
+            specmaticConfig = config,
+            withImplicitStubs = false
+        )
+        val stubConfig = stubLoadResults.filterIsInstance<FeatureStubsResult.Success>().single()
+
+        val testFeature = loadIfSupportedAPISpecification(testContractPathData.single(), config)?.second
+            ?: throw AssertionError("Could not load test feature from v3 config")
+
+        val requestTraffic = mutableListOf<String>()
+        val responseTraffic = mutableListOf<String>()
+        val result = HttpStub(stubConfig.feature, stubConfig.scenarioStubs).use { stub ->
+            testFeature.executeTests(object : TestExecutor {
+                override fun execute(request: HttpRequest): HttpResponse {
+                    val response = stub.client.execute(request)
+                    requestTraffic.add(request.toLogString(prettyPrint = false))
+                    responseTraffic.add(response.toLogString(prettyPrint = false))
+                    return response
+                }
+            })
+        }
+
+        assertThat(result.success()).withFailMessage(result.report()).isTrue()
+        assertThat(requestTraffic.joinToString("\n"))
+            .contains("Phone")
+            .contains("Gadget")
+        assertThat(responseTraffic.joinToString("\n"))
+            .contains("123")
     }
 
     private fun readContracts(filename: String): Pair<String, String> {

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
@@ -843,6 +843,9 @@ components:
         ).use { stub ->
 
             stub.registerRequestInterceptor(object: RequestInterceptor {
+                override val name: String
+                    get() = "requestInterceptor"
+
                 override fun interceptRequest(httpRequest: HttpRequest): HttpRequest {
                     val id = httpRequest.path?.split("/")?.last()?.toInt() ?: 0
                     val updatedPath = httpRequest.path?.split("/")?.map {
@@ -854,6 +857,9 @@ components:
             })
 
             stub.registerResponseInterceptor(object: ResponseInterceptor {
+                override val name: String
+                    get() = "responseInterceptor"
+
                 override fun interceptResponse(
                     httpRequest: HttpRequest,
                     httpResponse: HttpResponse


### PR DESCRIPTION
Reason for change: HttpLogMessage should hold information around the request and response interception so that the emitted MockEvents can also emit that.