### PR TITLE
Fix the parsing logic in the MatcherRegistry

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/matchers/CompositeMatcher.kt
+++ b/core/src/main/kotlin/io/specmatic/core/matchers/CompositeMatcher.kt
@@ -39,8 +39,9 @@ data class CompositeMatcher(
         }
     }
 
-    @MatcherKey("match")
     companion object : MatcherFactory {
+        override val matcherKey: String = "match"
+
         override fun parse(path: BreadCrumb, value: Value, context: MatcherContext): ReturnValue<CompositeMatcher> {
             val properties = extractPropertiesIfExist(value)
                 ?: return HasFailure("Cannot create CompositeMatcher from value '${value.displayableValue()}", path.value)

--- a/core/src/main/kotlin/io/specmatic/core/matchers/EqualityMatcher.kt
+++ b/core/src/main/kotlin/io/specmatic/core/matchers/EqualityMatcher.kt
@@ -103,16 +103,12 @@ data class EqualityMatcher(val path: BreadCrumb, val value: Value, val strategy:
             }
         }
 
-        @MatcherKey("eq")
-        object EqualityFactory : BaseEqualityFactory(
-            defaultStrategy = EqualityStrategy.EQUALS,
-            createPattern = { ExactValuePattern(it) },
-        )
+        object EqualityFactory: BaseEqualityFactory(defaultStrategy = EqualityStrategy.EQUALS, createPattern = { ExactValuePattern(it) }) {
+            override val matcherKey: String = "eq"
+        }
 
-        @MatcherKey("neq")
-        object NonEqualityFactory : BaseEqualityFactory(
-            defaultStrategy = EqualityStrategy.NOT_EQUALS,
-            createPattern = { it.deepPattern() },
-        )
+        object NonEqualityFactory : BaseEqualityFactory(defaultStrategy = EqualityStrategy.NOT_EQUALS, createPattern = { it.deepPattern() }) {
+            override val matcherKey: String = "neq"
+        }
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/matchers/Matcher.kt
+++ b/core/src/main/kotlin/io/specmatic/core/matchers/Matcher.kt
@@ -8,10 +8,6 @@ import io.specmatic.core.pattern.listFold
 import io.specmatic.core.value.Value
 import io.specmatic.test.traverse
 
-@Target(AnnotationTarget.CLASS)
-@Retention(AnnotationRetention.RUNTIME)
-annotation class MatcherKey(val key: String)
-
 interface Matcher {
     val canBeExhausted: Boolean
 

--- a/core/src/main/kotlin/io/specmatic/core/matchers/MatcherFactory.kt
+++ b/core/src/main/kotlin/io/specmatic/core/matchers/MatcherFactory.kt
@@ -8,6 +8,8 @@ import io.specmatic.core.value.StringValue
 import io.specmatic.core.value.Value
 
 interface MatcherFactory {
+    val matcherKey: String?
+
     fun parse(path: BreadCrumb, value: Value, context: MatcherContext): ReturnValue<out Matcher>
 
     fun canParseFrom(path: BreadCrumb, properties: Map<String, Value>): Boolean

--- a/core/src/main/kotlin/io/specmatic/core/matchers/MatcherRegistry.kt
+++ b/core/src/main/kotlin/io/specmatic/core/matchers/MatcherRegistry.kt
@@ -17,12 +17,6 @@ data class MatcherRegistry(
     private val fallbackFactories: CopyOnWriteArrayList<MatcherFactory> = CopyOnWriteArrayList<MatcherFactory>()
 ) {
     fun parse(path: BreadCrumb, value: Value, context: MatcherContext): ReturnValue<out Matcher>? {
-        val lastKey = path.last().value
-        if (keyedFactories.containsKey(lastKey)) {
-            val factory = keyedFactories.getValue(lastKey)
-            return factory.parse(path, value, context)
-        }
-
         val matcherValueDetails = extractMatcherFromValue(value)
         if (matcherValueDetails != null && keyedFactories.containsKey(matcherValueDetails.first)) {
             val factory = keyedFactories.getValue(matcherValueDetails.first)
@@ -78,9 +72,9 @@ data class MatcherRegistry(
             val fallbackFactories = CopyOnWriteArrayList<MatcherFactory>()
 
             ServiceLoader.load(MatcherFactory::class.java).plus(defaults).forEach { factory ->
-                val annotation = factory::class.java.getAnnotation(MatcherKey::class.java)
-                if (annotation != null) {
-                    keyToFactory[annotation.key] = factory
+                val matcherKey = factory.matcherKey
+                if (matcherKey != null) {
+                    keyToFactory[matcherKey] = factory
                 } else {
                     fallbackFactories.add(factory)
                 }

--- a/core/src/main/kotlin/io/specmatic/core/matchers/PatternMatcher.kt
+++ b/core/src/main/kotlin/io/specmatic/core/matchers/PatternMatcher.kt
@@ -61,10 +61,10 @@ class PatternMatcher(
         return MatcherResult.from(returnValue.breadCrumb(path.value), context)
     }
 
-    @MatcherKey("pattern")
     companion object : MatcherFactory {
         private const val DATA_TYPE_KEY = "dataType"
         private const val PARTIAL_KEY = "partial"
+        override val matcherKey: String = "pattern"
 
         override fun parse(path: BreadCrumb, value: Value, context: MatcherContext): ReturnValue<PatternMatcher> {
             if (value !is StringValue) return HasFailure("Invalid '$DATA_TYPE_KEY', expected String got ${value.displayableValue()}", path.value)

--- a/core/src/main/kotlin/io/specmatic/core/matchers/RegexMatcher.kt
+++ b/core/src/main/kotlin/io/specmatic/core/matchers/RegexMatcher.kt
@@ -49,6 +49,7 @@ data class RegexMatcher(val path: BreadCrumb, val regex: String) : Matcher {
 
     companion object : MatcherFactory {
         private const val PATTERN_KEY = "pattern"
+        override val matcherKey: String = PATTERN_KEY
 
         override fun parse(path: BreadCrumb, value: Value, context: MatcherContext): ReturnValue<RegexMatcher> {
             val properties = extractPropertiesIfExist(value)

--- a/core/src/main/kotlin/io/specmatic/core/matchers/RepetitionMatcher.kt
+++ b/core/src/main/kotlin/io/specmatic/core/matchers/RepetitionMatcher.kt
@@ -92,10 +92,10 @@ data class RepetitionMatcher(
         return MatcherResult.from(strategyUpdatedContext, updatedContext, isExhausted = isExhausted)
     }
 
-    @MatcherKey("repeat")
     companion object : MatcherFactory {
         private const val TIMES_KEY = "times"
         private const val STRATEGY_KEY = "value"
+        override val matcherKey: String = "repeat"
 
         override fun parse(path: BreadCrumb, value: Value, context: MatcherContext): ReturnValue<out Matcher> {
             val properties = extractPropertiesIfExist(value)

--- a/core/src/test/kotlin/io/specmatic/core/matchers/MatcherRegistryTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/matchers/MatcherRegistryTest.kt
@@ -1,0 +1,62 @@
+package io.specmatic.core.matchers
+
+import io.specmatic.core.BreadCrumb
+import io.specmatic.core.Resolver
+import io.specmatic.core.pattern.HasValue
+import io.specmatic.core.value.StringValue
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class MatcherRegistryTest {
+    private val context = MatcherContext(Resolver())
+
+    @Test
+    fun `parse should not infer matcher from leaf key`() {
+        val result = Matcher.parse(BreadCrumb("request.body.user.profile.pattern"), StringValue("string"), context)
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `parse should not infer matcher from leaf key in array paths`() {
+        val result = Matcher.parse(BreadCrumb("request.body.items[0].pattern"), StringValue("string"), context)
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `parse should not infer matcher from leaf key when value looks like properties`() {
+        val result = Matcher.parse(BreadCrumb("request.body.user.match"), StringValue("times: 2, value: each"), context)
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `parse should not infer matcher from leaf key for unknown matcher token`() {
+        val result = Matcher.parse(BreadCrumb("request.body.user.field"), StringValue($$"$unknown(string)"), context)
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `parse should not infer matcher from leaf key for malformed matcher token`() {
+        val result = Matcher.parse(BreadCrumb("request.body.user.field"), StringValue($$"$match"), context)
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `parse should not infer matcher from leaf key pattern when token has invalid syntax`() {
+        val result = Matcher.parse(BreadCrumb("request.body.user.field"), StringValue($$"$match (datType: string)"), context)
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `parse should still create pattern matcher when matcher syntax is in value`() {
+        val result = Matcher.parse(BreadCrumb("request.body.user.value"), StringValue($$"$match(dataType: string)"), context)
+        assertThat(result).isInstanceOf(HasValue::class.java)
+        assertThat((result as HasValue).value).isInstanceOf(CompositeMatcher::class.java)
+    }
+
+    @Test
+    fun `parse should still create matcher from explicit syntax even when leaf key is pattern`() {
+        val result = Matcher.parse(BreadCrumb("request.body.user.match"), StringValue($$"$match(dataType: string)"), context)
+        assertThat(result).isInstanceOf(HasValue::class.java)
+        assertThat((result as HasValue).value).isInstanceOf(CompositeMatcher::class.java)
+    }
+}


### PR DESCRIPTION
**What**: Fix the parsing logic in the `MatcherRegistry` for given key and value

**Why**: The `MatchesRegistry.parse` method could generate false positives when the leaf key corresponds to a recognized matcher key. For instance, with the key `body.nested.match` and the value `42`, it would incorrectly assume that `42` is a value to be parsed against the CompositeMatcher

**Checklist**:

- [x] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
