### PR TITLE
Fix issue with duplicate example loading logic in the HttpStub

### DIFF
--- a/core/src/main/kotlin/io/specmatic/stub/api.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/api.kt
@@ -301,7 +301,7 @@ fun loadContractStubsFromImplicitPathsAsResults(
                         )?.second ?: return emptyList()
 
                     try {
-                        val implicitDataDirs = implicitDirsForSpecifications(specFile, specmaticConfig, feature)
+                        val implicitDataDirs = implicitDirsForSpecifications(specFile, specmaticConfig)
                         val externalDataDirs = dataDirFiles(externalDataDirPaths)
 
                         val dataFiles = implicitDataDirs.flatMap { filesInDir(it).orEmpty() }
@@ -410,14 +410,12 @@ fun loadContractStubsFromImplicitPaths(
         processedInvalidSpecs,
     ).filterIsInstance<FeatureStubsResult.Success>().map { Pair(it.feature, it.scenarioStubs) }
 
-fun implicitDirsForSpecifications(contractPath: File, specmaticConfig: SpecmaticConfig, feature: Feature): List<File> {
-    val exampleDirPathsForAFeature = feature.exampleDirPaths.map { File(it) }
+fun implicitDirsForSpecifications(contractPath: File, specmaticConfig: SpecmaticConfig): List<File> {
     val customImplicitStubBase = customImplicitStubBase(specmaticConfig)
-
     return listOfNotNull(
         implicitContractDataDir(contractPath.path),
         customImplicitStubBase?.let { implicitContractDataDir(contractPath.path, it) }
-    ).plus(exampleDirPathsForAFeature).sorted()
+    ).sorted()
 }
 
 fun hasOpenApiFileExtension(contractPath: String): Boolean = OPENAPI_FILE_EXTENSIONS.any { contractPath.trim().endsWith(".$it") }


### PR DESCRIPTION
**What**: Fix issue with duplicate example loading logic in the HttpStub

**Why**: `implicitDirsForSpecifications` should exclude `feature.exampleDirPaths` as implicit directories to prevent double loading

**Checklist**:

- [x] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)