### PR TITLE
Ensure mock specification load failures are propagated

### DIFF
--- a/core/src/main/kotlin/io/specmatic/stub/api.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/api.kt
@@ -291,11 +291,14 @@ fun loadContractStubsFromImplicitPathsAsResults(
                         logger.newLine()
                         consoleLog(StringLog("Loading the spec file: $specFile${System.lineSeparator()}"))
                     }
-                    val feature =
-                        cachedFeature ?: loadIfSupportedAPISpecification(
-                            contractSource,
-                            specmaticConfig,
-                        )?.second ?: return emptyList()
+
+                    val feature = try {
+                        cachedFeature ?: loadIfSupportedAPISpecification(contractSource, specmaticConfig)?.second ?: return@flatMap emptyList()
+                    } catch (e: Throwable) {
+                        logger.log("Could not load ${specFile.canonicalPath}")
+                        logger.log(e)
+                        return@flatMap listOf(FeatureStubsResult.Failure(stubFile = specFile.path, errorMessage = exceptionCauseMessage(e)))
+                    }
 
                     try {
                         val implicitDataDirs = implicitDirsForSpecifications(specFile, specmaticConfig)
@@ -432,6 +435,7 @@ private fun logIgnoredFiles(implicitDataDir: File) {
     }
 }
 
+private data class SpecLoadResult(val feature: Pair<String, Feature>?, val failure: FeatureStubsResult.Failure? = null)
 fun loadContractStubsFromFilesAsResults(
     contractPathDataList: List<ContractPathData>,
     dataDirPaths: List<String>,
@@ -445,14 +449,21 @@ fun loadContractStubsFromFilesAsResults(
     consoleLog(StringLog("Loading the following spec files:${System.lineSeparator()}$contactPathsString${System.lineSeparator()}"))
 
     throwExceptionIfInvalidContractPathWhileInStrictMode(contractPathDataList, strictMode)
+    val specLoadResults = contractPathDataList.map { contractPathData ->
+        try {
+            SpecLoadResult(feature = loadIfSupportedAPISpecification(contractPathData, specmaticConfig))
+        } catch (e: Throwable) {
+            logger.log("Could not load ${contractPathData.path}")
+            logger.log(e)
+            SpecLoadResult(feature = null, failure = FeatureStubsResult.Failure(stubFile = contractPathData.path, errorMessage = exceptionCauseMessage(e)))
+        }
+    }
 
-    val features =
-        contractPathDataList
-            .mapNotNull { contractPathData ->
-                loadIfSupportedAPISpecification(contractPathData, specmaticConfig)
-            }.overrideInlineExamplesWithSameNameFrom(dataDirFiles(dataDirPaths))
-
+    val specLoadFailures = specLoadResults.mapNotNull { it.failure }
+    val failedSpecPaths = specLoadFailures.map { it.stubFile }.toSet()
+    val features = specLoadResults.mapNotNull { it.feature }.overrideInlineExamplesWithSameNameFrom(dataDirFiles(dataDirPaths))
     val exampleDirPathsFromFeatures = features.flatMap { it.second.exampleDirPaths }
+
     dataDirPaths.plus(exampleDirPathsFromFeatures).distinct().forEach { dataDirPath ->
         val dataFiles = dataDirFiles(listOf(dataDirPath))
         logger.boundary()
@@ -479,7 +490,7 @@ fun loadContractStubsFromFilesAsResults(
                 strictMode,
             )
         }
-    if (withImplicitStubs.not()) return explicitStubs
+    if (withImplicitStubs.not()) return specLoadFailures.plus(explicitStubs)
 
     val implicitStubs =
         loadContractStubsFromImplicitPathsAsResults(
@@ -487,13 +498,13 @@ fun loadContractStubsFromFilesAsResults(
             specmaticConfig = specmaticConfig,
             externalDataDirPaths = dataDirPaths,
             cachedFeatures = features.map { it.second },
-            processedInvalidSpecs = contractPathDataList.excludeUnsupportedSpecifications().map { it.path },
+            processedInvalidSpecs = contractPathDataList.excludeUnsupportedSpecifications().map { it.path } + failedSpecPaths,
         )
 
     val explicitStubsWithImplicitOverrides =
         explicitStubsWithOverriddenImplicitExamplesInFeatures(implicitStubs, explicitStubs)
 
-    return explicitStubsWithImplicitOverrides.plus(implicitStubs)
+    return specLoadFailures.plus(explicitStubsWithImplicitOverrides).plus(implicitStubs)
 }
 
 private fun explicitStubsWithOverriddenImplicitExamplesInFeatures(
@@ -1107,27 +1118,22 @@ fun loadIfSupportedAPISpecification(
 
     val specFile = File(contractPathData.path)
     val stubDictionary = specmaticConfig.getStubDictionary(specFile = specFile)
-    return try {
-        Pair(
+    return Pair(
+        contractPathData.path,
+        parseContractFileToFeature(
             contractPathData.path,
-            parseContractFileToFeature(
-                contractPathData.path,
-                CommandHook(HookName.stub_load_contract, specFile),
-                contractPathData.provider,
-                contractPathData.repository,
-                contractPathData.branch,
-                contractPathData.specificationPath,
-                overlayContent = overlayContent,
-                specmaticConfig = specmaticConfig,
-                strictMode = specmaticConfig.getStubStrictMode(null) ?: false,
-                lenientMode = contractPathData.lenientMode ?: specmaticConfig.getStubLenientMode(specFile) ?: false,
-                exampleDirPaths = contractPathData.exampleDirPaths.orEmpty()
-            ).copy(specmaticConfig = specmaticConfig).useDictionary(stubDictionary),
-        )
-    } catch (e: Throwable) {
-        logger.log(exceptionCauseMessage(e))
-        null
-    }
+            CommandHook(HookName.stub_load_contract, specFile),
+            contractPathData.provider,
+            contractPathData.repository,
+            contractPathData.branch,
+            contractPathData.specificationPath,
+            overlayContent = overlayContent,
+            specmaticConfig = specmaticConfig,
+            strictMode = specmaticConfig.getStubStrictMode(null) ?: false,
+            lenientMode = contractPathData.lenientMode ?: specmaticConfig.getStubLenientMode(specFile) ?: false,
+            exampleDirPaths = contractPathData.exampleDirPaths.orEmpty()
+        ).copy(specmaticConfig = specmaticConfig).useDictionary(stubDictionary),
+    )
 }
 
 private fun List<ContractPathData>.excludeUnsupportedSpecifications(): List<ContractPathData> {

--- a/core/src/test/kotlin/io/specmatic/stub/ApiKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/ApiKtTest.kt
@@ -880,11 +880,53 @@ Feature: Math API
             )
         }
 
-        assertThat(stubResults).isEmpty()
+        assertThat(stubResults).hasSize(1)
+        assertThat(stubResults.single()).isInstanceOf(FeatureStubsResult.Failure::class.java)
         assertThat(output)
             .contains("Expected dictionary file at")
             .contains(dictionaryFile.canonicalPath)
             .contains("does not exist")
+    }
+
+    @Test
+    fun `loadContractStubsFromFilesAsResults should return failure when spec loading fails due to invalid dictionary path in config`(@TempDir tempDir: File) {
+        val specFile = tempDir.resolve("api.yaml")
+        val dictionaryFile = tempDir.resolve("dictionary.yaml")
+        val configFile = tempDir.resolve("specmatic-v2.yaml")
+
+        specFile.writeText(minimalOpenApiSpec())
+        configFile.writeText(
+            yamlMapper.writeValueAsString(
+                SpecmaticConfigV2(
+                    version = SpecmaticConfigVersion.VERSION_2,
+                    stub = StubConfiguration(dictionary = dictionaryFile.canonicalPath),
+                    contracts = listOf(
+                        ContractConfig(
+                            filesystem = ContractConfig.FileSystemContractSource(tempDir.canonicalPath),
+                            consumes = listOf(SpecExecutionConfig.StringValue(specFile.name))
+                        )
+                    )
+                )
+            )
+        )
+
+        val (output, stubResults) = captureStandardOutput {
+            val paths = contractStubPaths(configFile.canonicalPath)
+            val specmaticConfig = loadSpecmaticConfig(configFile.canonicalPath)
+            loadContractStubsFromFilesAsResults(
+                contractPathDataList = paths,
+                dataDirPaths = emptyList(),
+                specmaticConfig = specmaticConfig,
+                withImplicitStubs = false
+            )
+        }
+
+        assertThat(stubResults).hasSize(1)
+        val failure = stubResults.single()
+        assertThat(failure).isInstanceOf(FeatureStubsResult.Failure::class.java); failure as FeatureStubsResult.Failure
+        assertThat(File(failure.stubFile).canonicalPath).isEqualTo(specFile.canonicalPath)
+        assertThat(failure.errorMessage).contains("Expected dictionary file at").contains(dictionaryFile.canonicalPath).contains("does not exist")
+        assertThat(output).contains("Expected dictionary file at").contains(dictionaryFile.canonicalPath)
     }
 
     @Test
@@ -931,7 +973,8 @@ Feature: Math API
             )
         }
 
-        assertThat(stubResults).isEmpty()
+        assertThat(stubResults).hasSize(1)
+        assertThat(stubResults.single()).isInstanceOf(FeatureStubsResult.Failure::class.java)
         assertThat(output)
             .contains("Expected dictionary file at")
             .contains(dictionaryFile.canonicalPath)
@@ -982,7 +1025,8 @@ Feature: Math API
             )
         }
 
-        assertThat(stubResults).isEmpty()
+        assertThat(stubResults).hasSize(1)
+        assertThat(stubResults.single()).isInstanceOf(FeatureStubsResult.Failure::class.java)
         assertThat(output)
             .contains("Expected dictionary file at")
             .contains(dictionaryFile.canonicalPath)


### PR DESCRIPTION
**What**: Make sure that any failures in loading mock specifications are properly propagated

**How**:
- Make sure that any specification load errors are propagated through `FeatureStubsResult`
- Rather than suppressing the exception, implement a try-catch block and convert it to a result

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
