### PR TITLE
Fix the path length limitation issue for example file names

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/utilities/Utilities.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/Utilities.kt
@@ -42,6 +42,10 @@ import javax.xml.transform.dom.DOMSource
 import javax.xml.transform.stream.StreamResult
 import kotlin.system.exitProcess
 
+private const val WINDOWS_MAX_PATH = 260
+private const val POSIX_MAX_FILENAME = 255
+private const val WINDOWS_MAX_FILENAME = 255
+
 class SystemExitException(
     val code: Int,
     message: String?,
@@ -482,24 +486,51 @@ fun nullOrExceptionString(fn: () -> Result): String? {
 
 private fun sanitizeFilename(input: String): String = input.replace(Regex("""[\\/:*?"'<>| ]"""), "_")
 
-fun uniqueNameForApiOperation(
-    httpRequest: HttpRequest,
-    baseURL: String,
-    responseStatus: Int,
-): String {
+fun uniqueNameForApiOperation(httpRequest: HttpRequest, scenario: Scenario, baseDir: File, prefix: String = ""): String {
+    val operationId = scenario.operationMetadata?.operationId?.takeUnless { it.isNullOrBlank() }
+    if (operationId != null) {
+        val fileName = "$prefix${operationId}_${scenario.status}"
+        return sanitizeAndFitOsPathBudget(baseDir, fileName)
+    }
+
+    return uniqueNameForApiOperation(httpRequest, "", scenario.status, baseDir, prefix)
+}
+
+fun uniqueNameForApiOperation(httpRequest: HttpRequest, baseURL: String, responseStatus: Int, baseDir: File, prefix: String = ""): String {
     val (method, path, headers) = httpRequest
-    val contentType =
-        if (method == "PATCH") {
-            "_" + headers[CONTENT_TYPE].orEmpty().replace("/", "_")
-        } else {
-            ""
-        }
+    val contentType = headers[CONTENT_TYPE]?.let { "_$it" }.orEmpty()
 
-    val formattedPath = path?.replace(baseURL, "")?.drop(1).orEmpty()
-    if (formattedPath.isEmpty()) return "${method}_$responseStatus"
+    val formattedPath = path?.removePrefix(baseURL)?.removePrefix("/").orEmpty()
+    val fileName = if (formattedPath.isEmpty()) {
+        "$prefix${method}_$responseStatus$contentType"
+    } else {
+        "$prefix${formattedPath}_${method}_${responseStatus}$contentType"
+    }
 
-    val rawName = "${formattedPath}_${method}_${responseStatus}$contentType"
-    return sanitizeFilename(rawName)
+    return sanitizeAndFitOsPathBudget(baseDir, fileName)
+}
+
+private fun isWindows(): Boolean = File.separatorChar == '\\'
+internal fun sanitizeAndFitOsPathBudget(baseDir: File, fileName: String, windows: Boolean = isWindows()): String {
+    val sanitizedFileName = sanitizeFilename(fileName)
+    val budget = if (windows) {
+        minOf(WINDOWS_MAX_FILENAME, WINDOWS_MAX_PATH - baseDir.absoluteFile.path.length - 1).coerceAtLeast(0)
+    } else {
+        POSIX_MAX_FILENAME
+    }
+
+    if (sanitizedFileName.length <= budget) return sanitizedFileName
+    val hash = stableHexHash(fileName)
+    val minWithUnderscore = hash.length + 1
+    if (budget < minWithUnderscore) return hash.take(maxOf(1, budget))
+
+    val prefixLen = budget - minWithUnderscore
+    return sanitizedFileName.take(prefixLen) + "_" + hash
+}
+
+private fun stableHexHash(input: String): String {
+    val bytes = java.security.MessageDigest.getInstance("SHA-256").digest(input.toByteArray(Charsets.UTF_8))
+    return bytes.take(6).joinToString("") { "%02x".format(it) }
 }
 
 fun consolePrintableURL(

--- a/core/src/main/kotlin/io/specmatic/core/utilities/Utilities.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/Utilities.kt
@@ -498,7 +498,7 @@ fun uniqueNameForApiOperation(httpRequest: HttpRequest, scenario: Scenario, base
 
 fun uniqueNameForApiOperation(httpRequest: HttpRequest, baseURL: String, responseStatus: Int, baseDir: File, prefix: String = ""): String {
     val (method, path, headers) = httpRequest
-    val contentType = headers[CONTENT_TYPE]?.let { "_$it" }.orEmpty()
+    val contentType = headers[CONTENT_TYPE]?.substringBefore(";")?.takeUnless { it.isBlank() }?.let { "_$it" }.orEmpty()
 
     val formattedPath = path?.removePrefix(baseURL)?.removePrefix("/").orEmpty()
     val fileName = if (formattedPath.isEmpty()) {

--- a/core/src/main/kotlin/io/specmatic/proxy/Proxy.kt
+++ b/core/src/main/kotlin/io/specmatic/proxy/Proxy.kt
@@ -55,6 +55,12 @@ class Proxy(
     specmaticConfigSource: SpecmaticConfigSource = SpecmaticConfigSource.None,
     private val specificationFileName: String = "proxy_generated",
 ) : Closeable {
+    private val defaultExamplesBaseDir = runCatching {
+        File(outputDirectory.fileName("${specificationFileName.dropExtension()}$EXAMPLES_DIR_SUFFIX"))
+    }.getOrElse {
+        File(".")
+    }
+
     constructor(
         host: String,
         port: Int,
@@ -264,7 +270,7 @@ class Proxy(
                                     if (isRecordingEnabled) stubs.add(
                                         NamedStub(
                                             name,
-                                            uniqueNameForApiOperation(recordedRequest, baseURL, recordedResponse.status),
+                                            uniqueNameForApiOperation(recordedRequest, baseURL, recordedResponse.status, defaultExamplesBaseDir),
                                             exampleTransformer.applyTo(
                                                 scenarioStub = ScenarioStub(
                                                 recordedRequest.dropIrrelevantHeaders(),

--- a/core/src/test/kotlin/io/specmatic/proxy/ProxyTest.kt
+++ b/core/src/test/kotlin/io/specmatic/proxy/ProxyTest.kt
@@ -103,7 +103,7 @@ internal class ProxyTest {
         assertThatCode { parsedJSON(fakeFileWriter.receivedStub ?: "") }.doesNotThrowAnyException()
         assertThat(fakeFileWriter.receivedPaths.toList()).containsExactlyInAnyOrder(
             "proxy_generated.yaml",
-            "POST_200_1.json",
+            "POST_200_text_plain_1.json",
         )
     }
 
@@ -132,7 +132,7 @@ internal class ProxyTest {
         assertThatCode { parsedJSON(fakeFileWriter.receivedStub ?: "") }.doesNotThrowAnyException()
         assertThat(fakeFileWriter.receivedPaths.toList()).containsExactlyInAnyOrder(
             "proxy_generated.yaml",
-            "multiply_POST_200_1.json",
+            "multiply_POST_200_text_plain_1.json",
         )
     }
 
@@ -183,7 +183,7 @@ internal class ProxyTest {
             )
         }.doesNotThrowAnyException()
         assertThatCode { parsedJSON(fakeFileWriter.receivedStub ?: "") }.doesNotThrowAnyException()
-        assertThat(fakeFileWriter.receivedPaths).containsExactlyInAnyOrder("proxy_generated.yaml", "POST_200_1.json")
+        assertThat(fakeFileWriter.receivedPaths).containsExactlyInAnyOrder("proxy_generated.yaml", "POST_200_text_plain_1.json")
     }
 
     @Test
@@ -430,7 +430,7 @@ internal class ProxyTest {
                 assertThatCode { parsedJSON(fakeFileWriter.receivedStub ?: "") }.doesNotThrowAnyException()
                 assertThat(fakeFileWriter.receivedPaths.toList()).contains(
                     "proxy_generated.yaml",
-                    "multiply_POST_200_1.json",
+                    "multiply_POST_200_text_plain_1.json",
                 )
             }
         }

--- a/core/src/test/kotlin/utilities/UtilitiesTest.kt
+++ b/core/src/test/kotlin/utilities/UtilitiesTest.kt
@@ -617,7 +617,8 @@ internal class UtilitiesTest {
         every { scenario.status } returns 200
 
         val output = uniqueNameForApiOperation(request, scenario, File("."))
-        assertThat(output.length).isEqualTo(255)
+        assertThat(output.length).isLessThan(300)
+        assertThat(output.length).isLessThanOrEqualTo(255)
         assertThat(output).matches("A*_[0-9a-f]{12}$")
     }
 
@@ -625,7 +626,8 @@ internal class UtilitiesTest {
     fun `uniqueNameForApiOperation with request details should budget long generated name`() {
         val request = HttpRequest("GET", "http://example.com/" + "segment/".repeat(80), emptyMap())
         val output = uniqueNameForApiOperation(request, "http://example.com", 200, File("."))
-        assertThat(output.length).isEqualTo(255)
+        assertThat(output.length).isLessThan(request.path!!.length)
+        assertThat(output.length).isLessThanOrEqualTo(255)
         assertThat(output).matches(".*_[0-9a-f]{12}$")
     }
 
@@ -659,7 +661,8 @@ internal class UtilitiesTest {
     fun `fitOsPathBudget should respect windows max filename cap`() {
         val filename = "a".repeat(300)
         val output = sanitizeAndFitOsPathBudget(File("/tmp"), filename, windows = true)
-        assertThat(output.length).isEqualTo(255)
+        assertThat(output.length).isLessThan(filename.length)
+        assertThat(output.length).isLessThanOrEqualTo(255)
         assertThat(output).matches("a*_[0-9a-f]{12}$")
     }
 

--- a/core/src/test/kotlin/utilities/UtilitiesTest.kt
+++ b/core/src/test/kotlin/utilities/UtilitiesTest.kt
@@ -1,8 +1,10 @@
 package utilities
 
+import io.specmatic.conversions.OperationMetadata
 import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.core.CONTRACT_EXTENSION
 import io.specmatic.core.HttpRequest
+import io.specmatic.core.Scenario
 import io.specmatic.core.SourceProvider
 import io.specmatic.core.git.GitCommand
 import io.specmatic.core.git.SystemGit
@@ -568,10 +570,107 @@ internal class UtilitiesTest {
     )
     fun `unique names from operation information names should be path valid`(path: String?, baseURL: String, method: String, status: Int, expected: String) {
         val request = HttpRequest(method, path, emptyMap())
-        val actual = uniqueNameForApiOperation(request, baseURL, status)
+        val actual = uniqueNameForApiOperation(request, baseURL, status, File("."))
 
         assertThat(actual).isEqualTo(expected)
         assertDoesNotThrow { File(actual).canonicalPath }
+    }
+
+    @Test
+    fun `uniqueNameForApiOperation should include the prefix if provided`() {
+        val request = HttpRequest("GET", "/path/that/should/not/be/used", emptyMap())
+        val scenario = mockk<Scenario>()
+        every { scenario.operationMetadata } returns OperationMetadata(operationId = "create-order")
+        every { scenario.status } returns 201
+
+        val output = uniqueNameForApiOperation(request, scenario, File("."), "prefix_")
+        assertThat(output).isEqualTo("prefix_create-order_201")
+    }
+
+    @Test
+    fun `uniqueNameForApiOperation should not use operationId if it is blank`() {
+        val request = HttpRequest("GET", "/path/that/should/be/used", emptyMap())
+        val scenario = mockk<Scenario>()
+        every { scenario.operationMetadata } returns OperationMetadata(operationId = "")
+        every { scenario.status } returns 201
+
+        val output = uniqueNameForApiOperation(request, scenario, File("."), "prefix_")
+        assertThat(output).isEqualTo("prefix_path_that_should_be_used_GET_201")
+    }
+
+    @Test
+    fun `uniqueNameForApiOperation with scenario should prefer operationId over request path`() {
+        val request = HttpRequest("GET", "/path/that/should/not/be/used", emptyMap())
+        val scenario = mockk<Scenario>()
+        every { scenario.operationMetadata } returns OperationMetadata(operationId = "create-order")
+        every { scenario.status } returns 201
+
+        val output = uniqueNameForApiOperation(request, scenario, File("."))
+        assertThat(output).isEqualTo("create-order_201")
+    }
+
+    @Test
+    fun `uniqueNameForApiOperation with scenario should budget long operationId`() {
+        val request = HttpRequest("GET", "/anything", emptyMap())
+        val scenario = mockk<Scenario>()
+        every { scenario.operationMetadata } returns OperationMetadata(operationId = "A".repeat(300))
+        every { scenario.status } returns 200
+
+        val output = uniqueNameForApiOperation(request, scenario, File("."))
+        assertThat(output.length).isEqualTo(255)
+        assertThat(output).matches("A*_[0-9a-f]{12}$")
+    }
+
+    @Test
+    fun `uniqueNameForApiOperation with request details should budget long generated name`() {
+        val request = HttpRequest("GET", "http://example.com/" + "segment/".repeat(80), emptyMap())
+        val output = uniqueNameForApiOperation(request, "http://example.com", 200, File("."))
+        assertThat(output.length).isEqualTo(255)
+        assertThat(output).matches(".*_[0-9a-f]{12}$")
+    }
+
+    @Test
+    fun `fitOsPathBudget should leave filename unchanged when it is within budget`() {
+        val filename = "users_GET_200"
+        val output = sanitizeAndFitOsPathBudget(File("."), filename, windows = false)
+        assertThat(output).isEqualTo(filename)
+    }
+
+    @Test
+    fun `fitOsPathBudget should cap posix filename length and append hash`() {
+        val longName = "a".repeat(300)
+        val output = sanitizeAndFitOsPathBudget(File("."), longName, windows = false)
+        assertThat(output.length).isEqualTo(255)
+        assertThat(output).matches("a*_[0-9a-f]{12}$")
+    }
+
+    @Test
+    fun `fitOsPathBudget should respect windows max path budget and keep hash suffix`() {
+        val baseDir = File("/" + "x".repeat(240))
+        val filename = "y".repeat(50)
+        val output = sanitizeAndFitOsPathBudget(baseDir, filename, windows = true)
+        val budget = (260 - baseDir.absoluteFile.path.length - 1).coerceAtLeast(0)
+
+        assertThat(output.length).isEqualTo(budget)
+        assertThat(output).matches("y*_[0-9a-f]{12}$")
+    }
+
+    @Test
+    fun `fitOsPathBudget should respect windows max filename cap`() {
+        val filename = "a".repeat(300)
+        val output = sanitizeAndFitOsPathBudget(File("/tmp"), filename, windows = true)
+        assertThat(output.length).isEqualTo(255)
+        assertThat(output).matches("a*_[0-9a-f]{12}$")
+    }
+
+    @Test
+    fun `fitOsPathBudget should return at least one character when windows path budget is zero`() {
+        val baseDir = File("/" + "x".repeat(300))
+        val output = sanitizeAndFitOsPathBudget(baseDir, "abc", windows = true)
+        val budget = (260 - baseDir.absoluteFile.path.length - 1).coerceAtLeast(0)
+        assertThat(budget).isEqualTo(0)
+        assertThat(output).hasSize(1)
+        assertThat(output).matches("[0-9a-f]")
     }
 
     private fun deleteGitIgnoreFile(){


### PR DESCRIPTION
**What**: Fix the path length limitation issue for example file names

**Why**: On Windows, file names are restricted to 255 characters, while the path length is limited to 260 characters. Similarly, on Unix systems, file names are also capped at 255 characters

**How**:
- Prefers using operationId-status when feasible, which is also budgeted
- Calculates the remaining budget, truncates the file name to ensure it stays within the specified limits, and appends a 6-character hash suffix to prevent any duplicates from overriding each other after budgeting

**Checklist**:

- [x] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
