### PR TITLE
Fix arguments precedence for contract tests across config, settings and CLI

### DIFF
--- a/application/src/main/kotlin/application/TestCommand.kt
+++ b/application/src/main/kotlin/application/TestCommand.kt
@@ -27,7 +27,9 @@ import org.w3c.dom.NodeList
 import org.xml.sax.InputSource
 import picocli.CommandLine
 import picocli.CommandLine.Command
+import picocli.CommandLine.Model.CommandSpec
 import picocli.CommandLine.Option
+import picocli.CommandLine.Spec
 import java.io.File
 import java.io.PrintWriter
 import java.io.StringReader
@@ -129,6 +131,9 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
     @Option(names = ["--lenient"], description = ["Parse the OpenAPI Specification with leniency"], required = false, hidden = true)
     var lenientMode: Boolean = false
 
+    @Spec
+    lateinit var commandSpec: CommandSpec
+
     private val specmaticConfig: SpecmaticConfig by lazy(LazyThreadSafetyMode.NONE) {
         configFileName?.let { Configuration.configFilePath = it }
         val resolvedConfigPath = configFileName ?: Configuration.configFilePath
@@ -225,6 +230,7 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
             inlineSuggestions = suggestions.takeIf(::isNotNullOrBlank),
             suggestionsPath = suggestionsPath.takeIf(::isNotNullOrBlank),
             variablesFileName = variablesFileName.takeIf(::isNotNullOrBlank),
+            isHostOrPortExplicitlySpecified = commandSpecHasParsedOption("--host") || commandSpecHasParsedOption("--port"),
         )
 
         val settings = ContractTestSettings(
@@ -240,6 +246,10 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
         )
 
         SpecmaticJUnitSupport.settingsStaging.set(settings)
+    }
+
+    private fun commandSpecHasParsedOption(option: String): Boolean {
+        return commandSpec.commandLine().parseResult?.hasMatchedOption(option) == true
     }
 
     private fun resolvedJunitReportDir(): String? {

--- a/application/src/test/kotlin/application/TestCommandTest.kt
+++ b/application/src/test/kotlin/application/TestCommandTest.kt
@@ -167,8 +167,17 @@ internal class TestCommandTest {
         assertThat(testCaseNode.attributes.getNamedItem("name").nodeValue).isEqualTo("Scenario: GET /pets/(petid:number) -> 200 — EX:200_OKAY")
     }
 
+    @ParameterizedTest
+    @MethodSource("hostPortExplicitnessCases")
+    fun `sets host or port explicitness flag based on parsed options`(testCase: HostPortExplicitnessCase) {
+        CommandLine(testCommand, factory).execute(*testCase.arguments.toTypedArray())
+        val settings = SpecmaticJUnitSupport.settingsStaging.get() ?: fail("Expected staged settings to be set")
+        assertThat(settings.isHostOrPortExplicitlySpecified).isEqualTo(testCase.expected)
+    }
+
     companion object {
         data class TestCommandCase(val argument: String?, val value: Any?, val extract: (ContractTestSettings) -> Any?, val expected: Any)
+        data class HostPortExplicitnessCase(val arguments: List<String>, val expected: Boolean)
         @JvmStatic
         fun commandLineArguments(): Stream<TestCommandCase> = listOf(
             // -------- positional arguments --------
@@ -213,6 +222,14 @@ internal class TestCommandTest {
             // -------- https / protocol mutations --------
             TestCommandCase(null, null, { it.protocol }, "http"),
             TestCommandCase("--https", true, { it.protocol }, "https"),
+        ).stream()
+
+        @JvmStatic
+        fun hostPortExplicitnessCases(): Stream<HostPortExplicitnessCase> = listOf(
+            HostPortExplicitnessCase(emptyList(), false),
+            HostPortExplicitnessCase(listOf("--host", "127.0.0.1"), true),
+            HostPortExplicitnessCase(listOf("--port", "8080"), true),
+            HostPortExplicitnessCase(listOf("--host", "127.0.0.1", "--port", "8080"), true),
         ).stream()
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -215,7 +215,7 @@ data class Feature(
                 positivePrefix = POSITIVE_TEST_DESCRIPTION_PREFIX,
                 negativePrefix = NEGATIVE_TEST_DESCRIPTION_PREFIX
             ),
-            specmaticConfig = specmaticConfig.copyResiliencyTestsConfig(onlyPositive)
+            specmaticConfig = specmaticConfig.enableResiliencyTests(onlyPositive)
         )
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -226,7 +226,7 @@ interface SpecmaticConfig {
     fun getActuatorUrl(): String?
 
     @JsonIgnore
-    fun copyResiliencyTestsConfig(onlyPositive: Boolean): SpecmaticConfig
+    fun enableResiliencyTests(onlyPositive: Boolean): SpecmaticConfig
 
     @JsonIgnore
     fun getStubIncludeMandatoryAndRequestedKeysInResponse(): Boolean

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -228,6 +228,7 @@ interface SpecmaticConfig {
     @JsonIgnore
     fun enableResiliencyTests(onlyPositive: Boolean): SpecmaticConfig
 
+    @JsonIgnore
     fun disableResiliencyTests(): SpecmaticConfig
 
     @JsonIgnore

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -228,6 +228,8 @@ interface SpecmaticConfig {
     @JsonIgnore
     fun enableResiliencyTests(onlyPositive: Boolean): SpecmaticConfig
 
+    fun disableResiliencyTests(): SpecmaticConfig
+
     @JsonIgnore
     fun getStubIncludeMandatoryAndRequestedKeysInResponse(): Boolean
 

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -396,7 +396,8 @@ interface SpecmaticConfig {
     fun updateReportConfiguration(reportConfiguration: ReportConfiguration): SpecmaticConfig
     fun getEnvironment(envName: String): JSONObjectValue
     fun enableResiliencyTests(): SpecmaticConfig
-    fun withTestModes(strictMode: Boolean?, lenientMode: Boolean): SpecmaticConfig
+    fun withTestBaseURL(testBaseURL: String): SpecmaticConfig
+    fun withTestModes(strictMode: Boolean?, lenientMode: Boolean?): SpecmaticConfig
     fun withTestFilter(filter: String? = null): SpecmaticConfig
     fun withTestTimeout(timeoutInMilliseconds: Long? = null): SpecmaticConfig
     fun withStubModes(strictMode: Boolean? = null): SpecmaticConfig

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfigV1V2Common.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfigV1V2Common.kt
@@ -907,7 +907,7 @@ data class SpecmaticConfigV1V2Common(
     }
 
     @JsonIgnore
-    override fun copyResiliencyTestsConfig(onlyPositive: Boolean): SpecmaticConfigV1V2Common {
+    override fun enableResiliencyTests(onlyPositive: Boolean): SpecmaticConfigV1V2Common {
         val testConfig = test ?: TestConfiguration()
         return this.copy(
             test = testConfig.copy(

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfigV1V2Common.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfigV1V2Common.kt
@@ -918,6 +918,12 @@ data class SpecmaticConfigV1V2Common(
         )
     }
 
+    override fun disableResiliencyTests(): SpecmaticConfig {
+        val testConfig = test ?: TestConfiguration()
+        val resiliencyTestsConfig = ResiliencyTestsConfig(enable = ResiliencyTestSuite.none)
+        return this.copy(test = testConfig.copy(resiliencyTests = resiliencyTestsConfig))
+    }
+
     @JsonIgnore
     override fun getStubIncludeMandatoryAndRequestedKeysInResponse(): Boolean {
         return getStubConfiguration(this).getIncludeMandatoryAndRequestedKeysInResponse() ?: true

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfigV1V2Common.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfigV1V2Common.kt
@@ -1287,14 +1287,19 @@ data class SpecmaticConfigV1V2Common(
         )
     }
 
-    override fun withTestModes(strictMode: Boolean?, lenientMode: Boolean): SpecmaticConfigV1V2Common {
+    override fun withTestModes(strictMode: Boolean?, lenientMode: Boolean?): SpecmaticConfigV1V2Common {
         val testConfig = test ?: TestConfiguration()
         return this.copy(
             test = testConfig.copy(
                 strictMode = strictMode ?: testConfig.strictMode,
-                lenientMode = lenientMode,
+                lenientMode = lenientMode ?: testConfig.lenientMode,
             ),
         )
+    }
+
+    override fun withTestBaseURL(testBaseURL: String): SpecmaticConfig {
+        val testConfig = test ?: TestConfiguration()
+        return this.copy(test = testConfig.copy(baseUrl = testBaseURL))
     }
 
     override fun withTestFilter(filter: String?): SpecmaticConfigV1V2Common {

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3Impl.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3Impl.kt
@@ -448,7 +448,7 @@ data class SpecmaticConfigV3Impl(val file: File? = null, private val specmaticCo
         return specmaticConfig.systemUnderTest?.getOpenApiTestConfig(resolver)?.actuatorUrl ?: getStringValue(TEST_ENDPOINTS_API)
     }
 
-    override fun copyResiliencyTestsConfig(onlyPositive: Boolean): SpecmaticConfig {
+    override fun enableResiliencyTests(onlyPositive: Boolean): SpecmaticConfig {
         val systemUnderTest = specmaticConfig.systemUnderTest ?: emptyTestServiceConfig()
         val resiliencyTestSuite = if (onlyPositive) ResiliencyTestSuite.positiveOnly else ResiliencyTestSuite.all
         val updatedSut = systemUnderTest.copyResiliencyTestsConfig(resolver, resiliencyTestSuite)
@@ -715,7 +715,7 @@ data class SpecmaticConfigV3Impl(val file: File? = null, private val specmaticCo
     }
 
     override fun enableResiliencyTests(): SpecmaticConfig {
-        return copyResiliencyTestsConfig(onlyPositive = false)
+        return enableResiliencyTests(onlyPositive = false)
     }
 
     override fun withTestBaseURL(testBaseURL: String): SpecmaticConfig {

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3Impl.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3Impl.kt
@@ -455,6 +455,12 @@ data class SpecmaticConfigV3Impl(val file: File? = null, private val specmaticCo
         return this.copy(specmaticConfig = specmaticConfig.copy(systemUnderTest = updatedSut))
     }
 
+    override fun disableResiliencyTests(): SpecmaticConfig {
+        val systemUnderTest = specmaticConfig.systemUnderTest ?: emptyTestServiceConfig()
+        val updatedSut = systemUnderTest.copyResiliencyTestsConfig(resolver, ResiliencyTestSuite.none)
+        return this.copy(specmaticConfig = specmaticConfig.copy(systemUnderTest = updatedSut))
+    }
+
     override fun getStubIncludeMandatoryAndRequestedKeysInResponse(): Boolean {
         return false
     }

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3Impl.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3Impl.kt
@@ -64,6 +64,8 @@ import io.specmatic.core.config.v3.components.runOptions.OpenApiMockConfig
 import io.specmatic.core.config.v3.components.runOptions.OpenApiRunOptionsSpecifications
 import io.specmatic.core.config.v3.components.runOptions.OpenApiTestConfig
 import io.specmatic.core.config.v3.components.runOptions.ProtobufRunOptions
+import io.specmatic.core.config.v3.components.services.MockServiceConfig
+import io.specmatic.core.config.v3.components.services.TestServiceConfig
 import io.specmatic.core.config.v3.components.settings.MockSettings
 import io.specmatic.core.config.v3.components.settings.TestSettings
 import io.specmatic.core.config.v3.components.sources.GitAuthentication
@@ -106,6 +108,8 @@ import kotlin.collections.orEmpty
 data class SpecmaticConfigV3Impl(val file: File? = null, private val specmaticConfig: SpecmaticConfigV3) : SpecmaticConfig {
     private val effectiveWorkingFile: File = file?.canonicalFile ?: File(".").canonicalFile
     private val resolver = SpecmaticConfigV3Resolver(specmaticConfig.components ?: Components(), effectiveWorkingFile.toPath())
+    private fun emptyTestServiceConfig() = TestServiceConfig(service = RefOrValue.Value(CommonServiceConfig(definitions = emptyList())))
+    private fun emptyMockServiceConfig() = MockServiceConfig(services = emptyList())
 
     private val specmaticSettings: ConcreteSettings by lazy(LazyThreadSafetyMode.NONE) {
         val settingsOrRef = specmaticConfig.specmatic?.settings ?: return@lazy ConcreteSettings()
@@ -445,7 +449,7 @@ data class SpecmaticConfigV3Impl(val file: File? = null, private val specmaticCo
     }
 
     override fun copyResiliencyTestsConfig(onlyPositive: Boolean): SpecmaticConfig {
-        val systemUnderTest = specmaticConfig.systemUnderTest ?: return this
+        val systemUnderTest = specmaticConfig.systemUnderTest ?: emptyTestServiceConfig()
         val resiliencyTestSuite = if (onlyPositive) ResiliencyTestSuite.positiveOnly else ResiliencyTestSuite.all
         val updatedSut = systemUnderTest.copyResiliencyTestsConfig(resolver, resiliencyTestSuite)
         return this.copy(specmaticConfig = specmaticConfig.copy(systemUnderTest = updatedSut))
@@ -714,45 +718,60 @@ data class SpecmaticConfigV3Impl(val file: File? = null, private val specmaticCo
         return copyResiliencyTestsConfig(onlyPositive = false)
     }
 
-    override fun withTestModes(strictMode: Boolean?, lenientMode: Boolean): SpecmaticConfig {
-        val systemUnderTest = specmaticConfig.systemUnderTest ?: return this
+    override fun withTestBaseURL(testBaseURL: String): SpecmaticConfig {
+        val systemUnderTest = specmaticConfig.systemUnderTest ?: emptyTestServiceConfig()
+        val updatedSut = systemUnderTest.withBaseUrl(resolver, testBaseURL)
+        return this.copy(specmaticConfig = specmaticConfig.copy(systemUnderTest = updatedSut))
+    }
+
+    override fun withTestModes(strictMode: Boolean?, lenientMode: Boolean?): SpecmaticConfig {
+        if (strictMode == null && lenientMode == null) return this
+        val systemUnderTest = specmaticConfig.systemUnderTest ?: emptyTestServiceConfig()
         val updatedSut = systemUnderTest.withTestMode(resolver, strictMode, lenientMode)
         return this.copy(specmaticConfig = specmaticConfig.copy(systemUnderTest = updatedSut))
     }
 
     override fun withTestFilter(filter: String?): SpecmaticConfig {
         if (filter == null) return this
-        val systemUnderTest = specmaticConfig.systemUnderTest ?: return this
+        val systemUnderTest = specmaticConfig.systemUnderTest ?: emptyTestServiceConfig()
         val updatedSut = systemUnderTest.withTestFilter(resolver, filter)
         return this.copy(specmaticConfig = specmaticConfig.copy(systemUnderTest = updatedSut))
     }
 
     override fun withTestTimeout(timeoutInMilliseconds: Long?): SpecmaticConfig {
-        val systemUnderTest = specmaticConfig.systemUnderTest ?: return this
+        if (timeoutInMilliseconds == null) return this
+        val systemUnderTest = specmaticConfig.systemUnderTest ?: emptyTestServiceConfig()
         val updatedSut = systemUnderTest.withTestTimeout(resolver, timeoutInMilliseconds)
         return this.copy(specmaticConfig = specmaticConfig.copy(systemUnderTest = updatedSut))
     }
 
     override fun withStubModes(strictMode: Boolean?): SpecmaticConfig {
         if (strictMode == null) return this
-        val updatedDependencies = specmaticConfig.dependencies?.withStubMode(resolver, strictMode) ?: return this
+        val dependencies = specmaticConfig.dependencies ?: emptyMockServiceConfig()
+        val updatedDependencies = dependencies.withStubMode(resolver, strictMode)
         return this.copy(specmaticConfig = specmaticConfig.copy(dependencies = updatedDependencies))
     }
 
     override fun withStubFilter(filter: String?): SpecmaticConfig {
         if (filter == null) return this
-        val updatedDependencies = specmaticConfig.dependencies?.withStubFilter(resolver, filter) ?: return this
+        val dependencies = specmaticConfig.dependencies ?: emptyMockServiceConfig()
+        val updatedDependencies = dependencies.withStubFilter(resolver, filter)
         return this.copy(specmaticConfig = specmaticConfig.copy(dependencies = updatedDependencies))
     }
 
     override fun withGlobalMockDelay(delayInMilliseconds: Long): SpecmaticConfig {
-        val updatedDependencies = specmaticConfig.dependencies?.withGlobalDelay(resolver, delayInMilliseconds) ?: return this
+        val dependencies = specmaticConfig.dependencies ?: emptyMockServiceConfig()
+        val updatedDependencies = dependencies.withGlobalDelay(resolver, delayInMilliseconds)
         return this.copy(specmaticConfig = specmaticConfig.copy(dependencies = updatedDependencies))
     }
 
     override fun withMatchBranch(matchBranch: Boolean): SpecmaticConfig {
-        val updatedSut = specmaticConfig.systemUnderTest?.withMatchBranch(resolver, matchBranch)
-        val updatedDependencies = specmaticConfig.dependencies?.withMatchBranch(resolver, matchBranch)
+        val systemUnderTest = specmaticConfig.systemUnderTest ?: emptyTestServiceConfig()
+        val updatedSut = systemUnderTest.withMatchBranch(resolver, matchBranch)
+
+        val dependencies = specmaticConfig.dependencies ?: emptyMockServiceConfig()
+        val updatedDependencies = dependencies.withMatchBranch(resolver, matchBranch)
+
         val updatedConfig = specmaticConfig.copy(systemUnderTest = updatedSut, dependencies = updatedDependencies)
         return this.copy(specmaticConfig = updatedConfig)
     }
@@ -779,8 +798,12 @@ data class SpecmaticConfigV3Impl(val file: File? = null, private val specmaticCo
     }
 
     override fun plusExamples(exampleDirectories: List<String>): SpecmaticConfig {
-        val updatedSut = specmaticConfig.systemUnderTest?.withExamples(resolver, exampleDirectories)
-        val updatedDependencies = specmaticConfig.dependencies?.withExamples(resolver, exampleDirectories)
+        val systemUnderTest = specmaticConfig.systemUnderTest ?: emptyTestServiceConfig()
+        val updatedSut = systemUnderTest.withExamples(resolver, exampleDirectories)
+
+        val dependencies = specmaticConfig.dependencies ?: emptyMockServiceConfig()
+        val updatedDependencies = dependencies.withExamples(resolver, exampleDirectories)
+
         val updatedConfig = specmaticConfig.copy(systemUnderTest = updatedSut, dependencies = updatedDependencies)
         return this.copy(specmaticConfig = updatedConfig)
     }

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/MockServiceConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/MockServiceConfig.kt
@@ -12,6 +12,7 @@ import io.specmatic.core.config.v3.components.ExampleDirectories
 import io.specmatic.core.config.v3.components.runOptions.ConfigWithCert
 import io.specmatic.core.config.v3.components.runOptions.IRunOptions
 import io.specmatic.core.config.v3.components.runOptions.MockRunOptions
+import io.specmatic.core.config.v3.components.runOptions.OpenApiMockConfig
 import io.specmatic.core.config.v3.components.settings.MockSettings
 import io.specmatic.core.config.v3.components.sources.SourceV3
 import io.specmatic.core.config.v3.determineSpecTypeFor
@@ -154,7 +155,7 @@ data class MockServiceConfig(val services: List<Value>, val data: Data? = null, 
             services = services.map { value ->
                 val service = value.service.resolveElseThrow(resolver)
                 val runOpts = service.runOptions?.resolveElseThrow(resolver) ?: MockRunOptions()
-                val openApiRunOpts = runOpts.openapi ?: return@map value
+                val openApiRunOpts = runOpts.openapi ?: OpenApiMockConfig()
                 val updatedOpenApiRunOpts = openApiRunOpts.copy(filter = filter)
                 val updatedRunOpts = runOpts.copy(openapi = updatedOpenApiRunOpts)
                 value.copy(service = RefOrValue.Value(service.copy(runOptions = RefOrValue.Value(updatedRunOpts))))

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/TestServiceConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/TestServiceConfig.kt
@@ -113,24 +113,32 @@ data class TestServiceConfig(val service: RefOrValue<CommonServiceConfig<TestRun
         return this.copy(service = RefOrValue.Value(service.copy(settings = RefOrValue.Value(updatedSettings))))
     }
 
-    fun withTestMode(resolver: RefOrValueResolver, strictMode: Boolean?, lenientMode: Boolean): TestServiceConfig {
+    fun withTestMode(resolver: RefOrValueResolver, strictMode: Boolean?, lenientMode: Boolean?): TestServiceConfig {
         val service = this.service.resolveElseThrow(resolver)
         val settings = service.settings?.resolveElseThrow(resolver) ?: TestSettings()
         val updatedSettings = TestSettings(strictMode = strictMode, lenientMode = lenientMode).merge(settings)
         return this.copy(service = RefOrValue.Value(service.copy(settings = RefOrValue.Value(updatedSettings))))
     }
 
-    fun withTestTimeout(resolver: RefOrValueResolver, timeout: Long?): TestServiceConfig {
+    fun withTestTimeout(resolver: RefOrValueResolver, timeout: Long): TestServiceConfig {
         val service = this.service.resolveElseThrow(resolver)
         val settings = service.settings?.resolveElseThrow(resolver) ?: TestSettings()
         val updatedSettings = TestSettings(timeoutInMilliseconds = timeout).merge(settings)
         return this.copy(service = RefOrValue.Value(service.copy(settings = RefOrValue.Value(updatedSettings))))
     }
 
+    fun withBaseUrl(resolver: SpecmaticConfigV3Resolver, testBaseURL: String): TestServiceConfig {
+        val service = this.service.resolveElseThrow(resolver)
+        val runOpts = service.runOptions?.resolveElseThrow(resolver) ?: TestRunOptions()
+        val openApiRunOpts = runOpts.openapi?.copy(baseUrl = testBaseURL) ?: OpenApiTestConfig(baseUrl = testBaseURL)
+        val updatedRunOpts = runOpts.copy(openapi = openApiRunOpts)
+        return copy(service = RefOrValue.Value(service.copy(runOptions = RefOrValue.Value(updatedRunOpts))))
+    }
+
     fun withTestFilter(resolver: RefOrValueResolver, filter: String): TestServiceConfig {
         val service = this.service.resolveElseThrow(resolver)
         val runOpts = service.runOptions?.resolveElseThrow(resolver) ?: TestRunOptions()
-        val openApiRunOpts = runOpts.openapi ?: return this
+        val openApiRunOpts = runOpts.openapi ?: OpenApiTestConfig()
         val updatedOpenApiRunOpts = openApiRunOpts.copy(filter = filter)
         val updatedRunOpts = runOpts.copy(openapi = updatedOpenApiRunOpts)
         return copy(service = RefOrValue.Value(service.copy(runOptions = RefOrValue.Value(updatedRunOpts))))

--- a/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigKtTest.kt
@@ -409,6 +409,20 @@ internal class SpecmaticConfigKtTest {
     }
 
     @Test
+    fun `withTestBaseURL should create v2 test config when missing`() {
+        val config = SpecmaticConfigV1V2Common(version = SpecmaticConfigVersion.VERSION_2, test = null)
+        val updated = config.withTestBaseURL("http://localhost:9090")
+        assertThat(updated.getTestBaseUrl(SpecType.OPENAPI)).isEqualTo("http://localhost:9090")
+    }
+
+    @Test
+    fun `withTestBaseURL should override existing v2 test base url`() {
+        val config = SpecmaticConfigV1V2Common(version = SpecmaticConfigVersion.VERSION_2, test = TestConfiguration(baseUrl = "http://localhost:8080"))
+        val updated = config.withTestBaseURL("http://localhost:9090")
+        assertThat(updated.getTestBaseUrl(SpecType.OPENAPI)).isEqualTo("http://localhost:9090")
+    }
+
+    @Test
     fun `should prefer v2 swagger UI base url from config over system properties`() {
         val config = SpecmaticConfigV1V2Common(
             version = SpecmaticConfigVersion.VERSION_2,

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3ImplTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3ImplTest.kt
@@ -1,9 +1,12 @@
 package io.specmatic.core.config.v3
 
 import io.specmatic.core.SpecmaticConfig
+import io.specmatic.core.ResiliencyTestSuite
 import io.specmatic.core.config.toSpecmaticConfig
 import io.specmatic.reporter.model.SpecType
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.params.ParameterizedTest
@@ -41,6 +44,242 @@ class SpecmaticConfigV3ImplTest {
     @ParameterizedTest
     @MethodSource("testData")
     fun `should return similar values between v2 and v3 test data`(testCase: TestCase) = testCase.run(tempDir)
+
+    @Nested
+    inner class ModificationMethods {
+        @Test
+        fun `copyResiliencyTestsConfig should create test config when missing`() {
+            val updated = v3Config("version: 3").copyResiliencyTestsConfig(onlyPositive = false)
+            assertThat(updated.getResiliencyTestsEnabled()).isEqualTo(ResiliencyTestSuite.all)
+        }
+
+        @Test
+        fun `enableResiliencyTests should set all resiliency tests`() {
+            val updated = v3Config("version: 3").enableResiliencyTests()
+            assertThat(updated.getResiliencyTestsEnabled()).isEqualTo(ResiliencyTestSuite.all)
+        }
+
+        @Test
+        fun `withTestBaseURL should create test config when missing`() {
+            val updated = v3Config("version: 3").withTestBaseURL("http://localhost:9090")
+            assertThat(updated.getTestBaseUrl(SpecType.OPENAPI)).isEqualTo("http://localhost:9090")
+        }
+
+        @Test
+        fun `withTestModes should create test settings when missing`() {
+            val updated = v3Config("version: 3").withTestModes(strictMode = true, lenientMode = false)
+            assertThat(updated.getTestStrictMode()).isTrue()
+            assertThat(updated.getTestLenientMode()).isFalse()
+        }
+
+        @Test
+        fun `withTestModes should preserve existing values when null is passed`() {
+            val updated = v3Config("""
+            version: 3
+            systemUnderTest:
+              service:
+                definitions: []
+                settings:
+                  strictMode: true
+                  lenientMode: false
+            """.trimIndent()).withTestModes(strictMode = null, lenientMode = true)
+            assertThat(updated.getTestStrictMode()).isTrue()
+            assertThat(updated.getTestLenientMode()).isTrue()
+        }
+
+        @Test
+        fun `withTestFilter should update existing openapi test run options`() {
+            val updated = v3Config("""
+            version: 3
+            systemUnderTest:
+              service:
+                definitions:
+                  - definition:
+                      source:
+                        filesystem:
+                          directory: ./specs
+                      specs:
+                        - test.yaml
+                runOptions:
+                  openapi:
+                    baseUrl: http://localhost:9000
+                    filter: original
+            """.trimIndent()).withTestFilter("updated")
+            assertThat(updated.getTestFilter()).isEqualTo("updated")
+        }
+
+        @Test
+        fun `withTestFilter should create and return config when test section is missing`() {
+            val original = v3Config("version: 3")
+            val updated = original.withTestFilter("updated")
+            assertThat(updated.getTestFilter()).isEqualTo("updated")
+        }
+
+        @Test
+        fun `withTestTimeout should create test settings when missing`() {
+            val updated = v3Config("version: 3").withTestTimeout(1234)
+            assertThat(updated.getTestTimeoutInMilliseconds()).isEqualTo(1234)
+        }
+
+        @Test
+        fun `withStubModes should create mock settings when missing`() {
+            val updated = v3Config("version: 3").withStubModes(true)
+            assertThat(updated.getStubStrictMode(null)).isTrue()
+        }
+
+        @Test
+        fun `withStubFilter should update existing openapi mock run options`() {
+            val updated = v3Config("""
+            version: 3
+            dependencies:
+              services:
+                - service:
+                    definitions:
+                      - definition:
+                          source:
+                            filesystem:
+                              directory: ./specs
+                          specs:
+                            - spec:
+                                path: stub.yaml
+                    runOptions:
+                      openapi:
+                        baseUrl: http://0.0.0.0:9000
+                        filter: original
+            """.trimIndent()).withStubFilter("updated")
+            assertThat(updated.getStubFilter(File("stub.yaml"))).isEqualTo("updated")
+        }
+
+        @Test
+        fun `withStubFilter should preserve existing filter when null is passed`() {
+            val updated = v3Config("""
+            version: 3
+            dependencies:
+              services:
+                - service:
+                    definitions:
+                      - definition:
+                          source:
+                            filesystem:
+                              directory: ./specs
+                          specs:
+                            - spec:
+                                path: stub.yaml
+                    runOptions:
+                      openapi:
+                        baseUrl: http://0.0.0.0:9000
+                        filter: original
+            """.trimIndent()).withStubFilter(null)
+            assertThat(updated.getStubFilter(File("stub.yaml"))).isEqualTo("original")
+        }
+
+        @Test
+        fun `withGlobalMockDelay should create mock settings when missing`() {
+            val updated = v3Config("version: 3").withGlobalMockDelay(250)
+            assertThat(updated.getStubDelayInMilliseconds(null)).isEqualTo(250)
+        }
+
+        @Test
+        fun `withMatchBranch should update test and mock sources`() {
+            writeSpec("specs/test.yaml")
+            writeSpec("specs/stub.yaml")
+            val updated = v3Config("""
+            version: 3
+            systemUnderTest:
+              service:
+                definitions:
+                  - definition:
+                      source:
+                        git:
+                          url: https://github.com/org/repo
+                          branch: main
+                          matchBranch: false
+                      specs:
+                        - test.yaml
+            dependencies:
+              services:
+                - service:
+                    definitions:
+                      - definition:
+                          source:
+                            git:
+                              url: https://github.com/org/repo
+                              branch: main
+                              matchBranch: false
+                          specs:
+                            - spec:
+                                path: stub.yaml
+            """.trimIndent()).withMatchBranch(true)
+
+            val entries = updated.getSpecificationSources().flatMap { it.test + it.mock }
+            assertThat(entries).isNotEmpty()
+            assertThat(entries.map { it.matchBranch }).containsOnly(true)
+        }
+
+        @Test
+        fun `plusExamples should append examples to test and mock sources`() {
+            writeSpec("specs/test.yaml")
+            writeSpec("specs/stub.yaml")
+            val updated = v3Config("""
+            version: 3
+            systemUnderTest:
+              service:
+                definitions:
+                  - definition:
+                      source:
+                        git:
+                          url: https://github.com/org/repo
+                          branch: main
+                          matchBranch: false
+                      specs:
+                        - test.yaml
+            dependencies:
+              services:
+                - service:
+                    definitions:
+                      - definition:
+                          source:
+                            git:
+                              url: https://github.com/org/repo
+                              branch: main
+                              matchBranch: false
+                          specs:
+                            - spec:
+                                path: stub.yaml
+            """.trimIndent()).plusExamples(listOf("examples"))
+
+            val entries = updated.getSpecificationSources().flatMap { it.test + it.mock }
+            assertThat(entries).isNotEmpty()
+            assertThat(entries.map { it.exampleDirs }).allSatisfy {
+                assertThat(it).containsExactly("examples")
+            }
+        }
+
+        @Test
+        fun `should fail to load v3 config when service definitions are missing`() {
+            assertThatThrownBy {
+                v3Config("""
+                version: 3
+                systemUnderTest:
+                  service:
+                    runOptions:
+                      openapi:
+                        baseUrl: http://localhost:9000
+                """.trimIndent())
+            }.hasMessageContaining("definitions")
+        }
+
+        private fun v3Config(yaml: String): SpecmaticConfig {
+            return tempDir.resolve("config-${System.nanoTime()}.yaml").apply { writeText(yaml) }.toSpecmaticConfig()
+        }
+
+        private fun writeSpec(path: String): File {
+            return tempDir.resolve(path).apply {
+                parentFile.mkdirs()
+                writeText("openapi: 3.0.0\ninfo: { title: test, version: '1.0.0' }\npaths: {}\n")
+            }
+        }
+    }
 
     @Test
     fun `getStubDictionary should fallback to dependency level dictionary when service dictionary is absent for matched spec`() {

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3ImplTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3ImplTest.kt
@@ -49,7 +49,7 @@ class SpecmaticConfigV3ImplTest {
     inner class ModificationMethods {
         @Test
         fun `copyResiliencyTestsConfig should create test config when missing`() {
-            val updated = v3Config("version: 3").copyResiliencyTestsConfig(onlyPositive = false)
+            val updated = v3Config("version: 3").enableResiliencyTests(onlyPositive = false)
             assertThat(updated.getResiliencyTestsEnabled()).isEqualTo(ResiliencyTestSuite.all)
         }
 

--- a/junit5-support/src/main/kotlin/io/specmatic/test/ContractTestSettings.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/ContractTestSettings.kt
@@ -7,8 +7,10 @@ import io.specmatic.core.getConfigFilePath
 import io.specmatic.core.loadSpecmaticConfigOrDefault
 import io.specmatic.core.loadSpecmaticConfigOrNull
 import io.specmatic.core.orDefault
+import io.specmatic.core.utilities.Flags
 
 import io.specmatic.reporter.model.SpecType
+import io.specmatic.test.SpecmaticJUnitSupport.Companion.TEST_BASE_URL
 import io.specmatic.test.reports.TestReportListener
 import java.io.File
 
@@ -36,7 +38,7 @@ data class ContractTestSettings(
     val reportBaseDirectory: String? = null,
     val coverageHooks: List<TestReportListener> = emptyList(),
     val strictMode: Boolean? = null,
-    val lenientMode: Boolean = false,
+    val lenientMode: Boolean? = null,
     val previousTestRuns: List<TestResultRecord> = emptyList(),
     val timeoutInMilliSeconds: Long? = null,
     val otherArguments: DeprecatedArguments? = null,
@@ -57,6 +59,10 @@ data class ContractTestSettings(
         return adjust(specmaticConfig)
     }
 
+    fun baseUrlFromConfig(): String? = specmaticConfig.getTestBaseUrl(SpecType.OPENAPI)
+
+    fun baseUrlFromArgOrSysProp(): String? = testBaseURL ?: Flags.getStringValue(TEST_BASE_URL)
+
     fun getReportFilter(): String? {
         if (specmaticConfig.getTestFilter() == filter) return filter
         return specmaticConfig.getTestFilter().nonNullElse(filter) { filter1, filter2 ->
@@ -66,6 +72,7 @@ data class ContractTestSettings(
 
     private fun adjust(specmaticConfig: SpecmaticConfig): SpecmaticConfig {
         return specmaticConfig
+            .let(::adjustTestBaseURL)
             .let(::adjustFilter)
             .let(::adjustExamples)
             .let(::adjustTestModes)
@@ -74,20 +81,23 @@ data class ContractTestSettings(
             .let(::adjustUseCurrentBranch)
     }
 
+    private fun adjustTestBaseURL(specmaticConfig: SpecmaticConfig): SpecmaticConfig {
+        if (testBaseURL == null) return specmaticConfig
+        return specmaticConfig.withTestBaseURL(testBaseURL)
+    }
+
     private fun adjustFilter(specmaticConfig: SpecmaticConfig): SpecmaticConfig {
         if (filter == null) return specmaticConfig
         return specmaticConfig.withTestFilter(filter)
     }
 
     private fun adjustResilience(specmaticConfig: SpecmaticConfig): SpecmaticConfig {
-        return if (generative == true) {
-            specmaticConfig.enableResiliencyTests()
-        } else {
-            specmaticConfig
-        }
+        if (generative == null) return specmaticConfig
+        return specmaticConfig.copyResiliencyTestsConfig(onlyPositive = !generative)
     }
 
     private fun adjustTestModes(specmaticConfig: SpecmaticConfig): SpecmaticConfig {
+        if (strictMode == null && lenientMode == null) return specmaticConfig
         return specmaticConfig.withTestModes(strictMode, lenientMode)
     }
 
@@ -120,15 +130,15 @@ data class ContractTestSettings(
     constructor(contractTestSettings: ContractTestSettings?, specmaticConfig: SpecmaticConfig) : this(
         generative = contractTestSettings?.generative,
         reportBaseDirectory = contractTestSettings?.reportBaseDirectory,
-        coverageHooks = contractTestSettings?.coverageHooks ?: emptyList(),
+        coverageHooks = contractTestSettings?.coverageHooks.orEmpty(),
         previousTestRuns = contractTestSettings?.previousTestRuns.orEmpty(),
         configFile = contractTestSettings?.configFile ?: getConfigFilePath(),
-        strictMode = contractTestSettings?.strictMode ?: SpecmaticConfig().getTestStrictMode(),
-        lenientMode = contractTestSettings?.lenientMode ?: SpecmaticConfig().getTestLenientMode() ?: false,
-        testBaseURL = contractTestSettings?.testBaseURL ?: specmaticConfig.getTestBaseUrl(SpecType.OPENAPI),
+        strictMode = contractTestSettings?.strictMode,
+        lenientMode = contractTestSettings?.lenientMode,
+        testBaseURL = contractTestSettings?.testBaseURL,
         contractPaths = contractTestSettings?.contractPaths,
         timeoutInMilliSeconds = contractTestSettings?.timeoutInMilliSeconds,
-        filter = contractTestSettings?.filter ?: specmaticConfig.getTestFilter(),
+        filter = contractTestSettings?.filter,
         otherArguments = DeprecatedArguments(
             host = contractTestSettings?.otherArguments?.host,
             port = contractTestSettings?.otherArguments?.port,
@@ -138,7 +148,7 @@ data class ContractTestSettings(
             suggestionsPath = contractTestSettings?.otherArguments?.suggestionsPath,
             inlineSuggestions = contractTestSettings?.otherArguments?.inlineSuggestions,
             variablesFileName = contractTestSettings?.otherArguments?.variablesFileName,
-            exampleDirectories = contractTestSettings?.otherArguments?.exampleDirectories ?: specmaticConfig.getExamples(),
+            exampleDirectories = contractTestSettings?.otherArguments?.exampleDirectories,
             filterName = contractTestSettings?.otherArguments?.filterName ?: specmaticConfig.getTestFilterName(),
             filterNotName = contractTestSettings?.otherArguments?.filterNotName ?: specmaticConfig.getTestFilterNotName(),
             overlayFilePath = contractTestSettings?.otherArguments?.overlayFilePath,

--- a/junit5-support/src/main/kotlin/io/specmatic/test/ContractTestSettings.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/ContractTestSettings.kt
@@ -95,7 +95,7 @@ data class ContractTestSettings(
 
     private fun adjustResilience(specmaticConfig: SpecmaticConfig): SpecmaticConfig {
         if (generative == null) return specmaticConfig
-        return specmaticConfig.copyResiliencyTestsConfig(onlyPositive = !generative)
+        return specmaticConfig.enableResiliencyTests(onlyPositive = !generative)
     }
 
     private fun adjustTestModes(specmaticConfig: SpecmaticConfig): SpecmaticConfig {

--- a/junit5-support/src/main/kotlin/io/specmatic/test/ContractTestSettings.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/ContractTestSettings.kt
@@ -26,7 +26,8 @@ data class DeprecatedArguments(
     val inlineSuggestions: String? = null,
     val variablesFileName: String? = null,
     val exampleDirectories: List<String>? = null,
-    val useCurrentBranchForCentralRepo: Boolean? = null
+    val useCurrentBranchForCentralRepo: Boolean? = null,
+    val isHostOrPortExplicitlySpecified: Boolean? = null,
 )
 
 data class ContractTestSettings(
@@ -53,6 +54,7 @@ data class ContractTestSettings(
     val suggestionsPath: String? = otherArguments?.suggestionsPath
     val inlineSuggestions: String? = otherArguments?.inlineSuggestions
     val variablesFileName: String? = otherArguments?.variablesFileName
+    val isHostOrPortExplicitlySpecified: Boolean = otherArguments?.isHostOrPortExplicitlySpecified == true
     private val specmaticConfig = loadSpecmaticConfigOrNull(configFile, explicitlySpecifiedByUser = configFile != null).orDefault()
 
     fun getSpecmaticConfig(): SpecmaticConfig {
@@ -144,6 +146,7 @@ data class ContractTestSettings(
             port = contractTestSettings?.otherArguments?.port,
             envName = contractTestSettings?.otherArguments?.envName,
             protocol = contractTestSettings?.otherArguments?.protocol,
+            isHostOrPortExplicitlySpecified = contractTestSettings?.otherArguments?.isHostOrPortExplicitlySpecified,
             useCurrentBranchForCentralRepo = contractTestSettings?.otherArguments?.useCurrentBranchForCentralRepo,
             suggestionsPath = contractTestSettings?.otherArguments?.suggestionsPath,
             inlineSuggestions = contractTestSettings?.otherArguments?.inlineSuggestions,

--- a/junit5-support/src/main/kotlin/io/specmatic/test/ContractTestSettings.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/ContractTestSettings.kt
@@ -95,7 +95,11 @@ data class ContractTestSettings(
 
     private fun adjustResilience(specmaticConfig: SpecmaticConfig): SpecmaticConfig {
         if (generative == null) return specmaticConfig
-        return specmaticConfig.enableResiliencyTests(onlyPositive = !generative)
+        return if (generative) {
+            specmaticConfig.enableResiliencyTests()
+        } else {
+            specmaticConfig.disableResiliencyTests()
+        }
     }
 
     private fun adjustTestModes(specmaticConfig: SpecmaticConfig): SpecmaticConfig {

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -428,7 +428,11 @@ open class SpecmaticJUnitSupport {
             return noTestsFoundError(reason)
         }
 
-        val actuatorBaseURL = settings.testBaseURL ?: testBuildResult.baseUrls.firstOrNull() ?: constructTestBaseURL()
+        val actuatorBaseURL = settings.baseUrlFromArgOrSysProp()
+            ?: settings.baseUrlFromConfig()
+            ?: testBuildResult.baseUrls.firstOrNull()
+            ?: constructTestBaseURL()
+
         return try {
             dynamicTestStream(
                 firstNScenarios(testScenariosWithUrls),
@@ -530,9 +534,10 @@ open class SpecmaticJUnitSupport {
     fun constructTestBaseURL(): String {
         val settings = settings
 
-        if (settings.testBaseURL != null) {
-            when (val validationResult = validateTestOrStubUri(settings.testBaseURL)) {
-                URIValidationResult.Success -> return settings.testBaseURL
+        val baseUrlFromArgOrSysProp = settings.baseUrlFromArgOrSysProp()
+        if (baseUrlFromArgOrSysProp != null) {
+            when (val validationResult = validateTestOrStubUri(baseUrlFromArgOrSysProp)) {
+                URIValidationResult.Success -> return baseUrlFromArgOrSysProp
                 else -> throw TestAbortedException("${validationResult.message} in $TEST_BASE_URL environment variable")
             }
         }
@@ -554,6 +559,14 @@ open class SpecmaticJUnitSupport {
             return when (validateTestOrStubUri(urlConstructedFromProtocolHostAndPort)) {
                 URIValidationResult.Success -> urlConstructedFromProtocolHostAndPort
                 else -> throw TestAbortedException("Please specify a valid $PROTOCOL, $HOST and $PORT environment variables")
+            }
+        }
+
+        val baseUrlFromConfig = settings.baseUrlFromConfig()
+        if (baseUrlFromConfig != null) {
+            when (val validationResult = validateTestOrStubUri(baseUrlFromConfig)) {
+                URIValidationResult.Success -> return baseUrlFromConfig
+                else -> throw TestAbortedException("${validationResult.message} in config file")
             }
         }
 

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -604,8 +604,8 @@ open class SpecmaticJUnitSupport {
         val strictMode = specmaticConfig.getTestStrictMode() ?: false
         val effectiveSpecmaticConfig =
             when (generative) {
-                ResiliencyTestSuite.positiveOnly -> specmaticConfig.copyResiliencyTestsConfig(onlyPositive = true)
-                ResiliencyTestSuite.all -> specmaticConfig.copyResiliencyTestsConfig(onlyPositive = false)
+                ResiliencyTestSuite.positiveOnly -> specmaticConfig.enableResiliencyTests(onlyPositive = true)
+                ResiliencyTestSuite.all -> specmaticConfig.enableResiliencyTests(onlyPositive = false)
                 ResiliencyTestSuite.none, null -> specmaticConfig
             }
 

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -331,9 +331,7 @@ open class SpecmaticJUnitSupport {
                     exitIfAnyDoNotExist("The following specifications do not exist", contractFilePaths.map { it.path })
 
                     // Compute default base URL only if any spec lacks a provides baseUrl
-                    val needsDefaultBase = contractFilePaths.any { it.baseUrl.isNullOrBlank() }
-                    val defaultBaseURL = if (needsDefaultBase) constructTestBaseURL() else ""
-
+                    val defaultBaseURL = constructTestBaseURL()
                     val loadedScenariosWithBaseUrlsByContractPath = contractFilePaths.filter {
                         File(it.path).extension in CONTRACT_EXTENSIONS
                     }.map { contractPathData ->
@@ -532,39 +530,45 @@ open class SpecmaticJUnitSupport {
     }
 
     fun constructTestBaseURL(): String {
-        val settings = settings
-        val baseUrlFromArgOrSysProp = settings.baseUrlFromArgOrSysProp()
-        if (baseUrlFromArgOrSysProp != null) {
-            return validateBaseUrlOrAbort(baseUrlFromArgOrSysProp, "$TEST_BASE_URL environment variable")
+        return testBaseUrlFromSettings()
+            ?: hostAndPortFromSettings()
+            ?: testBaseUrlFromConfig()
+            ?: "http://localhost:9000"
+    }
+
+    private fun testBaseUrlFromSettings(): String? {
+        val baseUrlFromArgOrSysProp = settings.baseUrlFromArgOrSysProp() ?: return null
+        return validateBaseUrlOrAbort(baseUrlFromArgOrSysProp, "$TEST_BASE_URL environment variable")
+    }
+
+    private fun hostAndPortFromSettings(): String? {
+        if (!settings.isHostOrPortExplicitlySpecified) return null
+
+        val hostFromSettings = settings.host
+        val portFromSettings = settings.port
+        if (hostFromSettings.isNullOrBlank() || portFromSettings.isNullOrBlank()) return null
+
+        val host = if (hostFromSettings.startsWith("http")) {
+            URI(hostFromSettings).host
+        } else {
+            hostFromSettings
         }
 
-        val baseUrlFromConfig = settings.baseUrlFromConfig()
-        if (!settings.isHostOrPortExplicitlySpecified && baseUrlFromConfig != null) {
-            return validateBaseUrlOrAbort(baseUrlFromConfig, "config file")
+        if (!isNumeric(portFromSettings)) {
+            throw TestAbortedException("Please specify a number value for $PORT environment variable")
         }
 
-        // If testBaseURL is not provided, assume http://localhost:9000 by default.
-        if (!settings.host.isNullOrBlank() && !settings.port.isNullOrBlank()) {
-            val host = if (settings.host.startsWith("http")) {
-                URI(settings.host).host
-            } else {
-                settings.host
-            }
-
-            if (!isNumeric(settings.port)) {
-                throw TestAbortedException("Please specify a number value for $PORT environment variable")
-            }
-
-            val protocol = settings.protocol ?: "http"
-            val urlConstructedFromProtocolHostAndPort = "$protocol://$host:${settings.port}"
-            return when (validateTestOrStubUri(urlConstructedFromProtocolHostAndPort)) {
-                URIValidationResult.Success -> urlConstructedFromProtocolHostAndPort
-                else -> throw TestAbortedException("Please specify a valid $PROTOCOL, $HOST and $PORT environment variables")
-            }
+        val protocol = settings.protocol ?: "http"
+        val urlConstructedFromProtocolHostAndPort = "$protocol://$host:$portFromSettings"
+        return when (validateTestOrStubUri(urlConstructedFromProtocolHostAndPort)) {
+            URIValidationResult.Success -> urlConstructedFromProtocolHostAndPort
+            else -> throw TestAbortedException("Please specify a valid $PROTOCOL, $HOST and $PORT environment variables")
         }
+    }
 
-        return if (baseUrlFromConfig != null) validateBaseUrlOrAbort(baseUrlFromConfig, "config file")
-        else "http://localhost:9000"
+    private fun testBaseUrlFromConfig(): String? {
+        val baseUrl = settings.baseUrlFromConfig() ?: return null
+        return validateBaseUrlOrAbort(baseUrl, "config file")
     }
 
     private fun validateBaseUrlOrAbort(baseUrl: String, source: String): String {

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -533,13 +533,14 @@ open class SpecmaticJUnitSupport {
 
     fun constructTestBaseURL(): String {
         val settings = settings
-
         val baseUrlFromArgOrSysProp = settings.baseUrlFromArgOrSysProp()
         if (baseUrlFromArgOrSysProp != null) {
-            when (val validationResult = validateTestOrStubUri(baseUrlFromArgOrSysProp)) {
-                URIValidationResult.Success -> return baseUrlFromArgOrSysProp
-                else -> throw TestAbortedException("${validationResult.message} in $TEST_BASE_URL environment variable")
-            }
+            return validateBaseUrlOrAbort(baseUrlFromArgOrSysProp, "$TEST_BASE_URL environment variable")
+        }
+
+        val baseUrlFromConfig = settings.baseUrlFromConfig()
+        if (!settings.isHostOrPortExplicitlySpecified && baseUrlFromConfig != null) {
+            return validateBaseUrlOrAbort(baseUrlFromConfig, "config file")
         }
 
         // If testBaseURL is not provided, assume http://localhost:9000 by default.
@@ -562,15 +563,15 @@ open class SpecmaticJUnitSupport {
             }
         }
 
-        val baseUrlFromConfig = settings.baseUrlFromConfig()
-        if (baseUrlFromConfig != null) {
-            when (val validationResult = validateTestOrStubUri(baseUrlFromConfig)) {
-                URIValidationResult.Success -> return baseUrlFromConfig
-                else -> throw TestAbortedException("${validationResult.message} in config file")
-            }
-        }
+        return if (baseUrlFromConfig != null) validateBaseUrlOrAbort(baseUrlFromConfig, "config file")
+        else "http://localhost:9000"
+    }
 
-        return "http://localhost:9000"
+    private fun validateBaseUrlOrAbort(baseUrl: String, source: String): String {
+        return when (val validationResult = validateTestOrStubUri(baseUrl)) {
+            URIValidationResult.Success -> baseUrl
+            else -> throw TestAbortedException("${validationResult.message} in $source")
+        }
     }
 
     private fun isNumeric(port: String?): Boolean {

--- a/junit5-support/src/test/kotlin/io/specmatic/test/ContractTestSettingsTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/ContractTestSettingsTest.kt
@@ -1,7 +1,6 @@
 package io.specmatic.test
 
 import io.specmatic.core.ResiliencyTestSuite
-import io.specmatic.core.ResiliencyTestsConfig
 import io.specmatic.core.SpecmaticConfigV1V2Common
 import io.specmatic.core.TestConfiguration
 import io.specmatic.core.config.SpecmaticConfigVersion
@@ -86,10 +85,10 @@ class ContractTestSettingsTest {
     }
 
     @Test
-    fun `getSpecmaticConfig should override resiliency config to positiveOnly when generative is false`(@TempDir tempDir: File) {
+    fun `getSpecmaticConfig should override resiliency config to none when generative is false`(@TempDir tempDir: File) {
         val configFile = writeSpecmaticConfig(tempDir, resiliency = ResiliencyTestSuite.all)
         val settings = ContractTestSettings(configFile = configFile.absolutePath, generative = false)
-        assertThat(settings.getSpecmaticConfig().getResiliencyTestsEnabled()).isEqualTo(ResiliencyTestSuite.positiveOnly)
+        assertThat(settings.getSpecmaticConfig().getResiliencyTestsEnabled()).isEqualTo(ResiliencyTestSuite.none)
     }
 
     @Test

--- a/junit5-support/src/test/kotlin/io/specmatic/test/ContractTestSettingsTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/ContractTestSettingsTest.kt
@@ -1,8 +1,25 @@
 package io.specmatic.test
 
+import io.specmatic.core.ResiliencyTestSuite
+import io.specmatic.core.ResiliencyTestsConfig
+import io.specmatic.core.SpecmaticConfigV1V2Common
+import io.specmatic.core.TestConfiguration
+import io.specmatic.core.config.SpecmaticConfigVersion
+import io.specmatic.core.config.SpecmaticConfigVersion.VERSION_2
+import io.specmatic.core.config.v3.RefOrValue
+import io.specmatic.core.config.v3.SpecmaticConfigV3
+import io.specmatic.core.config.v3.components.runOptions.OpenApiTestConfig
+import io.specmatic.core.config.v3.components.runOptions.TestRunOptions
+import io.specmatic.core.config.v3.components.services.CommonServiceConfig
+import io.specmatic.core.config.v3.components.services.TestServiceConfig
+import io.specmatic.core.config.v3.components.settings.TestSettings
+import io.specmatic.core.utilities.yamlMapper
+import io.specmatic.reporter.model.SpecType
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
 
 class ContractTestSettingsTest {
     private val filterPropertyKey = "filter"
@@ -43,5 +60,70 @@ class ContractTestSettingsTest {
         System.setProperty(filterPropertyKey, "PATH='/config'")
         val settings = ContractTestSettings(filter = null)
         assertThat(settings.getReportFilter()).isEqualTo("PATH='/config'")
+    }
+
+    @Test
+    fun `getSpecmaticConfig should override config test base url when explicit base url is provided`(@TempDir tempDir: File) {
+        val configFile = writeSpecmaticConfig(tempDir, baseUrl = "http://config.example:9000")
+        val settings = ContractTestSettings(configFile = configFile.absolutePath, testBaseURL = "http://override.example:8080")
+        assertThat(settings.baseUrlFromConfig()).isEqualTo("http://config.example:9000")
+        assertThat(settings.getSpecmaticConfig().getTestBaseUrl(SpecType.OPENAPI)).isEqualTo("http://override.example:8080")
+    }
+
+    @Test
+    fun `getSpecmaticConfig should use config test base url when explicit base url is not provided`(@TempDir tempDir: File) {
+        val configFile = writeSpecmaticConfig(tempDir, baseUrl = "http://config.example:9000")
+        val settings = ContractTestSettings(configFile = configFile.absolutePath)
+        assertThat(settings.baseUrlFromConfig()).isEqualTo("http://config.example:9000")
+        assertThat(settings.getSpecmaticConfig().getTestBaseUrl(SpecType.OPENAPI)).isEqualTo("http://config.example:9000")
+    }
+
+    @Test
+    fun `getSpecmaticConfig should override resiliency config to all when generative is true`(@TempDir tempDir: File) {
+        val configFile = writeSpecmaticConfig(tempDir, resiliency = ResiliencyTestSuite.positiveOnly)
+        val settings = ContractTestSettings(configFile = configFile.absolutePath, generative = true)
+        assertThat(settings.getSpecmaticConfig().getResiliencyTestsEnabled()).isEqualTo(ResiliencyTestSuite.all)
+    }
+
+    @Test
+    fun `getSpecmaticConfig should override resiliency config to positiveOnly when generative is false`(@TempDir tempDir: File) {
+        val configFile = writeSpecmaticConfig(tempDir, resiliency = ResiliencyTestSuite.all)
+        val settings = ContractTestSettings(configFile = configFile.absolutePath, generative = false)
+        assertThat(settings.getSpecmaticConfig().getResiliencyTestsEnabled()).isEqualTo(ResiliencyTestSuite.positiveOnly)
+    }
+
+    @Test
+    fun `getSpecmaticConfig should retain config resiliency config when generative is not provided`(@TempDir tempDir: File) {
+        val configFile = writeSpecmaticConfig(tempDir, resiliency = ResiliencyTestSuite.all)
+        val settings = ContractTestSettings(configFile = configFile.absolutePath, generative = null)
+        assertThat(settings.getSpecmaticConfig().getResiliencyTestsEnabled()).isEqualTo(ResiliencyTestSuite.all)
+    }
+
+    @Test
+    fun `copy constructor should not materialize config base url or test modes into fields`() {
+        val config = SpecmaticConfigV1V2Common(version = VERSION_2, test = TestConfiguration(baseUrl = "http://config.example:9000", strictMode = true, lenientMode = true))
+        val copied = ContractTestSettings(contractTestSettings = null, specmaticConfig = config)
+        assertThat(copied.testBaseURL).isNull()
+        assertThat(copied.strictMode).isNull()
+        assertThat(copied.lenientMode).isNull()
+    }
+
+    private fun writeSpecmaticConfig(tempDir: File, baseUrl: String? = null, resiliency: ResiliencyTestSuite? = null): File {
+        val configFile = tempDir.resolve("specmatic.yaml")
+        val config = SpecmaticConfigV3(
+            version = SpecmaticConfigVersion.VERSION_3,
+            systemUnderTest = TestServiceConfig(
+                service = RefOrValue.Value(
+                    CommonServiceConfig(
+                        definitions = emptyList(),
+                        runOptions = RefOrValue.Value(TestRunOptions(openapi = OpenApiTestConfig(baseUrl = baseUrl))),
+                        settings = RefOrValue.Value(TestSettings(schemaResiliencyTests = resiliency))
+                    )
+                )
+            )
+        )
+
+        configFile.writeText(yamlMapper.writeValueAsString(config))
+        return configFile
     }
 }

--- a/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
@@ -7,21 +7,24 @@ import io.specmatic.core.SPECMATIC_STUB_DICTIONARY
 import io.specmatic.core.SpecmaticConfigV1V2Common
 import io.specmatic.core.TestConfig
 import io.specmatic.core.config.SpecmaticConfigVersion
+import io.specmatic.core.config.v3.RefOrValue
+import io.specmatic.core.config.v3.SpecmaticConfigV3
+import io.specmatic.core.config.v3.components.runOptions.OpenApiTestConfig
+import io.specmatic.core.config.v3.components.runOptions.TestRunOptions
+import io.specmatic.core.config.v3.components.services.CommonServiceConfig
+import io.specmatic.core.config.v3.components.services.TestServiceConfig
+import io.specmatic.core.config.v3.components.settings.TestSettings
 import io.specmatic.core.config.v2.ContractConfig
 import io.specmatic.core.config.v2.SpecExecutionConfig
 import io.specmatic.core.config.v2.SpecmaticConfigV2
 import io.specmatic.core.config.v3.Data
-import io.specmatic.core.config.v3.RefOrValue
-import io.specmatic.core.config.v3.SpecmaticConfigV3
 import io.specmatic.core.config.v3.components.Dictionary
-import io.specmatic.core.config.v3.components.services.CommonServiceConfig
 import io.specmatic.core.config.v3.components.services.Definition
 import io.specmatic.core.config.v3.components.services.SpecificationDefinition
-import io.specmatic.core.config.v3.components.services.TestServiceConfig
 import io.specmatic.core.config.v3.components.sources.SourceV3
 import io.specmatic.core.filters.ScenarioMetadataFilter
-import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.utilities.yamlMapper
+import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.utilities.Flags
 import io.specmatic.license.core.SpecmaticProtocol
 import io.specmatic.reporter.model.SpecType
@@ -156,13 +159,61 @@ class SpecmaticJunitSupportTest {
         assertThat(url).isEqualTo("$protocol://$domain:$port")
     }
 
+    @Test
+    fun `should prefer explicit staged testBaseURL over config base url`(@TempDir tempDir: File) {
+        val configFile = writeSpecmaticConfig(tempDir, baseUrl = "http://config.example:9000")
+        SpecmaticJUnitSupport.settingsStaging.set(ContractTestSettings(configFile = configFile.absolutePath, testBaseURL = "http://override.example:8080"))
+        try {
+            val url = SpecmaticJUnitSupport().constructTestBaseURL()
+            assertThat(url).isEqualTo("http://override.example:8080")
+        } finally {
+            SpecmaticJUnitSupport.settingsStaging.remove()
+        }
+    }
+
+    @Test
+    fun `should prefer staged host and port over config base url`(@TempDir tempDir: File) {
+        val configFile = writeSpecmaticConfig(tempDir, baseUrl = "http://config.example:9000")
+        SpecmaticJUnitSupport.settingsStaging.set(ContractTestSettings(configFile = configFile.absolutePath, otherArguments = DeprecatedArguments(host = "override.example", port = "8081")))
+        try {
+            val url = SpecmaticJUnitSupport().constructTestBaseURL()
+            assertThat(url).isEqualTo("http://override.example:8081")
+        } finally {
+            SpecmaticJUnitSupport.settingsStaging.remove()
+        }
+    }
+
+    @Test
+    fun `should use config base url when no staged base url or host port are provided`(@TempDir tempDir: File) {
+        val configFile = writeSpecmaticConfig(tempDir, baseUrl = "http://config.example:9000")
+        SpecmaticJUnitSupport.settingsStaging.set(ContractTestSettings(configFile = configFile.absolutePath))
+        try {
+            val url = SpecmaticJUnitSupport().constructTestBaseURL()
+            assertThat(url).isEqualTo("http://config.example:9000")
+        } finally {
+            SpecmaticJUnitSupport.settingsStaging.remove()
+        }
+    }
+
+    @Test
+    fun `should validate config base url when used as fallback`(@TempDir tempDir: File) {
+        val configFile = writeSpecmaticConfig(tempDir, baseUrl = "http://invalid url.com")
+        SpecmaticJUnitSupport.settingsStaging.set(ContractTestSettings(configFile = configFile.absolutePath))
+        try {
+            val ex = assertThrows<TestAbortedException> { SpecmaticJUnitSupport().constructTestBaseURL() }
+            assertThat(ex.message).isEqualTo("Please specify a valid URL in 'scheme://host[:port][path]' format in config file")
+        } finally {
+            SpecmaticJUnitSupport.settingsStaging.remove()
+        }
+    }
+
     @ParameterizedTest
     @ValueSource(strings = ["http://invalid url.com", "http://localhost:abcd/", "http://localhost:80 80/", "http://localhost:a123/test"])
     fun `testBaseURL system property should be valid URI`(invalidURL: String) {
         System.setProperty(TEST_BASE_URL, invalidURL)
         val ex = assertThrows<TestAbortedException> {
-            SpecmaticJUnitSupport().constructTestBaseURL()
-        }
+                SpecmaticJUnitSupport().constructTestBaseURL()
+            }
         assertThat(ex.message).isEqualTo("Please specify a valid URL in 'scheme://host[:port][path]' format in testBaseURL environment variable")
     }
 
@@ -886,6 +937,24 @@ paths:
             .isEqualTo(0)
     }
 
+    private fun writeSpecmaticConfig(tempDir: File, baseUrl: String? = null): File {
+        val configFile = tempDir.resolve("specmatic.yaml")
+        val config = SpecmaticConfigV3(
+            version = SpecmaticConfigVersion.VERSION_3,
+            systemUnderTest = TestServiceConfig(
+                service = RefOrValue.Value(
+                    CommonServiceConfig(
+                        definitions = emptyList(),
+                        runOptions = RefOrValue.Value(TestRunOptions(openapi = OpenApiTestConfig(baseUrl = baseUrl))),
+                        settings = RefOrValue.Value(TestSettings())
+                    )
+                )
+            )
+        )
+        configFile.writeText(yamlMapper.writeValueAsString(config))
+        return configFile
+    }
+
     private class RecordingExampleErrorsListener : TestReportListener {
         val exampleErrorsCalls = mutableListOf<Map<String, Result>>()
         override fun onExampleErrors(resultsBySpecFile: Map<String, Result>) {
@@ -904,6 +973,7 @@ paths:
 
     @AfterEach
     fun tearDown() {
+        SpecmaticJUnitSupport.settingsStaging.remove()
         System.getProperties().keys.minus(initialPropertyKeys).forEach { println("Clearing $it"); System.clearProperty(it.toString()) }
     }
 }

--- a/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
@@ -248,7 +248,8 @@ class SpecmaticJunitSupportTest {
                 otherArguments = DeprecatedArguments(
                     host = "invalid domain",
                     port = "8080",
-                    protocol = "https"
+                    protocol = "https",
+                    isHostOrPortExplicitlySpecified = true
                 )
             )
         )
@@ -265,7 +266,8 @@ class SpecmaticJunitSupportTest {
                 otherArguments = DeprecatedArguments(
                     host = "test.com",
                     port = "8080",
-                    protocol = "invalid"
+                    protocol = "invalid",
+                    isHostOrPortExplicitlySpecified = true
                 )
             )
         )
@@ -282,7 +284,8 @@ class SpecmaticJunitSupportTest {
                 otherArguments = DeprecatedArguments(
                     host = "test.com",
                     port = "invalid_port",
-                    protocol = "https"
+                    protocol = "https",
+                    isHostOrPortExplicitlySpecified = true
                 )
             )
         )

--- a/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
@@ -174,10 +174,34 @@ class SpecmaticJunitSupportTest {
     @Test
     fun `should prefer staged host and port over config base url`(@TempDir tempDir: File) {
         val configFile = writeSpecmaticConfig(tempDir, baseUrl = "http://config.example:9000")
-        SpecmaticJUnitSupport.settingsStaging.set(ContractTestSettings(configFile = configFile.absolutePath, otherArguments = DeprecatedArguments(host = "override.example", port = "8081")))
+        SpecmaticJUnitSupport.settingsStaging.set(
+            ContractTestSettings(
+                configFile = configFile.absolutePath,
+                otherArguments = DeprecatedArguments(host = "override.example", port = "8081", isHostOrPortExplicitlySpecified = true)
+            )
+        )
+
         try {
             val url = SpecmaticJUnitSupport().constructTestBaseURL()
             assertThat(url).isEqualTo("http://override.example:8081")
+        } finally {
+            SpecmaticJUnitSupport.settingsStaging.remove()
+        }
+    }
+
+    @Test
+    fun `should prefer config base url when staged host and port are not explicitly specified`(@TempDir tempDir: File) {
+        val configFile = writeSpecmaticConfig(tempDir, baseUrl = "http://config.example:9000")
+        SpecmaticJUnitSupport.settingsStaging.set(
+            ContractTestSettings(
+                configFile = configFile.absolutePath,
+                otherArguments = DeprecatedArguments(host = "localhost", port = "9000", isHostOrPortExplicitlySpecified = false)
+            )
+        )
+
+        try {
+            val url = SpecmaticJUnitSupport().constructTestBaseURL()
+            assertThat(url).isEqualTo("http://config.example:9000")
         } finally {
             SpecmaticJUnitSupport.settingsStaging.remove()
         }


### PR DESCRIPTION
**What**: Fix arguments precedence for contract tests across config, settings and CLI

**How**:
- Added `withTestBaseURL(...)` support in config implementations
- Updated `SpecmaticJUnitSupport.constructTestBaseURL()` precedence logic 
- Fixed V3 config mutation paths (`withTestBaseURL`, test modes/filter/timeout and related config creation/update behavior)

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)