### PR TITLE
Refactor inline example handling to NamedStub list

### DIFF
--- a/application/src/main/kotlin/application/ExamplesCommand.kt
+++ b/application/src/main/kotlin/application/ExamplesCommand.kt
@@ -9,7 +9,6 @@ import io.specmatic.core.log.configureLogging
 import io.specmatic.core.log.logger
 import io.specmatic.core.utilities.capitalizeFirstChar
 import io.specmatic.license.core.cli.Category
-import io.specmatic.mock.ScenarioStub
 import io.specmatic.stub.isOpenAPI
 import picocli.CommandLine.*
 import java.io.File
@@ -264,11 +263,7 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
         private fun validateInlineExamples(feature: Feature): Map<String, Result> {
             return exampleValidationModule.validateInlineExamples(
                 feature,
-                examples = feature.stubsFromExamples.mapValues { (_, stub) ->
-                    stub.map { (request, response) ->
-                        ScenarioStub(request, response)
-                    }
-                },
+                examples = feature.inlineNamedStubs,
                 scenarioFilter = ScenarioFilter(filterName, filterNotName, filter)
             )
         }

--- a/application/src/main/kotlin/application/validate/OpenApiValidator.kt
+++ b/application/src/main/kotlin/application/validate/OpenApiValidator.kt
@@ -9,7 +9,6 @@ import io.specmatic.core.Result
 import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.examples.module.ExampleValidationModule
 import io.specmatic.core.parseContractFileToFeature
-import io.specmatic.mock.ScenarioStub
 import io.specmatic.test.asserts.toFailure
 import java.io.File
 
@@ -30,9 +29,7 @@ class OpenApiValidator: Validator<Feature> {
     override fun validateInlineExamples(specification: File, feature: Feature, specmaticConfig: SpecmaticConfig): Map<String, ExampleValidationResult> {
         return ExampleValidationModule(specmaticConfig = specmaticConfig).validateInlineExamples(
             feature = feature,
-            examples = feature.stubsFromExamples.mapValues { (_, stub) ->
-                stub.map { (request, response) -> ScenarioStub(request, response) }
-            },
+            examples = feature.inlineNamedStubs,
         ).mapValues { (_, result) ->
             ExampleValidationResult.ValidationResult(specification, result)
         }

--- a/application/src/test/kotlin/application/ExamplesCommandTest.kt
+++ b/application/src/test/kotlin/application/ExamplesCommandTest.kt
@@ -297,6 +297,90 @@ paths:
         }
 
         @Test
+        fun `should fail inline validation when duplicate inline example name has at least one invalid entry`(@TempDir tempDir: File) {
+            val contractFile = tempDir.resolve("duplicate-inline-example-name.yaml")
+            contractFile.writeText(
+                """
+                openapi: 3.0.0
+                info:
+                  title: Duplicate inline example name
+                  version: 1.0.0
+                paths:
+                  /products:
+                    post:
+                      requestBody:
+                        required: true
+                        content:
+                          application/json:
+                            schema:
+                              ${"$"}ref: '#/components/schemas/Product'
+                            examples:
+                              SUCCESS:
+                                value:
+                                  inventory: invalid
+                      responses:
+                        '200':
+                          description: OK
+                          content:
+                            application/json:
+                              schema:
+                                ${"$"}ref: '#/components/schemas/Product'
+                              examples:
+                                SUCCESS:
+                                  value:
+                                    inventory: 100
+                  /orders:
+                    post:
+                      requestBody:
+                        required: true
+                        content:
+                          application/json:
+                            schema:
+                              ${"$"}ref: '#/components/schemas/Product'
+                            examples:
+                              SUCCESS:
+                                value:
+                                  inventory: 200
+                      responses:
+                        '200':
+                          description: OK
+                          content:
+                            application/json:
+                              schema:
+                                ${"$"}ref: '#/components/schemas/Product'
+                              examples:
+                                SUCCESS:
+                                  value:
+                                    inventory: 200
+                components:
+                  schemas:
+                    Product:
+                      type: object
+                      required:
+                        - inventory
+                      properties:
+                        inventory:
+                          type: integer
+                """.trimIndent()
+            )
+
+            val command = ExamplesCommand.Validate().also {
+                it.contractFile = contractFile
+                it.examplesToValidate = ExamplesCommand.Validate.ExamplesToValidate.INLINE
+            }
+
+            val (stdOut, exitCode) = captureStandardOutput { command.call() }
+
+            assertThat(exitCode).isEqualTo(1)
+            assertThat(stdOut).containsIgnoringWhitespaces("Error(s) found in the Inline example - 'SUCCESS'")
+            assertThat(stdOut).containsIgnoringWhitespaces("""
+            =============== Inline Example Validation Summary ===============
+            All 1 example(s) are invalid.
+            =================================================================
+            """.trimIndent())
+        }
+
+        @Test
         fun `should validate external only when the examplesToValidate flag is set to external`() {
             val command = ExamplesCommand.Validate().also {
                 it.contractFile = specFile

--- a/core/src/main/kotlin/io/specmatic/conversions/IncludedSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/IncludedSpecification.kt
@@ -1,12 +1,11 @@
 package io.specmatic.conversions
 
-import io.specmatic.core.HttpRequest
-import io.specmatic.core.HttpResponse
+import io.specmatic.core.NamedStub
 import io.specmatic.core.ScenarioInfo
 import io.cucumber.messages.types.Step
 
 interface IncludedSpecification {
-    fun toScenarioInfos(): Pair<List<ScenarioInfo>, Map<String, List<Pair<HttpRequest, HttpResponse>>>>
+    fun toScenarioInfos(): Pair<List<ScenarioInfo>, List<NamedStub>>
     fun matches(
         specmaticScenarioInfo: ScenarioInfo,
         steps: List<Step>

--- a/core/src/main/kotlin/io/specmatic/conversions/WsdlSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/WsdlSpecification.kt
@@ -101,13 +101,13 @@ class WsdlSpecification(
         }
     }
 
-    override fun toScenarioInfos(): Pair<List<ScenarioInfo>, Map<String, List<Pair<HttpRequest, HttpResponse>>>> {
+    override fun toScenarioInfos(): Pair<List<ScenarioInfo>, List<NamedStub>> {
         return scenarioInfos(
             wsdlToFeatureChildren(wsdlFile),
             "",
             true,
             specmaticConfig = specmaticConfig,
-        ) to emptyMap()
+        ) to emptyList()
     }
 
     private fun wsdlToFeatureChildren(wsdlFile: WSDLContent): List<FeatureChild> {

--- a/core/src/main/kotlin/io/specmatic/core/ExampleStore.kt
+++ b/core/src/main/kotlin/io/specmatic/core/ExampleStore.kt
@@ -15,6 +15,25 @@ data class ExampleData(
 
 data class ExampleStore(val examples: List<ExampleData>, val size: Int = examples.size) {
     companion object {
+        fun from(examples: List<NamedStub>, type: ExampleType): ExampleStore {
+            return ExampleStore(
+                examples.map { namedStub ->
+                    ExampleData(
+                        name = namedStub.name,
+                        example = namedStub.stub,
+                        type = type,
+                        tags = namedStub.stub.getTags()
+                    )
+                }
+            )
+        }
+
+        @Deprecated(
+            message = "Use list-based API",
+            replaceWith = ReplaceWith(
+                "from(examples.flatMap { (name, pairs) -> pairs.map { (request, response) -> NamedStub(name, ScenarioStub(request = request, response = response)) } }, type)"
+            )
+        )
         fun from(examples: Map<String, List<Pair<HttpRequest, HttpResponse>>>, type: ExampleType): ExampleStore {
             return ExampleStore(
                 examples.flatMap { (name, pairs) ->

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -183,12 +183,22 @@ data class Feature(
     val protocol: SpecmaticProtocol,
     val exampleDirPaths: List<String> = emptyList()
 ): IFeature {
+    val inlineNamedStubs: List<NamedStub>
+        get() = exampleStore.examples
+            .asSequence()
+            .filter { it.type == ExampleType.INLINE }
+            .map { NamedStub(name = it.name, stub = it.example) }
+            .toList()
 
+    @Deprecated(
+        message = "Use inlineNamedStubs for collision-safe inline example access",
+        replaceWith = ReplaceWith("inlineNamedStubs.groupBy({ it.name }, { it.stub.request to it.stub.response })")
+    )
     val stubsFromExamples: Map<String, List<Pair<HttpRequest, HttpResponse>>>
         get() {
-            return exampleStore.examples.groupBy(
+            return inlineNamedStubs.groupBy(
                 keySelector = { it.name },
-                valueTransform = { it.example.request to it.example.response }
+                valueTransform = { it.stub.request to it.stub.response }
             )
         }
 
@@ -233,37 +243,37 @@ data class Feature(
     }
 
     fun loadInlineExamplesAsStub(): List<ReturnValue<HttpStubData>> {
-        return this.stubsFromExamples.entries.flatMap { (exampleName, examples) ->
-            examples.mapNotNull { (request, response) ->
-                try {
-                    val stubData: HttpStubData =
-                        this.matchingStub(request, response, NamedExampleMismatchMessages(exampleName))
+        return this.inlineNamedStubs.mapNotNull { namedStub ->
+            val exampleName = namedStub.name
+            val stub = namedStub.stub
+            try {
+                val stubData: HttpStubData =
+                    this.matchingStub(stub.request, stub.response, NamedExampleMismatchMessages(exampleName))
 
-                    if (stubData.matchFailure) {
-                        logger.newLine()
-                        logger.log(stubData.response.body.toStringLiteral())
-                        null
-                    } else {
-                        HasValue(stubData)
-                    }
-                } catch (e: Throwable) {
+                if (stubData.matchFailure) {
                     logger.newLine()
+                    logger.log(stubData.response.body.toStringLiteral())
+                    null
+                } else {
+                    HasValue(stubData)
+                }
+            } catch (e: Throwable) {
+                logger.newLine()
 
-                    when (e) {
-                        is ContractException -> {
-                            logger.log(e)
-                            null
-                        }
+                when (e) {
+                    is ContractException -> {
+                        logger.log(e)
+                        null
+                    }
 
-                        is NoMatchingScenario -> {
-                            logger.log(e, "[Example $exampleName]")
-                            HasFailure("[Example $exampleName] ${e.message}")
-                        }
+                    is NoMatchingScenario -> {
+                        logger.log(e, "[Example $exampleName]")
+                        HasFailure("[Example $exampleName] ${e.message}")
+                    }
 
-                        else -> {
-                            logger.log(e, "[Example $exampleName]")
-                            throw e
-                        }
+                    else -> {
+                        logger.log(e, "[Example $exampleName]")
+                        throw e
                     }
                 }
             }
@@ -2282,6 +2292,12 @@ data class Feature(
             return examplesDirFor(openApiFilePath, TEST_DIR_SUFFIX)
         }
 
+        @Deprecated(
+            message = "Use list-based inlineExamples overload",
+            replaceWith = ReplaceWith(
+                "from(scenarios, serverState, name, testVariables, testBaseURLs, path, sourceProvider, sourceRepository, sourceRepositoryBranch, specification, stubsFromExamples.flatMap { (exampleName, stubs) -> stubs.map { (request, response) -> NamedStub(exampleName, ScenarioStub(request = request, response = response)) } }, specmaticConfig, flagsBased, strictMode, protocol, exampleDirPaths)"
+            )
+        )
         fun from(
             scenarios: List<Scenario> = emptyList(),
             serverState: Map<String, Value> = emptyMap(),
@@ -2294,6 +2310,49 @@ data class Feature(
             sourceRepositoryBranch: String? = null,
             specification: String? = null,
             stubsFromExamples: Map<String, List<Pair<HttpRequest, HttpResponse>>> = emptyMap(),
+            specmaticConfig: SpecmaticConfig = SpecmaticConfig(),
+            flagsBased: FlagsBased = strategiesFromFlags(specmaticConfig),
+            strictMode: Boolean = false,
+            protocol: SpecmaticProtocol,
+            exampleDirPaths: List<String> = emptyList()
+        ): Feature {
+            val inlineExamples = stubsFromExamples.flatMap { (exampleName, stubs) ->
+                stubs.map { (request, response) ->
+                    NamedStub(exampleName, ScenarioStub(request = request, response = response))
+                }
+            }
+            return from(
+                scenarios = scenarios,
+                serverState = serverState,
+                name = name,
+                testVariables = testVariables,
+                testBaseURLs = testBaseURLs,
+                path = path,
+                sourceProvider = sourceProvider,
+                sourceRepository = sourceRepository,
+                sourceRepositoryBranch = sourceRepositoryBranch,
+                specification = specification,
+                inlineExamples = inlineExamples,
+                specmaticConfig = specmaticConfig,
+                flagsBased = flagsBased,
+                strictMode = strictMode,
+                protocol = protocol,
+                exampleDirPaths = exampleDirPaths
+            )
+        }
+
+        fun from(
+            scenarios: List<Scenario> = emptyList(),
+            serverState: Map<String, Value> = emptyMap(),
+            name: String,
+            testVariables: Map<String, String> = emptyMap(),
+            testBaseURLs: Map<String, String> = emptyMap(),
+            path: String = "",
+            sourceProvider: String? = null,
+            sourceRepository: String? = null,
+            sourceRepositoryBranch: String? = null,
+            specification: String? = null,
+            inlineExamples: List<NamedStub> = emptyList(),
             specmaticConfig: SpecmaticConfig = SpecmaticConfig(),
             flagsBased: FlagsBased = strategiesFromFlags(specmaticConfig),
             strictMode: Boolean = false,
@@ -2314,7 +2373,7 @@ data class Feature(
                 specmaticConfig = specmaticConfig,
                 flagsBased = flagsBased,
                 strictMode = strictMode,
-                exampleStore = ExampleStore.from(stubsFromExamples, type = ExampleType.INLINE),
+                exampleStore = ExampleStore.from(inlineExamples, type = ExampleType.INLINE),
                 protocol = protocol,
                 exampleDirPaths = exampleDirPaths
             )

--- a/core/src/main/kotlin/io/specmatic/core/examples/module/ExampleValidationModule.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/module/ExampleValidationModule.kt
@@ -19,8 +19,34 @@ import java.io.File
 class ExampleValidationModule(private val lenientMode: Boolean = false, private val specmaticConfig: SpecmaticConfig) {
     fun validateInlineExamples(
         feature: Feature,
+        examples: List<NamedStub>,
+        scenarioFilter: ScenarioFilter = ScenarioFilter()
+    ): Map<String, Result> {
+        val groupedExamples = examples.groupBy(
+            keySelector = { it.name },
+            valueTransform = { it.stub }
+        )
+        return validateInlineExamplesInternal(feature, groupedExamples, scenarioFilter)
+    }
+
+    @Deprecated(
+        message = "Use list-based inline examples API",
+        replaceWith = ReplaceWith(
+            "validateInlineExamples(feature, examples.flatMap { (name, stubs) -> stubs.map { NamedStub(name, it) } }, scenarioFilter)"
+        )
+    )
+    fun validateInlineExamples(
+        feature: Feature,
         examples: Map<String, List<ScenarioStub>> = emptyMap(),
         scenarioFilter: ScenarioFilter = ScenarioFilter()
+    ): Map<String, Result> {
+        return validateInlineExamplesInternal(feature, examples, scenarioFilter)
+    }
+
+    private fun validateInlineExamplesInternal(
+        feature: Feature,
+        examples: Map<String, List<ScenarioStub>>,
+        scenarioFilter: ScenarioFilter
     ): Map<String, Result> {
         val updatedFeature = scenarioFilter.filter(feature)
 


### PR DESCRIPTION
**What**:
- Reworked inline example conversion to expose `inlineNamedStubs`/`NamedStub` lists and plumbed this through the OpenAPI, WSDL, and feature loaders so validation and stubs keep their names.
- Added list-based `ExampleStore.from` and example validation APIs while leaving the map-based helpers deprecated for backward compatibility.
- Simplified inline example warning logic to run per operation and emit warnings for unused request examples even when names are reused.

**Why**:
- Preserve example names for better diagnostics, avoid collection ordering issues, and prepare for the eventual removal of the map-style `stubsFromExamples` API.
- Provide a clearer inline example validation path that aligns with the new list structure and supports the updated warnings.

**How**:
- Updated `OpenApiSpecification` and `ExampleValidationModule` to consume `inlineNamedStubs` rather than `stubsFromExamples`, merged request examples, and collected inline responses.
- Added list-based constructors and helpers in `Feature` and `ExampleStore`, keeping deprecated map-based overloads with replacement hints.
- Added new inline example warnings for unused examples across operations that reuse the same names.

**Checklist**:
- [ ] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)

## Summary
- Inline example flows now rely on `inlineNamedStubs`/`NamedStub`, enabling name-safe validation and warnings.
- Deprecated map-based example APIs remain for compatibility while promoting the new list-based helpers.

## Testing
- Not run (not requested)

When raising a pull request look for a github pull request template at .github/PULL_REQUEST_TEMPLATE.md.

If you find it, fill up the template, check off relevant items in the checklist, remove the Issue ID section at the endend. Then use it as the description of the pull request.