### PR TITLE
Ensure PathItem parameters are used alongside operation

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -717,15 +717,16 @@ class OpenApiSpecification(
                     logger.debug("${System.lineSeparator()}Processing $httpMethod $openApiPath")
 
                     val methodContext = pathsContext.at(openApiPath).at(httpMethod.lowercase())
+                    val parameters = (pathItem.parameters.orEmpty() + openApiOperation.parameters.orEmpty()).distinctByNameAndLocation()
                     val specmaticPathParam = toSpecmaticPathParam(
                         openApiPath = openApiPath,
-                        operation = openApiOperation,
+                        parameters = parameters,
                         otherPathPatterns = allPathPatternsGroupedByMethod[httpMethod].orEmpty(),
                         collectorContext = methodContext
                     )
 
                     val specmaticQueryParam = toSpecmaticQueryParam(
-                        operation = openApiOperation,
+                        parameters = parameters,
                         collectorContext = methodContext,
                         extensibleQueryParams = extensibleQueryParams
                     )
@@ -748,6 +749,7 @@ class OpenApiSpecification(
                             toHttpRequestPatterns(
                                 httpPathPattern = specmaticPathParam,
                                 httpQueryParamPattern = specmaticQueryParam,
+                                parameters = parameters,
                                 httpMethod = httpMethod,
                                 operation = openApiOperation,
                                 collectorContext = methodContext
@@ -791,7 +793,7 @@ class OpenApiSpecification(
                         val (response, _: MediaType, httpResponsePattern, responseExamples: Map<String, HttpResponse>) = responsePatternData
 
                         val specmaticExampleRows: List<Row> =
-                            testRowsFromExamples(responseExamples, requestExamples, openApiOperation, openApiRequest, first2xxResponseStatus)
+                            testRowsFromExamples(responseExamples, requestExamples, openApiOperation, parameters, openApiRequest, first2xxResponseStatus)
                         val scenarioName = scenarioName(openApiOperation, response, httpRequestPattern)
 
                         val ignoreFailure = openApiOperation.tags.orEmpty().map { it.trim() }.contains("WIP")
@@ -846,7 +848,7 @@ class OpenApiSpecification(
                                 requestExamples,
                                 unusedRequestExampleNames,
                                 scenarioInfos,
-                                openApiOperation,
+                                parameters,
                                 firstNoBodyResponseStatus
                             )
 
@@ -881,9 +883,14 @@ class OpenApiSpecification(
             val pathContext = collectorContext.at(openApiPath)
             openApiOperations(pathItem).map { (httpMethod, openApiOperation) ->
                 val methodContext = pathContext.at(httpMethod.lowercase())
-                httpMethod to toSpecmaticPathParam(openApiPath = openApiPath, operation = openApiOperation, collectorContext = methodContext)
+                val parameters = (pathItem.parameters.orEmpty() + openApiOperation.parameters.orEmpty()).distinctByNameAndLocation()
+                httpMethod to toSpecmaticPathParam(openApiPath = openApiPath, parameters = parameters, collectorContext = methodContext)
             }
         }.groupBy({ it.first }, { it.second })
+    }
+
+    private fun List<Parameter>.distinctByNameAndLocation(): List<Parameter> {
+        return associateBy { it.name to it.`in` }.values.toList()
     }
 
     private fun getUpdatedScenarioInfosWithNoBodyResponseExamples(
@@ -891,7 +898,7 @@ class OpenApiSpecification(
         requestExamples: Map<String, List<HttpRequest>>,
         unusedRequestExampleNames: Set<String>,
         scenarioInfos: List<ScenarioInfo>,
-        operation: Operation,
+        parameters: List<Parameter>,
         firstNoBodyResponseStatus: Int?,
     ): NoBodyExampleUpdate {
         val emptyResponse = HttpResponse(
@@ -915,7 +922,7 @@ class OpenApiSpecification(
                 val unusedRequestExample =
                     requestExamples.filter { it.key in unusedRequestExampleNames }
 
-                val rows = getRowsFromRequestExample(unusedRequestExample, operation, scenarioInfo)
+                val rows = getRowsFromRequestExample(unusedRequestExample, parameters, scenarioInfo)
 
                 val updatedExamples: List<Examples> = listOf(
                     Examples(
@@ -938,14 +945,14 @@ class OpenApiSpecification(
 
     private fun getRowsFromRequestExample(
         requestExample: Map<String, List<HttpRequest>>,
-        operation: Operation,
+        parameters: List<Parameter>,
         scenarioInfo: ScenarioInfo
     ): List<Row> {
         return requestExample.flatMap { (key, requests) ->
             requests.map { request ->
                 val paramExamples = (request.headers + request.queryParams.asMap()).toList()
                 val pathParameterExamples = try {
-                    parameterExamples(operation, key).mapValues { (it.value as? String) ?: jsonMapper.writeValueAsString(it.value) }
+                    parameterExamples(parameters, key).mapValues { (it.value as? String) ?: jsonMapper.writeValueAsString(it.value) }
                 } catch (_: Exception) {
                     emptyMap()
                 }.entries.map { it.key to it.value }
@@ -1073,12 +1080,13 @@ class OpenApiSpecification(
         responseExamples: Map<String, HttpResponse>,
         requestExampleAsHttpRequests: Map<String, List<HttpRequest>>,
         operation: Operation,
+        parameters: List<Parameter>,
         openApiRequest: Pair<String, MediaType>?,
         first2xxResponseStatus: Int?
     ): List<Row> {
 
         return responseExamples.mapNotNull { (exampleName, responseExample) ->
-            val parameterExamples: Map<String, Any> = parameterExamples(operation, exampleName)
+            val parameterExamples: Map<String, Any> = parameterExamples(parameters, exampleName)
 
             val requestBodyExample: Map<String, Any> =
                 requestBodyExample(openApiRequest, exampleName, operation.summary)
@@ -1168,8 +1176,8 @@ class OpenApiSpecification(
         } ?: example
     }
 
-    private fun parameterExamples(operation: Operation, exampleName: String): Map<String, Any> {
-        return operation.parameters.orEmpty().safeFilter<Parameter>(CollectorContext()).filter { (_, parameter) ->
+    private fun parameterExamples(parameters: List<Parameter>, exampleName: String): Map<String, Any> {
+        return parameters.safeFilter<Parameter>(CollectorContext()).filter { (_, parameter) ->
             parameter.examples.orEmpty().any { it.key == exampleName }
         }.associate { (_, parameter) ->
             // TODO: Collect as error
@@ -1391,6 +1399,7 @@ class OpenApiSpecification(
         httpQueryParamPattern: HttpQueryParamPattern,
         httpMethod: String,
         operation: Operation,
+        parameters: List<Parameter>,
         collectorContext: CollectorContext
     ): List<RequestPatternsData> {
         logger.debug("Processing requests for $httpMethod")
@@ -1401,7 +1410,6 @@ class OpenApiSpecification(
         }.toMap()
 
         val securitySchemesForRequestPattern = parseOperationSecuritySchemas(operation, securitySchemeComponents, collectorContext)
-        val parameters = operation.parameters.orEmpty()
         validateSecuritySchemeParameterDuplication(
             securitySchemes = securitySchemesForRequestPattern,
             parameters = parameters.safeFilter<Parameter>(collectorContext),
@@ -1430,9 +1438,9 @@ class OpenApiSpecification(
             securitySchemes = securitySchemesForRequestPattern
         )
 
-        val exampleQueryParams = namedExampleParams<QueryParameter>(operation)
-        val examplePathParams = namedExampleParams<PathParameter>(operation)
-        val exampleHeaderParams = namedExampleParams<HeaderParameter>(operation)
+        val exampleQueryParams = namedExampleParams<QueryParameter>(parameters)
+        val examplePathParams = namedExampleParams<PathParameter>(parameters)
+        val exampleHeaderParams = namedExampleParams<HeaderParameter>(parameters)
 
         val exampleRequestBuilder = ExampleRequestBuilder(
             examplePathParams,
@@ -1574,11 +1582,9 @@ class OpenApiSpecification(
         contentType = contentType
     )
 
-    private inline fun <reified T : Parameter> namedExampleParams(operation: Operation): Map<String, Map<String, String>> {
-        if (specmaticConfig.getIgnoreInlineExamples())
-            return emptyMap()
-
-        return operation.parameters.orEmpty().safeFilter<T>(CollectorContext()).map { it.value }.fold(emptyMap()) { acc, parameter ->
+    private inline fun <reified T : Parameter> namedExampleParams(parameters: List<Parameter>): Map<String, Map<String, String>> {
+        if (specmaticConfig.getIgnoreInlineExamples()) return emptyMap()
+        return parameters.safeFilter<T>(CollectorContext()).map { it.value }.fold(emptyMap()) { acc, parameter ->
             extractParameterExamples(parameter.examples, parameter.name, acc)
         }
     }
@@ -2492,17 +2498,8 @@ class OpenApiSpecification(
 
     private fun componentNameFromReference(component: String) = component.substringAfterLast("/")
 
-    private fun toSpecmaticQueryParam(
-        operation: Operation,
-        collectorContext: CollectorContext,
-        extensibleQueryParams: Boolean
-    ): HttpQueryParamPattern {
-        val parameters = operation.parameters ?: return HttpQueryParamPattern(
-            emptyMap(),
-            extensibleQueryParams = extensibleQueryParams
-        )
+    private fun toSpecmaticQueryParam(parameters: List<Parameter>, collectorContext: CollectorContext, extensibleQueryParams: Boolean): HttpQueryParamPattern {
         val queryParameters = parameters.safeFilter<QueryParameter>(collectorContext)
-
         val parametersContext = collectorContext.at("parameters")
         val queryPattern: Map<String, Pattern> = queryParameters.associate { (index, it) ->
             logger.debug("Processing query parameter ${it.name}")
@@ -2550,8 +2547,7 @@ class OpenApiSpecification(
         }
     }
 
-    private fun toSpecmaticPathParam(openApiPath: String, operation: Operation, otherPathPatterns: Collection<HttpPathPattern> = emptyList(), collectorContext: CollectorContext): HttpPathPattern {
-        val parameters = operation.parameters ?: emptyList()
+    private fun toSpecmaticPathParam(openApiPath: String, parameters: List<Parameter>, otherPathPatterns: Collection<HttpPathPattern> = emptyList(), collectorContext: CollectorContext): HttpPathPattern {
         val pathSegments: List<String> = openApiPath.removePrefix("/").removeSuffix("/").let {
             if (it.isBlank()) emptyList()
             else it.split("/")

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationParseTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationParseTest.kt
@@ -2,6 +2,7 @@ package io.specmatic.conversions
 
 import integration_tests.OpenApiVersion
 import io.specmatic.core.pattern.AnythingPattern
+import io.specmatic.core.pattern.BooleanPattern
 import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.pattern.DeferredPattern
 import io.specmatic.core.pattern.NumberPattern
@@ -16,11 +17,131 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
+import org.junit.jupiter.params.provider.ValueSource
 import java.io.File
 import java.math.BigDecimal
 import java.util.stream.Stream
 
 class OpenApiSpecificationParseTest {
+    @ParameterizedTest
+    @ValueSource(strings = ["3.0.0", "3.1.0"])
+    fun `should parse path item and operation parameters together for path query and header`(openApiVersion: String) {
+        val spec = """
+            openapi: $openApiVersion
+            info:
+              title: Parse merged params
+              version: 1.0.0
+            paths:
+              /orders/{orderId}:
+                parameters:
+                  - in: query
+                    name: includeDetails
+                    required: true
+                    schema:
+                      type: boolean
+                  - in: header
+                    name: X-Tenant-Id
+                    required: true
+                    schema:
+                      type: string
+                get:
+                  parameters:
+                    - in: path
+                      name: orderId
+                      required: true
+                      schema:
+                        type: string
+                    - in: query
+                      name: page
+                      required: true
+                      schema:
+                        type: integer
+                    - in: header
+                      name: X-Request-Id
+                      required: true
+                      schema:
+                        type: string
+                  responses:
+                    '200':
+                      description: OK
+        """.trimIndent()
+
+        val requestPattern = OpenApiSpecification.fromYAML(spec, "").toFeature().scenarios.single().httpRequestPattern
+        assertThat(requestPattern.httpPathPattern?.toRawPath()).isEqualTo("/orders/{orderId}")
+        assertThat(requestPattern.httpPathPattern?.path).contains("(orderId:string)")
+
+        val queryPatterns = requestPattern.httpQueryParamPattern.queryPatterns
+        assertThat(queryPatterns.keys).contains("includeDetails", "page")
+        assertThat(queryPatterns["includeDetails"]).isInstanceOf(QueryParameterScalarPattern::class.java)
+        assertThat((queryPatterns["includeDetails"] as QueryParameterScalarPattern).pattern).isInstanceOf(BooleanPattern::class.java)
+        assertThat(queryPatterns["page"]).isInstanceOf(QueryParameterScalarPattern::class.java)
+        assertThat((queryPatterns["page"] as QueryParameterScalarPattern).pattern).isInstanceOf(NumberPattern::class.java)
+
+        val headerPatterns = requestPattern.headersPattern.pattern
+        assertThat(headerPatterns.keys).contains("X-Tenant-Id", "X-Request-Id")
+        assertThat(headerPatterns["X-Tenant-Id"]).isInstanceOf(StringPattern::class.java)
+        assertThat(headerPatterns["X-Request-Id"]).isInstanceOf(StringPattern::class.java)
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["3.0.0", "3.1.0"])
+    fun `operation level parameters should override path item parameters with same name and location`(openApiVersion: String) {
+        val spec = """
+            openapi: $openApiVersion
+            info:
+              title: Parse override precedence
+              version: 1.0.0
+            paths:
+              /orders/{orderId}:
+                parameters:
+                  - in: path
+                    name: orderId
+                    required: true
+                    schema:
+                      type: string
+                  - in: query
+                    name: page
+                    required: true
+                    schema:
+                      type: string
+                  - in: header
+                    name: X-Request-Id
+                    required: true
+                    schema:
+                      type: string
+                get:
+                  parameters:
+                    - in: path
+                      name: orderId
+                      required: true
+                      schema:
+                        type: integer
+                    - in: query
+                      name: page
+                      required: true
+                      schema:
+                        type: integer
+                    - in: header
+                      name: X-Request-Id
+                      required: true
+                      schema:
+                        type: integer
+                  responses:
+                    '200':
+                      description: OK
+        """.trimIndent()
+
+        val requestPattern = OpenApiSpecification.fromYAML(spec, "").toFeature().scenarios.single().httpRequestPattern
+        assertThat(requestPattern.httpPathPattern?.path).contains("(orderId:number)")
+
+        val queryPattern = requestPattern.httpQueryParamPattern.queryPatterns["page"]
+        assertThat(queryPattern).isInstanceOf(QueryParameterScalarPattern::class.java)
+        assertThat((queryPattern as QueryParameterScalarPattern).pattern).isInstanceOf(NumberPattern::class.java)
+
+        val headerPattern = requestPattern.headersPattern.pattern["X-Request-Id"]
+        assertThat(headerPattern).isInstanceOf(NumberPattern::class.java)
+    }
+
     @Test
     fun `should be able to parse primitives inside XML pattern schemas with their constraints intact`() {
         val specFile = File("src/test/resources/openapi/has_xml_payloads/api.yaml")

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -12336,6 +12336,137 @@ paths:
         assertThat(testCount).isEqualTo(2)
     }
 
+    @Test
+    fun `should use path item parameter examples for path query and header when generating example driven tests`() {
+        val spec = """
+            openapi: 3.0.0
+            info:
+              title: Path Item Parameter Examples
+              version: 1.0.0
+            paths:
+              /orders/{orderId}:
+                parameters:
+                  - in: path
+                    name: orderId
+                    required: true
+                    schema:
+                      type: integer
+                    examples:
+                      SUCCESS:
+                        value: 42
+                  - in: query
+                    name: includeDetails
+                    required: true
+                    schema:
+                      type: boolean
+                    examples:
+                      SUCCESS:
+                        value: true
+                  - in: header
+                    name: X-Tenant-Id
+                    required: true
+                    schema:
+                      type: string
+                    examples:
+                      SUCCESS:
+                        value: tenant-123
+                get:
+                  responses:
+                    '200':
+                      description: OK
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                            required:
+                              - status
+                            properties:
+                              status:
+                                type: string
+                          examples:
+                            SUCCESS:
+                              value:
+                                status: ok
+        """.trimIndent()
+
+        var seenRequestPath: String? = null
+        var seenQueryValue: String? = null
+        var seenHeaderValue: String? = null
+
+        val feature = OpenApiSpecification.fromYAML(spec, "").toFeature()
+        val results = feature.executeTests(object : TestExecutor {
+            override fun execute(request: HttpRequest): HttpResponse {
+                if (request.path == "/orders/42") {
+                    seenRequestPath = request.path
+                    seenQueryValue = request.queryParams.asMap()["includeDetails"]
+                    seenHeaderValue = request.headers["X-Tenant-Id"]
+                }
+
+                return HttpResponse(200, parsedJSONObject("""{"status":"ok"}"""))
+            }
+        })
+
+        assertThat(results.success()).withFailMessage(results.report()).isTrue()
+        assertThat(seenRequestPath).isEqualTo("/orders/42")
+        assertThat(seenQueryValue).isEqualTo("true")
+        assertThat(seenHeaderValue).isEqualTo("tenant-123")
+    }
+
+    @Test
+    fun `should use path item parameter examples when request example exists but response has no body`() {
+        val spec = """
+            openapi: 3.0.0
+            info:
+              title: Path Item Parameters With No Body Response
+              version: 1.0.0
+            paths:
+              /tasks/{taskId}:
+                parameters:
+                  - in: path
+                    name: taskId
+                    required: true
+                    schema:
+                      type: string
+                    examples:
+                      COMPLETE:
+                        value: task-10
+                  - in: query
+                    name: dryRun
+                    required: true
+                    schema:
+                      type: boolean
+                    examples:
+                      COMPLETE:
+                        value: false
+                  - in: header
+                    name: X-Mode
+                    required: true
+                    schema:
+                      type: string
+                    examples:
+                      COMPLETE:
+                        value: batch
+                delete:
+                  responses:
+                    '204':
+                      description: Deleted
+        """.trimIndent()
+
+        var matchedExampleRequest = false
+        val feature = OpenApiSpecification.fromYAML(spec, "").toFeature()
+        val results = feature.executeTests(object : TestExecutor {
+            override fun execute(request: HttpRequest): HttpResponse {
+                if (request.method == "DELETE" && request.path == "/tasks/task-10" && request.queryParams.asMap()["dryRun"] == "false" && request.headers["X-Mode"] == "batch") {
+                    matchedExampleRequest = true
+                }
+                return HttpResponse(204)
+            }
+        })
+
+        assertThat(results.success()).withFailMessage(results.report()).isTrue()
+        assertThat(matchedExampleRequest).isTrue()
+    }
+
     private fun duplicateExampleNameAcrossOperationsSpec(): String {
         return """
             openapi: 3.0.0


### PR DESCRIPTION
**What**: Ensure that PathItem parameters are utilized in union with the operation level parameters

**Why**:
- Due a behavior change in SwaggerParser for V3.1 Specifications
- PathItem level parameters were being ignored and marked as missing

**Checklist**:

- [x] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
