### PR TITLE
fix: return a not equals pattern from not equals matcher's patternFrom

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/HttpPathPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpPathPattern.kt
@@ -378,6 +378,17 @@ data class HttpPathPattern(
         }
     }
 
+    fun patternFrom(path: String, resolver: Resolver): HttpPathPattern {
+        val pathSegments = path.split("/".toRegex()).filter { it.isNotEmpty() }
+        val pathSegmentPatternsFromPathTokens = pathSegmentPatterns.zip(pathSegments).map { (urlPathPattern, token) ->
+            urlPathPattern.patternFrom(
+                StringValue(removeKeyFromParameterToken(token)),
+                resolver
+            )
+        }
+        return this.copy(pathSegmentPatterns = pathSegmentPatternsFromPathTokens)
+    }
+
     private fun removeKeyFromParameterToken(token: String): String {
         if (!isPatternToken(token) || !token.contains(":")) return token
         val patternType = withoutPatternDelimiters(token).split(":").last()

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
@@ -23,8 +23,8 @@ import io.specmatic.core.pattern.Row
 import io.specmatic.core.pattern.ValueDetails
 import io.specmatic.core.pattern.attempt
 import io.specmatic.core.pattern.breadCrumb
+import io.specmatic.core.pattern.isMatcherToken
 import io.specmatic.core.pattern.isOptional
-import io.specmatic.core.pattern.isPatternOrMatcherToken
 import io.specmatic.core.pattern.isPatternToken
 import io.specmatic.core.pattern.newBasedOn
 import io.specmatic.core.pattern.newMapBasedOn
@@ -369,7 +369,7 @@ data class HttpRequestPattern(
 
             requestPattern = attempt(breadCrumb = "URL") {
                 val path = request.path ?: ""
-                val pathTypes = pathToPattern(path)
+                val pathTypes = this.httpPathPattern.patternFrom(path, resolver).pathSegmentPatterns
                 val queryParamTypes = toTypeMapForQueryParameters(request.queryParams, httpQueryParamPattern, resolver)
                 requestPattern.copy(
                     httpPathPattern = HttpPathPattern(pathTypes, path),
@@ -409,7 +409,7 @@ data class HttpRequestPattern(
                         EmptyString -> EmptyStringPattern
                         NoBodyValue -> NoBodyPattern
                         is StringValue -> encompassedType(request.bodyString, null, body, resolver)
-                        else -> request.body.exactMatchElseType()
+                        else -> this.body.patternFrom(request.body, resolver)
                     }
                 )
             }
@@ -531,7 +531,8 @@ data class HttpRequestPattern(
 
     private fun encompassedType(valueString: String, key: String?, type: Pattern, resolver: Resolver): Pattern {
         return when {
-            isPatternOrMatcherToken(valueString) -> resolvedHop(parsedPattern(valueString, key), resolver)
+            isPatternToken(valueString) -> resolvedHop(parsedPattern(valueString, key), resolver)
+            isMatcherToken(valueString) -> type.patternFrom(StringValue(valueString), resolver)
             else -> runCatching { type.parseToType(valueString, resolver) }.getOrElse { StringValue(valueString).exactMatchElseType() }
         }
     }

--- a/core/src/main/kotlin/io/specmatic/core/Resolver.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Resolver.kt
@@ -1,8 +1,10 @@
 package io.specmatic.core
 
-import io.specmatic.core.matchers.Matcher
 import io.specmatic.core.pattern.*
-import io.specmatic.core.value.*
+import io.specmatic.core.value.JSONArrayValue
+import io.specmatic.core.value.StringValue
+import io.specmatic.core.value.True
+import io.specmatic.core.value.Value
 import io.specmatic.test.ExampleProcessor
 import io.specmatic.test.asserts.WILDCARD_INDEX
 
@@ -100,7 +102,12 @@ data class Resolver(
 
     private fun patternTokenMatch(pattern: Pattern, sampleData: Value): Result? {
         if (!mockMode) return null
-        val patternFromValue = patternFromTokenBased(sampleData)
+
+        val patternFromValue = when {
+            isPatternToken(sampleData) -> patternFromTokenBased(sampleData)
+            sampleData.hasMatcherTemplate() -> pattern.patternFrom(sampleData, this)
+            else -> null
+        }
         if (patternFromValue == null || (patternFromValue as? ExactValuePattern)?.pattern == sampleData) {
             return Result.Success().takeIf { ExampleProcessor.isSubstitutionToken(sampleData) }
         }
@@ -125,7 +132,7 @@ data class Resolver(
     }
 
     fun patternFromTokenBased(sampleValue: Value): Pattern? {
-        if (sampleValue !is StringValue || !isPatternOrMatcherToken(sampleValue.string)) return null
+        if (sampleValue !is StringValue || !isPatternToken(sampleValue.string)) return null
         return getPattern(sampleValue.string).let {
             if (it is LookupRowPattern) resolvedHop(
                 it.pattern,
@@ -138,7 +145,7 @@ data class Resolver(
 
     fun getPattern(patternValue: String): Pattern =
         when {
-            isPatternOrMatcherToken(patternValue) -> {
+            isPatternToken(patternValue) -> {
                 val resolvedPattern = patterns[patternValue] ?: parsedPattern(patternValue, null).let {
                     if (it is DeferredPattern && it.pattern in patterns) patterns.getValue(it.pattern) else it
                 }

--- a/core/src/main/kotlin/io/specmatic/core/URLPathSegmentPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/URLPathSegmentPattern.kt
@@ -65,6 +65,10 @@ data class URLPathSegmentPattern(override val pattern: Pattern, override val key
         return JSONArrayValue(valueList)
     }
 
+    override fun patternFrom(value: Value, resolver: Resolver): URLPathSegmentPattern {
+        return this.copy(pattern = pattern.patternFrom(value, resolver))
+    }
+
     fun tryParse(token: String, resolver: Resolver): Value {
         return try {
             this.pattern.parse(token, resolver)

--- a/core/src/main/kotlin/io/specmatic/core/matchers/CompositeMatcher.kt
+++ b/core/src/main/kotlin/io/specmatic/core/matchers/CompositeMatcher.kt
@@ -1,6 +1,7 @@
 package io.specmatic.core.matchers
 
 import io.specmatic.core.BreadCrumb
+import io.specmatic.core.pattern.AnyPattern
 import io.specmatic.core.pattern.HasFailure
 import io.specmatic.core.pattern.HasValue
 import io.specmatic.core.pattern.Pattern
@@ -39,6 +40,15 @@ data class CompositeMatcher(
         }
     }
 
+    override fun patternFrom(originalPattern: Pattern): Pattern {
+        val matcher = matchers.find { it is EqualityMatcher }
+            ?: matchers.find { it is RegexMatcher }
+            ?: matchers.find { it is PatternMatcher }
+            ?: matchers.firstOrNull()
+
+        return matcher?.patternFrom(originalPattern) ?: originalPattern
+    }
+
     companion object : MatcherFactory {
         override val matcherKey: String = "match"
 
@@ -56,11 +66,6 @@ data class CompositeMatcher(
 
         override fun parseFrom(path: BreadCrumb, properties: Map<String, Value>, context: MatcherContext): ReturnValue<CompositeMatcher> {
             return HasFailure("CompositeMatcher cannot be parsed from properties", path.value)
-        }
-
-        override fun toPatternSimplified(value: Value): Pattern? {
-            val properties = extractPropertiesIfExist(value) ?: return null
-            return Matcher.toPatternSimplified(properties)
         }
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/matchers/EqualityMatcher.kt
+++ b/core/src/main/kotlin/io/specmatic/core/matchers/EqualityMatcher.kt
@@ -7,6 +7,7 @@ import io.specmatic.core.pattern.HasValue
 import io.specmatic.core.pattern.Pattern
 import io.specmatic.core.pattern.ReturnValue
 import io.specmatic.core.pattern.unwrapOrReturn
+import io.specmatic.core.value.ScalarValue
 import io.specmatic.core.value.StringValue
 import io.specmatic.core.value.Value
 
@@ -57,6 +58,14 @@ data class EqualityMatcher(val path: BreadCrumb, val value: Value, val strategy:
         )
     }
 
+    override fun patternFrom(originalPattern: Pattern): Pattern {
+        if(this.value !is ScalarValue) return originalPattern
+        return when(strategy) {
+            EqualityStrategy.EQUALS -> ExactValuePattern(this.value)
+            EqualityStrategy.NOT_EQUALS -> ExactValuePattern(this.value.alterValue())
+        }
+    }
+
     companion object {
         private const val VALUE_KEY = "exact"
         private const val EQUALITY_KEY = "matchType"
@@ -88,18 +97,6 @@ data class EqualityMatcher(val path: BreadCrumb, val value: Value, val strategy:
 
                 val strategy = EqualityStrategy.from(strategyKey.nativeValue).unwrapOrReturn { return it.cast() }
                 return HasValue(EqualityMatcher(path, value, strategy))
-            }
-
-            override fun toPatternSimplified(value: Value): Pattern? {
-                return null
-            }
-
-            override fun toPatternSimplified(properties: Map<String, Value>): Pattern? {
-                val value = properties[VALUE_KEY] ?: return null
-                val strategyKey = properties.getOrDefault(EQUALITY_KEY, StringValue("eq"))
-                val equalityStrategy = EqualityStrategy.from(strategyKey.toStringLiteral())
-                if (equalityStrategy.withDefault(EqualityStrategy.EQUALS) { it } != defaultStrategy) return null
-                return createPattern(value)
             }
         }
 

--- a/core/src/main/kotlin/io/specmatic/core/matchers/EqualityMatcher.kt
+++ b/core/src/main/kotlin/io/specmatic/core/matchers/EqualityMatcher.kt
@@ -4,6 +4,7 @@ import io.specmatic.core.BreadCrumb
 import io.specmatic.core.pattern.ExactValuePattern
 import io.specmatic.core.pattern.HasFailure
 import io.specmatic.core.pattern.HasValue
+import io.specmatic.core.pattern.NotEqualsPattern
 import io.specmatic.core.pattern.Pattern
 import io.specmatic.core.pattern.ReturnValue
 import io.specmatic.core.pattern.unwrapOrReturn
@@ -62,7 +63,7 @@ data class EqualityMatcher(val path: BreadCrumb, val value: Value, val strategy:
         if(this.value !is ScalarValue) return originalPattern
         return when(strategy) {
             EqualityStrategy.EQUALS -> ExactValuePattern(this.value)
-            EqualityStrategy.NOT_EQUALS -> ExactValuePattern(this.value.alterValue())
+            EqualityStrategy.NOT_EQUALS -> NotEqualsPattern(originalPattern, this.value)
         }
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/matchers/Matcher.kt
+++ b/core/src/main/kotlin/io/specmatic/core/matchers/Matcher.kt
@@ -2,9 +2,11 @@ package io.specmatic.core.matchers
 
 import io.specmatic.core.BreadCrumb
 import io.specmatic.core.Resolver
+import io.specmatic.core.pattern.HasValue
 import io.specmatic.core.pattern.Pattern
 import io.specmatic.core.pattern.ReturnValue
 import io.specmatic.core.pattern.listFold
+import io.specmatic.core.value.ScalarValue
 import io.specmatic.core.value.Value
 import io.specmatic.test.traverse
 
@@ -38,17 +40,21 @@ interface Matcher {
         }
     }
 
-    companion object {
-        private val defaultFactories: List<MatcherFactory> = buildList {
-            add(EqualityMatcher.Companion.EqualityFactory)
-            add(EqualityMatcher.Companion.NonEqualityFactory)
-            add(CompositeMatcher.Companion)
-            add(PatternMatcher.Companion)
-            add(RepetitionMatcher.Companion)
-            add(RegexMatcher.Companion)
-        }
+    fun patternFrom(originalPattern: Pattern): Pattern
 
-        private val registry: MatcherRegistry by lazy { MatcherRegistry.build(defaultFactories) }
+    companion object {
+
+        private val registry: MatcherRegistry by lazy {
+            val defaultFactories = buildList {
+                add(EqualityMatcher.Companion.EqualityFactory)
+                add(EqualityMatcher.Companion.NonEqualityFactory)
+                add(CompositeMatcher.Companion)
+                add(PatternMatcher.Companion)
+                add(RepetitionMatcher.Companion)
+                add(RegexMatcher.Companion)
+            }
+            MatcherRegistry.build(defaultFactories)
+        }
 
         fun parse(path: BreadCrumb, value: Value, context: MatcherContext): ReturnValue<out Matcher>? {
             return registry.parse(path, value, context)
@@ -57,10 +63,6 @@ interface Matcher {
         fun parse(path: BreadCrumb, properties: Map<String, Value>, context: MatcherContext): ReturnValue<List<Matcher>> {
             return registry.parse(path, properties, context)
         }
-
-        fun toPatternSimplified(value: Value): Pattern? = registry.toPatternSimplified(value)
-
-        fun toPatternSimplified(properties: Map<String, Value>): Pattern? = registry.toPatternSimplified(properties)
 
         fun from(value: Value, resolver: Resolver, prefix: String = ""): ReturnValue<List<Matcher>> {
             val context = MatcherContext(resolver = resolver)
@@ -74,6 +76,16 @@ interface Matcher {
                 onAssert = { _, _ -> emptyMap() },
             )
             return pathToMatchers.values.toList().listFold()
+        }
+
+        fun patternFrom(value: ScalarValue, originalPattern: Pattern, resolver: Resolver): Pattern {
+            val context = MatcherContext(resolver = resolver)
+            val matcher = parse(BreadCrumb.from(), value, context) ?: return originalPattern
+
+            if (matcher is HasValue<out Matcher>) {
+                return matcher.value.patternFrom(originalPattern)
+            }
+            return originalPattern
         }
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/matchers/MatcherFactory.kt
+++ b/core/src/main/kotlin/io/specmatic/core/matchers/MatcherFactory.kt
@@ -16,10 +16,6 @@ interface MatcherFactory {
 
     fun parseFrom(path: BreadCrumb, properties: Map<String, Value>, context: MatcherContext): ReturnValue<out Matcher>
 
-    fun toPatternSimplified(value: Value): Pattern? = null
-
-    fun toPatternSimplified(properties: Map<String, Value>): Pattern? = null
-
     fun extractPropertiesIfExist(value: Value): Map<String, Value>? {
         if (value !is StringValue) return null
         val hasColonPattern = value.nativeValue.contains(COLON_SEPARATED_PROPERTIES)

--- a/core/src/main/kotlin/io/specmatic/core/matchers/MatcherRegistry.kt
+++ b/core/src/main/kotlin/io/specmatic/core/matchers/MatcherRegistry.kt
@@ -1,9 +1,7 @@
 package io.specmatic.core.matchers
 
 import io.specmatic.core.BreadCrumb
-import io.specmatic.core.pattern.AnyPattern
 import io.specmatic.core.pattern.HasValue
-import io.specmatic.core.pattern.Pattern
 import io.specmatic.core.pattern.ReturnValue
 import io.specmatic.core.pattern.listFold
 import io.specmatic.core.value.StringValue
@@ -34,33 +32,6 @@ data class MatcherRegistry(
         }.map {
             it.parseFrom(path, properties, context)
         }.listFold()
-    }
-
-    fun toPatternSimplified(value: Value): Pattern? {
-        val matcherValueDetails = extractMatcherFromValue(value)
-        if (matcherValueDetails != null && keyedFactories.containsKey(matcherValueDetails.first)) {
-            val factory = keyedFactories.getValue(matcherValueDetails.first)
-            return factory.toPatternSimplified(matcherValueDetails.second)
-        }
-
-        return fallbackFactories.firstNotNullOfOrNull { factory ->
-            factory.toPatternSimplified(value)
-        }
-    }
-
-    fun toPatternSimplified(properties: Map<String, Value>): Pattern? {
-        val patterns = keyedFactories.values.plus(fallbackFactories).filter {
-            it.canParseFrom(BreadCrumb.from(), properties)
-        }.mapNotNull {
-            it.toPatternSimplified(properties)
-        }
-
-        return when (patterns.size){
-            0 -> null
-            1 -> patterns.single()
-            // TODO: Should ideally be an allOf Pattern
-            else -> AnyPattern(patterns, extensions = emptyMap())
-        }
     }
 
     companion object {

--- a/core/src/main/kotlin/io/specmatic/core/matchers/PatternMatcher.kt
+++ b/core/src/main/kotlin/io/specmatic/core/matchers/PatternMatcher.kt
@@ -61,6 +61,10 @@ class PatternMatcher(
         return MatcherResult.from(returnValue.breadCrumb(path.value), context)
     }
 
+    override fun patternFrom(originalPattern: Pattern): Pattern {
+        return this.pattern
+    }
+
     companion object : MatcherFactory {
         private const val DATA_TYPE_KEY = "dataType"
         private const val PARTIAL_KEY = "partial"
@@ -106,22 +110,6 @@ class PatternMatcher(
             return runCatching {
                 resolver.getPattern(withPatternDelimiters(value))
             }.map(::HasValue).getOrElse(::HasException)
-        }
-
-        override fun toPatternSimplified(value: Value): Pattern? {
-            if (value !is StringValue) return null
-            val properties = extractPropertiesIfExist(value)
-            return if (properties.isNullOrEmpty() || !canParseFrom(BreadCrumb.from(), properties)) {
-                DeferredPattern(withPatternDelimiters(value.nativeValue))
-            } else {
-                toPatternSimplified(properties)
-            }
-        }
-
-        override fun toPatternSimplified(properties: Map<String, Value>): Pattern? {
-            if (!canParseFrom(BreadCrumb.from(), properties)) return null
-            val dataType = properties.getValue(DATA_TYPE_KEY) as? StringValue ?: return null
-            return DeferredPattern(withPatternDelimiters(dataType.nativeValue))
         }
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/matchers/RegexMatcher.kt
+++ b/core/src/main/kotlin/io/specmatic/core/matchers/RegexMatcher.kt
@@ -1,15 +1,7 @@
 package io.specmatic.core.matchers
 
 import io.specmatic.core.BreadCrumb
-import io.specmatic.core.Resolver
-import io.specmatic.core.pattern.ExactValuePattern
-import io.specmatic.core.pattern.HasFailure
-import io.specmatic.core.pattern.HasValue
-import io.specmatic.core.pattern.Pattern
-import io.specmatic.core.pattern.ReturnValue
-import io.specmatic.core.pattern.StringPattern
-import io.specmatic.core.pattern.parsedScalarValue
-import io.specmatic.core.pattern.unwrapOrReturn
+import io.specmatic.core.pattern.*
 import io.specmatic.core.value.StringValue
 import io.specmatic.core.value.Value
 
@@ -47,6 +39,13 @@ data class RegexMatcher(val path: BreadCrumb, val regex: String) : Matcher {
         }
     }
 
+    override fun patternFrom(originalPattern: Pattern): Pattern {
+        return RegexConstrainedPattern(
+            basePattern = originalPattern,
+            regex = regex,
+        )
+    }
+
     companion object : MatcherFactory {
         private const val PATTERN_KEY = "pattern"
         override val matcherKey: String = "regex"
@@ -73,23 +72,5 @@ data class RegexMatcher(val path: BreadCrumb, val regex: String) : Matcher {
 
             return HasValue(RegexMatcher(path, patternValue.nativeValue))
         }
-
-        override fun toPatternSimplified(value: Value): Pattern? {
-            if (value !is StringValue) return null
-            val properties = extractPropertiesIfExist(value) ?: return null
-            return toPatternSimplified(properties)
-        }
-
-        override fun toPatternSimplified(properties: Map<String, Value>): Pattern? {
-            if (!canParseFrom(BreadCrumb.from(), properties)) return null
-            val regex = properties.getValue(PATTERN_KEY) as? StringValue ?: return null
-
-            val pattern = StringPattern(regex = regex.nativeValue)
-            val value = parsedScalarValue(
-                pattern.generate(Resolver()).toStringLiteral()
-            )
-            return ExactValuePattern(pattern = value)
-        }
     }
 }
-

--- a/core/src/main/kotlin/io/specmatic/core/matchers/RepetitionMatcher.kt
+++ b/core/src/main/kotlin/io/specmatic/core/matchers/RepetitionMatcher.kt
@@ -3,6 +3,7 @@ package io.specmatic.core.matchers
 import io.specmatic.core.BreadCrumb
 import io.specmatic.core.pattern.HasFailure
 import io.specmatic.core.pattern.HasValue
+import io.specmatic.core.pattern.Pattern
 import io.specmatic.core.pattern.ReturnValue
 import io.specmatic.core.pattern.unwrapOrReturn
 import io.specmatic.core.value.JSONArrayValue
@@ -90,6 +91,10 @@ data class RepetitionMatcher(
 
         val strategyUpdatedContext = strategy.tickAgainst(path, valueToMatch, updatedContext)
         return MatcherResult.from(strategyUpdatedContext, updatedContext, isExhausted = isExhausted)
+    }
+
+    override fun patternFrom(originalPattern: Pattern): Pattern {
+        return originalPattern
     }
 
     companion object : MatcherFactory {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
@@ -42,6 +42,28 @@ data class AnyPattern(
 
     data class AnyPatternMatch(val pattern: Pattern, val result: Result)
 
+    private fun extractDiscriminatorValue(value: Value): String? {
+        return if (discriminator != null && value is JSONObjectValue && discriminator.property in value.jsonObject) {
+            value.jsonObject.getValue(discriminator.property).toStringLiteral()
+        } else null
+    }
+
+    private fun selectPattern(value: Value, resolver: Resolver): Pattern {
+        val discriminatorValue = extractDiscriminatorValue(value)
+        if (discriminatorValue != null) {
+            val discriminatorBasedPattern = getDiscriminatorPattern(discriminatorValue, resolver)
+            if (discriminatorBasedPattern is HasValue) {
+                return discriminatorBasedPattern.value
+            }
+        }
+
+        val patternMatches = getUpdatedPattern(resolver).sortedBy(::isEmpty).map { pattern ->
+            AnyPatternMatch(pattern, pattern.matches(value, resolver))
+        }
+        val bestMatch = patternMatches.minBy { (it.result as? Failure)?.failureCount() ?: 0 }
+        return bestMatch.pattern
+    }
+
     override fun fixValue(
         value: Value, resolver: Resolver, discriminatorValue: String,
         onValidDiscValue: () -> Value?, onInvalidDiscValue: (Failure) -> Value?
@@ -59,25 +81,23 @@ data class AnyPattern(
 
     override fun fixValue(value: Value, resolver: Resolver): Value {
         if (resolver.matchesPattern(null, this, value).isSuccess()) return value
+
         val updatedResolver = resolver.updateLookupPath(this.typeAlias)
-        val discBasedFixedValue = if (discriminator != null && value is JSONObjectValue && discriminator.property in value.jsonObject) {
-            val discriminatorValue = value.jsonObject.getValue(discriminator.property).toStringLiteral()
-            fixValue(
-                value = value, resolver = resolver, discriminatorValue = discriminatorValue,
+
+        val discriminatorValue = extractDiscriminatorValue(value)
+        if (discriminatorValue != null) {
+            val discBasedFixedValue = fixValue(
+                value = value,
+                resolver = resolver,
+                discriminatorValue = discriminatorValue,
                 onValidDiscValue = { generateValue(updatedResolver, discriminatorValue) },
                 onInvalidDiscValue = { null }
             )
-        } else null
-
-        if (discBasedFixedValue != null) return discBasedFixedValue
-
-        val updatedPatterns = getUpdatedPattern(resolver).sortedBy(::isEmpty)
-        val patternMatches = updatedPatterns.map { pattern ->
-            AnyPatternMatch(pattern, pattern.matches(value, resolver))
+            if (discBasedFixedValue != null) return discBasedFixedValue
         }
 
-        val matchingPatternNew = patternMatches.minBy { (it.result as? Failure)?.failureCount() ?: 0 }
-        return matchingPatternNew.pattern.fixValue(value, updatedResolver)
+        val selectedPattern = selectPattern(value, resolver)
+        return selectedPattern.fixValue(value, updatedResolver)
     }
 
     override fun removeKeysNotPresentIn(keys: Set<String>, resolver: Resolver): Pattern {
@@ -579,6 +599,11 @@ data class AnyPattern(
         return setOf("{[$matchingPatternIndex]}")
     }
 
+    override fun patternFrom(value: Value, resolver: Resolver): Pattern {
+        val selectedPattern = selectPattern(value, resolver)
+        return selectedPattern.patternFrom(value, resolver)
+    }
+
     private fun allValuesAreScalar() = pattern.all { it is ExactValuePattern && it.pattern is ScalarValue }
 
     private fun hasNoAmbiguousPatterns(): Boolean {
@@ -617,6 +642,7 @@ data class AnyPattern(
 
     private fun isEmpty(it: Pattern) = it.typeAlias == "(empty)" || it is NullPattern || (it is ExactValuePattern && it.pattern is NullValue)
 }
+
 
 private interface FailedToFindAny {
     fun failedToFindAny(expected: String, results: List<Failure>, mismatchMessages: MismatchMessages): Failure

--- a/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
@@ -258,6 +258,16 @@ data class AnyPattern(
             ?: generateValue(resolver)
     }
 
+    override fun generateNotEqualTo(excluded: ScalarValue, resolver: Resolver): Value {
+        val enumValues = pattern.mapNotNull { (it as? ExactValuePattern)?.pattern as? ScalarValue }
+        if (enumValues.size == pattern.size) {
+            return enumValues.firstOrNull { it != excluded }
+                ?: throw ContractException("No value for $typeName can satisfy not-equals ${excluded.displayableValue()}")
+        }
+
+        return super.generateNotEqualTo(excluded, resolver)
+    }
+
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
         val updatedPatterns = discriminator?.let {
             it.updatePatternsWithDiscriminator(pattern, resolver).let { updatedPatterns ->

--- a/core/src/main/kotlin/io/specmatic/core/pattern/DeferredPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/DeferredPattern.kt
@@ -130,6 +130,10 @@ data class DeferredPattern(
 
     override fun patternSet(resolver: Resolver): List<Pattern> = resolvePattern(resolver).patternSet(resolver)
 
+    override fun patternFrom(value: Value, resolver: Resolver): Pattern {
+        return resolvePattern(resolver).patternFrom(value, resolver)
+    }
+
     override fun toString() = pattern
 }
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/EnumPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/EnumPattern.kt
@@ -6,6 +6,7 @@ import io.specmatic.core.Result
 import io.specmatic.core.Substitution
 import io.specmatic.core.pattern.config.NegativePatternConfiguration
 import io.specmatic.core.value.NullValue
+import io.specmatic.core.value.ScalarValue
 import io.specmatic.core.value.StringValue
 import io.specmatic.core.value.Value
 
@@ -120,6 +121,10 @@ data class EnumPattern(override val pattern: AnyPattern, val nullable: Boolean) 
 
     override fun fixValue(value: Value, resolver: Resolver): Value {
         return fixValue(value, this, resolver)
+    }
+
+    override fun generateNotEqualTo(excluded: ScalarValue, resolver: Resolver): Value {
+        return pattern.generateNotEqualTo(excluded, resolver)
     }
 
     override fun equals(other: Any?): Boolean = other is EnumPattern && other.pattern == this.pattern

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ExactValuePattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ExactValuePattern.kt
@@ -38,6 +38,12 @@ data class ExactValuePattern(override val pattern: Value, override val typeAlias
     }
 
     override fun generate(resolver: Resolver) = pattern
+    override fun generateNotEqualTo(excluded: ScalarValue, resolver: Resolver): Value {
+        if (pattern is ScalarValue && pattern == excluded) {
+            throw ContractException("No value for $typeName can satisfy not-equals ${excluded.displayableValue()}")
+        }
+        return pattern
+    }
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
         return sequenceOf(HasValue(this, "is set to exact value of ${pattern.displayableValue()}"))
     }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/Grammar.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/Grammar.kt
@@ -187,9 +187,6 @@ fun stringToPattern(patternValue: String, key: String?): Pattern =
 fun parsedPattern(rawContent: String, key: String? = null, typeAlias: String? = null, isWSDL: Boolean = false): Pattern {
     return rawContent.trim().removePrefix(UTF_BYTE_ORDER_MARK).let {
         when {
-            isMatcherToken(it) && Matcher.toPatternSimplified(StringValue(it)) != null -> {
-                Matcher.toPatternSimplified(StringValue(it))!!
-            }
             isPatternToken(it) && it.contains("/") -> {
                 val (container, type) = withoutPatternDelimiters(it).split("/")
                 if (container != "csv")

--- a/core/src/main/kotlin/io/specmatic/core/pattern/JSONArrayPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/JSONArrayPattern.kt
@@ -124,6 +124,16 @@ data class JSONArrayPattern(override val pattern: List<Pattern> = emptyList(), o
         }
     }
 
+    override fun patternFrom(value: Value, resolver: Resolver): Pattern {
+        if(value !is JSONArrayValue) return value.exactMatchElseType()
+        return JSONArrayPattern(
+            value.list.mapIndexed { index, indexedValue ->
+                val patternAtIndex = pattern.getOrElse(index) { indexedValue.exactMatchElseType() }
+                patternAtIndex.patternFrom(indexedValue, resolver)
+            }
+        )
+    }
+
     private fun validateInfiniteLength(otherMembers: MemberList, theseMembers: MemberList): Result = when {
         otherMembers.isEndless() && !theseMembers.isEndless() -> Result.Failure("Finite list is not a superset of an infinite list.")
         else -> Result.Success()

--- a/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
@@ -512,6 +512,17 @@ data class JSONObjectPattern(
 
     override val typeName: String = "json object"
 
+    override fun patternFrom(value: Value, resolver: Resolver): Pattern {
+        if (value !is JSONObjectValue) return value.exactMatchElseType()
+        return toJSONObjectPattern(
+            value.jsonObject.mapValues {
+                val keyPattern = this.patternForKey(it.key) ?: it.value.exactMatchElseType()
+                keyPattern.patternFrom(it.value, resolver)
+            },
+            typeAlias
+        )
+    }
+
     fun keysInNonOptionalFormat(): Set<String> {
         return this.pattern.map { withoutOptionality(it.key) }.toSet()
     }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
@@ -250,6 +250,13 @@ data class ListPattern(
         return this.copy(pattern = pattern.ensureAdditionalProperties(resolver))
     }
 
+    override fun patternFrom(value: Value, resolver: Resolver): Pattern {
+        if (value !is JSONArrayValue) return value.exactMatchElseType()
+        return JSONArrayPattern(
+            value.list.map { this.pattern.patternFrom(it, resolver) }
+        )
+    }
+
     fun calculatePath(value: Value, resolver: Resolver): Set<String> {
         if (value !is JSONArrayValue) return emptySet()
         

--- a/core/src/main/kotlin/io/specmatic/core/pattern/NotEqualsPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/NotEqualsPattern.kt
@@ -1,0 +1,62 @@
+package io.specmatic.core.pattern
+
+import io.specmatic.core.Resolver
+import io.specmatic.core.Result
+import io.specmatic.core.constraintMismatchResult
+import io.specmatic.core.patternMismatchResult
+import io.specmatic.core.value.ScalarValue
+import io.specmatic.core.value.Value
+
+data class NotEqualsPattern(val basePattern: Pattern, val excluded: ScalarValue) : Pattern by basePattern {
+    override fun matches(sampleData: Value?, resolver: Resolver): Result {
+        if (sampleData?.hasSupportedTemplate() == true) return Result.Success()
+
+        val baseResult = basePattern.matches(sampleData, resolver)
+        if (baseResult is Result.Failure) return baseResult
+
+        if (sampleData is ScalarValue && sampleData == excluded) {
+            return constraintMismatchResult(
+                expected = "value not equal to ${excluded.displayableValue()}",
+                actual = sampleData,
+                mismatchMessages = resolver.mismatchMessages
+            )
+        }
+
+        return baseResult
+    }
+
+    override fun generate(resolver: Resolver): Value {
+        return basePattern.generateNotEqualTo(excluded, resolver)
+    }
+
+    override fun encompasses(
+        otherPattern: Pattern,
+        thisResolver: Resolver,
+        otherResolver: Resolver,
+        typeStack: TypeStack
+    ): Result {
+        val resolvedOther = resolvedHop(otherPattern, otherResolver)
+        return when (resolvedOther) {
+            is ExactValuePattern -> {
+                if (resolvedOther.pattern == excluded)
+                    patternMismatchResult(this, otherPattern, thisResolver.mismatchMessages)
+                else
+                    basePattern.encompasses(resolvedOther, thisResolver, otherResolver, typeStack)
+            }
+            else -> basePattern.encompasses(resolvedOther, thisResolver, otherResolver, typeStack)
+        }
+    }
+
+    override fun fitsWithin(
+        otherPatterns: List<Pattern>,
+        thisResolver: Resolver,
+        otherResolver: Resolver,
+        typeStack: TypeStack
+    ): Result {
+        return basePattern.fitsWithin(otherPatterns, thisResolver, otherResolver, typeStack)
+    }
+
+    override fun patternFrom(value: Value, resolver: Resolver): Pattern {
+        return NotEqualsPattern(basePattern.patternFrom(value, resolver), excluded)
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/core/pattern/Pattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/Pattern.kt
@@ -21,6 +21,20 @@ interface Pattern {
 
     fun generate(resolver: Resolver): Value
     fun generateWithAll(resolver: Resolver) = resolver.withCyclePrevention(this, this::generate)
+    fun generateNotEqualTo(excluded: ScalarValue, resolver: Resolver): Value {
+        val excludedResult = matches(excluded, resolver)
+        if (excludedResult is Result.Failure) return generate(resolver)
+
+        val candidate = excluded.alterValue()
+        if (candidate == excluded) {
+            throw ContractException("No value for $typeName can satisfy not-equals ${excluded.displayableValue()}")
+        }
+        val candidateResult = matches(candidate, resolver)
+        if (candidateResult is Result.Failure) {
+            throw ContractException("No value for $typeName can satisfy not-equals ${excluded.displayableValue()}")
+        }
+        return candidate
+    }
     fun newBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>>
     fun negativeBasedOn(
         row: Row,

--- a/core/src/main/kotlin/io/specmatic/core/pattern/Pattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/Pattern.kt
@@ -97,6 +97,8 @@ interface Pattern {
         return fixValue(value, this, resolver)
     }
 
+    fun patternFrom(value: Value, resolver: Resolver): Pattern = value.exactMatchElseType()
+
     val typeAlias: String?
     val typeName: String
     val pattern: Any

--- a/core/src/main/kotlin/io/specmatic/core/pattern/RegexConstrainedPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/RegexConstrainedPattern.kt
@@ -1,0 +1,55 @@
+package io.specmatic.core.pattern
+
+import io.specmatic.core.Resolver
+import io.specmatic.core.Result
+import io.specmatic.core.patternMismatchResult
+import io.specmatic.core.value.StringValue
+import io.specmatic.core.value.Value
+
+data class RegexConstrainedPattern(val basePattern: Pattern, val regex: String) : Pattern by basePattern, ScalarType {
+    private val regexPattern = StringPattern(regex = regex)
+
+    override fun matches(sampleData: Value?, resolver: Resolver): Result {
+        if (sampleData?.hasSupportedTemplate() == true) return Result.Success()
+        val baseResult = basePattern.matches(sampleData, resolver)
+        if (baseResult is Result.Failure) return baseResult
+        val stringValue = sampleData?.toStringLiteral()?.let(::StringValue) ?: return baseResult
+        return regexPattern.matches(stringValue, resolver)
+    }
+
+    override fun generate(resolver: Resolver): Value {
+        val candidate = regexPattern.generate(resolver)
+
+        return runCatching {
+            basePattern.parse(candidate.toStringLiteral(), resolver)
+        }.getOrElse { candidate }
+    }
+
+    override fun patternSet(resolver: Resolver): List<Pattern> = listOf(this)
+
+    override fun encompasses(
+        otherPattern: Pattern,
+        thisResolver: Resolver,
+        otherResolver: Resolver,
+        typeStack: TypeStack
+    ): Result {
+        val resolvedOther = resolvedHop(otherPattern, otherResolver)
+        return when (resolvedOther) {
+            is ExactValuePattern -> resolvedOther.fitsWithin(patternSet(thisResolver), otherResolver, thisResolver, typeStack)
+            is RegexConstrainedPattern -> {
+                val otherFitsThis = matches(resolvedOther.generate(otherResolver), thisResolver)
+                if (otherFitsThis is Result.Success) Result.Success()
+                else {
+                    val thisFitsOther = resolvedOther.matches(generate(thisResolver), otherResolver)
+                    if (thisFitsOther is Result.Success) Result.Success()
+                    else patternMismatchResult(this, otherPattern, thisResolver.mismatchMessages)
+                }
+            }
+            else -> basePattern.encompasses(resolvedOther, thisResolver, otherResolver, typeStack)
+        }
+    }
+
+    override fun patternFrom(value: Value, resolver: Resolver): Pattern {
+        return RegexConstrainedPattern(basePattern.patternFrom(value, resolver), this.regex)
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ScalarType.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ScalarType.kt
@@ -1,6 +1,25 @@
 package io.specmatic.core.pattern
 
-interface ScalarType: Pattern
+import io.specmatic.core.Resolver
+import io.specmatic.core.matchers.Matcher
+import io.specmatic.core.value.ScalarValue
+import io.specmatic.core.value.StringValue
+import io.specmatic.core.value.Value
+
+interface ScalarType: Pattern {
+    override fun patternFrom(value: Value, resolver: Resolver): Pattern {
+        if(value !is ScalarValue) return value.exactMatchElseType()
+        if(value is StringValue && isPatternToken(value)) return DeferredPattern(value.string)
+        if(value is StringValue && isMatcherToken(value)) {
+            return Matcher.patternFrom(
+                value = value,
+                originalPattern = this,
+                resolver = resolver,
+            )
+        }
+        return value.exactMatchElseType()
+    }
+}
 
 fun scalarAnnotation(pattern: Pattern, negativePatterns: Sequence<Pattern>): Sequence<ReturnValue<Pattern>> {
     return negativePatterns.map {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/TabularPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/TabularPattern.kt
@@ -79,6 +79,21 @@ data class TabularPattern(
         })
     }
 
+    override fun patternFrom(value: Value, resolver: Resolver): Pattern {
+        if (value !is JSONObjectValue) return value.exactMatchElseType()
+
+        val updatedPattern = value.jsonObject.mapValues { (key, value) ->
+            val keyPattern = patternForKey(key) ?: value.exactMatchElseType()
+            keyPattern.patternFrom(value, resolver)
+        }
+
+        return this.copy(pattern = updatedPattern)
+    }
+
+    fun patternForKey(key: String): Pattern? {
+        return pattern[withoutOptionality(key)] ?: pattern[withOptionality(key)]
+    }
+
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
         val resolverWithNullType = withNullPattern(resolver)
         return allOrNothingCombinationIn(

--- a/core/src/test/kotlin/integration_tests/ExamplesAsStubTest.kt
+++ b/core/src/test/kotlin/integration_tests/ExamplesAsStubTest.kt
@@ -641,6 +641,100 @@ paths:
     }
 
     @Test
+    fun `should match request using match pattern in external example and respond with example response`() {
+        val specFile = File("src/test/resources/openapi/request_matchers_in_external_examples.yaml")
+        val contract = OpenApiSpecification.fromFile(specFile.canonicalPath).toFeature()
+        val exampleFile = File("src/test/resources/openapi/request_matchers_in_external_examples_examples/search_post.json")
+        val exampleStub = ScenarioStub.readFromFile(exampleFile)
+
+        HttpStub(contract, listOf(exampleStub)).use { stub ->
+            val response = stub.client.execute(
+                HttpRequest(
+                    "POST",
+                    "/search",
+                    emptyMap(),
+                    parsedJSONObject("""{"code":"ABC123"}""")
+                )
+            )
+            assertThat(response.status).isEqualTo(200)
+            assertThat(response.body).isEqualTo(parsedJSONObject("""{"message":"matched"}"""))
+        }
+    }
+
+    @Test
+    fun `should match only negative numbers using regex matcher in external example`() {
+        val specFile = File("src/test/resources/openapi/request_matchers_in_external_examples.yaml")
+        val contract = OpenApiSpecification.fromFile(specFile.canonicalPath).toFeature()
+        val exampleFile = File("src/test/resources/openapi/request_matchers_in_external_examples_examples/adjust_post.json")
+        val exampleStub = ScenarioStub.readFromFile(exampleFile)
+
+        HttpStub(contract, listOf(exampleStub)).use { stub ->
+            val negativeResponse = stub.client.execute(
+                HttpRequest(
+                    "POST",
+                    "/adjust",
+                    emptyMap(),
+                    parsedJSONObject("""{"amount":-12}""")
+                )
+            )
+            assertThat(negativeResponse.status).isEqualTo(200)
+            assertThat(negativeResponse.body).isEqualTo(parsedJSONObject("""{"message":"negative matched"}"""))
+
+            val positiveResponse = stub.client.execute(
+                HttpRequest(
+                    "POST",
+                    "/adjust",
+                    emptyMap(),
+                    parsedJSONObject("""{"amount":12}""")
+                )
+            )
+            assertThat(positiveResponse.body).isNotEqualTo(parsedJSONObject("""{"message":"negative matched"}"""))
+        }
+    }
+
+    @Test
+    fun `should match regex matcher for integer`() {
+        val specFile = File("src/test/resources/openapi/request_matchers_in_external_examples.yaml")
+        val contract = OpenApiSpecification.fromFile(specFile.canonicalPath).toFeature()
+        val exampleFile = File("src/test/resources/openapi/request_matchers_in_external_examples_examples/count_post.json")
+        val exampleStub = ScenarioStub.readFromFile(exampleFile)
+
+        HttpStub(contract, listOf(exampleStub)).use { stub ->
+            val response = stub.client.execute(
+                HttpRequest(
+                    "POST",
+                    "/count",
+                    emptyMap(),
+                    parsedJSONObject("""{"count":42}""")
+                )
+            )
+            assertThat(response.status).isEqualTo(200)
+            assertThat(response.body).isEqualTo(parsedJSONObject("""{"message":"count matched"}"""))
+        }
+    }
+
+    @Test
+    fun `should match regex matcher for boolean`() {
+        val specFile = File("src/test/resources/openapi/request_matchers_in_external_examples.yaml")
+        val contract = OpenApiSpecification.fromFile(specFile.canonicalPath).toFeature()
+        val exampleFile = File("src/test/resources/openapi/request_matchers_in_external_examples_examples/flag_post.json")
+        val exampleStub = ScenarioStub.readFromFile(exampleFile)
+
+        HttpStub(contract, listOf(exampleStub)).use { stub ->
+            val response = stub.client.execute(
+                HttpRequest(
+                    "POST",
+                    "/flag",
+                    emptyMap(),
+                    parsedJSONObject("""{"active":true}""")
+                )
+            )
+            assertThat(response.status).isEqualTo(200)
+            assertThat(response.body).isEqualTo(parsedJSONObject("""{"message":"flag matched"}"""))
+        }
+    }
+
+    @Test
     fun `errors when loading examples with invalid values as expectations should mention the example name`() {
         val nameOfExample = "EXAMPLE_OF_SUCCESS"
         val spec = """

--- a/core/src/test/kotlin/io/specmatic/core/HttpRequestPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpRequestPatternTest.kt
@@ -747,6 +747,27 @@ internal class HttpRequestPatternTest {
         assertThat(requestBodyPattern.patternForKey("key")).isEqualTo(ExactValuePattern(StringValue("value")))
     }
 
+    @Test
+    fun `generating a request pattern from an http request should retain matcher tokens in the body`() {
+        val originalRequestPattern = HttpRequestPattern(
+            httpPathPattern = buildHttpPathPattern("/"), method = "POST",
+            body = JSONObjectPattern(mapOf("id" to NumberPattern(), "name" to StringPattern()))
+        )
+        val httpRequest = HttpRequest(
+            body = JSONObjectValue(mapOf(
+                "id" to StringValue("\$match(pattern: POSITIVE_REGEX)"),
+                "name" to StringValue("(string)")
+            ))
+        )
+
+        val newRequestPattern = originalRequestPattern.generate(httpRequest, Resolver())
+        val requestBodyPattern = newRequestPattern.body as JSONObjectPattern
+
+        assertThat(requestBodyPattern.pattern.getValue("id"))
+            .isEqualTo(RegexConstrainedPattern(NumberPattern(), "POSITIVE_REGEX"))
+        assertThat(requestBodyPattern.pattern.getValue("name")).isEqualTo(DeferredPattern("(string)"))
+    }
+
     @ParameterizedTest
     @MethodSource("headersBasedSecuritySchemesProvider")
     fun `security schema headers should be ignored when converting headers from http request to pattern`(securityScheme: OpenAPISecurityScheme) {
@@ -893,7 +914,14 @@ internal class HttpRequestPatternTest {
         )
         val newRequestPattern = httpRequestPattern.generate(httpRequest, Resolver())
 
-        assertThat(newRequestPattern.httpPathPattern).isEqualTo(buildHttpPathPattern("/invalidUUID"))
+        assertThat(newRequestPattern.httpPathPattern).isEqualTo(
+            HttpPathPattern(
+                pathSegmentPatterns = listOf(
+                    URLPathSegmentPattern(ExactValuePattern(StringValue("invalidUUID")), "id")
+                ),
+                "/invalidUUID"
+            )
+        )
         assertThat(newRequestPattern.method).isEqualTo("GET")
         assertThat(newRequestPattern.headersPattern.pattern).isEqualTo(mapOf("key" to "invalidDate".toExactValuePattern()))
         assertThat(newRequestPattern.body).isEqualTo(JSONObjectPattern(mapOf("key" to "invalidEmail".toExactValuePattern())))

--- a/core/src/test/kotlin/io/specmatic/core/ResolverKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ResolverKtTest.kt
@@ -4,6 +4,11 @@ import io.specmatic.core.pattern.AnyValuePattern
 import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.Test
 import io.specmatic.core.pattern.ContractException
+import io.specmatic.core.pattern.ExactValuePattern
+import io.specmatic.core.pattern.NumberPattern
+import io.specmatic.core.pattern.StringPattern
+import io.specmatic.core.value.NumberValue
+import io.specmatic.core.value.StringValue
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
@@ -20,6 +25,82 @@ internal class ResolverKtTest {
     fun `should be able to combine typeAlias and lookupKey to a lookupPath`(typeAlias: String?, lookupKey: String, expectedLookupPath: String) {
         val resolver = Resolver().updateLookupPath(typeAlias, KeyWithPattern(lookupKey, AnyValuePattern))
         assertThat(resolver.dictionaryLookupPath).isEqualTo(expectedLookupPath)
+    }
+
+    @Test
+    fun `actualPatternMatch should match using the pattern from dataType matcher when in mock mode and return failure`() {
+        val resolver = Resolver(mockMode = true)
+        val result = resolver.actualPatternMatch(
+            null,
+            NumberPattern(),
+            StringValue("\$match(dataType: string)")
+        )
+
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
+    }
+
+    @Test
+    fun `actualPatternMatch should match using the pattern from dataType matcher when in mock mode and return success`() {
+        val resolver = Resolver(mockMode = true)
+        val result = resolver.actualPatternMatch(
+            null,
+            NumberPattern(),
+            StringValue("\$match(dataType: number)")
+        )
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+    }
+
+    @Test
+    fun `actualPatternMatch should match using the pattern from regex matcher when in mock mode and return failure`() {
+        val resolver = Resolver(mockMode = true)
+
+        val result = resolver.actualPatternMatch(
+            null,
+            NumberPattern(),
+            StringValue("\$match(pattern: abc)")
+        )
+
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
+    }
+
+    @Test
+    fun `actualPatternMatch should match using the pattern from regex matcher when in mock mode and return success`() {
+        val resolver = Resolver(mockMode = true)
+
+        val result = resolver.actualPatternMatch(
+            null,
+            NumberPattern(),
+            StringValue("\$match(pattern: 1)")
+        )
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+    }
+
+    @Test
+    fun `actualPatternMatch should match using the pattern from equality matcher when in mock mode and return failure`() {
+        val resolver = Resolver(mockMode = true)
+
+        val result = resolver.actualPatternMatch(
+            null,
+            StringPattern(),
+            StringValue("\$match(exact: 1)")
+        )
+
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
+    }
+
+    @Test
+    fun `actualPatternMatch should match using the pattern from equality matcher when in mock mode and return success`() {
+        val resolver = Resolver(mockMode = true)
+
+        val result = resolver.actualPatternMatch(
+            null,
+            ExactValuePattern(NumberValue(1)),
+            StringValue("\$match(exact: 1)")
+        )
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
     }
 
     companion object {

--- a/core/src/test/kotlin/io/specmatic/core/matchers/CompositeMatcherTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/matchers/CompositeMatcherTest.kt
@@ -6,8 +6,12 @@ import io.specmatic.core.BreadCrumb
 import io.specmatic.core.Resolver
 import io.specmatic.core.Result
 import io.specmatic.core.jsonoperator.RequestResponseOperator
+import io.specmatic.core.pattern.ExactValuePattern
 import io.specmatic.core.pattern.HasFailure
 import io.specmatic.core.pattern.HasValue
+import io.specmatic.core.pattern.NumberPattern
+import io.specmatic.core.pattern.RegexConstrainedPattern
+import io.specmatic.core.pattern.StringPattern
 import io.specmatic.core.value.StringValue
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
@@ -16,6 +20,55 @@ import org.junit.jupiter.api.Test
 class CompositeMatcherTest {
     private val mockResolver = mockk<Resolver>()
     private val mockOperator = mockk<RequestResponseOperator>()
+
+    @Test
+    fun `patternFrom should prefer equality matcher`() {
+        val matcher = CompositeMatcher(
+            matchers = listOf(
+                RegexMatcher(BreadCrumb.from(), "^Hello.*"),
+                EqualityMatcher(BreadCrumb.from(), StringValue("hello"), EqualityStrategy.EQUALS)
+            )
+        )
+        val original = StringPattern()
+
+        val result = matcher.patternFrom(original)
+
+        assertThat(result).isEqualTo(ExactValuePattern(StringValue("hello")))
+    }
+
+    @Test
+    fun `patternFrom should prefer regex matcher when no equality matcher is present`() {
+        val matcher = CompositeMatcher(
+            matchers = listOf(
+                PatternMatcher(BreadCrumb.from(), NumberPattern()),
+                RegexMatcher(BreadCrumb.from(), "^Hello.*")
+            )
+        )
+        val original = StringPattern()
+
+        val result = matcher.patternFrom(original)
+
+        assertThat(result).isEqualTo(RegexConstrainedPattern(original, "^Hello.*"))
+    }
+
+    @Test
+    fun `patternFrom should return pattern matcher when no equality or regex matcher is present`() {
+        val matcher = CompositeMatcher(matchers = listOf(PatternMatcher(BreadCrumb.from(), NumberPattern())))
+
+        val result = matcher.patternFrom(StringPattern())
+
+        assertThat(result).isEqualTo(NumberPattern())
+    }
+
+    @Test
+    fun `patternFrom should return original pattern when no matchers are present`() {
+        val matcher = CompositeMatcher(matchers = emptyList())
+        val original = StringPattern()
+
+        val result = matcher.patternFrom(original)
+
+        assertThat(result).isSameAs(original)
+    }
 
     @Test
     fun `should execute all non-exhaustive matchers first acting as a guard-clause`() {

--- a/core/src/test/kotlin/io/specmatic/core/matchers/EqualityMatcherTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/matchers/EqualityMatcherTest.kt
@@ -9,7 +9,10 @@ import io.specmatic.core.jsonoperator.RequestResponseOperator
 import io.specmatic.core.jsonoperator.value.ValueOperator
 import io.specmatic.core.pattern.HasFailure
 import io.specmatic.core.pattern.HasValue
+import io.specmatic.core.pattern.ExactValuePattern
+import io.specmatic.core.pattern.StringPattern
 import io.specmatic.core.value.NumberValue
+import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.StringValue
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
@@ -20,6 +23,40 @@ import org.junit.jupiter.params.provider.CsvSource
 class EqualityMatcherTest {
     private val mockResolver = mockk<Resolver>()
     private val mockOperator = mockk<RequestResponseOperator>()
+
+    @Test
+    fun `patternFrom should return exact value pattern for scalar equals`() {
+        val matcher = EqualityMatcher(BreadCrumb.from(), NumberValue(10), EqualityStrategy.EQUALS)
+
+        val result = matcher.patternFrom(StringPattern())
+
+        assertThat(result).isEqualTo(ExactValuePattern(NumberValue(10)))
+    }
+
+    @Test
+    fun `patternFrom should return original pattern for non scalar value`() {
+        val matcher = EqualityMatcher(
+            BreadCrumb.from(),
+            JSONObjectValue(mapOf("key" to StringValue("value"))),
+            EqualityStrategy.EQUALS
+        )
+        val original = StringPattern()
+
+        val result = matcher.patternFrom(original)
+
+        assertThat(result).isSameAs(original)
+    }
+
+    @Test
+    fun `patternFrom should return exact value pattern with alter value for non equals strategy`() {
+        val value = StringValue("hello")
+        val matcher = EqualityMatcher(BreadCrumb.from(), value, EqualityStrategy.NOT_EQUALS)
+        val original = StringPattern()
+
+        val result = matcher.patternFrom(original)
+
+        assertThat(result).isEqualTo(ExactValuePattern(value.alterValue()))
+    }
 
     @Test
     fun `should match when values are equal using EQUALS strategy`() {
@@ -194,48 +231,6 @@ class EqualityMatcherTest {
             )
 
             assertThat(result).isInstanceOf(HasFailure::class.java)
-        }
-
-        @ParameterizedTest(name = "value=''{0}'' → pattern should be created")
-        @CsvSource(
-            "1.23",
-            "0.5",
-            ".5",
-            "10.",
-            "123.0001",
-            "123",
-            "abc",
-            "abc.def",
-            "gmail.com",
-            "v1.2.3",
-            "foo.bar.baz",
-            "version.1",
-            "a.b"
-        )
-        fun `should create pattern for any string including dotted`(raw: String) {
-            val result = EqualityMatcher.Companion.EqualityFactory.toPatternSimplified(mapOf("exact" to StringValue(raw)))
-            assertThat(result).isNotNull()
-        }
-
-        @ParameterizedTest(name = "value=''{0}'' → pattern should be created")
-        @CsvSource(
-            "1.23",
-            "0.5",
-            ".5",
-            "10.",
-            "123.0001",
-            "123",
-            "abc",
-            "abc.def",
-            "gmail.com",
-            "v1.2.3",
-            "foo.bar.baz",
-            "version.1",
-            "a.b"
-        )
-        fun `should not create pattern for any string including dotted when called with $eq`(raw: String) {
-            val result = EqualityMatcher.Companion.EqualityFactory.toPatternSimplified(StringValue("\$eq($raw)"))
-            assertThat(result).isNull()
         }
     }
 

--- a/core/src/test/kotlin/io/specmatic/core/matchers/EqualityMatcherTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/matchers/EqualityMatcherTest.kt
@@ -10,6 +10,7 @@ import io.specmatic.core.jsonoperator.value.ValueOperator
 import io.specmatic.core.pattern.HasFailure
 import io.specmatic.core.pattern.HasValue
 import io.specmatic.core.pattern.ExactValuePattern
+import io.specmatic.core.pattern.NotEqualsPattern
 import io.specmatic.core.pattern.StringPattern
 import io.specmatic.core.value.NumberValue
 import io.specmatic.core.value.JSONObjectValue
@@ -48,14 +49,14 @@ class EqualityMatcherTest {
     }
 
     @Test
-    fun `patternFrom should return exact value pattern with alter value for non equals strategy`() {
+    fun `patternFrom should return not equals pattern for non equals strategy`() {
         val value = StringValue("hello")
         val matcher = EqualityMatcher(BreadCrumb.from(), value, EqualityStrategy.NOT_EQUALS)
         val original = StringPattern()
 
         val result = matcher.patternFrom(original)
 
-        assertThat(result).isEqualTo(ExactValuePattern(value.alterValue()))
+        assertThat(result).isEqualTo(NotEqualsPattern(original, value))
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/core/matchers/MatcherRegistryTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/matchers/MatcherRegistryTest.kt
@@ -5,6 +5,7 @@ import io.specmatic.core.Resolver
 import io.specmatic.core.pattern.AnyPattern
 import io.specmatic.core.pattern.ExactValuePattern
 import io.specmatic.core.pattern.HasValue
+import io.specmatic.core.pattern.NotEqualsPattern
 import io.specmatic.core.pattern.NumberPattern
 import io.specmatic.core.pattern.RegexConstrainedPattern
 import io.specmatic.core.pattern.StringPattern
@@ -127,7 +128,7 @@ class MatcherRegistryTest {
     }
 
     @Test
-    fun `patternFrom should return an exact value pattern with alter value when equality matcher is not equals`() {
+    fun `patternFrom should return a not equals pattern when equality matcher is not equals`() {
         val originalPattern = StringPattern()
         val value = StringValue("hello")
         val result = Matcher.patternFrom(
@@ -136,7 +137,7 @@ class MatcherRegistryTest {
             Resolver()
         )
 
-        assertThat(result).isEqualTo(ExactValuePattern(value.alterValue()))
+        assertThat(result).isEqualTo(NotEqualsPattern(basePattern = originalPattern, excluded = value))
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/core/matchers/MatcherRegistryTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/matchers/MatcherRegistryTest.kt
@@ -2,12 +2,13 @@ package io.specmatic.core.matchers
 
 import io.specmatic.core.BreadCrumb
 import io.specmatic.core.Resolver
-import io.specmatic.core.pattern.HasFailure
+import io.specmatic.core.pattern.AnyPattern
+import io.specmatic.core.pattern.ExactValuePattern
 import io.specmatic.core.pattern.HasValue
-import io.specmatic.core.pattern.Pattern
-import io.specmatic.core.pattern.ReturnValue
+import io.specmatic.core.pattern.NumberPattern
+import io.specmatic.core.pattern.RegexConstrainedPattern
+import io.specmatic.core.pattern.StringPattern
 import io.specmatic.core.value.StringValue
-import io.specmatic.core.value.Value
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
@@ -35,32 +36,32 @@ class MatcherRegistryTest {
 
     @Test
     fun `parse should not infer matcher from leaf key for unknown matcher token`() {
-        val result = Matcher.parse(BreadCrumb("request.body.user.field"), StringValue($$"$unknown(string)"), context)
+        val result = Matcher.parse(BreadCrumb("request.body.user.field"), StringValue("\$unknown(string)"), context)
         assertThat(result).isNull()
     }
 
     @Test
     fun `parse should not infer matcher from leaf key for malformed matcher token`() {
-        val result = Matcher.parse(BreadCrumb("request.body.user.field"), StringValue($$"$match"), context)
+        val result = Matcher.parse(BreadCrumb("request.body.user.field"), StringValue("\$match"), context)
         assertThat(result).isNull()
     }
 
     @Test
     fun `parse should not infer matcher from leaf key pattern when token has invalid syntax`() {
-        val result = Matcher.parse(BreadCrumb("request.body.user.field"), StringValue($$"$match (datType: string)"), context)
+        val result = Matcher.parse(BreadCrumb("request.body.user.field"), StringValue("\$match (datType: string)"), context)
         assertThat(result).isNull()
     }
 
     @Test
     fun `parse should still create pattern matcher when matcher syntax is in value`() {
-        val result = Matcher.parse(BreadCrumb("request.body.user.value"), StringValue($$"$match(dataType: string)"), context)
+        val result = Matcher.parse(BreadCrumb("request.body.user.value"), StringValue("${'$'}match(dataType: string)"), context)
         assertThat(result).isInstanceOf(HasValue::class.java)
         assertThat((result as HasValue).value).isInstanceOf(CompositeMatcher::class.java)
     }
 
     @Test
     fun `parse should still create matcher from explicit syntax even when leaf key is pattern`() {
-        val result = Matcher.parse(BreadCrumb("request.body.user.match"), StringValue($$"$match(dataType: string)"), context)
+        val result = Matcher.parse(BreadCrumb("request.body.user.match"), StringValue("${'$'}match(dataType: string)"), context)
         assertThat(result).isInstanceOf(HasValue::class.java)
         assertThat((result as HasValue).value).isInstanceOf(CompositeMatcher::class.java)
     }
@@ -70,5 +71,83 @@ class MatcherRegistryTest {
         assertThatThrownBy { MatcherRegistry.build(defaults = listOf(PatternMatcher.Companion, PatternMatcher.Companion)) }
             .isInstanceOf(IllegalArgumentException::class.java)
             .hasMessage("Duplicate matcher key: pattern")
+    }
+
+    @Test
+    fun `patternFrom should return original pattern when value does not resolve to a matcher`() {
+        val originalPattern = StringPattern()
+        val result = Matcher.patternFrom(StringValue("hello"), originalPattern, Resolver())
+
+        assertThat(result).isSameAs(originalPattern)
+    }
+
+    @Test
+    fun `patternFrom should unwrap single matcher inside composite`() {
+        val originalPattern = StringPattern()
+        val result = Matcher.patternFrom(StringValue("\$match(dataType: string)"), originalPattern, Resolver())
+
+        assertThat(result).isInstanceOf(StringPattern::class.java)
+        assertThat(result).isNotInstanceOf(AnyPattern::class.java)
+    }
+
+    @Test
+    fun `patternFrom should build regex constrained pattern`() {
+        val originalPattern = StringPattern()
+        val result = Matcher.patternFrom(StringValue("${'$'}match(pattern: ^Hello[A-Za-z ]*$)"), originalPattern, Resolver())
+
+        assertThat(result).isInstanceOf(RegexConstrainedPattern::class.java)
+        val constrained = result as RegexConstrainedPattern
+        assertThat(constrained.basePattern).isSameAs(originalPattern)
+        assertThat(constrained.regex).isEqualTo("^Hello[A-Za-z ]*$")
+    }
+
+    @Test
+    fun `patternFrom should prefer regex matcher when composite includes dataType and regex`() {
+        val originalPattern = NumberPattern()
+        val result = Matcher.patternFrom(
+            StringValue("${'$'}match(dataType: number, pattern: ^[0-9]+$)"),
+            originalPattern,
+            Resolver()
+        )
+
+        assertThat(result).isInstanceOf(RegexConstrainedPattern::class.java)
+        val constrained = result as RegexConstrainedPattern
+        assertThat(constrained.basePattern).isSameAs(originalPattern)
+        assertThat(constrained.regex).isEqualTo("^[0-9]+$")
+    }
+
+    @Test
+    fun `patternFrom should return the exact value pattern if there is an equality matcher present in the composite matcher`() {
+        val originalPattern = StringPattern()
+        val result = Matcher.patternFrom(StringValue("${'$'}match(dataType: string, exact: hello)"), originalPattern, Resolver())
+
+        assertThat(result).isInstanceOf(ExactValuePattern::class.java)
+        val pattern = result as ExactValuePattern
+        assertThat(pattern.pattern.toStringLiteral()).isEqualTo("hello")
+    }
+
+    @Test
+    fun `patternFrom should return an exact value pattern with alter value when equality matcher is not equals`() {
+        val originalPattern = StringPattern()
+        val value = StringValue("hello")
+        val result = Matcher.patternFrom(
+            StringValue("\$match(exact: ${value.nativeValue}, matchType: neq)"),
+            originalPattern,
+            Resolver()
+        )
+
+        assertThat(result).isEqualTo(ExactValuePattern(value.alterValue()))
+    }
+
+    @Test
+    fun `patternFrom should fall back to the first matcher when composite has no pattern or regex matcher`() {
+        val originalPattern = StringPattern()
+        val result = Matcher.patternFrom(
+            StringValue("\$match(times: 2, value: any)"),
+            originalPattern,
+            Resolver()
+        )
+
+        assertThat(result).isSameAs(originalPattern)
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/matchers/PatternMatcherTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/matchers/PatternMatcherTest.kt
@@ -20,6 +20,15 @@ class PatternMatcherTest {
     private val mockResolver = mockk<Resolver>()
 
     @Test
+    fun `patternFrom should return its pattern`() {
+        val matcher = PatternMatcher(BreadCrumb.from(), NumberPattern())
+
+        val result = matcher.patternFrom(StringPattern())
+
+        assertThat(result).isEqualTo(NumberPattern())
+    }
+
+    @Test
     fun `should match when value satisfies pattern with FULL strategy`() {
         val matcher = PatternMatcher(
             path = BreadCrumb.from("/email"),

--- a/core/src/test/kotlin/io/specmatic/core/matchers/RegexMatcherTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/matchers/RegexMatcherTest.kt
@@ -7,9 +7,10 @@ import io.specmatic.core.Resolver
 import io.specmatic.core.jsonoperator.Optional
 import io.specmatic.core.jsonoperator.RequestResponseOperator
 import io.specmatic.core.jsonoperator.value.ValueOperator
-import io.specmatic.core.pattern.ExactValuePattern
 import io.specmatic.core.pattern.HasFailure
 import io.specmatic.core.pattern.HasValue
+import io.specmatic.core.pattern.RegexConstrainedPattern
+import io.specmatic.core.pattern.StringPattern
 import io.specmatic.core.value.NumberValue
 import io.specmatic.core.value.StringValue
 import org.assertj.core.api.Assertions.*
@@ -19,6 +20,16 @@ import org.junit.jupiter.api.Test
 class RegexMatcherTest {
     private val resolver = Resolver()
     private val mockOperator = mockk<RequestResponseOperator>()
+
+    @Test
+    fun `patternFrom should build regex constrained pattern`() {
+        val matcher = RegexMatcher(BreadCrumb.from(), "^Hello.*")
+        val original = StringPattern()
+
+        val result = matcher.patternFrom(original)
+
+        assertThat(result).isEqualTo(RegexConstrainedPattern(original, "^Hello.*"))
+    }
 
     @Nested
     inner class ExecuteTest {
@@ -76,34 +87,6 @@ class RegexMatcherTest {
 
             val result = matcher.execute(context)
             assertThat(result).isInstanceOf(MatcherResult.MisMatch::class.java)
-        }
-    }
-
-    @Nested
-    inner class ToPatternSimplifiedTest {
-
-        @Test
-        fun `should return the pattern for the given regex pattern that matches a string`() {
-            val pattern = RegexMatcher.toPatternSimplified(
-                StringValue("pattern: ^J.*")
-            )
-
-            assertThat(pattern).isInstanceOf(ExactValuePattern::class.java)
-            val value = (pattern as ExactValuePattern).pattern
-            assertThat(value).isInstanceOf(StringValue::class.java)
-            assertThat(value.toStringLiteral()).startsWith("J")
-        }
-
-        @Test
-        fun `should return the pattern for the given regex pattern that matches a number`() {
-            val pattern = RegexMatcher.toPatternSimplified(
-                StringValue("pattern: ^2\\d*$")
-            )
-
-            assertThat(pattern).isInstanceOf(ExactValuePattern::class.java)
-            val value = (pattern as ExactValuePattern).pattern
-            assertThat(value).isInstanceOf(NumberValue::class.java)
-            assertThat(value.toStringLiteral()).startsWith("2")
         }
     }
 

--- a/core/src/test/kotlin/io/specmatic/core/matchers/RepetitionMatcherTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/matchers/RepetitionMatcherTest.kt
@@ -9,6 +9,7 @@ import io.specmatic.core.jsonoperator.Optional
 import io.specmatic.core.jsonoperator.RequestResponseOperator
 import io.specmatic.core.pattern.HasFailure
 import io.specmatic.core.pattern.HasValue
+import io.specmatic.core.pattern.StringPattern
 import io.specmatic.core.value.JSONArrayValue
 import io.specmatic.core.value.StringValue
 import org.assertj.core.api.Assertions.assertThat
@@ -18,6 +19,16 @@ import org.junit.jupiter.api.Test
 class RepetitionMatcherTest {
     private val mockResolver = mockk<Resolver>()
     private val mockOperator = mockk<RequestResponseOperator>()
+
+    @Test
+    fun `patternFrom should return original pattern`() {
+        val matcher = RepetitionMatcher(BreadCrumb.from(), times = 2, strategy = RepetitionStrategy.ANY)
+        val original = StringPattern()
+
+        val result = matcher.patternFrom(original)
+
+        assertThat(result).isSameAs(original)
+    }
 
     @Test
     fun `should succeed when times is -1 without checking exhaustion`() {

--- a/core/src/test/kotlin/io/specmatic/core/pattern/AnyPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/AnyPatternTest.kt
@@ -1324,6 +1324,241 @@ internal class AnyPatternTest {
         }
     }
 
+    @Nested
+    inner class PatternFromTest {
+        @Test
+        fun `patternFrom should resolve pattern tokens using the matching AnyPattern option`() {
+            val pattern = AnyPattern(listOf(StringPattern(), NumberPattern()), extensions = emptyMap())
+
+            val result = pattern.patternFrom(StringValue("(number)"), Resolver())
+
+            assertThat(result).isEqualTo(DeferredPattern("(number)"))
+        }
+
+        @Test
+        fun `patternFrom should return the discriminator based pattern`() {
+            val pattern = AnyPattern(
+                listOf(
+                    JSONObjectPattern(
+                        mapOf("type" to ExactValuePattern(StringValue("sub1")), "prop" to StringPattern()),
+                        typeAlias = "(Sub1)"
+                    ),
+                    JSONObjectPattern(mapOf("type" to ExactValuePattern(StringValue("sub2")), "prop" to NumberPattern()), typeAlias = "(Sub2)")
+                ), typeAlias = "(Base)",
+                discriminator = Discriminator(
+                    property = "type",
+                    values = setOf("sub1", "sub2"),
+                    mapping = mapOf("sub1" to "#/components/schemas/Sub1", "sub2" to "#/components/schemas/Sub2")
+                )
+            )
+
+            val result = pattern.patternFrom(
+                JSONObjectValue(
+                    mapOf(
+                        "type" to StringValue("sub1"),
+                        "prop" to StringValue("prop")
+                    )
+                ),
+                Resolver()
+            )
+
+            assertThat(result).isInstanceOf(JSONObjectPattern::class.java)
+
+            assertThat(result).isEqualTo(
+                JSONObjectPattern(
+                    mapOf(
+                        "type" to ExactValuePattern(StringValue("sub1")),
+                        "prop" to ExactValuePattern(StringValue("prop"))
+                    ), typeAlias = "(Sub1)"
+                )
+            )
+        }
+
+        @Test
+        fun `patternFrom should return the correct discriminator pattern on wrong or invalid discriminator value`() {
+            val pattern = AnyPattern(
+                listOf(
+                    JSONObjectPattern(mapOf("type" to ExactValuePattern(StringValue("sub1")), "prop" to StringPattern(), "extra" to StringPattern()), typeAlias = "(Sub1)"),
+                    JSONObjectPattern(mapOf("type" to ExactValuePattern(StringValue("sub2")), "prop" to NumberPattern()), typeAlias = "(Sub2)")
+                ), typeAlias = "(Base)",
+                discriminator = Discriminator(
+                    property = "type",
+                    values = setOf("sub1", "sub2"),
+                    mapping = mapOf("sub1" to "#/components/schemas/Sub1", "sub2" to "#/components/schemas/Sub2")
+                )
+            )
+
+            val invalidValue = JSONObjectValue(mapOf("type" to StringValue("notExists"), "prop" to NumberValue(999)))
+            val result = pattern.patternFrom(invalidValue, Resolver())
+
+            assertThat(result).isInstanceOf(JSONObjectPattern::class.java)
+
+            assertThat(result).isEqualTo(
+                JSONObjectPattern(
+                    mapOf(
+                        "type" to ExactValuePattern(StringValue("notExists")),
+                        "prop" to ExactValuePattern(NumberValue(999))
+                    ), typeAlias = "(Sub1)"
+                )
+            )
+        }
+
+        @Test
+        fun `patternFrom should return the pattern with least failures when discriminator key is missing from value`() {
+            val pattern = AnyPattern(
+                listOf(
+                    JSONObjectPattern(mapOf("type" to ExactValuePattern(StringValue("sub1")), "prop" to StringPattern(), "extra" to StringPattern()), typeAlias = "(Sub1)"),
+                    JSONObjectPattern(mapOf("type" to ExactValuePattern(StringValue("sub2")), "prop" to NumberPattern()), typeAlias = "(Sub2)")
+                ), typeAlias = "(Base)",
+                discriminator = Discriminator(
+                    property = "type",
+                    values = setOf("sub1", "sub2"),
+                    mapping = mapOf("sub1" to "#/components/schemas/Sub1", "sub2" to "#/components/schemas/Sub2")
+                )
+            )
+
+            val valueWithoutDiscriminator = JSONObjectValue(mapOf("prop" to NumberValue(999)))
+            val result = pattern.patternFrom(valueWithoutDiscriminator, Resolver())
+
+            assertThat(result).isInstanceOf(JSONObjectPattern::class.java)
+            assertThat(result).isEqualTo(
+                JSONObjectPattern(
+                    mapOf(
+                        "prop" to ExactValuePattern(NumberValue(999))
+                    )
+                )
+            )
+        }
+
+        @Test
+        fun `patternFrom should return the pattern with least failures when no discriminator is present in the pattern`() {
+            val pattern = AnyPattern(
+                listOf(
+                    JSONObjectPattern(mapOf("type" to ExactValuePattern(StringValue("sub1")), "prop" to StringPattern(), "extra" to StringPattern()), typeAlias = "(Sub1)"),
+                    JSONObjectPattern(mapOf("type" to ExactValuePattern(StringValue("sub2")), "prop" to NumberPattern()), typeAlias = "(Sub2)")
+                ), typeAlias = "(Base)",
+                discriminator = null
+            )
+
+            val value = JSONObjectValue(mapOf("prop" to NumberValue(999)))
+            val result = pattern.patternFrom(value, Resolver())
+
+            assertThat(result).isInstanceOf(JSONObjectPattern::class.java)
+            assertThat(result).isEqualTo(
+                JSONObjectPattern(
+                    mapOf(
+                        "prop" to ExactValuePattern(NumberValue(999))
+                    )
+                )
+            )
+        }
+
+        @Test
+        fun `patternFrom should retain pattern token if it matches when resolver is in mock mode`() {
+            val objectPattern = JSONObjectPattern(mapOf("type" to "object".toDiscriminator(), "number" to NumberPattern(), "string" to StringPattern()), typeAlias = "(Object)")
+            val pattern = AnyPattern(
+                pattern = listOf(objectPattern), typeAlias = "(AnyPattern)",
+                discriminatorValues = setOf("object"), discriminatorProperty = "type"
+            )
+            val resolver = Resolver(newPatterns = mapOf("(Object)" to objectPattern, "(AnyPattern)" to pattern), mockMode = true)
+            val validValues = listOf(StringValue("(Object)"), StringValue("(AnyPattern)"))
+
+            assertThat(validValues).allSatisfy {
+                val result = pattern.patternFrom(it, resolver)
+                assertThat(result).isEqualTo(DeferredPattern(it.string))
+            }
+        }
+
+        @Test
+        fun `patternFrom should generate pattern when pattern token does not match when resolver is in mock mode`() {
+            val objectPattern = JSONObjectPattern(mapOf("type" to "object".toDiscriminator(), "number" to NumberPattern(), "string" to StringPattern()), typeAlias = "(Object)")
+            val pattern = AnyPattern(
+                pattern = listOf(objectPattern), typeAlias = "(AnyPattern)",
+                discriminatorValues = setOf("object"), discriminatorProperty = "type"
+            )
+            val resolver = Resolver(newPatterns = mapOf("(Object)" to objectPattern, "(AnyPattern)" to pattern), mockMode = true)
+            val invalidValues = listOf(StringValue("(string)"), StringValue("(number)"))
+
+            assertThat(invalidValues).allSatisfy {
+                val result = pattern.patternFrom(it, resolver)
+                assertThat(result).isEqualTo(DeferredPattern(it.string))
+            }
+        }
+
+        @Test
+        fun `patternFrom should generate pattern even if pattern token matches but resolver is not in mock mode`() {
+            val objectPattern = JSONObjectPattern(mapOf("type" to "object".toDiscriminator(), "number" to NumberPattern(), "string" to StringPattern()), typeAlias = "(Object)")
+            val pattern = AnyPattern(
+                pattern = listOf(objectPattern), typeAlias = "(AnyPattern)",
+                discriminatorValues = setOf("object"), discriminatorProperty = "type"
+            )
+            val resolver = Resolver(newPatterns = mapOf("(Object)" to objectPattern, "(AnyPattern)" to pattern), mockMode = false)
+            val values = listOf(StringValue("(Object)"), StringValue("(AnyPattern)"))
+
+            assertThat(values).allSatisfy {
+                val result = pattern.patternFrom(it, resolver)
+                assertThat(result).isEqualTo(DeferredPattern(it.string))
+            }
+        }
+
+        @Test
+        fun `patternFrom should work when pattern is scalar based of nullable type`() {
+            val pattern = AnyPattern(listOf(NullPattern, NumberPattern()), extensions = emptyMap())
+            val resolver = Resolver()
+            val value = NumberValue(999)
+            val result = pattern.patternFrom(value, resolver)
+
+            assertThat(result).isEqualTo(ExactValuePattern(NumberValue(999)))
+        }
+
+        @Test
+        fun `patternFrom scalar pattern should be created when pattern has typeAlias`() {
+            val pattern = AnyPattern(listOf(NullPattern, NumberPattern()), typeAlias = "(NumberOrEmpty)", extensions = emptyMap())
+            val resolver = Resolver()
+            val value = NumberValue(999)
+            val result = pattern.patternFrom(value, resolver)
+
+            assertThat(result).isEqualTo(ExactValuePattern(NumberValue(999)))
+        }
+
+        @Test
+        fun `patternFrom should not throw an exception for a nullable pattern`() {
+            val pattern = AnyPattern(listOf(NullPattern, NumberPattern()), extensions = emptyMap())
+            val resolver = Resolver()
+
+            val value = NumberValue(999)
+            val result = assertDoesNotThrow { pattern.patternFrom(value, resolver) }
+
+            assertThat(result).isEqualTo(ExactValuePattern(NumberValue(999)))
+        }
+
+        @Test
+        fun `patternFrom should be able to create pattern from values with a partial resolver`() {
+            val pattern = AnyPattern(
+                listOf(
+                    JSONObjectPattern(mapOf("type" to "sub1".toDiscriminator(), "prop" to StringPattern(), "extra" to NumberPattern()), typeAlias = "(Sub1)"),
+                    JSONObjectPattern(mapOf("type" to "sub2".toDiscriminator(), "prop" to NumberPattern()), typeAlias = "(Sub2)")
+                ), typeAlias = "(Base)",
+                discriminator = Discriminator(
+                    property = "type",
+                    values = setOf("sub1", "sub2"),
+                    mapping = mapOf("sub1" to "#/components/schemas/Sub1", "sub2" to "#/components/schemas/Sub2")
+                )
+            )
+            val resolver = Resolver().partializeKeyCheck()
+            val partialValue = JSONObjectValue(mapOf("extra" to NumberValue(999)))
+            val result = pattern.patternFrom(partialValue, resolver)
+
+            assertThat(result).isEqualTo(
+                JSONObjectPattern(
+                    mapOf(
+                        "extra" to ExactValuePattern(NumberValue(999))
+                    )
+                )
+            )
+        }
+    }
+
     private fun String.toDiscriminator(): ExactValuePattern {
         return ExactValuePattern(StringValue(this))
     }

--- a/core/src/test/kotlin/io/specmatic/core/pattern/AnyPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/AnyPatternTest.kt
@@ -15,6 +15,47 @@ import org.junit.jupiter.api.assertThrows
 
 internal class AnyPatternTest {
     @Test
+    fun `generateNotEqualTo should return a different value for enum-like any pattern`() {
+        val pattern = AnyPattern(
+            pattern = listOf(
+                ExactValuePattern(StringValue("a")),
+                ExactValuePattern(StringValue("b"))
+            ),
+            extensions = emptyMap()
+        )
+
+        val generatedValue = pattern.generateNotEqualTo(StringValue("b"), Resolver())
+
+        assertThat(generatedValue).isEqualTo(StringValue("a"))
+    }
+
+    @Test
+    fun `generateNotEqualTo should throw when enum-like any pattern has no other values`() {
+        val pattern = AnyPattern(
+            pattern = listOf(
+                ExactValuePattern(StringValue("b"))
+            ),
+            extensions = emptyMap()
+        )
+
+        assertThrows<ContractException> {
+            pattern.generateNotEqualTo(StringValue("b"), Resolver())
+        }
+    }
+
+    @Test
+    fun `generateNotEqualTo should use alterValue when excluded matches pattern`() {
+        val pattern = AnyPattern(
+            pattern = listOf(StringPattern(), NumberPattern()),
+            extensions = emptyMap()
+        )
+
+        val generated = pattern.generateNotEqualTo(StringValue("hello"), Resolver())
+
+        assertThat(generated).isEqualTo(StringValue("hello_"))
+    }
+
+    @Test
     fun `should be able to generate for a discriminator value when it's nested inside another AnyPattern`() {
         val discriminator = Discriminator(
             property = "type",

--- a/core/src/test/kotlin/io/specmatic/core/pattern/EnumPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/EnumPatternTest.kt
@@ -63,6 +63,33 @@ class EnumPatternTest {
         }
 
         @Test
+        fun `generateNotEqualTo should return a different enum value`() {
+            val enum = EnumPattern(listOf(StringValue("a"), StringValue("b")))
+
+            val generatedValue = enum.generateNotEqualTo(StringValue("b"), Resolver())
+
+            assertThat(generatedValue).isEqualTo(StringValue("a"))
+        }
+
+        @Test
+        fun `generateNotEqualTo should return generate when excluded does not match enum type`() {
+            val enum = EnumPattern(listOf(StringValue("a"), StringValue("b")))
+
+            val generatedValue = enum.generateNotEqualTo(NumberValue(10), Resolver())
+
+            assertThat(generatedValue).isIn(listOf(StringValue("a"), StringValue("b")))
+        }
+
+        @Test
+        fun `generateNotEqualTo should throw when no other enum value exists`() {
+            val enum = EnumPattern(listOf(StringValue("b")))
+
+            assertThrows<ContractException> {
+                enum.generateNotEqualTo(StringValue("b"), Resolver())
+            }
+        }
+
+        @Test
         fun `it should parse a new value to the enum type`() {
             val enum = toMultiValueEnum("01", 10, true)
             assertThat(listOf("Three" to "Three", "03" to 3, "false" to false)).allSatisfy { (string, expectation) ->

--- a/core/src/test/kotlin/io/specmatic/core/pattern/ExactValuePatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/ExactValuePatternTest.kt
@@ -15,6 +15,7 @@ import io.specmatic.core.DefaultMismatchMessages
 import io.specmatic.shouldNotMatch
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
@@ -76,6 +77,24 @@ internal class ExactValuePatternTest {
             )
         }
         """.trimIndent())
+    }
+
+    @Test
+    fun `generateNotEqualTo should return value when excluded is different`() {
+        val pattern = ExactValuePattern(StringValue("a"))
+
+        val generatedValue = pattern.generateNotEqualTo(StringValue("b"), Resolver())
+
+        assertThat(generatedValue).isEqualTo(StringValue("a"))
+    }
+
+    @Test
+    fun `generateNotEqualTo should throw when excluded equals exact value`() {
+        val pattern = ExactValuePattern(StringValue("a"))
+
+        assertThrows<ContractException> {
+            pattern.generateNotEqualTo(StringValue("a"), Resolver())
+        }
     }
 
     companion object {

--- a/core/src/test/kotlin/io/specmatic/core/pattern/JSONArrayPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/JSONArrayPatternTest.kt
@@ -104,6 +104,20 @@ internal class JSONArrayPatternTest {
     }
 
     @Test
+    fun `patternFrom should use existing patterns and fallback to value types for extra elements`() {
+        val pattern = JSONArrayPattern(listOf(NumberPattern()))
+        val value = JSONArrayValue(listOf(
+            StringValue("(number)"),
+            StringValue("alpha")
+        ))
+
+        val result = pattern.patternFrom(value, Resolver()) as JSONArrayPattern
+
+        assertThat(result.pattern[0]).isEqualTo(DeferredPattern("(number)"))
+        assertThat(result.pattern[1]).isEqualTo(ExactValuePattern(StringValue("alpha")))
+    }
+
+    @Test
     fun `should encompass itself`() {
         val type = parsedPattern("""["(number)", "(number)"]""")
         assertThat(type.encompasses(type, Resolver(), Resolver())).isInstanceOf(Result.Success::class.java)

--- a/core/src/test/kotlin/io/specmatic/core/pattern/JSONObjectPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/JSONObjectPatternTest.kt
@@ -173,6 +173,73 @@ internal class JSONObjectPatternTest {
     }
 
     @Test
+    fun `patternFrom should retain explicit patterns for pattern and matcher tokens`() {
+        val pattern = JSONObjectPattern(
+            mapOf(
+                "id" to NumberPattern(),
+                "count" to NumberPattern(),
+                "active" to BooleanPattern(),
+                "name" to StringPattern()
+            )
+        )
+
+        val value = JSONObjectValue(
+            mapOf(
+                "id" to StringValue("${'$'}match(pattern: POSITIVE_REGEX)"),
+                "count" to StringValue("(number)"),
+                "active" to StringValue("(boolean)"),
+                "name" to StringValue("(string)")
+            )
+        )
+
+        val result = pattern.patternFrom(value, Resolver()) as JSONObjectPattern
+
+        assertThat(result.pattern.getValue("id"))
+            .isEqualTo(RegexConstrainedPattern(NumberPattern(), "POSITIVE_REGEX"))
+        assertThat(result.pattern.getValue("count")).isEqualTo(DeferredPattern("(number)"))
+        assertThat(result.pattern.getValue("active")).isEqualTo(DeferredPattern("(boolean)"))
+        assertThat(result.pattern.getValue("name")).isEqualTo(DeferredPattern("(string)"))
+    }
+
+    @Test
+    fun `patternFrom should retain nested patterns for pattern and matcher tokens`() {
+        val pattern = JSONObjectPattern(
+            mapOf(
+                "outerId" to NumberPattern(),
+                "meta" to JSONObjectPattern(
+                    mapOf(
+                        "id" to NumberPattern(),
+                        "active" to BooleanPattern(),
+                        "name" to StringPattern()
+                    )
+                )
+            )
+        )
+
+        val value = JSONObjectValue(
+            mapOf(
+                "outerId" to StringValue("(number)"),
+                "meta" to JSONObjectValue(
+                    mapOf(
+                        "id" to StringValue("${'$'}match(pattern: POSITIVE_REGEX)"),
+                        "active" to StringValue("(boolean)"),
+                        "name" to StringValue("(string)")
+                    )
+                )
+            )
+        )
+
+        val result = pattern.patternFrom(value, Resolver()) as JSONObjectPattern
+        val meta = result.pattern.getValue("meta") as JSONObjectPattern
+
+        assertThat(result.pattern.getValue("outerId")).isEqualTo(DeferredPattern("(number)"))
+        assertThat(meta.pattern.getValue("id"))
+            .isEqualTo(RegexConstrainedPattern(NumberPattern(), "POSITIVE_REGEX"))
+        assertThat(meta.pattern.getValue("active")).isEqualTo(DeferredPattern("(boolean)"))
+        assertThat(meta.pattern.getValue("name")).isEqualTo(DeferredPattern("(string)"))
+    }
+
+    @Test
     fun `it should encompass itself`() {
         val type = parsedPattern("""{"name": "(string)"}""")
         assertThat(type.encompasses(type, Resolver(), Resolver())).isInstanceOf(Result.Success::class.java)

--- a/core/src/test/kotlin/io/specmatic/core/pattern/ListPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/ListPatternTest.kt
@@ -73,6 +73,20 @@ internal class ListPatternTest {
     }
 
     @Test
+    fun `patternFrom should retain matcher tokens in list elements`() {
+        val pattern = ListPattern(NumberPattern())
+        val value = JSONArrayValue(listOf(
+            StringValue("${'$'}match(pattern: POSITIVE_REGEX)"),
+            NumberValue(10)
+        ))
+
+        val result = pattern.patternFrom(value, Resolver()) as JSONArrayPattern
+
+        assertThat(result.pattern[0]).isEqualTo(RegexConstrainedPattern(NumberPattern(), "POSITIVE_REGEX"))
+        assertThat(result.pattern[1]).isEqualTo(ExactValuePattern(NumberValue(10)))
+    }
+
+    @Test
     fun `should encompass itself`() {
         val type = ListPattern(NumberPattern())
         assertThat(type.encompasses(type, Resolver(), Resolver())).isInstanceOf(Result.Success::class.java)

--- a/core/src/test/kotlin/io/specmatic/core/pattern/NotEqualsPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/NotEqualsPatternTest.kt
@@ -1,0 +1,65 @@
+package io.specmatic.core.pattern
+
+import io.specmatic.core.Resolver
+import io.specmatic.core.Result
+import io.specmatic.core.value.StringValue
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class NotEqualsPatternTest {
+    @Test
+    fun `should fail when sample equals excluded value`() {
+        val pattern = NotEqualsPattern(StringPattern(), StringValue("hello"))
+
+        val result = pattern.matches(StringValue("hello"), Resolver())
+
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
+    }
+
+    @Test
+    fun `should match when sample is different from excluded value`() {
+        val pattern = NotEqualsPattern(StringPattern(), StringValue("hello"))
+
+        val result = pattern.matches(StringValue("world"), Resolver())
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+    }
+
+    @Test
+    fun `generate should return a value not equal to excluded`() {
+        val base = EnumPattern(listOf(StringValue("a"), StringValue("b")))
+        val pattern = NotEqualsPattern(base, StringValue("b"))
+
+        val generated = pattern.generate(Resolver())
+
+        assertThat(generated).isEqualTo(StringValue("a"))
+    }
+
+    @Test
+    fun `generate should throw when no other value can be generated`() {
+        val base = ExactValuePattern(StringValue("a"))
+        val pattern = NotEqualsPattern(base, StringValue("a"))
+
+        assertThrows<ContractException> { pattern.generate(Resolver()) }
+    }
+
+    @Test
+    fun `encompasses should fail when other pattern is exact excluded value`() {
+        val base = StringPattern()
+        val pattern = NotEqualsPattern(base, StringValue("x"))
+
+        val result = pattern.encompasses(ExactValuePattern(StringValue("x")), Resolver(), Resolver(), emptySet())
+
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
+    }
+
+    @Test
+    fun `patternFrom should keep excluded value and update base pattern`() {
+        val pattern = NotEqualsPattern(StringPattern(), StringValue("hello"))
+
+        val result = pattern.patternFrom(StringValue("ignored"), Resolver())
+
+        assertThat(result).isEqualTo(NotEqualsPattern(ExactValuePattern(StringValue("ignored")), StringValue("hello")))
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/pattern/NullPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/NullPatternTest.kt
@@ -8,6 +8,7 @@ import io.specmatic.core.value.StringValue
 import io.specmatic.shouldMatch
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.assertThrows
 
 internal class NullPatternTest {
     @Test
@@ -34,6 +35,13 @@ internal class NullPatternTest {
     @Test
     fun `should create a new array of patterns containing itself`() {
         assertEquals(listOf(NullPattern), newBasedOn(Row(), Resolver()).map { it.value }.toList())
+    }
+
+    @Test
+    fun `generateNotEqualTo should throw when excluded is null`() {
+        assertThrows<ContractException> {
+            NullPattern.generateNotEqualTo(NullValue, Resolver())
+        }
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/core/pattern/NumberPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/NumberPatternTest.kt
@@ -7,6 +7,7 @@ import io.specmatic.core.UseDefaultExample
 import io.specmatic.core.pattern.config.NegativePatternConfiguration
 import io.specmatic.core.value.NullValue
 import io.specmatic.core.value.NumberValue
+import io.specmatic.core.value.StringValue
 import io.specmatic.shouldNotMatch
 import io.specmatic.core.StandardRuleViolation
 import io.specmatic.toViolationReportString
@@ -628,5 +629,14 @@ internal class NumberPatternTest {
         assertThat(largerResult.isSuccess())
             .withFailMessage("Expected value larger than Int.MAX_VALUE to match, but it failed with: ${largerResult.reportString()}")
             .isTrue()
+    }
+
+    @Test
+    fun `generateNotEqualTo should fall back to generate when excluded does not match pattern`() {
+        val pattern = NumberPattern()
+
+        val generatedValue = pattern.generateNotEqualTo(StringValue("not-a-number"), Resolver())
+
+        assertThat(generatedValue).isInstanceOf(NumberValue::class.java)
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/pattern/RegexConstrainedPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/RegexConstrainedPatternTest.kt
@@ -1,0 +1,57 @@
+package io.specmatic.core.pattern
+
+import io.specmatic.core.Resolver
+import io.specmatic.core.Result
+import io.specmatic.core.value.NumberValue
+import io.specmatic.core.value.StringValue
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class RegexConstrainedPatternTest {
+    @Test
+    fun `matches should enforce regex after base pattern`() {
+        val pattern = RegexConstrainedPattern(StringPattern(), "^Hello.*")
+        val resolver = Resolver()
+
+        assertThat(pattern.matches(StringValue("Hello world"), resolver)).isInstanceOf(Result.Success::class.java)
+        assertThat(pattern.matches(StringValue("Bye"), resolver)).isInstanceOf(Result.Failure::class.java)
+    }
+
+    @Test
+    fun `matches should fail when base pattern fails even if regex matches`() {
+        val pattern = RegexConstrainedPattern(NumberPattern(), "^[A-Za-z]+$")
+        val resolver = Resolver()
+
+        assertThat(pattern.matches(StringValue("Alpha"), resolver)).isInstanceOf(Result.Failure::class.java)
+    }
+
+    @Test
+    fun `generate should return the regex based candidate when it does not get parsed by the basePattern`() {
+        val pattern = RegexConstrainedPattern(NumberPattern(), "^[A-Za-z]+$")
+        val generated = pattern.generate(Resolver())
+
+        assertThat(generated).isInstanceOf(StringValue::class.java)
+    }
+
+    @Test
+    fun `generate should return the generated value which is successfully parsed by the basePattern`() {
+        val pattern = RegexConstrainedPattern(NumberPattern(), "^1$")
+        val generated = pattern.generate(Resolver())
+
+        assertThat(generated).isInstanceOf(NumberValue::class.java)
+        assertThat((generated as NumberValue).number).isEqualTo(1)
+    }
+
+    @Test
+    fun `encompasses should accept exact value that matches regex`() {
+        val pattern = RegexConstrainedPattern(StringPattern(), "^Hello$")
+        val result = pattern.encompasses(
+            ExactValuePattern(StringValue("Hello")),
+            Resolver(),
+            Resolver(),
+            emptySet()
+        )
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/pattern/StringPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/StringPatternTest.kt
@@ -58,6 +58,24 @@ internal class StringPatternTest {
     }
 
     @Test
+    fun `generateNotEqualTo should return altered value when excluded matches pattern`() {
+        val pattern = StringPattern()
+
+        val generatedValue = pattern.generateNotEqualTo(StringValue("hello"), Resolver())
+
+        assertThat(generatedValue).isEqualTo(StringValue("hello_"))
+    }
+
+    @Test
+    fun `generateNotEqualTo should throw when altered value does not match regex`() {
+        val pattern = StringPattern(regex = "[0-9]+")
+
+        assertThrows<ContractException> {
+            pattern.generateNotEqualTo(StringValue("1"), Resolver())
+        }
+    }
+
+    @Test
     fun `newBasedOn should generate random string based on the regex and then it should match the regex`() {
         val maxLength = 32
         val regex = "[0-9a-f]{$maxLength}"

--- a/core/src/test/kotlin/io/specmatic/core/pattern/TabularPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/TabularPatternTest.kt
@@ -391,6 +391,24 @@ Feature: Recursive test
     }
 
     @Test
+    fun `patternFrom should apply optional key patterns and matcher tokens`() {
+        val pattern = toTabularPattern(mapOf(
+            "name?" to StringPattern(),
+            "age" to NumberPattern()
+        ))
+        val value = JSONObjectValue(mapOf(
+            "name" to StringValue("(string)"),
+            "age" to StringValue("\$match(pattern: POSITIVE_REGEX)")
+        ))
+
+        val result = pattern.patternFrom(value, Resolver()) as TabularPattern
+
+        assertThat(result.pattern.getValue("name")).isEqualTo(DeferredPattern("(string)"))
+        assertThat(result.pattern.getValue("age"))
+            .isEqualTo(RegexConstrainedPattern(NumberPattern(), "POSITIVE_REGEX"))
+    }
+
+    @Test
     fun `tabular type should encompass JSON type`() {
         val tabular = toTabularPattern(mapOf("key1" to StringPattern(), "key2" to StringPattern()))
         val json = JSONObjectPattern(tabular.pattern)

--- a/core/src/test/resources/openapi/request_matchers_in_external_examples.yaml
+++ b/core/src/test/resources/openapi/request_matchers_in_external_examples.yaml
@@ -1,0 +1,101 @@
+openapi: 3.0.0
+info:
+  title: Matcher External Example API
+  version: 0.1.0
+paths:
+  /search:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - code
+              properties:
+                code:
+                  type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - message
+                properties:
+                  message:
+                    type: string
+  /adjust:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - amount
+              properties:
+                amount:
+                  type: number
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - message
+                properties:
+                  message:
+                    type: string
+  /count:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - count
+              properties:
+                count:
+                  type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - message
+                properties:
+                  message:
+                    type: string
+  /flag:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - active
+              properties:
+                active:
+                  type: boolean
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - message
+                properties:
+                  message:
+                    type: string

--- a/core/src/test/resources/openapi/request_matchers_in_external_examples_examples/adjust_post.json
+++ b/core/src/test/resources/openapi/request_matchers_in_external_examples_examples/adjust_post.json
@@ -1,0 +1,18 @@
+{
+  "http-request": {
+    "method": "POST",
+    "path": "/adjust",
+    "body": {
+      "amount": "$match(pattern: ^-\\d+$)"
+    }
+  },
+  "http-response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "message": "negative matched"
+    }
+  }
+}

--- a/core/src/test/resources/openapi/request_matchers_in_external_examples_examples/count_post.json
+++ b/core/src/test/resources/openapi/request_matchers_in_external_examples_examples/count_post.json
@@ -1,0 +1,18 @@
+{
+  "http-request": {
+    "method": "POST",
+    "path": "/count",
+    "body": {
+      "count": "$match(pattern: ^\\d+$)"
+    }
+  },
+  "http-response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "message": "count matched"
+    }
+  }
+}

--- a/core/src/test/resources/openapi/request_matchers_in_external_examples_examples/flag_post.json
+++ b/core/src/test/resources/openapi/request_matchers_in_external_examples_examples/flag_post.json
@@ -1,0 +1,18 @@
+{
+  "http-request": {
+    "method": "POST",
+    "path": "/flag",
+    "body": {
+      "active": "$match(pattern: ^(true|false)$)"
+    }
+  },
+  "http-response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "message": "flag matched"
+    }
+  }
+}

--- a/core/src/test/resources/openapi/request_matchers_in_external_examples_examples/search_post.json
+++ b/core/src/test/resources/openapi/request_matchers_in_external_examples_examples/search_post.json
@@ -1,0 +1,18 @@
+{
+  "http-request": {
+    "method": "POST",
+    "path": "/search",
+    "body": {
+      "code": "$match(pattern: ^[A-Z]{3}[0-9]{3}$)"
+    }
+  },
+  "http-response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "message": "matched"
+    }
+  }
+}


### PR DESCRIPTION
Reason for change:
The pattern returned from not equals matcher was not able to handle enums properly where it would generate value which is not in the enum values set. This change ensures that not equals matcher always returns a pattern which will surely generate a value not equal to specified value while keeping the original pattern in tact.