### PR TITLE
Fix backward compatibility run failure for refed response headers

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/HttpResponsePattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpResponsePattern.kt
@@ -4,7 +4,6 @@ import io.specmatic.core.discriminator.DiscriminatorBasedItem
 import io.specmatic.core.discriminator.DiscriminatorBasedValueGenerator
 import io.specmatic.core.discriminator.DiscriminatorMetadata
 import io.specmatic.core.pattern.*
-import io.specmatic.core.utilities.capitalizeFirstChar
 import io.specmatic.core.value.StringValue
 import io.specmatic.core.value.Value
 import io.specmatic.stub.softCastValueToXML
@@ -165,7 +164,7 @@ data class HttpResponsePattern(
         if(status != other.status)
             return Result.Failure("The status didn't match", breadCrumb = "RESPONSE.STATUS", failureReason = FailureReason.StatusMismatch)
 
-        val headerResult = headersPattern.encompasses(other.headersPattern, Resolver(), Resolver())
+        val headerResult = headersPattern.encompasses(other.headersPattern, olderResolver, newerResolver)
         val bodyResult = resolvedHop(body, olderResolver).encompasses(resolvedHop(other.body, newerResolver), olderResolver, newerResolver).breadCrumb("BODY")
 
         return Result.fromResults(listOf(headerResult, bodyResult)).breadCrumb("RESPONSE")


### PR DESCRIPTION
**What**: Resolve the backward compatibility run failure due to referenced response headers

**How**: The `headersPattern.encompasses` method should receive `olderResolver` and `newerResolver` instead of fresh instances.

**Checklist**:

- [x] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)