### PR TITLE
fix: fix the --version command printing config not found error

### DIFF
--- a/application/src/test/kotlin/application/SpecmaticApplicationTest.kt
+++ b/application/src/test/kotlin/application/SpecmaticApplicationTest.kt
@@ -37,4 +37,25 @@ class SpecmaticApplicationTest {
         assertThat(exception.code).isEqualTo(0)
         assertThat(stdOut).containsPattern("v\\d+\\.\\d+\\.\\d+")
     }
+
+    @Test
+    fun `root version command should only print specmatic version`() {
+        val args = arrayOf("--version")
+        val (stdOut, exception) = captureStandardOutput {
+            assertThrows<SystemExitException> {
+                SystemExit.throwOnExit {
+                    SpecmaticApplication.main(args)
+                }
+            }
+        }
+
+        val nonBlankLines = stdOut.lineSequence()
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .toList()
+
+        assertThat(exception.code).isEqualTo(0)
+        assertThat(nonBlankLines).hasSize(1)
+        assertThat(nonBlankLines.single()).containsPattern("^Specmatic Version: v\\d+\\.\\d+\\.\\d+.*$")
+    }
 }


### PR DESCRIPTION
Reason for change -
The `specmatic --version` command printed an unwanted log saying `No specmatic.yaml found in current directory`.
This PR fixes that and prevents this log from getting logged.