### PR TITLE
Ensure feedback if the dictionary file is missing

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfigV1V2Common.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfigV1V2Common.kt
@@ -177,7 +177,7 @@ data class StubConfiguration(
         return filter
     }
 
-    fun getHttpsConfiguration(): HttpsConfiguration? {
+    fun getHttps(): HttpsConfiguration? {
         return https
     }
 
@@ -960,7 +960,7 @@ data class SpecmaticConfigV1V2Common(
     @JsonIgnore
     override fun getStubHttpsConfiguration(): CertRegistry {
         val registry = CertRegistry.empty()
-        val httpsConfiguration = getStubConfiguration(this).getHttpsConfiguration() ?: return registry
+        val httpsConfiguration = getStubConfiguration(this).getHttps() ?: return registry
         return registry.plusWildCard(httpsConfiguration)
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3Impl.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3Impl.kt
@@ -75,7 +75,6 @@ import io.specmatic.core.utilities.ContractSource
 import io.specmatic.core.utilities.Flags
 import io.specmatic.core.utilities.Flags.Companion.EXAMPLE_DIRECTORIES
 import io.specmatic.core.utilities.Flags.Companion.EXTENSIBLE_QUERY_PARAMS
-import io.specmatic.core.utilities.Flags.Companion.EXTENSIBLE_SCHEMA
 import io.specmatic.core.utilities.Flags.Companion.MAX_TEST_COUNT
 import io.specmatic.core.utilities.Flags.Companion.MAX_TEST_REQUEST_COMBINATIONS
 import io.specmatic.core.utilities.Flags.Companion.SPECMATIC_BASE_URL
@@ -467,9 +466,10 @@ data class SpecmaticConfigV3Impl(val file: File? = null, private val specmaticCo
     }
 
     override fun getStubDictionary(specFile: File?): String? {
-        val mockData = if (specFile == null) { specmaticConfig.dependencies?.data } else { getMockService(specFile)?.data }
+        val serviceData = specFile?.let { getMockService(it)?.data }
+        val dependencyData = specmaticConfig.dependencies?.data
         val fromSysProp = getStringValue(SPECMATIC_STUB_DICTIONARY)
-        val fromConfig = mockData?.dictionary?.resolveElseThrow(resolver)?.path
+        val fromConfig = serviceData?.dictionary?.resolveElseThrow(resolver)?.path ?: dependencyData?.dictionary?.resolveElseThrow(resolver)?.path
         return fromConfig ?: fromSysProp
     }
 

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3ImplTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3ImplTest.kt
@@ -4,6 +4,7 @@ import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.config.toSpecmaticConfig
 import io.specmatic.reporter.model.SpecType
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
@@ -40,6 +41,31 @@ class SpecmaticConfigV3ImplTest {
     @ParameterizedTest
     @MethodSource("testData")
     fun `should return similar values between v2 and v3 test data`(testCase: TestCase) = testCase.run(tempDir)
+
+    @Test
+    fun `getStubDictionary should fallback to dependency level dictionary when service dictionary is absent for matched spec`() {
+        val config = tempDir.resolve("specmatic.yaml").apply {
+            writeText("""
+            version: 3
+            dependencies:
+              services:
+              - service:
+                  definitions:
+                  - definition:
+                      source:
+                        filesystem: {}
+                      specs:
+                        - simple.yaml
+              data:
+                dictionary:
+                  path: ./dictionary_global.yaml
+            """.trimIndent())
+        }.toSpecmaticConfig()
+
+        val specificationSourceEntry = config.getFirstMockSourceMatching { it.specPathInConfig == "simple.yaml" }
+        assertThat(specificationSourceEntry).isNotNull
+        assertThat(config.getStubDictionary(specificationSourceEntry!!.specFile)).isEqualTo("./dictionary_global.yaml")
+    }
 
     companion object {
         data class TestCase(val v2: String, val v3: String, val extract: (SpecmaticConfig) -> Any?) {

--- a/core/src/test/kotlin/io/specmatic/stub/ApiKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/ApiKtTest.kt
@@ -1,11 +1,25 @@
 package io.specmatic.stub
 
+import io.specmatic.core.config.SpecmaticConfigVersion
+import io.specmatic.core.config.v2.ContractConfig
+import io.specmatic.core.config.v2.SpecExecutionConfig
+import io.specmatic.core.config.v2.SpecmaticConfigV2
+import io.specmatic.core.config.v3.Data
+import io.specmatic.core.config.v3.RefOrValue
+import io.specmatic.core.config.v3.SpecmaticConfigV3
+import io.specmatic.core.config.v3.components.Dictionary
+import io.specmatic.core.config.v3.components.services.CommonServiceConfig
+import io.specmatic.core.config.v3.components.services.Definition
+import io.specmatic.core.config.v3.components.services.MockServiceConfig
+import io.specmatic.core.config.v3.components.services.SpecificationDefinition
+import io.specmatic.core.config.v3.components.sources.SourceV3
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import io.specmatic.core.*
 import io.specmatic.core.pattern.parsedValue
 import io.specmatic.core.utilities.ContractPathData
 import io.specmatic.core.utilities.contractStubPaths
+import io.specmatic.core.utilities.yamlMapper
 import io.specmatic.core.value.*
 import io.specmatic.core.examples.server.ExampleMismatchMessages
 import io.specmatic.mock.NoMatchingScenario
@@ -785,6 +799,147 @@ Feature: Math API
         assertThat(output).contains("WARNING").contains("missing.yaml")
     }
 
+    @Test
+    fun `should complain when dictionary file provided in config does not exist for V2 stub`(@TempDir tempDir: File) {
+        val specFile = tempDir.resolve("api.yaml")
+        val dictionaryFile = tempDir.resolve("dictionary.yaml")
+        val configFile = tempDir.resolve("specmatic-v2.yaml")
+
+        specFile.writeText(minimalOpenApiSpec())
+        configFile.writeText(
+            yamlMapper.writeValueAsString(
+                SpecmaticConfigV2(
+                    version = SpecmaticConfigVersion.VERSION_2,
+                    stub = StubConfiguration(dictionary = dictionaryFile.canonicalPath),
+                    contracts = listOf(
+                        ContractConfig(
+                            filesystem = ContractConfig.FileSystemContractSource(tempDir.canonicalPath),
+                            consumes = listOf(SpecExecutionConfig.StringValue(specFile.name))
+                        )
+                    )
+                )
+            )
+        )
+
+        val (output, stubResults) = captureStandardOutput {
+            val paths = contractStubPaths(configFile.canonicalPath)
+            val specmaticConfig = loadSpecmaticConfig(configFile.canonicalPath)
+            loadContractStubsFromImplicitPathsAsResults(
+                contractPathDataList = paths,
+                specmaticConfig = specmaticConfig,
+                externalDataDirPaths = emptyList()
+            )
+        }
+
+        assertThat(stubResults).isEmpty()
+        assertThat(output)
+            .contains("Expected dictionary file at")
+            .contains(dictionaryFile.canonicalPath)
+            .contains("does not exist")
+    }
+
+    @Test
+    fun `should complain when dictionary file provided in config does not exist for V3 stub`(@TempDir tempDir: File) {
+        val specFile = tempDir.resolve("api.yaml")
+        val dictionaryFile = tempDir.resolve("dictionary.yaml")
+        val configFile = tempDir.resolve("specmatic-v3.yaml")
+
+        specFile.writeText(minimalOpenApiSpec())
+        configFile.writeText(
+            yamlMapper.writeValueAsString(
+                SpecmaticConfigV3(
+                    version = SpecmaticConfigVersion.VERSION_3,
+                    dependencies = MockServiceConfig(
+                        services = listOf(
+                            MockServiceConfig.Value(
+                                service = RefOrValue.Value(
+                                    CommonServiceConfig(
+                                        data = Data(dictionary = RefOrValue.Value(Dictionary(path = dictionaryFile.canonicalPath))),
+                                        definitions = listOf(
+                                            Definition(
+                                                Definition.Value(
+                                                    source = RefOrValue.Value(SourceV3.create(filesystem = SourceV3.FileSystem(tempDir.canonicalPath))),
+                                                    specs = listOf(SpecificationDefinition.StringValue(specFile.name))
+                                                )
+                                            )
+                                        ),
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+
+        val (output, stubResults) = captureStandardOutput {
+            val paths = contractStubPaths(configFile.canonicalPath)
+            val specmaticConfig = loadSpecmaticConfig(configFile.canonicalPath)
+            loadContractStubsFromImplicitPathsAsResults(
+                contractPathDataList = paths,
+                specmaticConfig = specmaticConfig,
+                externalDataDirPaths = emptyList()
+            )
+        }
+
+        assertThat(stubResults).isEmpty()
+        assertThat(output)
+            .contains("Expected dictionary file at")
+            .contains(dictionaryFile.canonicalPath)
+            .contains("does not exist")
+    }
+
+    @Test
+    fun `should complain when dictionary file provided in dependency level config does not exist for V3 stub`(@TempDir tempDir: File) {
+        val specFile = tempDir.resolve("api.yaml")
+        val dictionaryFile = tempDir.resolve("dictionary.yaml")
+        val configFile = tempDir.resolve("specmatic-v3-dependency-level.yaml")
+
+        specFile.writeText(minimalOpenApiSpec())
+        configFile.writeText(
+            yamlMapper.writeValueAsString(
+                SpecmaticConfigV3(
+                    version = SpecmaticConfigVersion.VERSION_3,
+                    dependencies = MockServiceConfig(
+                        data = Data(dictionary = RefOrValue.Value(Dictionary(path = dictionaryFile.canonicalPath))),
+                        services = listOf(
+                            MockServiceConfig.Value(
+                                service = RefOrValue.Value(
+                                    CommonServiceConfig(
+                                        definitions = listOf(
+                                            Definition(
+                                                Definition.Value(
+                                                    source = RefOrValue.Value(SourceV3.create(filesystem = SourceV3.FileSystem(tempDir.canonicalPath))),
+                                                    specs = listOf(SpecificationDefinition.StringValue(specFile.name))
+                                                )
+                                            )
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+
+        val (output, stubResults) = captureStandardOutput {
+            val paths = contractStubPaths(configFile.canonicalPath)
+            val specmaticConfig = loadSpecmaticConfig(configFile.canonicalPath)
+            loadContractStubsFromImplicitPathsAsResults(
+                contractPathDataList = paths,
+                specmaticConfig = specmaticConfig,
+                externalDataDirPaths = emptyList()
+            )
+        }
+
+        assertThat(stubResults).isEmpty()
+        assertThat(output)
+            .contains("Expected dictionary file at")
+            .contains(dictionaryFile.canonicalPath)
+            .contains("does not exist")
+    }
+
     companion object {
         @JvmStatic
         fun missingSpecConfigTemplates(): List<Arguments> =
@@ -820,6 +975,20 @@ Feature: Math API
     private fun loadedScenarioStubNames(results: List<FeatureStubsResult>): List<String> {
         return results.filterIsInstance<FeatureStubsResult.Success>().flatMap { it.scenarioStubs }.mapNotNull { it.name }
     }
+
+    private fun minimalOpenApiSpec(): String =
+        """
+        openapi: 3.0.0
+        info:
+          title: Sample
+          version: 1.0.0
+        paths:
+          /health:
+            get:
+              responses:
+                '200':
+                  description: OK
+        """.trimIndent()
 }
 
 fun <ReturnType> captureStandardOutput(trim: Boolean = true, fn: () -> ReturnType): Pair<String, ReturnType> {

--- a/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
@@ -2,8 +2,24 @@ package io.specmatic.test
 
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpResponse
+import io.specmatic.core.SPECMATIC_STUB_DICTIONARY
 import io.specmatic.core.TestConfig
+import io.specmatic.core.config.SpecmaticConfigVersion
+import io.specmatic.core.config.v2.ContractConfig
+import io.specmatic.core.config.v2.SpecExecutionConfig
+import io.specmatic.core.config.v2.SpecmaticConfigV2
+import io.specmatic.core.config.v3.Data
+import io.specmatic.core.config.v3.RefOrValue
+import io.specmatic.core.config.v3.SpecmaticConfigV3
+import io.specmatic.core.config.v3.components.Dictionary
+import io.specmatic.core.config.v3.components.services.CommonServiceConfig
+import io.specmatic.core.config.v3.components.services.Definition
+import io.specmatic.core.config.v3.components.services.SpecificationDefinition
+import io.specmatic.core.config.v3.components.services.TestServiceConfig
+import io.specmatic.core.config.v3.components.sources.SourceV3
 import io.specmatic.core.filters.ScenarioMetadataFilter
+import io.specmatic.core.utilities.yamlMapper
+import io.specmatic.core.utilities.Flags
 import io.specmatic.license.core.SpecmaticProtocol
 import io.specmatic.reporter.model.SpecType
 import io.specmatic.reporter.model.TestResult
@@ -650,6 +666,97 @@ paths:
         }
     }
 
+    @Test
+    fun `should complain when dictionary file provided in config does not exist for V2`(@TempDir tempDir: File) {
+        val specFile = tempDir.resolve("api.yaml")
+        val dictionaryFile = tempDir.resolve("dictionary.yaml")
+        val configFile = tempDir.resolve("specmatic.yaml")
+
+        specFile.writeText(
+        """
+        openapi: 3.0.0
+        info:
+          title: Sample
+          version: 1.0.0
+        paths:
+          /health:
+            get:
+              responses:
+                '200':
+                  description: OK
+        """.trimIndent())
+
+        configFile.writeText(
+            yamlMapper.writeValueAsString(
+                SpecmaticConfigV2(
+                    version = SpecmaticConfigVersion.VERSION_2,
+                    contracts = listOf(
+                        ContractConfig(
+                            filesystem = ContractConfig.FileSystemContractSource(tempDir.canonicalPath),
+                            provides = listOf(SpecExecutionConfig.StringValue(specFile.name))
+                        )
+                    )
+                )
+            )
+        )
+
+        Flags.using(SPECMATIC_STUB_DICTIONARY to dictionaryFile.canonicalPath) {
+            assertThatCode { loadTestScenariosWithConfig(configFile.canonicalPath, specFile.canonicalPath) }
+                .hasMessageContaining("Expected dictionary file at")
+                .hasMessageContaining(dictionaryFile.canonicalPath)
+                .hasMessageContaining("but it does not exist")
+        }
+    }
+
+    @Test
+    fun `should complain when dictionary file provided in config does not exist for V3`(@TempDir tempDir: File) {
+        val specFile = tempDir.resolve("api.yaml")
+        val dictionaryFile = tempDir.resolve("dictionary.yaml")
+        val configFile = tempDir.resolve("specmatic-v3.yaml")
+
+        specFile.writeText(
+        """
+        openapi: 3.0.0
+        info:
+          title: Sample
+          version: 1.0.0
+        paths:
+          /health:
+            get:
+              responses:
+                '200':
+                  description: OK
+        """.trimIndent())
+
+        configFile.writeText(
+            yamlMapper.writeValueAsString(
+                SpecmaticConfigV3(
+                    version = SpecmaticConfigVersion.VERSION_3,
+                    systemUnderTest = TestServiceConfig(
+                        service = RefOrValue.Value(
+                            CommonServiceConfig(
+                                data = Data(dictionary = RefOrValue.Value(Dictionary(path = dictionaryFile.canonicalPath))),
+                                definitions = listOf(
+                                    Definition(
+                                        Definition.Value(
+                                            source = RefOrValue.Value(SourceV3.create(filesystem = SourceV3.FileSystem(tempDir.canonicalPath))),
+                                            specs = listOf(SpecificationDefinition.StringValue(specFile.name))
+                                        )
+                                    )
+                                ),
+                            )
+                        )
+                    )
+                )
+            )
+        )
+
+        assertThatCode { loadTestScenariosWithConfig(configFile.canonicalPath, specFile.canonicalPath) }
+            .hasMessageContaining("Expected dictionary file at")
+            .hasMessageContaining(dictionaryFile.canonicalPath)
+            .hasMessageContaining("but it does not exist")
+    }
+
     private fun runContractTestWithConfig(configFilePath: String): String {
         SpecmaticJUnitSupport.settingsStaging.set(
             ContractTestSettings(
@@ -667,6 +774,23 @@ paths:
                 System.setOut(originalOut)
             }
             outputStream.toString()
+        } finally {
+            SpecmaticJUnitSupport.settingsStaging.remove()
+        }
+    }
+
+    private fun loadTestScenariosWithConfig(configFilePath: String, specFilePath: String) {
+        SpecmaticJUnitSupport.settingsStaging.set(ContractTestSettings(configFile = configFilePath))
+        try {
+            SpecmaticJUnitSupport().loadTestScenarios(
+                path = specFilePath,
+                suggestionsPath = "",
+                suggestionsData = "",
+                config = TestConfig(emptyMap(), emptyMap()),
+                filterName = null,
+                filterNotName = null,
+                filter = ScenarioMetadataFilter.from("")
+            )
         } finally {
             SpecmaticJUnitSupport.settingsStaging.remove()
         }


### PR DESCRIPTION
**What**: Provide feedback if the dictionary file specified in config/sys prop is missing

**How**:
- Ensure that exceptions are thrown with the canonical path when the dictionary file is missing
- Resolve the issue in V3Impl where it does not default to the dependencies level dictionary when the service level dictionary is not specified

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)