### PR TITLE
fix: Cleaner handling of auth header overrides

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -53,6 +53,7 @@ import io.swagger.v3.parser.OpenAPIV3Parser
 import io.swagger.v3.parser.core.models.ParseOptions
 import io.swagger.v3.parser.core.models.SwaggerParseResult
 import io.swagger.v3.parser.util.ClasspathHelper
+import org.apache.http.HttpHeaders.AUTHORIZATION
 import java.io.File
 import kotlin.collections.orEmpty
 
@@ -1425,9 +1426,14 @@ class OpenApiSpecification(
             )
         }
 
-        val contentTypeHeader = headersMap.entries.find { it.key.lowercase() in listOf("content-type", "content-type?") }?.value
+        val (effectiveHeadersMap, effectiveSecuritySchemes) = resolveSecurityHeaderOverrides(
+            headersMap = headersMap,
+            securitySchemes = securitySchemesForRequestPattern
+        )
+
+        val contentTypeHeader = effectiveHeadersMap.entries.find { it.key.lowercase() in listOf("content-type", "content-type?") }?.value
         val headersPattern = HttpHeadersPattern(
-            headersMap.mapValues { it.value.first },
+            effectiveHeadersMap.mapValues { it.value.first },
             preferEscapedSoapAction = preferEscapedSoapAction
         )
         val requestPattern = HttpRequestPattern(
@@ -1435,7 +1441,7 @@ class OpenApiSpecification(
             httpQueryParamPattern = httpQueryParamPattern,
             method = httpMethod,
             headersPattern = headersPattern,
-            securitySchemes = securitySchemesForRequestPattern
+            securitySchemes = effectiveSecuritySchemes
         )
 
         val exampleQueryParams = namedExampleParams<QueryParameter>(parameters)
@@ -1448,7 +1454,7 @@ class OpenApiSpecification(
             exampleQueryParams,
             httpPathPattern,
             httpMethod,
-            securitySchemesForRequestPattern
+            effectiveSecuritySchemes
         )
 
         val (requestBody, requestBodyContext) = resolveRequestBody(operation, collectorContext) ?: return listOf(
@@ -1573,6 +1579,83 @@ class OpenApiSpecification(
         }
 
         return contentType
+    }
+
+    private fun resolveSecurityHeaderOverrides(
+        headersMap: Map<String, Pair<Pattern, CollectorContext>>,
+        securitySchemes: List<OpenAPISecurityScheme>
+    ): Pair<Map<String, Pair<Pattern, CollectorContext>>, List<OpenAPISecurityScheme>> {
+        var effectiveHeaders = headersMap
+        var effectiveSecuritySchemes = securitySchemes
+
+        headersMap.forEach { (headerKey, headerValueWithContext) ->
+            val headerName = withoutOptionality(headerKey)
+            if (securityHeaderNames(effectiveSecuritySchemes).none { it.equals(headerName, ignoreCase = true) }) {
+                return@forEach
+            }
+
+            val (headerPattern, headerContext) = headerValueWithContext
+            when {
+                headerPattern.isUnconstrainedStringPattern() -> {
+                    headerContext.record(
+                        message = "Found header parameter with same name as security scheme \"$headerName\". The header parameter's datatype is an unconstrained string. Given that a security scheme requiring the same header has been declared, the parameter conveys no additional information and can be dropped.",
+                        isWarning = true,
+                        ruleViolation = OpenApiLintViolations.SECURITY_PROPERTY_REDEFINED
+                    )
+                    effectiveHeaders = effectiveHeaders.minus(headerKey)
+                }
+                headerPattern.isConstrainedStringOrEnumPattern() -> {
+                    headerContext.record(
+                        message = "Found constrained header parameter with same name as security scheme \"$headerName\". Specmatic will ignore the security scheme. But this can have unintended consequences, such as improper validation of a security scheme in an example or invalid value generation. To fix this issue, drop the header, as a security scheme has already been declared.",
+                        isWarning = true,
+                        ruleViolation = OpenApiLintViolations.SECURITY_PROPERTY_REDEFINED
+                    )
+                    effectiveSecuritySchemes = dropSecuritySchemeForHeader(effectiveSecuritySchemes, headerName)
+                }
+            }
+        }
+
+        if (effectiveSecuritySchemes.isEmpty()) {
+            effectiveSecuritySchemes = listOf(NoSecurityScheme())
+        }
+
+        return Pair(effectiveHeaders, effectiveSecuritySchemes)
+    }
+
+    private fun securityHeaderNames(securitySchemes: List<OpenAPISecurityScheme>): List<String> {
+        return securitySchemes.flatMap { securityHeaderNames(it) }
+    }
+
+    private fun securityHeaderNames(securityScheme: OpenAPISecurityScheme): List<String> {
+        return when (securityScheme) {
+            is CompositeSecurityScheme -> securityScheme.schemes.flatMap { securityHeaderNames(it) }
+            is BearerSecurityScheme, is BasicAuthSecurityScheme -> listOf(AUTHORIZATION)
+            is APIKeyInHeaderSecurityScheme -> listOf(securityScheme.name)
+            else -> emptyList()
+        }
+    }
+
+    private fun dropSecuritySchemeForHeader(
+        securitySchemes: List<OpenAPISecurityScheme>,
+        headerName: String
+    ): List<OpenAPISecurityScheme> {
+        return securitySchemes.mapNotNull { scheme ->
+            when (scheme) {
+                is CompositeSecurityScheme -> {
+                    val updatedSchemes = dropSecuritySchemeForHeader(scheme.schemes, headerName)
+                    when (updatedSchemes.size) {
+                        0 -> null
+                        1 -> updatedSchemes.single()
+                        else -> CompositeSecurityScheme(updatedSchemes)
+                    }
+                }
+                is BearerSecurityScheme, is BasicAuthSecurityScheme ->
+                    if (headerName.equals(AUTHORIZATION, ignoreCase = true)) null else scheme
+                is APIKeyInHeaderSecurityScheme ->
+                    if (scheme.name.equals(headerName, ignoreCase = true)) null else scheme
+                else -> scheme
+            }
+        }
     }
 
     private fun headersPatternWithContentType(
@@ -2797,6 +2880,19 @@ private fun <T> Result.returnLenientlyElseFail(lenient: Boolean = false, value: 
 
     this.throwOnFailure()
     return value
+}
+
+private fun Pattern.isUnconstrainedStringPattern(): Boolean {
+    return this is StringPattern && this.minLength == null && this.maxLength == null && this.regex == null
+}
+
+private fun Pattern.isConstrainedStringOrEnumPattern(): Boolean {
+    return when (this) {
+        is EnumPattern -> true
+        is StringPattern -> this.minLength != null || this.maxLength != null || this.regex != null
+        is ExactValuePattern -> this.pattern is StringValue
+        else -> false
+    }
 }
 
 internal fun validateSecuritySchemeParameterDuplication(securitySchemes: List<OpenAPISecurityScheme>, parameters: List<IndexedValue<Parameter>>?, collectorContext: CollectorContext) {

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -1594,22 +1594,12 @@ class OpenApiSpecification(
                 return@forEach
             }
 
-            val (headerPattern, headerContext) = headerValueWithContext
+            val (headerPattern, _) = headerValueWithContext
             when {
                 headerPattern.isUnconstrainedStringPattern() -> {
-                    headerContext.record(
-                        message = "Found header parameter with same name as security scheme \"$headerName\". The header parameter's datatype is an unconstrained string. Given that a security scheme requiring the same header has been declared, the parameter conveys no additional information and can be dropped.",
-                        isWarning = true,
-                        ruleViolation = OpenApiLintViolations.SECURITY_PROPERTY_REDEFINED
-                    )
                     effectiveHeaders = effectiveHeaders.minus(headerKey)
                 }
                 headerPattern.isConstrainedStringOrEnumPattern() -> {
-                    headerContext.record(
-                        message = "Found constrained header parameter with same name as security scheme \"$headerName\". Specmatic will ignore the security scheme. But this can have unintended consequences, such as improper validation of a security scheme in an example or invalid value generation. To fix this issue, drop the header, as a security scheme has already been declared.",
-                        isWarning = true,
-                        ruleViolation = OpenApiLintViolations.SECURITY_PROPERTY_REDEFINED
-                    )
                     effectiveSecuritySchemes = dropSecuritySchemeForHeader(effectiveSecuritySchemes, headerName)
                 }
             }

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationInfoTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationInfoTest.kt
@@ -1,6 +1,8 @@
 package io.specmatic.conversions
 
 import io.specmatic.core.pattern.parsedJSONObject
+import io.specmatic.core.pattern.withoutOptionality
+import io.specmatic.core.Resolver
 import io.swagger.v3.oas.models.*
 import io.swagger.v3.oas.models.info.Info
 import io.swagger.v3.oas.models.media.Schema
@@ -234,5 +236,84 @@ class OpenApiSpecificationInfoTest {
                 OpenApiLintViolations.SECURITY_PROPERTY_REDEFINED
             )
         )
+    }
+
+    @Test
+    fun `should ignore unconstrained auth header override and retain security scheme`() {
+        val spec = """
+            openapi: 3.0.3
+            info:
+              title: Greeting API with Authentication
+              version: 1.0.0
+            paths:
+              /greet:
+                get:
+                  security:
+                    - bearerAuth: []
+                  parameters:
+                    - name: Authorization
+                      in: header
+                      required: true
+                      schema:
+                        type: string
+                  responses:
+                    200:
+                      description: ok
+            components:
+              securitySchemes:
+                bearerAuth:
+                  type: http
+                  scheme: bearer
+        """.trimIndent()
+
+        val (output, feature) = captureStandardOutput { OpenApiSpecification.fromYAML(spec, "").toFeature() }
+        val scenario = feature.scenarios.first()
+        val generatedRequest = scenario.httpRequestPattern.generate(Resolver())
+
+        assertThat(scenario.httpRequestPattern.securitySchemes).hasOnlyElementsOfType(BearerSecurityScheme::class.java)
+        assertThat(scenario.httpRequestPattern.headersPattern.pattern.keys.map(::withoutOptionality))
+            .doesNotContain("Authorization")
+        assertThat(generatedRequest.getHeader("Authorization")).startsWith("Bearer")
+        assertThat(output).contains("The header parameter's datatype is an unconstrained string")
+    }
+
+    @Test
+    fun `should drop auth security scheme for constrained auth header override`() {
+        val spec = """
+            openapi: 3.0.3
+            info:
+              title: Greeting API with Authentication
+              version: 1.0.0
+            paths:
+              /greet:
+                get:
+                  security:
+                    - bearerAuth: []
+                  parameters:
+                    - name: Authorization
+                      in: header
+                      required: true
+                      schema:
+                        type: string
+                        minLength: 10
+                  responses:
+                    200:
+                      description: ok
+            components:
+              securitySchemes:
+                bearerAuth:
+                  type: http
+                  scheme: bearer
+        """.trimIndent()
+
+        val (output, feature) = captureStandardOutput { OpenApiSpecification.fromYAML(spec, "").toFeature() }
+        val scenario = feature.scenarios.first()
+        val generatedRequest = scenario.httpRequestPattern.generate(Resolver())
+
+        assertThat(scenario.httpRequestPattern.securitySchemes).isEqualTo(listOf(NoSecurityScheme()))
+        assertThat(scenario.httpRequestPattern.headersPattern.pattern.keys.map(::withoutOptionality))
+            .contains("Authorization")
+        assertThat(generatedRequest.getHeader("Authorization")).doesNotStartWith("Bearer")
+        assertThat(output).contains("Specmatic will ignore the security scheme")
     }
 }

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationInfoTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationInfoTest.kt
@@ -266,7 +266,7 @@ class OpenApiSpecificationInfoTest {
                   scheme: bearer
         """.trimIndent()
 
-        val (output, feature) = captureStandardOutput { OpenApiSpecification.fromYAML(spec, "").toFeature() }
+        val feature = OpenApiSpecification.fromYAML(spec, "").toFeature()
         val scenario = feature.scenarios.first()
         val generatedRequest = scenario.httpRequestPattern.generate(Resolver())
 
@@ -274,7 +274,6 @@ class OpenApiSpecificationInfoTest {
         assertThat(scenario.httpRequestPattern.headersPattern.pattern.keys.map(::withoutOptionality))
             .doesNotContain("Authorization")
         assertThat(generatedRequest.getHeader("Authorization")).startsWith("Bearer")
-        assertThat(output).contains("The header parameter's datatype is an unconstrained string")
     }
 
     @Test
@@ -306,7 +305,7 @@ class OpenApiSpecificationInfoTest {
                   scheme: bearer
         """.trimIndent()
 
-        val (output, feature) = captureStandardOutput { OpenApiSpecification.fromYAML(spec, "").toFeature() }
+        val feature = OpenApiSpecification.fromYAML(spec, "").toFeature()
         val scenario = feature.scenarios.first()
         val generatedRequest = scenario.httpRequestPattern.generate(Resolver())
 
@@ -314,6 +313,5 @@ class OpenApiSpecificationInfoTest {
         assertThat(scenario.httpRequestPattern.headersPattern.pattern.keys.map(::withoutOptionality))
             .contains("Authorization")
         assertThat(generatedRequest.getHeader("Authorization")).doesNotStartWith("Bearer")
-        assertThat(output).contains("Specmatic will ignore the security scheme")
     }
 }


### PR DESCRIPTION
**What**:
- Cleanly handle header overrides by resolving them at parse time

**Why**:
- Required by a bug that caused test vs mock loop test to fail when a header was overridden

**Checklist**:
- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)