### PR TITLE
chore: update specmatic reporter version to support rendering of WIP coverage status in html reporter

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 group=io.specmatic
 version=2.39.7-SNAPSHOT
 specmaticGradlePluginVersion=0.14.16
-specmaticReporterVersion=0.3.2
+specmaticReporterVersion=0.3.3
 kotlin.daemon.jvmargs=-Xmx2g
 org.gradle.jvmargs=-Xmx1024m


### PR DESCRIPTION
Reason to change: 
Update specmatic  reporter version to 0.3.3 which now supports rendering of WIP coverage status in remarks column in operation table in html reporter.