### PR TITLE
Ensure external test examples are filter based on the filter expression

### DIFF
--- a/application/src/main/kotlin/application/StubCommand.kt
+++ b/application/src/main/kotlin/application/StubCommand.kt
@@ -7,7 +7,7 @@ import io.specmatic.core.config.HttpsConfiguration
 import io.specmatic.core.config.LoggingConfiguration.Companion.LoggingFromOpts
 import io.specmatic.core.config.Switch
 import io.specmatic.core.filters.ExpressionStandardizer
-import io.specmatic.core.filters.HttpStubFilterContext
+import io.specmatic.core.filters.ExampleFilterContext
 import io.specmatic.core.filters.ScenarioMetadataFilter
 import io.specmatic.core.log.*
 import io.specmatic.core.utilities.*
@@ -295,7 +295,7 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
             ).toList()
             val stubFilterExpression = ExpressionStandardizer.filterToEvalEx(stubFilter)
             val filteredStubScenario = scenarioStubs.filter { it ->
-                stubFilterExpression.with("context", HttpStubFilterContext(it)).evaluate().booleanValue
+                stubFilterExpression.with("context", ExampleFilterContext(it)).evaluate().booleanValue
             }
             if (filteredScenarios.isNotEmpty()) {
                 val updatedFeature = feature.copy(scenarios = filteredScenarios)

--- a/core/src/main/kotlin/io/specmatic/conversions/ExampleFromFile.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/ExampleFromFile.kt
@@ -16,7 +16,7 @@ import io.specmatic.test.ExampleProcessor
 import java.io.File
 import java.net.URI
 
-class ExampleFromFile(private val scenarioStub: ScenarioStub, val file: File) {
+class ExampleFromFile(val scenarioStub: ScenarioStub, val file: File) {
     companion object {
         fun fromFile(file: File, strictMode: Boolean = true): ReturnValue<ExampleFromFile> {
             if (SchemaExample.matchesFilePattern(file)) {

--- a/core/src/main/kotlin/io/specmatic/conversions/ExampleFromFile.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/ExampleFromFile.kt
@@ -6,6 +6,7 @@ import io.specmatic.core.HttpResponse
 import io.specmatic.core.Result
 import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.examples.server.SchemaExample
+import io.specmatic.core.filters.ExampleFilterContext
 import io.specmatic.core.log.logger
 import io.specmatic.core.pattern.*
 import io.specmatic.core.value.EmptyString
@@ -16,7 +17,7 @@ import io.specmatic.test.ExampleProcessor
 import java.io.File
 import java.net.URI
 
-class ExampleFromFile(val scenarioStub: ScenarioStub, val file: File) {
+class ExampleFromFile(private val scenarioStub: ScenarioStub, val file: File) {
     companion object {
         fun fromFile(file: File, strictMode: Boolean = true): ReturnValue<ExampleFromFile> {
             if (SchemaExample.matchesFilePattern(file)) {
@@ -31,6 +32,10 @@ class ExampleFromFile(val scenarioStub: ScenarioStub, val file: File) {
 
     constructor(file: File, strictMode: Boolean = true): this(scenarioStub = ScenarioStub.readFromFile(file, strictMode), file = file)
     constructor(json: JSONObjectValue, file: File, strictMode: Boolean = true): this(scenarioStub = ScenarioStub.parse(json, strictMode), file = file)
+
+    fun toFilterContext(): ExampleFilterContext {
+        return ExampleFilterContext(scenarioStub)
+    }
 
     fun toRow(specmaticConfig: SpecmaticConfig = SpecmaticConfig()): Row {
         logger.log("Loading test file ${this.expectationFilePath}")

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -1,5 +1,6 @@
 package io.specmatic.core
 
+import com.ezylang.evalex.Expression
 import io.cucumber.gherkin.GherkinParser
 import io.cucumber.messages.types.*
 import io.cucumber.messages.types.Examples
@@ -21,6 +22,7 @@ import io.specmatic.core.pattern.Examples.Companion.examplesFrom
 import io.specmatic.core.utilities.*
 import io.specmatic.core.value.*
 import io.specmatic.core.Result.Success
+import io.specmatic.core.filters.HttpStubFilterContext
 import io.specmatic.license.core.SpecmaticProtocol
 import io.specmatic.mock.NoMatchingScenario
 import io.specmatic.mock.ScenarioStub
@@ -2227,7 +2229,7 @@ data class Feature(
         return this.copy(scenarios = scenariosWithExamples)
     }
 
-    private fun loadExternalisedJSONExamples(testsDirectory: File?): Map<OpenApiSpecification.OperationIdentifier, List<Row>> {
+    private fun loadExternalisedJSONExamples(testsDirectory: File?, filter: Expression? = null): Map<OpenApiSpecification.OperationIdentifier, List<Row>> {
         if (testsDirectory == null)
             return emptyMap()
 
@@ -2244,44 +2246,44 @@ data class Feature(
             files.filter {
                 it.isDirectory
             }.fold(emptyMap()) { acc, item ->
-                acc + loadExternalisedJSONExamples(item)
+                acc + loadExternalisedJSONExamples(item, filter)
             }
 
         logger.log("Loading externalised examples in ${testsDirectory.path}: ")
         logger.boundary()
 
-        return examplesInSubdirectories + files.asSequence().filterNot {
-            it.isDirectory
-        }.mapNotNull { example ->
-            runCatching { ExampleFromFile(example) }.mapCatching { exampleFromFile ->
-                with(exampleFromFile) {
-                    OpenApiSpecification.OperationIdentifier(
-                        requestMethod = requestMethod.orEmpty(),
-                        requestPath = requestPath.orEmpty(),
-                        responseStatus = responseStatus ?: 0,
-                        requestContentType = requestContentType,
-                        responseContentType = responseContentType
-                    ) to toRow(specmaticConfig)
+        return examplesInSubdirectories + files.asSequence()
+            .filterNot { it.isDirectory }
+            .mapNotNull { exampleFile ->
+                runCatching { ExampleFromFile(exampleFile) }.getOrElse { e ->
+                    logger.log("Could not load test file ${exampleFile.canonicalPath}")
+                    logger.log(e)
+                    logger.boundary()
+                    if (strictMode) throw ContractException(exceptionCauseMessage(e))
+                    null
                 }
-            }.getOrElse { e ->
-                logger.log("Could not load test file ${example.canonicalPath}")
-                logger.log(e)
-                logger.boundary()
-                if (strictMode) throw ContractException(exceptionCauseMessage(e))
-                null
-            }
-        }
-        .groupBy { (operationIdentifier, _) -> operationIdentifier }
-        .mapValues { (_, value) -> value.map { it.second } }
+            }.filter { example ->
+                if (filter == null) return@filter true
+                filter.with("context", HttpStubFilterContext(example.scenarioStub)).evaluate().booleanValue
+            }.map { example ->
+                OpenApiSpecification.OperationIdentifier(
+                    requestMethod = example.requestMethod.orEmpty(),
+                    requestPath = example.requestPath.orEmpty(),
+                    responseStatus = example.responseStatus ?: 0,
+                    requestContentType = example.requestContentType,
+                    responseContentType = example.responseContentType
+                ) to example.toRow(specmaticConfig)
+            }.groupBy { (operationIdentifier, _) -> operationIdentifier }
+            .mapValues { (_, value) -> value.map { it.second } }
     }
 
-    fun loadExternalisedExamplesAndListUnloadableExamples(): Pair<Feature, Set<String>> {
+    fun loadExternalisedExamplesAndListUnloadableExamples(filter: Expression? = null): Pair<Feature, Set<String>> {
         val testsDirectory = getTestsDirectory(File(this.path), specmaticConfig)
-        val externalisedExamplesFromDefaultDirectory = loadExternalisedJSONExamples(testsDirectory)
+        val externalisedExamplesFromDefaultDirectory = loadExternalisedJSONExamples(testsDirectory, filter)
         val externalisedExampleDirsFromConfig = specmaticConfig.getTestExampleDirs(File(path)) + exampleDirPaths
 
         val externalisedExamplesFromExampleDirs = externalisedExampleDirsFromConfig.flatMap { directory ->
-            loadExternalisedJSONExamples(File(directory)).entries
+            loadExternalisedJSONExamples(File(directory), filter).entries
         }.associate { it.toPair() }
 
         val allExternalisedJSONExamples = externalisedExamplesFromDefaultDirectory + externalisedExamplesFromExampleDirs
@@ -2341,8 +2343,8 @@ data class Feature(
         return featureWithExternalisedExamples to unusedExternalizedExamples
     }
 
-    fun loadExternalisedExamples(): Feature {
-        return loadExternalisedExamplesAndListUnloadableExamples().first
+    fun loadExternalisedExamples(filter: Expression? = null): Feature {
+        return loadExternalisedExamplesAndListUnloadableExamples(filter).first
     }
 
     fun validateAndFilterExamples(): Pair<Feature, Result> {

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -22,7 +22,6 @@ import io.specmatic.core.pattern.Examples.Companion.examplesFrom
 import io.specmatic.core.utilities.*
 import io.specmatic.core.value.*
 import io.specmatic.core.Result.Success
-import io.specmatic.core.filters.HttpStubFilterContext
 import io.specmatic.license.core.SpecmaticProtocol
 import io.specmatic.mock.NoMatchingScenario
 import io.specmatic.mock.ScenarioStub
@@ -2264,7 +2263,7 @@ data class Feature(
                 }
             }.filter { example ->
                 if (filter == null) return@filter true
-                filter.with("context", HttpStubFilterContext(example.scenarioStub)).evaluate().booleanValue
+                filter.with("context", example.toFilterContext()).evaluate().booleanValue
             }.map { example ->
                 OpenApiSpecification.OperationIdentifier(
                     requestMethod = example.requestMethod.orEmpty(),

--- a/core/src/main/kotlin/io/specmatic/core/filters/ExampleFilterContext.kt
+++ b/core/src/main/kotlin/io/specmatic/core/filters/ExampleFilterContext.kt
@@ -3,7 +3,7 @@ package io.specmatic.core.filters
 import io.specmatic.core.filters.HTTPFilterKeys.*
 import io.specmatic.mock.ScenarioStub
 
-class HttpStubFilterContext(private val scenario: ScenarioStub) : FilterContext {
+class ExampleFilterContext(private val scenario: ScenarioStub) : FilterContext {
     override fun includes(key: String, values: List<String>): Boolean {
         val filterKey = HTTPFilterKeys.fromKey(key)
         return values.any { eachValue ->

--- a/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
@@ -8,8 +8,7 @@ import io.mockk.mockk
 import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.core.discriminator.DiscriminatorBasedItem
 import io.specmatic.core.discriminator.DiscriminatorMetadata
-import io.specmatic.core.log.DebugLogger
-import io.specmatic.core.log.withLogger
+import io.specmatic.core.filters.ExpressionStandardizer
 import io.specmatic.core.pattern.*
 import io.specmatic.core.utilities.Flags
 import io.specmatic.core.utilities.exceptionCauseMessage
@@ -3240,6 +3239,27 @@ paths:
 
         assertThat(error.message)
             .contains("POST /order_partial -> 200 does not match any operation in the specification")
+    }
+
+    @Test
+    fun `should not load external examples that do not match filter`() {
+        val feature = OpenApiSpecification.fromFile("src/test/resources/openapi/simple_partial_non_partial_examples_with_dictionary/simple_pets.yaml",).toFeature()
+        val filteredFeature = feature.loadExternalisedExamples(ExpressionStandardizer.filterToEvalEx("METHOD='PATCH'"))
+        val loadedExamplePaths = filteredFeature.scenarios.flatMap { it.examples }.flatMap { it.rows }.mapNotNull { it.fileSource }
+
+        assertThat(loadedExamplePaths).hasSize(1)
+        assertThat(loadedExamplePaths.single()).endsWith("pets_patch.json")
+        assertThat(loadedExamplePaths).noneMatch {
+            it.endsWith("pets_get.json") || it.endsWith("pets_post.json")
+        }
+    }
+
+    @Test
+    fun `should not throw unused external example exception in strict mode when filter excludes them`() {
+        val feature = OpenApiSpecification.fromFile("src/test/resources/openapi/has_irrelevant_externalized_test.yaml",).toFeature().copy(strictMode = true)
+        assertDoesNotThrow {
+            feature.loadExternalisedExamples(ExpressionStandardizer.filterToEvalEx("METHOD='GET'"))
+        }
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/core/filters/ExampleFilterContextTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/filters/ExampleFilterContextTest.kt
@@ -8,7 +8,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 
-class HttpStubFilterContextTest {
+class ExampleFilterContextTest {
     @ParameterizedTest
     @MethodSource("provideTestParameters")
     fun `test includes method with various parameters`(
@@ -17,7 +17,7 @@ class HttpStubFilterContextTest {
         expected: Boolean,
         scenario: ScenarioStub
     ) {
-        val httpFilterContext = HttpStubFilterContext(scenario)
+        val httpFilterContext = ExampleFilterContext(scenario)
         assertThat(httpFilterContext.includes(key, listOf(value))).isEqualTo(expected)
     }
 
@@ -30,7 +30,7 @@ class HttpStubFilterContextTest {
         expected: Boolean,
         scenario: ScenarioStub
     ) {
-        val httpFilterContext = HttpStubFilterContext(scenario)
+        val httpFilterContext = ExampleFilterContext(scenario)
         assertThat(httpFilterContext.compare(key, operator, value)).isEqualTo(expected)
     }
 

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -703,7 +703,7 @@ open class SpecmaticJUnitSupport {
             )
         }.toList()
 
-        val filteredFeature = feature.copy(scenarios = filteredScenarios.toList()).loadExternalisedExamples()
+        val filteredFeature = feature.copy(scenarios = filteredScenarios.toList()).loadExternalisedExamples(filter.expression)
         val (validExampleFeature, result) = filteredFeature.validateAndFilterExamples()
         if (specmaticConfig.getTestLenientMode() == false) result.throwOnFailure()
 

--- a/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
@@ -580,6 +580,26 @@ paths:
     }
 
     @Test
+    fun `loadTestScenarios should pass filter to external example loading`() {
+        val specFile = File("src/test/resources/openapi/has_irrelevant_externalized_test.yaml")
+        val strictModeConfig = SpecmaticConfigV1V2Common().withTestModes(strictMode = true, lenientMode = null)
+        val loaded = assertDoesNotThrow {
+            SpecmaticJUnitSupport().loadTestScenarios(
+                path = specFile.canonicalPath,
+                suggestionsPath = "",
+                suggestionsData = "",
+                config = TestConfig(emptyMap(), emptyMap()),
+                filterName = null,
+                filterNotName = null,
+                specmaticConfig = strictModeConfig,
+                filter = ScenarioMetadataFilter.from("METHOD='GET'")
+            )
+        }
+
+        assertThat(loaded.scenarios.map { it.testDescription() }.toList()).allMatch { it.contains("GET /order_action_figure") }
+    }
+
+    @Test
     fun `loadTestScenarios should filter invalid examples in lenient mode and return validation result`() {
         val specFile = File("src/test/resources/invalid_example/openapi.yaml")
         val specmaticConfig = SpecmaticConfigV1V2Common().withTestModes(strictMode = null, lenientMode = true)


### PR DESCRIPTION
**What**: Ensure `loadExternalisedExamples` uses expression to filter examples

**Why**:
- When an API is filtered, the corresponding matching external examples must also be filtered
- If the loader fails to achieve this, it may lead to unexpected orphan example exceptions in strict mode

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
