### PR TITLE
chore: update specmatic reporter version which now render actuator url in html report.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 group=io.specmatic
 version=2.39.5-SNAPSHOT
 specmaticGradlePluginVersion=0.14.16
-specmaticReporterVersion=0.3.0
+specmaticReporterVersion=0.3.1
 kotlin.daemon.jvmargs=-Xmx2g
 org.gradle.jvmargs=-Xmx1024m


### PR DESCRIPTION
Reason for change: 
This PR updates the specmatic reporter version to 0.3.1. This new reporter version now ensures that actuator url is rendered in html report if present in the specmatic configuration file.