### PR TITLE
Isolate ContractExecutionListener state per test run

### DIFF
--- a/junit5-support/src/main/kotlin/io/specmatic/test/listeners/ContractExecutionListener.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/listeners/ContractExecutionListener.kt
@@ -8,7 +8,10 @@ import org.junit.platform.engine.TestExecutionResult.Status
 import org.junit.platform.launcher.TestExecutionListener
 import org.junit.platform.launcher.TestIdentifier
 import org.junit.platform.launcher.TestPlan
-import kotlin.system.exitProcess
+import java.util.Collections
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
 
 fun getContractExecutionPrinter(): ContractExecutionPrinter {
     return if(stdOutIsRedirected())
@@ -23,30 +26,38 @@ private fun colorIsRequested() = System.getenv("SPECMATIC_COLOR") == "1"
 private fun stdOutIsRedirected() = System.console() == null
 
 class ContractExecutionListener : TestExecutionListener {
+    private val success = AtomicInteger(0)
+    private val failure = AtomicInteger(0)
+    private val aborted = AtomicInteger(0)
+    private val couldNotStart = AtomicBoolean(false)
+    private val testSuiteFailed = AtomicBoolean(false)
+    private val printer: ContractExecutionPrinter = getContractExecutionPrinter()
+    private val failedLog: MutableList<String> = Collections.synchronizedList(mutableListOf())
+    private val exceptionsThrown: MutableList<Throwable> = Collections.synchronizedList(mutableListOf())
+
+    init {
+        latestListener.set(this)
+    }
+
     companion object {
-        private var success: Int = 0
-        private var failure: Int = 0
-        private var aborted: Int = 0
+        private val latestListener = AtomicReference<ContractExecutionListener?>(null)
+        internal fun reset() { latestListener.get()?.reset() }
+        fun exitCode(): Int = latestListener.get()?.exitCode() ?: 1
+    }
 
-        private val failedLog: MutableList<String> = mutableListOf()
-        private var couldNotStart = false
-        private var testSuiteFailed = false
-        private val exceptionsThrown = mutableListOf<Throwable>()
-        private val printer: ContractExecutionPrinter = getContractExecutionPrinter()
+    internal fun exitCode(): Int = if (testSuiteFailed.get() || couldNotStart.get() || failure.get() > 0) 1 else 0
+    internal fun reset() {
+        success.set(0)
+        failure.set(0)
+        aborted.set(0)
+        couldNotStart.set(false)
+        testSuiteFailed.set(false)
+        failedLog.clear()
+        exceptionsThrown.clear()
+    }
 
-        fun exitCode(): Int = exitStatus()
-
-        internal fun exitStatus(): Int = if (testSuiteFailed || couldNotStart || failure > 0) 1 else 0
-
-        internal fun reset() {
-            success = 0
-            failure = 0
-            aborted = 0
-            couldNotStart = false
-            testSuiteFailed = false
-            failedLog.clear()
-            exceptionsThrown.clear()
-        }
+    override fun testPlanExecutionStarted(testPlan: TestPlan?) {
+        reset()
     }
 
     override fun executionFinished(testIdentifier: TestIdentifier?, testExecutionResult: TestExecutionResult?) {
@@ -56,8 +67,10 @@ class ContractExecutionListener : TestExecutionListener {
             testExecutionResult?.let {
                 it.throwable?.ifPresent { throwable -> exceptionsThrown.add(throwable) }
                 if (it.status != Status.SUCCESSFUL) {
-                    testSuiteFailed = true
-                    couldNotStart = couldNotStart || (success + failure + aborted == 0)
+                    testSuiteFailed.set(true)
+                    if (success.get() + failure.get() + aborted.get() == 0) {
+                        couldNotStart.set(true)
+                    }
                 }
             }
 
@@ -68,15 +81,15 @@ class ContractExecutionListener : TestExecutionListener {
 
         when (testExecutionResult?.status) {
             Status.SUCCESSFUL -> {
-                success++
+                success.incrementAndGet()
                 println()
             }
             Status.ABORTED -> {
-                aborted++
+                aborted.incrementAndGet()
                 printAndLogFailure(testExecutionResult, testIdentifier)
             }
             Status.FAILED -> {
-                failure++
+                failure.incrementAndGet()
                 printAndLogFailure(testExecutionResult, testIdentifier)
             }
             else -> {
@@ -101,7 +114,8 @@ class ContractExecutionListener : TestExecutionListener {
 
         println()
 
-        exceptionsThrown.map { exceptionThrown ->
+        val exceptionSnapshot = synchronized(exceptionsThrown) { exceptionsThrown.toList() }
+        exceptionSnapshot.forEach { exceptionThrown ->
             logger.log(exceptionThrown)
         }
 
@@ -121,13 +135,21 @@ class ContractExecutionListener : TestExecutionListener {
             println()
         }
 
-        if (failedLog.isNotEmpty()) {
+        val failedLogSnapshot = synchronized(failedLog) { failedLog.toList() }
+        if (failedLogSnapshot.isNotEmpty()) {
             println()
             printer.printFailureTitle("Unsuccessful Scenarios:")
-            println(failedLog.joinToString(System.lineSeparator() + System.lineSeparator()) { it.prependIndent("  ") })
+            println(failedLogSnapshot.joinToString(System.lineSeparator() + System.lineSeparator()) { it.prependIndent("  ") })
             println()
         }
 
-        printer.printFinalSummary(TestSummary(success, SpecmaticJUnitSupport.partialSuccesses.size, aborted, failure))
+        printer.printFinalSummary(
+            TestSummary(
+                success = success.get(),
+                partialSuccesses = SpecmaticJUnitSupport.partialSuccesses.size,
+                aborted = aborted.get(),
+                failure = failure.get()
+            )
+        )
     }
 }

--- a/junit5-support/src/test/kotlin/io/specmatic/test/listeners/ContractExecutionListenerTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/listeners/ContractExecutionListenerTest.kt
@@ -27,7 +27,7 @@ class ContractExecutionListenerTest {
         listener.executionFinished(testIdentifier(TestDescriptor.Type.TEST), TestExecutionResult.successful())
         listener.testPlanExecutionFinished(null)
 
-        assertEquals(0, ContractExecutionListener.exitStatus())
+        assertEquals(0, ContractExecutionListener.exitCode())
     }
 
     @Test
@@ -40,7 +40,7 @@ class ContractExecutionListenerTest {
         )
         listener.testPlanExecutionFinished(null)
 
-        assertEquals(0, ContractExecutionListener.exitStatus())
+        assertEquals(0, ContractExecutionListener.exitCode())
     }
 
     @Test
@@ -53,7 +53,7 @@ class ContractExecutionListenerTest {
 
         listener.testPlanExecutionFinished(null)
 
-        assertEquals(0, ContractExecutionListener.exitStatus())
+        assertEquals(0, ContractExecutionListener.exitCode())
     }
 
     @Test
@@ -67,7 +67,7 @@ class ContractExecutionListenerTest {
         )
         listener.testPlanExecutionFinished(null)
 
-        assertEquals(1, ContractExecutionListener.exitStatus())
+        assertEquals(1, ContractExecutionListener.exitCode())
     }
 
     @Test
@@ -80,7 +80,52 @@ class ContractExecutionListenerTest {
         )
         listener.testPlanExecutionFinished(null)
 
-        assertEquals(1, ContractExecutionListener.exitStatus())
+        assertEquals(1, ContractExecutionListener.exitCode())
+    }
+
+    @Test
+    fun `listener instances maintain independent state`() {
+        val failedRunListener = ContractExecutionListener()
+        val successfulRunListener = ContractExecutionListener()
+
+        failedRunListener.executionFinished(testIdentifier(TestDescriptor.Type.TEST), TestExecutionResult.failed(AssertionError("Kaboom ? Yes Rico Kaboom!")))
+        failedRunListener.testPlanExecutionFinished(null)
+
+        successfulRunListener.executionFinished(testIdentifier(TestDescriptor.Type.TEST), TestExecutionResult.successful())
+        successfulRunListener.testPlanExecutionFinished(null)
+
+        assertEquals(1, failedRunListener.exitCode())
+        assertEquals(0, successfulRunListener.exitCode())
+    }
+
+    @Test
+    fun `static exitCode tracks the latest listener instance`() {
+        val failedRunListener = ContractExecutionListener()
+        failedRunListener.executionFinished(testIdentifier(TestDescriptor.Type.TEST), TestExecutionResult.failed(AssertionError("boom")))
+        failedRunListener.testPlanExecutionFinished(null)
+        assertEquals(1, ContractExecutionListener.exitCode())
+
+        val successfulRunListener = ContractExecutionListener()
+        successfulRunListener.executionFinished(testIdentifier(TestDescriptor.Type.TEST), TestExecutionResult.successful())
+        successfulRunListener.testPlanExecutionFinished(null)
+
+        assertEquals(0, ContractExecutionListener.exitCode())
+    }
+
+    @Test
+    fun `testPlanExecutionStarted resets listener state and prevents accumulation across runs`() {
+        val listener = ContractExecutionListener()
+
+        listener.executionFinished(testIdentifier(TestDescriptor.Type.TEST), TestExecutionResult.failed(AssertionError("first run failure")))
+        listener.testPlanExecutionFinished(null)
+        assertEquals(1, listener.exitCode())
+
+        listener.testPlanExecutionStarted(null)
+        listener.executionFinished(testIdentifier(TestDescriptor.Type.TEST), TestExecutionResult.successful())
+        listener.testPlanExecutionFinished(null)
+
+        assertEquals(0, listener.exitCode())
+        assertEquals(0, ContractExecutionListener.exitCode())
     }
 }
 


### PR DESCRIPTION
**What:**
- Moves `ContractExecutionListener` counters/logs from shared static state to instance state
- Preserves `ContractExecutionListener.exitCode()` for `TestCommand` compatibility

**How:**
- Replaced companion-state counters/flags with atomics and synchronized lists on the listener instance
- Kept a companion `latestListener` reference so static `exitCode()` still works for the current CLI flow

**Note:** 
- `ContractExecutionListener.exitCode()` is intentionally defined against the latest listener instance and is relied on by the current `TestCommand` single-launcher execution path

**Checklist**:

- [x] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)->
