### PR TITLE
Replace javax MimeType with Ktor ContentType

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/filters/HTTPFilterKeys.kt
+++ b/core/src/main/kotlin/io/specmatic/core/filters/HTTPFilterKeys.kt
@@ -1,10 +1,10 @@
 package io.specmatic.core.filters
 
+import io.ktor.http.ContentType
 import io.specmatic.conversions.convertPathParameterStyle
 import io.specmatic.core.Scenario
 import io.specmatic.mock.ScenarioStub
 import java.util.regex.Pattern
-import javax.activation.MimeType
 
 enum class HTTPFilterKeys(val key: String, val isPrefix: Boolean) {
     PATH("PATH", false) {
@@ -116,15 +116,18 @@ enum class HTTPFilterKeys(val key: String, val isPrefix: Boolean) {
     },
     REQUEST_BODY_CONTENT_TYPE("REQUEST-BODY.CONTENT-TYPE", false) {
         override fun includes(scenario: Scenario, key: String, value: String): Boolean {
+            if (value.isBlank()) return false
+            val contentType = scenario.httpRequestPattern.headersPattern.contentType ?: return false
             return try {
-                MimeType(scenario.httpRequestPattern.headersPattern.contentType).match(MimeType(value))
+                ContentType.parse(contentType).match(value)
             } catch (_: Exception) {
                 false
             }
         }
         override fun includes(stub: ScenarioStub, key: String, value: String): Boolean {
+            if (value.isBlank()) return false
             return try {
-                MimeType(stub.request.body.httpContentType).match(MimeType(value))
+                ContentType.parse(stub.request.body.httpContentType).match(value)
             } catch (_: Exception) {
                 false
             }
@@ -132,15 +135,18 @@ enum class HTTPFilterKeys(val key: String, val isPrefix: Boolean) {
     },
     RESPONSE_CONTENT_TYPE("RESPONSE.CONTENT-TYPE", false) {
         override fun includes(scenario: Scenario, key: String, value: String): Boolean {
+            if (value.isBlank()) return false
+            val contentType = scenario.httpResponsePattern.headersPattern.contentType ?: return false
             return try {
-                MimeType(scenario.httpResponsePattern.headersPattern.contentType).match(MimeType(value))
+                ContentType.parse(contentType).match(value)
             } catch (_: Exception) {
                 false
             }
         }
         override fun includes(stub: ScenarioStub, key: String, value: String): Boolean {
+            if (value.isBlank()) return false
             return try {
-                MimeType(stub.response.body.httpContentType).match(MimeType(value))
+                ContentType.parse(stub.response.body.httpContentType).match(value)
             } catch (_: Exception) {
                 false
             }

--- a/core/src/main/kotlin/io/specmatic/core/filters/HttpStubFilterContext.kt
+++ b/core/src/main/kotlin/io/specmatic/core/filters/HttpStubFilterContext.kt
@@ -2,8 +2,6 @@ package io.specmatic.core.filters
 
 import io.specmatic.core.filters.HTTPFilterKeys.*
 import io.specmatic.mock.ScenarioStub
-import java.util.regex.Pattern
-import javax.activation.MimeType
 
 class HttpStubFilterContext(private val scenario: ScenarioStub) : FilterContext {
     override fun includes(key: String, values: List<String>): Boolean {

--- a/core/src/main/kotlin/io/specmatic/proxy/ProxyOperation.kt
+++ b/core/src/main/kotlin/io/specmatic/proxy/ProxyOperation.kt
@@ -1,10 +1,10 @@
 package io.specmatic.proxy
 
+import io.ktor.http.ContentType
 import io.specmatic.core.CONTENT_TYPE
 import io.specmatic.core.HttpPathPattern
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.Resolver
-import javax.activation.MimeType
 
 sealed interface ContentTypeExpectation {
     data object Unspecified : ContentTypeExpectation
@@ -32,7 +32,7 @@ data class ProxyOperation(val pathPattern: HttpPathPattern, val method: String, 
             ContentTypeExpectation.Unspecified -> true
             ContentTypeExpectation.MustBeAbsent -> actualContentType == null
             is ContentTypeExpectation.MustMatch -> {
-                actualContentType != null && MimeType(expected.value).match(MimeType(actualContentType))
+                actualContentType != null && ContentType.parse(actualContentType).match(expected.value)
             }
         }
     }

--- a/core/src/test/kotlin/io/specmatic/core/filters/HTTPFilterKeysTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/filters/HTTPFilterKeysTest.kt
@@ -295,6 +295,16 @@ class HTTPFilterKeysTest {
         assertThat(HTTPFilterKeys.REQUEST_BODY_CONTENT_TYPE.includes(scenario, "REQUEST-BODY.CONTENT-TYPE", "application/json")).isFalse()
     }
 
+    @ParameterizedTest(name = "blank request filter value should not match scenario request content type: \"{0}\"")
+    @CsvSource(
+        "'',false",
+        "'   ',false"
+    )
+    fun `REQUEST_BODY_CONTENT_TYPE includes should return false when request filter value is blank for scenario`(filterValue: String, expected: Boolean) {
+        val scenario = scenarioWithContentTypes("application/json", "application/json")
+        assertThat(HTTPFilterKeys.REQUEST_BODY_CONTENT_TYPE.includes(scenario, "REQUEST-BODY.CONTENT-TYPE", filterValue)).isEqualTo(expected)
+    }
+
     @ParameterizedTest(name = "response content type in scenario \"{0}\" should match filter value \"{1}\" as {2}")
     @CsvSource(
         "application/json,application/json,true",
@@ -316,6 +326,16 @@ class HTTPFilterKeysTest {
         assertThat(HTTPFilterKeys.RESPONSE_CONTENT_TYPE.includes(scenario, "RESPONSE.CONTENT-TYPE", "application/json")).isFalse()
     }
 
+    @ParameterizedTest(name = "blank response filter value should not match scenario response content type: \"{0}\"")
+    @CsvSource(
+        "'',false",
+        "'   ',false"
+    )
+    fun `RESPONSE_CONTENT_TYPE includes should return false when response filter value is blank for scenario`(filterValue: String, expected: Boolean) {
+        val scenario = scenarioWithContentTypes("application/json", "application/json")
+        assertThat(HTTPFilterKeys.RESPONSE_CONTENT_TYPE.includes(scenario, "RESPONSE.CONTENT-TYPE", filterValue)).isEqualTo(expected)
+    }
+
     @ParameterizedTest(name = "stub request body should match request filter value \"{0}\" as {1}")
     @CsvSource(
         "application/json,true",
@@ -328,6 +348,16 @@ class HTTPFilterKeysTest {
         assertThat(HTTPFilterKeys.REQUEST_BODY_CONTENT_TYPE.includes(stub, "REQUEST-BODY.CONTENT-TYPE", filterValue)).isEqualTo(expected)
     }
 
+    @ParameterizedTest(name = "blank request filter value should not match stub request content type: \"{0}\"")
+    @CsvSource(
+        "'',false",
+        "'   ',false"
+    )
+    fun `REQUEST_BODY_CONTENT_TYPE includes should return false when request filter value is blank for stub`(filterValue: String, expected: Boolean) {
+        val stub = ScenarioStub(request = HttpRequest(body = JSONObjectValue()))
+        assertThat(HTTPFilterKeys.REQUEST_BODY_CONTENT_TYPE.includes(stub, "REQUEST-BODY.CONTENT-TYPE", filterValue)).isEqualTo(expected)
+    }
+
     @ParameterizedTest(name = "stub response body should match response filter value \"{0}\" as {1}")
     @CsvSource(
         "application/json,true",
@@ -336,6 +366,16 @@ class HTTPFilterKeysTest {
         "not a content type,false"
     )
     fun `RESPONSE_CONTENT_TYPE includes should safely match stub response body content types`(filterValue: String, expected: Boolean) {
+        val stub = ScenarioStub(response = HttpResponse(200, body = JSONObjectValue()))
+        assertThat(HTTPFilterKeys.RESPONSE_CONTENT_TYPE.includes(stub, "RESPONSE.CONTENT-TYPE", filterValue)).isEqualTo(expected)
+    }
+
+    @ParameterizedTest(name = "blank response filter value should not match stub response content type: \"{0}\"")
+    @CsvSource(
+        "'',false",
+        "'   ',false"
+    )
+    fun `RESPONSE_CONTENT_TYPE includes should return false when response filter value is blank for stub`(filterValue: String, expected: Boolean) {
         val stub = ScenarioStub(response = HttpResponse(200, body = JSONObjectValue()))
         assertThat(HTTPFilterKeys.RESPONSE_CONTENT_TYPE.includes(stub, "RESPONSE.CONTENT-TYPE", filterValue)).isEqualTo(expected)
     }

--- a/core/src/test/kotlin/io/specmatic/core/filters/HTTPFilterKeysTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/filters/HTTPFilterKeysTest.kt
@@ -5,6 +5,11 @@ import io.specmatic.core.HttpRequestPattern
 import io.specmatic.core.HttpResponsePattern
 import io.specmatic.core.Scenario
 import io.specmatic.core.ScenarioInfo
+import io.specmatic.core.HttpRequest
+import io.specmatic.core.HttpResponse
+import io.specmatic.core.HttpHeadersPattern
+import io.specmatic.core.value.JSONObjectValue
+import io.specmatic.mock.ScenarioStub
 import io.specmatic.license.core.SpecmaticProtocol
 import io.specmatic.reporter.model.SpecType
 import org.assertj.core.api.Assertions.assertThat
@@ -269,6 +274,72 @@ class HTTPFilterKeysTest {
         assertThat(items.caseSensitiveContains("")).isTrue()
     }
 
+    @ParameterizedTest(name = "request content type in scenario \"{0}\" should match filter value \"{1}\" as {2}")
+    @CsvSource(
+        "application/json,application/json,true",
+        "application/json,application/*,true",
+        "application/json,text/*,false",
+        "text/plain,text/plain,true",
+        "text/plain,application/*,false",
+        "invalid-content-type,application/*,false",
+        "application/json,not a content type,false"
+    )
+    fun `REQUEST_BODY_CONTENT_TYPE includes should safely match scenario request content types`(requestContentType: String, filterValue: String, expected: Boolean) {
+        val scenario = scenarioWithContentTypes(requestContentType, "application/json")
+        assertThat(HTTPFilterKeys.REQUEST_BODY_CONTENT_TYPE.includes(scenario, "REQUEST-BODY.CONTENT-TYPE", filterValue)).isEqualTo(expected)
+    }
+
+    @Test
+    fun `REQUEST_BODY_CONTENT_TYPE includes should return false when scenario request content type is absent`() {
+        val scenario = scenarioWithContentTypes(null, "application/json")
+        assertThat(HTTPFilterKeys.REQUEST_BODY_CONTENT_TYPE.includes(scenario, "REQUEST-BODY.CONTENT-TYPE", "application/json")).isFalse()
+    }
+
+    @ParameterizedTest(name = "response content type in scenario \"{0}\" should match filter value \"{1}\" as {2}")
+    @CsvSource(
+        "application/json,application/json,true",
+        "application/json,application/*,true",
+        "application/json,text/*,false",
+        "application/xml,application/*,true",
+        "application/xml,text/*,false",
+        "invalid-content-type,application/*,false",
+        "application/json,not a content type,false"
+    )
+    fun `RESPONSE_CONTENT_TYPE includes should safely match scenario response content types`(responseContentType: String, filterValue: String, expected: Boolean) {
+        val scenario = scenarioWithContentTypes("application/json", responseContentType)
+        assertThat(HTTPFilterKeys.RESPONSE_CONTENT_TYPE.includes(scenario, "RESPONSE.CONTENT-TYPE", filterValue)).isEqualTo(expected)
+    }
+
+    @Test
+    fun `RESPONSE_CONTENT_TYPE includes should return false when scenario response content type is absent`() {
+        val scenario = scenarioWithContentTypes("application/json", null)
+        assertThat(HTTPFilterKeys.RESPONSE_CONTENT_TYPE.includes(scenario, "RESPONSE.CONTENT-TYPE", "application/json")).isFalse()
+    }
+
+    @ParameterizedTest(name = "stub request body should match request filter value \"{0}\" as {1}")
+    @CsvSource(
+        "application/json,true",
+        "application/*,true",
+        "text/*,false",
+        "not a content type,false"
+    )
+    fun `REQUEST_BODY_CONTENT_TYPE includes should safely match stub request body content types`(filterValue: String, expected: Boolean) {
+        val stub = ScenarioStub(request = HttpRequest(body = JSONObjectValue()))
+        assertThat(HTTPFilterKeys.REQUEST_BODY_CONTENT_TYPE.includes(stub, "REQUEST-BODY.CONTENT-TYPE", filterValue)).isEqualTo(expected)
+    }
+
+    @ParameterizedTest(name = "stub response body should match response filter value \"{0}\" as {1}")
+    @CsvSource(
+        "application/json,true",
+        "application/*,true",
+        "text/*,false",
+        "not a content type,false"
+    )
+    fun `RESPONSE_CONTENT_TYPE includes should safely match stub response body content types`(filterValue: String, expected: Boolean) {
+        val stub = ScenarioStub(response = HttpResponse(200, body = JSONObjectValue()))
+        assertThat(HTTPFilterKeys.RESPONSE_CONTENT_TYPE.includes(stub, "RESPONSE.CONTENT-TYPE", filterValue)).isEqualTo(expected)
+    }
+
     companion object {
         @JvmStatic
         fun pathFilterCases() = listOf(
@@ -292,6 +363,18 @@ class HTTPFilterKeysTest {
                     httpResponsePattern = HttpResponsePattern(status = 200),
                     protocol = SpecmaticProtocol.HTTP,
                     specType = SpecType.OPENAPI
+                )
+            )
+        }
+
+        private fun scenarioWithContentTypes(requestContentType: String?, responseContentType: String?): Scenario {
+            return Scenario(
+                ScenarioInfo(
+                    specType = SpecType.OPENAPI,
+                    scenarioName = "POST /orders",
+                    protocol = SpecmaticProtocol.HTTP,
+                    httpRequestPattern = HttpRequestPattern(method = "POST", httpPathPattern = HttpPathPattern.from("/orders"), headersPattern = HttpHeadersPattern(contentType = requestContentType)),
+                    httpResponsePattern = HttpResponsePattern(status = 200, headersPattern = HttpHeadersPattern(contentType = responseContentType)),
                 )
             )
         }

--- a/core/src/test/kotlin/io/specmatic/proxy/ProxyOperationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/proxy/ProxyOperationTest.kt
@@ -4,6 +4,8 @@ import io.specmatic.core.CONTENT_TYPE
 import io.specmatic.core.HttpPathPattern
 import io.specmatic.core.HttpRequest
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
@@ -32,6 +34,24 @@ class ProxyOperationTest {
         )
 
         assertThat(operation.matches(request)).isEqualTo(expectedMatchResult)
+    }
+
+    @Test
+    fun `should throw when actual request content type is malformed and expectation requires match`() {
+        val operation = ProxyOperation(
+            pathPattern = HttpPathPattern.from("/orders"),
+            method = "POST",
+            requestContentType = ContentTypeExpectation.MustMatch("application/json")
+        )
+
+        val request = HttpRequest(
+            method = "POST",
+            path = "/orders",
+            headers = mapOf(CONTENT_TYPE to "not a content type")
+        )
+
+        assertThatThrownBy { operation.matches(request) }
+            .isInstanceOf(Exception::class.java)
     }
 
     companion object {

--- a/core/src/test/kotlin/io/specmatic/proxy/ProxyOperationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/proxy/ProxyOperationTest.kt
@@ -1,0 +1,51 @@
+package io.specmatic.proxy
+
+import io.specmatic.core.CONTENT_TYPE
+import io.specmatic.core.HttpPathPattern
+import io.specmatic.core.HttpRequest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+class ProxyOperationTest {
+    @ParameterizedTest(name = "expected={0}, actual={1}, result={2}")
+    @MethodSource("contentTypeExpectationCases")
+    fun `should evaluate request content type expectations`(expectedContentType: String?, actualContentType: String?, expectedMatchResult: Boolean) {
+        val expectation = when (expectedContentType) {
+            null -> ContentTypeExpectation.Unspecified
+            "__MUST_BE_ABSENT__" -> ContentTypeExpectation.MustBeAbsent
+            else -> ContentTypeExpectation.MustMatch(expectedContentType)
+        }
+
+        val operation = ProxyOperation(
+            pathPattern = HttpPathPattern.from("/orders"),
+            method = "POST",
+            requestContentType = expectation
+        )
+
+        val headers = if (actualContentType != null) mapOf(CONTENT_TYPE to actualContentType) else emptyMap()
+        val request = HttpRequest(
+            method = "POST",
+            path = "/orders",
+            headers = headers
+        )
+
+        assertThat(operation.matches(request)).isEqualTo(expectedMatchResult)
+    }
+
+    companion object {
+        @JvmStatic
+        fun contentTypeExpectationCases() = listOf(
+            Arguments.of("application/json", "application/json", true),
+            Arguments.of("application/*", "application/json", true),
+            Arguments.of("application/json", "application/json; charset=utf-8", true),
+            Arguments.of("application/json", "text/plain", false),
+            Arguments.of("application/json", null, false),
+            Arguments.of(null, null, true),
+            Arguments.of(null, "application/json", true),
+            Arguments.of("__MUST_BE_ABSENT__", null, true),
+            Arguments.of("__MUST_BE_ABSENT__", "application/json", false)
+        )
+    }
+}


### PR DESCRIPTION
**What**: Move to using `io.ktor.http.ContentType` instead of `javax.activation.MimeType`

**Why**: Replace `javax.activation.MimeType` with Ktor ContentType to remove fragile runtime dependency on javax.activation (which is no longer bundled with modern JDKs), eliminating NoClassDefFoundError risk

**Checklist**:

- [x] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
