### PR TITLE
fix: use the file to find out the spec associated to the file instead of relying on absoluteSpecPath while figuring out the ctrf spec config

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -92,7 +92,7 @@ interface SpecmaticConfig {
 
     @JsonIgnore
     fun getCtrfSpecConfig(
-        absoluteSpecPath: String,
+        specFile: File,
         testType: String,
         protocol: String,
         specType: String
@@ -405,10 +405,10 @@ interface SpecmaticConfig {
     fun withMatchBranch(matchBranch: Boolean): SpecmaticConfig
 
     @JsonIgnore
-    fun testSpecPathFromConfigFor(absoluteSpecPath: String): String?
+    fun testSpecPathFromConfigFor(specFile: File): String?
 
     @JsonIgnore
-    fun stubSpecPathFromConfigFor(absoluteSpecPath: String): String?
+    fun stubSpecPathFromConfigFor(specFile: File): String?
 
     @JsonIgnore
     fun getLicensePath(): Path?

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3Impl.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3Impl.kt
@@ -220,15 +220,15 @@ data class SpecmaticConfigV3Impl(val file: File? = null, private val specmaticCo
         return stubConfigFor(File(specPath), specType)
     }
 
-    override fun getCtrfSpecConfig(absoluteSpecPath: String, testType: String, protocol: String, specType: String): CtrfSpecConfig {
+    override fun getCtrfSpecConfig(specFile: File, testType: String, protocol: String, specType: String): CtrfSpecConfig {
         val source = when (testType) {
-            CONTRACT_TEST_TEST_TYPE -> specmaticConfig.systemUnderTest?.getSourcesContaining(File(absoluteSpecPath), resolver)
-            else -> specmaticConfig.dependencies?.getSourcesContaining(File(absoluteSpecPath), resolver)
+            CONTRACT_TEST_TEST_TYPE -> specmaticConfig.systemUnderTest?.getSourcesContaining(specFile, resolver)
+            else -> specmaticConfig.dependencies?.getSourcesContaining(specFile, resolver)
         }
 
         val specPathFromConfig = when(testType) {
-            CONTRACT_TEST_TEST_TYPE -> testSpecPathFromConfigFor(absoluteSpecPath)
-            else -> stubSpecPathFromConfigFor(absoluteSpecPath)
+            CONTRACT_TEST_TEST_TYPE -> testSpecPathFromConfigFor(specFile)
+            else -> stubSpecPathFromConfigFor(specFile)
         }
 
         return CtrfSpecConfig(
@@ -757,14 +757,14 @@ data class SpecmaticConfigV3Impl(val file: File? = null, private val specmaticCo
         return this.copy(specmaticConfig = updatedConfig)
     }
 
-    override fun testSpecPathFromConfigFor(absoluteSpecPath: String): String? {
-        val specDefinition = specmaticConfig.systemUnderTest?.getSpecDefinitionFor(File(absoluteSpecPath), resolver)
+    override fun testSpecPathFromConfigFor(specFile: File): String? {
+        val specDefinition = specmaticConfig.systemUnderTest?.getSpecDefinitionFor(specFile, resolver)
         return specDefinition?.getSpecificationPath()
     }
 
-    override fun stubSpecPathFromConfigFor(absoluteSpecPath: String): String? {
-        val service = specmaticConfig.dependencies?.getService(File(absoluteSpecPath), resolver) ?: return null
-        val specDefinition = specmaticConfig.dependencies.getSpecDefinitionFor(File(absoluteSpecPath), service, resolver)
+    override fun stubSpecPathFromConfigFor(specFile: File): String? {
+        val service = specmaticConfig.dependencies?.getService(specFile, resolver) ?: return null
+        val specDefinition = specmaticConfig.dependencies.getSpecDefinitionFor(specFile, service, resolver)
         return specDefinition?.getSpecificationPath()
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/report/CtrfSpecConfigUtils.kt
+++ b/core/src/main/kotlin/io/specmatic/core/report/CtrfSpecConfigUtils.kt
@@ -3,6 +3,7 @@ package io.specmatic.core.report
 import io.specmatic.core.SpecmaticConfig
 import io.specmatic.reporter.ctrf.model.CtrfSpecConfig
 import io.specmatic.reporter.ctrf.model.CtrfTestResultRecord
+import java.io.File
 
 fun ctrfSpecConfigsFrom(
     specmaticConfig: SpecmaticConfig,
@@ -14,7 +15,12 @@ fun ctrfSpecConfigsFrom(
             val absoluteSpecPath = it.specification
             when {
                 absoluteSpecPath.isNullOrBlank() -> null
-                else -> specmaticConfig.getCtrfSpecConfig(absoluteSpecPath, it.testType, protocol.key, it.specType.value)
+                else -> specmaticConfig.getCtrfSpecConfig(
+                    File(absoluteSpecPath),
+                    it.testType,
+                    protocol.key,
+                    it.specType.value
+                )
             }
         }
     }

--- a/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigKtTest.kt
@@ -20,9 +20,11 @@ import io.specmatic.core.utilities.Flags.Companion.SPECMATIC_STUB_DELAY
 import io.specmatic.core.utilities.Flags.Companion.SPECMATIC_TEST_TIMEOUT
 import io.specmatic.core.utilities.Flags.Companion.VALIDATE_RESPONSE_VALUE
 import io.specmatic.reporter.model.SpecType
+import io.specmatic.test.TestResultRecord.Companion.CONTRACT_TEST_TEST_TYPE
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
@@ -1693,6 +1695,46 @@ internal class SpecmaticConfigKtTest {
             val advanced = result["advanced"] as Map<String, Any>
             assertThat(advanced["compression"]).isEqualTo(true)
             assertThat(advanced["maxMessageSize"]).isEqualTo(2048)
+        }
+    }
+
+    @Nested
+    inner class CtrfSpecConfigForTests {
+        @Test
+        fun `getCtrfSpecConfig should resolve spec path from config for file input in v1 config`(@TempDir tempDir: File) {
+            val specFile = tempDir.resolve("contracts").resolve("order.yaml").apply {
+                parentFile.mkdirs()
+                writeText("openapi: 3.0.0")
+            }
+            val configFile = tempDir.resolve("specmatic.yaml").apply { writeText("version: 2") }
+            val originalConfigPath = Configuration.configFilePath
+
+            try {
+                Configuration.configFilePath = configFile.canonicalPath
+                val config = SpecmaticConfigV1V2Common(
+                    sources = listOf(
+                        Source(
+                            provider = SourceProvider.filesystem,
+                            directory = "contracts",
+                            test = listOf(SpecExecutionConfig.StringValue("order.yaml"))
+                        )
+                    )
+                )
+
+                val ctrfConfig = config.getCtrfSpecConfig(
+                    specFile = specFile,
+                    testType = CONTRACT_TEST_TEST_TYPE,
+                    protocol = "HTTP",
+                    specType = "OPENAPI"
+                )
+
+                assertThat(ctrfConfig.specification).isEqualTo("order.yaml")
+                assertThat(ctrfConfig.sourceProvider).isEqualTo(SourceProvider.filesystem.name)
+                assertThat(ctrfConfig.repository).isEmpty()
+                assertThat(ctrfConfig.branch).isEqualTo("main")
+            } finally {
+                Configuration.configFilePath = originalConfigPath
+            }
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 group=io.specmatic
 version=2.39.4-SNAPSHOT
 specmaticGradlePluginVersion=0.14.16
-specmaticReporterVersion=0.2.34
+specmaticReporterVersion=0.3.0
 kotlin.daemon.jvmargs=-Xmx2g
 org.gradle.jvmargs=-Xmx1024m


### PR DESCRIPTION
Reason for change -
The ctrf reports were missing operations in some cases. 