### PR TITLE
Fix HttpStub issues with generative enabled

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -1220,10 +1220,10 @@ data class Feature(
         }
     }
 
-    fun identifierMatchingScenario(httpRequest: HttpRequest): Scenario? {
-        return scenarios.asSequence().filter {
-            it.httpRequestPattern.matchesPathStructureMethodAndContentType(httpRequest, it.resolver).isSuccess()
-        }.firstOrNull()
+    fun identifierMatchingScenario(httpRequest: HttpRequest, furtherPredicate: (Scenario) -> Boolean = { true }): Scenario? {
+        return scenarios.firstOrNull { scenario ->
+            scenario.httpRequestPattern.matchesPathStructureMethodAndContentType(httpRequest, scenario.resolver).isSuccess() && furtherPredicate(scenario)
+        }
     }
 
     private fun getScenarioWithDescription(scenarioResult: ReturnValue<Scenario>): ReturnValue<Scenario> {

--- a/core/src/main/kotlin/io/specmatic/core/log/HttpLogMessage.kt
+++ b/core/src/main/kotlin/io/specmatic/core/log/HttpLogMessage.kt
@@ -173,10 +173,12 @@ data class HttpLogMessage(
     }
 
     fun toResult(): TestResult {
+        val scenario = this.scenario ?: return TestResult.MissingInSpec
+        val result = this.result
         return when {
+            result != null -> result.testResult()
             this.matchedAnExample -> TestResult.Success
-            this.scenario != null && response?.status !in invalidRequestStatuses -> TestResult.Success
-            scenario == null -> TestResult.MissingInSpec
+            response?.status == scenario.status -> TestResult.Success
             else -> TestResult.Failed
         }
     }
@@ -185,7 +187,7 @@ data class HttpLogMessage(
         return when {
             this.isInlineExample -> "Request Matched Inline Example: ${this.resolvedExampleName}"
             this.isExternalExample -> "Request Matched External Example: ${this.resolvedExampleName}"
-            this.scenario != null && response?.status !in invalidRequestStatuses -> "Request Matched Contract ${scenario?.defaultAPIDescription}"
+            this.scenario != null && response?.status == this.scenario!!.status -> "Request Matched Contract ${scenario?.defaultAPIDescription}"
             this.exception != null -> "Invalid Request\n${exception?.let(::exceptionCauseMessage)}"
             else -> response?.body?.toStringLiteral() ?: "Request Didn't Match Contract"
         }

--- a/core/src/main/kotlin/io/specmatic/core/log/HttpLogMessage.kt
+++ b/core/src/main/kotlin/io/specmatic/core/log/HttpLogMessage.kt
@@ -184,10 +184,12 @@ data class HttpLogMessage(
     }
 
     fun toDetails(): String {
+        val scenario = this.scenario
+
         return when {
             this.isInlineExample -> "Request Matched Inline Example: ${this.resolvedExampleName}"
             this.isExternalExample -> "Request Matched External Example: ${this.resolvedExampleName}"
-            this.scenario != null && response?.status == this.scenario!!.status -> "Request Matched Contract ${scenario?.defaultAPIDescription}"
+            scenario != null && response?.status == scenario.status -> "Request Matched Contract ${scenario.defaultAPIDescription}"
             this.exception != null -> "Invalid Request\n${exception?.let(::exceptionCauseMessage)}"
             else -> response?.body?.toStringLiteral() ?: "Request Didn't Match Contract"
         }

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -1436,17 +1436,10 @@ fun fakeHttpResponse(
             }.firstOrNull()
 
             if (firstScenarioWith400Response != null && specmaticConfig.getStubGenerative(File(firstScenarioWith400Response.first.path))) {
+                val feature = firstScenarioWith400Response.first
                 val scenario = firstScenarioWith400Response.second as Scenario
                 val errorResponse = scenario.responseWithStubError(combinedFailureResult.report())
-
-                FoundStubbedResponse(
-                    HttpStubResponse(
-                        errorResponse,
-                        contractPath = "",
-                        feature = fakeResponse?.feature,
-                        scenario = fakeResponse?.successResponse?.scenario
-                    )
-                )
+                FoundStubbedResponse(HttpStubResponse(errorResponse, contractPath = feature.path, scenario = scenario, feature = feature))
             } else {
                 val httpFailureResponse = combinedFailureResult.generateErrorHttpResponse(httpRequest)
                 val nearestScenario = features.firstNotNullOfOrNull { it.identifierMatchingScenario(httpRequest) }

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -40,6 +40,7 @@ import io.specmatic.core.Scenario
 import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.WorkingDirectory
 import io.specmatic.core.examples.server.ExampleMismatchMessages
+import io.specmatic.core.invalidRequestStatuses
 import io.specmatic.core.listOfExcludedHeaders
 import io.specmatic.core.log.HttpLogMessage
 import io.specmatic.core.log.LogMessage
@@ -1568,51 +1569,35 @@ private fun strictModeHttp400Response(
     matchResults: List<Pair<Result, HttpStubData>>,
     generative: Boolean
 ): NotStubbed {
-    val failureResults = matchResults.map { it.first }
-    val results = Results(failureResults).withoutFluff().withoutViolationReport()
+    val results = Results(matchResults.map { it.first }).withoutFluff().withoutViolationReport()
     val strictModeReport = results.strictModeReport(httpRequest)
-
-    val nonFluffyMismatches = matchResults.filter { !it.first.isFluffy() }
-    val failedFeatures = nonFluffyMismatches.map { it.second }.distinct()
-
-    val requestDetailsInExampleScenario = nonFluffyMismatches.firstNotNullOfOrNull { (_, stub) -> stub.scenario?.let { it.getRequestDetails() } }
-
-    val errorStatuses = listOf(400, 422)
-
-    val firstScenarioWith400Response = features.firstNotNullOfOrNull {
-        it.scenarios.find {
-            it.getRequestDetails() == requestDetailsInExampleScenario && it.status in errorStatuses
-        }
+    val scenario = features.firstNotNullOfOrNull { it.identifierMatchingScenario(httpRequest) }
+    val response = if (generative) {
+        generativeStrictModeResponse(httpRequest, features, strictModeReport) ?: strictModeFallbackResponse(strictModeReport)
+    } else {
+        strictModeFallbackResponse(strictModeReport)
     }
-
-    if (firstScenarioWith400Response == null) {
-        val defaultHeaders = mapOf("Content-Type" to "text/plain", SPECMATIC_RESULT_HEADER to "failure")
-        val headers = when {
-            strictModeReport.isEmpty() -> defaultHeaders.plus(SPECMATIC_EMPTY_HEADER to "true")
-            else -> defaultHeaders
-        }
-
-        return NotStubbed(
-            stubResult = results.toResultIfAnyWithCauses(),
-            response = HttpStubResponse(
-                scenario = features.firstNotNullOfOrNull { it.identifierMatchingScenario(httpRequest) },
-                response = HttpResponse(
-                    status = 400, headers = headers,
-                    body = StringValue("STRICT MODE ON${System.lineSeparator()}${System.lineSeparator()}$strictModeReport")
-                ),
-            ),
-        )
-    }
-
-    val httpResponse = firstScenarioWith400Response.responseWithStubError(strictModeReport)
 
     return NotStubbed(
         stubResult = results.toResultIfAnyWithCauses(),
-        response = HttpStubResponse(
-            scenario = features.firstNotNullOfOrNull { it.identifierMatchingScenario(httpRequest) },
-            response = httpResponse
-            ),
-        )
+        response = HttpStubResponse(scenario = scenario, response = response),
+    )
+}
+
+private fun generativeStrictModeResponse(httpRequest: HttpRequest, features: List<Feature>, strictModeReport: String): HttpResponse? {
+    return features.firstNotNullOfOrNull { feature ->
+        feature.identifierMatchingScenario(httpRequest) { it.status in invalidRequestStatuses }
+    }?.responseWithStubError(strictModeReport)
+}
+
+private fun strictModeFallbackResponse(strictModeReport: String): HttpResponse {
+    val defaultHeaders = mapOf("Content-Type" to "text/plain", SPECMATIC_RESULT_HEADER to "failure")
+    val headers = if (strictModeReport.isEmpty()) defaultHeaders + (SPECMATIC_EMPTY_HEADER to "true") else defaultHeaders
+    return HttpResponse(
+        status = 400,
+        headers = headers,
+        body = StringValue("STRICT MODE ON${System.lineSeparator()}${System.lineSeparator()}$strictModeReport")
+    )
 }
 
 fun stubResponse(

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -1439,11 +1439,29 @@ fun fakeHttpResponse(
                 val feature = firstScenarioWith400Response.first
                 val scenario = firstScenarioWith400Response.second as Scenario
                 val errorResponse = scenario.responseWithStubError(combinedFailureResult.report())
-                FoundStubbedResponse(HttpStubResponse(errorResponse, contractPath = feature.path, scenario = scenario, feature = feature))
+                NotStubbed(
+                    HttpStubResponse(errorResponse, contractPath = feature.path, scenario = scenario, feature = feature),
+                    combinedFailureResult.toResultIfAnyWithCauses(),
+                )
             } else {
                 val httpFailureResponse = combinedFailureResult.generateErrorHttpResponse(httpRequest)
-                val nearestScenario = features.firstNotNullOfOrNull { it.identifierMatchingScenario(httpRequest) }
-                NotStubbed(HttpStubResponse(httpFailureResponse, scenario = nearestScenario), stubResult = combinedFailureResult.toResultIfAnyWithCauses())
+
+                val (nearestMatchingFeature, nearestMatchingScenario) =
+                    features.firstNotNullOfOrNull { feature ->
+                        feature.identifierMatchingScenario(httpRequest)?.let { scenario ->
+                            feature to scenario
+                        }
+                    } ?: Pair (null, null)
+
+                NotStubbed(
+                    response = HttpStubResponse(
+                        response = httpFailureResponse,
+                        scenario = nearestMatchingScenario,
+                        contractPath = nearestMatchingFeature?.path.orEmpty(),
+                        feature = nearestMatchingFeature
+                    ),
+                    stubResult = combinedFailureResult.toResultIfAnyWithCauses(),
+                )
             }
         }
 

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubKtTest.kt
@@ -398,16 +398,246 @@ Feature: Test
         val stubData = feature.matchingStub(scenarioStub)
 
         val request = HttpRequest(method = "POST", path = "/", body = parsedJSON("""{"number": "Hello"}"""))
-        val response = stubResponse(request, listOf(feature), listOf(stubData), true)
+        val result = getHttpResponse(
+            httpRequest = request,
+            features = listOf(feature),
+            httpExpectations = HttpExpectations(mutableListOf(stubData)),
+            strictMode = true,
+            specmaticConfig = SpecmaticConfigV1V2Common(stub = StubConfiguration(generative = true))
+        )
 
         val strictModeReport = Results(listOf(stubData.matches(request)))
             .withoutFluff()
             .withoutViolationReport()
             .strictModeReport(request)
 
+        assertThat(result).isInstanceOf(NotStubbed::class.java)
+        val response = (result as NotStubbed).response
         assertThat(response.response.status).isEqualTo(400)
         val responseBody = response.response.body as JSONObjectValue
         assertThat(responseBody.jsonObject.getValue("message").toStringLiteral()).isEqualTo(strictModeReport)
+    }
+
+    @Test
+    fun `in strict mode without generative mode the stub replies with strict mode fallback even if 400 response exists`() {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+            openapi: 3.0.3
+            info:
+              title: Strict mode error payload
+              version: 1.0.0
+            paths:
+              /:
+                post:
+                  requestBody:
+                    required: true
+                    content:
+                      application/json:
+                        schema:
+                          type: object
+                          required:
+                            - number
+                          properties:
+                            number:
+                              type: number
+                  responses:
+                    '200':
+                      description: OK
+                    '400':
+                      description: Bad request
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                            required:
+                              - message
+                            properties:
+                              message:
+                                type: string
+            """.trimIndent(), ""
+        ).toFeature()
+
+        val stubRequest = HttpRequest(method = "POST", path = "/", body = parsedJSON("""{"number": 10}"""))
+        val scenarioStub = ScenarioStub(stubRequest, HttpResponse.OK, null)
+        val stubData = feature.matchingStub(scenarioStub)
+
+        val request = HttpRequest(method = "POST", path = "/", body = parsedJSON("""{"number": "Hello"}"""))
+        val result = getHttpResponse(
+            httpRequest = request,
+            features = listOf(feature),
+            httpExpectations = HttpExpectations(mutableListOf(stubData)),
+            strictMode = true,
+            specmaticConfig = SpecmaticConfigV1V2Common(stub = StubConfiguration(generative = false))
+        )
+
+        val strictModeReport = Results(listOf(stubData.matches(request)))
+            .withoutFluff()
+            .withoutViolationReport()
+            .strictModeReport(request)
+
+        assertThat(result).isInstanceOf(NotStubbed::class.java)
+        assertResponseFailure((result as NotStubbed).response, """
+        STRICT MODE ON
+
+        $strictModeReport
+        """.trimIndent())
+    }
+
+    @Test
+    fun `in generative strict mode without stubs it should still use matching 400 response payload`() {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+            openapi: 3.0.3
+            info:
+              title: Strict mode error payload without stubs
+              version: 1.0.0
+            paths:
+              /:
+                post:
+                  requestBody:
+                    required: true
+                    content:
+                      application/json:
+                        schema:
+                          type: object
+                          required:
+                            - number
+                          properties:
+                            number:
+                              type: number
+                  responses:
+                    '200':
+                      description: OK
+                    '400':
+                      description: Bad request
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                            required:
+                              - message
+                            properties:
+                              message:
+                                type: string
+            """.trimIndent(), ""
+        ).toFeature()
+
+        val request = HttpRequest(method = "POST", path = "/", body = parsedJSON("""{"number": "Hello"}"""))
+        val result = getHttpResponse(
+            httpRequest = request,
+            features = listOf(feature),
+            httpExpectations = HttpExpectations(mutableListOf()),
+            strictMode = true,
+            specmaticConfig = SpecmaticConfigV1V2Common(stub = StubConfiguration(generative = true))
+        )
+
+        assertThat(result).isInstanceOf(NotStubbed::class.java)
+        val response = (result as NotStubbed).response.response
+        assertThat(response.status).isEqualTo(400)
+        assertThat(response.body).isInstanceOf(JSONObjectValue::class.java)
+        val responseBody = response.body as JSONObjectValue
+        assertThat(responseBody.jsonObject.getValue("message")).isInstanceOf(StringValue::class.java)
+        assertThat((responseBody.jsonObject.getValue("message") as StringValue).string).doesNotContain("STRICT MODE ON")
+    }
+
+    @Test
+    fun `in generative strict mode without stubs it should use matching 422 response payload`() {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+            openapi: 3.0.3
+            info:
+              title: Strict mode error payload without stubs
+              version: 1.0.0
+            paths:
+              /:
+                post:
+                  requestBody:
+                    required: true
+                    content:
+                      application/json:
+                        schema:
+                          type: object
+                          required:
+                            - number
+                          properties:
+                            number:
+                              type: number
+                  responses:
+                    '200':
+                      description: OK
+                    '422':
+                      description: Validation error
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                            required:
+                              - message
+                            properties:
+                              message:
+                                type: string
+            """.trimIndent(), ""
+        ).toFeature()
+
+        val request = HttpRequest(method = "POST", path = "/", body = parsedJSON("""{"number": "Hello"}"""))
+        val result = getHttpResponse(
+            httpRequest = request,
+            features = listOf(feature),
+            httpExpectations = HttpExpectations(mutableListOf()),
+            strictMode = true,
+            specmaticConfig = SpecmaticConfigV1V2Common(stub = StubConfiguration(generative = true))
+        )
+
+        assertThat(result).isInstanceOf(NotStubbed::class.java)
+        val response = (result as NotStubbed).response.response
+        assertThat(response.status).isEqualTo(422)
+        assertThat(response.body).isInstanceOf(JSONObjectValue::class.java)
+    }
+
+    @Test
+    fun `in generative strict mode without invalid request responses it should fall back to strict mode text response`() {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+            openapi: 3.0.3
+            info:
+              title: Strict mode fallback when no invalid response exists
+              version: 1.0.0
+            paths:
+              /:
+                post:
+                  requestBody:
+                    required: true
+                    content:
+                      application/json:
+                        schema:
+                          type: object
+                          required:
+                            - number
+                          properties:
+                            number:
+                              type: number
+                  responses:
+                    '200':
+                      description: OK
+            """.trimIndent(), ""
+        ).toFeature()
+
+        val request = HttpRequest(method = "POST", path = "/", body = parsedJSON("""{"number": "Hello"}"""))
+        val result = getHttpResponse(
+            httpRequest = request,
+            features = listOf(feature),
+            httpExpectations = HttpExpectations(mutableListOf()),
+            strictMode = true,
+            specmaticConfig = SpecmaticConfigV1V2Common(stub = StubConfiguration(generative = true))
+        )
+
+        assertThat(result).isInstanceOf(NotStubbed::class.java)
+        val response = (result as NotStubbed).response.response
+        assertThat(response.status).isEqualTo(400)
+        assertThat(response.headers).containsEntry(SPECMATIC_RESULT_HEADER, "failure")
+        assertThat(response.body).isInstanceOf(StringValue::class.java)
+        assertThat(response.body.toStringLiteral()).contains("STRICT MODE ON")
+        assertThat(response.body.toStringLiteral()).contains("No matching REST stub")
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubKtTest.kt
@@ -641,7 +641,7 @@ Feature: Test
     }
 
     @Test
-    fun `fake response should honor response schema constraints when error report does not match`() {
+    fun `generative error response should honor response schema constraints when error report does not match`() {
         val feature = OpenApiSpecification.fromYAML(
             """
             openapi: 3.0.3
@@ -690,8 +690,8 @@ Feature: Test
             SpecmaticConfigV1V2Common(stub = StubConfiguration(generative = true))
         )
 
-        assertThat(result).isInstanceOf(FoundStubbedResponse::class.java)
-        val stubbedResponse = (result as FoundStubbedResponse).response
+        assertThat(result).isInstanceOf(NotStubbed::class.java)
+        val stubbedResponse = (result as NotStubbed).response
         val response = stubbedResponse.response
         assertThat(response.status).isEqualTo(400)
         assertThat(stubbedResponse.contractPath).isEqualTo(feature.path)

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubKtTest.kt
@@ -680,7 +680,7 @@ Feature: Test
                             properties:
                               message:
                                 type: string
-            """.trimIndent(), ""
+            """.trimIndent(), "contracts/generative-error-payload.yaml"
         ).toFeature()
 
         val request = HttpRequest(method = "POST", path = "/hello", body = parsedJSONObject("""{"data": 10}"""))
@@ -691,8 +691,13 @@ Feature: Test
         )
 
         assertThat(result).isInstanceOf(FoundStubbedResponse::class.java)
-        val response = (result as FoundStubbedResponse).response.response
+        val stubbedResponse = (result as FoundStubbedResponse).response
+        val response = stubbedResponse.response
         assertThat(response.status).isEqualTo(400)
+        assertThat(stubbedResponse.contractPath).isEqualTo(feature.path)
+        assertThat(stubbedResponse.feature).isEqualTo(feature)
+        assertThat(stubbedResponse.scenario).isNotNull
+        assertThat(stubbedResponse.scenario?.status).isEqualTo(400)
 
         val responseBody = response.body as JSONObjectValue
         val messageValue = responseBody.jsonObject.getValue("message")

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
@@ -2071,9 +2071,11 @@ paths:
 
             val feature = OpenApiSpecification.fromYAML(spec, "").toFeature()
 
+            val config = SpecmaticConfigV1V2Common(stub = StubConfiguration(generative = true))
             HttpStub(
                 listOf(feature),
                 strictMode = true,
+                specmaticConfigSource = SpecmaticConfigSource.fromConfig(config)
             ).use { stub ->
                 val request =
                     HttpRequest(

--- a/core/src/test/kotlin/io/specmatic/stub/listener/MockEventListenerTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/listener/MockEventListenerTest.kt
@@ -1,12 +1,19 @@
 package io.specmatic.stub.listener
 
 import io.specmatic.core.HttpRequest
+import io.specmatic.core.HttpResponse
 import io.specmatic.core.Result
+import io.specmatic.core.SpecmaticConfigV1V2Common
+import io.specmatic.core.StubConfiguration
+import io.specmatic.core.log.HttpLogMessage
 import io.specmatic.core.parseContractFileToFeature
+import io.specmatic.core.pattern.parsedJSONObject
+import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.NullValue
 import io.specmatic.mock.ScenarioStub
 import io.specmatic.reporter.model.TestResult
 import io.specmatic.stub.HttpStub
+import io.specmatic.stub.SpecmaticConfigSource
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.io.File
@@ -15,8 +22,10 @@ class MockEventListenerTest {
     companion object {
         private val openApiFile = File("src/test/resources/openapi/partial_example_tests/simple.yaml")
         private val inlineExamplesOpenApiFile = File("src/test/resources/openapi/has_multiple_inline_examples.yaml")
+        private val generative4xxOpenApiFile = File("src/test/resources/openapi/mock_event_listener_generative_4xx.yaml")
         val feature = parseContractFileToFeature(openApiFile)
         val featureWithInlineExamples = parseContractFileToFeature(inlineExamplesOpenApiFile)
+        val featureWithGenerative4xxResponse = parseContractFileToFeature(generative4xxOpenApiFile)
     }
 
     private fun captureMockEvents(testBlock: (MockEventListener) -> Unit): List<MockEvent> {
@@ -131,6 +140,61 @@ class MockEventListenerTest {
         assertThat(event.name).isEqualToIgnoringWhitespace("Scenario: PATCH /creators/(creatorId:number)/pets/(petId:number) -> 201")
         assertThat(event.details).contains("Specification expected json object but request contained an empty string or no body value")
         assertThat(event.scenario).isEqualTo(feature.scenarios.first())
+        assertThat(event.stubResult).isEqualTo(TestResult.Failed)
+    }
+
+    @Test
+    fun `should send generated 400 response data to listener when generative stub is enabled`() {
+        val feature = featureWithGenerative4xxResponse
+        val config = SpecmaticConfigV1V2Common(stub = StubConfiguration(generative = true))
+        val events = captureMockEvents { listener ->
+            HttpStub(features = listOf(feature), listeners = listOf(listener), specmaticConfigSource = SpecmaticConfigSource.fromConfig(config)).use { stub ->
+                stub.client.execute(HttpRequest(method = "POST", path = "/hello", body = parsedJSONObject("""{"data": 10}""")))
+            }
+        }
+
+        assertThat(events).hasSize(1)
+        val event = events.single()
+        assertThat(event.response?.status).isEqualTo(400)
+        assertThat(event.scenario?.status).isEqualTo(400)
+        assertThat(event.stubResult).isEqualTo(TestResult.Success)
+        assertThat(event.result).isEqualTo(Result.Success())
+    }
+
+    @Test
+    fun `should report failure to listener for same invalid request when generative stub is disabled`() {
+        val feature = featureWithGenerative4xxResponse
+        val config = SpecmaticConfigV1V2Common(stub = StubConfiguration(generative = false))
+        val events = captureMockEvents { listener ->
+            HttpStub(features = listOf(feature), listeners = listOf(listener), specmaticConfigSource = SpecmaticConfigSource.fromConfig(config)).use { stub ->
+                stub.client.execute(HttpRequest(method = "POST", path = "/hello", body = parsedJSONObject("""{"data": 10}""")))
+            }
+        }
+
+        assertThat(events).hasSize(1)
+        val event = events.single()
+        assertThat(event.response?.status).isEqualTo(400)
+        assertThat(event.scenario?.status).isNotEqualTo(event.response?.status)
+        assertThat(event.stubResult).isEqualTo(TestResult.Failed)
+        assertThat(event.result).isInstanceOf(Result.Failure::class.java)
+    }
+
+    @Test
+    fun `strict generative mock event should keep 400 response format but remain failure`() {
+        val first400Scenario = featureWithGenerative4xxResponse.scenarios.first { it.status == 400 }
+        val event = MockEvent(
+            HttpLogMessage(
+                request = HttpRequest(method = "POST", path = "/hello", body = parsedJSONObject("""{"data": 10}""")),
+                response = HttpResponse(status = 400, body = parsedJSONObject("""{"message": "REQUEST.BODY.data mismatch"}""")),
+                scenario = first400Scenario,
+                result = Result.Failure("strict mode mismatch")
+            )
+        )
+
+        assertThat(event.response?.status).isEqualTo(400)
+        assertThat(event.response?.body).isInstanceOf(JSONObjectValue::class.java)
+        assertThat(event.scenario?.status).isEqualTo(400)
+        assertThat(event.result).isInstanceOf(Result.Failure::class.java)
         assertThat(event.stubResult).isEqualTo(TestResult.Failed)
     }
 

--- a/core/src/test/kotlin/io/specmatic/stub/listener/MockEventListenerTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/listener/MockEventListenerTest.kt
@@ -157,12 +157,12 @@ class MockEventListenerTest {
         val event = events.single()
         assertThat(event.response?.status).isEqualTo(400)
         assertThat(event.scenario?.status).isEqualTo(400)
-        assertThat(event.stubResult).isEqualTo(TestResult.Success)
-        assertThat(event.result).isEqualTo(Result.Success())
+        assertThat(event.stubResult).isEqualTo(TestResult.Failed)
+        assertThat(event.result).isInstanceOf(Result.Failure::class.java)
     }
 
     @Test
-    fun `should report failure to listener for same invalid request when generative stub is disabled`() {
+    fun `should report failure to listener for invalid request when generative stub is disabled`() {
         val feature = featureWithGenerative4xxResponse
         val config = SpecmaticConfigV1V2Common(stub = StubConfiguration(generative = false))
         val events = captureMockEvents { listener ->

--- a/core/src/test/resources/openapi/mock_event_listener_generative_4xx.yaml
+++ b/core/src/test/resources/openapi/mock_event_listener_generative_4xx.yaml
@@ -1,0 +1,50 @@
+openapi: 3.0.0
+info:
+  title: Listener Generative Stub Test
+  version: 1.0.0
+paths:
+  /hello:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - data
+              properties:
+                data:
+                  type: string
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+        '400':
+          description: bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - message
+                properties:
+                  message:
+                    type: string
+        '422':
+          description: validation error
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - message
+                properties:
+                  message:
+                    type: string


### PR DESCRIPTION
**What**: Fix HttpStub Issues with generative enabled, with and without strictMode

**How**:
- Resolve the issue where strict generative is always true, even when not configured
- Address issue of strict generative not functioning correctly when no examples are supplied for the endpoint
- Resolve issue of incorrect details being sent to `MockEvents` when generative is enabled

**Checklist**:

- [x] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
