### PR TITLE
Modify the filter used by OpenApiCoverageReportInput

### DIFF
--- a/junit5-support/src/main/kotlin/io/specmatic/test/ContractTestSettings.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/ContractTestSettings.kt
@@ -2,6 +2,7 @@ package io.specmatic.test
 
 import io.specmatic.core.Configuration
 import io.specmatic.core.SpecmaticConfig
+import io.specmatic.core.config.nonNullElse
 import io.specmatic.core.getConfigFilePath
 import io.specmatic.core.loadSpecmaticConfigOrDefault
 import io.specmatic.core.loadSpecmaticConfigOrNull
@@ -50,10 +51,17 @@ data class ContractTestSettings(
     val suggestionsPath: String? = otherArguments?.suggestionsPath
     val inlineSuggestions: String? = otherArguments?.inlineSuggestions
     val variablesFileName: String? = otherArguments?.variablesFileName
+    private val specmaticConfig = loadSpecmaticConfigOrNull(configFile, explicitlySpecifiedByUser = configFile != null).orDefault()
 
     fun getSpecmaticConfig(): SpecmaticConfig {
-        val specmaticConfig = loadSpecmaticConfigOrNull(configFile, explicitlySpecifiedByUser = configFile != null).orDefault()
         return adjust(specmaticConfig)
+    }
+
+    fun getReportFilter(): String? {
+        if (specmaticConfig.getTestFilter() == filter) return filter
+        return specmaticConfig.getTestFilter().nonNullElse(filter) { filter1, filter2 ->
+            listOf(filter1, filter2).filter(String::isNotBlank).joinToString(separator = " && ") { "( $it )" }
+        }
     }
 
     private fun adjust(specmaticConfig: SpecmaticConfig): SpecmaticConfig {

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -88,7 +88,7 @@ open class SpecmaticJUnitSupport {
     internal val openApiCoverageReportInput: OpenApiCoverageReportInput =
         OpenApiCoverageReportInput(
             configFilePath = getConfigFileWithAbsolutePath(),
-            filterExpression = specmaticConfig.getTestFilter().orEmpty(),
+            filterExpression = settings.getReportFilter().orEmpty(),
             coverageHooks = settings.coverageHooks,
             httpInteractionsLog = httpInteractionsLog,
             previousTestResultRecord = settings.previousTestRuns,

--- a/junit5-support/src/test/kotlin/io/specmatic/test/ContractTestSettingsTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/ContractTestSettingsTest.kt
@@ -1,0 +1,47 @@
+package io.specmatic.test
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+
+class ContractTestSettingsTest {
+    private val filterPropertyKey = "filter"
+    private val originalFilterValue = System.getProperty(filterPropertyKey)
+
+    @AfterEach
+    fun restoreFilterProperty() {
+        if (originalFilterValue != null) {
+            System.setProperty(filterPropertyKey, originalFilterValue)
+        } else {
+            System.clearProperty(filterPropertyKey)
+        }
+    }
+
+    @Test
+    fun `getReportFilter returns config filter when override matches`() {
+        System.setProperty(filterPropertyKey, "PATH='/config'")
+        val settings = ContractTestSettings(filter = "PATH='/config'")
+        assertThat(settings.getReportFilter()).isEqualTo("PATH='/config'")
+    }
+
+    @Test
+    fun `getReportFilter combines config and override filters when they differ`() {
+        System.setProperty(filterPropertyKey, "PATH='/config'")
+        val settings = ContractTestSettings(filter = "STATUS='200'")
+        assertThat(settings.getReportFilter()).isEqualTo("( PATH='/config' ) && ( STATUS='200' )")
+    }
+
+    @Test
+    fun `getReportFilter uses override when config filter is missing`() {
+        System.clearProperty(filterPropertyKey)
+        val settings = ContractTestSettings(filter = "STATUS='200'")
+        assertThat(settings.getReportFilter()).isEqualTo("STATUS='200'")
+    }
+
+    @Test
+    fun `getReportFilter uses config filter when override is missing`() {
+        System.setProperty(filterPropertyKey, "PATH='/config'")
+        val settings = ContractTestSettings(filter = null)
+        assertThat(settings.getReportFilter()).isEqualTo("PATH='/config'")
+    }
+}


### PR DESCRIPTION
**What**: The OpenApiCoverageReportInput should utilize a combination of the config and testSettings filters

**Checklist**:

- [x] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
