### PR TITLE
Fix RegexMatcher overriding PatternMatcher

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/matchers/MatcherRegistry.kt
+++ b/core/src/main/kotlin/io/specmatic/core/matchers/MatcherRegistry.kt
@@ -74,6 +74,7 @@ data class MatcherRegistry(
             ServiceLoader.load(MatcherFactory::class.java).plus(defaults).forEach { factory ->
                 val matcherKey = factory.matcherKey
                 if (matcherKey != null) {
+                    if (keyToFactory.containsKey(matcherKey)) throw IllegalArgumentException("Duplicate matcher key: $matcherKey")
                     keyToFactory[matcherKey] = factory
                 } else {
                     fallbackFactories.add(factory)

--- a/core/src/main/kotlin/io/specmatic/core/matchers/RegexMatcher.kt
+++ b/core/src/main/kotlin/io/specmatic/core/matchers/RegexMatcher.kt
@@ -49,7 +49,7 @@ data class RegexMatcher(val path: BreadCrumb, val regex: String) : Matcher {
 
     companion object : MatcherFactory {
         private const val PATTERN_KEY = "pattern"
-        override val matcherKey: String = PATTERN_KEY
+        override val matcherKey: String = "regex"
 
         override fun parse(path: BreadCrumb, value: Value, context: MatcherContext): ReturnValue<RegexMatcher> {
             val properties = extractPropertiesIfExist(value)

--- a/core/src/test/kotlin/io/specmatic/core/matchers/MatcherRegistryTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/matchers/MatcherRegistryTest.kt
@@ -2,9 +2,14 @@ package io.specmatic.core.matchers
 
 import io.specmatic.core.BreadCrumb
 import io.specmatic.core.Resolver
+import io.specmatic.core.pattern.HasFailure
 import io.specmatic.core.pattern.HasValue
+import io.specmatic.core.pattern.Pattern
+import io.specmatic.core.pattern.ReturnValue
 import io.specmatic.core.value.StringValue
+import io.specmatic.core.value.Value
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 
 class MatcherRegistryTest {
@@ -58,5 +63,12 @@ class MatcherRegistryTest {
         val result = Matcher.parse(BreadCrumb("request.body.user.match"), StringValue($$"$match(dataType: string)"), context)
         assertThat(result).isInstanceOf(HasValue::class.java)
         assertThat((result as HasValue).value).isInstanceOf(CompositeMatcher::class.java)
+    }
+
+    @Test
+    fun `build should throw when defaults contain duplicate matcher keys`() {
+        assertThatThrownBy { MatcherRegistry.build(defaults = listOf(PatternMatcher.Companion, PatternMatcher.Companion)) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessage("Duplicate matcher key: pattern")
     }
 }


### PR DESCRIPTION
**What**: Fix RegexMatcher overriding PatternMatcher

**Why**: Due to them sharing the same matcherKey the latter overrides the first

**Checklist**:

- [x] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)