### PR TITLE
Implement spec-level isolation for HttpStub interceptors

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -11,6 +11,7 @@ import io.specmatic.core.config.SpecmaticSpecConfig
 import io.specmatic.core.config.Switch
 import io.specmatic.core.utilities.ContractSource
 import io.specmatic.core.utilities.ContractSourceEntry
+import io.specmatic.core.utilities.FileAssociation
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.Value
 import io.specmatic.reporter.ctrf.model.CtrfSpecConfig
@@ -299,6 +300,9 @@ interface SpecmaticConfig {
 
     @JsonIgnore
     fun getHooks(): Map<String, String>
+
+    @JsonIgnore
+    fun getStubHooks(): List<FileAssociation<Map<String, String>>>
 
     @JsonIgnore
     fun getProxyConfig(): ProxyConfig?

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfigV1V2Common.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfigV1V2Common.kt
@@ -1050,6 +1050,10 @@ data class SpecmaticConfigV1V2Common(
         return hooks
     }
 
+    override fun getStubHooks(): List<FileAssociation<Map<String, String>>> {
+        return listOf(FileAssociation.Global(this.hooks))
+    }
+
     @JsonIgnore
     override fun getProxyConfig(): ProxyConfig? {
         return proxy

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3Impl.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3Impl.kt
@@ -74,6 +74,7 @@ import io.specmatic.core.config.v3.specmatic.SuccessCriterion
 import io.specmatic.core.defaultReportDirPath
 import io.specmatic.core.readEnvVarOrProperty
 import io.specmatic.core.utilities.ContractSource
+import io.specmatic.core.utilities.FileAssociation
 import io.specmatic.core.utilities.Flags
 import io.specmatic.core.utilities.Flags.Companion.EXAMPLE_DIRECTORIES
 import io.specmatic.core.utilities.Flags.Companion.EXTENSIBLE_QUERY_PARAMS
@@ -557,6 +558,10 @@ data class SpecmaticConfigV3Impl(val file: File? = null, private val specmaticCo
     override fun getHooks(): Map<String, String> {
         val fromDependencies = specmaticConfig.dependencies?.data?.adapters?.resolveElseThrow(resolver)?.hooks
         return fromDependencies.orEmpty()
+    }
+
+    override fun getStubHooks(): List<FileAssociation<Map<String, String>>> {
+        return specmaticConfig.dependencies?.getHooks(resolver).orEmpty()
     }
 
     override fun getProxyConfig(): ProxyConfig? {

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/MockServiceConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/MockServiceConfig.kt
@@ -17,6 +17,7 @@ import io.specmatic.core.config.v3.components.settings.MockSettings
 import io.specmatic.core.config.v3.components.sources.SourceV3
 import io.specmatic.core.config.v3.determineSpecTypeFor
 import io.specmatic.core.config.v3.resolveElseThrow
+import io.specmatic.core.utilities.FileAssociation
 import io.specmatic.reporter.model.SpecType
 import java.io.File
 import kotlin.collections.orEmpty
@@ -201,5 +202,21 @@ data class MockServiceConfig(val services: List<Value>, val data: Data? = null, 
                 value.copy(service = RefOrValue.Value(service.copy(data = existingData.copy(examples = RefOrValue.Value(updatedExamples)))))
             }
         )
+    }
+
+    @JsonIgnore
+    fun getHooks(resolver: SpecmaticConfigV3Resolver): List<FileAssociation<Map<String, String>>> {
+        val globalHooks = data?.adapters?.resolveElseThrow(resolver)?.hooks?.let { FileAssociation.Global(it) }
+        val serviceHooks = services.asSequence().map { it.service.resolveElseThrow(resolver) }.flatMap { service ->
+            val hooks = service.data?.adapters?.resolveElseThrow(resolver)?.hooks.orEmpty()
+            service.definitions.asSequence().map { it.definition }.flatMap { definition ->
+                val source = definition.source.resolveElseThrow(resolver)
+                definition.specs.asSequence().map { specDef ->
+                    val specFile = source.resolveSpecification(File(specDef.getSpecificationPath()))
+                    FileAssociation.FileScoped(specFile, hooks)
+                }
+            }
+        }
+        return listOfNotNull(globalHooks) + serviceHooks
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/utilities/FileAssociation.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/FileAssociation.kt
@@ -1,0 +1,14 @@
+package io.specmatic.core.utilities
+
+import java.io.File
+
+sealed interface FileAssociation<T> {
+    data class Global<T>(val data: T) : FileAssociation<T>
+    data class FileScoped<T>(val file: File, val data: T) : FileAssociation<T> {
+        fun matches(file: File): Boolean {
+            return runCatching { this.file.canonicalPath == file.canonicalPath }.getOrElse {
+                this.file.absolutePath == file.absolutePath
+            }
+        }
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/core/utilities/FileAssociation.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/FileAssociation.kt
@@ -13,11 +13,4 @@ sealed interface FileAssociation<T> {
             }
         }
     }
-
-    fun <U> map(transform: (T) -> U): FileAssociation<U> {
-        return when (this) {
-            is Global -> Global(transform(this.data))
-            is FileScoped -> FileScoped(this.file, transform(this.data))
-        }
-    }
 }

--- a/core/src/main/kotlin/io/specmatic/core/utilities/FileAssociation.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/FileAssociation.kt
@@ -3,12 +3,21 @@ package io.specmatic.core.utilities
 import java.io.File
 
 sealed interface FileAssociation<T> {
-    data class Global<T>(val data: T) : FileAssociation<T>
-    data class FileScoped<T>(val file: File, val data: T) : FileAssociation<T> {
+    val data: T
+
+    data class Global<T>(override val data: T) : FileAssociation<T>
+    data class FileScoped<T>(val file: File, override val data: T) : FileAssociation<T> {
         fun matches(file: File): Boolean {
             return runCatching { this.file.canonicalPath == file.canonicalPath }.getOrElse {
                 this.file.absolutePath == file.absolutePath
             }
+        }
+    }
+
+    fun <U> map(transform: (T) -> U): FileAssociation<U> {
+        return when (this) {
+            is Global -> Global(transform(this.data))
+            is FileScoped -> FileScoped(this.file, transform(this.data))
         }
     }
 }

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -642,14 +642,13 @@ class HttpStub(
     }
 
     private fun applyResponseInterceptors(httpRequest: HttpRequest, httpResponse: HttpResponse, specFile: File?): Pair<HttpResponse, List<InterceptorResult<HttpResponse>>> {
-        val global = responseInterceptors.asSequence().filterIsInstance<FileAssociation.Global<ResponseInterceptor>>().map { it.data }
-        val (updatedResponse, globalResult) = applyInterceptors(httpResponse, global) { interceptor, req ->
+        val specLevel = if (specFile != null) responseInterceptors.filterMatching(specFile) else emptySequence()
+        val (specUpdatedResponse, specResult) = applyInterceptors(httpResponse, specLevel) { interceptor, req ->
             interceptor.interceptResponseAndReturnErrors(httpRequest, req)
         }
 
-        if (specFile == null) return Pair(updatedResponse, globalResult)
-        val specLevel = responseInterceptors.filterMatching(specFile)
-        return applyInterceptors(updatedResponse, specLevel, globalResult) { interceptor, req ->
+        val global = responseInterceptors.asSequence().filterIsInstance<FileAssociation.Global<ResponseInterceptor>>().map { it.data }
+        return applyInterceptors(specUpdatedResponse, global, specResult) { interceptor, req ->
             interceptor.interceptResponseAndReturnErrors(httpRequest, req)
         }
     }

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -105,6 +105,7 @@ import io.netty.handler.ssl.SslProvider
 import io.netty.handler.ssl.SupportedCipherSuiteFilter
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory
 import io.netty.handler.codec.http2.Http2SecurityUtil
+import io.specmatic.core.utilities.FileAssociation
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.BroadcastChannel
 import kotlinx.coroutines.channels.BufferOverflow
@@ -304,17 +305,25 @@ class HttpStub(
 
     private val broadcastChannels: Vector<BroadcastChannel<SseEvent>> = Vector(50, 10)
 
-    private val requestInterceptors: MutableList<RequestInterceptor> = mutableListOf()
+    private val requestInterceptors: MutableList<FileAssociation<RequestInterceptor>> = mutableListOf()
 
-    private val responseInterceptors: MutableList<ResponseInterceptor> = mutableListOf()
+    private val responseInterceptors: MutableList<FileAssociation<ResponseInterceptor>> = mutableListOf()
 
     fun registerRequestInterceptor(requestInterceptor: RequestInterceptor) {
+        registerRequestInterceptor(FileAssociation.Global(requestInterceptor))
+    }
+
+    fun registerResponseInterceptor(responseInterceptor: ResponseInterceptor) {
+        registerResponseInterceptor(FileAssociation.Global(responseInterceptor))
+    }
+
+    fun registerRequestInterceptor(requestInterceptor: FileAssociation<RequestInterceptor>) {
         if (!requestInterceptors.contains(requestInterceptor)) {
             requestInterceptors.add(requestInterceptor)
         }
     }
 
-    fun registerResponseInterceptor(responseInterceptor: ResponseInterceptor) {
+    fun registerResponseInterceptor(responseInterceptor: FileAssociation<ResponseInterceptor>) {
         if (!responseInterceptors.contains(responseInterceptor)) {
             responseInterceptors.add(responseInterceptor)
         }
@@ -336,16 +345,19 @@ class HttpStub(
                 var responseInterceptorResults: List<InterceptorResult<HttpResponse>> = emptyList()
 
                 try {
+                    val requestBaseUrl = "${call.request.local.scheme}://${call.request.local.localHost}:${call.request.local.localPort}"
+                    val requestUrlPath = call.request.path()
+                    val defaultBaseUrl = endPointFromHostAndPort(host, port, keyDataRegistry.hasAny())
                     val rawHttpRequest = ktorHttpRequestToHttpRequest(call).also {
                         if (it.isHealthCheckRequest()) return@intercept
                     }
 
-                    val (httpRequest, requestInterceptorResults) = requestInterceptors.fold(
-                        rawHttpRequest to emptyList<InterceptorResult<HttpRequest>>()
-                    ) { (request, results), interceptor ->
-                        val result = interceptor.interceptRequestAndReturnErrors(request)
-                        (result.processedValue ?: request) to results + result
-                    }
+                    val (httpRequest, requestInterceptorResults) = applyRequestInterceptors(
+                        rawHttpRequest = rawHttpRequest,
+                        baseUrl = requestBaseUrl,
+                        defaultBaseUrl = defaultBaseUrl,
+                        urlPath = requestUrlPath
+                    )
                     val requestInterceptorErrors = requestInterceptorResults.flatMap { it.errors }
 
                     LicenseResolver.utilize(
@@ -404,25 +416,18 @@ class HttpStub(
                         isStateSetupRequest(httpRequest) -> handleStateSetupRequest(httpRequest).copy(isInternalStubPath = true)
                         isFlushTransientStubsRequest(httpRequest) -> handleFlushTransientStubsRequest(httpRequest).copy(isInternalStubPath = true)
                         else -> {
-                            val responseResult = serveStubResponse(
-                                httpRequest,
-                                baseUrl = "${call.request.local.scheme}://${call.request.local.localHost}:${call.request.local.localPort}",
-                                defaultBaseUrl = endPointFromHostAndPort(host, port, keyDataRegistry.hasAny()),
-                                urlPath = call.request.path()
-                            )
+                            val responseResult = serveStubResponse(httpRequest, baseUrl = requestBaseUrl, defaultBaseUrl = defaultBaseUrl, urlPath = requestUrlPath)
                             if (responseResult is NotStubbed) httpLogMessage.addResult(responseResult.stubResult)
                             responseResult.response
                         }
                     }
 
 
-                    val (httpResponse, responseInterceptorResultsList) = responseInterceptors.fold(
-                        httpStubResponse.response to emptyList<InterceptorResult<HttpResponse>>()
-                    ) { (response, results), interceptor ->
-                        val result = interceptor.interceptResponseAndReturnErrors(httpRequest, response)
-                        (result.processedValue ?: response) to results + result
-                    }
-
+                    val (httpResponse, responseInterceptorResultsList) = applyResponseInterceptors(
+                        httpRequest = httpRequest,
+                        httpResponse = httpStubResponse.response,
+                        specFile = httpStubResponse.contractPath.takeUnless(String::isBlank)?.let(::File)
+                    )
                     responseInterceptorResults = responseInterceptorResultsList
 
                     // Store encoded response for later logging if different
@@ -615,6 +620,62 @@ class HttpStub(
                 "Incoming mTLS is enabled, but no HTTPS key material is configured for ports: ${portsWithIncomingMtlsButNoHttps.joinToString(", ")}"
             )
         }
+    }
+
+    private fun applyRequestInterceptors(rawHttpRequest: HttpRequest, baseUrl: String, defaultBaseUrl: String, urlPath: String): Pair<HttpRequest, List<InterceptorResult<HttpRequest>>> {
+        val global = requestInterceptors.asSequence().filterIsInstance<FileAssociation.Global<RequestInterceptor>>().map { it.data }
+        val (updatedRequest, globalResults) = applyInterceptors(rawHttpRequest, global) { interceptor, req ->
+            interceptor.interceptRequestAndReturnErrors(req)
+        }
+
+        val specLevel = matchingInterceptors(
+            httpRequest = updatedRequest,
+            interceptors = requestInterceptors,
+            baseUrl = baseUrl,
+            defaultBaseUrl = defaultBaseUrl,
+            urlPath = urlPath
+        )
+
+        return applyInterceptors(updatedRequest, specLevel, globalResults) { interceptor, req ->
+            interceptor.interceptRequestAndReturnErrors(req)
+        }
+    }
+
+    private fun applyResponseInterceptors(httpRequest: HttpRequest, httpResponse: HttpResponse, specFile: File?): Pair<HttpResponse, List<InterceptorResult<HttpResponse>>> {
+        val global = responseInterceptors.asSequence().filterIsInstance<FileAssociation.Global<ResponseInterceptor>>().map { it.data }
+        val (updatedResponse, globalResult) = applyInterceptors(httpResponse, global) { interceptor, req ->
+            interceptor.interceptResponseAndReturnErrors(httpRequest, req)
+        }
+
+        if (specFile == null) return Pair(updatedResponse, globalResult)
+        val specLevel = responseInterceptors.filterMatching(specFile)
+        return applyInterceptors(updatedResponse, specLevel, globalResult) { interceptor, req ->
+            interceptor.interceptResponseAndReturnErrors(httpRequest, req)
+        }
+    }
+
+    private fun <T> matchingInterceptors(httpRequest: HttpRequest, interceptors: List<FileAssociation<T>>, baseUrl: String, defaultBaseUrl: String, urlPath: String): Sequence<T> {
+        val feature = matchingFeatureForInterceptors(httpRequest = httpRequest, baseUrl = baseUrl, defaultBaseUrl = defaultBaseUrl, urlPath = urlPath) ?: return emptySequence()
+        return interceptors.filterMatching(File(feature.path))
+    }
+
+    private fun matchingFeatureForInterceptors(httpRequest: HttpRequest, baseUrl: String, defaultBaseUrl: String, urlPath: String): Feature? {
+        val url = "$baseUrl$urlPath"
+        val stubBaseUrlPath = specmaticConfigInstance.stubBaseUrlPathAssociatedTo(url, defaultBaseUrl)
+        val trimmedRequest = httpRequest.trimBaseUrlPath(stubBaseUrlPath)
+        val candidateFeatures = featuresAssociatedTo(baseUrl, features, specToBaseUrlMap, urlPath)
+        return candidateFeatures.firstOrNull { it.identifierMatchingScenario(trimmedRequest) != null }
+    }
+
+    private fun <T, I> applyInterceptors(initial: T, interceptors: Sequence<I>, results: List<InterceptorResult<T>> = emptyList(), run: (I, T) -> InterceptorResult<T>): Pair<T, List<InterceptorResult<T>>> {
+        return interceptors.fold(initial to results) { (value, res), interceptor ->
+            val result = run(interceptor, value)
+            (result.processedValue ?: value) to res + result
+        }
+    }
+
+    private fun <T> List<FileAssociation<T>>.filterMatching(file: File): Sequence<T> {
+        return asSequence().filterIsInstance<FileAssociation.FileScoped<T>>().filter { it.matches(file) }.map { it.data }
     }
 
     private fun targetServerForPort(port: Int): String {

--- a/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigKtTest.kt
@@ -10,6 +10,7 @@ import io.specmatic.core.config.KeyStoreConfiguration
 import io.specmatic.core.config.v2.SpecExecutionConfig
 import io.specmatic.core.config.v2.ContractConfig
 import io.specmatic.core.config.SpecmaticConfigVersion
+import io.specmatic.core.utilities.FileAssociation
 import io.specmatic.core.utilities.ContractSourceEntry
 import io.specmatic.core.utilities.Flags.Companion.EXAMPLE_DIRECTORIES
 import io.specmatic.core.config.v2.SpecmaticConfigV2
@@ -39,6 +40,13 @@ import java.security.KeyStore
 import java.util.stream.Stream
 
 internal class SpecmaticConfigKtTest {
+    @Test
+    fun `getStubHooks should return global hook associations for v1 v2 config`() {
+        val hooks = mapOf("preSpecmaticRequestProcessor" to "./hooks/decode_request.sh")
+        val config = SpecmaticConfigV1V2Common(version = SpecmaticConfigVersion.VERSION_2, hooks = hooks)
+        assertThat(config.getStubHooks()).containsExactly(FileAssociation.Global(hooks))
+    }
+
     @Test
     fun `should return test https configuration from v2 test config`() {
         val config = SpecmaticConfigV1V2Common(

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3ImplTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3ImplTest.kt
@@ -4,6 +4,7 @@ import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.KeyData
 import io.specmatic.core.ResiliencyTestSuite
 import io.specmatic.core.config.toSpecmaticConfig
+import io.specmatic.core.utilities.FileAssociation
 import io.specmatic.reporter.model.SpecType
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -299,6 +300,37 @@ class SpecmaticConfigV3ImplTest {
                 """.trimIndent()
             )
         }.hasMessageContaining("incomingMtlsEnabled")
+    }
+
+    @Test
+    fun `getStubHooks should return global and file scoped hook associations`() {
+        val config = v3Config("""
+        version: 3
+        dependencies:
+          data:
+            adapters:
+              preSpecmaticRequestProcessor: ./hooks/global_decode.sh
+          services:
+            - service:
+                definitions:
+                  - definition:
+                      source:
+                        filesystem: {}
+                      specs:
+                        - one.yaml
+                        - two.yaml
+                data:
+                  adapters:
+                    postSpecmaticResponseProcessor: ./hooks/service_encode.sh
+        """.trimIndent())
+
+        val oneSpecFile = config.getFirstMockSourceMatching { it.specPathInConfig == "one.yaml" }!!.specFile
+        val twoSpecFile = config.getFirstMockSourceMatching { it.specPathInConfig == "two.yaml" }!!.specFile
+        assertThat(config.getStubHooks()).containsExactlyInAnyOrder(
+            FileAssociation.Global(mapOf("preSpecmaticRequestProcessor" to "./hooks/global_decode.sh")),
+            FileAssociation.FileScoped(oneSpecFile, mapOf("postSpecmaticResponseProcessor" to "./hooks/service_encode.sh")),
+            FileAssociation.FileScoped(twoSpecFile, mapOf("postSpecmaticResponseProcessor" to "./hooks/service_encode.sh")),
+        )
     }
 
     @Nested

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
@@ -1251,7 +1251,7 @@ components:
     }
 
     @Test
-    fun `should apply global response interceptors before spec scoped response interceptors`() {
+    fun `should apply spec scoped response interceptors before global scoped response interceptors`() {
         val contractPath = "src/test/resources/openapi/hello.yaml"
         createStubFromContracts(contractPaths = listOf(contractPath), dataDirPaths = emptyList(), timeoutMillis = 0).use { stub ->
             stub.registerResponseInterceptor(object : ResponseInterceptor {
@@ -1273,7 +1273,7 @@ components:
             ))
 
             val response = stub.client.execute(HttpRequest("GET", "/hello/10", headers = mapOf("Authorization" to "Bearer token")))
-            assertThat(response.body.toStringLiteral()).isEqualTo("spec-after-global")
+            assertThat(response.body.toStringLiteral()).isEqualTo("spec-before-global")
         }
     }
 

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
@@ -38,6 +38,7 @@ import org.springframework.web.client.postForEntity
 import java.io.File
 import java.net.ConnectException
 import java.net.URI
+import java.net.ServerSocket
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.util.*
@@ -1068,6 +1069,261 @@ components:
             val response = stub.client.execute(request).body.toStringLiteral()
 
             assertThat(response).isEqualTo("This is a response for id : 100")
+        }
+    }
+
+    @Test
+    fun `should apply global request interceptors before spec scoped request interceptors`() {
+        val contractPath = "src/test/resources/openapi/hello.yaml"
+        createStubFromContracts(contractPaths = listOf(contractPath), dataDirPaths = emptyList(), timeoutMillis = 0).use { stub ->
+            stub.registerRequestInterceptor(object : RequestInterceptor {
+                override val name: String = "global-request-interceptor"
+                override fun interceptRequest(httpRequest: HttpRequest): HttpRequest {
+                    return httpRequest.copy(headers = httpRequest.headers + ("X-Global-Request-Interceptor" to "present"))
+                }
+            })
+
+            stub.registerRequestInterceptor(FileAssociation.FileScoped(
+                file = File(contractPath),
+                data = object : RequestInterceptor {
+                    override val name: String = "spec-request-interceptor"
+                    override fun interceptRequest(httpRequest: HttpRequest): HttpRequest {
+                        val selectedMarker = if (httpRequest.headers["X-Global-Request-Interceptor"] == "present") "spec-after-global" else "spec-before-global"
+                        return httpRequest.copy(headers = httpRequest.headers + ("X-Selected-Spec" to selectedMarker))
+                    }
+                }
+            ))
+
+            stub.registerResponseInterceptor(object : ResponseInterceptor {
+                override val name: String = "global-response-interceptor"
+                override fun interceptResponse(httpRequest: HttpRequest, httpResponse: HttpResponse): HttpResponse {
+                    return httpResponse.copy(body = StringValue(httpRequest.headers["X-Selected-Spec"] ?: "missing"))
+                }
+            })
+
+            val response = stub.client.execute(HttpRequest("GET", "/hello/10", headers = mapOf("Authorization" to "Bearer token")))
+            assertThat(response.body.toStringLiteral()).isEqualTo("spec-after-global")
+        }
+    }
+
+    @Test
+    fun `should use only global request interceptors when no spec scoped interceptor matches`() {
+        val contractPath = "src/test/resources/openapi/hello.yaml"
+        createStubFromContracts(contractPaths = listOf(contractPath), dataDirPaths = emptyList(), timeoutMillis = 0).use { stub ->
+            stub.registerRequestInterceptor(object : RequestInterceptor {
+                override val name: String = "global-request-interceptor"
+                override fun interceptRequest(httpRequest: HttpRequest): HttpRequest {
+                    return httpRequest.copy(headers = httpRequest.headers + ("X-Selected-Spec" to "global-only"))
+                }
+            })
+
+            stub.registerRequestInterceptor(FileAssociation.FileScoped(
+                file = File("src/test/resources/openapi/non_existent.yaml"),
+                data = object : RequestInterceptor {
+                    override val name: String = "non-matching-spec-request-interceptor"
+                    override fun interceptRequest(httpRequest: HttpRequest): HttpRequest {
+                        return httpRequest.copy(headers = httpRequest.headers + ("X-Selected-Spec" to "unexpected-spec"))
+                    }
+                }
+            ))
+
+            stub.registerResponseInterceptor(object : ResponseInterceptor {
+                override val name: String = "global-response-interceptor"
+                override fun interceptResponse(httpRequest: HttpRequest, httpResponse: HttpResponse): HttpResponse {
+                    return httpResponse.copy(body = StringValue(httpRequest.headers["X-Selected-Spec"] ?: "missing"))
+                }
+            })
+
+            val response = stub.client.execute(HttpRequest("GET", "/hello/10", headers = mapOf("Authorization" to "Bearer token")))
+            assertThat(response.body.toStringLiteral()).isEqualTo("global-only")
+        }
+    }
+
+    @Test
+    fun `should use first matching spec scoped request interceptor when multiple specs match`() {
+        val firstContractPath = "src/test/resources/multi_base_url_dynamic_stubs/specs/product.yaml"
+        val secondContractPath = "src/test/resources/multi_base_url_dynamic_stubs/specs/product-2.yaml"
+        createStubFromContracts(contractPaths = listOf(firstContractPath, secondContractPath), dataDirPaths = emptyList(), timeoutMillis = 0).use { stub ->
+            stub.registerRequestInterceptor(FileAssociation.FileScoped(
+                file = File(firstContractPath),
+                data = object : RequestInterceptor {
+                    override val name: String = "first-spec-request-interceptor"
+                    override fun interceptRequest(httpRequest: HttpRequest): HttpRequest {
+                        return httpRequest.copy(headers = httpRequest.headers + ("X-Selected-Spec" to "first"))
+                    }
+                }
+            ))
+
+            stub.registerRequestInterceptor(FileAssociation.FileScoped(
+                file = File(secondContractPath),
+                data = object : RequestInterceptor {
+                    override val name: String = "second-spec-request-interceptor"
+                    override fun interceptRequest(httpRequest: HttpRequest): HttpRequest {
+                        return httpRequest.copy(headers = httpRequest.headers + ("X-Selected-Spec" to "second"))
+                    }
+                }
+            ))
+
+            stub.registerResponseInterceptor(object : ResponseInterceptor {
+                override val name: String = "global-response-interceptor"
+                override fun interceptResponse(httpRequest: HttpRequest, httpResponse: HttpResponse): HttpResponse {
+                    return httpResponse.copy(body = StringValue(httpRequest.headers["X-Selected-Spec"] ?: "missing"))
+                }
+            })
+
+            val response = stub.client.execute(
+                HttpRequest(
+                    method = "POST",
+                    path = "/products",
+                    headers = mapOf("Content-Type" to "application/json"),
+                    body = parsedJSONObject("""{"name": "Widget", "price": 9.99, "category": "Books"}""")
+                )
+            )
+
+            assertThat(response.body.toStringLiteral()).isEqualTo("first")
+        }
+    }
+
+    @Test
+    fun `should pick spec scoped request interceptor based on baseUrl before matching`() {
+        val firstContractPath = "src/test/resources/multi_base_url_dynamic_stubs/specs/product.yaml"
+        val firstPort = ServerSocket(0).use { it.localPort }
+        val firstFeature = parseContractFileToFeature(firstContractPath)
+
+        val secondContractPath = "src/test/resources/multi_base_url_dynamic_stubs/specs/product-2.yaml"
+        val secondPort = ServerSocket(0).use { it.localPort }
+        val secondFeature = parseContractFileToFeature(secondContractPath)
+
+        HttpStub(
+            features = listOf(firstFeature, secondFeature),
+            port = firstPort,
+            timeoutMillis = 0,
+            specToStubBaseUrlMap = mapOf(firstFeature.path to "http://localhost:$firstPort", secondFeature.path to "http://localhost:$secondPort")
+        ).use { stub ->
+            stub.registerRequestInterceptor(FileAssociation.FileScoped(
+                file = File(firstFeature.path),
+                data = object : RequestInterceptor {
+                    override val name: String = "first-port-request-interceptor"
+                    override fun interceptRequest(httpRequest: HttpRequest): HttpRequest {
+                        return httpRequest.copy(headers = httpRequest.headers + ("X-Selected-Spec" to "first"))
+                    }
+                }
+            ))
+
+            stub.registerRequestInterceptor(FileAssociation.FileScoped(
+                file = File(secondFeature.path),
+                data = object : RequestInterceptor {
+                    override val name: String = "second-port-request-interceptor"
+                    override fun interceptRequest(httpRequest: HttpRequest): HttpRequest {
+                        return httpRequest.copy(headers = httpRequest.headers + ("X-Selected-Spec" to "second"))
+                    }
+                }
+            ))
+
+            stub.registerResponseInterceptor(object : ResponseInterceptor {
+                override val name: String = "global-response-interceptor"
+                override fun interceptResponse(httpRequest: HttpRequest, httpResponse: HttpResponse): HttpResponse {
+                    return httpResponse.copy(body = StringValue(httpRequest.headers["X-Selected-Spec"] ?: "missing"))
+                }
+            })
+
+            val firstPortResponse = LegacyHttpClient("http://localhost:$firstPort").execute(
+                HttpRequest(
+                    method = "POST",
+                    path = "/products",
+                    headers = mapOf("Content-Type" to "application/json"),
+                    body = parsedJSONObject("""{"name": "Widget", "price": 9.99, "category": "Books"}""")
+                )
+            )
+
+            val secondPortResponse = LegacyHttpClient("http://localhost:$secondPort").execute(
+                HttpRequest(
+                    method = "POST",
+                    path = "/products",
+                    headers = mapOf("Content-Type" to "application/json"),
+                    body = parsedJSONObject("""{"name": "Widget", "price": 9.99, "category": "Books"}""")
+                )
+            )
+
+            assertThat(firstPortResponse.body.toStringLiteral()).isEqualTo("first")
+            assertThat(secondPortResponse.body.toStringLiteral()).isEqualTo("second")
+        }
+    }
+
+    @Test
+    fun `should apply global response interceptors before spec scoped response interceptors`() {
+        val contractPath = "src/test/resources/openapi/hello.yaml"
+        createStubFromContracts(contractPaths = listOf(contractPath), dataDirPaths = emptyList(), timeoutMillis = 0).use { stub ->
+            stub.registerResponseInterceptor(object : ResponseInterceptor {
+                override val name: String = "global-response-interceptor"
+                override fun interceptResponse(httpRequest: HttpRequest, httpResponse: HttpResponse): HttpResponse {
+                    return httpResponse.copy(headers = httpResponse.headers + ("X-Response-Interceptor-Order" to "global"))
+                }
+            })
+
+            stub.registerResponseInterceptor(FileAssociation.FileScoped(
+                file = File(contractPath),
+                data = object : ResponseInterceptor {
+                    override val name: String = "spec-response-interceptor"
+                    override fun interceptResponse(httpRequest: HttpRequest, httpResponse: HttpResponse): HttpResponse {
+                        val marker = if (httpResponse.headers["X-Response-Interceptor-Order"] == "global") "spec-after-global" else "spec-before-global"
+                        return httpResponse.copy(body = StringValue(marker))
+                    }
+                }
+            ))
+
+            val response = stub.client.execute(HttpRequest("GET", "/hello/10", headers = mapOf("Authorization" to "Bearer token")))
+            assertThat(response.body.toStringLiteral()).isEqualTo("spec-after-global")
+        }
+    }
+
+    @Test
+    fun `should choose spec scoped request interceptor based on globally rewritten request`() {
+        val helloContractPath = "src/test/resources/openapi/hello.yaml"
+        val productContractPath = "src/test/resources/multi_base_url_dynamic_stubs/specs/product.yaml"
+
+        createStubFromContracts(contractPaths = listOf(helloContractPath, productContractPath), dataDirPaths = emptyList(), timeoutMillis = 0).use { stub ->
+            stub.registerRequestInterceptor(object : RequestInterceptor {
+                override val name: String = "global-request-interceptor"
+                override fun interceptRequest(httpRequest: HttpRequest): HttpRequest {
+                    return httpRequest.copy(
+                        method = "POST",
+                        path = "/products",
+                        headers = httpRequest.headers + ("Content-Type" to "application/json"),
+                        body = parsedJSONObject("""{"name": "Widget", "price": 9.99, "category": "Books"}""")
+                    )
+                }
+            })
+
+            stub.registerRequestInterceptor(FileAssociation.FileScoped(
+                file = File(helloContractPath),
+                data = object : RequestInterceptor {
+                    override val name: String = "hello-spec-request-interceptor"
+                    override fun interceptRequest(httpRequest: HttpRequest): HttpRequest {
+                        return httpRequest.copy(headers = httpRequest.headers + ("X-Selected-Spec" to "hello"))
+                    }
+                }
+            ))
+
+            stub.registerRequestInterceptor(FileAssociation.FileScoped(
+                file = File(productContractPath),
+                data = object : RequestInterceptor {
+                    override val name: String = "product-spec-request-interceptor"
+                    override fun interceptRequest(httpRequest: HttpRequest): HttpRequest {
+                        return httpRequest.copy(headers = httpRequest.headers + ("X-Selected-Spec" to "product"))
+                    }
+                }
+            ))
+
+            stub.registerResponseInterceptor(object : ResponseInterceptor {
+                override val name: String = "global-response-interceptor"
+                override fun interceptResponse(httpRequest: HttpRequest, httpResponse: HttpResponse): HttpResponse {
+                    return httpResponse.copy(body = StringValue(httpRequest.headers["X-Selected-Spec"] ?: "missing"))
+                }
+            })
+
+            val response = stub.client.execute(HttpRequest("GET", "/hello/10", headers = mapOf("Authorization" to "Bearer token")))
+            assertThat(response.body.toStringLiteral()).isEqualTo("product")
         }
     }
 


### PR DESCRIPTION
**What**: Implement spec-level isolation for HttpStub interceptors

**Why**: Config V3 enables spec-level isolation for defining adapters, in contrast to V2, where all hooks were treated as global. This PR fixes HttpStub to permit isolation on a per-spec basis to work with V3

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
