### PR TITLE
Initialize RegExSpec once per StringPattern instance

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/pattern/StringPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/StringPattern.kt
@@ -24,8 +24,8 @@ data class StringPattern (
     private val downsampledMin: Boolean = false,
     private val downsampledMax: Boolean = false,
 ) : Pattern, ScalarType, HasDefaultExample {
-    private val regExSpec get() = RegExSpec(regex)
-    private val effectiveMinLength get() = minLength ?: 0
+    internal val regExSpec = RegExSpec(regex)
+    private val effectiveMinLength = minLength ?: 0
 
     init {
         if (effectiveMinLength < 0) {

--- a/core/src/test/kotlin/io/specmatic/core/pattern/StringPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/StringPatternTest.kt
@@ -661,4 +661,17 @@ internal class StringPatternTest {
         val result = RegExSpec("$character").generateRandomString(1, 1) as StringValue
         assertThat(result.string).isEqualTo("$character")
     }
+
+    @Test
+    fun `should reuse regex spec within same StringPattern instance`() {
+        val pattern = StringPattern(regex = "^[a-z]{3}$", minLength = 3, maxLength = 3)
+        assertThat(pattern.regExSpec).isSameAs(pattern.regExSpec)
+    }
+
+    @Test
+    fun `should create an independent regex spec for new StringPattern`() {
+        val numericPattern = StringPattern(regex = "^[0-9]{3}$")
+        val alphabeticPattern = numericPattern.copy(regex = "^[a-z]{3}$")
+        assertThat(alphabeticPattern.regExSpec).isNotSameAs(numericPattern.regExSpec)
+    }
 }


### PR DESCRIPTION
**What**: Improve `StringPattern` performance by initializing `RegExSpec` only once per `StringPattern` instance instead of recreating it on each access

**Why**: Recreating `RegExSpec` repeatedly adds avoidable overhead of regex validation

**Checklist**:
- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate (N/A)
- [ ] Security scans don't report any vulnerabilities (N/A)
- [ ] Documentation added/updated (share link) (N/A)
- [ ] Sample Project added/updated (share link) (N/A)
- [ ] Demo video (share link) (N/A)
- [ ] Article on Website (share link) (N/A)
- [ ] Roadmpap updated (share link) (N/A)
- [ ] Conference Talk (share link) (N/A)