### PR TITLE
Fix Config V3 serialization for path primitives

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3Impl.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3Impl.kt
@@ -769,11 +769,11 @@ data class SpecmaticConfigV3Impl(val file: File? = null, private val specmaticCo
     }
 
     override fun getLicensePath(): Path? {
-        return specmaticConfig.specmatic?.license?.path
+        return specmaticConfig.specmatic?.license?.path?.let(Path::of)
     }
 
     override fun getReportDirPath(suffix: String?): Path {
-        val reportDirPath = specmaticConfig.specmatic?.governance?.report?.outputDirectory ?: defaultReportDirPath
+        val reportDirPath = specmaticConfig.specmatic?.governance?.report?.outputDirectory?.let(Path::of) ?: defaultReportDirPath
         if (suffix == null) return reportDirPath
         return reportDirPath.resolve(suffix)
     }

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/specmatic/License.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/specmatic/License.kt
@@ -1,5 +1,3 @@
 package io.specmatic.core.config.v3.specmatic
 
-import java.nio.file.Path
-
-data class License(val path: Path)
+data class License(val path: String)

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/specmatic/Report.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/specmatic/Report.kt
@@ -2,7 +2,6 @@ package io.specmatic.core.config.v3.specmatic
 
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonValue
-import java.nio.file.Path
 
 enum class ReportFormat(val value: String) {
     HTML("html"),
@@ -22,4 +21,4 @@ enum class ReportFormat(val value: String) {
     }
 }
 
-data class Report(val formats: List<ReportFormat>? = null, val outputDirectory: Path? = null)
+data class Report(val formats: List<ReportFormat>? = null, val outputDirectory: String? = null)


### PR DESCRIPTION
**What**: Fix Config V3 serialization for path primitives

**Reason**: Some fields were marked as `Path`, which results in the serialization including path information such as `file://` alongside the actual value

**How**: Just use `String` instead of `Path`

**Checklist**:

- [x] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
