### PR TITLE
Fix OAS 3.1 referenced parameter resolution

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/APIKeyInHeaderSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/APIKeyInHeaderSecurityScheme.kt
@@ -1,6 +1,5 @@
 package io.specmatic.conversions
 
-import io.specmatic.conversions.lenient.CollectorContext
 import io.specmatic.core.*
 import io.specmatic.core.pattern.Row
 import io.specmatic.core.pattern.StringPattern
@@ -43,13 +42,12 @@ data class APIKeyInHeaderSecurityScheme(val name: String, private val apiKey:Str
         return request.hasHeader(name)
     }
 
-    override fun collectErrorIfExistsInParameters(parameter: List<IndexedValue<Parameter>>, collectorContext: CollectorContext) {
-        parameter.filter { indexedValue -> indexedValue.value is HeaderParameter }.forEach { (index, value) ->
-            val paramContext = collectorContext.at("parameters").at(index)
-            paramContext.check(name = "name", value = value, isValid = { !it.name.equals(name, ignoreCase = true) })
+    override fun collectErrorIfExistsInParameters(parameter: List<ParameterWithContext<Parameter>>) {
+        parameter.filter { parameterWithContext -> parameterWithContext.parameter is HeaderParameter }.forEach { parameterWithContext ->
+            parameterWithContext.collectorContext.check(name = "name", value = parameterWithContext.parameter, isValid = { !it.name.equals(name, ignoreCase = true) })
                 .violation { OpenApiLintViolations.SECURITY_PROPERTY_REDEFINED }
                 .message { "Found header parameter with same name as header api-key security scheme \"$name\"" }
-                .orUse { value }
+                .orUse { parameterWithContext.parameter }
                 .build(isWarning = true)
         }
     }

--- a/core/src/main/kotlin/io/specmatic/conversions/APIKeyInQueryParamSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/APIKeyInQueryParamSecurityScheme.kt
@@ -1,6 +1,5 @@
 package io.specmatic.conversions
 
-import io.specmatic.conversions.lenient.CollectorContext
 import io.specmatic.core.*
 import io.specmatic.core.pattern.*
 import io.specmatic.core.value.StringValue
@@ -60,13 +59,12 @@ data class APIKeyInQueryParamSecurityScheme(val name: String, private val apiKey
         return apiKeyParamName
     }
 
-    override fun collectErrorIfExistsInParameters(parameter: List<IndexedValue<Parameter>>, collectorContext: CollectorContext) {
-        parameter.filter { indexedValue -> indexedValue.value is QueryParameter }.forEach { (index, value) ->
-            val paramContext = collectorContext.at("parameters").at(index)
-            paramContext.check(name = "name", value = value, isValid = { !it.name.equals(name, ignoreCase = true) })
+    override fun collectErrorIfExistsInParameters(parameter: List<ParameterWithContext<Parameter>>) {
+        parameter.filter { parameterWithContext -> parameterWithContext.parameter is QueryParameter }.forEach { parameterWithContext ->
+            parameterWithContext.collectorContext.check(name = "name", value = parameterWithContext.parameter, isValid = { !it.name.equals(name, ignoreCase = true) })
                 .violation { OpenApiLintViolations.SECURITY_PROPERTY_REDEFINED }
                 .message { "Found query parameter with same name as query api-key security scheme \"$name\"" }
-                .orUse { value }
+                .orUse { parameterWithContext.parameter }
                 .build(isWarning = true)
         }
     }

--- a/core/src/main/kotlin/io/specmatic/conversions/BasicAuthSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/BasicAuthSecurityScheme.kt
@@ -1,6 +1,5 @@
 package io.specmatic.conversions
 
-import io.specmatic.conversions.lenient.CollectorContext
 import io.specmatic.core.*
 import io.specmatic.core.pattern.*
 import io.specmatic.core.value.StringValue
@@ -136,13 +135,12 @@ data class BasicAuthSecurityScheme(private val token: String? = null) : OpenAPIS
         return AUTHORIZATION
     }
 
-    override fun collectErrorIfExistsInParameters(parameter: List<IndexedValue<Parameter>>, collectorContext: CollectorContext) {
-        parameter.filter { indexedValue -> indexedValue.value is HeaderParameter }.forEach { (index, value) ->
-            val paramContext = collectorContext.at("parameters").at(index)
-            paramContext.check(name = "name", value = value, isValid = { !it.name.equals(AUTHORIZATION, ignoreCase = true) })
+    override fun collectErrorIfExistsInParameters(parameter: List<ParameterWithContext<Parameter>>) {
+        parameter.filter { parameterWithContext -> parameterWithContext.parameter is HeaderParameter }.forEach { parameterWithContext ->
+            parameterWithContext.collectorContext.check(name = "name", value = parameterWithContext.parameter, isValid = { !it.name.equals(AUTHORIZATION, ignoreCase = true) })
                 .violation { OpenApiLintViolations.SECURITY_PROPERTY_REDEFINED }
                 .message { "Found header parameter with same name as Basic Auth security scheme" }
-                .orUse { value }
+                .orUse { parameterWithContext.parameter }
                 .build(isWarning = true)
         }
     }

--- a/core/src/main/kotlin/io/specmatic/conversions/BearerSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/BearerSecurityScheme.kt
@@ -1,6 +1,5 @@
 package io.specmatic.conversions
 
-import io.specmatic.conversions.lenient.CollectorContext
 import io.specmatic.core.*
 import io.specmatic.core.pattern.Row
 import io.specmatic.core.pattern.StringPattern
@@ -67,13 +66,12 @@ data class BearerSecurityScheme(private val configuredToken: String? = null) : O
         return AUTHORIZATION
     }
 
-    override fun collectErrorIfExistsInParameters(parameter: List<IndexedValue<Parameter>>, collectorContext: CollectorContext) {
-        parameter.filter { indexedValue -> indexedValue.value is HeaderParameter }.forEach { (index, value) ->
-            val paramContext = collectorContext.at("parameters").at(index)
-            paramContext.check(name = "name", value = value, isValid = { !it.name.equals(AUTHORIZATION, ignoreCase = true) })
+    override fun collectErrorIfExistsInParameters(parameter: List<ParameterWithContext<Parameter>>) {
+        parameter.filter { parameterWithContext -> parameterWithContext.parameter is HeaderParameter }.forEach { parameterWithContext ->
+            parameterWithContext.collectorContext.check(name = "name", value = parameterWithContext.parameter, isValid = { !it.name.equals(AUTHORIZATION, ignoreCase = true) })
                 .violation { OpenApiLintViolations.SECURITY_PROPERTY_REDEFINED }
                 .message { "Found header parameter with same name as Bearer Authorization security scheme" }
-                .orUse { value }
+                .orUse { parameterWithContext.parameter }
                 .build(isWarning = true)
         }
     }

--- a/core/src/main/kotlin/io/specmatic/conversions/CompositeSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/CompositeSecurityScheme.kt
@@ -1,6 +1,5 @@
 package io.specmatic.conversions
 
-import io.specmatic.conversions.lenient.CollectorContext
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpRequestPattern
 import io.specmatic.core.Resolver
@@ -47,9 +46,9 @@ data class CompositeSecurityScheme(val schemes: List<OpenAPISecurityScheme>): Op
         else schemes.all { it.isInRequest(request, true) }
     }
 
-    override fun collectErrorIfExistsInParameters(parameter: List<IndexedValue<Parameter>>, collectorContext: CollectorContext) {
+    override fun collectErrorIfExistsInParameters(parameter: List<ParameterWithContext<Parameter>>) {
         schemes.forEach { securityScheme ->
-            securityScheme.collectErrorIfExistsInParameters(parameter, collectorContext)
+            securityScheme.collectErrorIfExistsInParameters(parameter)
         }
     }
 }

--- a/core/src/main/kotlin/io/specmatic/conversions/NoSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/NoSecurityScheme.kt
@@ -1,6 +1,5 @@
 package io.specmatic.conversions
 
-import io.specmatic.conversions.lenient.CollectorContext
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpRequestPattern
 import io.specmatic.core.Resolver
@@ -45,7 +44,7 @@ class NoSecurityScheme : OpenAPISecurityScheme {
         return false
     }
 
-    override fun collectErrorIfExistsInParameters(parameter: List<IndexedValue<Parameter>>, collectorContext: CollectorContext) {
+    override fun collectErrorIfExistsInParameters(parameter: List<ParameterWithContext<Parameter>>) {
         return
     }
 }

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenAPISecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenAPISecurityScheme.kt
@@ -1,6 +1,5 @@
 package io.specmatic.conversions
 
-import io.specmatic.conversions.lenient.CollectorContext
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpRequestPattern
 import io.specmatic.core.Resolver
@@ -18,7 +17,7 @@ interface OpenAPISecurityScheme {
     fun isInRow(row: Row): Boolean
     fun isInRequest(request: HttpRequest, complete: Boolean): Boolean
     fun getHeaderKey(): String? = null
-    fun collectErrorIfExistsInParameters(parameter: List<IndexedValue<Parameter>>, collectorContext: CollectorContext)
+    fun collectErrorIfExistsInParameters(parameter: List<ParameterWithContext<Parameter>>)
 }
 
 fun addToHeaderType(

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -77,6 +77,7 @@ internal fun missingResponseExampleErrorMessageForTest(exampleName: String): Str
 
 private const val SPECMATIC_TEST_WITH_NO_REQ_EX = "SPECMATIC-TEST-WITH-NO-REQ-EX"
 
+data class ParameterWithContext<T: Parameter>(val parameter: T, val collectorContext: CollectorContext)
 data class OperationMetadata(
     val tags: List<String> = emptyList(),
     val summary: String = "",
@@ -1178,9 +1179,11 @@ class OpenApiSpecification(
     }
 
     private fun parameterExamples(parameters: List<Parameter>, exampleName: String): Map<String, Any> {
-        return parameters.safeFilter<Parameter>(CollectorContext()).filter { (_, parameter) ->
+        return parameters.safeFilter<Parameter>(CollectorContext()).filter { parameterWithContext ->
+            val parameter = parameterWithContext.parameter
             parameter.examples.orEmpty().any { it.key == exampleName }
-        }.associate { (_, parameter) ->
+        }.associate { parameterWithContext ->
+            val parameter = parameterWithContext.parameter
             // TODO: Collect as error
             val exampleValue: Example = parameter.examples[exampleName] ?: throw ContractException("The value of ${parameter.name} in example $exampleName was unexpectedly found to be null.")
             parameter.name to (resolveExample(exampleValue)?.value ?: "")
@@ -1413,13 +1416,13 @@ class OpenApiSpecification(
         val securitySchemesForRequestPattern = parseOperationSecuritySchemas(operation, securitySchemeComponents, collectorContext)
         validateSecuritySchemeParameterDuplication(
             securitySchemes = securitySchemesForRequestPattern,
-            parameters = parameters.safeFilter<Parameter>(collectorContext),
-            collectorContext = collectorContext
+            parameters = parameters.safeFilter<Parameter>(collectorContext)
         )
 
-        val headersMap = parameters.safeFilter<HeaderParameter>(collectorContext).associate { (index, parameter) ->
+        val headersMap = parameters.safeFilter<HeaderParameter>(collectorContext).associate { parameterWithContext ->
+            val parameter = parameterWithContext.parameter
             logger.debug("Processing request header ${parameter.name}")
-            val headerParamScope = collectorContext.at("parameters").at(index)
+            val headerParamScope = parameterWithContext.collectorContext
             toSpecmaticParamName(parameter.required != true, parameter.name) to Pair(
                 first = toSpecmaticPattern(schema = parameter.schema, typeStack = emptyList(), collectorContext = headerParamScope.at("schema")),
                 second = headerParamScope
@@ -1657,7 +1660,7 @@ class OpenApiSpecification(
 
     private inline fun <reified T : Parameter> namedExampleParams(parameters: List<Parameter>): Map<String, Map<String, String>> {
         if (specmaticConfig.getIgnoreInlineExamples()) return emptyMap()
-        return parameters.safeFilter<T>(CollectorContext()).map { it.value }.fold(emptyMap()) { acc, parameter ->
+        return parameters.safeFilter<T>(CollectorContext()).map { it.parameter }.fold(emptyMap()) { acc, parameter ->
             extractParameterExamples(parameter.examples, parameter.name, acc)
         }
     }
@@ -2573,30 +2576,30 @@ class OpenApiSpecification(
 
     private fun toSpecmaticQueryParam(parameters: List<Parameter>, collectorContext: CollectorContext, extensibleQueryParams: Boolean): HttpQueryParamPattern {
         val queryParameters = parameters.safeFilter<QueryParameter>(collectorContext)
-        val parametersContext = collectorContext.at("parameters")
-        val queryPattern: Map<String, Pattern> = queryParameters.associate { (index, it) ->
-            logger.debug("Processing query parameter ${it.name}")
-            val queryParamContext = parametersContext.at(index)
-            val (resolvedSchema, paramContext) = resolveSchemaIfRefElseAtSchema(it.schema, collectorContext = queryParamContext)
+        val queryPattern: Map<String, Pattern> = queryParameters.associate { queryParamWithContext ->
+            val parameter = queryParamWithContext.parameter
+            logger.debug("Processing query parameter ${parameter.name}")
+            val queryParamContext = queryParamWithContext.collectorContext
+            val (resolvedSchema, paramContext) = resolveSchemaIfRefElseAtSchema(parameter.schema, collectorContext = queryParamContext)
             val specmaticPattern: Pattern? = if (resolvedSchema.isSchema(ARRAY_TYPE)) {
                 val itemsSchema = paramContext.requirePojo(extract = { resolvedSchema.items }, createDefault = { Schema<Any>() }, message = { "No items schema defined for array schema defaulting to empty schema" })
-                QueryParameterArrayPattern(listOf(toSpecmaticPattern(schema = itemsSchema, typeStack = emptyList(), collectorContext = paramContext.at("items"))), it.name)
+                QueryParameterArrayPattern(listOf(toSpecmaticPattern(schema = itemsSchema, typeStack = emptyList(), collectorContext = paramContext.at("items"))), parameter.name)
             } else if (!resolvedSchema.isSchema(OBJECT_TYPE)) {
-                QueryParameterScalarPattern(toSpecmaticPattern(schema = it.schema, typeStack = emptyList(), collectorContext = queryParamContext.at("schema")))
+                QueryParameterScalarPattern(toSpecmaticPattern(schema = parameter.schema, typeStack = emptyList(), collectorContext = queryParamContext.at("schema")))
             } else {
                 queryParamContext.at("schema").record(
-                    message = "Query parameter ${it.name} is an object, and not yet supported",
+                    message = "Query parameter ${parameter.name} is an object, and not yet supported",
                     ruleViolation = OpenApiLintViolations.UNSUPPORTED_FEATURE,
                     isWarning = true
                 )
                 null
             }
 
-            val queryParamKey = if (it.required == true) it.name else "${it.name}?"
+            val queryParamKey = if (parameter.required == true) parameter.name else "${parameter.name}?"
             queryParamKey to specmaticPattern
         }.filterValues { it != null }.mapValues { it.value!! }
 
-        val additionalProperties = additionalPropertiesInQueryParam(queryParameters, collectorContext)
+        val additionalProperties = additionalPropertiesInQueryParam(queryParameters)
         return HttpQueryParamPattern(
             queryPattern,
             additionalProperties,
@@ -2604,15 +2607,13 @@ class OpenApiSpecification(
         )
     }
 
-    private fun additionalPropertiesInQueryParam(queryParameters: List<IndexedValue<QueryParameter>>, collectorContext: CollectorContext): Pattern? {
-        val (index, additionalProperties) = queryParameters.firstOrNull { indexedParam ->
-            val (_, parameter) = indexedParam
-            parameter.schema.isSchema(OBJECT_TYPE, multi = false) && parameter.schema.extractAdditionalProperties() != null
-        }?.let {
-            it.index to it.value.schema.extractAdditionalProperties()
+    private fun additionalPropertiesInQueryParam(queryParameters: List<ParameterWithContext<QueryParameter>>): Pattern? {
+        val queryParamWithContext = queryParameters.firstOrNull {
+            it.parameter.schema.isSchema(OBJECT_TYPE, multi = false) && it.parameter.schema.extractAdditionalProperties() != null
         } ?: return null
+        val additionalProperties = queryParamWithContext.parameter.schema.extractAdditionalProperties() ?: return null
 
-        val additionalPropContext = collectorContext.at(index).at("additionalProperties")
+        val additionalPropContext = queryParamWithContext.collectorContext.at("additionalProperties")
         return when (additionalProperties) {
             true -> AnythingPattern
             is Schema<*> -> toSpecmaticPattern(additionalProperties, emptyList(), collectorContext = additionalPropContext)
@@ -2628,7 +2629,7 @@ class OpenApiSpecification(
 
         val pathParamMap = parameters
             .safeFilter<PathParameter>(collectorContext)
-            .associateBy { indexedParam -> indexedParam.value.name }
+            .associateBy { parameterWithContext -> parameterWithContext.parameter.name }
 
         val parameterContext = collectorContext.at("parameters")
         val pathPattern = pathSegments.mapIndexed { _, pathSegment ->
@@ -2638,15 +2639,12 @@ class OpenApiSpecification(
             }
 
             val paramName = pathSegment.removeSurrounding("{", "}")
-            val pathParamContext = if (pathParamMap.containsKey(paramName)) {
-                parameterContext.at(pathParamMap.getValue(paramName).index)
-            } else {
-                parameterContext
-            }
+            val resolvedPathParameter = pathParamMap[paramName]
+            val pathParamContext = resolvedPathParameter?.collectorContext ?: parameterContext
 
             val parameter = pathParamContext.requirePojo(
                 message = { "Expected path parameter with name $paramName is missing, defaulting to empty schema" },
-                extract = { pathParamMap[paramName]?.value },
+                extract = { resolvedPathParameter?.parameter },
                 ruleViolation = { OpenApiLintViolations.PATH_PARAMETER_MISSING },
                 createDefault = {
                     PathParameter().apply {
@@ -2672,7 +2670,7 @@ class OpenApiSpecification(
 
     private fun toSpecmaticFormattedPathString(parameters: List<Parameter>, openApiPath: String): String {
         val throwAwayCollectorContext = CollectorContext()
-        return parameters.safeFilter<PathParameter>(throwAwayCollectorContext).map { it.value }.foldRight(openApiPath) { it, specmaticPath ->
+        return parameters.safeFilter<PathParameter>(throwAwayCollectorContext).map { it.parameter }.foldRight(openApiPath) { it, specmaticPath ->
             val pattern = if (it.schema.enum != null) StringPattern("") else toSpecmaticPattern(it.schema, emptyList(), collectorContext = throwAwayCollectorContext)
             specmaticPath.replace("{${it.name}}", "(${it.name}:${pattern.typeName})")
         }
@@ -2817,30 +2815,53 @@ class OpenApiSpecification(
         return SchemaMeta(isNullable, isMulti, effectiveTypes)
     }
 
-    private inline fun <reified T: Parameter> List<Parameter>.safeFilter(collectorContext: CollectorContext): List<IndexedValue<T>> {
+    private fun resolveParameter(parameter: Parameter, collectorContext: CollectorContext): Pair<Parameter, CollectorContext> {
+        if (parameter.`$ref` == null) return Pair(parameter, collectorContext)
+        val parameterComponentName = extractComponentName(parameter.`$ref`, collectorContext)
+        val hasReusableParameter = parsedOpenApi.components?.parameters?.contains(parameterComponentName) == true
+
+        val resolvedParameter = collectorContext.at("\$ref").requirePojo(
+            message = { "Parameter reference '${parameter.`$ref`}' could not be resolved, keeping unresolved parameter definition" },
+            extract = { parsedOpenApi.components?.parameters?.get(parameterComponentName) },
+            ruleViolation = { OpenApiLintViolations.UNRESOLVED_REFERENCE },
+            createDefault = { parameter }
+        )
+
+        val parameterContext = if (hasReusableParameter) {
+            collectorContext.withPath("components").at("parameters").at(parameterComponentName)
+        } else {
+            collectorContext
+        }
+
+        return Pair(resolvedParameter, parameterContext)
+    }
+
+    private inline fun <reified T: Parameter> List<Parameter>.safeFilter(collectorContext: CollectorContext): List<ParameterWithContext<T>> {
         val parameterContext = collectorContext.at("parameters")
         return this.mapIndexedNotNull { index, parameter ->
-            if (parameter !is T) return@mapIndexedNotNull null
             val itemContext = parameterContext.at(index)
-            val validNameParam = itemContext.check<T?>(parameter) { it?.name != null }
+            val (resolvedParameter, resolvedParameterContext) = resolveParameter(parameter, itemContext)
+            if (resolvedParameter !is T) return@mapIndexedNotNull null
+
+            val validNameParam = resolvedParameterContext.check<T?>(resolvedParameter) { it?.name != null }
                 .violation { OpenApiLintViolations.INVALID_PARAMETER_DEFINITION }
                 .message { "Parameter has no name defined, ignoring this parameter" }
                 .orUse { null }
                 .build() ?: return@mapIndexedNotNull null
 
-            val schemaEnsuredParameter = itemContext.check(value = validNameParam) { it.schema != null }
+            val schemaEnsuredParameter = resolvedParameterContext.check(value = validNameParam) { it.schema != null }
                 .violation { OpenApiLintViolations.INVALID_PARAMETER_DEFINITION }
                 .message { "Parameter has no schema defined, defaulting to empty schema" }
                 .orUse { validNameParam.apply { schema = Schema<Any>() } }
                 .build()
 
-            val itemsSchemaEnsuredParameter = itemContext.at("schema").check(value = schemaEnsuredParameter) { !it.schema.isSchema("array") || it.schema.items != null }
+            val itemsSchemaEnsuredParameter = resolvedParameterContext.at("schema").check(value = schemaEnsuredParameter) { !it.schema.isSchema("array") || it.schema.items != null }
                 .violation { OpenApiLintViolations.INVALID_PARAMETER_DEFINITION }
                 .message { "Array Parameter has no items schema defined, defaulting to empty schema" }
                 .orUse { schemaEnsuredParameter.apply { schema.apply { items = Schema<Any>() } } }
                 .build()
 
-            IndexedValue(index, itemsSchemaEnsuredParameter)
+            ParameterWithContext(itemsSchemaEnsuredParameter, resolvedParameterContext)
         }
     }
 
@@ -2885,8 +2906,8 @@ private fun Pattern.isConstrainedStringOrEnumPattern(): Boolean {
     }
 }
 
-internal fun validateSecuritySchemeParameterDuplication(securitySchemes: List<OpenAPISecurityScheme>, parameters: List<IndexedValue<Parameter>>?, collectorContext: CollectorContext) {
+internal fun validateSecuritySchemeParameterDuplication(securitySchemes: List<OpenAPISecurityScheme>, parameters: List<ParameterWithContext<Parameter>>?) {
     securitySchemes.forEach { securityScheme ->
-        securityScheme.collectErrorIfExistsInParameters(parameters.orEmpty(), collectorContext)
+        securityScheme.collectErrorIfExistsInParameters(parameters.orEmpty())
     }
 }

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -719,7 +719,7 @@ class OpenApiSpecification(
                     logger.debug("${System.lineSeparator()}Processing $httpMethod $openApiPath")
 
                     val methodContext = pathsContext.at(openApiPath).at(httpMethod.lowercase())
-                    val parameters = (pathItem.parameters.orEmpty() + openApiOperation.parameters.orEmpty()).distinctByNameAndLocation()
+                    val parameters = (pathItem.parameters.orEmpty() + openApiOperation.parameters.orEmpty()).distinctByNameAndLocation(methodContext)
                     val specmaticPathParam = toSpecmaticPathParam(
                         openApiPath = openApiPath,
                         parameters = parameters,
@@ -885,14 +885,29 @@ class OpenApiSpecification(
             val pathContext = collectorContext.at(openApiPath)
             openApiOperations(pathItem).map { (httpMethod, openApiOperation) ->
                 val methodContext = pathContext.at(httpMethod.lowercase())
-                val parameters = (pathItem.parameters.orEmpty() + openApiOperation.parameters.orEmpty()).distinctByNameAndLocation()
+                val parameters = (pathItem.parameters.orEmpty() + openApiOperation.parameters.orEmpty()).distinctByNameAndLocation(methodContext)
                 httpMethod to toSpecmaticPathParam(openApiPath = openApiPath, parameters = parameters, collectorContext = methodContext)
             }
         }.groupBy({ it.first }, { it.second })
     }
 
-    private fun List<Parameter>.distinctByNameAndLocation(): List<Parameter> {
-        return associateBy { it.name to it.`in` }.values.toList()
+    private fun List<Parameter>.distinctByNameAndLocation(collectorContext: CollectorContext): List<Parameter> {
+        val parameterContext = collectorContext.at("parameters")
+        return mapIndexed { index, parameter ->
+            keyForParameter(parameter, index, parameterContext) to parameter
+        }.foldRight(emptySet<String>() to emptyList<Parameter>()) { (key, parameter), (seen, kept) ->
+            if (key in seen) return@foldRight seen to kept
+            seen.plus(key) to listOf(parameter).plus(kept)
+        }.second
+    }
+
+    private fun keyForParameter(parameter: Parameter, index: Int, parameterContext: CollectorContext): String {
+        val (resolved, _) = resolveParameter(parameter, parameterContext.at(index))
+        return when {
+            resolved.name != null && resolved.`in` != null -> "name:${resolved.name}|in:${resolved.`in`}"
+            parameter.`$ref` != null -> "ref:${parameter.`$ref`}"
+            else -> "index:$index"
+        }
     }
 
     private fun getUpdatedScenarioInfosWithNoBodyResponseExamples(

--- a/core/src/test/kotlin/integration_tests/LenientParserTest.kt
+++ b/core/src/test/kotlin/integration_tests/LenientParserTest.kt
@@ -206,6 +206,120 @@ class LenientParserTest {
                         toContainText("We will use a more reasonable minLength of 4MB")
                     }
                 },
+                singleVersionLenientCase(name = "refed out parameter has no schema", version = OpenApiVersion.OAS30) {
+                    openApi {
+                        paths {
+                            path("/test/{id}") {
+                                operation("get") {
+                                    parameter {
+                                        put($$"$ref", "#/components/parameters/IdPathParam")
+                                    }
+                                }
+                            }
+                        }
+                        components {
+                            parameters {
+                                parameter("IdPathParam") {
+                                    put("name", "id")
+                                    put("in", "path")
+                                    put("required", true)
+                                }
+                            }
+                        }
+                    }
+                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(1); totalViolations(1) }
+                    assert("paths./test/{id}.get.parameters[0]") {
+                        toHaveSeverity(IssueSeverity.ERROR)
+                        toContainViolation(OpenApiLintViolations.INVALID_PARAMETER_DEFINITION)
+                        toMatchText("Parameter has no schema defined, defaulting to empty schema")
+                    }
+                },
+                singleVersionLenientCase(name = "refed out parameter schema has issue", version = OpenApiVersion.OAS30) {
+                    openApi {
+                        paths {
+                            path("/test/{id}") {
+                                operation("get") {
+                                    parameter {
+                                        put($$"$ref", "#/components/parameters/IdPathParam")
+                                    }
+                                }
+                            }
+                        }
+                        components {
+                            parameters {
+                                parameter("IdPathParam") {
+                                    put("name", "id")
+                                    put("in", "path")
+                                    put("required", true)
+                                    put("schema", mapOf("type" to "string", "minLength" to REASONABLE_STRING_LENGTH.plus(10)))
+                                }
+                            }
+                        }
+                    }
+                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(1); totalViolations(1) }
+                    assert("paths./test/{id}.get.parameters[0].schema.minLength") {
+                        toHaveSeverity(IssueSeverity.WARNING)
+                        toContainViolation(OpenApiLintViolations.LENGTH_EXCEEDS_LIMIT)
+                        toContainText("We will use a more reasonable minLength of 4MB")
+                    }
+                },
+                singleVersionLenientCase(name = "refed out parameter has no schema", version = OpenApiVersion.OAS31) {
+                    openApi {
+                        paths {
+                            path("/test/{id}") {
+                                operation("get") {
+                                    parameter {
+                                        put($$"$ref", "#/components/parameters/IdPathParam")
+                                    }
+                                }
+                            }
+                        }
+                        components {
+                            parameters {
+                                parameter("IdPathParam") {
+                                    put("name", "id")
+                                    put("in", "path")
+                                    put("required", true)
+                                }
+                            }
+                        }
+                    }
+                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(1); totalViolations(1) }
+                    assert("components.parameters.IdPathParam") {
+                        toHaveSeverity(IssueSeverity.ERROR)
+                        toContainViolation(OpenApiLintViolations.INVALID_PARAMETER_DEFINITION)
+                        toMatchText("Parameter has no schema defined, defaulting to empty schema")
+                    }
+                },
+                singleVersionLenientCase(name = "refed out parameter schema has issue", version = OpenApiVersion.OAS31) {
+                    openApi {
+                        paths {
+                            path("/test/{id}") {
+                                operation("get") {
+                                    parameter {
+                                        put($$"$ref", "#/components/parameters/IdPathParam")
+                                    }
+                                }
+                            }
+                        }
+                        components {
+                            parameters {
+                                parameter("IdPathParam") {
+                                    put("name", "id")
+                                    put("in", "path")
+                                    put("required", true)
+                                    put("schema", mapOf("type" to "string", "minLength" to REASONABLE_STRING_LENGTH.plus(10)))
+                                }
+                            }
+                        }
+                    }
+                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(1); totalViolations(1) }
+                    assert("components.parameters.IdPathParam.schema.minLength") {
+                        toHaveSeverity(IssueSeverity.WARNING)
+                        toContainViolation(OpenApiLintViolations.LENGTH_EXCEEDS_LIMIT)
+                        toContainText("We will use a more reasonable minLength of 4MB")
+                    }
+                },
             ).flatten().stream()
         }
 
@@ -3492,6 +3606,11 @@ data class LenientParseTestCase(val openApi: Map<String, Any?>, val checks: List
                 block(SchemasDsl(schemas))
             }
 
+            fun parameters(block: ParametersDsl.() -> Unit) {
+                val parameters = components.map("parameters") { }
+                block(ParametersDsl(parameters))
+            }
+
             fun securitySchemes(block: SecuritySchemeDsl.() -> Unit) {
                 val schemas = components.map("securitySchemes") { }
                 block(SecuritySchemeDsl(schemas))
@@ -3516,6 +3635,12 @@ data class LenientParseTestCase(val openApi: Map<String, Any?>, val checks: List
         class SchemasDsl(private val schemas: AnyValueMap) {
             fun schema(name: String, block: AnyValueMap.() -> Unit) {
                 schemas[name] = mutableMapOf<String, Any?>().apply(block)
+            }
+        }
+
+        class ParametersDsl(private val parameters: AnyValueMap) {
+            fun parameter(name: String, block: AnyValueMap.() -> Unit) {
+                parameters[name] = mutableMapOf<String, Any?>().apply(block)
             }
         }
 

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationParseTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationParseTest.kt
@@ -171,6 +171,90 @@ class OpenApiSpecificationParseTest {
         assertThat(requestPattern.httpPathPattern?.path).isEqualTo("/orders/(orderId:string)")
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = ["3.0.0", "3.1.0"])
+    fun `should not collapse ref-only parameter lists while deduplicating`(openApiVersion: String) {
+        val spec = $$"""
+            openapi: $$openApiVersion
+            info:
+              title: Parse ref-only dedup params
+              version: 1.0.0
+            paths:
+              /orders/{orderId}:
+                parameters:
+                  - $ref: '#/components/parameters/OrderIdPathParam'
+                get:
+                  parameters:
+                    - $ref: '#/components/parameters/IncludeDetailsQueryParam'
+                    - $ref: '#/components/parameters/TenantHeaderParam'
+                  responses:
+                    '200':
+                      description: OK
+            components:
+              parameters:
+                OrderIdPathParam:
+                  name: orderId
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+                IncludeDetailsQueryParam:
+                  name: includeDetails
+                  in: query
+                  required: true
+                  schema:
+                    type: boolean
+                TenantHeaderParam:
+                  name: X-Tenant-Id
+                  in: header
+                  required: true
+                  schema:
+                    type: string
+        """.trimIndent()
+
+        val requestPattern = OpenApiSpecification.fromYAML(spec, "").toFeature().scenarios.single().httpRequestPattern
+
+        assertThat(requestPattern.httpPathPattern?.path).isEqualTo("/orders/(orderId:string)")
+        assertThat(requestPattern.httpQueryParamPattern.queryPatterns).containsKey("includeDetails")
+        assertThat(requestPattern.headersPattern.pattern).containsKey("X-Tenant-Id")
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["3.0.0", "3.1.0"])
+    fun `operation level ref parameter should override path item inline parameter with same name and location`(openApiVersion: String) {
+        val spec = $$"""
+            openapi: $$openApiVersion
+            info:
+              title: Parse mixed override precedence
+              version: 1.0.0
+            paths:
+              /orders/{orderId}:
+                parameters:
+                  - in: path
+                    name: orderId
+                    required: true
+                    schema:
+                      type: string
+                get:
+                  parameters:
+                    - $ref: '#/components/parameters/OrderIdPathParam'
+                  responses:
+                    '200':
+                      description: OK
+            components:
+              parameters:
+                OrderIdPathParam:
+                  name: orderId
+                  in: path
+                  required: true
+                  schema:
+                    type: integer
+        """.trimIndent()
+
+        val requestPattern = OpenApiSpecification.fromYAML(spec, "").toFeature().scenarios.single().httpRequestPattern
+        assertThat(requestPattern.httpPathPattern?.path).contains("(orderId:number)")
+    }
+
     @Test
     fun `should be able to parse primitives inside XML pattern schemas with their constraints intact`() {
         val specFile = File("src/test/resources/openapi/has_xml_payloads/api.yaml")

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationParseTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationParseTest.kt
@@ -141,6 +141,36 @@ class OpenApiSpecificationParseTest {
         assertThat(headerPattern).isInstanceOf(NumberPattern::class.java)
     }
 
+    @ParameterizedTest(name = "openapi {0}")
+    @ValueSource(strings = ["3.0.3", "3.1.0"])
+    fun `should resolve path item parameter referenced from components`(openApiVersion: String) {
+        val spec = $$"""
+            openapi: $$openApiVersion
+            info:
+              title: Parse refed path param in components
+              version: 1.0.0
+            paths:
+              /orders/{orderId}:
+                parameters:
+                  - $ref: '#/components/parameters/OrderIdPathParam'
+                get:
+                  responses:
+                    '200':
+                      description: OK
+            components:
+              parameters:
+                OrderIdPathParam:
+                  name: orderId
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+        """.trimIndent()
+
+        val requestPattern = OpenApiSpecification.fromYAML(spec, "").toFeature().scenarios.single().httpRequestPattern
+        assertThat(requestPattern.httpPathPattern?.path).isEqualTo("/orders/(orderId:string)")
+    }
+
     @Test
     fun `should be able to parse primitives inside XML pattern schemas with their constraints intact`() {
         val specFile = File("src/test/resources/openapi/has_xml_payloads/api.yaml")

--- a/core/src/test/kotlin/io/specmatic/conversions/SecuritySchemeWarnIfExistsInParametersTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/SecuritySchemeWarnIfExistsInParametersTest.kt
@@ -4,23 +4,26 @@ import io.specmatic.conversions.lenient.CollectorContext
 import io.specmatic.core.Result
 import io.specmatic.toViolationReportString
 import io.swagger.v3.oas.models.parameters.HeaderParameter
-import io.swagger.v3.oas.models.parameters.Parameter
 import io.swagger.v3.oas.models.parameters.QueryParameter
 import org.apache.http.HttpHeaders.AUTHORIZATION
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class SecuritySchemeWarnIfExistsInParametersTest {
+    private fun parameterWithContext(parameter: io.swagger.v3.oas.models.parameters.Parameter, collectorContext: CollectorContext): ParameterWithContext<io.swagger.v3.oas.models.parameters.Parameter> {
+        return ParameterWithContext(parameter, collectorContext)
+    }
+
     @Test
     fun `APIKeyInHeaderSecurityScheme should collect error if header param exists`() {
         val scheme = APIKeyInHeaderSecurityScheme("X-API-KEY", null)
         val context = CollectorContext()
         val parameters = listOf(
-            IndexedValue(index = 0, value = HeaderParameter().apply { name = "X-API-KEY" }),
-            IndexedValue(index = 1, value = QueryParameter().apply { name = "apiKey" })
+            parameterWithContext(parameter = HeaderParameter().apply { name = "X-API-KEY" }, collectorContext = context.at("parameters").at(0)),
+            parameterWithContext(parameter = QueryParameter().apply { name = "apiKey" }, collectorContext = context.at("parameters").at(1))
         )
 
-        scheme.collectErrorIfExistsInParameters(parameters, context)
+        scheme.collectErrorIfExistsInParameters(parameters)
         assertThat(context.toCollector().getEntries()).hasSize(1)
         assertThat(context.toCollector().toResult().reportString()).isEqualToIgnoringWhitespace(
             toViolationReportString(
@@ -36,11 +39,11 @@ class SecuritySchemeWarnIfExistsInParametersTest {
         val scheme = APIKeyInQueryParamSecurityScheme("apiKey", null)
         val context = CollectorContext()
         val parameters = listOf(
-            IndexedValue(index = 0, value = HeaderParameter().apply { name = "X-API-KEY" }),
-            IndexedValue(index = 1, value = QueryParameter().apply { name = "apiKey" })
+            parameterWithContext(parameter = HeaderParameter().apply { name = "X-API-KEY" }, collectorContext = context.at("parameters").at(0)),
+            parameterWithContext(parameter = QueryParameter().apply { name = "apiKey" }, collectorContext = context.at("parameters").at(1))
         )
 
-        scheme.collectErrorIfExistsInParameters(parameters, context)
+        scheme.collectErrorIfExistsInParameters(parameters)
         assertThat(context.toCollector().getEntries()).hasSize(1)
         assertThat(context.toCollector().toResult().reportString()).isEqualToIgnoringWhitespace(
             toViolationReportString(
@@ -56,12 +59,12 @@ class SecuritySchemeWarnIfExistsInParametersTest {
         val scheme = BasicAuthSecurityScheme()
         val context = CollectorContext()
         val parameters = listOf(
-            IndexedValue(index = 0, value = HeaderParameter().apply { name = AUTHORIZATION }),
-            IndexedValue(index = 1, value = HeaderParameter().apply { name = "X-API-KEY" }),
-            IndexedValue(index = 2, value = QueryParameter().apply { name = "apiKey" })
+            parameterWithContext(parameter = HeaderParameter().apply { name = AUTHORIZATION }, collectorContext = context.at("parameters").at(0)),
+            parameterWithContext(parameter = HeaderParameter().apply { name = "X-API-KEY" }, collectorContext = context.at("parameters").at(1)),
+            parameterWithContext(parameter = QueryParameter().apply { name = "apiKey" }, collectorContext = context.at("parameters").at(2))
         )
 
-        scheme.collectErrorIfExistsInParameters(parameters, context)
+        scheme.collectErrorIfExistsInParameters(parameters)
         assertThat(context.toCollector().getEntries()).hasSize(1)
         assertThat(context.toCollector().toResult().reportString()).isEqualToIgnoringWhitespace(
             toViolationReportString(
@@ -77,12 +80,12 @@ class SecuritySchemeWarnIfExistsInParametersTest {
         val scheme = BearerSecurityScheme()
         val context = CollectorContext()
         val parameters = listOf(
-            IndexedValue(index = 0, value = HeaderParameter().apply { name = AUTHORIZATION }),
-            IndexedValue(index = 1, value = HeaderParameter().apply { name = "X-API-KEY" }),
-            IndexedValue(index = 2, value = QueryParameter().apply { name = "apiKey" })
+            parameterWithContext(parameter = HeaderParameter().apply { name = AUTHORIZATION }, collectorContext = context.at("parameters").at(0)),
+            parameterWithContext(parameter = HeaderParameter().apply { name = "X-API-KEY" }, collectorContext = context.at("parameters").at(1)),
+            parameterWithContext(parameter = QueryParameter().apply { name = "apiKey" }, collectorContext = context.at("parameters").at(2))
         )
 
-        scheme.collectErrorIfExistsInParameters(parameters, context)
+        scheme.collectErrorIfExistsInParameters(parameters)
         assertThat(context.toCollector().getEntries()).hasSize(1)
         assertThat(context.toCollector().toResult().reportString()).isEqualToIgnoringWhitespace(
             toViolationReportString(
@@ -100,12 +103,12 @@ class SecuritySchemeWarnIfExistsInParametersTest {
         val composite = CompositeSecurityScheme(listOf(headerScheme, bearerScheme))
         val context = CollectorContext()
         val parameters = listOf(
-            IndexedValue(index = 0, value = HeaderParameter().apply { name = AUTHORIZATION }),
-            IndexedValue(index = 1, value = HeaderParameter().apply { name = "X-API-KEY" }),
-            IndexedValue(index = 2, value = QueryParameter().apply { name = "apiKey" })
+            parameterWithContext(parameter = HeaderParameter().apply { name = AUTHORIZATION }, collectorContext = context.at("parameters").at(0)),
+            parameterWithContext(parameter = HeaderParameter().apply { name = "X-API-KEY" }, collectorContext = context.at("parameters").at(1)),
+            parameterWithContext(parameter = QueryParameter().apply { name = "apiKey" }, collectorContext = context.at("parameters").at(2))
         )
 
-        composite.collectErrorIfExistsInParameters(parameters, context)
+        composite.collectErrorIfExistsInParameters(parameters)
         assertThat(context.toCollector().getEntries()).hasSize(2)
         assertThat(context.toCollector().toResult().reportString()).isEqualToIgnoringWhitespace("""
         ${
@@ -129,9 +132,9 @@ class SecuritySchemeWarnIfExistsInParametersTest {
     fun `no warning if header security scheme and query param have same name`() {
         val scheme = APIKeyInHeaderSecurityScheme("X-API-KEY", null)
         val context = CollectorContext()
-        val parameters = listOf(IndexedValue(index = 2, value = QueryParameter().apply { name = "X-API-KEY" }))
+        val parameters = listOf(parameterWithContext(parameter = QueryParameter().apply { name = "X-API-KEY" }, collectorContext = context.at("parameters").at(2)))
 
-        scheme.collectErrorIfExistsInParameters(parameters, context)
+        scheme.collectErrorIfExistsInParameters(parameters)
         assertThat(context.toCollector().getEntries()).isEmpty()
         assertThat(context.toCollector().toResult()).isInstanceOf(Result.Success::class.java)
     }
@@ -141,12 +144,12 @@ class SecuritySchemeWarnIfExistsInParametersTest {
         val scheme = NoSecurityScheme()
         val context = CollectorContext()
         val parameters = listOf(
-            IndexedValue(index = 0, value = HeaderParameter().apply { name = AUTHORIZATION }),
-            IndexedValue(index = 1, value = HeaderParameter().apply { name = "X-API-KEY" }),
-            IndexedValue(index = 2, value = QueryParameter().apply { name = "apiKey" })
+            parameterWithContext(parameter = HeaderParameter().apply { name = AUTHORIZATION }, collectorContext = context.at("parameters").at(0)),
+            parameterWithContext(parameter = HeaderParameter().apply { name = "X-API-KEY" }, collectorContext = context.at("parameters").at(1)),
+            parameterWithContext(parameter = QueryParameter().apply { name = "apiKey" }, collectorContext = context.at("parameters").at(2))
         )
 
-        scheme.collectErrorIfExistsInParameters(parameters, context)
+        scheme.collectErrorIfExistsInParameters(parameters)
         assertThat(context.toCollector().getEntries()).isEmpty()
         assertThat(context.toCollector().toResult()).isInstanceOf(Result.Success::class.java)
     }
@@ -154,7 +157,7 @@ class SecuritySchemeWarnIfExistsInParametersTest {
     @Test
     fun `no warning if there are security schemes and no parameters`() {
         val context = CollectorContext()
-        val parameters = emptyList<IndexedValue<Parameter>>()
+        val parameters = emptyList<ParameterWithContext<io.swagger.v3.oas.models.parameters.Parameter>>()
         val composite = CompositeSecurityScheme(listOf(
             APIKeyInHeaderSecurityScheme("X-API-KEY", null),
             APIKeyInQueryParamSecurityScheme("api_key", null),
@@ -162,7 +165,7 @@ class SecuritySchemeWarnIfExistsInParametersTest {
             BasicAuthSecurityScheme()
         ))
 
-        composite.collectErrorIfExistsInParameters(parameters, context)
+        composite.collectErrorIfExistsInParameters(parameters)
         assertThat(context.toCollector().getEntries()).isEmpty()
         assertThat(context.toCollector().toResult()).isInstanceOf(Result.Success::class.java)
     }
@@ -178,11 +181,11 @@ class SecuritySchemeWarnIfExistsInParametersTest {
 
         val context = CollectorContext()
         val parameters = listOf(
-            IndexedValue(index = 1, value = HeaderParameter().apply { name = "SOME-OTHER-HEADER" }),
-            IndexedValue(index = 2, value = QueryParameter().apply { name = "some_other_query" })
+            parameterWithContext(parameter = HeaderParameter().apply { name = "SOME-OTHER-HEADER" }, collectorContext = context.at("parameters").at(1)),
+            parameterWithContext(parameter = QueryParameter().apply { name = "some_other_query" }, collectorContext = context.at("parameters").at(2))
         )
 
-        composite.collectErrorIfExistsInParameters(parameters, context)
+        composite.collectErrorIfExistsInParameters(parameters)
         assertThat(context.toCollector().getEntries()).isEmpty()
         assertThat(context.toCollector().toResult()).isInstanceOf(Result.Success::class.java)
     }


### PR DESCRIPTION
**What:**
- Fixed ref param resolution from `components.parameters` for OAS 3.1
- Fixed path/operation parameter dedupe so mixed and ref-only parameter lists are handled correctly

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)