### PR TITLE
Implement helper in ExampleModule to get firstExampleDir

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3Impl.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3Impl.kt
@@ -593,7 +593,7 @@ data class SpecmaticConfigV3Impl(val file: File? = null, private val specmaticCo
 
     override fun getTestExampleDirs(specFile: File): List<String> {
         return buildList {
-            addAll(specmaticConfig.systemUnderTest?.getExampleDirs(resolver).orEmpty())
+            addAll(specmaticConfig.systemUnderTest?.getExampleDirs(specFile, resolver).orEmpty())
             addAll(exampleFromSysProp())
         }
     }

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/MockServiceConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/MockServiceConfig.kt
@@ -89,9 +89,9 @@ data class MockServiceConfig(val services: List<Value>, val data: Data? = null, 
 
     @JsonIgnore
     fun getExampleDirs(specFile: File, resolver: RefOrValueResolver): List<String> {
+        val service = getService(specFile, resolver) ?: return emptyList()
         val dependencyExamples = data?.toExampleDirs(resolver)
-        val service = getService(specFile, resolver)
-        val serviceExamples = service?.data?.toExampleDirs(resolver)
+        val serviceExamples = service.data?.toExampleDirs(resolver)
         return mergeExamples(dependencyExamples, serviceExamples).orEmpty()
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/MockServiceConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/MockServiceConfig.kt
@@ -21,7 +21,7 @@ import java.io.File
 import kotlin.collections.orEmpty
 import kotlin.collections.plus
 
-data class MockServiceConfig(val services: List<Value>, val data: Data? = null, val settings: RefOrValue<MockSettings>?) {
+data class MockServiceConfig(val services: List<Value>, val data: Data? = null, val settings: RefOrValue<MockSettings>? = null) {
     data class Value(val service: RefOrValue<CommonServiceConfig<MockRunOptions, MockSettings>>)
 
     @JsonIgnore

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/TestServiceConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/TestServiceConfig.kt
@@ -83,6 +83,18 @@ data class TestServiceConfig(val service: RefOrValue<CommonServiceConfig<TestRun
     }
 
     @JsonIgnore
+    fun getExampleDirs(specFile: File, resolver: RefOrValueResolver): List<String>? {
+        val service = service.resolveElseThrow(resolver)
+        val containsDefinition = service.definitions.map { it.definition }.any { definition ->
+            val source = definition.source.resolveElseThrow(resolver)
+            definition.specs.any { it.matchesFile(source, specFile) }
+        }
+
+        if (!containsDefinition) return null
+        return service.data?.toExampleDirs(resolver)
+    }
+
+    @JsonIgnore
     fun getExampleDirs(resolver: RefOrValueResolver): List<String>? {
         val service = service.resolveElseThrow(resolver)
         return service.data?.toExampleDirs(resolver)


### PR DESCRIPTION
**What**: Implement a helper in ExampleModule to retrieve firstExampleDir

**Why**: Allows example generation to re-use an already existing directory specified in the config

**How**: The ExampleModule will return the following in order of priority:
- The first common directory between the test and mock exampleDirs for the specified specFile
- The first test directory, if available
- The first mock directory, if available
- The default _examples directory, if none of the above conditions are met

**Checklist**:

- [x] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
