### PR TITLE
fix: fix RegexMatcher to properly support other scalar patterns other than StringPattern

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/matchers/RegexMatcher.kt
+++ b/core/src/main/kotlin/io/specmatic/core/matchers/RegexMatcher.kt
@@ -2,10 +2,10 @@ package io.specmatic.core.matchers
 
 import io.specmatic.core.BreadCrumb
 import io.specmatic.core.Resolver
-import io.specmatic.core.pattern.ExactValuePattern
 import io.specmatic.core.pattern.HasFailure
 import io.specmatic.core.pattern.HasValue
 import io.specmatic.core.pattern.Pattern
+import io.specmatic.core.pattern.RegexConstrainedPattern
 import io.specmatic.core.pattern.ReturnValue
 import io.specmatic.core.pattern.StringPattern
 import io.specmatic.core.pattern.parsedScalarValue
@@ -84,12 +84,11 @@ data class RegexMatcher(val path: BreadCrumb, val regex: String) : Matcher {
             if (!canParseFrom(BreadCrumb.from(), properties)) return null
             val regex = properties.getValue(PATTERN_KEY) as? StringValue ?: return null
 
-            val pattern = StringPattern(regex = regex.nativeValue)
-            val value = parsedScalarValue(
-                pattern.generate(Resolver()).toStringLiteral()
+            val stringPattern = StringPattern(regex = regex.nativeValue)
+            val generatedValue = parsedScalarValue(
+                stringPattern.generate(Resolver()).toStringLiteral()
             )
-            return ExactValuePattern(pattern = value)
+            return RegexConstrainedPattern(generatedValue.type(), regex.nativeValue)
         }
     }
 }
-

--- a/core/src/main/kotlin/io/specmatic/core/pattern/RegexConstrainedPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/RegexConstrainedPattern.kt
@@ -1,0 +1,57 @@
+package io.specmatic.core.pattern
+
+import io.specmatic.core.Resolver
+import io.specmatic.core.Result
+import io.specmatic.core.patternMismatchResult
+import io.specmatic.core.value.StringValue
+import io.specmatic.core.value.Value
+
+data class RegexConstrainedPattern(val basePattern: Pattern, val regex: String) : Pattern by basePattern, ScalarType {
+    private val regexPattern = StringPattern(regex = regex)
+
+    override fun matches(sampleData: Value?, resolver: Resolver): Result {
+        if (sampleData?.hasSupportedTemplate() == true) return Result.Success()
+        val baseResult = basePattern.matches(sampleData, resolver)
+        if (baseResult is Result.Failure) return baseResult
+        val stringValue = sampleData?.toStringLiteral()?.let(::StringValue) ?: return baseResult
+        return regexPattern.matches(stringValue, resolver)
+    }
+
+    override fun generate(resolver: Resolver): Value {
+        val candidate = runCatching {
+            regexPattern.generate(resolver).toStringLiteral()
+        }.getOrNull()
+
+        if (candidate != null) {
+            runCatching { basePattern.parse(candidate, resolver) }
+                .getOrNull()
+                ?.let { return it }
+        }
+
+        return basePattern.generate(resolver)
+    }
+
+    override fun patternSet(resolver: Resolver): List<Pattern> = listOf(this)
+
+    override fun encompasses(
+        otherPattern: Pattern,
+        thisResolver: Resolver,
+        otherResolver: Resolver,
+        typeStack: TypeStack
+    ): Result {
+        val resolvedOther = resolvedHop(otherPattern, otherResolver)
+        return when (resolvedOther) {
+            is ExactValuePattern -> resolvedOther.fitsWithin(patternSet(thisResolver), otherResolver, thisResolver, typeStack)
+            is RegexConstrainedPattern -> {
+                val otherFitsThis = matches(resolvedOther.generate(otherResolver), thisResolver)
+                if (otherFitsThis is Result.Success) Result.Success()
+                else {
+                    val thisFitsOther = resolvedOther.matches(generate(thisResolver), otherResolver)
+                    if (thisFitsOther is Result.Success) Result.Success()
+                    else patternMismatchResult(this, otherPattern, thisResolver.mismatchMessages)
+                }
+            }
+            else -> basePattern.encompasses(resolvedOther, thisResolver, otherResolver, typeStack)
+        }
+    }
+}

--- a/core/src/test/kotlin/integration_tests/ExamplesAsStubTest.kt
+++ b/core/src/test/kotlin/integration_tests/ExamplesAsStubTest.kt
@@ -641,6 +641,100 @@ paths:
     }
 
     @Test
+    fun `should match request using match pattern in external example and respond with example response`() {
+        val specFile = File("src/test/resources/openapi/request_matchers_in_external_examples.yaml")
+        val contract = OpenApiSpecification.fromFile(specFile.canonicalPath).toFeature()
+        val exampleFile = File("src/test/resources/openapi/request_matchers_in_external_examples_examples/search_post.json")
+        val exampleStub = ScenarioStub.readFromFile(exampleFile)
+
+        HttpStub(contract, listOf(exampleStub)).use { stub ->
+            val response = stub.client.execute(
+                HttpRequest(
+                    "POST",
+                    "/search",
+                    emptyMap(),
+                    parsedJSONObject("""{"code":"ABC123"}""")
+                )
+            )
+            assertThat(response.status).isEqualTo(200)
+            assertThat(response.body).isEqualTo(parsedJSONObject("""{"message":"matched"}"""))
+        }
+    }
+
+    @Test
+    fun `should match only negative numbers using regex matcher in external example`() {
+        val specFile = File("src/test/resources/openapi/request_matchers_in_external_examples.yaml")
+        val contract = OpenApiSpecification.fromFile(specFile.canonicalPath).toFeature()
+        val exampleFile = File("src/test/resources/openapi/request_matchers_in_external_examples_examples/adjust_post.json")
+        val exampleStub = ScenarioStub.readFromFile(exampleFile)
+
+        HttpStub(contract, listOf(exampleStub)).use { stub ->
+            val negativeResponse = stub.client.execute(
+                HttpRequest(
+                    "POST",
+                    "/adjust",
+                    emptyMap(),
+                    parsedJSONObject("""{"amount":-12}""")
+                )
+            )
+            assertThat(negativeResponse.status).isEqualTo(200)
+            assertThat(negativeResponse.body).isEqualTo(parsedJSONObject("""{"message":"negative matched"}"""))
+
+            val positiveResponse = stub.client.execute(
+                HttpRequest(
+                    "POST",
+                    "/adjust",
+                    emptyMap(),
+                    parsedJSONObject("""{"amount":12}""")
+                )
+            )
+            assertThat(positiveResponse.body).isNotEqualTo(parsedJSONObject("""{"message":"negative matched"}"""))
+        }
+    }
+
+    @Test
+    fun `should match regex matcher for integer`() {
+        val specFile = File("src/test/resources/openapi/request_matchers_in_external_examples.yaml")
+        val contract = OpenApiSpecification.fromFile(specFile.canonicalPath).toFeature()
+        val exampleFile = File("src/test/resources/openapi/request_matchers_in_external_examples_examples/count_post.json")
+        val exampleStub = ScenarioStub.readFromFile(exampleFile)
+
+        HttpStub(contract, listOf(exampleStub)).use { stub ->
+            val response = stub.client.execute(
+                HttpRequest(
+                    "POST",
+                    "/count",
+                    emptyMap(),
+                    parsedJSONObject("""{"count":42}""")
+                )
+            )
+            assertThat(response.status).isEqualTo(200)
+            assertThat(response.body).isEqualTo(parsedJSONObject("""{"message":"count matched"}"""))
+        }
+    }
+
+    @Test
+    fun `should match regex matcher for boolean`() {
+        val specFile = File("src/test/resources/openapi/request_matchers_in_external_examples.yaml")
+        val contract = OpenApiSpecification.fromFile(specFile.canonicalPath).toFeature()
+        val exampleFile = File("src/test/resources/openapi/request_matchers_in_external_examples_examples/flag_post.json")
+        val exampleStub = ScenarioStub.readFromFile(exampleFile)
+
+        HttpStub(contract, listOf(exampleStub)).use { stub ->
+            val response = stub.client.execute(
+                HttpRequest(
+                    "POST",
+                    "/flag",
+                    emptyMap(),
+                    parsedJSONObject("""{"active":true}""")
+                )
+            )
+            assertThat(response.status).isEqualTo(200)
+            assertThat(response.body).isEqualTo(parsedJSONObject("""{"message":"flag matched"}"""))
+        }
+    }
+
+    @Test
     fun `errors when loading examples with invalid values as expectations should mention the example name`() {
         val nameOfExample = "EXAMPLE_OF_SUCCESS"
         val spec = """

--- a/core/src/test/kotlin/io/specmatic/core/matchers/RegexMatcherTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/matchers/RegexMatcherTest.kt
@@ -7,9 +7,11 @@ import io.specmatic.core.Resolver
 import io.specmatic.core.jsonoperator.Optional
 import io.specmatic.core.jsonoperator.RequestResponseOperator
 import io.specmatic.core.jsonoperator.value.ValueOperator
-import io.specmatic.core.pattern.ExactValuePattern
 import io.specmatic.core.pattern.HasFailure
 import io.specmatic.core.pattern.HasValue
+import io.specmatic.core.pattern.NumberPattern
+import io.specmatic.core.pattern.RegexConstrainedPattern
+import io.specmatic.core.pattern.StringPattern
 import io.specmatic.core.value.NumberValue
 import io.specmatic.core.value.StringValue
 import org.assertj.core.api.Assertions.*
@@ -88,10 +90,12 @@ class RegexMatcherTest {
                 StringValue("pattern: ^J.*")
             )
 
-            assertThat(pattern).isInstanceOf(ExactValuePattern::class.java)
-            val value = (pattern as ExactValuePattern).pattern
-            assertThat(value).isInstanceOf(StringValue::class.java)
-            assertThat(value.toStringLiteral()).startsWith("J")
+            assertThat(pattern).isInstanceOf(RegexConstrainedPattern::class.java)
+            val constrainedPattern = pattern as RegexConstrainedPattern
+            assertThat(constrainedPattern.basePattern).isInstanceOf(StringPattern::class.java)
+            val generated = constrainedPattern.generate(Resolver())
+            assertThat(generated).isInstanceOf(StringValue::class.java)
+            assertThat(generated.toStringLiteral()).startsWith("J")
         }
 
         @Test
@@ -100,10 +104,12 @@ class RegexMatcherTest {
                 StringValue("pattern: ^2\\d*$")
             )
 
-            assertThat(pattern).isInstanceOf(ExactValuePattern::class.java)
-            val value = (pattern as ExactValuePattern).pattern
-            assertThat(value).isInstanceOf(NumberValue::class.java)
-            assertThat(value.toStringLiteral()).startsWith("2")
+            assertThat(pattern).isInstanceOf(RegexConstrainedPattern::class.java)
+            val constrainedPattern = pattern as RegexConstrainedPattern
+            assertThat(constrainedPattern.basePattern).isInstanceOf(NumberPattern::class.java)
+            val generated = constrainedPattern.generate(Resolver())
+            assertThat(generated).isInstanceOf(NumberValue::class.java)
+            assertThat(generated.toStringLiteral()).startsWith("2")
         }
     }
 

--- a/core/src/test/resources/openapi/request_matchers_in_external_examples.yaml
+++ b/core/src/test/resources/openapi/request_matchers_in_external_examples.yaml
@@ -1,0 +1,101 @@
+openapi: 3.0.0
+info:
+  title: Matcher External Example API
+  version: 0.1.0
+paths:
+  /search:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - code
+              properties:
+                code:
+                  type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - message
+                properties:
+                  message:
+                    type: string
+  /adjust:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - amount
+              properties:
+                amount:
+                  type: number
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - message
+                properties:
+                  message:
+                    type: string
+  /count:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - count
+              properties:
+                count:
+                  type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - message
+                properties:
+                  message:
+                    type: string
+  /flag:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - active
+              properties:
+                active:
+                  type: boolean
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - message
+                properties:
+                  message:
+                    type: string

--- a/core/src/test/resources/openapi/request_matchers_in_external_examples_examples/adjust_post.json
+++ b/core/src/test/resources/openapi/request_matchers_in_external_examples_examples/adjust_post.json
@@ -1,0 +1,18 @@
+{
+  "http-request": {
+    "method": "POST",
+    "path": "/adjust",
+    "body": {
+      "amount": "$match(pattern: ^-\\d+$)"
+    }
+  },
+  "http-response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "message": "negative matched"
+    }
+  }
+}

--- a/core/src/test/resources/openapi/request_matchers_in_external_examples_examples/count_post.json
+++ b/core/src/test/resources/openapi/request_matchers_in_external_examples_examples/count_post.json
@@ -1,0 +1,18 @@
+{
+  "http-request": {
+    "method": "POST",
+    "path": "/count",
+    "body": {
+      "count": "$match(pattern: ^\\d+$)"
+    }
+  },
+  "http-response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "message": "count matched"
+    }
+  }
+}

--- a/core/src/test/resources/openapi/request_matchers_in_external_examples_examples/flag_post.json
+++ b/core/src/test/resources/openapi/request_matchers_in_external_examples_examples/flag_post.json
@@ -1,0 +1,18 @@
+{
+  "http-request": {
+    "method": "POST",
+    "path": "/flag",
+    "body": {
+      "active": "$match(pattern: ^(true|false)$)"
+    }
+  },
+  "http-response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "message": "flag matched"
+    }
+  }
+}

--- a/core/src/test/resources/openapi/request_matchers_in_external_examples_examples/search_post.json
+++ b/core/src/test/resources/openapi/request_matchers_in_external_examples_examples/search_post.json
@@ -1,0 +1,18 @@
+{
+  "http-request": {
+    "method": "POST",
+    "path": "/search",
+    "body": {
+      "code": "$match(pattern: ^[A-Z]{3}[0-9]{3}$)"
+    }
+  },
+  "http-response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "message": "matched"
+    }
+  }
+}


### PR DESCRIPTION
Reason for change: RegexMatcher was not working for request matching on mock side due to this bug.