### PR TITLE
fix: Use external example name if present

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/log/HttpLogMessage.kt
+++ b/core/src/main/kotlin/io/specmatic/core/log/HttpLogMessage.kt
@@ -38,6 +38,9 @@ data class HttpLogMessage(
     private val matchedAnExample: Boolean
         get() = (exampleName ?: examplePath) != null
 
+    private val resolvedExampleName: String?
+        get() = exampleName ?: examplePath
+
     fun combineLog(): String {
         val request = this.request.toLogString(prettyPrint = prettyPrint).trim('\n')
         val response = this.response?.toLogString(prettyPrint = prettyPrint)?.trim('\n') ?: "No response"
@@ -105,8 +108,8 @@ data class HttpLogMessage(
 
         val contractPathLines = if(contractPath.isNotBlank()) {
             val exampleLine = when {
-                isInlineExample -> "${linePrefix}Inline Example matched: $exampleName"
-                isExternalExample -> "${linePrefix}External Example matched: $examplePath"
+                isInlineExample -> "${linePrefix}Inline Example matched: $resolvedExampleName"
+                isExternalExample -> "${linePrefix}External Example matched: $resolvedExampleName"
                 else -> null
             }
 
@@ -180,8 +183,8 @@ data class HttpLogMessage(
 
     fun toDetails(): String {
         return when {
-            this.isInlineExample -> "Request Matched Inline Example: ${this.exampleName}"
-            this.isExternalExample -> "Request Matched External Example: ${this.examplePath}"
+            this.isInlineExample -> "Request Matched Inline Example: ${this.resolvedExampleName}"
+            this.isExternalExample -> "Request Matched External Example: ${this.resolvedExampleName}"
             this.scenario != null && response?.status !in invalidRequestStatuses -> "Request Matched Contract ${scenario?.defaultAPIDescription}"
             this.exception != null -> "Invalid Request\n${exception?.let(::exceptionCauseMessage)}"
             else -> response?.body?.toStringLiteral() ?: "Request Didn't Match Contract"

--- a/core/src/test/kotlin/HttpLogMessageTest.kt
+++ b/core/src/test/kotlin/HttpLogMessageTest.kt
@@ -99,4 +99,30 @@ internal class HttpLogMessageTest {
         )
         assertThat(message.toName()).contains("external example 'example.json'")
     }
+
+    @Test
+    fun `toDetails should mention inline example name for inline example matches`() {
+        val message = HttpLogMessage(
+            request = scenario.generateHttpRequest(),
+            response = scenario.generateHttpResponse(emptyMap()),
+            contractPath = "/path/to/file",
+            scenario = scenario,
+            exampleName = "FIND_SUCCESS"
+        )
+
+        assertThat(message.toDetails()).isEqualTo("Request Matched Inline Example: FIND_SUCCESS")
+    }
+
+    @Test
+    fun `toDetails should mention external example path for external example matches`() {
+        val message = HttpLogMessage(
+            request = scenario.generateHttpRequest(),
+            response = scenario.generateHttpResponse(emptyMap()),
+            contractPath = "/path/to/file",
+            scenario = scenario,
+            examplePath = "examples/example.json"
+        )
+
+        assertThat(message.toDetails()).isEqualTo("Request Matched External Example: examples/example.json")
+    }
 }


### PR DESCRIPTION
**What**:

Refactor HttpLogMessage to use resolvedExampleName in order to use the example name in an external example if present for logs / events

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #123

<!-- feel free to add additional comments -->
