### PR TITLE
Minor modifications to HttpStub CtrfTestResultRecord

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/jsonoperator/RequestOperator.kt
+++ b/core/src/main/kotlin/io/specmatic/core/jsonoperator/RequestOperator.kt
@@ -27,6 +27,7 @@ data class RequestOperator(
         put("path", pathOperator)
         put("query", queryOperator)
         put("header", headerOperator)
+        put("method", ValueOperator(StringValue(originalHttpRequest.method.orEmpty())))
         put("url", ValueOperator(StringValue(originalHttpRequest.path.orEmpty())))
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/jsonoperator/RequestResponseOperator.kt
+++ b/core/src/main/kotlin/io/specmatic/core/jsonoperator/RequestResponseOperator.kt
@@ -9,6 +9,7 @@ import io.specmatic.core.pattern.ReturnValue
 import io.specmatic.core.pattern.unwrapOrReturn
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.Value
+import io.specmatic.mock.ScenarioStub
 
 data class RequestResponseOperator(
     private val requestOperator: RequestOperator,
@@ -28,6 +29,12 @@ data class RequestResponseOperator(
         val request = requestOperator.finalize().unwrapOrReturn { return it.cast() }
         val response = responseOperator.finalize().unwrapOrReturn { return it.cast() }
         return HasValue(JSONObjectValue(mapOf("request" to request.toJSON(), "response" to response.toJSON())))
+    }
+
+    fun finalizeToScenarioStub(): ReturnValue<ScenarioStub> {
+        val request = requestOperator.finalize().unwrapOrReturn { return it.cast() }
+        val response = responseOperator.finalize().unwrapOrReturn { return it.cast() }
+        return HasValue(ScenarioStub(request = request, response = response))
     }
 
     companion object {

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -514,6 +514,7 @@ class HttpStub(
             request = httpRequest,
             response = httpResponse,
             result = httpLogMessage.toResult(),
+            scenarioResult = (httpLogMessage.result ?: Result.Success()).updateScenario(httpLogMessage.scenario ?: httpLogMessage.result?.scenario),
             specType = httpLogMessage.scenario?.specType ?: SpecType.OPENAPI,
             requestContentType = requestContentType,
             specification = httpStubResponse.scenario?.specification,

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -514,7 +514,7 @@ class HttpStub(
             request = httpRequest,
             response = httpResponse,
             result = httpLogMessage.toResult(),
-            scenarioResult = (httpLogMessage.result ?: Result.Success()).updateScenario(httpLogMessage.scenario ?: httpLogMessage.result?.scenario),
+            scenarioResult = (httpLogMessage.result ?: Result.Success()).updateScenario(httpLogMessage.scenario),
             specType = httpLogMessage.scenario?.specType ?: SpecType.OPENAPI,
             requestContentType = requestContentType,
             specification = httpStubResponse.scenario?.specification,

--- a/core/src/test/kotlin/io/specmatic/core/jsonoperator/RequestOperatorTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/jsonoperator/RequestOperatorTest.kt
@@ -41,6 +41,14 @@ class RequestOperatorTest {
     }
 
     @Test
+    fun `should be able to retrieve method using pointer`() {
+        val request = HttpRequest(method = "PATCH", path = "/api/users/123")
+        val operator = RequestOperator.from(request, mockRequestPattern, mockResolver)
+        val result = operator.get("/method").finalizeValue()
+        assertThat(result.value.getOrNull()).isEqualTo(StringValue("PATCH"))
+    }
+
+    @Test
     fun `should extract path parameters when pattern is provided`() {
         val mockPathPattern = mockk<HttpPathPattern>()
         val mockSegmentPattern = mockk<URLPathSegmentPattern>()
@@ -163,7 +171,7 @@ class RequestOperatorTest {
 
         assertThat(result).isInstanceOf(HasFailure::class.java)
         assertThat((result as HasFailure).failure.reportString())
-            .contains("Invalid key invalid, must be oneof body, path, query, header, url")
+            .contains("Invalid key invalid, must be oneof body, path, query, header, method, url")
     }
 
     @Test
@@ -243,7 +251,7 @@ class RequestOperatorTest {
     fun `should have routes map with all expected keys`() {
         val request = HttpRequest(method = "GET", path = "/api/users")
         val operator = RequestOperator.from(request, mockRequestPattern, mockResolver)
-        assertThat(operator.routes.keys).containsExactlyInAnyOrder("body", "path", "query", "header", "url")
+        assertThat(operator.routes.keys).containsExactlyInAnyOrder("body", "path", "query", "header", "method", "url")
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/core/jsonoperator/RequestResponseOperatorTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/jsonoperator/RequestResponseOperatorTest.kt
@@ -10,6 +10,7 @@ import io.specmatic.core.pattern.HasFailure
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.NumberValue
 import io.specmatic.core.value.StringValue
+import io.specmatic.mock.ScenarioStub
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -82,5 +83,19 @@ class RequestResponseOperatorTest {
 
         val jsonObject = (result as JSONObjectValue).jsonObject
         assertThat(jsonObject).containsKeys("request", "response")
+    }
+
+    @Test
+    fun `should be able to finalize to scenario stub`() {
+        val request = HttpRequest(method = "POST", path = "/api/users", body = StringValue("request body"))
+        val response = HttpResponse(status = 201, body = StringValue("response body"))
+        val operator = RequestResponseOperator.from(request, response, mockScenario)
+
+        val result = operator.finalizeToScenarioStub().value
+        assertThat(result).isInstanceOf(ScenarioStub::class.java)
+        assertThat(result.request.method).isEqualTo("POST")
+        assertThat(result.request.path).isEqualTo("/")
+        assertThat(result.response.status).isEqualTo(201)
+        assertThat(result.response.body).isEqualTo(StringValue("response body"))
     }
 }

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
@@ -3799,6 +3799,58 @@ Then status 200
         }
     }
 
+    @Test
+    fun `should capture scenario result from failure even when request does not match any scenario identifier`() {
+        val tempDir = Files.createTempDirectory("specmatic-openapi-scenario-result").toFile()
+        val openApiSpec = tempDir.resolve("api.yaml")
+        openApiSpec.writeText("""
+        openapi: 3.0.0
+        info:
+          title: Scenario Result API
+          version: 1.0.0
+        paths:
+          /hello:
+            post:
+              requestBody:
+                required: true
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        name:
+                          type: string
+              responses:
+                "200":
+                  description: OK
+        """.trimIndent())
+
+        try {
+            val feature = parseContractFileToFeature(openApiSpec)
+            HttpStub(feature).use { stub ->
+                val response = stub.client.execute(
+                    HttpRequest(
+                        method = "POST",
+                        path = "/hello",
+                        headers = mapOf("Content-Type" to "application/json"),
+                        body = StringValue("hello")
+                    )
+                )
+
+                assertThat(response.status).isEqualTo(400)
+                val testResultRecord = stub.ctrfTestResultRecords().single()
+                assertThat(testResultRecord.scenarioResult).isNotNull
+                assertThat(testResultRecord.scenarioResult?.scenario).isNotNull
+                assertThat(testResultRecord.scenarioResult?.scenario?.method).isEqualTo("POST")
+                assertThat(testResultRecord.scenarioResult?.scenario?.path).isEqualTo("/hello")
+            }
+        } finally {
+            tempDir.deleteRecursively()
+        }
+    }
+
     private fun String.replaceFileSeparator(): String {
         return this.replace("/", File.separator)
     }


### PR DESCRIPTION
**What**: Minor modifications to HttpStub CtrfTestResultRecord

**How**: 
- Set `scenarioResult` in CtrfTestResultRecord which was previously not being set
- Add helpers method to `RequestResponseOperator` and `method` to `RequestOperator`

**Checklist**:
- [x] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)