### PR TITLE
Fix OpenAPI components.pathItems refs dropping operations

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -247,9 +247,13 @@ class OpenApiSpecification(
         }
 
         fun checkSpecValidity(openApiFilePath: String, lenientMode: Boolean = false) {
+            val preprocessedYaml = preprocessYamlForParser(
+                yaml = checkExists(File(openApiFilePath)).readText(),
+                collectorContext = CollectorContext()
+            )
             val parseResult: SwaggerParseResult =
                 OpenAPIV3Parser().readContents(
-                    checkExists(File(openApiFilePath)).readText(),
+                    preprocessedYaml,
                     null,
                     resolveExternalReferences(),
                     openApiFilePath,
@@ -286,7 +290,7 @@ class OpenApiSpecification(
             val collectorContext = CollectorContext()
             val implicitOverlayFile = getImplicitOverlayContent(openApiFilePath)
             val mergedYaml = yamlContent.applyOverlay(overlayContent).applyOverlay(implicitOverlayFile)
-            val preprocessedYaml = preprocessYamlForAdditionalProperties(mergedYaml, collectorContext)
+            val preprocessedYaml = preprocessYamlForParser(mergedYaml, collectorContext)
 
             val parseResult: SwaggerParseResult =
                 OpenAPIV3Parser().readContents(
@@ -368,16 +372,54 @@ class OpenApiSpecification(
             ).registerKotlinModule()
         }
 
-        private fun preprocessYamlForAdditionalProperties(yaml: String, collectorContext: CollectorContext): String {
+        private fun preprocessYamlForParser(yaml: String, collectorContext: CollectorContext): String {
             if (yaml.isBlank()) return yaml
 
             return try {
                 val root = yamlPreprocessorMapper.readTree(yaml) ?: return yaml
+                inlinePathItemReferences(root)
                 removeInvalidAdditionalProperties(root, collectorContext = collectorContext)
                 yamlPreprocessorMapper.writeValueAsString(root)
             } catch (exception: Exception) {
-                logger.debug("Skipping additionalProperties preprocessing due to error: ${exception.message}")
+                logger.debug("Skipping OpenAPI preprocessing due to error: ${exception.message}")
                 yaml
+            }
+        }
+
+        private fun inlinePathItemReferences(root: JsonNode) {
+            val openApiVersion = root.get("openapi")?.asText()?.trim().orEmpty()
+            val componentsNode = root.get("components") as? ObjectNode ?: return
+            if (componentsNode.get("pathItems") !is ObjectNode) return
+            val pathsNode = root.get("paths") as? ObjectNode ?: return
+
+            val pathNames = pathsNode.fieldNames().asSequence().toList()
+            pathNames.forEach { pathName ->
+                val pathNode = pathsNode.get(pathName) as? ObjectNode ?: return@forEach
+                val ref = pathNode.get("\$ref")?.asText() ?: return@forEach
+                if (!ref.startsWith("#/components/pathItems/")) return@forEach
+
+                val referencedPathItem = root.at(ref.removePrefix("#"))
+                if (referencedPathItem !is ObjectNode || referencedPathItem.isMissingNode) return@forEach
+
+                val resolvedPathItem = referencedPathItem.deepCopy<ObjectNode>()
+                val inlineFieldNames = pathNode.fieldNames().asSequence().toList()
+                inlineFieldNames.forEach { fieldName ->
+                    if (fieldName != "\$ref") {
+                        val fieldValue = pathNode.get(fieldName)
+                        if (fieldValue != null) {
+                            resolvedPathItem.set<JsonNode>(fieldName, fieldValue.deepCopy())
+                        }
+                    }
+                }
+
+                pathsNode.set<ObjectNode>(pathName, resolvedPathItem)
+            }
+
+            if (openApiVersion.startsWith("3.0")) {
+                componentsNode.remove("pathItems")
+                if (componentsNode.size() == 0) {
+                    (root as? ObjectNode)?.remove("components")
+                }
             }
         }
 

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -386,6 +386,11 @@ class OpenApiSpecification(
             }
         }
 
+        @Suppress("unused")
+        private fun preprocessYamlForAdditionalProperties(yaml: String, collectorContext: CollectorContext): String {
+            return preprocessYamlForParser(yaml, collectorContext)
+        }
+
         private fun inlinePathItemReferences(root: JsonNode) {
             val openApiVersion = root.get("openapi")?.asText()?.trim().orEmpty()
             val componentsNode = root.get("components") as? ObjectNode ?: return


### PR DESCRIPTION
**What**:
- Fix OpenAPI parsing/conversion for path-level `$ref` values that point to `#/components/pathItems/*`.
- Add a parameterized regression test that covers both OpenAPI `3.0.1` and `3.1.0` with the same `components.pathItems` sample shape.

**Why**:
- Specs using `components.pathItems` were failing validation on `3.0.1` (`attribute components.pathItems is unexpected`) and operations were being dropped (`API Operations: 0`) in both `3.0.1` and `3.1.0` test scenarios.

**How**:
- Introduced parser preprocessing in `OpenApiSpecification` that inlines path-level `#/components/pathItems/*` refs into concrete path items before parsing.
- Applied the same preprocessing path in both `fromYAML(...)` and `checkSpecValidity(...)`.
- For OpenAPI `3.0.x`, removed `components.pathItems` after inlining to avoid parser warnings about unsupported attributes.
- Kept existing additionalProperties preprocessing intact.

**Checklist**:
- [x] Unit Tests
- [ ] Build passing locally (targeted tests were run; full suite not run)
- [ ] Sonar Quality Gate (N/A)
- [ ] Security scans don't report any vulnerabilities (N/A)
- [ ] Documentation added/updated (share link) (N/A)
- [ ] Sample Project added/updated (share link) (N/A)
- [ ] Demo video (share link) (N/A)
- [ ] Article on Website (share link) (N/A)
- [ ] Roadmpap updated (share link) (N/A)
- [ ] Conference Talk (share link) (N/A)

**Issue ID**:
Closes: N/A

**Validation**:
- `./gradlew :specmatic-core:test --tests "io.specmatic.conversions.OpenApiSpecificationTest.checkSpecValidity should accept components pathItems references"`
- `./gradlew :specmatic-core:test --tests "io.specmatic.conversions.OpenApiSpecificationTest.should pass checkSpecValidity with valid openapi file" --tests "io.specmatic.conversions.OpenApiSpecificationTest.checkSpecValidity should throw ContractException when a valid openapi file gets parsed with issues" --tests "io.specmatic.conversions.OpenApiSpecificationTest.parser errors should be printed as a WARNING statement on the console"`
