### PR TITLE
fix: fix the example validation to work with examples that contain matchers

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/pattern/Base64StringPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/Base64StringPattern.kt
@@ -3,7 +3,6 @@ package io.specmatic.core.pattern
 import io.specmatic.core.Resolver
 import io.specmatic.core.Result
 import io.specmatic.core.dataTypeMismatchResult
-import io.specmatic.core.valueMismatchResult
 import io.specmatic.core.pattern.config.NegativePatternConfiguration
 import io.specmatic.core.value.JSONArrayValue
 import io.specmatic.core.value.StringValue
@@ -13,7 +12,7 @@ import java.util.*
 
 data class Base64StringPattern(override val typeAlias: String? = null) : Pattern, ScalarType {
     override fun matches(sampleData: Value?, resolver: Resolver): Result {
-        if (sampleData?.hasTemplate() == true) return Result.Success()
+        if(sampleData?.hasSupportedTemplate() == true) return Result.Success()
         return when {
             sampleData is StringValue && Base64.isBase64(sampleData.string) -> Result.Success()
             else -> dataTypeMismatchResult(actualTypeName, sampleData, resolver.mismatchMessages)

--- a/core/src/main/kotlin/io/specmatic/core/pattern/BinaryPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/BinaryPattern.kt
@@ -15,7 +15,7 @@ data class BinaryPattern(
 ) : Pattern, ScalarType {
 
     override fun matches(sampleData: Value?, resolver: Resolver): Result {
-        if (sampleData?.hasTemplate() == true)
+        if (sampleData?.hasSupportedTemplate() == true)
             return Result.Success()
 
         return when (sampleData) {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/BooleanPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/BooleanPattern.kt
@@ -11,7 +11,7 @@ import java.util.*
 
 data class BooleanPattern(override val example: String? = null) : Pattern, ScalarType, HasDefaultExample {
     override fun matches(sampleData: Value?, resolver: Resolver): Result {
-        if (sampleData?.hasTemplate() == true)
+        if(sampleData?.hasSupportedTemplate() == true)
             return Result.Success()
 
         return when (sampleData) {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/DatePattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/DatePattern.kt
@@ -11,7 +11,7 @@ import io.specmatic.core.value.Value
 
 object DatePattern : Pattern, ScalarType {
     override fun matches(sampleData: Value?, resolver: Resolver): Result {
-        if (sampleData?.hasTemplate() == true)
+        if(sampleData?.hasSupportedTemplate() == true)
             return Result.Success()
 
         return when (sampleData) {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/DateTimePattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/DateTimePattern.kt
@@ -11,7 +11,7 @@ import io.specmatic.core.value.Value
 
 object DateTimePattern : Pattern, ScalarType {
     override fun matches(sampleData: Value?, resolver: Resolver): Result {
-        if (sampleData?.hasTemplate() == true)
+        if(sampleData?.hasSupportedTemplate() == true)
             return Result.Success()
 
         return when (sampleData) {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/EmailPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/EmailPattern.kt
@@ -32,7 +32,7 @@ class EmailPattern (private val stringPatternDelegate: StringPattern, val exampl
     }
 
     override fun matches(sampleData: Value?, resolver: Resolver): Result {
-        if (sampleData?.hasTemplate() == true)
+        if(sampleData?.hasSupportedTemplate() == true)
             return Result.Success()
 
         if (sampleData !is StringValue) return dataTypeMismatchResult(this, sampleData, resolver.mismatchMessages)

--- a/core/src/main/kotlin/io/specmatic/core/pattern/EnumPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/EnumPattern.kt
@@ -60,7 +60,7 @@ data class EnumPattern(override val pattern: AnyPattern, val nullable: Boolean) 
     }
 
     override fun matches(sampleData: Value?, resolver: Resolver): Result {
-        if(sampleData is StringValue && (sampleData.hasTemplate() || sampleData.hasDataTemplate())) {
+        if(sampleData is StringValue && (sampleData.hasSupportedTemplate())) {
             return Result.Success()
         }
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/NullPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/NullPattern.kt
@@ -13,7 +13,7 @@ const val NULL_TYPE = "(null)"
 
 object NullPattern : Pattern, ScalarType {
     override fun matches(sampleData: Value?, resolver: Resolver): Result {
-        if (sampleData?.hasTemplate() == true)
+        if(sampleData?.hasSupportedTemplate() == true)
             return Result.Success()
 
         return when {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/NumberPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/NumberPattern.kt
@@ -55,7 +55,7 @@ data class NumberPattern(
     }
 
     override fun matches(sampleData: Value?, resolver: Resolver): Result {
-        if (sampleData?.hasTemplate() == true)
+        if(sampleData?.hasSupportedTemplate() == true)
             return Result.Success()
 
         if (sampleData !is NumberValue)

--- a/core/src/main/kotlin/io/specmatic/core/pattern/StringPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/StringPattern.kt
@@ -41,7 +41,7 @@ data class StringPattern (
     }
 
     override fun matches(sampleData: Value?, resolver: Resolver): Result {
-        if (sampleData?.hasTemplate() == true)
+        if(sampleData?.hasSupportedTemplate() == true)
             return Result.Success()
 
         val sampleData =

--- a/core/src/main/kotlin/io/specmatic/core/pattern/TimePattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/TimePattern.kt
@@ -11,7 +11,7 @@ import io.specmatic.core.value.Value
 
 object TimePattern : Pattern, ScalarType {
     override fun matches(sampleData: Value?, resolver: Resolver): Result {
-        if (sampleData?.hasTemplate() == true)
+        if(sampleData?.hasSupportedTemplate() == true)
             return Result.Success()
 
         return when (sampleData) {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/UUIDPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/UUIDPattern.kt
@@ -12,7 +12,7 @@ import java.util.*
 
 object UUIDPattern : Pattern, ScalarType {
     override fun matches(sampleData: Value?, resolver: Resolver): Result {
-        if (sampleData?.hasTemplate() == true)
+        if(sampleData?.hasSupportedTemplate() == true)
             return Result.Success()
 
         return when (sampleData) {

--- a/core/src/main/kotlin/io/specmatic/core/value/Value.kt
+++ b/core/src/main/kotlin/io/specmatic/core/value/Value.kt
@@ -33,7 +33,17 @@ interface Value {
     fun typeDeclarationWithKey(key: String, types: Map<String, Pattern>, exampleDeclarations: ExampleDeclarations): Pair<TypeDeclaration, ExampleDeclarations>
     fun listOf(valueList: List<Value>): Value
 
-    fun hasTemplate(): Boolean {
+    fun hasSupportedTemplate(): Boolean {
+        return hasPatternTemplate() || hasMatcherTemplate() || hasDataTemplate()
+    }
+
+    fun hasMatcherTemplate(): Boolean {
+        return this is StringValue
+                && this.string.startsWith("\$match(")
+                && this.string.endsWith(")")
+    }
+
+    fun hasPatternTemplate(): Boolean {
         return this is StringValue
                 && this.string.startsWith("$(")
                 && this.string.endsWith(")")

--- a/core/src/main/kotlin/io/specmatic/core/value/Value.kt
+++ b/core/src/main/kotlin/io/specmatic/core/value/Value.kt
@@ -34,7 +34,7 @@ interface Value {
     fun listOf(valueList: List<Value>): Value
 
     fun hasSupportedTemplate(): Boolean {
-        return hasPatternTemplate() || hasMatcherTemplate() || hasDataTemplate()
+        return hasPatternTemplate() || hasMatcherTemplate()
     }
 
     fun hasMatcherTemplate(): Boolean {
@@ -44,13 +44,7 @@ interface Value {
     }
 
     fun hasPatternTemplate(): Boolean {
-        return this is StringValue
-                && this.string.startsWith("$(")
-                && this.string.endsWith(")")
-    }
-
-    fun hasDataTemplate(): Boolean {
-        return this is StringValue && this.string.hasDataTemplate()
+        return this is StringValue && string.hasDataTemplate()
     }
 
     fun generality(): Int {

--- a/core/src/main/kotlin/io/specmatic/mock/ScenarioStub.kt
+++ b/core/src/main/kotlin/io/specmatic/mock/ScenarioStub.kt
@@ -211,7 +211,7 @@ data class ScenarioStub(
     ): Value {
         return when (value) {
             is StringValue -> {
-                if (value.hasDataTemplate()) {
+                if (value.hasPatternTemplate()) {
                     val substitutionSetName = value.string.removeSurrounding("{{", "}}")
                     val substitutionSet = substitutions[substitutionSetName]
                         ?: throw ContractException("$substitutionSetName does not exist in the data")
@@ -335,7 +335,7 @@ data class ScenarioStub(
     ): Value {
         return when (value) {
             is StringValue -> {
-                if (value.hasDataTemplate()) {
+                if (value.hasPatternTemplate()) {
                     val dataSetIdentifiers = DataSetIdentifiers(value.string, key)
 
                     val substitutionSet = substitutions[dataSetIdentifiers.name]

--- a/core/src/test/kotlin/io/specmatic/core/pattern/SupportedTemplatePatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/SupportedTemplatePatternTest.kt
@@ -1,0 +1,47 @@
+package io.specmatic.core.pattern
+
+import io.specmatic.core.Resolver
+import io.specmatic.core.Result
+import io.specmatic.core.value.StringValue
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+internal class SupportedTemplatePatternTest {
+    @ParameterizedTest
+    @ValueSource(strings = ["\$match(data.id)", "$(string)"])
+    fun `supported templates should be treated as valid input by scalar patterns`(template: String) {
+        val supportedTemplate = StringValue(template)
+        val patterns = listOf(
+            Base64StringPattern(),
+            BinaryPattern(),
+            BooleanPattern(),
+            DatePattern,
+            DateTimePattern,
+            EmailPattern(),
+            EnumPattern(listOf(StringValue("one"))),
+            NullPattern,
+            NumberPattern(),
+            StringPattern(),
+            TimePattern,
+            UUIDPattern
+        )
+
+        patterns.forEach { pattern ->
+            val result = pattern.matches(supportedTemplate, Resolver())
+            assertThat(result)
+                .withFailMessage("Expected template $template to pass for ${pattern::class.simpleName}")
+                .isInstanceOf(Result.Success::class.java)
+        }
+    }
+
+    @Test
+    fun `malformed matcher template should not bypass regular type checks`() {
+        val malformedMatcherTemplate = StringValue("\$match(data.id")
+
+        val result = NumberPattern().matches(malformedMatcherTemplate, Resolver())
+
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
+    }
+}


### PR DESCRIPTION
Reason for change -
The example validation was failing for an example containing matchers. This PR fixes the same.