### PR TITLE
Ensure inlineExample names are recorded by mock

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -255,7 +255,7 @@ data class Feature(
                     logger.log(stubData.response.body.toStringLiteral())
                     null
                 } else {
-                    HasValue(stubData)
+                    HasValue(stubData.copy(scenarioStub = namedStub.stub.withName(exampleName)))
                 }
             } catch (e: Throwable) {
                 logger.newLine()

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -927,17 +927,18 @@ fun testDescription(
     generativePrefix: String,
     apiDescription: String,
     exampleName: String?,
-    requestChangeSummary: String?
+    requestChangeSummary: String?,
+    exampleLabel: String = "example"
 ): String {
     val hasExample = exampleName.isNullOrBlank().not()
     val hasRequestChangeSummary = requestChangeSummary.isNullOrBlank().not()
 
     return when {
         hasExample && hasRequestChangeSummary ->
-            "$generativePrefix Scenario: $apiDescription with the request from the example '${exampleName?.trim()}' where $requestChangeSummary"
+            "$generativePrefix Scenario: $apiDescription with the request from the $exampleLabel '${exampleName?.trim()}' where $requestChangeSummary"
 
         hasExample ->
-            "$generativePrefix Scenario: $apiDescription with the request from the example '${exampleName?.trim()}'"
+            "$generativePrefix Scenario: $apiDescription with the request from the $exampleLabel '${exampleName?.trim()}'"
 
         hasRequestChangeSummary ->
             "$generativePrefix Scenario: $apiDescription with a request where $requestChangeSummary"

--- a/core/src/main/kotlin/io/specmatic/core/log/HttpLogMessage.kt
+++ b/core/src/main/kotlin/io/specmatic/core/log/HttpLogMessage.kt
@@ -29,6 +29,12 @@ data class HttpLogMessage(
     var result: Result? = null,
     val prettyPrint: Boolean = true,
 ) : LogMessage {
+    private val isInlineExample: Boolean
+        get() = exampleName != null && examplePath == null
+
+    private val exampleNameOrPath: String?
+        get() = exampleName ?: examplePath
+
     fun combineLog(): String {
         val request = this.request.toLogString(prettyPrint = prettyPrint).trim('\n')
         val response = this.response?.toLogString(prettyPrint = prettyPrint)?.trim('\n') ?: "No response"
@@ -95,10 +101,10 @@ data class HttpLogMessage(
         }
 
         val contractPathLines = if(contractPath.isNotBlank()) {
-            val exampleLine = if (exampleName != null || examplePath != null) {
-                "${linePrefix}Example matched: ${exampleName ?: examplePath}"
-            } else {
-                null
+            val exampleLine = when {
+                isInlineExample -> "${linePrefix}Inline Example matched: $exampleName"
+                exampleNameOrPath != null -> "${linePrefix}External Example matched: $exampleNameOrPath"
+                else -> null
             }
 
             listOfNotNull(
@@ -162,7 +168,7 @@ data class HttpLogMessage(
 
     fun toResult(): TestResult {
         return when {
-            this.exampleName != null || this.examplePath != null -> TestResult.Success
+            this.exampleNameOrPath != null -> TestResult.Success
             this.scenario != null && response?.status !in invalidRequestStatuses -> TestResult.Success
             scenario == null -> TestResult.MissingInSpec
             else -> TestResult.Failed
@@ -171,7 +177,8 @@ data class HttpLogMessage(
 
     fun toDetails(): String {
         return when {
-            this.exampleName != null || this.examplePath != null -> "Request Matched Example: ${this.exampleName ?: this.examplePath}"
+            this.isInlineExample -> "Request Matched Inline Example: ${this.exampleNameOrPath}"
+            this.exampleNameOrPath != null -> "Request Matched External Example: ${this.exampleNameOrPath}"
             this.scenario != null && response?.status !in invalidRequestStatuses -> "Request Matched Contract ${scenario?.defaultAPIDescription}"
             this.exception != null -> "Invalid Request\n${exception?.let(::exceptionCauseMessage)}"
             else -> response?.body?.toStringLiteral() ?: "Request Didn't Match Contract"
@@ -180,10 +187,17 @@ data class HttpLogMessage(
 
     fun toName(): String {
         val scenario = this.scenario ?: return "Unknown Request"
-        return when {
-            this.exampleName != null -> scenario.copy(exampleName = this.exampleName).testDescription()
-            this.examplePath != null -> scenario.copy(exampleName = this.examplePath?.let(::File)?.name).testDescription()
-            else -> scenario.testDescription()
-        }
+        val apiDescription = scenario.customAPIDescription ?: scenario.defaultAPIDescription
+        return testDescription(
+            generativePrefix = "",
+            requestChangeSummary = null,
+            apiDescription = apiDescription,
+            exampleLabel = if (this.isInlineExample) "inline example" else "external example",
+            exampleName = when {
+                this.exampleName != null -> this.exampleName
+                examplePath != null -> examplePath?.let(::File)?.name
+                else -> null
+            },
+        )
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/log/HttpLogMessage.kt
+++ b/core/src/main/kotlin/io/specmatic/core/log/HttpLogMessage.kt
@@ -32,8 +32,11 @@ data class HttpLogMessage(
     private val isInlineExample: Boolean
         get() = exampleName != null && examplePath == null
 
-    private val exampleNameOrPath: String?
-        get() = exampleName ?: examplePath
+    private val isExternalExample: Boolean
+        get() = examplePath != null
+
+    private val matchedAnExample: Boolean
+        get() = (exampleName ?: examplePath) != null
 
     fun combineLog(): String {
         val request = this.request.toLogString(prettyPrint = prettyPrint).trim('\n')
@@ -103,7 +106,7 @@ data class HttpLogMessage(
         val contractPathLines = if(contractPath.isNotBlank()) {
             val exampleLine = when {
                 isInlineExample -> "${linePrefix}Inline Example matched: $exampleName"
-                exampleNameOrPath != null -> "${linePrefix}External Example matched: $exampleNameOrPath"
+                isExternalExample -> "${linePrefix}External Example matched: $examplePath"
                 else -> null
             }
 
@@ -168,7 +171,7 @@ data class HttpLogMessage(
 
     fun toResult(): TestResult {
         return when {
-            this.exampleNameOrPath != null -> TestResult.Success
+            this.matchedAnExample -> TestResult.Success
             this.scenario != null && response?.status !in invalidRequestStatuses -> TestResult.Success
             scenario == null -> TestResult.MissingInSpec
             else -> TestResult.Failed
@@ -177,8 +180,8 @@ data class HttpLogMessage(
 
     fun toDetails(): String {
         return when {
-            this.isInlineExample -> "Request Matched Inline Example: ${this.exampleNameOrPath}"
-            this.exampleNameOrPath != null -> "Request Matched External Example: ${this.exampleNameOrPath}"
+            this.isInlineExample -> "Request Matched Inline Example: ${this.exampleName}"
+            this.isExternalExample -> "Request Matched External Example: ${this.examplePath}"
             this.scenario != null && response?.status !in invalidRequestStatuses -> "Request Matched Contract ${scenario?.defaultAPIDescription}"
             this.exception != null -> "Invalid Request\n${exception?.let(::exceptionCauseMessage)}"
             else -> response?.body?.toStringLiteral() ?: "Request Didn't Match Contract"

--- a/core/src/main/kotlin/io/specmatic/core/log/HttpLogMessage.kt
+++ b/core/src/main/kotlin/io/specmatic/core/log/HttpLogMessage.kt
@@ -20,6 +20,7 @@ data class HttpLogMessage(
     var postHookResponseTime: CurrentDate? = null,
     var postHookResponse: InterceptorResult<HttpResponse>? = null,
     var contractPath: String = "",
+    var exampleName: String? = null,
     var examplePath: String? = null,
     val targetServer: String = "",
     val comment: String? = null,
@@ -94,7 +95,11 @@ data class HttpLogMessage(
         }
 
         val contractPathLines = if(contractPath.isNotBlank()) {
-            val exampleLine = examplePath?.let { "${linePrefix}Example matched: $examplePath" }
+            val exampleLine = if (exampleName != null || examplePath != null) {
+                "${linePrefix}Example matched: ${exampleName ?: examplePath}"
+            } else {
+                null
+            }
 
             listOfNotNull(
                 "${linePrefix}Contract matched: $contractPath",
@@ -132,6 +137,7 @@ data class HttpLogMessage(
     fun addResponse(stubResponse: HttpStubResponse) {
         addResponseWithCurrentTime(stubResponse.response)
         contractPath = stubResponse.contractPath
+        exampleName = stubResponse.exampleName
         examplePath = stubResponse.examplePath
         scenario = stubResponse.scenario
     }
@@ -156,7 +162,7 @@ data class HttpLogMessage(
 
     fun toResult(): TestResult {
         return when {
-            this.examplePath != null -> TestResult.Success
+            this.exampleName != null || this.examplePath != null -> TestResult.Success
             this.scenario != null && response?.status !in invalidRequestStatuses -> TestResult.Success
             scenario == null -> TestResult.MissingInSpec
             else -> TestResult.Failed
@@ -165,7 +171,7 @@ data class HttpLogMessage(
 
     fun toDetails(): String {
         return when {
-            this.examplePath != null -> "Request Matched Example: ${this.examplePath}"
+            this.exampleName != null || this.examplePath != null -> "Request Matched Example: ${this.exampleName ?: this.examplePath}"
             this.scenario != null && response?.status !in invalidRequestStatuses -> "Request Matched Contract ${scenario?.defaultAPIDescription}"
             this.exception != null -> "Invalid Request\n${exception?.let(::exceptionCauseMessage)}"
             else -> response?.body?.toStringLiteral() ?: "Request Didn't Match Contract"
@@ -174,6 +180,10 @@ data class HttpLogMessage(
 
     fun toName(): String {
         val scenario = this.scenario ?: return "Unknown Request"
-        return scenario.copy(exampleName = this.examplePath?.let(::File)?.name).testDescription()
+        return when {
+            this.exampleName != null -> scenario.copy(exampleName = this.exampleName).testDescription()
+            this.examplePath != null -> scenario.copy(exampleName = this.examplePath?.let(::File)?.name).testDescription()
+            else -> scenario.testDescription()
+        }
     }
 }

--- a/core/src/main/kotlin/io/specmatic/mock/ScenarioStub.kt
+++ b/core/src/main/kotlin/io/specmatic/mock/ScenarioStub.kt
@@ -65,6 +65,10 @@ data class ScenarioStub(
 
     val nameOrFileName: String? = runCatching { name ?: filePath?.let(::File)?.nameWithoutExtension }.getOrNull()
 
+    fun withName(name: String): ScenarioStub {
+        return copy(data = data.copy(jsonObject = data.jsonObject + mapOf("name" to StringValue(name))))
+    }
+
     fun toJSON(): JSONObjectValue {
         val requestResponse: Map<String, Value> =
             if (partial != null) {

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -1381,9 +1381,10 @@ private fun stubbedResponse(
     val stubResponse = stubData?.let {
         val softCastResponse = it.softCastResponseToXML(httpRequest).response
         HttpStubResponse(
-            softCastResponse,
-            it.delayInMilliseconds,
-            it.contractPath,
+            response = softCastResponse,
+            delayInMilliSeconds = it.delayInMilliseconds,
+            contractPath = it.contractPath,
+            exampleName = it.name,
             examplePath = it.examplePath,
             feature = stubData.feature,
             scenario = stubData.scenario,
@@ -1850,3 +1851,4 @@ fun writeEvent(event: SseEvent, writer: Writer) {
     writer.write("\n")
     writer.flush()
 }
+

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStubResponse.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStubResponse.kt
@@ -7,6 +7,7 @@ data class HttpStubResponse(
     val response: HttpResponse,
     val delayInMilliSeconds: Long? = null,
     val contractPath: String = "",
+    val exampleName: String? = null,
     val examplePath: String? = null,
     val feature: Feature? = null,
     val scenario: Scenario? = null,

--- a/core/src/test/kotlin/HttpLogMessageTest.kt
+++ b/core/src/test/kotlin/HttpLogMessageTest.kt
@@ -1,5 +1,6 @@
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpResponse
+import io.specmatic.core.parseContractFileToFeature
 import io.specmatic.core.log.CurrentDate
 import io.specmatic.core.log.HttpLogMessage
 import io.specmatic.core.value.JSONObjectValue
@@ -9,8 +10,11 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.api.Test
+import java.io.File
 
 internal class HttpLogMessageTest {
+    private val feature = parseContractFileToFeature(File("src/test/resources/openapi/partial_example_tests/simple.yaml"))
+    private val scenario = feature.scenarios.first()
     private val dateTime: CurrentDate = CurrentDate()
     private val httpLog = HttpLogMessage(
         requestTime =dateTime,
@@ -70,5 +74,29 @@ internal class HttpLogMessageTest {
     ) {
         val message = HttpLogMessage(request = HttpRequest(method, path))
         assertThat(message.isInternalControlRequestForMockEvent()).isEqualTo(expected)
+    }
+
+    @Test
+    fun `toName should mention inline example for internal example matches`() {
+        val message = HttpLogMessage(
+            request = scenario.generateHttpRequest(),
+            response = scenario.generateHttpResponse(emptyMap()),
+            contractPath = "/path/to/file",
+            scenario = scenario,
+            exampleName = "FIND_SUCCESS"
+        )
+        assertThat(message.toName()).contains("inline example 'FIND_SUCCESS'")
+    }
+
+    @Test
+    fun `toName should mention external example for external examples matches`() {
+        val message = HttpLogMessage(
+            request = scenario.generateHttpRequest(),
+            response = scenario.generateHttpResponse(emptyMap()),
+            contractPath = "/path/to/file",
+            scenario = scenario,
+            examplePath = "examples/example.json"
+        )
+        assertThat(message.toName()).contains("external example 'example.json'")
     }
 }

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
@@ -156,6 +156,52 @@ internal class HttpStubTest {
     }
 
     @Test
+    fun `should include matched inline example name in console logs for non 2xx inline example`() {
+        val specFile = File("src/test/resources/openapi/has_multiple_inline_examples.yaml").canonicalFile
+        val feature = parseContractFileToFeature(specFile)
+
+        val (consoleOutput, _) = captureStandardOutput(trim = false) {
+            HttpStub(features = listOf(feature), log = ::consoleLog).use { stub ->
+                stub.client.execute(
+                    HttpRequest(
+                        method = "GET",
+                        path = "/findAvailableProducts",
+                        headers = mapOf("pageSize" to "20"),
+                        queryParametersMap = mapOf("type" to "other")
+                    )
+                )
+            }
+        }
+
+        assertThat(consoleOutput).contains("Contract matched: ${specFile.path}")
+        assertThat(consoleOutput).contains("Example matched: FIND_TIMEOUT")
+        assertThat(consoleOutput).contains("503 Service Unavailable")
+    }
+
+    @Test
+    fun `should include matched inline example name in console logs for 2xx inline example`() {
+        val specFile = File("src/test/resources/openapi/has_multiple_inline_examples.yaml").canonicalFile
+        val feature = parseContractFileToFeature(specFile)
+
+        val (consoleOutput, _) = captureStandardOutput(trim = false) {
+            HttpStub(features = listOf(feature), log = ::consoleLog).use { stub ->
+                stub.client.execute(
+                    HttpRequest(
+                        method = "GET",
+                        path = "/findAvailableProducts",
+                        headers = mapOf("pageSize" to "10"),
+                        queryParametersMap = mapOf("type" to "gadget")
+                    )
+                )
+            }
+        }
+
+        assertThat(consoleOutput).contains("Contract matched: ${specFile.path}")
+        assertThat(consoleOutput).contains("Example matched: FIND_SUCCESS")
+        assertThat(consoleOutput).contains("200 OK")
+    }
+
+    @Test
     fun `should return plain text 409 from swagger endpoints when only wsdl is mocked`() {
         LogTail.clear()
         val wsdlFeature = parseContractFileToFeature("src/test/resources/wsdl/hello.wsdl")

--- a/core/src/test/kotlin/io/specmatic/stub/listener/MockEventListenerTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/listener/MockEventListenerTest.kt
@@ -19,46 +19,7 @@ class MockEventListenerTest {
         val featureWithInlineExamples = parseContractFileToFeature(inlineExamplesOpenApiFile)
     }
 
-    @Test
-    fun `should callback with appropriate data when request matches the contract`() {
-        val listener = object : MockEventListener {
-            override fun onRespond(data: MockEvent) {
-                assertThat(data.name).isEqualToIgnoringWhitespace("Scenario: PATCH /creators/(creatorId:number)/pets/(petId:number) -> 201")
-                assertThat(data.details).isEqualToIgnoringWhitespace("Request Matched Contract PATCH /creators/(creatorId:number)/pets/(petId:number) -> 201")
-                assertThat(data.scenario).isEqualTo(feature.scenarios.first())
-                assertThat(data.response).isNotNull
-                assertThat(data.responseTime).isNotNull()
-                assertThat(data.stubResult).isEqualTo(TestResult.Success)
-            }
-        }
-
-        HttpStub(feature, listeners = listOf(listener)).use { stub ->
-            val validRequest = feature.scenarios.first().generateHttpRequest()
-            stub.client.execute(validRequest)
-        }
-    }
-
-    @Test
-    fun `should mention matched example in name and details if match occurs`() {
-        val listener = object : MockEventListener {
-            override fun onRespond(data: MockEvent) {
-                assertThat(data.name).contains("EX:example.json")
-                assertThat(data.details).contains("Request Matched Example: examples/example.json")
-                assertThat(data.stubResult).isEqualTo(TestResult.Success)
-            }
-        }
-
-        val (request, response) = feature.scenarios.first().let {
-            it.generateHttpRequest() to it.generateHttpResponse(emptyMap()).copy(headers = emptyMap())
-        }
-        val exampleStub = ScenarioStub(request = request, response = response, filePath = "examples/example.json")
-        HttpStub(feature, scenarioStubs = listOf(exampleStub), listeners = listOf(listener)).use { stub ->
-            stub.client.execute(request)
-        }
-    }
-
-    @Test
-    fun `should include inline example name in mock event when request matches inline example`() {
+    private fun captureMockEvents(testBlock: (MockEventListener) -> Unit): List<MockEvent> {
         val events = mutableListOf<MockEvent>()
         val listener = object : MockEventListener {
             override fun onRespond(data: MockEvent) {
@@ -66,19 +27,67 @@ class MockEventListenerTest {
             }
         }
 
-        HttpStub(featureWithInlineExamples, listeners = listOf(listener)).use { stub ->
-            stub.client.execute(
-                HttpRequest(
-                    method = "GET",
-                    path = "/findAvailableProducts",
-                    headers = mapOf("pageSize" to "20"),
-                    queryParametersMap = mapOf("type" to "other")
+        testBlock(listener)
+        return events
+    }
+
+    @Test
+    fun `should callback with appropriate data when request matches the contract`() {
+        val captureMockEvents = captureMockEvents { listener ->
+            HttpStub(feature, listeners = listOf(listener)).use { stub ->
+                val validRequest = feature.scenarios.first().generateHttpRequest()
+                stub.client.execute(validRequest)
+            }
+        }
+
+        assertThat(captureMockEvents).hasSize(1)
+        val event = captureMockEvents.single()
+        assertThat(event.name).isEqualToIgnoringWhitespace("Scenario: PATCH /creators/(creatorId:number)/pets/(petId:number) -> 201")
+        assertThat(event.details).isEqualToIgnoringWhitespace("Request Matched Contract PATCH /creators/(creatorId:number)/pets/(petId:number) -> 201")
+        assertThat(event.scenario).isEqualTo(feature.scenarios.first())
+        assertThat(event.response).isNotNull
+        assertThat(event.responseTime).isNotNull()
+        assertThat(event.stubResult).isEqualTo(TestResult.Success)
+    }
+
+    @Test
+    fun `should mention matched example in name and details if match occurs`() {
+        val (request, response) = feature.scenarios.first().let {
+            it.generateHttpRequest() to it.generateHttpResponse(emptyMap()).copy(headers = emptyMap())
+        }
+
+        val exampleStub = ScenarioStub(request = request, response = response, filePath = "examples/example.json")
+        val captureMockEvents = captureMockEvents { listener ->
+            HttpStub(feature, scenarioStubs = listOf(exampleStub), listeners = listOf(listener)).use { stub ->
+                stub.client.execute(request)
+            }
+        }
+
+        assertThat(captureMockEvents).hasSize(1)
+        val event = captureMockEvents.single()
+        assertThat(event.name).contains("external example 'example.json'")
+        assertThat(event.details).contains("Request Matched External Example: examples/example.json")
+        assertThat(event.stubResult).isEqualTo(TestResult.Success)
+    }
+
+    @Test
+    fun `should include inline example name in mock event when request matches inline example`() {
+        val events = captureMockEvents { listener ->
+            HttpStub(featureWithInlineExamples, listeners = listOf(listener)).use { stub ->
+                stub.client.execute(
+                    HttpRequest(
+                        method = "GET",
+                        path = "/findAvailableProducts",
+                        headers = mapOf("pageSize" to "20"),
+                        queryParametersMap = mapOf("type" to "other")
+                    )
                 )
-            )
+            }
         }
 
         assertThat(events).hasSize(1)
-        assertThat(events.single().details).isEqualTo("Request Matched Example: FIND_TIMEOUT")
+        assertThat(events.single().details).isEqualTo("Request Matched Inline Example: FIND_TIMEOUT")
+        assertThat(events.single().name).contains("inline example 'FIND_TIMEOUT'")
         assertThat(events.single().name).contains("FIND_TIMEOUT")
         assertThat(events.single().stubResult).isEqualTo(TestResult.Success)
         assertThat(events.single().result).isEqualTo(Result.Success())
@@ -87,26 +96,22 @@ class MockEventListenerTest {
 
     @Test
     fun `should choose the correct inline example name when multiple inline examples exist`() {
-        val events = mutableListOf<MockEvent>()
-        val listener = object : MockEventListener {
-            override fun onRespond(data: MockEvent) {
-                events.add(data)
+        val events = captureMockEvents { listener ->
+            HttpStub(featureWithInlineExamples, listeners = listOf(listener)).use { stub ->
+                stub.client.execute(
+                    HttpRequest(
+                        method = "GET",
+                        path = "/findAvailableProducts",
+                        headers = mapOf("pageSize" to "10"),
+                        queryParametersMap = mapOf("type" to "gadget")
+                    )
+                )
             }
         }
 
-        HttpStub(featureWithInlineExamples, listeners = listOf(listener)).use { stub ->
-            stub.client.execute(
-                HttpRequest(
-                    method = "GET",
-                    path = "/findAvailableProducts",
-                    headers = mapOf("pageSize" to "10"),
-                    queryParametersMap = mapOf("type" to "gadget")
-                )
-            )
-        }
-
         assertThat(events).hasSize(1)
-        assertThat(events.single().details).isEqualTo("Request Matched Example: FIND_SUCCESS")
+        assertThat(events.single().details).isEqualTo("Request Matched Inline Example: FIND_SUCCESS")
+        assertThat(events.single().name).contains("inline example 'FIND_SUCCESS'")
         assertThat(events.single().name).contains("FIND_SUCCESS")
         assertThat(events.single().name).doesNotContain("FIND_TIMEOUT")
         assertThat(events.single().response?.status).isEqualTo(200)
@@ -114,72 +119,61 @@ class MockEventListenerTest {
 
     @Test
     fun `should provide nearest matching scenario details for bad request with no examples`() {
-        val listener = object : MockEventListener {
-            override fun onRespond(data: MockEvent) {
-                assertThat(data.name).isEqualToIgnoringWhitespace("Scenario: PATCH /creators/(creatorId:number)/pets/(petId:number) -> 201")
-                assertThat(data.details).contains("Contract expected json object but request contained an empty string or no body value")
-                assertThat(data.scenario).isEqualTo(feature.scenarios.first())
-                assertThat(data.stubResult).isEqualTo(TestResult.Failed)
+        val events = captureMockEvents { listener ->
+            HttpStub(feature, listeners = listOf(listener)).use { stub ->
+                val request = feature.scenarios.first().generateHttpRequest()
+                stub.client.execute(request.updateBody(NullValue))
             }
         }
 
-        HttpStub(feature, listeners = listOf(listener)).use { stub ->
-            val request = feature.scenarios.first().generateHttpRequest()
-            stub.client.execute(request.updateBody(NullValue))
-        }
+        assertThat(events).hasSize(1)
+        val event = events.single()
+        assertThat(event.name).isEqualToIgnoringWhitespace("Scenario: PATCH /creators/(creatorId:number)/pets/(petId:number) -> 201")
+        assertThat(event.details).contains("Specification expected json object but request contained an empty string or no body value")
+        assertThat(event.scenario).isEqualTo(feature.scenarios.first())
+        assertThat(event.stubResult).isEqualTo(TestResult.Failed)
     }
 
     @Test
     fun `should return missing-in-spec when request doesn't match any scenario identifiers`() {
-        val listener = object : MockEventListener {
-            override fun onRespond(data: MockEvent) {
-                assertThat(data.name).isEqualTo("Unknown Request")
-                assertThat(data.details).isEqualTo("No matching REST stub or contract found for method PATCH and path /test")
-                assertThat(data.scenario).isNull()
-                assertThat(data.stubResult).isEqualTo(TestResult.MissingInSpec)
+        val events = captureMockEvents { listener ->
+            HttpStub(feature, listeners = listOf(listener)).use { stub ->
+                val request = feature.scenarios.first().generateHttpRequest()
+                stub.client.execute(request.updatePath("/test"))
             }
         }
 
-        HttpStub(feature, listeners = listOf(listener)).use { stub ->
-            val request = feature.scenarios.first().generateHttpRequest()
-            stub.client.execute(request.updatePath("/test"))
-        }
+        assertThat(events).hasSize(1)
+        val event = events.single()
+        assertThat(event.name).isEqualTo("Unknown Request")
+        assertThat(event.details).isEqualTo("No matching REST stub or contract found for method PATCH and path /test")
+        assertThat(event.scenario).isNull()
+        assertThat(event.stubResult).isEqualTo(TestResult.MissingInSpec)
     }
 
     @Test
     fun `should not emit mock events for internal control endpoints`() {
-        val events = mutableListOf<MockEvent>()
-        val listener = object : MockEventListener {
-            override fun onRespond(data: MockEvent) {
-                events.add(data)
+        val events = captureMockEvents { listener ->
+            HttpStub(feature, listeners = listOf(listener)).use { stub ->
+                stub.client.execute(HttpRequest("GET", "/_specmatic/log"))
+                stub.client.execute(HttpRequest("POST", "/_specmatic/expectations"))
+                stub.client.execute(HttpRequest("DELETE", "/_specmatic/http-stub/123"))
+                stub.client.execute(HttpRequest("POST", "/_specmatic/verify", queryParametersMap = mapOf("exampleId" to "abc123")))
+                stub.client.execute(HttpRequest("GET", "/swagger/v1/swagger.yaml"))
+                stub.client.execute(HttpRequest("HEAD", "/"))
+                stub.client.execute(HttpRequest("GET", "/actuator/health"))
             }
         }
-
-        HttpStub(feature, listeners = listOf(listener)).use { stub ->
-            stub.client.execute(HttpRequest("GET", "/_specmatic/log"))
-            stub.client.execute(HttpRequest("POST", "/_specmatic/expectations"))
-            stub.client.execute(HttpRequest("DELETE", "/_specmatic/http-stub/123"))
-            stub.client.execute(HttpRequest("POST", "/_specmatic/verify", queryParametersMap = mapOf("exampleId" to "abc123")))
-            stub.client.execute(HttpRequest("GET", "/swagger/v1/swagger.yaml"))
-            stub.client.execute(HttpRequest("HEAD", "/"))
-            stub.client.execute(HttpRequest("GET", "/actuator/health"))
-        }
-
         assertThat(events).isEmpty()
     }
 
     @Test
     fun `should continue emitting mock events for non-internal endpoints`() {
-        val events = mutableListOf<MockEvent>()
-        val listener = object : MockEventListener {
-            override fun onRespond(data: MockEvent) {
-                events.add(data)
+        val events = captureMockEvents { listener ->
+            HttpStub(feature, listeners = listOf(listener)).use { stub ->
+                val validRequest = feature.scenarios.first().generateHttpRequest()
+                stub.client.execute(validRequest)
             }
-        }
-
-        HttpStub(feature, listeners = listOf(listener)).use { stub ->
-            val validRequest = feature.scenarios.first().generateHttpRequest()
-            stub.client.execute(validRequest)
         }
 
         assertThat(events).hasSize(1)

--- a/core/src/test/kotlin/io/specmatic/stub/listener/MockEventListenerTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/listener/MockEventListenerTest.kt
@@ -1,6 +1,7 @@
 package io.specmatic.stub.listener
 
 import io.specmatic.core.HttpRequest
+import io.specmatic.core.Result
 import io.specmatic.core.parseContractFileToFeature
 import io.specmatic.core.value.NullValue
 import io.specmatic.mock.ScenarioStub
@@ -11,10 +12,11 @@ import org.junit.jupiter.api.Test
 import java.io.File
 
 class MockEventListenerTest {
-
     companion object {
         private val openApiFile = File("src/test/resources/openapi/partial_example_tests/simple.yaml")
+        private val inlineExamplesOpenApiFile = File("src/test/resources/openapi/has_multiple_inline_examples.yaml")
         val feature = parseContractFileToFeature(openApiFile)
+        val featureWithInlineExamples = parseContractFileToFeature(inlineExamplesOpenApiFile)
     }
 
     @Test
@@ -26,7 +28,7 @@ class MockEventListenerTest {
                 assertThat(data.scenario).isEqualTo(feature.scenarios.first())
                 assertThat(data.response).isNotNull
                 assertThat(data.responseTime).isNotNull()
-                assertThat(data.result).isEqualTo(TestResult.Success)
+                assertThat(data.stubResult).isEqualTo(TestResult.Success)
             }
         }
 
@@ -42,7 +44,7 @@ class MockEventListenerTest {
             override fun onRespond(data: MockEvent) {
                 assertThat(data.name).contains("EX:example.json")
                 assertThat(data.details).contains("Request Matched Example: examples/example.json")
-                assertThat(data.result).isEqualTo(TestResult.Success)
+                assertThat(data.stubResult).isEqualTo(TestResult.Success)
             }
         }
 
@@ -56,13 +58,68 @@ class MockEventListenerTest {
     }
 
     @Test
+    fun `should include inline example name in mock event when request matches inline example`() {
+        val events = mutableListOf<MockEvent>()
+        val listener = object : MockEventListener {
+            override fun onRespond(data: MockEvent) {
+                events.add(data)
+            }
+        }
+
+        HttpStub(featureWithInlineExamples, listeners = listOf(listener)).use { stub ->
+            stub.client.execute(
+                HttpRequest(
+                    method = "GET",
+                    path = "/findAvailableProducts",
+                    headers = mapOf("pageSize" to "20"),
+                    queryParametersMap = mapOf("type" to "other")
+                )
+            )
+        }
+
+        assertThat(events).hasSize(1)
+        assertThat(events.single().details).isEqualTo("Request Matched Example: FIND_TIMEOUT")
+        assertThat(events.single().name).contains("FIND_TIMEOUT")
+        assertThat(events.single().stubResult).isEqualTo(TestResult.Success)
+        assertThat(events.single().result).isEqualTo(Result.Success())
+        assertThat(events.single().response?.status).isEqualTo(503)
+    }
+
+    @Test
+    fun `should choose the correct inline example name when multiple inline examples exist`() {
+        val events = mutableListOf<MockEvent>()
+        val listener = object : MockEventListener {
+            override fun onRespond(data: MockEvent) {
+                events.add(data)
+            }
+        }
+
+        HttpStub(featureWithInlineExamples, listeners = listOf(listener)).use { stub ->
+            stub.client.execute(
+                HttpRequest(
+                    method = "GET",
+                    path = "/findAvailableProducts",
+                    headers = mapOf("pageSize" to "10"),
+                    queryParametersMap = mapOf("type" to "gadget")
+                )
+            )
+        }
+
+        assertThat(events).hasSize(1)
+        assertThat(events.single().details).isEqualTo("Request Matched Example: FIND_SUCCESS")
+        assertThat(events.single().name).contains("FIND_SUCCESS")
+        assertThat(events.single().name).doesNotContain("FIND_TIMEOUT")
+        assertThat(events.single().response?.status).isEqualTo(200)
+    }
+
+    @Test
     fun `should provide nearest matching scenario details for bad request with no examples`() {
         val listener = object : MockEventListener {
             override fun onRespond(data: MockEvent) {
                 assertThat(data.name).isEqualToIgnoringWhitespace("Scenario: PATCH /creators/(creatorId:number)/pets/(petId:number) -> 201")
                 assertThat(data.details).contains("Contract expected json object but request contained an empty string or no body value")
                 assertThat(data.scenario).isEqualTo(feature.scenarios.first())
-                assertThat(data.result).isEqualTo(TestResult.Failed)
+                assertThat(data.stubResult).isEqualTo(TestResult.Failed)
             }
         }
 
@@ -79,7 +136,7 @@ class MockEventListenerTest {
                 assertThat(data.name).isEqualTo("Unknown Request")
                 assertThat(data.details).isEqualTo("No matching REST stub or contract found for method PATCH and path /test")
                 assertThat(data.scenario).isNull()
-                assertThat(data.result).isEqualTo(TestResult.MissingInSpec)
+                assertThat(data.stubResult).isEqualTo(TestResult.MissingInSpec)
             }
         }
 


### PR DESCRIPTION
**What**: Ensure that inlineExample names are logged by the mock both in the terminal and on the listeners

**How**:
- Ensure that example names are logged to the console when the request matches inline examples
- Ensure that mockHooks receive the exampleName as intended

**Checklist**:

- [x] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)