### PR TITLE
Implement lenient tests in SpecmaticJUnitSupport

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -2414,6 +2414,11 @@ data class Feature(
         return loadExternalisedExamplesAndListUnloadableExamples().first
     }
 
+    fun validateAndFilterExamples(): Pair<Feature, Result> {
+        val result = scenarios.map { scenario -> scenario.validateAndFilterExamples(flagsBased) }
+        return Pair(this.copy(scenarios = result.map { it.first }), Result.fromResults(result.map { it.second }))
+    }
+
     fun validateExamplesOrException(disallowExtraHeaders: Boolean = true) {
         val errors = scenarios.mapNotNull { scenario ->
             try {

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -509,6 +509,31 @@ data class Scenario(
         }
     }
 
+    fun validateAndFilterExamples(flagsBased: FlagsBased): Pair<Scenario, Result> {
+        val apiDesc = defaultAPIDescription.trim()
+        val invalidResults = mutableListOf<Result>()
+        val newExamples = examples.mapNotNull { example ->
+            val validRows = example.rows.filter { row ->
+                val resolverForExample = flagsBased.update(resolver = resolverForValidation(resolver, row))
+                val requestResult = validateRequestExample(row, resolverForExample)
+                val responseResult = validateResponseExample(row, resolverForExample)
+                val exampleResult = Result.fromResults(listOf(requestResult, responseResult))
+
+                if (exampleResult !is Result.Failure || exampleResult.isPartial) return@filter true
+                invalidResults += exampleResult.breadCrumb(
+                    if (row.fileSource != null) "Error loading example for $apiDesc from ${row.fileSource}"
+                    else "Error loading example named ${row.name} for $apiDesc"
+                )
+                false
+            }
+
+            if (validRows.isEmpty()) return@mapNotNull null
+            example.copy(rows = validRows)
+        }
+
+        return copy(examples = newExamples) to Result.fromResults(invalidResults)
+    }
+
     fun validExamplesOrException(flagsBased: FlagsBased, disallowExtraHeaders: Boolean = true) {
         val rowsToValidate = examples.flatMap { it.rows }
 

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -511,27 +511,38 @@ data class Scenario(
 
     fun validateAndFilterExamples(flagsBased: FlagsBased): Pair<Scenario, Result> {
         val apiDesc = defaultAPIDescription.trim()
-        val invalidResults = mutableListOf<Result>()
-        val newExamples = examples.mapNotNull { example ->
-            val validRows = example.rows.filter { row ->
+
+        val examplesAndMatchFailures = examples.map { example ->
+            val validRowsAndMatchFailures = example.rows.map { row ->
                 val resolverForExample = flagsBased.update(resolver = resolverForValidation(resolver, row))
                 val requestResult = validateRequestExample(row, resolverForExample)
                 val responseResult = validateResponseExample(row, resolverForExample)
                 val exampleResult = Result.fromResults(listOf(requestResult, responseResult))
 
-                if (exampleResult !is Result.Failure || exampleResult.isPartial) return@filter true
-                invalidResults += exampleResult.breadCrumb(
-                    if (row.fileSource != null) "Error loading example for $apiDesc from ${row.fileSource}"
-                    else "Error loading example named ${row.name} for $apiDesc"
-                )
-                false
+                if (exampleResult !is Result.Failure || exampleResult.isPartial) {
+                    row to null
+                } else {
+                    null to exampleResult.breadCrumb(
+                        if (row.fileSource != null) "Error loading example for $apiDesc from ${row.fileSource}"
+                        else "Error loading example named ${row.name} for $apiDesc"
+                    )
+                }
             }
 
-            if (validRows.isEmpty()) return@mapNotNull null
-            example.copy(rows = validRows)
+            val validRows = validRowsAndMatchFailures.mapNotNull { it.first }
+            val matchFailures = validRowsAndMatchFailures.mapNotNull { it.second }
+
+            if (validRows.isEmpty()) {
+                null to Result.fromResults(matchFailures)
+            } else {
+                example.copy(rows = validRows) to Result.fromResults(matchFailures)
+            }
         }
 
-        return copy(examples = newExamples) to Result.fromResults(invalidResults)
+        val newExamples = examplesAndMatchFailures.mapNotNull { it.first }
+        val invalidResults = Result.fromResults(examplesAndMatchFailures.map { it.second })
+
+        return copy(examples = newExamples) to invalidResults
     }
 
     fun validExamplesOrException(flagsBased: FlagsBased, disallowExtraHeaders: Boolean = true) {

--- a/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
@@ -4041,6 +4041,61 @@ paths:
     @DisplayName("Strict Mode Tests")
     inner class StrictModeTests {
         @Test
+        fun `validateAndFilterExamples should filter scenario rows and aggregate errors across scenarios`() {
+            val scenarioWithMixedRows = Scenario(
+                name = "Mixed rows",
+                protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI,
+                httpRequestPattern = HttpRequestPattern(method = "POST", httpPathPattern = buildHttpPathPattern("/orders"), body = JSONObjectPattern(mapOf("id" to NumberPattern()))),
+                httpResponsePattern = HttpResponsePattern(status = 200, body = JSONObjectPattern(mapOf("id" to NumberPattern()))),
+                examples = listOf(
+                    Examples(
+                        rows = listOf(
+                            Row(
+                                name = "valid-row",
+                                requestExample = HttpRequest(path = "/orders", method = "POST", body = JSONObjectValue(mapOf("id" to NumberValue(1)))),
+                                responseExample = HttpResponse(status = 200, body = JSONObjectValue(mapOf("id" to NumberValue(2))))
+                            ),
+                            Row(
+                                name = "invalid-row",
+                                requestExample = HttpRequest(path = "/orders", method = "POST", body = JSONObjectValue(mapOf("id" to StringValue("oops")))),
+                                responseExample = HttpResponse(status = 200, body = JSONObjectValue(mapOf("id" to NumberValue(2))))
+                            )
+                        )
+                    )
+                )
+            )
+
+            val scenarioAllValid = Scenario(
+                name = "All valid",
+                protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI,
+                httpRequestPattern = HttpRequestPattern(method = "GET", httpPathPattern = buildHttpPathPattern("/orders")),
+                httpResponsePattern = HttpResponsePattern(status = 200),
+                examples = listOf(
+                    Examples(
+                        rows = listOf(
+                            Row(
+                                name = "valid-get",
+                                requestExample = HttpRequest(path = "/orders", method = "GET"),
+                                responseExample = HttpResponse(status = 200)
+                            )
+                        )
+                    )
+                )
+            )
+
+            val feature = Feature(scenarios = listOf(scenarioWithMixedRows, scenarioAllValid), name = "Example validation filter", protocol = SpecmaticProtocol.HTTP)
+            val (filteredFeature, result) = feature.validateAndFilterExamples()
+
+            assertThat(filteredFeature.scenarios).hasSize(2)
+            assertThat(filteredFeature.scenarios[0].examples.single().rows).hasSize(1)
+            assertThat(filteredFeature.scenarios[0].examples.single().rows.single().name).isEqualTo("valid-row")
+            assertThat(filteredFeature.scenarios[1].examples.single().rows).hasSize(1)
+            assertThat(filteredFeature.scenarios[1].examples.single().rows.single().name).isEqualTo("valid-get")
+            assertThat(result).isInstanceOf(Result.Failure::class.java)
+            assertThat(result.reportString()).contains("Error loading example named invalid-row for POST /orders -> 200")
+        }
+
+        @Test
         fun `strict mode filters out positive scenarios without example rows`() {
             val scenarioWithRows = Scenario(
                 name = "Scenario with rows",

--- a/core/src/test/kotlin/io/specmatic/core/ScenarioTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ScenarioTest.kt
@@ -315,6 +315,95 @@ class ScenarioTest {
     }
 
     @Test
+    fun `validateAndFilterExamples should retain valid rows and remove invalid rows`() {
+        val scenario = Scenario(
+            name = "SIMPLE POST",
+            protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI,
+            httpRequestPattern = HttpRequestPattern(httpPathPattern = buildHttpPathPattern("/"), method = "POST", body = JSONObjectPattern(mapOf("id" to NumberPattern()))),
+            httpResponsePattern = HttpResponsePattern(status = 200, body = JSONObjectPattern(mapOf("id" to NumberPattern()))),
+            examples = listOf(
+                Examples(
+                    rows = listOf(
+                        Row(
+                            name = "valid-example",
+                            requestExample = HttpRequest(path = "/", method = "POST", body = JSONObjectValue(mapOf("id" to NumberValue(10)))),
+                            responseExample = HttpResponse(status = 200, body = JSONObjectValue(mapOf("id" to NumberValue(20))))
+                        ),
+                        Row(
+                            name = "invalid-example",
+                            requestExample = HttpRequest(path = "/", method = "POST", body = JSONObjectValue(mapOf("id" to StringValue("not-a-number")))),
+                            responseExample = HttpResponse(status = 200, body = JSONObjectValue(mapOf("id" to NumberValue(20))))
+                        )
+                    )
+                )
+            )
+        )
+
+        val (filteredScenario, result) = scenario.validateAndFilterExamples(DefaultStrategies)
+        assertThat(filteredScenario.examples).hasSize(1)
+        assertThat(filteredScenario.examples.single().rows).hasSize(1)
+        assertThat(filteredScenario.examples.single().rows.single().name).isEqualTo("valid-example")
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
+        assertThat(result.reportString())
+            .contains("Error loading example named invalid-example for POST / -> 200")
+            .contains("REQUEST.BODY")
+    }
+
+    @Test
+    fun `validateAndFilterExamples should drop example groups with no valid rows`() {
+        val scenario = Scenario(
+            name = "SIMPLE POST",
+            protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI,
+            httpRequestPattern = HttpRequestPattern(httpPathPattern = buildHttpPathPattern("/"), method = "POST", body = JSONObjectPattern(mapOf("id" to NumberPattern()))),
+            httpResponsePattern = HttpResponsePattern(status = 200, body = JSONObjectPattern(mapOf("id" to NumberPattern()))),
+            examples = listOf(
+                Examples(
+                    rows = listOf(
+                        Row(
+                            name = "invalid-example",
+                            requestExample = HttpRequest(path = "/", method = "POST", body = JSONObjectValue(mapOf("id" to StringValue("not-a-number")))),
+                            responseExample = HttpResponse(status = 200, body = JSONObjectValue(mapOf("id" to NumberValue(20))))
+                        )
+                    )
+                )
+            )
+        )
+
+        val (filteredScenario, result) = scenario.validateAndFilterExamples(DefaultStrategies)
+        assertThat(filteredScenario.examples).isEmpty()
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
+        assertThat(result.reportString()).contains("Error loading example named invalid-example for POST / -> 200")
+    }
+
+    @Test
+    fun `validateAndFilterExamples should retain partial example rows without failing`() {
+        val scenario = Scenario(
+            name = "SIMPLE POST",
+            protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI,
+            httpRequestPattern = HttpRequestPattern(httpPathPattern = buildHttpPathPattern("/"), method = "POST", headersPattern = HttpHeadersPattern(mapOf("USER-ID" to UUIDPattern))),
+            httpResponsePattern = HttpResponsePattern(status = 200, headersPattern = HttpHeadersPattern(mapOf("TICKET-ID" to UUIDPattern))),
+            examples = listOf(
+                Examples(
+                    rows = listOf(
+                        Row(
+                            name = "partial-example",
+                            isPartial = true,
+                            requestExample = HttpRequest(path = "/", method = "POST", headers = mapOf("USER-ID" to "123e4567-e89b-12d3-a456-426655440000", "X-EXTRA-HEADERS" to "ExtraValue")),
+                            responseExample = HttpResponse(status = 200, headers = mapOf("TICKET-ID" to "123e4567-e89b-12d3-a456-426655440000", "X-EXTRA-HEADERS" to "ExtraValue"))
+                        )
+                    )
+                )
+            )
+        )
+
+        val (filteredScenario, result) = scenario.validateAndFilterExamples(DefaultStrategies)
+        assertThat(filteredScenario.examples).hasSize(1)
+        assertThat(filteredScenario.examples.single().rows).hasSize(1)
+        assertThat(filteredScenario.examples.single().rows.single().name).isEqualTo("partial-example")
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+    }
+
+    @Test
     fun `should return scenarioMetadata from scenario`() {
         val httpRequestPattern = mockk<HttpRequestPattern> {
             every {

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -289,34 +289,32 @@ open class SpecmaticJUnitSupport {
                 settings.contractPaths != null -> {
                     // Default base URL is mandatory for this mode
                     val defaultBaseURL = constructTestBaseURL()
-
-                    val testScenariosAndEndpointsPairList = settings.contractPaths.orEmpty().split(",").filter {
-                        File(it).extension in CONTRACT_EXTENSIONS
-                    }.map {
-                        val overlayFilePath: String? = settings.overlayFilePath?.canonicalPath ?: specmaticConfig.getTestOverlayFilePath(File(it), SpecType.OPENAPI)
+                    val contractPaths = settings.contractPaths.orEmpty().split(",").filter { File(it).extension in CONTRACT_EXTENSIONS }
+                    val loadedScenariosByContractPath = contractPaths.map { contractPath ->
+                        val overlayFilePath: String? = settings.overlayFilePath?.canonicalPath ?: specmaticConfig.getTestOverlayFilePath(File(contractPath), SpecType.OPENAPI)
                         val overlayContent = if (overlayFilePath.isNullOrBlank()) "" else readFrom(overlayFilePath, "overlay")
-                        val (tests, endpoints, filteredEndpoints) = loadTestScenarios(
-                            it,
+                        contractPath to loadTestScenarios(
+                            contractPath,
                             suggestionsPath,
                             suggestionsData,
                             testConfig,
-                            specificationPath = it,
+                            specificationPath = contractPath,
                             filterName = filterName,
                             filterNotName = filterNotName,
                             specmaticConfig = specmaticConfig,
                             overlayContent = overlayContent,
                             filter = testFilter
                         )
-
-                        Triple(tests.map { test -> Pair(test, defaultBaseURL) }, endpoints, filteredEndpoints)
                     }
 
-                    val testsWithUrls: Sequence<Pair<ContractTest, String>> =
-                        testScenariosAndEndpointsPairList.asSequence().flatMap { it.first }
-                    val endpoints: List<Endpoint> = testScenariosAndEndpointsPairList.flatMap { it.second }
-                    val filteredEndpoints: List<Endpoint> = testScenariosAndEndpointsPairList.flatMap { it.third }
+                    val endpoints: List<Endpoint> = loadedScenariosByContractPath.flatMap { (_, loaded) -> loaded.allEndpoints }
+                    val filteredEndpoints: List<Endpoint> = loadedScenariosByContractPath.flatMap { (_, loaded) -> loaded.filteredEndpoints }
+                    val exampleValidationResults = loadedScenariosByContractPath.associate { (contractPath, loaded) -> contractPath to loaded.exampleValidationResult }
+                    val testsWithUrls: Sequence<Pair<ContractTest, String>> = loadedScenariosByContractPath.asSequence().flatMap { (_, loaded) ->
+                        loaded.scenarios.map { test -> Pair(test, defaultBaseURL) }
+                    }
 
-                    TestData(testsWithUrls, endpoints, filteredEndpoints, setOf(defaultBaseURL))
+                    TestData(testsWithUrls, endpoints, filteredEndpoints, setOf(defaultBaseURL), exampleValidationResults)
                 }
 
                 else -> {
@@ -336,13 +334,12 @@ open class SpecmaticJUnitSupport {
                     val needsDefaultBase = contractFilePaths.any { it.baseUrl.isNullOrBlank() }
                     val defaultBaseURL = if (needsDefaultBase) constructTestBaseURL() else ""
 
-                    val baseUrls = mutableSetOf<String>()
-                    val testScenariosAndEndpointsPairList = contractFilePaths.filter {
+                    val loadedScenariosWithBaseUrlsByContractPath = contractFilePaths.filter {
                         File(it.path).extension in CONTRACT_EXTENSIONS
                     }.map { contractPathData ->
                         val overlayFilePath: String? = settings.overlayFilePath?.canonicalPath ?: specmaticConfig.getTestOverlayFilePath(File(contractPathData.path), SpecType.OPENAPI)
                         val overlayContent = if (overlayFilePath.isNullOrBlank()) "" else readFrom(overlayFilePath, "overlay")
-                        val (tests, endpoints, filteredEndpoints) = loadTestScenarios(
+                        val loadedTestScenarios = loadTestScenarios(
                             contractPathData.path,
                             "",
                             "",
@@ -362,16 +359,18 @@ open class SpecmaticJUnitSupport {
                         )
 
                         val resolvedBaseURL = contractPathData.baseUrl ?: defaultBaseURL
-                        baseUrls.add(resolvedBaseURL)
-                        Triple(tests.map { test -> Pair(test, resolvedBaseURL) }, endpoints, filteredEndpoints)
+                        Triple(contractPathData.path, loadedTestScenarios, resolvedBaseURL)
                     }
 
-                    val testsWithUrls: Sequence<Pair<ContractTest, String>> =
-                        testScenariosAndEndpointsPairList.asSequence().flatMap { it.first }
-                    val endpoints: List<Endpoint> = testScenariosAndEndpointsPairList.flatMap { it.second }
-                    val filteredEndpoints: List<Endpoint> = testScenariosAndEndpointsPairList.flatMap { it.third }
+                    val baseUrls = loadedScenariosWithBaseUrlsByContractPath.map { (_, _, resolvedBaseURL) -> resolvedBaseURL }.toSet()
+                    val endpoints: List<Endpoint> = loadedScenariosWithBaseUrlsByContractPath.flatMap { (_, loaded, _) -> loaded.allEndpoints }
+                    val filteredEndpoints: List<Endpoint> = loadedScenariosWithBaseUrlsByContractPath.flatMap { (_, loaded, _) -> loaded.filteredEndpoints }
+                    val exampleValidationResults = loadedScenariosWithBaseUrlsByContractPath.associate { (contractPath, loaded, _) -> contractPath to loaded.exampleValidationResult }
+                    val testsWithUrls: Sequence<Pair<ContractTest, String>> = loadedScenariosWithBaseUrlsByContractPath.asSequence().flatMap { (_, loaded, resolvedBaseURL) ->
+                        loaded.scenarios.map { test -> Pair(test, resolvedBaseURL) }
+                    }
 
-                    TestData(testsWithUrls, endpoints, filteredEndpoints, baseUrls.toSet())
+                    TestData(testsWithUrls, endpoints, filteredEndpoints, baseUrls, exampleValidationResults)
                 }
             }
         } catch (e: ContractException) {
@@ -380,6 +379,7 @@ open class SpecmaticJUnitSupport {
             return loadExceptionAsTestError(e)
         }
 
+        settings.coverageHooks.forEach { it.onExampleErrors(testBuildResult.exampleValidationResults) }
         testBuildResult.baseUrls.forEach { baseUrl ->
             if (isBaseURLReachable(baseUrl)) return@forEach
             return loadExceptionAsTestError(e = ContractException("""
@@ -665,12 +665,12 @@ open class SpecmaticJUnitSupport {
             )
         }.toList()
 
-        val filteredFeature = feature
-            .copy(scenarios = filteredScenarios.toList())
-            .loadExternalisedExamples()
-            .also { it.validateExamplesOrException() }
+        val filteredFeature = feature.copy(scenarios = filteredScenarios.toList()).loadExternalisedExamples()
+        val (validExampleFeature, result) = filteredFeature.validateAndFilterExamples()
+        if (specmaticConfig.getTestLenientMode() == false) result.throwOnFailure()
 
-        val tests: Sequence<ContractTest> = filteredFeature.also {
+        validExampleFeature.validateExamplesOrException()
+        val tests: Sequence<ContractTest> = validExampleFeature.also {
             if (it.scenarios.isEmpty()) {
                 logger.log("All scenarios were filtered out.")
             } else if (it.scenarios.size < feature.scenarios.size) {
@@ -679,7 +679,7 @@ open class SpecmaticJUnitSupport {
             }
         }.generateContractTests(suggestions, originalScenarios = feature.scenarios)
 
-        return LoadedTestScenarios(tests, allEndpoints, filteredEndpoints)
+        return LoadedTestScenarios(tests, allEndpoints, filteredEndpoints, result)
     }
 
     private fun suggestionsFromFile(suggestionsPath: String): List<Scenario> {
@@ -736,7 +736,8 @@ open class SpecmaticJUnitSupport {
 data class LoadedTestScenarios(
     val scenarios: Sequence<ContractTest>,
     val allEndpoints: List<Endpoint>,
-    val filteredEndpoints: List<Endpoint>
+    val filteredEndpoints: List<Endpoint>,
+    val exampleValidationResult: Result = Result.Success()
 )
 
 private data class TestData(
@@ -744,6 +745,7 @@ private data class TestData(
     val allEndpoints: List<Endpoint>,
     val filteredEndpoints: List<Endpoint>,
     val baseUrls: Set<String>,
+    val exampleValidationResults: Map<String, Result>,
 )
 
 private fun columnsFromExamples(exampleData: JSONArrayValue): List<String> {

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/TestHooks.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/TestHooks.kt
@@ -29,6 +29,7 @@ interface TestReportListener {
     fun onActuatorApis(apisNotExcluded: List<API>, apisExcluded: List<API>)
     fun onEndpointApis(endpointsNotExcluded: List<Endpoint>, endpointsExcluded: List<Endpoint>)
     fun onTestResult(result: TestExecutionResult)
+    fun onExampleErrors(resultsBySpecFile: Map<String, Result>)
     fun onTestsComplete()
     fun onEnd()
     fun onCoverageCalculated(coverage: Int)

--- a/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
@@ -2,7 +2,9 @@ package io.specmatic.test
 
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpResponse
+import io.specmatic.core.Result
 import io.specmatic.core.SPECMATIC_STUB_DICTIONARY
+import io.specmatic.core.SpecmaticConfigV1V2Common
 import io.specmatic.core.TestConfig
 import io.specmatic.core.config.SpecmaticConfigVersion
 import io.specmatic.core.config.v2.ContractConfig
@@ -18,6 +20,7 @@ import io.specmatic.core.config.v3.components.services.SpecificationDefinition
 import io.specmatic.core.config.v3.components.services.TestServiceConfig
 import io.specmatic.core.config.v3.components.sources.SourceV3
 import io.specmatic.core.filters.ScenarioMetadataFilter
+import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.utilities.yamlMapper
 import io.specmatic.core.utilities.Flags
 import io.specmatic.license.core.SpecmaticProtocol
@@ -28,6 +31,7 @@ import io.specmatic.test.SpecmaticJUnitSupport.Companion.PORT
 import io.specmatic.test.SpecmaticJUnitSupport.Companion.PROTOCOL
 import io.specmatic.test.SpecmaticJUnitSupport.Companion.TEST_BASE_URL
 import io.specmatic.test.listeners.ContractExecutionListener
+import io.specmatic.test.reports.TestReportListener
 import io.specmatic.test.reports.coverage.Endpoint
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatCode
@@ -498,6 +502,80 @@ paths:
     }
 
     @Test
+    fun `loadTestScenarios should filter invalid examples in lenient mode and return validation result`() {
+        val specFile = File("src/test/resources/invalid_example/openapi.yaml")
+        val specmaticConfig = SpecmaticConfigV1V2Common().withTestModes(strictMode = null, lenientMode = true)
+        val loaded = SpecmaticJUnitSupport().loadTestScenarios(
+            path = specFile.canonicalPath,
+            suggestionsPath = "",
+            suggestionsData = "",
+            config = TestConfig(emptyMap(), emptyMap()),
+            filterName = null,
+            filterNotName = null,
+            specmaticConfig = specmaticConfig,
+            filter = ScenarioMetadataFilter.from("")
+        )
+
+        val testDescriptions = loaded.scenarios.map { it.testDescription() }.toList()
+        assertThat(loaded.exampleValidationResult).isInstanceOf(Result.Failure::class.java)
+        assertThat(loaded.exampleValidationResult.reportString()).contains("invalid_test_GET_200.json").contains("Error loading example")
+        assertThat(testDescriptions).anyMatch { it.contains("POST /test -> 201") }
+        assertThat(testDescriptions).noneMatch { it.contains("invalid_test_GET_200") }
+        assertThat(testDescriptions).anyMatch { it.contains("GET /test -> 200") }
+    }
+
+    @Test
+    fun `loadTestScenarios should throw when invalid examples exist in non lenient mode`() {
+        val specFile = File("src/test/resources/invalid_example/openapi.yaml")
+        val specmaticConfig = SpecmaticConfigV1V2Common().withTestModes(strictMode = null, lenientMode = false)
+        val exception = assertThrows<ContractException> {
+            SpecmaticJUnitSupport().loadTestScenarios(
+                path = specFile.canonicalPath,
+                suggestionsPath = "",
+                suggestionsData = "",
+                config = TestConfig(emptyMap(), emptyMap()),
+                filterName = null,
+                filterNotName = null,
+                specmaticConfig = specmaticConfig,
+                filter = ScenarioMetadataFilter.from("")
+            )
+        }
+
+        assertThat(exception.report()).contains("invalid_test_GET_200.json")
+    }
+
+    @Test
+    fun `contractTest should send example validation errors to coverage hooks`() {
+        val specFile = File("src/test/resources/invalid_example/openapi.yaml")
+        val listener = RecordingExampleErrorsListener()
+        SpecmaticJUnitSupport.settingsStaging.set(
+            ContractTestSettings(
+                testBaseURL = "http://localhost:1",
+                contractPaths = specFile.canonicalPath,
+                filter = "",
+                configFile = "",
+                generative = false,
+                reportBaseDirectory = null,
+                coverageHooks = listOf<TestReportListener>(listener),
+                strictMode = false,
+                lenientMode = true
+            )
+        )
+
+        try {
+            SpecmaticJUnitSupport().contractTest().toList()
+            assertThat(listener.exampleErrorsCalls).hasSize(1)
+            val resultsBySpec = listener.exampleErrorsCalls.single()
+            assertThat(resultsBySpec).containsKey(specFile.canonicalPath)
+            val result = resultsBySpec.getValue(specFile.canonicalPath)
+            assertThat(result).isInstanceOf(Result.Failure::class.java)
+            assertThat(result.reportString()).contains("invalid_test_GET_200.json").contains("Error loading example")
+        } finally {
+            SpecmaticJUnitSupport.settingsStaging.remove()
+        }
+    }
+
+    @Test
     fun `should load soapAction from scenarios into Endpoints if specification is WSDL`() {
         val specFile = File("src/test/resources/simple.wsdl")
         val specmaticJUnitSupport = SpecmaticJUnitSupport()
@@ -806,6 +884,22 @@ paths:
         assertThat(exitCode)
             .withFailMessage("Command failed: ${command.joinToString(" ")}\n$output")
             .isEqualTo(0)
+    }
+
+    private class RecordingExampleErrorsListener : TestReportListener {
+        val exampleErrorsCalls = mutableListOf<Map<String, Result>>()
+        override fun onExampleErrors(resultsBySpecFile: Map<String, Result>) {
+            exampleErrorsCalls.add(resultsBySpecFile)
+        }
+
+        override fun onActuator(enabled: Boolean) = Unit
+        override fun onActuatorApis(apisNotExcluded: List<API>, apisExcluded: List<API>) = Unit
+        override fun onEndpointApis(endpointsNotExcluded: List<Endpoint>, endpointsExcluded: List<Endpoint>) = Unit
+        override fun onTestResult(result: io.specmatic.test.reports.TestExecutionResult) = Unit
+        override fun onTestsComplete() = Unit
+        override fun onEnd() = Unit
+        override fun onCoverageCalculated(coverage: Int) = Unit
+        override fun onPathCoverageCalculated(path: String, pathCoverage: Int) = Unit
     }
 
     @AfterEach

--- a/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInputTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInputTest.kt
@@ -617,6 +617,7 @@ class OpenApiCoverageReportInputTest {
         override fun onActuator(enabled: Boolean) = Unit
         override fun onTestResult(result: TestExecutionResult) = Unit
         override fun onTestsComplete() = Unit
+        override fun onExampleErrors(resultsBySpecFile: Map<String, io.specmatic.core.Result>) = Unit
         override fun onEnd() = Unit
         override fun onCoverageCalculated(coverage: Int) = Unit
         override fun onPathCoverageCalculated(path: String, pathCoverage: Int) = Unit


### PR DESCRIPTION
**What**: Implement lenient tests in SpecmaticJUnitSupport

**How**:
- When lenient mode is activated, invalid examples are filtered out from scenarios
- Implement a method in TestHooks to relay example errors

**Checklist**:

- [x] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)