### PR TITLE
Fix HTTPFilterKeys PATH filtering logic

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/HttpPathPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpPathPattern.kt
@@ -15,12 +15,6 @@ data class HttpPathPattern(
     val path: String,
     val otherPathPatterns: Collection<HttpPathPattern> = emptyList(),
 ) {
-    fun toRawPath(): String {
-        return pathSegmentPatterns.joinToString("/", prefix = "/") { segment ->
-            segment.key?.let { "{$it}" } ?: segment.pattern.toString()
-        }
-    }
-
     private fun calculateSpecificity(): Int = pathSegmentPatterns.count { it.pattern is ExactValuePattern }
 
     fun encompasses(otherHttpPathPattern: HttpPathPattern, thisResolver: Resolver, otherResolver: Resolver): Result {

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -121,11 +121,6 @@ data class Scenario(
             return httpRequestPattern.httpPathPattern?.path ?: ""
         }
 
-    val rawPath: String
-        get() {
-            return httpRequestPattern.httpPathPattern?.toRawPath() ?: ""
-        }
-
     override val status: Int
         get() {
             return if(isNegative) 400 else httpResponsePattern.status

--- a/core/src/main/kotlin/io/specmatic/core/filters/HTTPFilterKeys.kt
+++ b/core/src/main/kotlin/io/specmatic/core/filters/HTTPFilterKeys.kt
@@ -1,5 +1,6 @@
 package io.specmatic.core.filters
 
+import io.specmatic.conversions.convertPathParameterStyle
 import io.specmatic.core.Scenario
 import io.specmatic.mock.ScenarioStub
 import java.util.regex.Pattern
@@ -8,7 +9,8 @@ import javax.activation.MimeType
 enum class HTTPFilterKeys(val key: String, val isPrefix: Boolean) {
     PATH("PATH", false) {
         override fun includes(scenario: Scenario, key: String, value: String): Boolean {
-            return value == scenario.rawPath || matchesPath(scenario.rawPath, value)
+            val scenarioPath = convertPathParameterStyle(scenario.path)
+            return value == scenarioPath || matchesPath(scenarioPath, value)
         }
         override fun includes(stub: ScenarioStub, key: String, value: String): Boolean {
             return value == stub.request.path || matchesPath(stub.request.path ?: "", value)

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationParseTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationParseTest.kt
@@ -67,8 +67,7 @@ class OpenApiSpecificationParseTest {
         """.trimIndent()
 
         val requestPattern = OpenApiSpecification.fromYAML(spec, "").toFeature().scenarios.single().httpRequestPattern
-        assertThat(requestPattern.httpPathPattern?.toRawPath()).isEqualTo("/orders/{orderId}")
-        assertThat(requestPattern.httpPathPattern?.path).contains("(orderId:string)")
+        assertThat(requestPattern.httpPathPattern?.path).isEqualTo("/orders/(orderId:string)")
 
         val queryPatterns = requestPattern.httpQueryParamPattern.queryPatterns
         assertThat(queryPatterns.keys).contains("includeDetails", "page")

--- a/core/src/test/kotlin/io/specmatic/core/filters/HTTPFilterKeysTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/filters/HTTPFilterKeysTest.kt
@@ -1,11 +1,19 @@
-import io.specmatic.core.filters.HTTPFilterKeys
-import io.specmatic.core.filters.caseInsensitiveContains
-import io.specmatic.core.filters.caseSensitiveContains
+package io.specmatic.core.filters
+
+import io.specmatic.core.HttpPathPattern
+import io.specmatic.core.HttpRequestPattern
+import io.specmatic.core.HttpResponsePattern
+import io.specmatic.core.Scenario
+import io.specmatic.core.ScenarioInfo
+import io.specmatic.license.core.SpecmaticProtocol
+import io.specmatic.reporter.model.SpecType
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.MethodSource
 
 class HTTPFilterKeysTest {
 
@@ -66,6 +74,12 @@ class HTTPFilterKeysTest {
         assertThatThrownBy { HTTPFilterKeys.fromKey("INVALID_KEY") }
             .isInstanceOf(IllegalArgumentException::class.java)
             .hasMessage("Invalid filter key: INVALID_KEY")
+    }
+
+    @ParameterizedTest(name = "scenario path \"{0}\" with filter \"{1}\" should be {2}")
+    @MethodSource("pathFilterCases")
+    fun `PATH includes handles trailing slash and path parameter edge cases`(scenario: Scenario, filterValue: String, expected: Boolean) {
+        assertThat(HTTPFilterKeys.PATH.includes(scenario, "PATH", filterValue)).isEqualTo(expected)
     }
 
     @Test
@@ -255,4 +269,31 @@ class HTTPFilterKeysTest {
         assertThat(items.caseSensitiveContains("")).isTrue()
     }
 
+    companion object {
+        @JvmStatic
+        fun pathFilterCases() = listOf(
+            Arguments.of(scenarioForPath("/order/(id:string)/"), "/order/{id}/", true),
+            Arguments.of(scenarioForPath("/order/(id:string)"), "/order/{id}", true),
+            Arguments.of(scenarioForPath("/order/(id:string)/"), "/order/*/", true),
+            Arguments.of(scenarioForPath("/order/(id:string)/"), "/order/*", true),
+            Arguments.of(scenarioForPath("/order/(id:string)/events"), "/order/*", true),
+            Arguments.of(scenarioForPath("/order/(id:string)/"), "/order/{id}", false),
+            Arguments.of(scenarioForPath("/order/(id:string)"), "/order/{id}/", false),
+            Arguments.of(scenarioForPath("/order/(id:string)/"), "/ORDER/{id}/", false),
+            Arguments.of(scenarioForPath("/order/(id:string)/"), "/order/{orderId}/", false),
+            Arguments.of(scenarioForPath("/order/(id:string)/events"), "/order/{id}", false),
+        )
+
+        private fun scenarioForPath(path: String): Scenario {
+            return Scenario(
+                ScenarioInfo(
+                    scenarioName = "GET $path",
+                    httpRequestPattern = HttpRequestPattern(method = "GET", httpPathPattern = HttpPathPattern.from(path)),
+                    httpResponsePattern = HttpResponsePattern(status = 200),
+                    protocol = SpecmaticProtocol.HTTP,
+                    specType = SpecType.OPENAPI
+                )
+            )
+        }
+    }
 }


### PR DESCRIPTION
**What**: Correct the logic for PATH filter matching in HTTPFilterKeys

**Why**: When the path had a `/` suffix and the filter also had a `/` suffix, the `rawPath` did not reconstruct the path with the suffix, resulting in a failed match.

**How**: Utilize `convertPathParameterStyle` with the original path rather than generating a new one

**Checklist**:

- [x] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)