### PR TITLE
Fix baseUrlExtraction logic in ConfigV3

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/MockServiceConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/MockServiceConfig.kt
@@ -14,9 +14,9 @@ import io.specmatic.core.config.v3.components.runOptions.IRunOptions
 import io.specmatic.core.config.v3.components.runOptions.MockRunOptions
 import io.specmatic.core.config.v3.components.settings.MockSettings
 import io.specmatic.core.config.v3.components.sources.SourceV3
+import io.specmatic.core.config.v3.determineSpecTypeFor
 import io.specmatic.core.config.v3.resolveElseThrow
 import io.specmatic.reporter.model.SpecType
-import io.specmatic.stub.isOpenAPI
 import java.io.File
 import kotlin.collections.orEmpty
 import kotlin.collections.plus
@@ -113,14 +113,7 @@ data class MockServiceConfig(val services: List<Value>, val data: Data? = null, 
 
     @JsonIgnore
     private fun getFirstBaseUrlFromRunOpts(specId: String?, specFile: File, service: CommonServiceConfig<MockRunOptions, MockSettings>, resolver: RefOrValueResolver): String? {
-        val specTypesToCheck = when {
-            specFile.extension == "wsdl" -> listOf(SpecType.WSDL)
-            specFile.extension == "proto" -> listOf(SpecType.PROTOBUF)
-            specFile.extension in setOf("graphql", "graphqls") -> listOf(SpecType.GRAPHQL)
-            isOpenAPI(specFile.canonicalPath, logFailure = false) -> listOf(SpecType.OPENAPI)
-            else -> listOf(SpecType.OPENAPI, SpecType.ASYNCAPI)
-        }
-
+        val specTypesToCheck = determineSpecTypeFor(specFile)
         return specTypesToCheck.firstNotNullOfOrNull {
             val runOptions = getRunOptions(service, resolver, it) ?: return@firstNotNullOfOrNull null
             val runOptionSpecOverride = specId?.let(runOptions::getMatchingSpecification)

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/utils.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/utils.kt
@@ -1,0 +1,26 @@
+package io.specmatic.core.config.v3
+
+import io.specmatic.reporter.model.SpecType
+import io.specmatic.stub.isOpenAPI
+import org.yaml.snakeyaml.Yaml
+import java.io.File
+import kotlin.collections.contains
+
+internal fun determineSpecTypeFor(specFile: File): List<SpecType> {
+    return when {
+        specFile.extension == "wsdl" -> listOf(SpecType.WSDL)
+        specFile.extension == "proto" -> listOf(SpecType.PROTOBUF)
+        specFile.extension in setOf("graphql", "graphqls") -> listOf(SpecType.GRAPHQL)
+        isOpenAPI(specFile.canonicalPath, logFailure = false) -> listOf(SpecType.OPENAPI)
+        isAsyncAPI(specFile.canonicalPath) -> listOf(SpecType.ASYNCAPI)
+        else -> return listOf(SpecType.OPENAPI, SpecType.ASYNCAPI)
+    }
+}
+
+private fun isAsyncAPI(path: String): Boolean = try {
+    File(path).reader().use { reader ->
+        Yaml().load<MutableMap<String, Any?>>(reader).contains("asyncapi")
+    }
+} catch (_: Throwable) {
+    false
+}

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/components/services/MockServiceConfigTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/components/services/MockServiceConfigTest.kt
@@ -5,7 +5,14 @@ import io.specmatic.core.config.v3.RefOrValue
 import io.specmatic.core.config.v3.RefOrValueResolver
 import io.specmatic.core.config.v3.components.ExampleDirectories
 import io.specmatic.core.config.v3.components.runOptions.AsyncApiMockConfig
+import io.specmatic.core.config.v3.components.runOptions.GraphQLSdlMockConfig
 import io.specmatic.core.config.v3.components.runOptions.MockRunOptions
+import io.specmatic.core.config.v3.components.runOptions.OpenApiMockConfig
+import io.specmatic.core.config.v3.components.runOptions.OpenApiRunOptionsSpecifications
+import io.specmatic.core.config.v3.components.runOptions.ProtobufMockConfig
+import io.specmatic.core.config.v3.components.runOptions.RunOptionsSpecifications
+import io.specmatic.core.config.v3.components.runOptions.WsdlMockConfig
+import io.specmatic.core.config.v3.components.runOptions.WsdlRunOptionsSpecifications
 import io.specmatic.core.config.v3.components.sources.SourceV3
 import io.specmatic.core.config.v3.components.settings.MockSettings
 import org.assertj.core.api.Assertions.assertThat
@@ -62,7 +69,7 @@ class MockServiceConfigTest {
 
     @Test
     fun `getSpecificationSources should use asyncapi inMemoryBroker for async runOptions`(@TempDir tempDir: File) {
-        val specFile = tempDir.resolve("contract.yaml").apply { writeText("asycnapi: 3.0.0") }
+        val specFile = tempDir.resolve("contract.yaml").apply { writeText("asyncapi: 3.0.0") }
         val source = SourceV3.create(filesystem = SourceV3.FileSystem(directory = tempDir.canonicalPath))
 
         val asyncApiMockConfig = AsyncApiMockConfig().apply {
@@ -90,5 +97,352 @@ class MockServiceConfigTest {
 
         assertThat(sourceEntries).hasSize(1)
         assertThat(sourceEntries.single().baseUrl).isEqualTo("localhost:8081")
+    }
+
+    @Test
+    fun `getSpecificationSources should use openapi per-spec baseUrl when spec id matches`(@TempDir tempDir: File) {
+        val specFile = tempDir.resolve("orders.yaml").apply { writeText("openapi: 3.0.0") }
+        val source = SourceV3.create(filesystem = SourceV3.FileSystem(directory = tempDir.canonicalPath))
+
+        val serviceConfig = CommonServiceConfig<MockRunOptions, MockSettings>(
+            definitions = listOf(
+                Definition(
+                    Definition.Value(
+                        source = RefOrValue.Value(source),
+                        specs = listOf(
+                            SpecificationDefinition.ObjectValue(
+                                SpecificationDefinition.Specification(
+                                    id = "orders-spec",
+                                    path = specFile.name
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            runOptions = RefOrValue.Value(
+                MockRunOptions(
+                    openapi = OpenApiMockConfig(
+                        baseUrl = "http://default-mock-base-url:9000",
+                        specs = listOf(
+                            OpenApiRunOptionsSpecifications(
+                                spec = OpenApiRunOptionsSpecifications.Value(
+                                    id = "orders-spec",
+                                    baseUrl = "http://spec-level-mock-base-url:9001"
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+
+        val mockServiceConfig = MockServiceConfig(
+            services = listOf(MockServiceConfig.Value(service = RefOrValue.Value(serviceConfig))),
+            settings = null
+        )
+
+        val sourceEntries = mockServiceConfig.getSpecificationSources(resolver).values.flatten()
+
+        assertThat(sourceEntries).hasSize(1)
+        assertThat(sourceEntries.single().baseUrl).isEqualTo("http://spec-level-mock-base-url:9001")
+    }
+
+    @Test
+    fun `getSpecificationSources should fallback to openapi runOption baseUrl when spec id has no match`(@TempDir tempDir: File) {
+        val specFile = tempDir.resolve("orders.yaml").apply { writeText("openapi: 3.0.0") }
+        val source = SourceV3.create(filesystem = SourceV3.FileSystem(directory = tempDir.canonicalPath))
+        val serviceConfig = CommonServiceConfig<MockRunOptions, MockSettings>(
+            definitions = listOf(
+                Definition(
+                    Definition.Value(
+                        source = RefOrValue.Value(source),
+                        specs = listOf(
+                            SpecificationDefinition.ObjectValue(
+                                SpecificationDefinition.Specification(
+                                    id = "orders-spec",
+                                    path = specFile.name
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            runOptions = RefOrValue.Value(
+                MockRunOptions(
+                    openapi = OpenApiMockConfig(
+                        baseUrl = "http://default-mock-base-url:9000",
+                        specs = listOf(
+                            OpenApiRunOptionsSpecifications(
+                                spec = OpenApiRunOptionsSpecifications.Value(
+                                    id = "different-spec-id",
+                                    baseUrl = "http://spec-level-mock-base-url:9001"
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+
+        val mockServiceConfig = MockServiceConfig(services = listOf(MockServiceConfig.Value(service = RefOrValue.Value(serviceConfig))), settings = null)
+        val sourceEntries = mockServiceConfig.getSpecificationSources(resolver).values.flatten()
+        assertThat(sourceEntries).hasSize(1)
+        assertThat(sourceEntries.single().baseUrl).isEqualTo("http://default-mock-base-url:9000")
+    }
+
+    @Test
+    fun `getSpecificationSources should use wsdl per-spec baseUrl when spec id matches`(@TempDir tempDir: File) {
+        val specFile = tempDir.resolve("service.wsdl").apply { writeText("<definitions/>") }
+        val source = SourceV3.create(filesystem = SourceV3.FileSystem(directory = tempDir.canonicalPath))
+        val serviceConfig = CommonServiceConfig<MockRunOptions, MockSettings>(
+            definitions = listOf(
+                Definition(
+                    Definition.Value(
+                        source = RefOrValue.Value(source),
+                        specs = listOf(
+                            SpecificationDefinition.ObjectValue(
+                                SpecificationDefinition.Specification(id = "wsdl-spec", path = specFile.name)
+                            )
+                        )
+                    )
+                )
+            ),
+            runOptions = RefOrValue.Value(
+                MockRunOptions(
+                    wsdl = WsdlMockConfig(
+                        baseUrl = "http://wsdl-default:9100",
+                        specs = listOf(
+                            WsdlRunOptionsSpecifications(
+                                WsdlRunOptionsSpecifications.Value(
+                                    id = "wsdl-spec",
+                                    baseUrl = "http://wsdl-spec:9101"
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+
+        val entries = MockServiceConfig(services = listOf(MockServiceConfig.Value(service = RefOrValue.Value(serviceConfig))), settings = null).getSpecificationSources(resolver).values.flatten()
+        assertThat(entries.single().baseUrl).isEqualTo("http://wsdl-spec:9101")
+    }
+
+    @Test
+    fun `getSpecificationSources should fallback to wsdl runOption baseUrl when spec id has no match`(@TempDir tempDir: File) {
+        val specFile = tempDir.resolve("service.wsdl").apply { writeText("<definitions/>") }
+        val source = SourceV3.create(filesystem = SourceV3.FileSystem(directory = tempDir.canonicalPath))
+        val serviceConfig = CommonServiceConfig<MockRunOptions, MockSettings>(
+            definitions = listOf(
+                Definition(
+                    Definition.Value(
+                        source = RefOrValue.Value(source),
+                        specs = listOf(
+                            SpecificationDefinition.ObjectValue(
+                                SpecificationDefinition.Specification(id = "wsdl-spec", path = specFile.name)
+                            )
+                        )
+                    )
+                )
+            ),
+            runOptions = RefOrValue.Value(
+                MockRunOptions(
+                    wsdl = WsdlMockConfig(
+                        baseUrl = "http://wsdl-default:9100",
+                        specs = listOf(
+                            WsdlRunOptionsSpecifications(
+                                WsdlRunOptionsSpecifications.Value(
+                                    id = "different-spec-id",
+                                    baseUrl = "http://wsdl-spec:9101"
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+
+        val entries = MockServiceConfig(services = listOf(MockServiceConfig.Value(service = RefOrValue.Value(serviceConfig))), settings = null).getSpecificationSources(resolver).values.flatten()
+        assertThat(entries.single().baseUrl).isEqualTo("http://wsdl-default:9100")
+    }
+
+    @Test
+    fun `getSpecificationSources should use protobuf per-spec baseUrl when spec id matches`(@TempDir tempDir: File) {
+        val specFile = tempDir.resolve("service.proto").apply { writeText("syntax = \"proto3\";") }
+        val source = SourceV3.create(filesystem = SourceV3.FileSystem(directory = tempDir.canonicalPath))
+        val protobufConfig = ProtobufMockConfig(
+            specs = listOf(
+                RunOptionsSpecifications(
+                    RunOptionsSpecifications.Value(id = "proto-spec", host = "proto-spec", port = 9201)
+                )
+            )
+        ).apply {
+            put("host", "proto-default")
+            put("port", 9200)
+        }
+
+        val serviceConfig = CommonServiceConfig<MockRunOptions, MockSettings>(
+            definitions = listOf(
+                Definition(
+                    Definition.Value(
+                        source = RefOrValue.Value(source),
+                        specs = listOf(
+                            SpecificationDefinition.ObjectValue(
+                                SpecificationDefinition.Specification(id = "proto-spec", path = specFile.name)
+                            )
+                        )
+                    )
+                )
+            ),
+            runOptions = RefOrValue.Value(MockRunOptions(protobuf = protobufConfig))
+        )
+
+        val entries = MockServiceConfig(services = listOf(MockServiceConfig.Value(service = RefOrValue.Value(serviceConfig))), settings = null).getSpecificationSources(resolver).values.flatten()
+        assertThat(entries.single().baseUrl).isEqualTo("proto-spec:9201")
+    }
+
+    @Test
+    fun `getSpecificationSources should fallback to protobuf runOption baseUrl when spec id has no match`(@TempDir tempDir: File) {
+        val specFile = tempDir.resolve("service.proto").apply { writeText("syntax = \"proto3\";") }
+        val source = SourceV3.create(filesystem = SourceV3.FileSystem(directory = tempDir.canonicalPath))
+        val protobufConfig = ProtobufMockConfig(
+            specs = listOf(
+                RunOptionsSpecifications(
+                    RunOptionsSpecifications.Value(id = "different-spec-id", host = "proto-spec", port = 9201)
+                )
+            )
+        ).apply {
+            put("host", "proto-default")
+            put("port", 9200)
+        }
+
+        val serviceConfig = CommonServiceConfig<MockRunOptions, MockSettings>(
+            definitions = listOf(
+                Definition(
+                    Definition.Value(
+                        source = RefOrValue.Value(source),
+                        specs = listOf(
+                            SpecificationDefinition.ObjectValue(
+                                SpecificationDefinition.Specification(id = "proto-spec", path = specFile.name)
+                            )
+                        )
+                    )
+                )
+            ),
+            runOptions = RefOrValue.Value(MockRunOptions(protobuf = protobufConfig))
+        )
+
+        val entries = MockServiceConfig(services = listOf(MockServiceConfig.Value(service = RefOrValue.Value(serviceConfig))), settings = null).getSpecificationSources(resolver).values.flatten()
+        assertThat(entries.single().baseUrl).isEqualTo("proto-default:9200")
+    }
+
+    @Test
+    fun `getSpecificationSources should use graphql per-spec baseUrl when spec id matches`(@TempDir tempDir: File) {
+        val specFile = tempDir.resolve("service.graphql").apply { writeText("type Query { ping: String }") }
+        val source = SourceV3.create(filesystem = SourceV3.FileSystem(directory = tempDir.canonicalPath))
+        val graphConfig = GraphQLSdlMockConfig(
+            specs = listOf(
+                RunOptionsSpecifications(
+                    RunOptionsSpecifications.Value(id = "graphql-spec", host = "graphql-spec", port = 9301)
+                )
+            )
+        ).apply {
+            put("host", "graphql-default")
+            put("port", 9300)
+        }
+
+        val serviceConfig = CommonServiceConfig<MockRunOptions, MockSettings>(
+            definitions = listOf(
+                Definition(
+                    Definition.Value(
+                        source = RefOrValue.Value(source),
+                        specs = listOf(
+                            SpecificationDefinition.ObjectValue(
+                                SpecificationDefinition.Specification(id = "graphql-spec", path = specFile.name)
+                            )
+                        )
+                    )
+                )
+            ),
+            runOptions = RefOrValue.Value(MockRunOptions(graphqlsdl = graphConfig))
+        )
+
+        val entries = MockServiceConfig(services = listOf(MockServiceConfig.Value(service = RefOrValue.Value(serviceConfig))), settings = null).getSpecificationSources(resolver).values.flatten()
+        assertThat(entries.single().baseUrl).isEqualTo("graphql-spec:9301")
+    }
+
+    @Test
+    fun `getSpecificationSources should fallback to graphql runOption baseUrl when spec id has no match`(@TempDir tempDir: File) {
+        val specFile = tempDir.resolve("service.graphql").apply { writeText("type Query { ping: String }") }
+        val source = SourceV3.create(filesystem = SourceV3.FileSystem(directory = tempDir.canonicalPath))
+        val graphConfig = GraphQLSdlMockConfig(
+            specs = listOf(
+                RunOptionsSpecifications(
+                    RunOptionsSpecifications.Value(id = "different-spec-id", host = "graphql-spec", port = 9301)
+                )
+            )
+        ).apply {
+            put("host", "graphql-default")
+            put("port", 9300)
+        }
+
+        val serviceConfig = CommonServiceConfig<MockRunOptions, MockSettings>(
+            definitions = listOf(
+                Definition(
+                    Definition.Value(
+                        source = RefOrValue.Value(source),
+                        specs = listOf(
+                            SpecificationDefinition.ObjectValue(
+                                SpecificationDefinition.Specification(id = "graphql-spec", path = specFile.name)
+                            )
+                        )
+                    )
+                )
+            ),
+            runOptions = RefOrValue.Value(MockRunOptions(graphqlsdl = graphConfig))
+        )
+
+        val entries = MockServiceConfig(services = listOf(MockServiceConfig.Value(service = RefOrValue.Value(serviceConfig))), settings = null).getSpecificationSources(resolver).values.flatten()
+        assertThat(entries.single().baseUrl).isEqualTo("graphql-default:9300")
+    }
+
+    @Test
+    fun `getSpecificationSources should resolve openapi and asyncapi yaml specs in same service`(@TempDir tempDir: File) {
+        val openApiSpecFile = tempDir.resolve("openapi-contract.yaml").apply { writeText("openapi: 3.0.0") }
+        val asyncApiSpecFile = tempDir.resolve("asyncapi-contract.yaml").apply { writeText("asyncapi: 2.6.0") }
+        val source = SourceV3.create(filesystem = SourceV3.FileSystem(directory = tempDir.canonicalPath))
+        val asyncConfig = AsyncApiMockConfig().apply {
+            put("inMemoryBroker", mapOf("host" to "async-host", "port" to 9400))
+        }
+
+        val serviceConfig = CommonServiceConfig<MockRunOptions, MockSettings>(
+            definitions = listOf(
+                Definition(
+                    Definition.Value(
+                        source = RefOrValue.Value(source),
+                        specs = listOf(
+                            SpecificationDefinition.StringValue(openApiSpecFile.name),
+                            SpecificationDefinition.StringValue(asyncApiSpecFile.name)
+                        )
+                    )
+                )
+            ),
+            runOptions = RefOrValue.Value(
+                MockRunOptions(
+                    openapi = OpenApiMockConfig(baseUrl = "http://openapi-host:9401"),
+                    asyncapi = asyncConfig
+                )
+            )
+        )
+
+        val entriesByPath = MockServiceConfig(services = listOf(MockServiceConfig.Value(service = RefOrValue.Value(serviceConfig))), settings = null)
+            .getSpecificationSources(resolver)
+            .values
+            .flatten()
+            .associateBy { it.specPathInConfig }
+
+        assertThat(entriesByPath[openApiSpecFile.name]?.baseUrl).isEqualTo("http://openapi-host:9401")
+        assertThat(entriesByPath[asyncApiSpecFile.name]?.baseUrl).isEqualTo("async-host:9400")
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/components/services/TestServiceConfigTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/components/services/TestServiceConfigTest.kt
@@ -3,7 +3,14 @@ package io.specmatic.core.config.v3.components.services
 import io.specmatic.core.config.v3.RefOrValue
 import io.specmatic.core.config.v3.RefOrValueResolver
 import io.specmatic.core.config.v3.components.runOptions.AsyncApiTestConfig
+import io.specmatic.core.config.v3.components.runOptions.GraphQLSdlTestConfig
+import io.specmatic.core.config.v3.components.runOptions.OpenApiRunOptionsSpecifications
+import io.specmatic.core.config.v3.components.runOptions.OpenApiTestConfig
+import io.specmatic.core.config.v3.components.runOptions.ProtobufTestConfig
+import io.specmatic.core.config.v3.components.runOptions.RunOptionsSpecifications
 import io.specmatic.core.config.v3.components.runOptions.TestRunOptions
+import io.specmatic.core.config.v3.components.runOptions.WsdlRunOptionsSpecifications
+import io.specmatic.core.config.v3.components.runOptions.WsdlTestConfig
 import io.specmatic.core.config.v3.components.settings.TestSettings
 import io.specmatic.core.config.v3.components.sources.SourceV3
 import org.assertj.core.api.Assertions.assertThat
@@ -20,7 +27,7 @@ class TestServiceConfigTest {
 
     @Test
     fun `getSpecificationSources should use asyncapi inMemoryBroker for async runOptions`(@TempDir tempDir: File) {
-        val specFile = tempDir.resolve("contract.yaml").apply { writeText("asycnapi: 3.0.0") }
+        val specFile = tempDir.resolve("contract.yaml").apply { writeText("asyncapi: 3.0.0") }
         val source = SourceV3.create(filesystem = SourceV3.FileSystem(directory = tempDir.canonicalPath))
         val asyncApiTestConfig = AsyncApiTestConfig().apply {
             put("inMemoryBroker", mapOf("host" to "localhost", "port" to 8082))
@@ -73,5 +80,352 @@ class TestServiceConfigTest {
 
         assertThat(sourceEntriesBySource).hasSize(1)
         assertThat(sourceEntriesBySource.values.single()).hasSize(2)
+    }
+
+    @Test
+    fun `getSpecificationSources should use openapi per-spec baseUrl when spec id matches`(@TempDir tempDir: File) {
+        val specFile = tempDir.resolve("orders.yaml").apply { writeText("openapi: 3.0.0") }
+        val source = SourceV3.create(filesystem = SourceV3.FileSystem(directory = tempDir.canonicalPath))
+
+        val serviceConfig = CommonServiceConfig<TestRunOptions, TestSettings>(
+            definitions = listOf(
+                Definition(
+                    Definition.Value(
+                        source = RefOrValue.Value(source),
+                        specs = listOf(
+                            SpecificationDefinition.ObjectValue(
+                                SpecificationDefinition.Specification(
+                                    id = "orders-spec",
+                                    path = specFile.name
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            runOptions = RefOrValue.Value(
+                TestRunOptions(
+                    openapi = OpenApiTestConfig(
+                        baseUrl = "http://default-base-url:9000",
+                        specs = listOf(
+                            OpenApiRunOptionsSpecifications(
+                                spec = OpenApiRunOptionsSpecifications.Value(
+                                    id = "orders-spec",
+                                    baseUrl = "http://spec-level-base-url:9001"
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+
+        val testServiceConfig = TestServiceConfig(service = RefOrValue.Value(serviceConfig))
+        val sourceEntries = testServiceConfig.getSpecificationSources(resolver, testSettings = null).values.flatten()
+
+        assertThat(sourceEntries).hasSize(1)
+        assertThat(sourceEntries.single().baseUrl).isEqualTo("http://spec-level-base-url:9001")
+    }
+
+    @Test
+    fun `getSpecificationSources should fallback to openapi runOption baseUrl when spec id has no match`(@TempDir tempDir: File) {
+        val specFile = tempDir.resolve("orders.yaml").apply { writeText("openapi: 3.0.0") }
+        val source = SourceV3.create(filesystem = SourceV3.FileSystem(directory = tempDir.canonicalPath))
+
+        val serviceConfig = CommonServiceConfig<TestRunOptions, TestSettings>(
+            definitions = listOf(
+                Definition(
+                    Definition.Value(
+                        source = RefOrValue.Value(source),
+                        specs = listOf(
+                            SpecificationDefinition.ObjectValue(
+                                SpecificationDefinition.Specification(
+                                    id = "orders-spec",
+                                    path = specFile.name
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            runOptions = RefOrValue.Value(
+                TestRunOptions(
+                    openapi = OpenApiTestConfig(
+                        baseUrl = "http://default-base-url:9000",
+                        specs = listOf(
+                            OpenApiRunOptionsSpecifications(
+                                spec = OpenApiRunOptionsSpecifications.Value(
+                                    id = "different-spec-id",
+                                    baseUrl = "http://spec-level-base-url:9001"
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+
+        val testServiceConfig = TestServiceConfig(service = RefOrValue.Value(serviceConfig))
+        val sourceEntries = testServiceConfig.getSpecificationSources(resolver, testSettings = null).values.flatten()
+
+        assertThat(sourceEntries).hasSize(1)
+        assertThat(sourceEntries.single().baseUrl).isEqualTo("http://default-base-url:9000")
+    }
+
+    @Test
+    fun `getSpecificationSources should use wsdl per-spec baseUrl when spec id matches`(@TempDir tempDir: File) {
+        val specFile = tempDir.resolve("service.wsdl").apply { writeText("<definitions/>") }
+        val source = SourceV3.create(filesystem = SourceV3.FileSystem(directory = tempDir.canonicalPath))
+
+        val serviceConfig = CommonServiceConfig<TestRunOptions, TestSettings>(
+            definitions = listOf(
+                Definition(
+                    Definition.Value(
+                        source = RefOrValue.Value(source),
+                        specs = listOf(
+                            SpecificationDefinition.ObjectValue(
+                                SpecificationDefinition.Specification(id = "wsdl-spec", path = specFile.name)
+                            )
+                        )
+                    )
+                )
+            ),
+            runOptions = RefOrValue.Value(
+                TestRunOptions(
+                    wsdl = WsdlTestConfig(
+                        baseUrl = "http://wsdl-default:9100",
+                        specs = listOf(
+                            WsdlRunOptionsSpecifications(
+                                WsdlRunOptionsSpecifications.Value(
+                                    id = "wsdl-spec",
+                                    baseUrl = "http://wsdl-spec:9101"
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+
+        val entries = TestServiceConfig(service = RefOrValue.Value(serviceConfig)).getSpecificationSources(resolver, null).values.flatten()
+        assertThat(entries.single().baseUrl).isEqualTo("http://wsdl-spec:9101")
+    }
+
+    @Test
+    fun `getSpecificationSources should fallback to wsdl runOption baseUrl when spec id has no match`(@TempDir tempDir: File) {
+        val specFile = tempDir.resolve("service.wsdl").apply { writeText("<definitions/>") }
+        val source = SourceV3.create(filesystem = SourceV3.FileSystem(directory = tempDir.canonicalPath))
+
+        val serviceConfig = CommonServiceConfig<TestRunOptions, TestSettings>(
+            definitions = listOf(
+                Definition(
+                    Definition.Value(
+                        source = RefOrValue.Value(source),
+                        specs = listOf(
+                            SpecificationDefinition.ObjectValue(
+                                SpecificationDefinition.Specification(id = "wsdl-spec", path = specFile.name)
+                            )
+                        )
+                    )
+                )
+            ),
+            runOptions = RefOrValue.Value(
+                TestRunOptions(
+                    wsdl = WsdlTestConfig(
+                        baseUrl = "http://wsdl-default:9100",
+                        specs = listOf(
+                            WsdlRunOptionsSpecifications(
+                                WsdlRunOptionsSpecifications.Value(
+                                    id = "different-spec-id",
+                                    baseUrl = "http://wsdl-spec:9101"
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+
+        val entries = TestServiceConfig(service = RefOrValue.Value(serviceConfig)).getSpecificationSources(resolver, null).values.flatten()
+        assertThat(entries.single().baseUrl).isEqualTo("http://wsdl-default:9100")
+    }
+
+    @Test
+    fun `getSpecificationSources should use protobuf per-spec baseUrl when spec id matches`(@TempDir tempDir: File) {
+        val specFile = tempDir.resolve("service.proto").apply { writeText("syntax = \"proto3\";") }
+        val source = SourceV3.create(filesystem = SourceV3.FileSystem(directory = tempDir.canonicalPath))
+        val protobufConfig = ProtobufTestConfig(
+            specs = listOf(
+                RunOptionsSpecifications(
+                    RunOptionsSpecifications.Value(id = "proto-spec", host = "proto-spec", port = 9201)
+                )
+            )
+        ).apply {
+            put("host", "proto-default")
+            put("port", 9200)
+        }
+
+        val serviceConfig = CommonServiceConfig<TestRunOptions, TestSettings>(
+            definitions = listOf(
+                Definition(
+                    Definition.Value(
+                        source = RefOrValue.Value(source),
+                        specs = listOf(
+                            SpecificationDefinition.ObjectValue(
+                                SpecificationDefinition.Specification(id = "proto-spec", path = specFile.name)
+                            )
+                        )
+                    )
+                )
+            ),
+            runOptions = RefOrValue.Value(TestRunOptions(protobuf = protobufConfig))
+        )
+
+        val entries = TestServiceConfig(service = RefOrValue.Value(serviceConfig)).getSpecificationSources(resolver, null).values.flatten()
+        assertThat(entries.single().baseUrl).isEqualTo("proto-spec:9201")
+    }
+
+    @Test
+    fun `getSpecificationSources should fallback to protobuf runOption baseUrl when spec id has no match`(@TempDir tempDir: File) {
+        val specFile = tempDir.resolve("service.proto").apply { writeText("syntax = \"proto3\";") }
+        val source = SourceV3.create(filesystem = SourceV3.FileSystem(directory = tempDir.canonicalPath))
+        val protobufConfig = ProtobufTestConfig(
+            specs = listOf(
+                RunOptionsSpecifications(
+                    RunOptionsSpecifications.Value(id = "different-spec-id", host = "proto-spec", port = 9201)
+                )
+            )
+        ).apply {
+            put("host", "proto-default")
+            put("port", 9200)
+        }
+
+        val serviceConfig = CommonServiceConfig<TestRunOptions, TestSettings>(
+            definitions = listOf(
+                Definition(
+                    Definition.Value(
+                        source = RefOrValue.Value(source),
+                        specs = listOf(
+                            SpecificationDefinition.ObjectValue(
+                                SpecificationDefinition.Specification(id = "proto-spec", path = specFile.name)
+                            )
+                        )
+                    )
+                )
+            ),
+            runOptions = RefOrValue.Value(TestRunOptions(protobuf = protobufConfig))
+        )
+
+        val entries = TestServiceConfig(service = RefOrValue.Value(serviceConfig)).getSpecificationSources(resolver, null).values.flatten()
+        assertThat(entries.single().baseUrl).isEqualTo("proto-default:9200")
+    }
+
+    @Test
+    fun `getSpecificationSources should use graphql per-spec baseUrl when spec id matches`(@TempDir tempDir: File) {
+        val specFile = tempDir.resolve("service.graphql").apply { writeText("type Query { ping: String }") }
+        val source = SourceV3.create(filesystem = SourceV3.FileSystem(directory = tempDir.canonicalPath))
+        val graphConfig = GraphQLSdlTestConfig(
+            specs = listOf(
+                RunOptionsSpecifications(
+                    RunOptionsSpecifications.Value(id = "graphql-spec", host = "graphql-spec", port = 9301)
+                )
+            )
+        ).apply {
+            put("host", "graphql-default")
+            put("port", 9300)
+        }
+
+        val serviceConfig = CommonServiceConfig<TestRunOptions, TestSettings>(
+            definitions = listOf(
+                Definition(
+                    Definition.Value(
+                        source = RefOrValue.Value(source),
+                        specs = listOf(
+                            SpecificationDefinition.ObjectValue(
+                                SpecificationDefinition.Specification(id = "graphql-spec", path = specFile.name)
+                            )
+                        )
+                    )
+                )
+            ),
+            runOptions = RefOrValue.Value(TestRunOptions(graphqlsdl = graphConfig))
+        )
+
+        val entries = TestServiceConfig(service = RefOrValue.Value(serviceConfig)).getSpecificationSources(resolver, null).values.flatten()
+        assertThat(entries.single().baseUrl).isEqualTo("graphql-spec:9301")
+    }
+
+    @Test
+    fun `getSpecificationSources should fallback to graphql runOption baseUrl when spec id has no match`(@TempDir tempDir: File) {
+        val specFile = tempDir.resolve("service.graphql").apply { writeText("type Query { ping: String }") }
+        val source = SourceV3.create(filesystem = SourceV3.FileSystem(directory = tempDir.canonicalPath))
+        val graphConfig = GraphQLSdlTestConfig(
+            specs = listOf(
+                RunOptionsSpecifications(
+                    RunOptionsSpecifications.Value(id = "different-spec-id", host = "graphql-spec", port = 9301)
+                )
+            )
+        ).apply {
+            put("host", "graphql-default")
+            put("port", 9300)
+        }
+
+        val serviceConfig = CommonServiceConfig<TestRunOptions, TestSettings>(
+            definitions = listOf(
+                Definition(
+                    Definition.Value(
+                        source = RefOrValue.Value(source),
+                        specs = listOf(
+                            SpecificationDefinition.ObjectValue(
+                                SpecificationDefinition.Specification(id = "graphql-spec", path = specFile.name)
+                            )
+                        )
+                    )
+                )
+            ),
+            runOptions = RefOrValue.Value(TestRunOptions(graphqlsdl = graphConfig))
+        )
+
+        val entries = TestServiceConfig(service = RefOrValue.Value(serviceConfig)).getSpecificationSources(resolver, null).values.flatten()
+        assertThat(entries.single().baseUrl).isEqualTo("graphql-default:9300")
+    }
+
+    @Test
+    fun `getSpecificationSources should resolve openapi and asyncapi yaml specs in same service`(@TempDir tempDir: File) {
+        val openApiSpecFile = tempDir.resolve("openapi-contract.yaml").apply { writeText("openapi: 3.0.0") }
+        val asyncApiSpecFile = tempDir.resolve("asyncapi-contract.yaml").apply { writeText("asyncapi: 2.6.0") }
+        val source = SourceV3.create(filesystem = SourceV3.FileSystem(directory = tempDir.canonicalPath))
+        val asyncConfig = AsyncApiTestConfig().apply {
+            put("inMemoryBroker", mapOf("host" to "async-host", "port" to 9400))
+        }
+
+        val serviceConfig = CommonServiceConfig<TestRunOptions, TestSettings>(
+            definitions = listOf(
+                Definition(
+                    Definition.Value(
+                        source = RefOrValue.Value(source),
+                        specs = listOf(
+                            SpecificationDefinition.StringValue(openApiSpecFile.name),
+                            SpecificationDefinition.StringValue(asyncApiSpecFile.name)
+                        )
+                    )
+                )
+            ),
+            runOptions = RefOrValue.Value(
+                TestRunOptions(
+                    openapi = OpenApiTestConfig(baseUrl = "http://openapi-host:9401"),
+                    asyncapi = asyncConfig
+                )
+            )
+        )
+
+        val entriesByPath = TestServiceConfig(service = RefOrValue.Value(serviceConfig))
+            .getSpecificationSources(resolver, null)
+            .values
+            .flatten()
+            .associateBy { it.specPathInConfig }
+
+        assertThat(entriesByPath[openApiSpecFile.name]?.baseUrl).isEqualTo("http://openapi-host:9401")
+        assertThat(entriesByPath[asyncApiSpecFile.name]?.baseUrl).isEqualTo("async-host:9400")
     }
 }


### PR DESCRIPTION
**What**: Update the baseUrl extraction logic in Specmatic configuration version 3.

**Why**: The `AsyncAPI` specType was previously prioritizing the `openAPI` section, resulting in incorrect values being selected

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)