### PR TITLE
Ensure that the Result modifier operations retain metadata

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/Result.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Result.kt
@@ -7,8 +7,8 @@ import io.specmatic.core.value.Value
 import io.specmatic.reporter.model.TestResult
 
 sealed class Result {
-    var scenario: ScenarioDetailsForResult? = null
-    var contractPath: String? = null
+    abstract val scenario: ScenarioDetailsForResult?
+    abstract val contractPath: String?
 
     companion object {
         fun fromFailures(failures: List<Failure>): Result {
@@ -41,11 +41,8 @@ sealed class Result {
     }
 
     abstract fun isAnyFluffy(acceptableFluffLevel: Int): Boolean
-
-    fun updateScenario(scenario: ScenarioDetailsForResult?): Result {
-        this.scenario = scenario
-        return this
-    }
+    abstract fun updateScenario(scenario: ScenarioDetailsForResult?): Result
+    abstract fun updatePath(path: String?): Result
 
     abstract fun isSuccess(): Boolean
 
@@ -57,11 +54,6 @@ sealed class Result {
     open fun withRuleViolation(ruleViolation: RuleViolation): Result = this
 
     abstract fun shouldBeIgnored(): Boolean
-
-    fun updatePath(path: String): Result {
-        this.contractPath = path
-        return this
-    }
 
     fun toReport(scenarioMessage: String? = null): Report {
         return when (this) {
@@ -121,20 +113,32 @@ sealed class Result {
         }
     }
 
-    data class Failure(val causes: List<FailureCause> = emptyList(), val breadCrumb: String = "", val failureReason: FailureReason? = null, val isPartial: Boolean = false, val ruleViolationReport: RuleViolationReport? = null) : Result() {
+    data class Failure(
+        val causes: List<FailureCause> = emptyList(),
+        val breadCrumb: String = "",
+        val failureReason: FailureReason? = null,
+        val isPartial: Boolean = false,
+        val ruleViolationReport: RuleViolationReport? = null,
+        override val scenario: ScenarioDetailsForResult? = null,
+        override val contractPath: String? = null
+    ) : Result() {
         constructor(
             message: String = "",
             cause: Failure? = null,
             breadCrumb: String = "",
             failureReason: FailureReason? = null,
             isPartial: Boolean? = false,
-            ruleViolation: RuleViolation? = null
+            ruleViolation: RuleViolation? = null,
+            scenario: ScenarioDetailsForResult? = null,
+            contractPath: String? = null
         ) : this (
             causes = listOf(element = FailureCause(message, cause)),
             breadCrumb = breadCrumb,
             failureReason = failureReason,
             isPartial = isPartial ?: false,
-            ruleViolationReport = ruleViolation?.let(RuleViolationReport::from)
+            ruleViolationReport = ruleViolation?.let(RuleViolationReport::from),
+            scenario = scenario,
+            contractPath = contractPath
         )
 
         companion object {
@@ -179,6 +183,14 @@ sealed class Result {
             return this.scenario?.ignoreFailure == true
         }
 
+        override fun updatePath(path: String?): Failure {
+            return this.copy(contractPath = path)
+        }
+
+        override fun updateScenario(scenario: ScenarioDetailsForResult?): Failure {
+            return this.copy(scenario = scenario)
+        }
+
         override fun partialSuccess(message: String): Result {
             return this
         }
@@ -208,8 +220,8 @@ sealed class Result {
             return null
         }
 
-        fun reason(errorMessage: String) = Failure(errorMessage, this)
-        override fun breadCrumb(breadCrumb: String) = Failure(cause = this, breadCrumb = breadCrumb, isPartial = isPartial)
+        fun reason(errorMessage: String) = Failure(errorMessage, this, scenario = scenario, contractPath = contractPath)
+        override fun breadCrumb(breadCrumb: String) = Failure(cause = this, breadCrumb = breadCrumb, isPartial = isPartial, scenario = scenario, contractPath = contractPath)
         override fun failureReason(failureReason: FailureReason?): Result {
             return this.copy(failureReason = failureReason)
         }
@@ -323,13 +335,27 @@ sealed class Result {
         }
     }
 
-    data class Success(val variables: Map<String, String> = emptyMap(), val partialSuccessMessage: String? = null) : Result() {
+    data class Success(
+        val variables: Map<String, String> = emptyMap(),
+        val partialSuccessMessage: String? = null,
+        override val scenario: ScenarioDetailsForResult? = null,
+        override val contractPath: String? = null
+    ) : Result() {
         override fun isAnyFluffy(acceptableFluffLevel: Int): Boolean {
             return false
         }
 
         override fun isSuccess() = true
         override fun ifSuccess(function: () -> Result) = function()
+
+        override fun updatePath(path: String?): Success {
+            return this.copy(contractPath = path)
+        }
+
+        override fun updateScenario(scenario: ScenarioDetailsForResult?): Success {
+            return this.copy(scenario = scenario)
+        }
+
         override fun withBindings(bindings: Map<String, String>, response: HttpResponse): Result {
             return this.copy(variables = response.export(bindings))
         }

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -211,11 +211,10 @@ data class Scenario(
         headersResolver: Resolver
     ): Result {
         if (!serverStateMatches(serverState, resolver)) {
-            return Result.Failure("Facts mismatch", breadCrumb = "FACTS").also { it.updateScenario(this) }
+            return Result.Failure("Facts mismatch", breadCrumb = "FACTS").updateScenario(this)
         }
-        return httpRequestPattern.matches(httpRequest, resolver, headersResolver).also {
-            it.updateScenario(this)
-        }
+
+        return httpRequestPattern.matches(httpRequest, resolver, headersResolver).updateScenario(this)
     }
 
     fun generateHttpResponse(actualFacts: Map<String, Value>, requestContext: Context = NoContext): HttpResponse =

--- a/core/src/main/kotlin/io/specmatic/core/TestBackwardCompatibility.kt
+++ b/core/src/main/kotlin/io/specmatic/core/TestBackwardCompatibility.kt
@@ -46,14 +46,12 @@ fun testBackwardCompatibility(
                     newerResponsePattern,
                     oldScenario.resolver.copy(mismatchMessages = NewAndOldSpecificationResponseMismatches),
                     newerScenario.resolver.copy(mismatchMessages = NewAndOldSpecificationResponseMismatches),
-                ).also {
-                    it.scenario = newerScenario
-                }
+                )
 
                 if (responseResult.isFluffy())
                     null
                 else
-                    Pair(requestResult, responseResult)
+                    Pair(requestResult, responseResult.updateScenario(newerScenario))
             }
 
         if(wholeMatchResults.isEmpty())

--- a/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
@@ -213,8 +213,7 @@ data class ScenarioAsTest(
             )
         } catch (exception: Throwable) {
             return ContractTestExecutionResult(
-                result = Result.Failure(exceptionCauseMessage(exception))
-                    .also { failure -> failure.updateScenario(testScenario) }
+                result = Result.Failure(exceptionCauseMessage(exception)).updateScenario(testScenario)
             )
         }
     }

--- a/core/src/test/kotlin/io/specmatic/core/ResultKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ResultKtTest.kt
@@ -1,22 +1,33 @@
 package io.specmatic.core
 
+import io.specmatic.core.Result.Failure
+import io.specmatic.core.Result.Success
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.util.function.Consumer
 
 internal class ResultKtTest {
+    private val scenario = object : ScenarioDetailsForResult {
+        override val status: Int = 200
+        override val ignoreFailure: Boolean = false
+        override val name: String = "scenario"
+        override val method: String = "GET"
+        override val path: String = "/route"
+        override fun testDescription(): String = "scenario description"
+    }
+
     @Test
     fun `add response body to result variables`() {
-        val result = Result.Success().withBindings(mapOf("data" to "response-body"), HttpResponse.ok("10")) as Result.Success
+        val result = Success().withBindings(mapOf("data" to "response-body"), HttpResponse.ok("10")) as Success
         assertThat(result.variables).isEqualTo(mapOf("data" to "10"))
     }
 
     @Test
     fun `result report for failure with multiple causes`() {
-        val result = Result.Failure(
+        val result = Failure(
             causes = listOf(
-                Result.FailureCause("", cause = Result.Failure("Failure 1", breadCrumb = "id")),
-                Result.FailureCause("", cause = Result.Failure("Failure 2", breadCrumb = "height"))
+                Result.FailureCause("", cause = Failure("Failure 1", breadCrumb = "id")),
+                Result.FailureCause("", cause = Failure("Failure 2", breadCrumb = "height"))
             ), breadCrumb = "person"
         )
 
@@ -28,5 +39,40 @@ internal class ResultKtTest {
 
             println(result.reportString())
         })
+    }
+
+    @Test
+    fun `failure copy operation should preserve metadata`() {
+        val baseFailure = Failure(message = "error").updateScenario(scenario).updatePath("contract-path-failure")
+        val transformedFailure = baseFailure.copy(breadCrumb = "REQUEST")
+        assertMetadata(transformedFailure, scenario, "contract-path-failure")
+    }
+
+    @Test
+    fun `failure nesting operations should preserve metadata`() {
+        val baseFailure = Failure(message = "error").updateScenario(scenario).updatePath("contract-path-failure")
+        assertMetadata(baseFailure.reason("nested"), scenario, "contract-path-failure")
+        assertMetadata(baseFailure.breadCrumb("REQUEST"), scenario, "contract-path-failure")
+    }
+
+    @Test
+    fun `success copy operation should preserve metadata`() {
+        val baseSuccess = Success().updateScenario(scenario).updatePath("contract-path-success") as Success
+        val transformedSuccess = baseSuccess.copy(variables = mapOf("x" to "1"))
+        assertMetadata(transformedSuccess, scenario, "contract-path-success")
+    }
+
+    @Test
+    fun `failure aggregation operation should not use metadata from one of the failures`() {
+        val first = Failure("error-1").updateScenario(scenario).updatePath("contract-path-1")
+        val second = Failure("error-2").updateScenario(scenario).updatePath("contract-path-2")
+        val result = Result.fromFailures(listOf(first, second))
+        assertThat(result.scenario).isNull()
+        assertThat(result.contractPath).isNull()
+    }
+
+    private fun assertMetadata(result: Result, scenario: ScenarioDetailsForResult?, contractPath: String?) {
+        assertThat(result.scenario).isEqualTo(scenario)
+        assertThat(result.contractPath).isEqualTo(contractPath)
     }
 }

--- a/junit5-support/src/test/kotlin/io/specmatic/test/listeners/ContractExecutionListenerTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/listeners/ContractExecutionListenerTest.kt
@@ -47,8 +47,7 @@ class ContractExecutionListenerTest {
     fun `test plan reports partial successes`() {
         val listener = ContractExecutionListener()
 
-        val partialSuccess = Result.Success(partialSuccessMessage = "partial coverage")
-        partialSuccess.scenario = FakeScenario()
+        val partialSuccess = Result.Success(partialSuccessMessage = "partial coverage").updateScenario(FakeScenario())
         SpecmaticJUnitSupport.partialSuccesses.add(partialSuccess)
 
         listener.testPlanExecutionFinished(null)


### PR DESCRIPTION
**What**: Ensure that the Result modifier operations retain metadata

**How**:
- Abstracted `scenario` and `contractPath`
- Update the call sites to avoid wrapping the update in `also` that can drop the new instance

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)