### PR TITLE
Fix test example filtering

### DIFF
--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -673,8 +673,10 @@ open class SpecmaticJUnitSupport {
             )
         }
 
+        val featureWithExternalizedExamples = feature.loadExternalisedExamples()
+
         val filteredScenariosBasedOnName = selectTestsToRun(
-            feature.scenarios.asSequence(),
+            featureWithExternalizedExamples.scenarios.asSequence(),
             filterName,
             filterNotName
         ) {
@@ -703,7 +705,7 @@ open class SpecmaticJUnitSupport {
             )
         }.toList()
 
-        val filteredFeature = feature.copy(scenarios = filteredScenarios.toList()).loadExternalisedExamples(filter.expression)
+        val filteredFeature = featureWithExternalizedExamples.copy(scenarios = filteredScenarios.toList())
         val (validExampleFeature, result) = filteredFeature.validateAndFilterExamples()
         if (specmaticConfig.getTestLenientMode() == false) result.throwOnFailure()
 


### PR DESCRIPTION
**What**:

Cleaner example filtering for test. 


**Why**:

Previous example filtering would filter the actual examples. The issue with this is that scenarios may be filtered on tokens that do not appear in examples, e.g. tags. If a scenario is filtered out, due to a tag, it's examples will not be filtered out, and will look orphaned, resulting in errors or warnings.

**How**:

The approach now is to load them first, then filter the scenarios out.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
