### PR TITLE
Add missing spec-file warning coverage and focused tests

### DIFF
--- a/application/src/main/kotlin/application/StubCommand.kt
+++ b/application/src/main/kotlin/application/StubCommand.kt
@@ -183,8 +183,6 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
             ),
             LoggingConfigSource.FromConfig(specmaticConfiguration.getLogConfigurationOrDefault()))
 
-        val defaultHost = DEFAULT_HTTP_STUB_HOST
-        val defaultPort = DEFAULT_HTTP_STUB_PORT.toInt()
         val parseResult = commandSpec.commandLine().parseResult
         val hostSpecified = parseResult?.hasMatchedOption("--host") == true
         val portSpecified = parseResult?.hasMatchedOption("--port") == true

--- a/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
+++ b/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
@@ -429,6 +429,21 @@ class BackwardCompatibilityCheckCommandV2Test {
             )
         }
 
+        @Test
+        fun `should fail when externalised example changes but corresponding spec file is missing`() {
+            val exampleDir = tempDir.resolve("orders_examples").apply { mkdirs() }
+            val exampleFile = exampleDir.resolve("example.json").apply { writeText("""{"id":1}""") }
+            commitAndPush(tempDir, "Initial commit")
+            exampleFile.writeText("""{"id":2}""")
+
+            val (stdOut, exitCode) = captureStandardOutput(redirectStdErrToStdout = true) {
+                BackwardCompatibilityCheckCommandV2().apply { repoDir = tempDir.canonicalPath }.call()
+            }
+
+            assertThat(exitCode).isEqualTo(1)
+            assertThat(stdOut).contains("orders.yaml")
+        }
+
         @ParameterizedTest
         @CsvSource(
             "/api/api_examples/example.json, /api/api_examples",

--- a/application/src/test/kotlin/application/StubCommandTest.kt
+++ b/application/src/test/kotlin/application/StubCommandTest.kt
@@ -17,7 +17,6 @@ import io.specmatic.stub.HttpStub
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.params.ParameterizedTest
@@ -195,6 +194,18 @@ internal class StubCommandTest {
         every { specmaticConfig.contractStubPaths() }.returns(arrayListOf("/config/path/to/contract.$CONTRACT_EXTENSION"))
 
         CommandLine(stubCommand).execute(specFilePath)
+    }
+
+    @Test
+    fun `when an explicit contract path does not exist command should return non-zero`(@TempDir tempDir: Path) {
+        val missingSpecPath = tempDir.resolve("missing.$CONTRACT_EXTENSION").toAbsolutePath().toString()
+
+        val (output, exitCode) = captureStandardOutput(redirectStdErrToStdout = true) {
+            CommandLine(stubCommand).execute(missingSpecPath)
+        }
+
+        assertThat(exitCode).isEqualTo(1)
+        assertThat(output).contains("The following specifications do not exist").contains(missingSpecPath)
     }
 
     @Test

--- a/application/src/test/kotlin/application/TestCommandTest.kt
+++ b/application/src/test/kotlin/application/TestCommandTest.kt
@@ -64,6 +64,18 @@ internal class TestCommandTest {
     }
 
     @Test
+    fun `when an explicit contract path does not exist test command should return non-zero`(@TempDir tempDir: File) {
+        val missingSpecPath = tempDir.resolve("missing.$CONTRACT_EXTENSION").absolutePath
+
+        val (output, exitCode) = captureStandardOutput(redirectStdErrToStdout = true) {
+            CommandLine(TestCommand()).execute(missingSpecPath)
+        }
+
+        assertThat(exitCode).isEqualTo(1)
+        assertThat(output).contains("does not exist").contains("missing.$CONTRACT_EXTENSION")
+    }
+
+    @Test
     fun `ContractExecutionListener should be registered`() {
         val registeredListeners = ServiceLoader.load(TestExecutionListener::class.java)
             .map { it.javaClass.name }

--- a/core/src/main/kotlin/io/specmatic/core/utilities/Utilities.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/Utilities.kt
@@ -383,6 +383,13 @@ fun contractFilePathsFrom(
             it.loadContracts(selector, workingDirectory, configFilePath)
         }
 
+    contractPathData
+        .filter { File(it.path).exists().not() }
+        .forEach { missingContract ->
+            val configuredPath = missingContract.specificationPath ?: missingContract.path
+            logger.log("WARNING: Specification '$configuredPath' from config '$configFilePath' could not be found at '${missingContract.path}'. It will be ignored.")
+        }
+
     logger.debug("Spec file paths in $configFilePath:")
     logger.debug(contractPathData.joinToString(System.lineSeparator()) { "- ${it.path}" })
 

--- a/core/src/test/kotlin/io/specmatic/stub/ApiKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/ApiKtTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test
 import io.specmatic.core.*
 import io.specmatic.core.pattern.parsedValue
 import io.specmatic.core.utilities.ContractPathData
+import io.specmatic.core.utilities.contractStubPaths
 import io.specmatic.core.value.*
 import io.specmatic.core.examples.server.ExampleMismatchMessages
 import io.specmatic.mock.NoMatchingScenario
@@ -12,7 +13,9 @@ import io.specmatic.mock.ScenarioStub
 import io.specmatic.trimmedLinesList
 import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.MethodSource
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.PrintStream
@@ -735,6 +738,60 @@ Feature: Math API
             No matching SOAP stub or contract found for SOAPAction "/orders/createProductDoesNotExist" and path /
             """.trimIndent())
         }
+    }
+
+    @ParameterizedTest
+    @MethodSource("missingSpecConfigTemplates")
+    fun `should warn when a config-driven stub specification path does not exist`(
+        configTemplate: String,
+        @TempDir tempDir: File
+    ) {
+        val configFile = tempDir.resolve("specmatic.yaml")
+        configFile.writeText(configTemplate.format(tempDir.canonicalPath))
+
+        val (output, stubResults) = captureStandardOutput {
+            val paths = contractStubPaths(configFile.canonicalPath)
+            loadContractStubsFromImplicitPathsAsResults(
+                contractPathDataList = paths,
+                specmaticConfig = SpecmaticConfig(),
+                externalDataDirPaths = emptyList()
+            )
+        }
+
+        assertThat(stubResults).isEmpty()
+        assertThat(output).contains("WARNING").contains("missing.yaml")
+    }
+
+    companion object {
+        @JvmStatic
+        fun missingSpecConfigTemplates(): List<Arguments> =
+            listOf(
+                Arguments.of(
+                    """
+                    version: 3
+                    dependencies:
+                      services:
+                        - service:
+                            definitions:
+                              - definition:
+                                  source:
+                                    filesystem:
+                                      directory: %s
+                                  specs:
+                                    - missing.yaml
+                    """.trimIndent()
+                ),
+                Arguments.of(
+                    """
+                    version: 2
+                    contracts:
+                      - filesystem:
+                          directory: %s
+                        consumes:
+                          - missing.yaml
+                    """.trimIndent()
+                )
+            )
     }
 }
 

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -198,7 +198,7 @@ open class SpecmaticJUnitSupport {
             }
         }
 
-        val reportDirPath = specmaticConfig?.getReportDirPath() ?: defaultReportDirPath
+        val reportDirPath = specmaticConfig.getReportDirPath()
         ReportGenerator.generateReport(
             testResultRecords = report.testResultRecords,
             startTime = start,
@@ -246,13 +246,13 @@ open class SpecmaticJUnitSupport {
     }
 
     private fun loadExceptionAsTestError(e: Throwable): Stream<DynamicTest> {
-        return sequenceOf(DynamicTest.dynamicTest("Load Error") {
+        return sequenceOf(DynamicTest.dynamicTest("Specmatic Test Suite") {
             ResultAssert.assertThat(Result.Failure(exceptionCauseMessage(e))).isSuccess()
         }).asStream()
     }
 
     private fun noTestsFoundError(reason: String): Stream<DynamicTest> {
-        return sequenceOf(DynamicTest.dynamicTest("No Tests Found") {
+        return sequenceOf(DynamicTest.dynamicTest("Specmatic Test Suite") {
             ResultAssert.assertThat(Result.Failure("No tests found to run. $reason")).isSuccess()
         }).asStream()
     }
@@ -454,8 +454,6 @@ open class SpecmaticJUnitSupport {
         timeoutInMilliseconds: Long,
     ): Stream<DynamicTest>
     {
-        val settings = settings
-
         try {
             if (queryActuator().failed && actuatorFromSwagger(actuatorBaseURL).failed) {
                 openApiCoverageReportInput.setEndpointsAPIFlag(false)
@@ -497,8 +495,8 @@ open class SpecmaticJUnitSupport {
                         )
 
                     testResult =
-                        httpClient.use { httpClient ->
-                            contractTest.runTest(httpClient)
+                        httpClient.use {
+                            contractTest.runTest(it)
                         }
                     val (result) = testResult
 

--- a/specmatic-mcp/src/main/kotlin/io/specmatic/mcp/test/McpScenario.kt
+++ b/specmatic-mcp/src/main/kotlin/io/specmatic/mcp/test/McpScenario.kt
@@ -107,7 +107,7 @@ data class McpScenario(
     private fun executionResultForNegativeScenario(response: JsonRpcResponse): Result {
         if (response.error != null) {
             if(response.error.isInvalidParamsStatusCode()) return Result.Success()
-            return Result.Failure("Expected an error with code -32602 but got ${response.error?.code ?: "no error"}")
+            return Result.Failure("Expected an error with code -32602 but got ${response.error.code}")
         }
 
         val toolResponse = try {


### PR DESCRIPTION
**What**:
- add centralized warning logging for missing config-resolved spec files
- add focused tests for missing-spec behavior across config-driven and CLI flows
- add git-source tests for both missing and existing spec paths
- refactor newly added v2/v3 tests into parameterized forms to reduce duplication

**Why**:
- Specmatic was silently ignoring missing spec files in config-driven paths, which made diagnosis difficult
- tests now protect behavior across commands and programmatic entry points

**How**:
- warning log added in shared contract path resolution (`contractFilePathsFrom`) when a resolved spec path does not exist
- added/updated tests in `junit5-support`, `specmatic-core`, and `application` modules
- consolidated duplicated v2/v3 tests using `@ParameterizedTest` + `@MethodSource`

**Checklist**:
- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate N/A
- [ ] Security scans don't report any vulnerabilities N/A
- [ ] Documentation added/updated (share link) N/A
- [ ] Sample Project added/updated (share link) N/A
- [ ] Demo video (share link) N/A
- [ ] Article on Website (share link) N/A
- [ ] Roadmpap updated (share link) N/A
- [ ] Conference Talk (share link) N/A
