### PR TITLE
Fix EqualityMatcher toPattern conversion to allow floats

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/matchers/EqualityMatcher.kt
+++ b/core/src/main/kotlin/io/specmatic/core/matchers/EqualityMatcher.kt
@@ -93,7 +93,7 @@ data class EqualityMatcher(val path: BreadCrumb, val value: Value, val strategy:
             override fun toPatternSimplified(value: Value): Pattern? {
                 val properties = extractPropertiesIfExist(value)
                 return if (properties.isNullOrEmpty() || !canParseFrom(BreadCrumb.from(), properties)) {
-                    if (value is StringValue && value.nativeValue.contains(".")) return null
+                    if (value is StringValue && isDottedNonNumeric(value.nativeValue)) return null
                     if (defaultStrategy == EqualityStrategy.EQUALS) createPattern(value) else null
                 } else {
                     toPatternSimplified(properties)
@@ -102,12 +102,14 @@ data class EqualityMatcher(val path: BreadCrumb, val value: Value, val strategy:
 
             override fun toPatternSimplified(properties: Map<String, Value>): Pattern? {
                 val value = properties[VALUE_KEY] ?: return null
-                if (value is StringValue && value.nativeValue.contains(".")) return null
+                if (value is StringValue && isDottedNonNumeric(value.nativeValue)) return null
                 val strategyKey = properties.getOrDefault(EQUALITY_KEY, StringValue("eq"))
                 val equalityStrategy = EqualityStrategy.from(strategyKey.toStringLiteral())
                 if (equalityStrategy.withDefault(EqualityStrategy.EQUALS) { it } != defaultStrategy) return null
                 return createPattern(value)
             }
+
+            private fun isDottedNonNumeric(value: String): Boolean = value.contains(".") && value.toBigDecimalOrNull() == null
         }
 
         @MatcherKey("eq")

--- a/core/src/main/kotlin/io/specmatic/core/matchers/EqualityMatcher.kt
+++ b/core/src/main/kotlin/io/specmatic/core/matchers/EqualityMatcher.kt
@@ -91,25 +91,16 @@ data class EqualityMatcher(val path: BreadCrumb, val value: Value, val strategy:
             }
 
             override fun toPatternSimplified(value: Value): Pattern? {
-                val properties = extractPropertiesIfExist(value)
-                return if (properties.isNullOrEmpty() || !canParseFrom(BreadCrumb.from(), properties)) {
-                    if (value is StringValue && isDottedNonNumeric(value.nativeValue)) return null
-                    if (defaultStrategy == EqualityStrategy.EQUALS) createPattern(value) else null
-                } else {
-                    toPatternSimplified(properties)
-                }
+                return null
             }
 
             override fun toPatternSimplified(properties: Map<String, Value>): Pattern? {
                 val value = properties[VALUE_KEY] ?: return null
-                if (value is StringValue && isDottedNonNumeric(value.nativeValue)) return null
                 val strategyKey = properties.getOrDefault(EQUALITY_KEY, StringValue("eq"))
                 val equalityStrategy = EqualityStrategy.from(strategyKey.toStringLiteral())
                 if (equalityStrategy.withDefault(EqualityStrategy.EQUALS) { it } != defaultStrategy) return null
                 return createPattern(value)
             }
-
-            private fun isDottedNonNumeric(value: String): Boolean = value.contains(".") && value.toBigDecimalOrNull() == null
         }
 
         @MatcherKey("eq")

--- a/core/src/test/kotlin/io/specmatic/core/matchers/EqualityMatcherTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/matchers/EqualityMatcherTest.kt
@@ -14,6 +14,8 @@ import io.specmatic.core.value.StringValue
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 
 class EqualityMatcherTest {
     private val mockResolver = mockk<Resolver>()
@@ -192,6 +194,30 @@ class EqualityMatcherTest {
             )
 
             assertThat(result).isInstanceOf(HasFailure::class.java)
+        }
+
+        @ParameterizedTest(name = "value=''{0}'' → shouldSkip={1}")
+        @CsvSource(
+            "1.23, false",
+            "0.5, false",
+            ".5, false",
+            "10., false",
+            "123.0001, false",
+            "123, false",
+            "abc, false",
+            "abc.def, true",
+            "v1.2.3, true",
+            "foo.bar.baz, true",
+            "version.1, true"
+        )
+        fun `should skip only dotted non-numeric strings`(raw: String, shouldSkip: Boolean) {
+            val value = StringValue(raw)
+            val result = EqualityMatcher.Companion.EqualityFactory.toPatternSimplified(value)
+            if (shouldSkip) {
+                assertThat(result).isNull()
+            } else {
+                assertThat(result).isNotNull()
+            }
         }
     }
 

--- a/core/src/test/kotlin/io/specmatic/core/matchers/EqualityMatcherTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/matchers/EqualityMatcherTest.kt
@@ -196,28 +196,46 @@ class EqualityMatcherTest {
             assertThat(result).isInstanceOf(HasFailure::class.java)
         }
 
-        @ParameterizedTest(name = "value=''{0}'' → shouldSkip={1}")
+        @ParameterizedTest(name = "value=''{0}'' → pattern should be created")
         @CsvSource(
-            "1.23, false",
-            "0.5, false",
-            ".5, false",
-            "10., false",
-            "123.0001, false",
-            "123, false",
-            "abc, false",
-            "abc.def, true",
-            "v1.2.3, true",
-            "foo.bar.baz, true",
-            "version.1, true"
+            "1.23",
+            "0.5",
+            ".5",
+            "10.",
+            "123.0001",
+            "123",
+            "abc",
+            "abc.def",
+            "gmail.com",
+            "v1.2.3",
+            "foo.bar.baz",
+            "version.1",
+            "a.b"
         )
-        fun `should skip only dotted non-numeric strings`(raw: String, shouldSkip: Boolean) {
-            val value = StringValue(raw)
-            val result = EqualityMatcher.Companion.EqualityFactory.toPatternSimplified(value)
-            if (shouldSkip) {
-                assertThat(result).isNull()
-            } else {
-                assertThat(result).isNotNull()
-            }
+        fun `should create pattern for any string including dotted`(raw: String) {
+            val result = EqualityMatcher.Companion.EqualityFactory.toPatternSimplified(mapOf("exact" to StringValue(raw)))
+            assertThat(result).isNotNull()
+        }
+
+        @ParameterizedTest(name = "value=''{0}'' → pattern should be created")
+        @CsvSource(
+            "1.23",
+            "0.5",
+            ".5",
+            "10.",
+            "123.0001",
+            "123",
+            "abc",
+            "abc.def",
+            "gmail.com",
+            "v1.2.3",
+            "foo.bar.baz",
+            "version.1",
+            "a.b"
+        )
+        fun `should not create pattern for any string including dotted when called with $eq`(raw: String) {
+            val result = EqualityMatcher.Companion.EqualityFactory.toPatternSimplified(StringValue("\$eq($raw)"))
+            assertThat(result).isNull()
         }
     }
 


### PR DESCRIPTION
**What**: Fix the EqualityMatcher toPattern conversion to support float values

**Checklist**:
- [x] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)