### PR TITLE
fix: Make parsing of Bearer security scheme declared in OpenAPI spec case insensitive

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -58,13 +58,11 @@ import java.io.File
 import kotlin.collections.orEmpty
 
 private const val BEARER_SECURITY_SCHEME = "bearer"
+private const val BASIC_SECURITY_SCHEME = "basic"
 
 private const val X_SPECMATIC_HINT = "x-specmatic-hint"
 private const val HINT_BOUNDARY_TESTING_ENABLED = "boundary_testing_enabled"
 private val HINT_VALUE_DELIMITERS = charArrayOf(',')
-
-const val testDirectoryEnvironmentVariable = "SPECMATIC_TESTS_DIRECTORY"
-const val testDirectoryProperty = "specmaticTestsDirectory"
 
 var missingRequestExampleErrorMessageForTest: String = "WARNING: Ignoring response example named %s for test or stub data, because no associated request example named %s was found."
 var missingResponseExampleErrorMessageForTest: String = "WARNING: Ignoring request example named %s for test or stub data, because no associated response example named %s was found."
@@ -1704,7 +1702,9 @@ class OpenApiSpecification(
 
     private fun toSecurityScheme(schemeName: String, securityScheme: SecurityScheme, collectorContext: CollectorContext): OpenAPISecurityScheme? {
         val securitySchemeConfiguration = securityConfiguration?.getOpenAPISecurityScheme(schemeName)
-        if (securityScheme.scheme == BEARER_SECURITY_SCHEME) {
+        val normalizedScheme = securityScheme.scheme?.lowercase()
+
+        if (normalizedScheme == BEARER_SECURITY_SCHEME) {
             return toBearerSecurityScheme(securitySchemeConfiguration, schemeName)
         }
 
@@ -1718,7 +1718,7 @@ class OpenApiSpecification(
             if (securityScheme.`in` == SecurityScheme.In.QUERY) return APIKeyInQueryParamSecurityScheme(securityScheme.name, apiKey)
         }
 
-        if (securityScheme.type == SecurityScheme.Type.HTTP && securityScheme.scheme == "basic") {
+        if (securityScheme.type == SecurityScheme.Type.HTTP && normalizedScheme == BASIC_SECURITY_SCHEME) {
             return toBasicAuthSecurityScheme(securitySchemeConfiguration, schemeName)
         }
 

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiIntegrationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiIntegrationTest.kt
@@ -781,6 +781,47 @@ Background:
         }
 
         @Test
+        fun `should match http request when basic auth security scheme in spec uses uppercase scheme value`() {
+            val feature = OpenApiSpecification.fromYAML(
+                """
+                openapi: 3.0.0
+                info:
+                  title: Hello world
+                  version: "1.0"
+                paths:
+                  /hello/{id}:
+                    get:
+                      parameters:
+                        - in: path
+                          name: id
+                          required: true
+                          schema:
+                            type: integer
+                      security:
+                        - basicAuth: []
+                      responses:
+                        '200':
+                          description: OK
+                components:
+                  securitySchemes:
+                    basicAuth:
+                      type: http
+                      scheme: Basic
+                """.trimIndent(), ""
+            ).toFeature()
+
+            val httpRequest = HttpRequest(
+                "GET",
+                "/hello/1",
+                mapOf("Authorization" to "Basic $base64EncodedCredentials")
+            )
+
+            val result = feature.scenarios.first().httpRequestPattern.matches(httpRequest, Resolver())
+
+            assertThat(result).isInstanceOf(Result.Success::class.java)
+        }
+
+        @Test
         fun `can set expectations with basic auth header`() {
             val feature = feature()
 

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiIntegrationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiIntegrationTest.kt
@@ -516,6 +516,47 @@ Background:
         }
 
         @Test
+        fun `should match http request when bearer security scheme in spec uses uppercase scheme value`() {
+            val feature = OpenApiSpecification.fromYAML(
+                """
+                openapi: 3.0.0
+                info:
+                  title: Hello world
+                  version: "1.0"
+                paths:
+                  /hello/{id}:
+                    get:
+                      parameters:
+                        - in: path
+                          name: id
+                          required: true
+                          schema:
+                            type: integer
+                      security:
+                        - BearerAuth: []
+                      responses:
+                        '200':
+                          description: OK
+                components:
+                  securitySchemes:
+                    BearerAuth:
+                      type: http
+                      scheme: Bearer
+                """.trimIndent(), ""
+            ).toFeature()
+
+            val httpRequest = HttpRequest(
+                "GET",
+                "/hello/1",
+                mapOf(HttpHeaders.AUTHORIZATION to "Bearer foo")
+            )
+
+            val result = feature.scenarios.first().httpRequestPattern.matches(httpRequest, Resolver())
+
+            assertThat(result).isInstanceOf(Result.Success::class.java)
+        }
+
+        @Test
         fun `should match http request for spec with bearer security scheme with token defined in environment variable even if the token value in the request is different`() {
             val token = "ENV1234"
             val tokenMap = mapOf(
@@ -584,6 +625,49 @@ Background:
             val result = feature.scenarios.first().httpRequestPattern.matches(httpRequest, Resolver())
             assertThat(result).isInstanceOf(Result.Failure::class.java)
             assertThat(result.reportString()).contains("Authorization header must be prefixed with \"Bearer\"")
+        }
+
+        @Test
+        fun `should generate authorization header when bearer security scheme in spec uses uppercase scheme value`() {
+            val feature = OpenApiSpecification.fromYAML(
+                """
+                openapi: 3.0.0
+                info:
+                  title: Hello world
+                  version: "1.0"
+                paths:
+                  /hello/{id}:
+                    get:
+                      parameters:
+                        - in: path
+                          name: id
+                          required: true
+                          schema:
+                            type: integer
+                      security:
+                        - BearerAuth: []
+                      responses:
+                        '200':
+                          description: OK
+                components:
+                  securitySchemes:
+                    BearerAuth:
+                      type: http
+                      scheme: Bearer
+                """.trimIndent(), ""
+            ).toFeature()
+
+            val result = feature.generateContractTests(emptyList()).single().runTest(object : TestExecutor {
+                override fun execute(request: HttpRequest): HttpResponse {
+                    assertThat(request.headers[HttpHeaders.AUTHORIZATION]).matches("Bearer (\\S+)")
+                    return HttpResponse.OK
+                }
+
+                override fun setServerState(serverState: Map<String, Value>) {
+                }
+            }).result
+
+            assertThat(result).isInstanceOf(Result.Success::class.java)
         }
 
         private fun securityConfigurationForBearerScheme(token: String) = SecurityConfiguration(


### PR DESCRIPTION
**What**:

Bearer security scheme in an OpenAPI spec was expected to be lower case ("bearer"). This has been fixed now, so it will work with Pascal case "Bearer" as well.

```yaml
components:
  securitySchemes:
    BearerAuth:
      type: http
      scheme: Bearer # had to be all lower case previously, Pascal case Bearer now works
```



**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
