### PR TITLE
Fix interpolated template resolution for ConfigV3 syntax

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/config/ConfigTemplateUtils.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/ConfigTemplateUtils.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.node.TextNode
 
 data class ConfigTemplateVariable(val startIndex: Int, val endIndex: Int, val names: Set<String>, val default: String, val fullText: String)
 object ConfigTemplateUtils {
-    private val VARIABLE_TOKEN_REGEX = Regex("""\$?\{([^}:]+):([^}]*)}""")
+    internal val VARIABLE_TOKEN_REGEX = Regex("""\$?\{([^}:]+):([^}]*)}""")
     private const val MULTI_VARIABLE_SEPARATOR = "|"
 
     fun findVariableTokens(templateText: String): List<ConfigTemplateVariable> {

--- a/core/src/main/kotlin/io/specmatic/core/config/VersionAwareConfigParser.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/VersionAwareConfigParser.kt
@@ -108,15 +108,13 @@ private fun parseTemplate(value: String): TemplateDefinition? {
 
 private fun resolveTemplateValueFromEnvOrDefault(template: TemplateDefinition): String {
     return template.keys.asSequence()
-        .mapNotNull { key -> System.getenv(key) ?: System.getProperty(key) ?: template.defaultValue }
+        .map { key -> System.getenv(key) ?: System.getProperty(key) ?: template.defaultValue }
         .firstOrNull()
         ?: template.defaultValue
 }
 
-private val TEMPLATE_REGEX = Regex("\\{([^:{}]+):([^}]*)}")
-
 private fun interpolateTemplates(original: String): String? {
-    val matches = TEMPLATE_REGEX.findAll(original).toList()
+    val matches = ConfigTemplateUtils.VARIABLE_TOKEN_REGEX.findAll(original).toList()
     if (matches.isEmpty()) return null
 
     var result = original
@@ -124,13 +122,8 @@ private fun interpolateTemplates(original: String): String? {
     for (match in matches.asReversed()) {
         val keyExpression = match.groupValues[1]
         val defaultValue = match.groupValues[2]
-
         val keys = keyExpression.split('|').map { it.trim() }.filter { it.isNotEmpty() }
-        val resolved = keys.asSequence()
-            .mapNotNull { key -> System.getenv(key) ?: System.getProperty(key) }
-            .firstOrNull()
-            ?: defaultValue
-
+        val resolved = keys.firstNotNullOfOrNull { key -> System.getenv(key) ?: System.getProperty(key) } ?: defaultValue
         result = result.replaceRange(match.range, resolved)
     }
 

--- a/core/src/test/kotlin/io/specmatic/core/config/VersionAwareConfigParserTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/VersionAwareConfigParserTest.kt
@@ -2,6 +2,7 @@ package io.specmatic.core.config
 
 import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.SpecmaticConfigV1V2Common
+import io.specmatic.core.utilities.Flags
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
@@ -211,6 +212,40 @@ class VersionAwareConfigParserTest {
         }
     }
 
+    @ParameterizedTest(name = "embedded interpolation default preserves value for {0}")
+    @MethodSource("embeddedInterpolationDefaultCases")
+    fun `embedded interpolation resolves generic defaults including primitive values and arrays`(templateExpression: String, expectedResolvedValue: String) {
+        val configFile = tempDir.resolve("specmatic.yaml").apply {
+            writeText("""
+            version: 2
+            contracts: []
+            hooks:
+              after: 'prefix-$templateExpression-suffix'
+            """.trimIndent())
+        }
+
+        val config: SpecmaticConfig = configFile.toSpecmaticConfig()
+        assertThat(SpecmaticConfigV1V2Common.getHooks(config as SpecmaticConfigV1V2Common)["after"])
+            .isEqualTo("prefix-$expectedResolvedValue-suffix")
+    }
+
+    @ParameterizedTest(name = "embedded interpolation uses TEST_PROP property for {0}")
+    @MethodSource("embeddedInterpolationTestPropertyCases")
+    fun `embedded interpolation uses system property instead of default for specmatic base url`(templateExpression: String, propertyValue: String) {
+        val configFile = tempDir.resolve("specmatic.yaml").apply {
+            writeText("""
+            version: 2
+            contracts: []
+            hooks:
+              after: 'prefix-$templateExpression-suffix'
+            """.trimIndent())
+        }
+
+        val config = Flags.using("TEST_PROP" to propertyValue) { configFile.toSpecmaticConfig() }
+        assertThat(SpecmaticConfigV1V2Common.getHooks(config as SpecmaticConfigV1V2Common)["after"])
+            .isEqualTo("prefix-$propertyValue-suffix")
+    }
+
     @ParameterizedTest(name = "isConfigTemplate({0}) -> {1}")
     @MethodSource("isConfigTemplateCases")
     fun `isConfigTemplate identifies template expressions`(value: String, expected: Boolean) {
@@ -253,13 +288,37 @@ class VersionAwareConfigParserTest {
             Arguments.of("{SYSTEM_PROP:default-value}", "default-value"),
             Arguments.of("\${SYSTEM_PROP:default-value}", "default-value"),
             Arguments.of("{VAR1|VAR2:default-value}", "default-value"),
+            Arguments.of("\${VAR1|VAR2:default-value}", "default-value"),
             Arguments.of("prefix-{SYSTEM_PROP:default}-suffix", "prefix-default-suffix"),
+            Arguments.of("prefix-\${SYSTEM_PROP:default}-suffix", "prefix-default-suffix"),
             Arguments.of("prefix-{VAR1|VAR2:default}-suffix", "prefix-default-suffix"),
+            Arguments.of("prefix-\${VAR1|VAR2:default}-suffix", "prefix-default-suffix"),
             Arguments.of("prefix-{A:1}-{B:2}-suffix", "prefix-1-2-suffix"),
+            Arguments.of("prefix-\${A:1}-\${B:2}-suffix", "prefix-1-2-suffix"),
             Arguments.of("{SYSTEM_PROP}", "{SYSTEM_PROP}"),
             Arguments.of("\${SYSTEM_PROP}", "\${SYSTEM_PROP}"),
             Arguments.of("{:default}", "{:default}"),
             Arguments.of("plain-value", "plain-value"),
+        )
+
+        @JvmStatic
+        fun embeddedInterpolationDefaultCases(): Stream<Arguments> = Stream.of(
+            Arguments.of("{HOOK_VALUE:plain-text}", "plain-text"),
+            Arguments.of("\${HOOK_VALUE:plain-text}", "plain-text"),
+            Arguments.of("{HOOK_VALUE:true}", "true"),
+            Arguments.of("\${HOOK_VALUE:true}", "true"),
+            Arguments.of("{HOOK_VALUE:123}", "123"),
+            Arguments.of("\${HOOK_VALUE:123}", "123"),
+            Arguments.of("{HOOK_ARRAY:[1,true,\"x\"]}", """[1,true,"x"]"""),
+            Arguments.of("\${HOOK_ARRAY:[1,true,\"x\"]}", """[1,true,"x"]"""),
+        )
+
+        @JvmStatic
+        fun embeddedInterpolationTestPropertyCases(): Stream<Arguments> = Stream.of(
+            Arguments.of("{TEST_PROP:default-base}", "https://example.test"),
+            Arguments.of("\${TEST_PROP:default-base}", "https://example.test"),
+            Arguments.of("{TEST_PROP:[0]}", """[1,true,"x"]"""),
+            Arguments.of("\${TEST_PROP:[0]}", """[1,true,"x"]"""),
         )
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3Test.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3Test.kt
@@ -84,6 +84,34 @@ class SpecmaticConfigV3Test {
         assertThat(config.getTestTimeoutInMilliseconds()).isEqualTo(30000)
     }
 
+    @Test
+    fun `should resolve interpolated env var syntax with default when no property set`(@TempDir tempDir: File) {
+        val yaml = """
+        version: 3
+        specmatic:
+          settings:
+            test:
+              junitReportDir: "reports/${'$'}{REPORT_DIR:junit}/results"
+        """.trimIndent()
+        val file = tempDir.resolve("specmatic.yaml").apply { writeText(yaml) }
+        val config = file.toSpecmaticConfig()
+        assertThat(config.getTestJunitReportDir()).isEqualTo("reports/junit/results")
+    }
+
+    @Test
+    fun `should resolve interpolated env var syntax with default when property is set`(@TempDir tempDir: File) {
+        val yaml = """
+        version: 3
+        specmatic:
+          settings:
+            test:
+              junitReportDir: "reports/${'$'}{REPORT_DIR:junit}/results"
+        """.trimIndent()
+        val file = tempDir.resolve("specmatic.yaml").apply { writeText(yaml) }
+        val config = Flags.using("REPORT_DIR" to "custom-reports") { file.toSpecmaticConfig() }
+        assertThat(config.getTestJunitReportDir()).isEqualTo("reports/custom-reports/results")
+    }
+
     @Nested
     inner class Components {
         @Test


### PR DESCRIPTION
**What**: Fix interpolated template resolution for ConfigV3 syntax

**Why**: Interpolated template resolution using V3 syntax i.e. `prefix-${prop:default{}-suffix` is broken

**Checklist**:

- [x] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)