### PR TITLE
Add support for mTLS to both mock and test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# Instructions
+
+## Running gradle commands
+- Run gradle tests one at a time. Many tests listen on hard-coded ports. So if tests run in parallel, they will collide on the ports and run into bind errors.
+- When running a focused test, be sure to use the fully qualified test class name in the gradle command, e.g. `./gradlew test --tests "com.example.TestClass"`
+
+## Project structure
+
+The following is a list of directories and the gradle modules that they contain:
+- directory: 'core', module: 'specmatic-core'
+- directory: 'application', module: 'specmatic-executable'
+- directory: 'junit5-support', module: 'junit5-support'

--- a/application/src/main/kotlin/application/HTTPStubEngine.kt
+++ b/application/src/main/kotlin/application/HTTPStubEngine.kt
@@ -1,6 +1,7 @@
 package application
 
 import io.specmatic.core.Feature
+import io.specmatic.core.IncomingMtlsRegistry
 import io.specmatic.core.KeyDataRegistry
 import io.specmatic.core.WorkingDirectory
 import io.specmatic.core.log.consoleLog
@@ -18,6 +19,7 @@ class HTTPStubEngine {
         host: String,
         port: Int,
         keyDataRegistry: KeyDataRegistry,
+        incomingMtlsRegistry: IncomingMtlsRegistry,
         strictMode: Boolean,
         passThroughTargetBase: String = "",
         specmaticConfigSource: SpecmaticConfigSource,
@@ -36,6 +38,7 @@ class HTTPStubEngine {
             log = ::consoleLog,
             strictMode = strictMode,
             keyDataRegistry = keyDataRegistry,
+            incomingMtlsRegistry = incomingMtlsRegistry,
             passThroughTargetBase = passThroughTargetBase,
             httpClientFactory = httpClientFactory,
             workingDirectory = workingDirectory,

--- a/application/src/main/kotlin/application/StubCommand.kt
+++ b/application/src/main/kotlin/application/StubCommand.kt
@@ -13,6 +13,7 @@ import io.specmatic.core.log.*
 import io.specmatic.core.utilities.*
 import io.specmatic.core.utilities.ContractPathData.Companion.specToBaseUrlMap
 import io.specmatic.core.loadSpecmaticConfigOrNull
+import io.specmatic.core.toIncomingMtlsRegistryForStub
 import io.specmatic.core.utilities.Flags.Companion.SPECMATIC_BASE_URL
 import io.specmatic.license.core.cli.Category
 import io.specmatic.mock.ScenarioStub
@@ -185,6 +186,10 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
         }
     }
 
+    private val incomingMtlsRegistry: IncomingMtlsRegistry by lazy(LazyThreadSafetyMode.NONE) {
+        specmaticConfiguration.getStubHttpsConfiguration().toIncomingMtlsRegistryForStub()
+    }
+
     override fun call(): Int {
         configureLogging(
             LoggingFromOpts(
@@ -316,6 +321,7 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
             host = host,
             port = port,
             keyDataRegistry = keyDataRegistry,
+            incomingMtlsRegistry = incomingMtlsRegistry,
             strictMode = resolvedStrictMode,
             passThroughTargetBase = passThroughTargetBase,
             specmaticConfigSource = specmaticConfigurationSource,

--- a/application/src/test/kotlin/application/HTTPStubEngineTest.kt
+++ b/application/src/test/kotlin/application/HTTPStubEngineTest.kt
@@ -3,6 +3,7 @@ package application
 import io.mockk.every
 import io.mockk.mockk
 import io.specmatic.core.Feature
+import io.specmatic.core.IncomingMtlsRegistry
 import io.specmatic.core.KeyDataRegistry
 import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.WorkingDirectory
@@ -20,6 +21,7 @@ class HTTPStubEngineTest {
                 host = "0.0.0.0",
                 port = 9000,
                 keyDataRegistry = KeyDataRegistry.empty(),
+                incomingMtlsRegistry = IncomingMtlsRegistry.empty(),
                 strictMode = false,
                 httpClientFactory = HttpClientFactory(),
                 workingDirectory = WorkingDirectory(),

--- a/application/src/test/kotlin/application/StubCommandTest.kt
+++ b/application/src/test/kotlin/application/StubCommandTest.kt
@@ -649,7 +649,7 @@ internal class StubCommandTest {
         version: 2
         stub:
           https:
-            incomingMtlsEnabled: true
+            mtlsEnabled: true
             keyStorePassword: pass
             keyStore:
               file: ${keystoreFile.canonicalPath}

--- a/application/src/test/kotlin/application/StubCommandTest.kt
+++ b/application/src/test/kotlin/application/StubCommandTest.kt
@@ -5,7 +5,7 @@ import io.mockk.*
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.specmatic.core.CONTRACT_EXTENSION
-import io.specmatic.core.KeyData
+import io.specmatic.core.IncomingMtlsRegistry
 import io.specmatic.core.KeyDataRegistry
 import io.specmatic.core.parseGherkinStringToFeature
 import io.specmatic.core.utilities.ContractPathData
@@ -118,6 +118,7 @@ internal class StubCommandTest {
                     host,
                     port,
                     any(),
+                    any(),
                     strictMode,
                     any(),
                     httpClientFactory = any(),
@@ -139,6 +140,7 @@ internal class StubCommandTest {
 
             verify(exactly = 1) {
                 httpStubEngine.runHTTPStub(
+                    any(),
                     any(),
                     any(),
                     any(),
@@ -171,7 +173,7 @@ internal class StubCommandTest {
         every { specmaticConfig.contractStubPaths() }.returns(arrayListOf("/config/path/to/contract.$extension"))
         every { specmaticConfig.contractStubPathData() } returns emptyList()
         every { stubLoaderEngine.loadStubs(any(), any(), any(), any()) } returns emptyList()
-        every { httpStubEngine.runHTTPStub(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } answers {
+        every { httpStubEngine.runHTTPStub(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } answers {
             mockk<HttpStub> { every { close() } returns Unit }
         }
 
@@ -246,6 +248,7 @@ internal class StubCommandTest {
                     host,
                     port,
                     any(),
+                    any(),
                     strictMode,
                     passThroughTargetBase,
                     httpClientFactory = any(),
@@ -274,6 +277,7 @@ internal class StubCommandTest {
                     host,
                     any(),
                     any(),
+                    any(),
                     strictMode,
                     any(),
                     httpClientFactory = any(),
@@ -295,7 +299,7 @@ internal class StubCommandTest {
         every { specmaticConfig.contractStubPaths() } returns emptyList()
         every { specmaticConfig.contractStubPathData() } returns emptyList()
         every {
-            httpStubEngine.runHTTPStub(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+            httpStubEngine.runHTTPStub(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
         } returns mockk { every { close() } returns Unit }
 
         try {
@@ -345,6 +349,7 @@ internal class StubCommandTest {
                 capture(hostSlot),
                 capture(portSlot),
                 capture(keyDataSlot),
+                any(),
                 capture(strictModeSlot),
                 any(),
                 any(),
@@ -405,6 +410,7 @@ internal class StubCommandTest {
                 capture(hostSlot),
                 capture(portSlot),
                 capture(keyDataSlot),
+                any(),
                 capture(strictModeSlot),
                 capture(passThroughSlot),
                 any(),
@@ -441,7 +447,7 @@ internal class StubCommandTest {
         val portSlot = slot<Int>()
         val strictModeSlot = slot<Boolean>()
         val timeoutSlot = slot<Long>()
-        var capturedKeyData: KeyData? = null
+        var capturedKeyDataRegistry: KeyDataRegistry? = null
 
         every { stubLoaderEngine.loadStubs(any(), any(), any(), any()) } returns emptyList()
         every { watchMaker.make(any()) } returns watcher
@@ -454,6 +460,7 @@ internal class StubCommandTest {
                 capture(hostSlot),
                 capture(portSlot),
                 any(),
+                any(),
                 capture(strictModeSlot),
                 any(),
                 any(),
@@ -464,13 +471,13 @@ internal class StubCommandTest {
                 any()
             )
         } answers {
-            capturedKeyData = arg(3) as KeyData?
+            capturedKeyDataRegistry = arg(3)
             mockk<HttpStub> { every { close() } returns Unit }
         }
 
         CommandLine(stubCommand).execute()
 
-        assertThat(capturedKeyData).isNull()
+        assertThat(capturedKeyDataRegistry?.hasAny()).isFalse()
         assertThat(hostSlot.captured).isEqualTo("0.0.0.0")
         assertThat(portSlot.captured).isEqualTo(9000)
         assertThat(strictModeSlot.captured).isFalse()
@@ -498,6 +505,7 @@ internal class StubCommandTest {
                 any(),
                 capture(hostSlot),
                 capture(portSlot),
+                any(),
                 any(),
                 any(),
                 any(),
@@ -547,6 +555,7 @@ internal class StubCommandTest {
                 any(),
                 any(),
                 any(),
+                any(),
                 any()
             )
         } returns mockk { every { close() } returns Unit }
@@ -575,6 +584,7 @@ internal class StubCommandTest {
                 any(),
                 any(),
                 capture(keyDataSlot),
+                any(),
                 any(),
                 any(),
                 any(),
@@ -621,12 +631,55 @@ internal class StubCommandTest {
                 any(),
                 any(),
                 any(),
+                any(),
                 any()
             )
         } returns mockk { every { close() } returns Unit }
 
         Flags.using(CONFIG_FILE_PATH to configFile.canonicalPath) { CommandLine(stubCommand).execute() }
         assertThat(keyDataSlot.captured).isNotNull
+    }
+
+    @Test
+    fun `uses incoming mTLS from config when provided`(@TempDir tempDir: File) {
+        val incomingMtlsSlot = slot<IncomingMtlsRegistry>()
+        val keystoreFile = tempDir.resolve("config.jks")
+        createEmptyKeyStore(keystoreFile, "pass")
+        val configFile = writeSpecmaticYaml(tempDir, """
+        version: 2
+        stub:
+          https:
+            incomingMtlsEnabled: true
+            keyStorePassword: pass
+            keyStore:
+              file: ${keystoreFile.canonicalPath}
+        """.trimIndent())
+
+        every { stubLoaderEngine.loadStubs(any(), any(), any(), any()) } returns emptyList()
+        every { watchMaker.make(any()) } returns watcher
+        every { specmaticConfig.contractStubPaths() } returns emptyList()
+        every { specmaticConfig.contractStubPathData() } returns emptyList()
+        every {
+            httpStubEngine.runHTTPStub(
+                any(),
+                any(),
+                any(),
+                any(),
+                capture(incomingMtlsSlot),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any()
+            )
+        } returns mockk { every { close() } returns Unit }
+
+        Flags.using(CONFIG_FILE_PATH to configFile.canonicalPath) { CommandLine(stubCommand).execute() }
+
+        assertThat(incomingMtlsSlot.captured.get("localhost", 443)).isTrue()
     }
 
     @Test
@@ -659,6 +712,7 @@ internal class StubCommandTest {
                 capture(hostSlot),
                 any(),
                 capture(keyDataSlot),
+                any(),
                 capture(strictModeSlot),
                 any(),
                 any(),

--- a/application/src/test/kotlin/io/specmatic/test/SpecmaticContractMtlsTest.kt
+++ b/application/src/test/kotlin/io/specmatic/test/SpecmaticContractMtlsTest.kt
@@ -1,0 +1,141 @@
+package io.specmatic.test
+
+import io.ktor.network.tls.certificates.generateCertificate
+import io.specmatic.core.HttpRequest
+import io.specmatic.core.KeyData
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.net.InetSocketAddress
+import java.nio.file.Path
+import java.security.KeyStore
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import javax.net.ssl.KeyManagerFactory
+import javax.net.ssl.SSLContext
+import javax.net.ssl.TrustManagerFactory
+import com.sun.net.httpserver.HttpsConfigurator
+import com.sun.net.httpserver.HttpsParameters
+import com.sun.net.httpserver.HttpsServer
+
+class SpecmaticContractMtlsTest {
+    @Test
+    fun `should fail reachability check against mTLS endpoint when client certificate is not configured`(@TempDir tempDir: Path) {
+        mtlsServer(tempDir.toFile()).use { server ->
+            val baseUrl = "https://localhost:${server.port}"
+
+            assertThat(isBaseURLReachable(baseUrl)).isFalse()
+        }
+    }
+
+    @Test
+    fun `should connect to mTLS endpoint with configured client certificate`(@TempDir tempDir: Path) {
+        mtlsServer(tempDir.toFile()).use { server ->
+            val baseUrl = "https://localhost:${server.port}"
+            val keyData = KeyData(
+                keyStore = loadJks(server.clientKeyStoreFile, CLIENT_KEYSTORE_PASSWORD),
+                keyStorePassword = CLIENT_KEYSTORE_PASSWORD,
+                keyAlias = CLIENT_ALIAS,
+                keyPassword = CLIENT_KEY_PASSWORD
+            )
+
+            assertThat(isBaseURLReachable(baseUrl, keyData = keyData)).isTrue()
+
+            val response = HttpClient(baseUrl, keyData = keyData).use { client ->
+                client.execute(HttpRequest(path = "/", method = "GET"))
+            }
+
+            assertThat(response.status).isEqualTo(200)
+        }
+    }
+
+    private fun mtlsServer(tempDir: File): MtlsTestServer {
+        val serverKeyStoreFile = tempDir.resolve("server.jks")
+        val clientKeyStoreFile = tempDir.resolve("client.jks")
+
+        val serverKeyStore = generateCertificate(
+            file = serverKeyStoreFile,
+            jksPassword = SERVER_KEYSTORE_PASSWORD,
+            keyAlias = SERVER_ALIAS,
+            keyPassword = SERVER_KEY_PASSWORD
+        )
+
+        val clientKeyStore = generateCertificate(
+            file = clientKeyStoreFile,
+            jksPassword = CLIENT_KEYSTORE_PASSWORD,
+            keyAlias = CLIENT_ALIAS,
+            keyPassword = CLIENT_KEY_PASSWORD
+        )
+
+        val trustStore = KeyStore.getInstance("JKS").apply {
+            load(null, null)
+            setCertificateEntry("trusted-client", clientKeyStore.getCertificate(CLIENT_ALIAS))
+        }
+
+        val keyManagers = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm()).apply {
+            init(serverKeyStore, SERVER_KEY_PASSWORD.toCharArray())
+        }.keyManagers
+
+        val trustManagers = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm()).apply {
+            init(trustStore)
+        }.trustManagers
+
+        val sslContext = SSLContext.getInstance("TLS").apply {
+            init(keyManagers, trustManagers, null)
+        }
+
+        val server = HttpsServer.create(InetSocketAddress("localhost", 0), 0)
+        server.httpsConfigurator = object : HttpsConfigurator(sslContext) {
+            override fun configure(parameters: HttpsParameters) {
+                val sslParameters = sslContext.defaultSSLParameters
+                sslParameters.needClientAuth = true
+                parameters.setSSLParameters(sslParameters)
+                parameters.needClientAuth = true
+            }
+        }
+        server.createContext("/") { exchange ->
+            val response = "ok".toByteArray()
+            exchange.sendResponseHeaders(200, response.size.toLong())
+            exchange.responseBody.use { outputStream -> outputStream.write(response) }
+            exchange.close()
+        }
+
+        val executor = Executors.newSingleThreadExecutor()
+        server.executor = executor
+        server.start()
+
+        return MtlsTestServer(server, executor, clientKeyStoreFile)
+    }
+
+    private fun loadJks(file: File, password: String): KeyStore {
+        return KeyStore.getInstance("JKS").apply {
+            file.inputStream().use { inputStream ->
+                load(inputStream, password.toCharArray())
+            }
+        }
+    }
+
+    private data class MtlsTestServer(
+        val httpsServer: HttpsServer,
+        val executor: ExecutorService,
+        val clientKeyStoreFile: File
+    ) : AutoCloseable {
+        val port: Int = httpsServer.address.port
+
+        override fun close() {
+            httpsServer.stop(0)
+            executor.shutdownNow()
+        }
+    }
+
+    companion object {
+        private const val SERVER_ALIAS = "specmatic-server"
+        private const val SERVER_KEYSTORE_PASSWORD = "server-store-pass"
+        private const val SERVER_KEY_PASSWORD = "server-key-pass"
+
+        private const val CLIENT_ALIAS = "specmatic-client"
+        private const val CLIENT_KEYSTORE_PASSWORD = "client-store-pass"
+        private const val CLIENT_KEY_PASSWORD = "client-key-pass"
+    }
+}

--- a/application/src/test/kotlin/io/specmatic/test/SpecmaticContractMtlsTest.kt
+++ b/application/src/test/kotlin/io/specmatic/test/SpecmaticContractMtlsTest.kt
@@ -3,6 +3,7 @@ package io.specmatic.test
 import io.ktor.network.tls.certificates.generateCertificate
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.KeyData
+import io.specmatic.core.log.LogMessage
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -42,11 +43,39 @@ class SpecmaticContractMtlsTest {
 
             assertThat(isBaseURLReachable(baseUrl, keyData = keyData)).isTrue()
 
-            val response = HttpClient(baseUrl, keyData = keyData).use { client ->
+            val logs = mutableListOf<String>()
+            val response = HttpClient(baseUrl, keyData = keyData, log = captureLogs(logs)).use { client ->
                 client.execute(HttpRequest(path = "/", method = "GET"))
             }
 
             assertThat(response.status).isEqualTo(200)
+            assertThat(logs.joinToString(System.lineSeparator())).contains("Request to $baseUrl (mTLS)")
+        }
+    }
+
+    @Test
+    fun `should not mark request as mTLS when server is HTTPS without client auth`(@TempDir tempDir: Path) {
+        httpsServerWithoutClientAuth(tempDir.toFile()).use { server ->
+            val baseUrl = "https://localhost:${server.port}"
+            val keyData = KeyData(
+                keyStore = loadJks(server.clientKeyStoreFile, CLIENT_KEYSTORE_PASSWORD),
+                keyStorePassword = CLIENT_KEYSTORE_PASSWORD,
+                keyAlias = CLIENT_ALIAS,
+                keyPassword = CLIENT_KEY_PASSWORD
+            )
+
+            assertThat(isBaseURLReachable(baseUrl, keyData = keyData)).isTrue()
+
+            val logs = mutableListOf<String>()
+            val response = HttpClient(baseUrl, keyData = keyData, log = captureLogs(logs)).use { client ->
+                client.execute(HttpRequest(path = "/", method = "GET"))
+            }
+
+            val renderedLog = logs.joinToString(System.lineSeparator())
+
+            assertThat(response.status).isEqualTo(200)
+            assertThat(renderedLog).contains("Request to $baseUrl at")
+            assertThat(renderedLog).doesNotContain("(mTLS)")
         }
     }
 
@@ -106,6 +135,58 @@ class SpecmaticContractMtlsTest {
         server.start()
 
         return MtlsTestServer(server, executor, clientKeyStoreFile)
+    }
+
+    private fun httpsServerWithoutClientAuth(tempDir: File): MtlsTestServer {
+        val serverKeyStoreFile = tempDir.resolve("server-https.jks")
+        val clientKeyStoreFile = tempDir.resolve("client-https.jks")
+
+        val serverKeyStore = generateCertificate(
+            file = serverKeyStoreFile,
+            jksPassword = SERVER_KEYSTORE_PASSWORD,
+            keyAlias = SERVER_ALIAS,
+            keyPassword = SERVER_KEY_PASSWORD
+        )
+        generateCertificate(
+            file = clientKeyStoreFile,
+            jksPassword = CLIENT_KEYSTORE_PASSWORD,
+            keyAlias = CLIENT_ALIAS,
+            keyPassword = CLIENT_KEY_PASSWORD
+        )
+
+        val keyManagers = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm()).apply {
+            init(serverKeyStore, SERVER_KEY_PASSWORD.toCharArray())
+        }.keyManagers
+
+        val sslContext = SSLContext.getInstance("TLS").apply {
+            init(keyManagers, null, null)
+        }
+
+        val server = HttpsServer.create(InetSocketAddress("localhost", 0), 0)
+        server.httpsConfigurator = object : HttpsConfigurator(sslContext) {
+            override fun configure(parameters: HttpsParameters) {
+                val sslParameters = sslContext.defaultSSLParameters
+                sslParameters.needClientAuth = false
+                parameters.setSSLParameters(sslParameters)
+                parameters.needClientAuth = false
+            }
+        }
+        server.createContext("/") { exchange ->
+            val response = "ok".toByteArray()
+            exchange.sendResponseHeaders(200, response.size.toLong())
+            exchange.responseBody.use { outputStream -> outputStream.write(response) }
+            exchange.close()
+        }
+
+        val executor = Executors.newSingleThreadExecutor()
+        server.executor = executor
+        server.start()
+
+        return MtlsTestServer(server, executor, clientKeyStoreFile)
+    }
+
+    private fun captureLogs(buffer: MutableList<String>): (LogMessage) -> Unit {
+        return { message -> buffer.add(message.toLogString()) }
     }
 
     private fun loadJks(file: File, password: String): KeyStore {

--- a/application/src/test/kotlin/io/specmatic/test/SpecmaticMockIncomingMtlsTest.kt
+++ b/application/src/test/kotlin/io/specmatic/test/SpecmaticMockIncomingMtlsTest.kt
@@ -1,0 +1,138 @@
+package io.specmatic.test
+
+import application.findRandomFreePort
+import io.ktor.network.tls.certificates.generateCertificate
+import io.specmatic.core.IncomingMtlsRegistry
+import io.specmatic.core.KeyData
+import io.specmatic.core.KeyDataRegistry
+import io.specmatic.core.parseGherkinStringToFeature
+import io.specmatic.stub.HttpStub
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+import java.security.KeyStore
+import javax.net.ssl.HttpsURLConnection
+import javax.net.ssl.KeyManager
+import javax.net.ssl.KeyManagerFactory
+import javax.net.ssl.SSLContext
+import javax.net.ssl.TrustManager
+import javax.net.ssl.X509TrustManager
+
+class SpecmaticMockIncomingMtlsTest {
+    @Test
+    fun `mock should reject request without client certificate when incoming mTLS is enabled`(@TempDir tempDir: Path) {
+        val port = findRandomFreePort()
+        val serverKeyData = createKeyData(
+            file = tempDir.resolve("server.jks").toFile(),
+            keyStorePassword = "server-store-pass",
+            keyAlias = "specmatic-mock-server",
+            keyPassword = "server-key-pass"
+        )
+
+        val stub = createStub(
+            port = port,
+            keyDataRegistry = KeyDataRegistry.empty().plus("localhost", port, serverKeyData),
+            incomingMtlsRegistry = IncomingMtlsRegistry.empty().plus("localhost", port, true)
+        )
+
+        try {
+            assertThatThrownBy {
+                executeGet("https://localhost:$port/hello")
+            }.isInstanceOf(Exception::class.java)
+        } finally {
+            stub.close()
+        }
+    }
+
+    @Test
+    fun `mock should accept request with client certificate when incoming mTLS is enabled`(@TempDir tempDir: Path) {
+        val port = findRandomFreePort()
+        val serverKeyData = createKeyData(
+            file = tempDir.resolve("server.jks").toFile(),
+            keyStorePassword = "server-store-pass",
+            keyAlias = "specmatic-mock-server",
+            keyPassword = "server-key-pass"
+        )
+        val clientKeyData = createKeyData(
+            file = tempDir.resolve("client.jks").toFile(),
+            keyStorePassword = "client-store-pass",
+            keyAlias = "specmatic-mock-client",
+            keyPassword = "client-key-pass"
+        )
+
+        val stub = createStub(
+            port = port,
+            keyDataRegistry = KeyDataRegistry.empty().plus("localhost", port, serverKeyData),
+            incomingMtlsRegistry = IncomingMtlsRegistry.empty().plus("localhost", port, true)
+        )
+
+        try {
+            assertThat(executeGet("https://localhost:$port/hello", clientKeyData)).isEqualTo(200)
+        } finally {
+            stub.close()
+        }
+    }
+
+    private fun createStub(port: Int, keyDataRegistry: KeyDataRegistry, incomingMtlsRegistry: IncomingMtlsRegistry): HttpStub {
+        val feature = parseGherkinStringToFeature(
+            """
+            Feature: Incoming mTLS in mock
+            
+            Scenario: hello
+              When GET /hello
+              Then status 200
+              And response-body (string)
+            """.trimIndent()
+        )
+
+        return HttpStub(
+            features = listOf(feature),
+            host = "localhost",
+            port = port,
+            keyDataRegistry = keyDataRegistry,
+            incomingMtlsRegistry = incomingMtlsRegistry
+        )
+    }
+
+    private fun createKeyData(file: File, keyStorePassword: String, keyAlias: String, keyPassword: String): KeyData {
+        generateCertificate(file = file, jksPassword = keyStorePassword, keyAlias = keyAlias, keyPassword = keyPassword)
+        val keyStore = KeyStore.getInstance("JKS").apply {
+            file.inputStream().use { load(it, keyStorePassword.toCharArray()) }
+        }
+        return KeyData(
+            keyStore = keyStore,
+            keyStorePassword = keyStorePassword,
+            keyAlias = keyAlias,
+            keyPassword = keyPassword
+        )
+    }
+
+    private fun executeGet(url: String, keyData: KeyData? = null): Int {
+        val keyManagers: Array<KeyManager>? = keyData?.let {
+            KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm()).apply {
+                init(it.keyStore, it.keyPassword.toCharArray())
+            }.keyManagers
+        }
+
+        val trustManagers = arrayOf<TrustManager>(object : X509TrustManager {
+            override fun getAcceptedIssuers() = emptyArray<java.security.cert.X509Certificate>()
+            override fun checkClientTrusted(chain: Array<java.security.cert.X509Certificate>, authType: String) {}
+            override fun checkServerTrusted(chain: Array<java.security.cert.X509Certificate>, authType: String) {}
+        })
+
+        val sslContext = SSLContext.getInstance("TLS").apply {
+            init(keyManagers, trustManagers, null)
+        }
+
+        return (java.net.URL(url).openConnection() as HttpsURLConnection).run {
+            sslSocketFactory = sslContext.socketFactory
+            hostnameVerifier = javax.net.ssl.HostnameVerifier { _, _ -> true }
+            requestMethod = "GET"
+            connect()
+            responseCode
+        }
+    }
+}

--- a/application/src/test/kotlin/io/specmatic/test/SpecmaticMockIncomingMtlsTest.kt
+++ b/application/src/test/kotlin/io/specmatic/test/SpecmaticMockIncomingMtlsTest.kt
@@ -47,7 +47,7 @@ class SpecmaticMockIncomingMtlsTest {
     }
 
     @Test
-    fun `mock should log TLS request when HTTPS is enabled without incoming mTLS`(@TempDir tempDir: Path) {
+    fun `mock should log HTTPS request without transport marker when incoming mTLS is disabled`(@TempDir tempDir: Path) {
         val port = findRandomFreePort()
         val serverKeyData = createKeyData(
             file = tempDir.resolve("server.jks").toFile(),
@@ -66,7 +66,8 @@ class SpecmaticMockIncomingMtlsTest {
             assertThat(executeGet("https://localhost:$port/hello")).isEqualTo(200)
             val log = fetchLog("https://localhost:$port/_specmatic/log")
 
-            assertThat(log).contains("Request to port '$port' (TLS) at")
+            assertThat(log).contains("Request to port '$port' at")
+            assertThat(log).doesNotContain("Request to port '$port' (TLS) at")
         } finally {
             stub.close()
             LogTail.clear()

--- a/application/src/test/kotlin/io/specmatic/test/SpecmaticMockIncomingMtlsTest.kt
+++ b/application/src/test/kotlin/io/specmatic/test/SpecmaticMockIncomingMtlsTest.kt
@@ -5,6 +5,7 @@ import io.ktor.network.tls.certificates.generateCertificate
 import io.specmatic.core.IncomingMtlsRegistry
 import io.specmatic.core.KeyData
 import io.specmatic.core.KeyDataRegistry
+import io.specmatic.core.log.LogTail
 import io.specmatic.core.parseGherkinStringToFeature
 import io.specmatic.stub.HttpStub
 import org.assertj.core.api.Assertions.assertThat
@@ -12,6 +13,7 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
+import java.net.HttpURLConnection
 import java.nio.file.Path
 import java.security.KeyStore
 import javax.net.ssl.HttpsURLConnection
@@ -22,6 +24,55 @@ import javax.net.ssl.TrustManager
 import javax.net.ssl.X509TrustManager
 
 class SpecmaticMockIncomingMtlsTest {
+    @Test
+    fun `mock should log plain HTTP request without transport marker`() {
+        val port = findRandomFreePort()
+        val stub = createStub(
+            port = port,
+            keyDataRegistry = KeyDataRegistry.empty(),
+            incomingMtlsRegistry = IncomingMtlsRegistry.empty()
+        )
+
+        try {
+            assertThat(executeGet("http://localhost:$port/hello")).isEqualTo(200)
+            val log = fetchLog("http://localhost:$port/_specmatic/log")
+
+            assertThat(log).contains("Request to port '$port' at")
+            assertThat(log).doesNotContain("Request to port '$port' (TLS) at")
+            assertThat(log).doesNotContain("Request to port '$port' (mTLS) at")
+        } finally {
+            stub.close()
+            LogTail.clear()
+        }
+    }
+
+    @Test
+    fun `mock should log TLS request when HTTPS is enabled without incoming mTLS`(@TempDir tempDir: Path) {
+        val port = findRandomFreePort()
+        val serverKeyData = createKeyData(
+            file = tempDir.resolve("server.jks").toFile(),
+            keyStorePassword = "server-store-pass",
+            keyAlias = "specmatic-mock-server",
+            keyPassword = "server-key-pass"
+        )
+
+        val stub = createStub(
+            port = port,
+            keyDataRegistry = KeyDataRegistry.empty().plus("localhost", port, serverKeyData),
+            incomingMtlsRegistry = IncomingMtlsRegistry.empty().plus("localhost", port, false)
+        )
+
+        try {
+            assertThat(executeGet("https://localhost:$port/hello")).isEqualTo(200)
+            val log = fetchLog("https://localhost:$port/_specmatic/log")
+
+            assertThat(log).contains("Request to port '$port' (TLS) at")
+        } finally {
+            stub.close()
+            LogTail.clear()
+        }
+    }
+
     @Test
     fun `mock should reject request without client certificate when incoming mTLS is enabled`(@TempDir tempDir: Path) {
         val port = findRandomFreePort()
@@ -44,6 +95,7 @@ class SpecmaticMockIncomingMtlsTest {
             }.isInstanceOf(Exception::class.java)
         } finally {
             stub.close()
+            LogTail.clear()
         }
     }
 
@@ -71,8 +123,11 @@ class SpecmaticMockIncomingMtlsTest {
 
         try {
             assertThat(executeGet("https://localhost:$port/hello", clientKeyData)).isEqualTo(200)
+            val log = fetchLog("https://localhost:$port/_specmatic/log", clientKeyData)
+            assertThat(log).contains("Request to port '$port' (mTLS) at")
         } finally {
             stub.close()
+            LogTail.clear()
         }
     }
 
@@ -111,6 +166,26 @@ class SpecmaticMockIncomingMtlsTest {
     }
 
     private fun executeGet(url: String, keyData: KeyData? = null): Int {
+        return (openConnection(url, keyData) as HttpURLConnection).run {
+            requestMethod = "GET"
+            connect()
+            responseCode
+        }
+    }
+
+    private fun fetchLog(url: String, keyData: KeyData? = null): String {
+        return (openConnection(url, keyData) as HttpURLConnection).run {
+            requestMethod = "GET"
+            connect()
+            inputStream.bufferedReader().use { it.readText() }
+        }
+    }
+
+    private fun openConnection(url: String, keyData: KeyData?): java.net.URLConnection {
+        if (!url.startsWith("https://")) {
+            return java.net.URL(url).openConnection()
+        }
+
         val keyManagers: Array<KeyManager>? = keyData?.let {
             KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm()).apply {
                 init(it.keyStore, it.keyPassword.toCharArray())
@@ -127,12 +202,9 @@ class SpecmaticMockIncomingMtlsTest {
             init(keyManagers, trustManagers, null)
         }
 
-        return (java.net.URL(url).openConnection() as HttpsURLConnection).run {
+        return (java.net.URL(url).openConnection() as HttpsURLConnection).apply {
             sslSocketFactory = sslContext.socketFactory
             hostnameVerifier = javax.net.ssl.HostnameVerifier { _, _ -> true }
-            requestMethod = "GET"
-            connect()
-            responseCode
         }
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/CertRegistry.kt
+++ b/core/src/main/kotlin/io/specmatic/core/CertRegistry.kt
@@ -39,8 +39,8 @@ class CertRegistry private constructor(private val certificates: List<Pair<HostP
     fun toIncomingMtlsRegistry(): IncomingMtlsRegistry {
         return groupedCertificatesOrException().entries.fold(IncomingMtlsRegistry.empty()) { acc, (identifier, cert) ->
             when (identifier) {
-                is HostPortIdentifier.Matching -> acc.plus(identifier.host, identifier.port, cert.isIncomingMtlsEnabled())
-                else -> acc.plusWildCard(cert.isIncomingMtlsEnabled())
+                is HostPortIdentifier.Matching -> acc.plus(identifier.host, identifier.port, cert.isMtlsEnabled())
+                else -> acc.plusWildCard(cert.isMtlsEnabled())
             }
         }
     }

--- a/core/src/main/kotlin/io/specmatic/core/CertRegistry.kt
+++ b/core/src/main/kotlin/io/specmatic/core/CertRegistry.kt
@@ -10,7 +10,7 @@ private sealed interface HostPortIdentifier {
 }
 
 class CertRegistry private constructor(private val certificates: List<Pair<HostPortIdentifier, HttpsConfiguration>>) {
-    fun toKeyDataRegistry(transform: (HttpsConfiguration) -> KeyData?): KeyDataRegistry {
+    private fun groupedCertificatesOrException(): Map<HostPortIdentifier, HttpsConfiguration> {
         val groupedCerts = certificates.groupBy({ it.first }, { it.second })
         val conflicts = groupedCerts.filterValues { it.distinct().size > 1 }.map { (identifier, certs) -> "$identifier -> ${certs.size} certificates" }
         if (conflicts.isNotEmpty()) {
@@ -22,12 +22,25 @@ class CertRegistry private constructor(private val certificates: List<Pair<HostP
             )
         }
 
-        val keyData = groupedCerts.mapValues { (_, certs) -> transform(certs.single()) }
+        return groupedCerts.mapValues { (_, certs) -> certs.single() }
+    }
+
+    fun toKeyDataRegistry(transform: (HttpsConfiguration) -> KeyData?): KeyDataRegistry {
+        val keyData = groupedCertificatesOrException().mapValues { (_, cert) -> transform(cert) }
         return keyData.entries.fold(KeyDataRegistry.empty()) { acc, (identifier, keyData) ->
             if (keyData == null) return@fold acc
             when (identifier) {
                 is HostPortIdentifier.Matching -> acc.plus(identifier.host, identifier.port, keyData)
                 else -> acc.plusWildCard(keyData)
+            }
+        }
+    }
+
+    fun toIncomingMtlsRegistry(): IncomingMtlsRegistry {
+        return groupedCertificatesOrException().entries.fold(IncomingMtlsRegistry.empty()) { acc, (identifier, cert) ->
+            when (identifier) {
+                is HostPortIdentifier.Matching -> acc.plus(identifier.host, identifier.port, cert.isIncomingMtlsEnabled())
+                else -> acc.plusWildCard(cert.isIncomingMtlsEnabled())
             }
         }
     }
@@ -77,4 +90,22 @@ class KeyDataRegistry private constructor(private val keyData: Map<HostPortIdent
     }
 
     companion object { fun empty(): KeyDataRegistry = KeyDataRegistry(emptyMap()) }
+}
+
+class IncomingMtlsRegistry private constructor(private val mtlsLookup: Map<HostPortIdentifier, Boolean>) {
+    fun plus(host: String, port: Int, enabled: Boolean): IncomingMtlsRegistry {
+        val identifier = HostPortIdentifier.Matching(normalizeHost(host), port)
+        return IncomingMtlsRegistry(mtlsLookup + (identifier to enabled))
+    }
+
+    fun plusWildCard(enabled: Boolean): IncomingMtlsRegistry {
+        return IncomingMtlsRegistry(mtlsLookup + (HostPortIdentifier.WildCard to enabled))
+    }
+
+    fun get(host: String, port: Int): Boolean {
+        val identifier = HostPortIdentifier.Matching(normalizeHost(host), port)
+        return mtlsLookup[identifier] ?: mtlsLookup[HostPortIdentifier.WildCard] ?: false
+    }
+
+    companion object { fun empty(): IncomingMtlsRegistry = IncomingMtlsRegistry(emptyMap()) }
 }

--- a/core/src/main/kotlin/io/specmatic/core/HttpsKeyData.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpsKeyData.kt
@@ -1,0 +1,58 @@
+package io.specmatic.core
+
+import io.specmatic.core.config.HttpsConfiguration
+import io.specmatic.core.pattern.ContractException
+import java.io.File
+import java.security.KeyStore
+
+fun HttpsConfiguration.toKeyData(aliasSuffix: String): KeyData? {
+    val keyStoreFilePath = keyStoreFile()
+    if (keyStoreFilePath != null) {
+        return KeyData(
+            keyStore = loadKeyStoreFromFile(keyStoreFilePath, keyStorePasswordOrDefault()),
+            keyStorePassword = keyStorePasswordOrDefault(),
+            keyAlias = keyStoreAliasOrDefault(aliasSuffix),
+            keyPassword = keyPasswordOrDefault()
+        )
+    }
+
+    val keyStoreDirPath = keyStoreDir()
+    if (keyStoreDirPath != null) {
+        val keyStoreFile = File(keyStoreDirPath).resolve("$APPLICATION_NAME_LOWER_CASE.jks")
+        if (!keyStoreFile.exists()) {
+            throw ContractException("No keystore file found at ${keyStoreFile.canonicalPath}. Please provide a valid client certificate keystore.")
+        }
+
+        return KeyData(
+            keyStore = loadKeyStoreFromFile(keyStoreFile.canonicalPath, keyStorePasswordOrDefault()),
+            keyStorePassword = keyStorePasswordOrDefault(),
+            keyAlias = keyStoreAliasOrDefault(aliasSuffix),
+            keyPassword = keyPasswordOrDefault()
+        )
+    }
+
+    return null
+}
+
+fun CertRegistry.toTestKeyDataRegistry(): KeyDataRegistry {
+    return toKeyDataRegistry { httpsConfiguration ->
+        httpsConfiguration.toKeyData(aliasSuffix = "test")
+    }
+}
+
+fun CertRegistry.toIncomingMtlsRegistryForStub(): IncomingMtlsRegistry = toIncomingMtlsRegistry()
+
+private fun loadKeyStoreFromFile(keyStoreFile: String, keyStorePassword: String): KeyStore {
+    val keyStorePath = File(keyStoreFile)
+    val keyStoreType = when (keyStorePath.extension.lowercase()) {
+        "jks" -> "JKS"
+        "p12", "pfx" -> "PKCS12"
+        else -> throw ContractException("Unsupported keystore format in $keyStoreFile. Supported formats are .jks, .p12 and .pfx")
+    }
+
+    return KeyStore.getInstance(keyStoreType).apply {
+        keyStorePath.inputStream().use { inputStream ->
+            load(inputStream, keyStorePassword.toCharArray())
+        }
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -259,6 +259,9 @@ interface SpecmaticConfig {
     fun getStubHttpsConfiguration(): CertRegistry
 
     @JsonIgnore
+    fun getTestHttpsConfiguration(): CertRegistry
+
+    @JsonIgnore
     fun getStubGracefulRestartTimeoutInMilliseconds(): Long?
 
     @JsonIgnore

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfigV1V2Common.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfigV1V2Common.kt
@@ -971,6 +971,13 @@ data class SpecmaticConfigV1V2Common(
     }
 
     @JsonIgnore
+    override fun getTestHttpsConfiguration(): CertRegistry {
+        val registry = CertRegistry.empty()
+        val httpsConfiguration = test?.https ?: return registry
+        return registry.plusWildCard(httpsConfiguration)
+    }
+
+    @JsonIgnore
     override fun getStubGracefulRestartTimeoutInMilliseconds(): Long? {
         return getStubConfiguration(this).getGracefulRestartTimeoutInMilliseconds()
     }
@@ -1449,6 +1456,7 @@ data class TestConfiguration(
     val filterNotName: String? = null,
     val overlayFilePath: String? = null,
     val junitReportDir: String? = null,
+    val https: HttpsConfiguration? = null,
 )
 
 enum class ResiliencyTestSuite {

--- a/core/src/main/kotlin/io/specmatic/core/config/HttpsConfiguration.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/HttpsConfiguration.kt
@@ -96,7 +96,7 @@ sealed interface KeyStoreConfiguration {
 data class HttpsConfiguration(
     val keyStore: KeyStoreConfiguration? = null,
     val keyStorePassword: String? = null,
-    val incomingMtlsEnabled: Boolean? = null
+    val mtlsEnabled: Boolean? = null
 ) {
     fun keyStoreFile(): String? = keyStore?.getFilePath()
 
@@ -108,13 +108,13 @@ data class HttpsConfiguration(
 
     fun keyPasswordOrDefault(): String = keyStore?.password ?: "forgotten"
 
-    fun isIncomingMtlsEnabled(): Boolean = incomingMtlsEnabled == true
+    fun isMtlsEnabled(): Boolean = mtlsEnabled == true
 
     fun overrideWith(other: HttpsConfiguration?): HttpsConfiguration {
         if (other == null) return this
         return this.copy(
             keyStorePassword = this.keyStorePassword ?: other.keyStorePassword,
-            incomingMtlsEnabled = this.incomingMtlsEnabled ?: other.incomingMtlsEnabled,
+            mtlsEnabled = this.mtlsEnabled ?: other.mtlsEnabled,
             keyStore = this.keyStore.nonNullElse(other.keyStore, KeyStoreConfiguration::overrideWith),
         )
     }

--- a/core/src/main/kotlin/io/specmatic/core/config/HttpsConfiguration.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/HttpsConfiguration.kt
@@ -93,7 +93,11 @@ sealed interface KeyStoreConfiguration {
     }
 }
 
-data class HttpsConfiguration(val keyStore: KeyStoreConfiguration? = null, val keyStorePassword: String? = null) {
+data class HttpsConfiguration(
+    val keyStore: KeyStoreConfiguration? = null,
+    val keyStorePassword: String? = null,
+    val incomingMtlsEnabled: Boolean? = null
+) {
     fun keyStoreFile(): String? = keyStore?.getFilePath()
 
     fun keyStoreDir(): String? = keyStore?.getDirectoryPath()
@@ -104,10 +108,13 @@ data class HttpsConfiguration(val keyStore: KeyStoreConfiguration? = null, val k
 
     fun keyPasswordOrDefault(): String = keyStore?.password ?: "forgotten"
 
+    fun isIncomingMtlsEnabled(): Boolean = incomingMtlsEnabled == true
+
     fun overrideWith(other: HttpsConfiguration?): HttpsConfiguration {
         if (other == null) return this
         return this.copy(
             keyStorePassword = this.keyStorePassword ?: other.keyStorePassword,
+            incomingMtlsEnabled = this.incomingMtlsEnabled ?: other.incomingMtlsEnabled,
             keyStore = this.keyStore.nonNullElse(other.keyStore, KeyStoreConfiguration::overrideWith),
         )
     }

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3Impl.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3Impl.kt
@@ -499,6 +499,12 @@ data class SpecmaticConfigV3Impl(val file: File? = null, private val specmaticCo
         return certificates.fold(registry) { acc, (baseUrl, cert) -> acc.plus(baseUrl, cert) }
     }
 
+    override fun getTestHttpsConfiguration(): CertRegistry {
+        val registry = CertRegistry.empty()
+        val certificates: List<Pair<String, HttpsConfiguration>> = specmaticConfig.systemUnderTest?.getCerts(resolver).orEmpty()
+        return certificates.fold(registry) { acc, (baseUrl, cert) -> acc.plus(baseUrl, cert) }
+    }
+
     override fun getStubGracefulRestartTimeoutInMilliseconds(): Long? {
         val mockSettings = getMockSettings()
         return mockSettings.gracefulRestartTimeoutInMilliseconds

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/OpenApiRunOptions.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/OpenApiRunOptions.kt
@@ -24,8 +24,9 @@ data class OpenApiTestConfig(
     val swaggerUiBaseUrl: String? = null,
     val swaggerUrl: String? = null,
     val actuatorUrl: String? = null,
+    override val cert: RefOrValue<HttpsConfiguration>? = null,
     override val specs: List<OpenApiRunOptionsSpecifications>? = null
-) : OpenApiRunOptions {
+) : OpenApiRunOptions, ConfigWithCert {
     override val config: Map<String, Any> = emptyMap()
 
     @JsonIgnore

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/RunOptionsSpecifications.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/RunOptionsSpecifications.kt
@@ -94,6 +94,7 @@ data class WsdlRunOptionsSpecifications(val spec: Value) : IRunOptionSpecificati
         val baseUrl: String? = null,
         val host: String? = null,
         val port: Int? = null,
+        val incomingMtlsEnabled: Boolean? = null,
     )
 }
 
@@ -132,5 +133,6 @@ data class OpenApiRunOptionsSpecifications(val spec: Value) : IRunOptionSpecific
         val port: Int? = null,
         val overlayFilePath: String? = null,
         val securitySchemes: Map<String, SecuritySchemeConfigurationV3>? = null,
+        val incomingMtlsEnabled: Boolean? = null,
     )
 }

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/RunOptionsSpecifications.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/RunOptionsSpecifications.kt
@@ -94,7 +94,6 @@ data class WsdlRunOptionsSpecifications(val spec: Value) : IRunOptionSpecificati
         val baseUrl: String? = null,
         val host: String? = null,
         val port: Int? = null,
-        val incomingMtlsEnabled: Boolean? = null,
     )
 }
 
@@ -133,6 +132,5 @@ data class OpenApiRunOptionsSpecifications(val spec: Value) : IRunOptionSpecific
         val port: Int? = null,
         val overlayFilePath: String? = null,
         val securitySchemes: Map<String, SecuritySchemeConfigurationV3>? = null,
-        val incomingMtlsEnabled: Boolean? = null,
     )
 }

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/MockServiceConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/MockServiceConfig.kt
@@ -13,6 +13,8 @@ import io.specmatic.core.config.v3.components.runOptions.ConfigWithCert
 import io.specmatic.core.config.v3.components.runOptions.IRunOptions
 import io.specmatic.core.config.v3.components.runOptions.MockRunOptions
 import io.specmatic.core.config.v3.components.runOptions.OpenApiMockConfig
+import io.specmatic.core.config.v3.components.runOptions.OpenApiRunOptionsSpecifications
+import io.specmatic.core.config.v3.components.runOptions.WsdlRunOptionsSpecifications
 import io.specmatic.core.config.v3.components.settings.MockSettings
 import io.specmatic.core.config.v3.components.sources.SourceV3
 import io.specmatic.core.config.v3.determineSpecTypeFor
@@ -136,11 +138,24 @@ data class MockServiceConfig(val services: List<Value>, val data: Data? = null, 
 
     @JsonIgnore
     fun getCerts(resolver: RefOrValueResolver): List<Pair<String, HttpsConfiguration>> {
-        return services.map { it.service.resolveElseThrow(resolver) }.mapNotNull { service ->
-            val runOpts = getRunOptions(service, resolver, SpecType.OPENAPI) ?: return@mapNotNull null
-            val baseUrl = runOpts.getBaseUrlIfExists() ?: return@mapNotNull null
-            val cert = (runOpts as? ConfigWithCert)?.cert?.resolveElseThrow(resolver) ?: return@mapNotNull null
-            Pair(baseUrl, cert)
+        return services.map { it.service.resolveElseThrow(resolver) }.flatMap { service ->
+            service.definitions.map { it.definition }.flatMap { definition ->
+                definition.specs.mapNotNull { specDefinition ->
+                    val specPath = specDefinition.getSpecificationPath().lowercase()
+                    val specType = if (specPath.endsWith(".wsdl")) SpecType.WSDL else SpecType.OPENAPI
+                    val runOptions = getRunOptions(service, resolver, specType) ?: return@mapNotNull null
+                    val cert = (runOptions as? ConfigWithCert)?.cert?.resolveElseThrow(resolver) ?: return@mapNotNull null
+                    val specId = specDefinition.getSpecificationId()
+                    val runOptionSpecOverride = specId?.let(runOptions::getMatchingSpecification)
+                    val baseUrl = runOptionSpecOverride?.getBaseUrl("0.0.0.0") ?: runOptions.getBaseUrlIfExists() ?: return@mapNotNull null
+                    val incomingMtlsOverride = when (runOptionSpecOverride) {
+                        is OpenApiRunOptionsSpecifications -> runOptionSpecOverride.spec.incomingMtlsEnabled
+                        is WsdlRunOptionsSpecifications -> runOptionSpecOverride.spec.incomingMtlsEnabled
+                        else -> null
+                    }
+                    Pair(baseUrl, cert.copy(incomingMtlsEnabled = incomingMtlsOverride ?: cert.incomingMtlsEnabled))
+                }
+            }
         }
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/MockServiceConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/MockServiceConfig.kt
@@ -13,8 +13,6 @@ import io.specmatic.core.config.v3.components.runOptions.ConfigWithCert
 import io.specmatic.core.config.v3.components.runOptions.IRunOptions
 import io.specmatic.core.config.v3.components.runOptions.MockRunOptions
 import io.specmatic.core.config.v3.components.runOptions.OpenApiMockConfig
-import io.specmatic.core.config.v3.components.runOptions.OpenApiRunOptionsSpecifications
-import io.specmatic.core.config.v3.components.runOptions.WsdlRunOptionsSpecifications
 import io.specmatic.core.config.v3.components.settings.MockSettings
 import io.specmatic.core.config.v3.components.sources.SourceV3
 import io.specmatic.core.config.v3.determineSpecTypeFor
@@ -144,16 +142,11 @@ data class MockServiceConfig(val services: List<Value>, val data: Data? = null, 
                     val specPath = specDefinition.getSpecificationPath().lowercase()
                     val specType = if (specPath.endsWith(".wsdl")) SpecType.WSDL else SpecType.OPENAPI
                     val runOptions = getRunOptions(service, resolver, specType) ?: return@mapNotNull null
-                    val cert = (runOptions as? ConfigWithCert)?.cert?.resolveElseThrow(resolver) ?: return@mapNotNull null
+                    val runCert = (runOptions as? ConfigWithCert)?.cert?.resolveElseThrow(resolver) ?: return@mapNotNull null
                     val specId = specDefinition.getSpecificationId()
                     val runOptionSpecOverride = specId?.let(runOptions::getMatchingSpecification)
                     val baseUrl = runOptionSpecOverride?.getBaseUrl("0.0.0.0") ?: runOptions.getBaseUrlIfExists() ?: return@mapNotNull null
-                    val incomingMtlsOverride = when (runOptionSpecOverride) {
-                        is OpenApiRunOptionsSpecifications -> runOptionSpecOverride.spec.incomingMtlsEnabled
-                        is WsdlRunOptionsSpecifications -> runOptionSpecOverride.spec.incomingMtlsEnabled
-                        else -> null
-                    }
-                    Pair(baseUrl, cert.copy(incomingMtlsEnabled = incomingMtlsOverride ?: cert.incomingMtlsEnabled))
+                    Pair(baseUrl, runCert)
                 }
             }
         }

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/TestServiceConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/TestServiceConfig.kt
@@ -1,6 +1,7 @@
 package io.specmatic.core.config.v3.components.services
 
 import com.fasterxml.jackson.annotation.JsonIgnore
+import io.specmatic.core.config.HttpsConfiguration
 import io.specmatic.core.ResiliencyTestSuite
 import io.specmatic.core.SpecificationSourceEntry
 import io.specmatic.core.config.nonNullElse
@@ -12,6 +13,7 @@ import io.specmatic.core.config.v3.components.ExampleDirectories
 import io.specmatic.core.config.v3.components.runOptions.IRunOptions
 import io.specmatic.core.config.v3.components.runOptions.OpenApiTestConfig
 import io.specmatic.core.config.v3.components.runOptions.TestRunOptions
+import io.specmatic.core.config.v3.components.runOptions.ConfigWithCert
 import io.specmatic.core.config.v3.components.settings.TestSettings
 import io.specmatic.core.config.v3.components.sources.SourceV3
 import io.specmatic.core.config.v3.determineSpecTypeFor
@@ -104,6 +106,14 @@ data class TestServiceConfig(val service: RefOrValue<CommonServiceConfig<TestRun
     fun getDictionaryPath(resolver: RefOrValueResolver): String? {
         val service = service.resolveElseThrow(resolver)
         return service.data?.dictionary?.resolveElseThrow(resolver)?.path
+    }
+
+    @JsonIgnore
+    fun getCerts(resolver: RefOrValueResolver): List<Pair<String, HttpsConfiguration>> {
+        val runOptions = getRunOptions(resolver, SpecType.OPENAPI) ?: return emptyList()
+        val baseUrl = runOptions.getBaseUrlIfExists() ?: return emptyList()
+        val cert = (runOptions as? ConfigWithCert)?.cert?.resolveElseThrow(resolver) ?: return emptyList()
+        return listOf(baseUrl to cert)
     }
 
     fun copyResiliencyTestsConfig(resolver: RefOrValueResolver, resiliencyTestSuite: ResiliencyTestSuite): TestServiceConfig {

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/TestServiceConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/TestServiceConfig.kt
@@ -110,10 +110,19 @@ data class TestServiceConfig(val service: RefOrValue<CommonServiceConfig<TestRun
 
     @JsonIgnore
     fun getCerts(resolver: RefOrValueResolver): List<Pair<String, HttpsConfiguration>> {
-        val runOptions = getRunOptions(resolver, SpecType.OPENAPI) ?: return emptyList()
-        val baseUrl = runOptions.getBaseUrlIfExists() ?: return emptyList()
-        val cert = (runOptions as? ConfigWithCert)?.cert?.resolveElseThrow(resolver) ?: return emptyList()
-        return listOf(baseUrl to cert)
+        val serviceConfig = service.resolveElseThrow(resolver)
+        return serviceConfig.definitions.map { it.definition }.flatMap { definition ->
+            definition.specs.mapNotNull { specDefinition ->
+                val specPath = specDefinition.getSpecificationPath().lowercase()
+                val specType = if (specPath.endsWith(".wsdl")) SpecType.WSDL else SpecType.OPENAPI
+                val runOptions = getRunOptions(resolver, specType) ?: return@mapNotNull null
+                val runCert = (runOptions as? ConfigWithCert)?.cert?.resolveElseThrow(resolver) ?: return@mapNotNull null
+                val specId = specDefinition.getSpecificationId()
+                val runOptionSpecOverride = specId?.let(runOptions::getMatchingSpecification)
+                val baseUrl = runOptionSpecOverride?.getBaseUrl("localhost") ?: runOptions.getBaseUrlIfExists() ?: return@mapNotNull null
+                Pair(baseUrl, runCert)
+            }
+        }
     }
 
     fun copyResiliencyTestsConfig(resolver: RefOrValueResolver, resiliencyTestSuite: ResiliencyTestSuite): TestServiceConfig {

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/utils.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/utils.kt
@@ -1,5 +1,6 @@
 package io.specmatic.core.config.v3
 
+import io.specmatic.core.OPENAPI_FILE_EXTENSIONS
 import io.specmatic.reporter.model.SpecType
 import io.specmatic.stub.isOpenAPI
 import org.yaml.snakeyaml.Yaml
@@ -7,13 +8,19 @@ import java.io.File
 import kotlin.collections.contains
 
 internal fun determineSpecTypeFor(specFile: File): List<SpecType> {
-    return when {
-        specFile.extension == "wsdl" -> listOf(SpecType.WSDL)
-        specFile.extension == "proto" -> listOf(SpecType.PROTOBUF)
-        specFile.extension in setOf("graphql", "graphqls") -> listOf(SpecType.GRAPHQL)
-        isOpenAPI(specFile.canonicalPath, logFailure = false) -> listOf(SpecType.OPENAPI)
-        isAsyncAPI(specFile.canonicalPath) -> listOf(SpecType.ASYNCAPI)
-        else -> return listOf(SpecType.OPENAPI, SpecType.ASYNCAPI)
+    return when(specFile.extension.lowercase()) {
+        "wsdl" ->
+            listOf(SpecType.WSDL)
+        "proto" ->
+            listOf(SpecType.PROTOBUF)
+        in setOf("graphql", "graphqls") ->
+            listOf(SpecType.GRAPHQL)
+        in OPENAPI_FILE_EXTENSIONS if isOpenAPI(specFile.canonicalPath, logFailure = false) ->
+            listOf(SpecType.OPENAPI)
+        in OPENAPI_FILE_EXTENSIONS if isAsyncAPI(specFile.canonicalPath) ->
+            listOf(SpecType.ASYNCAPI)
+        else ->
+            listOf(SpecType.OPENAPI, SpecType.ASYNCAPI)
     }
 }
 

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -21,6 +21,7 @@ import io.specmatic.core.APPLICATION_NAME_LOWER_CASE
 import io.specmatic.core.Feature
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpResponse
+import io.specmatic.core.IncomingMtlsRegistry
 import io.specmatic.core.KeyData
 import io.specmatic.core.KeyDataRegistry
 import io.specmatic.core.MismatchMessages
@@ -94,6 +95,16 @@ import io.specmatic.test.TestResultRecord
 import io.specmatic.test.TestResultRecord.Companion.STUB_TEST_TYPE
 import io.specmatic.test.TestResultRecord.Companion.getCoverageStatus
 import io.specmatic.test.internalHeadersToKtorHeaders
+import io.netty.handler.ssl.ClientAuth
+import io.netty.handler.ssl.ApplicationProtocolConfig
+import io.netty.handler.ssl.ApplicationProtocolNames
+import io.netty.handler.ssl.SslContext
+import io.netty.handler.ssl.SslContextBuilder
+import io.netty.handler.ssl.SslHandler
+import io.netty.handler.ssl.SslProvider
+import io.netty.handler.ssl.SupportedCipherSuiteFilter
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory
+import io.netty.handler.codec.http2.Http2SecurityUtil
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.BroadcastChannel
 import kotlinx.coroutines.channels.BufferOverflow
@@ -107,10 +118,13 @@ import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.Writer
 import java.net.InetAddress
+import java.net.InetSocketAddress
 import java.net.URI
 import java.nio.charset.Charset
 import java.time.Instant
 import java.util.*
+import java.security.PrivateKey
+import java.security.cert.X509Certificate
 import kotlin.text.toCharArray
 
 const val SPECMATIC_RESPONSE_CODE_HEADER = "Specmatic-Response-Code"
@@ -128,6 +142,7 @@ class HttpStub(
     private val log: (event: LogMessage) -> Unit = dontPrintToConsole,
     private val strictMode: Boolean = false,
     val keyDataRegistry: KeyDataRegistry = KeyDataRegistry.empty(),
+    val incomingMtlsRegistry: IncomingMtlsRegistry = IncomingMtlsRegistry.empty(),
     val passThroughTargetBase: String = "",
     val httpClientFactory: HttpClientFactory = HttpClientFactory(),
     val workingDirectory: WorkingDirectory? = null,
@@ -141,6 +156,7 @@ class HttpStub(
     private val startTime: Instant = Instant.now(),
     var requestHandlers: MutableList<RequestHandler> = mutableListOf()
 ) : ContractStub {
+    private val incomingMtlsSslContextsByPort: MutableMap<Int, SslContext> = mutableMapOf()
     private enum class SwaggerSpecResponseFormat {
         YAML,
         JSON
@@ -566,15 +582,72 @@ class HttpStub(
 
     private fun ApplicationEngineEnvironmentBuilder.configureHostPorts() {
         val hostPortList = getHostAndPortList()
+        val mtlsByPort = hostPortList.groupBy(
+            keySelector = { (_, port) -> port },
+            valueTransform = { (host, port) -> incomingMtlsRegistry.get(host, port) }
+        )
+        val portsWithMixedMtlsMode = mtlsByPort.filterValues { it.distinct().size > 1 }.keys
+        if (portsWithMixedMtlsMode.isNotEmpty()) {
+            throw ContractException(
+                "Incoming mTLS configuration is ambiguous for ports: ${portsWithMixedMtlsMode.joinToString(", ")}. Please ensure all host mappings for a shared port use the same incoming mTLS setting."
+            )
+        }
+
         connectors.addAll(hostPortList.map { (host, port) ->
+            val incomingMtlsEnabled = incomingMtlsRegistry.get(host, port)
             val keyData = keyDataRegistry.get(host, port) ?: return@map EngineConnectorBuilder().also { it.host = host; it.port = port }
+            if (incomingMtlsEnabled) {
+                incomingMtlsSslContextsByPort[port] = incomingMtlsServerContext(keyData)
+            }
             EngineSSLConnectorBuilder(
                 keyStore = keyData.keyStore,
                 keyAlias = keyData.keyAlias,
                 privateKeyPassword = { keyData.keyPassword.toCharArray() },
-                keyStorePassword = { keyData.keyPassword.toCharArray() }
+                keyStorePassword = { keyData.keyStorePassword.toCharArray() }
             ).also { it.host = host; it.port = port }
         })
+
+        val portsWithIncomingMtlsButNoHttps = hostPortList.filter { (host, port) ->
+            incomingMtlsRegistry.get(host, port) && keyDataRegistry.get(host, port) == null
+        }.map { (_, port) -> port }
+        if (portsWithIncomingMtlsButNoHttps.isNotEmpty()) {
+            throw ContractException(
+                "Incoming mTLS is enabled, but no HTTPS key material is configured for ports: ${portsWithIncomingMtlsButNoHttps.joinToString(", ")}"
+            )
+        }
+    }
+
+    private fun incomingMtlsServerContext(keyData: KeyData): SslContext {
+        @Suppress("UNCHECKED_CAST")
+        val certificateChain = keyData.keyStore.getCertificateChain(keyData.keyAlias).toList() as List<X509Certificate>
+        val privateKey = keyData.keyStore.getKey(keyData.keyAlias, keyData.keyPassword.toCharArray()) as PrivateKey
+        val sslContextBuilder = SslContextBuilder.forServer(privateKey, *certificateChain.toTypedArray())
+            .trustManager(InsecureTrustManagerFactory.INSTANCE)
+            .clientAuth(ClientAuth.REQUIRE)
+
+        findAlpnProvider()?.let { alpnProvider ->
+            sslContextBuilder.sslProvider(alpnProvider)
+            sslContextBuilder.ciphers(Http2SecurityUtil.CIPHERS, SupportedCipherSuiteFilter.INSTANCE)
+            sslContextBuilder.applicationProtocolConfig(
+                ApplicationProtocolConfig(
+                    ApplicationProtocolConfig.Protocol.ALPN,
+                    ApplicationProtocolConfig.SelectorFailureBehavior.NO_ADVERTISE,
+                    ApplicationProtocolConfig.SelectedListenerFailureBehavior.ACCEPT,
+                    ApplicationProtocolNames.HTTP_2,
+                    ApplicationProtocolNames.HTTP_1_1
+                )
+            )
+        }
+
+        return sslContextBuilder.build()
+    }
+
+    private fun findAlpnProvider(): SslProvider? {
+        return when {
+            SslProvider.isAlpnSupported(SslProvider.OPENSSL) -> SslProvider.OPENSSL
+            SslProvider.isAlpnSupported(SslProvider.JDK) -> SslProvider.JDK
+            else -> null
+        }
     }
 
     private fun Application.configure(CORS: ApplicationPlugin<CORSConfig>) {
@@ -737,6 +810,19 @@ class HttpStub(
 
     private val server: ApplicationEngine = embeddedServer(Netty, environment, configure = {
         this.callGroupSize = 20
+        this.channelPipelineConfig = {
+            val localAddress = channel().localAddress() as? InetSocketAddress
+            if (localAddress != null) {
+                val mtlsSslContext = incomingMtlsSslContextsByPort[localAddress.port]
+                if (mtlsSslContext != null) {
+                    val sslHandler = get("ssl") as? SslHandler
+                    if (sslHandler != null) {
+                        val newSslHandler = mtlsSslContext.newHandler(channel().alloc())
+                        replace(sslHandler, "ssl", newSslHandler)
+                    }
+                }
+            }
+        }
     })
 
     private fun handleFetchLoadLogRequest(): HttpStubResponse =

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -634,7 +634,6 @@ class HttpStub(
     private fun targetServerForPort(port: Int): String {
         val transportSuffix = when (transportModeByPort[port]) {
             TransportMode.MTLS -> " (mTLS)"
-            TransportMode.TLS -> " (TLS)"
             else -> ""
         }
 

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -157,6 +157,14 @@ class HttpStub(
     var requestHandlers: MutableList<RequestHandler> = mutableListOf()
 ) : ContractStub {
     private val incomingMtlsSslContextsByPort: MutableMap<Int, SslContext> = mutableMapOf()
+    private val transportModeByPort: MutableMap<Int, TransportMode> = mutableMapOf()
+
+    private enum class TransportMode {
+        HTTP,
+        TLS,
+        MTLS
+    }
+
     private enum class SwaggerSpecResponseFormat {
         YAML,
         JSON
@@ -325,7 +333,7 @@ class HttpStub(
 
             intercept(ApplicationCallPipeline.Call) {
                 val httpLogMessage = HttpLogMessage(
-                    targetServer = "port '${call.request.local.localPort}'",
+                    targetServer = targetServerForPort(call.request.local.localPort),
                     prettyPrint = prettyPrint,
                 )
                 var transformedResponse: HttpResponse? = null
@@ -582,6 +590,11 @@ class HttpStub(
 
     private fun ApplicationEngineEnvironmentBuilder.configureHostPorts() {
         val hostPortList = getHostAndPortList()
+        transportModeByPort.clear()
+        hostPortList.forEach { (host, port) ->
+            recordTransportMode(port, transportMode(host, port))
+        }
+
         val mtlsByPort = hostPortList.groupBy(
             keySelector = { (_, port) -> port },
             valueTransform = { (host, port) -> incomingMtlsRegistry.get(host, port) }
@@ -616,6 +629,33 @@ class HttpStub(
                 "Incoming mTLS is enabled, but no HTTPS key material is configured for ports: ${portsWithIncomingMtlsButNoHttps.joinToString(", ")}"
             )
         }
+    }
+
+    private fun targetServerForPort(port: Int): String {
+        val transportSuffix = when (transportModeByPort[port]) {
+            TransportMode.MTLS -> " (mTLS)"
+            TransportMode.TLS -> " (TLS)"
+            else -> ""
+        }
+
+        return "port '$port'$transportSuffix"
+    }
+
+    private fun transportMode(host: String, port: Int): TransportMode {
+        if (keyDataRegistry.get(host, port) == null) return TransportMode.HTTP
+        return if (incomingMtlsRegistry.get(host, port)) TransportMode.MTLS else TransportMode.TLS
+    }
+
+    private fun recordTransportMode(port: Int, mode: TransportMode) {
+        val existingMode = transportModeByPort[port]
+        if (existingMode == null || existingMode == mode) {
+            transportModeByPort[port] = mode
+            return
+        }
+
+        throw ContractException(
+            "Transport mode configuration is ambiguous for port $port. Please ensure all host mappings for a shared port use the same transport mode."
+        )
     }
 
     private fun incomingMtlsServerContext(keyData: KeyData): SslContext {

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -598,6 +598,7 @@ class HttpStub(
             val keyData = keyDataRegistry.get(host, port) ?: return@map EngineConnectorBuilder().also { it.host = host; it.port = port }
             if (incomingMtlsEnabled) {
                 incomingMtlsSslContextsByPort[port] = incomingMtlsServerContext(keyData)
+                return@map EngineConnectorBuilder().also { it.host = host; it.port = port }
             }
             EngineSSLConnectorBuilder(
                 keyStore = keyData.keyStore,
@@ -816,9 +817,11 @@ class HttpStub(
                 val mtlsSslContext = incomingMtlsSslContextsByPort[localAddress.port]
                 if (mtlsSslContext != null) {
                     val sslHandler = get("ssl") as? SslHandler
+                    val newSslHandler = mtlsSslContext.newHandler(channel().alloc())
                     if (sslHandler != null) {
-                        val newSslHandler = mtlsSslContext.newHandler(channel().alloc())
                         replace(sslHandler, "ssl", newSslHandler)
+                    } else {
+                        addFirst("ssl", newSslHandler)
                     }
                 }
             }

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -157,13 +157,7 @@ class HttpStub(
     var requestHandlers: MutableList<RequestHandler> = mutableListOf()
 ) : ContractStub {
     private val incomingMtlsSslContextsByPort: MutableMap<Int, SslContext> = mutableMapOf()
-    private val transportModeByPort: MutableMap<Int, TransportMode> = mutableMapOf()
-
-    private enum class TransportMode {
-        HTTP,
-        TLS,
-        MTLS
-    }
+    private val mtlsEnabledByPort: MutableMap<Int, Boolean> = mutableMapOf()
 
     private enum class SwaggerSpecResponseFormat {
         YAML,
@@ -590,20 +584,11 @@ class HttpStub(
 
     private fun ApplicationEngineEnvironmentBuilder.configureHostPorts() {
         val hostPortList = getHostAndPortList()
-        transportModeByPort.clear()
+        mtlsEnabledByPort.clear()
+        validateTlsConfigurationByPort(hostPortList)
+        validateIncomingMtlsConfigurationByPort(hostPortList)
         hostPortList.forEach { (host, port) ->
-            recordTransportMode(port, transportMode(host, port))
-        }
-
-        val mtlsByPort = hostPortList.groupBy(
-            keySelector = { (_, port) -> port },
-            valueTransform = { (host, port) -> incomingMtlsRegistry.get(host, port) }
-        )
-        val portsWithMixedMtlsMode = mtlsByPort.filterValues { it.distinct().size > 1 }.keys
-        if (portsWithMixedMtlsMode.isNotEmpty()) {
-            throw ContractException(
-                "Incoming mTLS configuration is ambiguous for ports: ${portsWithMixedMtlsMode.joinToString(", ")}. Please ensure all host mappings for a shared port use the same incoming mTLS setting."
-            )
+            recordIncomingMtlsByPort(port, incomingMtlsRegistry.get(host, port))
         }
 
         connectors.addAll(hostPortList.map { (host, port) ->
@@ -632,28 +617,46 @@ class HttpStub(
     }
 
     private fun targetServerForPort(port: Int): String {
-        val transportSuffix = when (transportModeByPort[port]) {
-            TransportMode.MTLS -> " (mTLS)"
-            else -> ""
-        }
+        val transportSuffix = if (mtlsEnabledByPort[port] == true) " (mTLS)" else ""
 
         return "port '$port'$transportSuffix"
     }
 
-    private fun transportMode(host: String, port: Int): TransportMode {
-        if (keyDataRegistry.get(host, port) == null) return TransportMode.HTTP
-        return if (incomingMtlsRegistry.get(host, port)) TransportMode.MTLS else TransportMode.TLS
+    private fun validateTlsConfigurationByPort(hostPortList: List<Pair<String, Int>>) {
+        val tlsByPort = hostPortList.groupBy(
+            keySelector = { (_, port) -> port },
+            valueTransform = { (host, port) -> keyDataRegistry.get(host, port) != null }
+        )
+        val portsWithMixedTlsMode = tlsByPort.filterValues { it.distinct().size > 1 }.keys
+        if (portsWithMixedTlsMode.isNotEmpty()) {
+            throw ContractException(
+                "Transport mode configuration is ambiguous for ports: ${portsWithMixedTlsMode.joinToString(", ")}. Please ensure all host mappings for a shared port use the same transport mode."
+            )
+        }
     }
 
-    private fun recordTransportMode(port: Int, mode: TransportMode) {
-        val existingMode = transportModeByPort[port]
-        if (existingMode == null || existingMode == mode) {
-            transportModeByPort[port] = mode
+    private fun validateIncomingMtlsConfigurationByPort(hostPortList: List<Pair<String, Int>>) {
+        val mtlsByPort = hostPortList.groupBy(
+            keySelector = { (_, port) -> port },
+            valueTransform = { (host, port) -> incomingMtlsRegistry.get(host, port) }
+        )
+        val portsWithMixedMtlsMode = mtlsByPort.filterValues { it.distinct().size > 1 }.keys
+        if (portsWithMixedMtlsMode.isNotEmpty()) {
+            throw ContractException(
+                "Incoming mTLS configuration is ambiguous for ports: ${portsWithMixedMtlsMode.joinToString(", ")}. Please ensure all host mappings for a shared port use the same incoming mTLS setting."
+            )
+        }
+    }
+
+    private fun recordIncomingMtlsByPort(port: Int, mtlsEnabled: Boolean) {
+        val existingMode = mtlsEnabledByPort[port]
+        if (existingMode == null || existingMode == mtlsEnabled) {
+            mtlsEnabledByPort[port] = mtlsEnabled
             return
         }
 
         throw ContractException(
-            "Transport mode configuration is ambiguous for port $port. Please ensure all host mappings for a shared port use the same transport mode."
+            "Incoming mTLS configuration is ambiguous for port $port. Please ensure all host mappings for a shared port use the same incoming mTLS setting."
         )
     }
 

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -594,9 +594,9 @@ class HttpStub(
         }
 
         connectors.addAll(hostPortList.map { (host, port) ->
-            val incomingMtlsEnabled = incomingMtlsRegistry.get(host, port)
+            val mtlsEnabled = incomingMtlsRegistry.get(host, port)
             val keyData = keyDataRegistry.get(host, port) ?: return@map EngineConnectorBuilder().also { it.host = host; it.port = port }
-            if (incomingMtlsEnabled) {
+            if (mtlsEnabled) {
                 incomingMtlsSslContextsByPort[port] = incomingMtlsServerContext(keyData)
                 return@map EngineConnectorBuilder().also { it.host = host; it.port = port }
             }

--- a/core/src/main/kotlin/io/specmatic/test/ApacheHttpClientFactory.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ApacheHttpClientFactory.kt
@@ -4,17 +4,29 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.apache.*
 import io.ktor.client.plugins.*
 import io.specmatic.core.KeyData
+import org.apache.http.HttpResponseInterceptor
+import org.apache.http.conn.ManagedHttpClientConnection
+import org.apache.http.nio.conn.ManagedNHttpClientConnection
 import org.apache.http.conn.ssl.NoopHostnameVerifier
 import org.apache.http.conn.ssl.TrustAllStrategy
+import org.apache.http.protocol.HttpCoreContext
 import org.apache.http.ssl.SSLContextBuilder
 
 const val BREATHING_ROOM_FOR_REQUEST_TIMEOUT_TO_KICK_IN_FIRST = 1
 
+data class TransportInfo(val mtlsNegotiated: Boolean = false)
+
 class ApacheHttpClientFactory(
     override val timeoutPolicy: TimeoutPolicy,
-    private val keyData: KeyData? = null
+    private val keyData: KeyData? = null,
+    private val onTransportInfo: (TransportInfo) -> Unit = {}
 ): HttpClientFactory {
-    constructor(timeoutInMilliseconds: Long, keyData: KeyData? = null): this(TimeoutPolicy(timeoutInMilliseconds), keyData)
+    constructor(timeoutInMilliseconds: Long, keyData: KeyData? = null): this(TimeoutPolicy(timeoutInMilliseconds), keyData, {})
+    constructor(
+        timeoutInMilliseconds: Long,
+        keyData: KeyData? = null,
+        onTransportInfo: (TransportInfo) -> Unit
+    ): this(TimeoutPolicy(timeoutInMilliseconds), keyData, onTransportInfo)
 
     override fun create(): HttpClient = HttpClient(Apache) {
         expectSuccess = false
@@ -23,6 +35,18 @@ class ApacheHttpClientFactory(
 
         engine {
             customizeClient {
+                addInterceptorLast(HttpResponseInterceptor { response, context ->
+                    val coreContext = HttpCoreContext.adapt(context)
+                    val connection = coreContext.connection
+                    val sslSession = when (connection) {
+                        is ManagedNHttpClientConnection -> connection.sslSession
+                        is ManagedHttpClientConnection -> connection.sslSession
+                        else -> null
+                    }
+                    val clientCertPresented = sslSession?.localCertificates?.isNotEmpty() == true
+                    onTransportInfo(TransportInfo(mtlsNegotiated = clientCertPresented))
+                })
+
                 val sslContextBuilder = SSLContextBuilder.create().loadTrustMaterial(TrustAllStrategy())
                 if (keyData != null) {
                     sslContextBuilder.loadKeyMaterial(keyData.keyStore, keyData.keyPassword.toCharArray()) { aliases, _ ->

--- a/core/src/main/kotlin/io/specmatic/test/ApacheHttpClientFactory.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ApacheHttpClientFactory.kt
@@ -3,14 +3,18 @@ package io.specmatic.test
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.apache.*
 import io.ktor.client.plugins.*
+import io.specmatic.core.KeyData
 import org.apache.http.conn.ssl.NoopHostnameVerifier
 import org.apache.http.conn.ssl.TrustAllStrategy
 import org.apache.http.ssl.SSLContextBuilder
 
 const val BREATHING_ROOM_FOR_REQUEST_TIMEOUT_TO_KICK_IN_FIRST = 1
 
-class ApacheHttpClientFactory(override val timeoutPolicy: TimeoutPolicy): HttpClientFactory {
-    constructor(timeoutInMilliseconds: Long): this(TimeoutPolicy(timeoutInMilliseconds))
+class ApacheHttpClientFactory(
+    override val timeoutPolicy: TimeoutPolicy,
+    private val keyData: KeyData? = null
+): HttpClientFactory {
+    constructor(timeoutInMilliseconds: Long, keyData: KeyData? = null): this(TimeoutPolicy(timeoutInMilliseconds), keyData)
 
     override fun create(): HttpClient = HttpClient(Apache) {
         expectSuccess = false
@@ -19,10 +23,16 @@ class ApacheHttpClientFactory(override val timeoutPolicy: TimeoutPolicy): HttpCl
 
         engine {
             customizeClient {
+                val sslContextBuilder = SSLContextBuilder.create().loadTrustMaterial(TrustAllStrategy())
+                if (keyData != null) {
+                    sslContextBuilder.loadKeyMaterial(keyData.keyStore, keyData.keyPassword.toCharArray()) { aliases, _ ->
+                        val configuredAlias = keyData.keyAlias.takeIf { it.isNotBlank() }
+                        configuredAlias?.takeIf(aliases::containsKey) ?: aliases.keys.firstOrNull()
+                    }
+                }
+
                 setSSLContext(
-                    SSLContextBuilder.create()
-                        .loadTrustMaterial(TrustAllStrategy())
-                        .build()
+                    sslContextBuilder.build()
                 )
                 setSSLHostnameVerifier(NoopHostnameVerifier())
                 useSystemProperties()

--- a/core/src/main/kotlin/io/specmatic/test/HttpClient.kt
+++ b/core/src/main/kotlin/io/specmatic/test/HttpClient.kt
@@ -39,8 +39,9 @@ data class HttpClient(
     val timeoutInMilliseconds: Long = 6000,
     private val log: (event: LogMessage) -> Unit = ::consoleLog,
     private val prettyPrint: Boolean = true,
+    private val keyData: KeyData? = null,
     private var httpLogMessage: HttpLogMessage = HttpLogMessage(targetServer = baseURL, prettyPrint = prettyPrint),
-    private val httpClientFactory: Lazy<ApacheHttpClientFactory> = lazy { ApacheHttpClientFactory(timeoutInMilliseconds) },
+    private val httpClientFactory: Lazy<ApacheHttpClientFactory> = lazy { ApacheHttpClientFactory(timeoutInMilliseconds, keyData) },
     private val httpClient: Lazy<io.ktor.client.HttpClient> = lazy { httpClientFactory.value.create() },
     private val httpInteractionsLog: HttpInteractionsLog = HttpInteractionsLog()
 ) : TestExecutor, AutoCloseable {
@@ -151,18 +152,19 @@ data class LegacyHttpClient(
     val timeoutInMilliseconds: Long = 6000,
     val log: (event: LogMessage) -> Unit = ::consoleLog,
     val prettyPrint: Boolean = true,
+    val keyData: KeyData? = null,
 ) : TestExecutor {
 
     override fun execute(request: HttpRequest): HttpResponse {
-        return HttpClient(baseURL, timeoutInMilliseconds, log, prettyPrint).use { it.execute(request) }
+        return HttpClient(baseURL, timeoutInMilliseconds, log, prettyPrint, keyData = keyData).use { it.execute(request) }
     }
 
     override fun setServerState(serverState: Map<String, Value>) {
-        HttpClient(baseURL, timeoutInMilliseconds, log, prettyPrint).use { it.setServerState(serverState) }
+        HttpClient(baseURL, timeoutInMilliseconds, log, prettyPrint, keyData = keyData).use { it.setServerState(serverState) }
     }
 
     override fun preExecuteScenario(scenario: Scenario, request: HttpRequest) {
-        HttpClient(baseURL, timeoutInMilliseconds, log, prettyPrint).preExecuteScenario(scenario, request)
+        HttpClient(baseURL, timeoutInMilliseconds, log, prettyPrint, keyData = keyData).preExecuteScenario(scenario, request)
     }
 }
 

--- a/core/src/main/kotlin/io/specmatic/test/HttpClient.kt
+++ b/core/src/main/kotlin/io/specmatic/test/HttpClient.kt
@@ -26,6 +26,7 @@ import io.specmatic.stub.toParams
 import kotlinx.coroutines.runBlocking
 import java.net.URL
 import java.util.*
+import java.util.concurrent.atomic.AtomicReference
 import java.util.zip.GZIPInputStream
 
 // API for non-Kotlin invokers
@@ -40,8 +41,16 @@ data class HttpClient(
     private val log: (event: LogMessage) -> Unit = ::consoleLog,
     private val prettyPrint: Boolean = true,
     private val keyData: KeyData? = null,
-    private var httpLogMessage: HttpLogMessage = HttpLogMessage(targetServer = baseURL, prettyPrint = prettyPrint),
-    private val httpClientFactory: Lazy<ApacheHttpClientFactory> = lazy { ApacheHttpClientFactory(timeoutInMilliseconds, keyData) },
+    private var httpLogMessage: HttpLogMessage = HttpLogMessage(
+        targetServer = targetServer(baseURL, mtlsNegotiated = false),
+        prettyPrint = prettyPrint
+    ),
+    private val requestTransportInfo: AtomicReference<TransportInfo> = AtomicReference(TransportInfo()),
+    private val httpClientFactory: Lazy<ApacheHttpClientFactory> = lazy {
+        ApacheHttpClientFactory(timeoutInMilliseconds, keyData) { transportInfo ->
+            requestTransportInfo.set(transportInfo)
+        }
+    },
     private val httpClient: Lazy<io.ktor.client.HttpClient> = lazy { httpClientFactory.value.create() },
     private val httpInteractionsLog: HttpInteractionsLog = HttpInteractionsLog()
 ) : TestExecutor, AutoCloseable {
@@ -55,6 +64,7 @@ data class HttpClient(
         logger.debug("Starting request ${request.method} ${request.path}")
 
         return try {
+            requestTransportInfo.set(TransportInfo())
             runBlocking {
                 val ktorResponse: io.ktor.client.statement.HttpResponse = httpClient.value.request(url) {
                     requestWithFileContent.buildKTORRequest(this)
@@ -65,9 +75,14 @@ data class HttpClient(
 
                 ktorResponseToHttpResponse(ktorResponse)
                     .adjustPayloadForContentType()
-                    .also {
+                    .let {
+                        val mtlsNegotiated = requestTransportInfo.get().mtlsNegotiated
+                        httpLogMessage = httpLogMessage.copy(
+                            targetServer = targetServer(baseURL, mtlsNegotiated)
+                        )
                         httpLogMessage.addResponseWithCurrentTime(it)
                         log(httpLogMessage)
+                        it
                     }
             }
         } catch (e: Exception) {
@@ -143,6 +158,11 @@ data class HttpClient(
     fun withLogger(log: (LogMessage) -> Unit): TestExecutor {
         return this.copy(log = log)
     }
+}
+
+internal fun targetServer(baseURL: String, mtlsNegotiated: Boolean): String {
+    val mtlsInvolved = mtlsNegotiated && baseURL.startsWith("https://", ignoreCase = true)
+    return if (mtlsInvolved) "$baseURL (mTLS)" else baseURL
 }
 
 

--- a/core/src/test/kotlin/io/specmatic/core/CertRegistryTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/CertRegistryTest.kt
@@ -51,8 +51,8 @@ class CertRegistryTest {
     @Test
     fun `incoming mTLS registry should prefer exact host port over wildcard`() {
         val registry = CertRegistry.empty()
-            .plusWildCard(httpsConfig("wildcard.jks", incomingMtlsEnabled = false))
-            .plus("https://api.example.com:9443", httpsConfig("exact.jks", incomingMtlsEnabled = true))
+            .plusWildCard(httpsConfig("wildcard.jks", mtlsEnabled = false))
+            .plus("https://api.example.com:9443", httpsConfig("exact.jks", mtlsEnabled = true))
 
         val incomingMtlsRegistry = registry.toIncomingMtlsRegistry()
 
@@ -61,18 +61,18 @@ class CertRegistryTest {
 
     @Test
     fun `incoming mTLS registry should fallback to wildcard when exact host port is unavailable`() {
-        val registry = CertRegistry.empty().plusWildCard(httpsConfig("wildcard.jks", incomingMtlsEnabled = true))
+        val registry = CertRegistry.empty().plusWildCard(httpsConfig("wildcard.jks", mtlsEnabled = true))
 
         val incomingMtlsRegistry = registry.toIncomingMtlsRegistry()
 
         assertThat(incomingMtlsRegistry.get("unmapped-host.example", 443)).isTrue()
     }
 
-    private fun httpsConfig(file: String, incomingMtlsEnabled: Boolean? = null): HttpsConfiguration {
+    private fun httpsConfig(file: String, mtlsEnabled: Boolean? = null): HttpsConfiguration {
         return HttpsConfiguration(
             keyStore = KeyStoreConfiguration.FileBasedConfig(file = file),
             keyStorePassword = "password",
-            incomingMtlsEnabled = incomingMtlsEnabled
+            mtlsEnabled = mtlsEnabled
         )
     }
 

--- a/core/src/test/kotlin/io/specmatic/core/CertRegistryTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/CertRegistryTest.kt
@@ -1,0 +1,82 @@
+package io.specmatic.core
+
+import io.specmatic.core.config.HttpsConfiguration
+import io.specmatic.core.config.KeyStoreConfiguration
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.security.KeyStore
+
+class CertRegistryTest {
+    @Test
+    fun `toKeyDataRegistry should fail when multiple certs map to same host and port`() {
+        val registry = CertRegistry.empty()
+            .plus("https://api.example.com:9443", httpsConfig("client-a.jks"))
+            .plus("https://api.example.com:9443", httpsConfig("client-b.jks"))
+
+        assertThatThrownBy { registry.toKeyDataRegistry { null } }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Multiple certificates found for the same host/port")
+    }
+
+    @Test
+    fun `keyDataRegistry should prefer exact host port over wildcard`() {
+        val wildcardConfig = httpsConfig("wildcard.jks")
+        val exactConfig = httpsConfig("exact.jks")
+        val registry = CertRegistry.empty()
+            .plusWildCard(wildcardConfig)
+            .plus("https://api.example.com:9443", exactConfig)
+
+        val keyDataRegistry = registry.toKeyDataRegistry { config ->
+            when (config) {
+                wildcardConfig -> KeyData(emptyKeyStore(), "password", keyAlias = "wildcard")
+                exactConfig -> KeyData(emptyKeyStore(), "password", keyAlias = "exact")
+                else -> null
+            }
+        }
+
+        assertThat(keyDataRegistry.get("api.example.com", 9443)?.keyAlias).isEqualTo("exact")
+    }
+
+    @Test
+    fun `keyDataRegistry should fall back to wildcard when exact host port is unavailable`() {
+        val registry = CertRegistry.empty().plusWildCard(httpsConfig("wildcard.jks"))
+        val wildcardKeyData = KeyData(emptyKeyStore(), "password", keyAlias = "wildcard")
+
+        val keyDataRegistry = registry.toKeyDataRegistry { wildcardKeyData }
+
+        assertThat(keyDataRegistry.get("unmapped-host.example", 443)).isEqualTo(wildcardKeyData)
+    }
+
+    @Test
+    fun `incoming mTLS registry should prefer exact host port over wildcard`() {
+        val registry = CertRegistry.empty()
+            .plusWildCard(httpsConfig("wildcard.jks", incomingMtlsEnabled = false))
+            .plus("https://api.example.com:9443", httpsConfig("exact.jks", incomingMtlsEnabled = true))
+
+        val incomingMtlsRegistry = registry.toIncomingMtlsRegistry()
+
+        assertThat(incomingMtlsRegistry.get("api.example.com", 9443)).isTrue()
+    }
+
+    @Test
+    fun `incoming mTLS registry should fallback to wildcard when exact host port is unavailable`() {
+        val registry = CertRegistry.empty().plusWildCard(httpsConfig("wildcard.jks", incomingMtlsEnabled = true))
+
+        val incomingMtlsRegistry = registry.toIncomingMtlsRegistry()
+
+        assertThat(incomingMtlsRegistry.get("unmapped-host.example", 443)).isTrue()
+    }
+
+    private fun httpsConfig(file: String, incomingMtlsEnabled: Boolean? = null): HttpsConfiguration {
+        return HttpsConfiguration(
+            keyStore = KeyStoreConfiguration.FileBasedConfig(file = file),
+            keyStorePassword = "password",
+            incomingMtlsEnabled = incomingMtlsEnabled
+        )
+    }
+
+    private fun emptyKeyStore(): KeyStore {
+        return KeyStore.getInstance("JKS").apply { load(null, null) }
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/CertRegistryTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/CertRegistryTest.kt
@@ -68,6 +68,41 @@ class CertRegistryTest {
         assertThat(incomingMtlsRegistry.get("unmapped-host.example", 443)).isTrue()
     }
 
+    @Test
+    fun `incoming mTLS registry should fail when multiple configs map to same host and port with different values`() {
+        val registry = CertRegistry.empty()
+            .plus("https://api.example.com:9443", httpsConfig("a.jks", mtlsEnabled = true))
+            .plus("https://api.example.com:9443", httpsConfig("b.jks", mtlsEnabled = false))
+
+        assertThatThrownBy { registry.toIncomingMtlsRegistry() }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Multiple certificates found for the same host/port")
+    }
+
+    @Test
+    fun `keyDataRegistry should resolve deterministic certs in a multi target suite`() {
+        val wildcardConfig = httpsConfig("wildcard.jks")
+        val paymentsConfig = httpsConfig("payments.jks")
+        val ordersConfig = httpsConfig("orders.jks")
+        val registry = CertRegistry.empty()
+            .plusWildCard(wildcardConfig)
+            .plus("https://payments.example.com:9443", paymentsConfig)
+            .plus("https://orders.example.com:9443", ordersConfig)
+
+        val keyDataRegistry = registry.toKeyDataRegistry { config ->
+            when (config) {
+                wildcardConfig -> KeyData(emptyKeyStore(), "password", keyAlias = "wildcard")
+                paymentsConfig -> KeyData(emptyKeyStore(), "password", keyAlias = "payments")
+                ordersConfig -> KeyData(emptyKeyStore(), "password", keyAlias = "orders")
+                else -> null
+            }
+        }
+
+        assertThat(keyDataRegistry.get("payments.example.com", 9443)?.keyAlias).isEqualTo("payments")
+        assertThat(keyDataRegistry.get("orders.example.com", 9443)?.keyAlias).isEqualTo("orders")
+        assertThat(keyDataRegistry.get("inventory.example.com", 9443)?.keyAlias).isEqualTo("wildcard")
+    }
+
     private fun httpsConfig(file: String, mtlsEnabled: Boolean? = null): HttpsConfiguration {
         return HttpsConfiguration(
             keyStore = KeyStoreConfiguration.FileBasedConfig(file = file),

--- a/core/src/test/kotlin/io/specmatic/core/ContractTests.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ContractTests.kt
@@ -15,7 +15,7 @@ import io.specmatic.core.pattern.parsedJSONObject
 import io.specmatic.core.utilities.Flags
 import io.specmatic.core.value.*
 import io.specmatic.osAgnosticPath
-import io.specmatic.test.LegacyHttpClient
+import io.specmatic.test.HttpClient
 import io.specmatic.test.TestExecutor
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.*
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.fail
 import java.io.File
+import java.net.ServerSocket
 
 class ContractTests {
     @Test
@@ -786,7 +787,7 @@ Examples:
         try {
             server.start(wait = false)
 
-            val results = spec.executeTests(LegacyHttpClient("http://localhost:8080"))
+            val results = spec.executeTests(HttpClient("http://localhost:8080"))
             assertThat(results.success()).withFailMessage(results.report()).isTrue()
             assertThat(results.successCount).isPositive()
         } finally {
@@ -827,7 +828,7 @@ Examples:
         try {
             server.start(wait = false)
 
-            val results = spec.executeTests(LegacyHttpClient("http://localhost:8080"))
+            val results = spec.executeTests(HttpClient("http://localhost:8080"))
             assertThat(results.success()).withFailMessage(results.report()).isTrue()
             assertThat(results.successCount).isPositive()
         } finally {
@@ -868,7 +869,8 @@ Examples:
 
         val pathsSeen = mutableListOf<String>()
 
-        val server = embeddedServer(Netty, port = 9001) {
+        val port = ServerSocket(0).use { it.localPort }
+        val server = embeddedServer(Netty, port = port) {
             routing {
                 route("/{...}") {
                     handle {
@@ -881,7 +883,7 @@ Examples:
 
         val results = try {
             server.start(wait = false)
-            specification.executeTests(LegacyHttpClient("http://localhost:9001"))
+            specification.executeTests(HttpClient("http://localhost:$port"))
         } finally {
             server.stop()
         }
@@ -929,7 +931,8 @@ Examples:
 
         val pathsSeen = mutableListOf<String>()
 
-        val server = embeddedServer(Netty, port = 9001) {
+        val port = ServerSocket(0).use { it.localPort }
+        val server = embeddedServer(Netty, port = port) {
             routing {
                 route("/{...}") {
                     handle {
@@ -942,7 +945,7 @@ Examples:
 
         val results = try {
             server.start(wait = false)
-            specification.executeTests(LegacyHttpClient("http://localhost:9001"))
+            specification.executeTests(HttpClient("http://localhost:$port"))
         } finally {
             server.stop()
         }
@@ -1000,7 +1003,8 @@ Examples:
 
         val queryParamsSeen = mutableListOf<Map<String, List<String>>>()
 
-        val server = embeddedServer(Netty, port = 9001) {
+        val port = ServerSocket(0).use { it.localPort }
+        val server = embeddedServer(Netty, port = port) {
             routing {
                 route("/{...}") {
                     handle {
@@ -1013,7 +1017,7 @@ Examples:
 
         val results = try {
             server.start(wait = false)
-            specification.executeTests(LegacyHttpClient("http://localhost:9001"))
+            specification.executeTests(io.specmatic.test.HttpClient("http://localhost:$port"))
         } finally {
             server.stop()
         }
@@ -1073,7 +1077,8 @@ Examples:
                             type: string
         """.trimIndent(), "").toFeature()
 
-        val server = embeddedServer(Netty, port = 9001) {
+        val port = ServerSocket(0).use { it.localPort }
+        val server = embeddedServer(Netty, port = port) {
             routing {
                 route("/{...}") {
                     handle {
@@ -1092,7 +1097,7 @@ Examples:
 
         val results = try {
             server.start(wait = false)
-            specification.enableGenerativeTesting().executeTests(LegacyHttpClient("http://localhost:9001"))
+            specification.enableGenerativeTesting().executeTests(io.specmatic.test.HttpClient("http://localhost:$port"))
         } finally {
             server.stop()
         }

--- a/core/src/test/kotlin/io/specmatic/core/HttpClientTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpClientTest.kt
@@ -16,6 +16,7 @@ import io.specmatic.test.LegacyHttpClient
 import io.specmatic.test.SET_COOKIE_SEPARATOR
 import io.specmatic.test.internalHeadersToKtorHeaders
 import io.specmatic.test.ktorHeadersToInternalHeaders
+import io.specmatic.test.targetServer
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.json.JSONObject
@@ -23,6 +24,27 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
 class HttpClientTest {
+    @Test
+    fun `should append mTLS marker to target server when mtls was negotiated`() {
+        val target = targetServer("https://localhost:9443", mtlsNegotiated = true)
+
+        assertThat(target).isEqualTo("https://localhost:9443 (mTLS)")
+    }
+
+    @Test
+    fun `should not append mTLS marker to target server when mtls was not negotiated`() {
+        val target = targetServer("https://localhost:9443", mtlsNegotiated = false)
+
+        assertThat(target).isEqualTo("https://localhost:9443")
+    }
+
+    @Test
+    fun `should not append mTLS marker to target server when base URL is HTTP`() {
+        val target = targetServer("http://localhost:9000", mtlsNegotiated = true)
+
+        assertThat(target).isEqualTo("http://localhost:9000")
+    }
+
 
     @Test
     fun clientShouldNotRedirect() {

--- a/core/src/test/kotlin/io/specmatic/core/HttpsKeyDataTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpsKeyDataTest.kt
@@ -1,0 +1,70 @@
+package io.specmatic.core
+
+import io.specmatic.core.config.HttpsConfiguration
+import io.specmatic.core.config.KeyStoreConfiguration
+import io.specmatic.core.pattern.ContractException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+import java.security.KeyStore
+
+class HttpsKeyDataTest {
+    @Test
+    fun `should load JKS keystore from file`(@TempDir tempDir: Path) {
+        val keyStoreFile = tempDir.resolve("client.jks").toFile()
+        createEmptyKeyStore(keyStoreFile, "store-pass", "JKS")
+
+        val keyData = httpsConfig(keyStoreFile, "store-pass").toKeyData(aliasSuffix = "test")
+
+        assertThat(keyData).isNotNull()
+    }
+
+    @Test
+    fun `should load PKCS12 keystore from file`(@TempDir tempDir: Path) {
+        val keyStoreFile = tempDir.resolve("client.p12").toFile()
+        createEmptyKeyStore(keyStoreFile, "store-pass", "PKCS12")
+
+        val keyData = httpsConfig(keyStoreFile, "store-pass").toKeyData(aliasSuffix = "test")
+
+        assertThat(keyData).isNotNull()
+    }
+
+    @Test
+    fun `should fail for unsupported keystore extension`(@TempDir tempDir: Path) {
+        val keyStoreFile = tempDir.resolve("client.txt").toFile().apply {
+            writeText("not-a-keystore")
+        }
+
+        assertThatThrownBy {
+            httpsConfig(keyStoreFile, "store-pass").toKeyData(aliasSuffix = "test")
+        }.isInstanceOf(ContractException::class.java)
+            .hasMessageContaining("Unsupported keystore format")
+    }
+
+    @Test
+    fun `should fail when keystore password is incorrect`(@TempDir tempDir: Path) {
+        val keyStoreFile = tempDir.resolve("client.jks").toFile()
+        createEmptyKeyStore(keyStoreFile, "correct-pass", "JKS")
+
+        assertThatThrownBy {
+            httpsConfig(keyStoreFile, "wrong-pass").toKeyData(aliasSuffix = "test")
+        }.isInstanceOf(Exception::class.java)
+    }
+
+    private fun httpsConfig(file: File, keyStorePassword: String): HttpsConfiguration {
+        return HttpsConfiguration(
+            keyStore = KeyStoreConfiguration.FileBasedConfig(file = file.canonicalPath),
+            keyStorePassword = keyStorePassword
+        )
+    }
+
+    private fun createEmptyKeyStore(file: File, password: String, type: String) {
+        val keyStore = KeyStore.getInstance(type).apply { load(null, password.toCharArray()) }
+        file.outputStream().use { outputStream ->
+            keyStore.store(outputStream, password.toCharArray())
+        }
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigKtTest.kt
@@ -24,6 +24,7 @@ import io.specmatic.core.utilities.Flags.Companion.VALIDATE_RESPONSE_VALUE
 import io.specmatic.reporter.model.SpecType
 import io.specmatic.test.TestResultRecord.Companion.CONTRACT_TEST_TEST_TYPE
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -77,7 +78,7 @@ internal class SpecmaticConfigKtTest {
                 https = HttpsConfiguration(
                     keyStore = KeyStoreConfiguration.FileBasedConfig(file = "server-cert.jks"),
                     keyStorePassword = "password",
-                    incomingMtlsEnabled = true
+                    mtlsEnabled = true
                 )
             )
         )
@@ -85,6 +86,42 @@ internal class SpecmaticConfigKtTest {
         val incomingMtlsRegistry = config.getStubHttpsConfiguration().toIncomingMtlsRegistry()
 
         assertThat(incomingMtlsRegistry.get("any-host.example", 443)).isTrue()
+    }
+
+    @Test
+    fun `should parse mtlsEnabled from v2 yaml configuration`() {
+        val config = ObjectMapper(YAMLFactory()).registerKotlinModule().readValue(
+            """
+            version: 2
+            stub:
+              https:
+                mtlsEnabled: true
+                keyStore:
+                  file: server-cert.jks
+                keyStorePassword: password
+            """.trimIndent(), SpecmaticConfigV1V2Common::class.java
+        )
+
+        val incomingMtlsRegistry = config.getStubHttpsConfiguration().toIncomingMtlsRegistry()
+
+        assertThat(incomingMtlsRegistry.get("any-host.example", 443)).isTrue()
+    }
+
+    @Test
+    fun `should reject incomingMtlsEnabled from v2 yaml configuration`() {
+        assertThatThrownBy {
+            ObjectMapper(YAMLFactory()).registerKotlinModule().readValue(
+                """
+                version: 2
+                stub:
+                  https:
+                    incomingMtlsEnabled: true
+                    keyStore:
+                      file: server-cert.jks
+                    keyStorePassword: password
+                """.trimIndent(), SpecmaticConfigV1V2Common::class.java
+            )
+        }.hasMessageContaining("incomingMtlsEnabled")
     }
 
     private fun emptyKeyStore(): KeyStore {

--- a/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigKtTest.kt
@@ -4,8 +4,10 @@ import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.kotlin.readValue
-import io.specmatic.core.config.v2.SpecExecutionConfig
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import io.specmatic.core.config.HttpsConfiguration
+import io.specmatic.core.config.KeyStoreConfiguration
+import io.specmatic.core.config.v2.SpecExecutionConfig
 import io.specmatic.core.config.v2.ContractConfig
 import io.specmatic.core.config.SpecmaticConfigVersion
 import io.specmatic.core.utilities.ContractSourceEntry
@@ -32,9 +34,62 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.MethodSource
 import java.io.File
+import java.security.KeyStore
 import java.util.stream.Stream
 
 internal class SpecmaticConfigKtTest {
+    @Test
+    fun `should return test https configuration from v2 test config`() {
+        val config = SpecmaticConfigV1V2Common(
+            version = SpecmaticConfigVersion.VERSION_2,
+            test = TestConfiguration(
+                https = HttpsConfiguration(
+                    keyStore = KeyStoreConfiguration.FileBasedConfig(file = "client-cert.jks"),
+                    keyStorePassword = "password"
+                )
+            )
+        )
+
+        val keyDataRegistry = config.getTestHttpsConfiguration().toKeyDataRegistry {
+            KeyData(emptyKeyStore(), "password")
+        }
+
+        assertThat(keyDataRegistry.hasAny()).isTrue()
+        assertThat(keyDataRegistry.get("any-host.example", 443)).isNotNull()
+    }
+
+    @Test
+    fun `should return empty test https configuration when not configured`() {
+        val config = SpecmaticConfigV1V2Common(version = SpecmaticConfigVersion.VERSION_2, test = TestConfiguration())
+
+        val keyDataRegistry = config.getTestHttpsConfiguration().toKeyDataRegistry {
+            KeyData(emptyKeyStore(), "password")
+        }
+
+        assertThat(keyDataRegistry.hasAny()).isFalse()
+    }
+
+    @Test
+    fun `should return incoming mTLS setting from v2 stub https configuration`() {
+        val config = SpecmaticConfigV1V2Common(
+            version = SpecmaticConfigVersion.VERSION_2,
+            stub = StubConfiguration(
+                https = HttpsConfiguration(
+                    keyStore = KeyStoreConfiguration.FileBasedConfig(file = "server-cert.jks"),
+                    keyStorePassword = "password",
+                    incomingMtlsEnabled = true
+                )
+            )
+        )
+
+        val incomingMtlsRegistry = config.getStubHttpsConfiguration().toIncomingMtlsRegistry()
+
+        assertThat(incomingMtlsRegistry.get("any-host.example", 443)).isTrue()
+    }
+
+    private fun emptyKeyStore(): KeyStore {
+        return KeyStore.getInstance("JKS").apply { load(null, null) }
+    }
 
     @Test
     fun `toContractSourceEntry should preserve the path from config`() {

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3ImplTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3ImplTest.kt
@@ -113,6 +113,40 @@ class SpecmaticConfigV3ImplTest {
     }
 
     @Test
+    fun `should resolve mTLS setting from v3 wsdl mock run options cert`() {
+        val config = v3Config(
+            """
+            version: 3
+            dependencies:
+              services:
+                - service:
+                    definitions:
+                      - definition:
+                          source:
+                            filesystem:
+                              directory: ./specs
+                          specs:
+                            - spec:
+                                id: payment-wsdl
+                                path: payment.wsdl
+                    runOptions:
+                      wsdl:
+                        host: localhost
+                        port: 9450
+                        cert:
+                          mtlsEnabled: true
+                          keyStore:
+                            file: ./server-cert.jks
+                          keyStorePassword: password
+            """.trimIndent()
+        )
+
+        val incomingMtlsRegistry = config.getStubHttpsConfiguration().toIncomingMtlsRegistry()
+
+        assertThat(incomingMtlsRegistry.get("localhost", 9450)).isTrue()
+    }
+
+    @Test
     fun `should reject spec cert override in openapi run options spec`() {
         assertThatThrownBy {
             v3Config(

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3ImplTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3ImplTest.kt
@@ -79,7 +79,7 @@ class SpecmaticConfigV3ImplTest {
     }
 
     @Test
-    fun `should resolve incoming mTLS setting from v3 mock run options with spec override`() {
+    fun `should resolve mTLS setting from v3 mock run options cert`() {
         val config = v3Config(
             """
             version: 3
@@ -100,20 +100,171 @@ class SpecmaticConfigV3ImplTest {
                         host: localhost
                         port: 9443
                         cert:
-                          incomingMtlsEnabled: false
+                          mtlsEnabled: true
                           keyStore:
                             file: ./server-cert.jks
                           keyStorePassword: password
-                        specs:
-                          - spec:
-                              id: order-api
-                              incomingMtlsEnabled: true
             """.trimIndent()
         )
 
         val incomingMtlsRegistry = config.getStubHttpsConfiguration().toIncomingMtlsRegistry()
 
         assertThat(incomingMtlsRegistry.get("localhost", 9443)).isTrue()
+    }
+
+    @Test
+    fun `should reject spec cert override in openapi run options spec`() {
+        assertThatThrownBy {
+            v3Config(
+                """
+                version: 3
+                systemUnderTest:
+                  service:
+                    definitions:
+                      - definition:
+                          source:
+                            filesystem:
+                              directory: ./specs
+                          specs:
+                            - spec:
+                                id: api-spec
+                                path: api.yaml
+                    runOptions:
+                      openapi:
+                        specs:
+                          - spec:
+                              id: api-spec
+                              baseUrl: https://localhost:9443
+                              cert:
+                                keyStore:
+                                  file: ./client-cert.jks
+                                keyStorePassword: password
+                """.trimIndent()
+            )
+        }.hasMessageContaining("cert")
+    }
+
+    @Test
+    fun `should reject spec mtlsEnabled override in openapi run options spec`() {
+        assertThatThrownBy {
+            v3Config(
+                """
+                version: 3
+                dependencies:
+                  services:
+                    - service:
+                        definitions:
+                          - definition:
+                              source:
+                                filesystem:
+                                  directory: ./specs
+                              specs:
+                                - spec:
+                                    id: order-api
+                                    path: order.yaml
+                        runOptions:
+                          openapi:
+                            specs:
+                              - spec:
+                                  id: order-api
+                                  mtlsEnabled: true
+                """.trimIndent()
+            )
+        }.hasMessageContaining("mtlsEnabled")
+    }
+
+    @Test
+    fun `should reject spec cert override in wsdl run options spec`() {
+        assertThatThrownBy {
+            v3Config(
+                """
+                version: 3
+                dependencies:
+                  services:
+                    - service:
+                        definitions:
+                          - definition:
+                              source:
+                                filesystem:
+                                  directory: ./specs
+                              specs:
+                                - spec:
+                                    id: wsdl-spec
+                                    path: service.wsdl
+                        runOptions:
+                          wsdl:
+                            specs:
+                              - spec:
+                                  id: wsdl-spec
+                                  baseUrl: https://localhost:9443
+                                  cert:
+                                    keyStore:
+                                      file: ./server-cert.jks
+                                    keyStorePassword: password
+                """.trimIndent()
+            )
+        }.hasMessageContaining("cert")
+    }
+
+    @Test
+    fun `should reject spec mtlsEnabled override in wsdl run options spec`() {
+        assertThatThrownBy {
+            v3Config(
+                """
+                version: 3
+                dependencies:
+                  services:
+                    - service:
+                        definitions:
+                          - definition:
+                              source:
+                                filesystem:
+                                  directory: ./specs
+                              specs:
+                                - spec:
+                                    id: wsdl-spec
+                                    path: service.wsdl
+                        runOptions:
+                          wsdl:
+                            specs:
+                              - spec:
+                                  id: wsdl-spec
+                                  mtlsEnabled: true
+                """.trimIndent()
+            )
+        }.hasMessageContaining("mtlsEnabled")
+    }
+
+    @Test
+    fun `should reject incomingMtlsEnabled in v3 config`() {
+        assertThatThrownBy {
+            v3Config(
+                """
+                version: 3
+                dependencies:
+                  services:
+                    - service:
+                        definitions:
+                          - definition:
+                              source:
+                                filesystem:
+                                  directory: ./specs
+                              specs:
+                                - spec:
+                                    id: order-api
+                                    path: order.yaml
+                        runOptions:
+                          openapi:
+                            host: localhost
+                            port: 9443
+                            cert:
+                              incomingMtlsEnabled: true
+                              keyStore:
+                                file: ./server-cert.jks
+                              keyStorePassword: password
+                """.trimIndent()
+            )
+        }.hasMessageContaining("incomingMtlsEnabled")
     }
 
     @Nested

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3ImplTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3ImplTest.kt
@@ -1,6 +1,7 @@
 package io.specmatic.core.config.v3
 
 import io.specmatic.core.SpecmaticConfig
+import io.specmatic.core.KeyData
 import io.specmatic.core.ResiliencyTestSuite
 import io.specmatic.core.config.toSpecmaticConfig
 import io.specmatic.reporter.model.SpecType
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import java.io.File
+import java.security.KeyStore
 
 class SpecmaticConfigV3ImplTest {
     @TempDir
@@ -44,6 +46,75 @@ class SpecmaticConfigV3ImplTest {
     @ParameterizedTest
     @MethodSource("testData")
     fun `should return similar values between v2 and v3 test data`(testCase: TestCase) = testCase.run(tempDir)
+
+    @Test
+    fun `should resolve test certificate from v3 run options`() {
+        val config = v3Config(
+            """
+            version: 3
+            systemUnderTest:
+              service:
+                definitions:
+                  - definition:
+                      source:
+                        filesystem:
+                          directory: ./specs
+                      specs:
+                        - simple.yaml
+                runOptions:
+                  openapi:
+                    baseUrl: https://api.example.com:9443
+                    cert:
+                      keyStore:
+                        file: ./client-cert.jks
+                      keyStorePassword: password
+            """.trimIndent()
+        )
+
+        val keyDataRegistry = config.getTestHttpsConfiguration().toKeyDataRegistry {
+            KeyData(emptyKeyStore(), "password")
+        }
+
+        assertThat(keyDataRegistry.get("api.example.com", 9443)).isNotNull()
+    }
+
+    @Test
+    fun `should resolve incoming mTLS setting from v3 mock run options with spec override`() {
+        val config = v3Config(
+            """
+            version: 3
+            dependencies:
+              services:
+                - service:
+                    definitions:
+                      - definition:
+                          source:
+                            filesystem:
+                              directory: ./specs
+                          specs:
+                            - spec:
+                                id: order-api
+                                path: order.yaml
+                    runOptions:
+                      openapi:
+                        host: localhost
+                        port: 9443
+                        cert:
+                          incomingMtlsEnabled: false
+                          keyStore:
+                            file: ./server-cert.jks
+                          keyStorePassword: password
+                        specs:
+                          - spec:
+                              id: order-api
+                              incomingMtlsEnabled: true
+            """.trimIndent()
+        )
+
+        val incomingMtlsRegistry = config.getStubHttpsConfiguration().toIncomingMtlsRegistry()
+
+        assertThat(incomingMtlsRegistry.get("localhost", 9443)).isTrue()
+    }
 
     @Nested
     inner class ModificationMethods {
@@ -919,5 +990,13 @@ class SpecmaticConfigV3ImplTest {
                 ),
             )
         }
+    }
+
+    private fun v3Config(yaml: String): SpecmaticConfig {
+        return tempDir.resolve("config-${System.nanoTime()}.yaml").apply { writeText(yaml) }.toSpecmaticConfig()
+    }
+
+    private fun emptyKeyStore(): KeyStore {
+        return KeyStore.getInstance("JKS").apply { load(null, null) }
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/components/services/MockServiceConfigTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/components/services/MockServiceConfigTest.kt
@@ -1,5 +1,7 @@
 package io.specmatic.core.config.v3.components.services
 
+import io.specmatic.core.config.HttpsConfiguration
+import io.specmatic.core.config.KeyStoreConfiguration
 import io.specmatic.core.config.v3.Data
 import io.specmatic.core.config.v3.RefOrValue
 import io.specmatic.core.config.v3.RefOrValueResolver
@@ -444,5 +446,97 @@ class MockServiceConfigTest {
 
         assertThat(entriesByPath[openApiSpecFile.name]?.baseUrl).isEqualTo("http://openapi-host:9401")
         assertThat(entriesByPath[asyncApiSpecFile.name]?.baseUrl).isEqualTo("async-host:9400")
+    }
+
+    @Test
+    fun `getCerts should apply openapi incoming mTLS override from spec`() {
+        val serviceConfig = CommonServiceConfig<MockRunOptions, MockSettings>(
+            definitions = listOf(
+                Definition(
+                    Definition.Value(
+                        source = RefOrValue.Value(SourceV3.create(filesystem = SourceV3.FileSystem(directory = "."))),
+                        specs = listOf(
+                            SpecificationDefinition.ObjectValue(
+                                SpecificationDefinition.Specification(id = "orders-spec", path = "orders.yaml")
+                            )
+                        )
+                    )
+                )
+            ),
+            runOptions = RefOrValue.Value(
+                MockRunOptions(
+                    openapi = OpenApiMockConfig(
+                        baseUrl = "https://localhost:9443",
+                        cert = RefOrValue.Value(
+                            HttpsConfiguration(
+                                keyStore = KeyStoreConfiguration.FileBasedConfig(file = "./server.jks"),
+                                keyStorePassword = "password",
+                                incomingMtlsEnabled = false
+                            )
+                        ),
+                        specs = listOf(
+                            OpenApiRunOptionsSpecifications(
+                                spec = OpenApiRunOptionsSpecifications.Value(id = "orders-spec", incomingMtlsEnabled = true)
+                            )
+                        )
+                    )
+                )
+            )
+        )
+
+        val certs = MockServiceConfig(
+            services = listOf(MockServiceConfig.Value(service = RefOrValue.Value(serviceConfig))),
+            settings = null
+        ).getCerts(resolver)
+
+        assertThat(certs).hasSize(1)
+        assertThat(certs.single().first).isEqualTo("https://localhost:9443")
+        assertThat(certs.single().second.isIncomingMtlsEnabled()).isTrue()
+    }
+
+    @Test
+    fun `getCerts should apply wsdl incoming mTLS override from spec`() {
+        val serviceConfig = CommonServiceConfig<MockRunOptions, MockSettings>(
+            definitions = listOf(
+                Definition(
+                    Definition.Value(
+                        source = RefOrValue.Value(SourceV3.create(filesystem = SourceV3.FileSystem(directory = "."))),
+                        specs = listOf(
+                            SpecificationDefinition.ObjectValue(
+                                SpecificationDefinition.Specification(id = "wsdl-spec", path = "service.wsdl")
+                            )
+                        )
+                    )
+                )
+            ),
+            runOptions = RefOrValue.Value(
+                MockRunOptions(
+                    wsdl = WsdlMockConfig(
+                        baseUrl = "https://localhost:9443",
+                        cert = RefOrValue.Value(
+                            HttpsConfiguration(
+                                keyStore = KeyStoreConfiguration.FileBasedConfig(file = "./server.jks"),
+                                keyStorePassword = "password",
+                                incomingMtlsEnabled = false
+                            )
+                        ),
+                        specs = listOf(
+                            WsdlRunOptionsSpecifications(
+                                spec = WsdlRunOptionsSpecifications.Value(id = "wsdl-spec", incomingMtlsEnabled = true)
+                            )
+                        )
+                    )
+                )
+            )
+        )
+
+        val certs = MockServiceConfig(
+            services = listOf(MockServiceConfig.Value(service = RefOrValue.Value(serviceConfig))),
+            settings = null
+        ).getCerts(resolver)
+
+        assertThat(certs).hasSize(1)
+        assertThat(certs.single().first).isEqualTo("https://localhost:9443")
+        assertThat(certs.single().second.isIncomingMtlsEnabled()).isTrue()
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/components/services/MockServiceConfigTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/components/services/MockServiceConfigTest.kt
@@ -1,7 +1,5 @@
 package io.specmatic.core.config.v3.components.services
 
-import io.specmatic.core.config.HttpsConfiguration
-import io.specmatic.core.config.KeyStoreConfiguration
 import io.specmatic.core.config.v3.Data
 import io.specmatic.core.config.v3.RefOrValue
 import io.specmatic.core.config.v3.RefOrValueResolver
@@ -448,95 +446,4 @@ class MockServiceConfigTest {
         assertThat(entriesByPath[asyncApiSpecFile.name]?.baseUrl).isEqualTo("async-host:9400")
     }
 
-    @Test
-    fun `getCerts should apply openapi incoming mTLS override from spec`() {
-        val serviceConfig = CommonServiceConfig<MockRunOptions, MockSettings>(
-            definitions = listOf(
-                Definition(
-                    Definition.Value(
-                        source = RefOrValue.Value(SourceV3.create(filesystem = SourceV3.FileSystem(directory = "."))),
-                        specs = listOf(
-                            SpecificationDefinition.ObjectValue(
-                                SpecificationDefinition.Specification(id = "orders-spec", path = "orders.yaml")
-                            )
-                        )
-                    )
-                )
-            ),
-            runOptions = RefOrValue.Value(
-                MockRunOptions(
-                    openapi = OpenApiMockConfig(
-                        baseUrl = "https://localhost:9443",
-                        cert = RefOrValue.Value(
-                            HttpsConfiguration(
-                                keyStore = KeyStoreConfiguration.FileBasedConfig(file = "./server.jks"),
-                                keyStorePassword = "password",
-                                incomingMtlsEnabled = false
-                            )
-                        ),
-                        specs = listOf(
-                            OpenApiRunOptionsSpecifications(
-                                spec = OpenApiRunOptionsSpecifications.Value(id = "orders-spec", incomingMtlsEnabled = true)
-                            )
-                        )
-                    )
-                )
-            )
-        )
-
-        val certs = MockServiceConfig(
-            services = listOf(MockServiceConfig.Value(service = RefOrValue.Value(serviceConfig))),
-            settings = null
-        ).getCerts(resolver)
-
-        assertThat(certs).hasSize(1)
-        assertThat(certs.single().first).isEqualTo("https://localhost:9443")
-        assertThat(certs.single().second.isIncomingMtlsEnabled()).isTrue()
-    }
-
-    @Test
-    fun `getCerts should apply wsdl incoming mTLS override from spec`() {
-        val serviceConfig = CommonServiceConfig<MockRunOptions, MockSettings>(
-            definitions = listOf(
-                Definition(
-                    Definition.Value(
-                        source = RefOrValue.Value(SourceV3.create(filesystem = SourceV3.FileSystem(directory = "."))),
-                        specs = listOf(
-                            SpecificationDefinition.ObjectValue(
-                                SpecificationDefinition.Specification(id = "wsdl-spec", path = "service.wsdl")
-                            )
-                        )
-                    )
-                )
-            ),
-            runOptions = RefOrValue.Value(
-                MockRunOptions(
-                    wsdl = WsdlMockConfig(
-                        baseUrl = "https://localhost:9443",
-                        cert = RefOrValue.Value(
-                            HttpsConfiguration(
-                                keyStore = KeyStoreConfiguration.FileBasedConfig(file = "./server.jks"),
-                                keyStorePassword = "password",
-                                incomingMtlsEnabled = false
-                            )
-                        ),
-                        specs = listOf(
-                            WsdlRunOptionsSpecifications(
-                                spec = WsdlRunOptionsSpecifications.Value(id = "wsdl-spec", incomingMtlsEnabled = true)
-                            )
-                        )
-                    )
-                )
-            )
-        )
-
-        val certs = MockServiceConfig(
-            services = listOf(MockServiceConfig.Value(service = RefOrValue.Value(serviceConfig))),
-            settings = null
-        ).getCerts(resolver)
-
-        assertThat(certs).hasSize(1)
-        assertThat(certs.single().first).isEqualTo("https://localhost:9443")
-        assertThat(certs.single().second.isIncomingMtlsEnabled()).isTrue()
-    }
 }

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/components/services/TestServiceConfigTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/components/services/TestServiceConfigTest.kt
@@ -428,4 +428,5 @@ class TestServiceConfigTest {
         assertThat(entriesByPath[openApiSpecFile.name]?.baseUrl).isEqualTo("http://openapi-host:9401")
         assertThat(entriesByPath[asyncApiSpecFile.name]?.baseUrl).isEqualTo("async-host:9400")
     }
+
 }

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -50,6 +50,7 @@ import java.security.SecureRandom
 import java.security.cert.X509Certificate
 import javax.net.ssl.HostnameVerifier
 import javax.net.ssl.HttpsURLConnection
+import javax.net.ssl.KeyManagerFactory
 import javax.net.ssl.SSLContext
 import javax.net.ssl.TrustManager
 import javax.net.ssl.X509TrustManager
@@ -67,6 +68,7 @@ open class SpecmaticJUnitSupport {
     private var settings = ContractTestSettings(settingsStaging)
 
     private val specmaticConfig: SpecmaticConfig = settings.getSpecmaticConfig()
+    private val keyDataRegistry: KeyDataRegistry = specmaticConfig.getTestHttpsConfiguration().toTestKeyDataRegistry()
     private val httpInteractionsLog: HttpInteractionsLog = HttpInteractionsLog()
     private val testFilter = ScenarioMetadataFilter.from(specmaticConfig.getTestFilter().orEmpty())
     private val prettyPrint = specmaticConfig.getPrettyPrint()
@@ -118,9 +120,19 @@ open class SpecmaticJUnitSupport {
             else -> "$defaultBaseURL/swagger/v1/swagger.yaml"
         }
 
-        val httpClient = client ?: LegacyHttpClient(swaggerDocUrl, log = ignoreLog, prettyPrint = prettyPrint)
         val request = HttpRequest(path = "/", method = "GET")
-        val response = httpClient.execute(request)
+        val response = if (client != null) {
+            client.execute(request)
+        } else {
+            HttpClient(
+                swaggerDocUrl,
+                log = ignoreLog,
+                prettyPrint = prettyPrint,
+                keyData = keyDataFor(swaggerDocUrl)
+            ).use { httpClient ->
+                httpClient.execute(request)
+            }
+        }
 
         if (response.status != 200) {
             logger.debug("Failed to query swaggerUI, status code: ${response.status}")
@@ -141,7 +153,14 @@ open class SpecmaticJUnitSupport {
     fun queryActuator(): ActuatorSetupResult {
         val endpointsAPI = specmaticConfig.getActuatorUrl() ?: return ActuatorSetupResult.Failure
         val request = HttpRequest("GET")
-        val response = LegacyHttpClient(endpointsAPI, log = ignoreLog, prettyPrint = prettyPrint).execute(request)
+        val response = HttpClient(
+            endpointsAPI,
+            log = ignoreLog,
+            prettyPrint = prettyPrint,
+            keyData = keyDataFor(endpointsAPI)
+        ).use { httpClient ->
+            httpClient.execute(request)
+        }
 
         if (response.status != 200) {
             logger.debug("Failed to query actuator, status code: ${response.status}")
@@ -379,7 +398,7 @@ open class SpecmaticJUnitSupport {
 
         settings.coverageHooks.forEach { it.onExampleErrors(testBuildResult.exampleValidationResults) }
         testBuildResult.baseUrls.forEach { baseUrl ->
-            if (isBaseURLReachable(baseUrl)) return@forEach
+            if (isBaseURLReachable(baseUrl, keyData = keyDataFor(baseUrl))) return@forEach
             return loadExceptionAsTestError(e = ContractException("""
             Cannot connect to server at: $baseUrl
             Please check:
@@ -491,6 +510,7 @@ open class SpecmaticJUnitSupport {
                             log = log,
                             timeoutInMilliseconds = timeoutInMilliseconds,
                             prettyPrint = prettyPrint,
+                            keyData = keyDataFor(baseURL),
                             httpInteractionsLog = httpInteractionsLog,
                         )
 
@@ -749,6 +769,18 @@ open class SpecmaticJUnitSupport {
         }
         return File(path).readText()
     }
+
+    private fun keyDataFor(url: String): KeyData? {
+        val uri = URI(url)
+        val host = uri.host ?: return null
+        val port = if (uri.port != -1) uri.port else when (uri.scheme?.lowercase()) {
+            "https" -> 443
+            "http" -> 80
+            else -> return null
+        }
+
+        return keyDataRegistry.get(host, port)
+    }
 }
 
 data class LoadedTestScenarios(
@@ -811,7 +843,7 @@ fun <T> selectTestsToRun(
 }
 
 
-fun isBaseURLReachable(baseUrl: String, timeOutMs: Int = 3000): Boolean {
+fun isBaseURLReachable(baseUrl: String, timeOutMs: Int = 3000, keyData: KeyData? = null): Boolean {
     return try {
         val url = if (baseUrl.endsWith("/")) baseUrl else "$baseUrl/"
         val connection = URL(url).openConnection() as HttpURLConnection
@@ -824,8 +856,15 @@ fun isBaseURLReachable(baseUrl: String, timeOutMs: Int = 3000): Boolean {
                     override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String) = Unit
                 }
             )
+
+            val keyManagers = keyData?.let {
+                KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm()).apply {
+                    init(it.keyStore, it.keyPassword.toCharArray())
+                }.keyManagers
+            }
+
             val sslContext = SSLContext.getInstance("TLS").apply {
-                init(null, trustAllCerts, SecureRandom())
+                init(keyManagers, trustAllCerts, SecureRandom())
             }
             connection.sslSocketFactory = sslContext.socketFactory
             connection.hostnameVerifier = HostnameVerifier { _, _ -> true }


### PR DESCRIPTION
**What**:

When mock runs with mTLS enabled, it will send a challenge to the client but will accept any certificate.

When test runs and receives an mTLS challenge, it will respond using the configured certificate.

Here's a sample config with mTLS support and certs configured.

```yaml
version: 3

systemUnderTest:
  service:
    definitions:
      - definition:
          source:
            filesystem:
              directory: ./specifications
          specs:
            - api.yaml
    runOptions:
      openapi:
        baseUrl: https://localhost:9443
        cert:
          keyStorePassword: client-store-pass
          keyStore:
            file: ./certs/client.pfx
            alias: specmatic-client
            password: client-store-pass

dependencies:
  services:
    - service:
        definitions:
          - definition:
              source:
                filesystem:
                  directory: ./specifications
              specs:
                - api.yaml
        runOptions:
          openapi:
            baseUrl: https://localhost:9443
            cert:
              mtlsEnabled: true
              keyStorePassword: server-store-pass
              keyStore:
                file: ./certs/server.pfx
                alias: specmatic-server
                password: server-store-pass
```

**Why**:

Services deployed in a testing environment may be behind an API gateway that leverages mTLS. Users testing their services in this environment cannot run contract tests without mTLS. Mocks may have to be started up with mTLS negotiation enabled in order to test mTLS support by the consumer components.

**Checklist**:
- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
