### PR TITLE
Ensure example loading logs are displayed for mocks

### DIFF
--- a/core/src/main/kotlin/io/specmatic/stub/api.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/api.kt
@@ -452,11 +452,12 @@ fun loadContractStubsFromFilesAsResults(
                 loadIfSupportedAPISpecification(contractPathData, specmaticConfig)
             }.overrideInlineExamplesWithSameNameFrom(dataDirFiles(dataDirPaths))
 
-    dataDirPaths.forEach { dataDirPath ->
+    val exampleDirPathsFromFeatures = features.flatMap { it.second.exampleDirPaths }
+    dataDirPaths.plus(exampleDirPathsFromFeatures).distinct().forEach { dataDirPath ->
         val dataFiles = dataDirFiles(listOf(dataDirPath))
         logger.boundary()
         if (dataFiles.isEmpty()) {
-            debugLogNonExistentDataFiles(dataDirPaths)
+            debugLogNonExistentDataFiles(listOf(dataDirPath))
         } else {
             consoleLog(dataFilesLogForStubScan(dataFiles, listOf(dataDirPath).relativePaths(), logger is Verbose))
             logger.boundary()
@@ -562,8 +563,8 @@ fun loadExpectationsForFeaturesAsResults(
     dirsToBeSkipped: Set<String> = emptySet(),
 ): List<FeatureStubsResult> {
     val exampleDirPathsFromFeatures = features.flatMap { it.second.exampleDirPaths }
-    val dataFiles = dataDirFiles(dataDirPaths + exampleDirPathsFromFeatures, dirsToBeSkipped)
-    logStubScanForDebugging(features, dataFiles, dataDirPaths)
+    val combinedDataDirs = dataDirPaths.plus(exampleDirPathsFromFeatures)
+    val dataFiles = dataDirFiles(combinedDataDirs, dirsToBeSkipped)
 
     val mockData =
         dataFiles.mapNotNull {
@@ -579,6 +580,7 @@ fun loadExpectationsForFeaturesAsResults(
             }
         }
 
+    logStubScanForDebugging(features, mockData.map { File(it.first) }, combinedDataDirs.relativePaths())
     return loadContractStubsAsResults(features, mockData, strictMode)
 }
 

--- a/core/src/main/kotlin/io/specmatic/stub/api.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/api.kt
@@ -608,14 +608,15 @@ private fun List<String>.withAbsolutePaths(): String =
 private fun List<String>.relativePaths(): List<String> {
     val currentWorkingDirectory = File(".").canonicalFile
     return this.map(::File).map {
-        runCatching {
+        val resolved = runCatching {
             it.canonicalFile.relativeTo(currentWorkingDirectory)
         }.getOrElse { e ->
             logger.debug(e, "Failed to relativize ${it.canonicalPath} against ${currentWorkingDirectory.canonicalPath}")
             it
         }
-    }.map {
-        ".${File.separator}${it.path}"
+
+        if (resolved.isAbsolute) return@map resolved.path
+        File(".", resolved.path).path
     }
 }
 

--- a/core/src/test/kotlin/io/specmatic/stub/ApiKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/ApiKtTest.kt
@@ -8,6 +8,8 @@ import io.specmatic.core.utilities.ContractPathData
 import io.specmatic.core.utilities.contractStubPaths
 import io.specmatic.core.value.*
 import io.specmatic.core.examples.server.ExampleMismatchMessages
+import io.specmatic.core.log.DebugLogger
+import io.specmatic.core.log.withLogger
 import io.specmatic.mock.NoMatchingScenario
 import io.specmatic.mock.ScenarioStub
 import io.specmatic.trimmedLinesList
@@ -679,6 +681,53 @@ Feature: Math API
             assertThat(it.scenarioStubs).hasSize(1)
             assertThat(it.scenarioStubs.single().name).isEqualTo("createProduct")
         }
+    }
+
+    @Test
+    fun `loadContractStubsFromFilesAsResults should log example details for feature example directories in debug mode`() {
+        val specFile = File("src/test/resources/wsdl/with_examples/order_api.wsdl")
+        val externalExamplesDir = "src/test/resources/wsdl/with_examples/order_api_examples"
+        val contractPathData = listOf(ContractPathData("", specFile.path, exampleDirPaths = listOf(externalExamplesDir)))
+        val (output, _) = captureStandardOutput(trim = false) {
+            withLogger(DebugLogger) {
+                loadContractStubsFromFilesAsResults(contractPathData, emptyList(), SpecmaticConfig(), withImplicitStubs = false)
+            }
+        }
+
+        val normalizedOutput = output.replace('\\', '/')
+        assertThat(normalizedOutput)
+            .contains("1 examples(s) found in ./src/test/resources/wsdl/with_examples/order_api_examples")
+            .contains("Scanning example files from './src/test/resources/wsdl/with_examples/order_api_examples'")
+            .contains("src/test/resources/wsdl/with_examples/order_api_examples/create_product.json")
+    }
+
+    @Test
+    fun `loadContractStubsFromFilesAsResults should log example count for feature example directories`() {
+        val specFile = File("src/test/resources/wsdl/with_examples/order_api.wsdl")
+        val externalExamplesDir = "src/test/resources/wsdl/with_examples/order_api_examples"
+        val contractPathData = listOf(ContractPathData("", specFile.path, exampleDirPaths = listOf(externalExamplesDir)))
+        val (output, _) = captureStandardOutput(trim = false) {
+            loadContractStubsFromFilesAsResults(contractPathData, emptyList(), SpecmaticConfig(), withImplicitStubs = false)
+        }
+
+        val normalizedOutput = output.replace('\\', '/')
+        assertThat(normalizedOutput)
+            .contains("1 examples(s) found in ./src/test/resources/wsdl/with_examples/order_api_examples")
+            .doesNotContain("Scanning example files from './src/test/resources/wsdl/with_examples/order_api_examples'")
+            .doesNotContain("src/test/resources/wsdl/with_examples/order_api_examples/create_product.json")
+    }
+
+    @Test
+    fun `loadContractStubsFromFilesAsResults should not log explicit example count twice`() {
+        val specFile = File("src/test/resources/wsdl/with_examples/order_api.wsdl")
+        val externalExamplesDir = "src/test/resources/wsdl/with_examples/order_api_examples"
+        val contractPathData = listOf(ContractPathData("", specFile.path))
+        val (output, _) = captureStandardOutput(trim = false) {
+            loadContractStubsFromFilesAsResults(contractPathData, listOf(externalExamplesDir), SpecmaticConfig(), withImplicitStubs = false)
+        }
+
+        val normalizedOutput = output.replace('\\', '/')
+        assertThat(normalizedOutput).containsOnlyOnce("1 examples(s) found in ./src/test/resources/wsdl/with_examples/order_api_examples")
     }
 
     @Test


### PR DESCRIPTION
**What**: Ensure example loading logs are displayed for mock

**Why**: Recent modification in the code path caused mockCommand and programmatic mocks to stop displaying example load information, including count in info mode and detailed paths in debug mode

**Checklist**:

- [x] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
