### PR TITLE
fix: fix the matcher token parsing issue where it used to fail where the regex matcher had a regex with a comma

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/matchers/MatcherFactory.kt
+++ b/core/src/main/kotlin/io/specmatic/core/matchers/MatcherFactory.kt
@@ -3,7 +3,6 @@ package io.specmatic.core.matchers
 import io.specmatic.core.BreadCrumb
 import io.specmatic.core.pattern.Pattern
 import io.specmatic.core.pattern.ReturnValue
-import io.specmatic.core.utilities.fromYamlProperties
 import io.specmatic.core.value.StringValue
 import io.specmatic.core.value.Value
 
@@ -22,7 +21,7 @@ interface MatcherFactory {
         val hasMultiplePairs = value.nativeValue.count { it == ',' } > 0 || value.nativeValue.count { it == ':' } > 0
         if (!hasColonPattern || !hasMultiplePairs) return null
         return runCatching {
-            fromYamlProperties(value.nativeValue).takeUnless(Map<String, Value>::isEmpty)
+            parseMatcherTokenProperties(value.nativeValue).takeUnless(Map<String, Value>::isEmpty)
         }.getOrNull()
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/matchers/MatcherTokenParser.kt
+++ b/core/src/main/kotlin/io/specmatic/core/matchers/MatcherTokenParser.kt
@@ -1,0 +1,38 @@
+package io.specmatic.core.matchers
+
+import io.specmatic.core.utilities.yamlStringToValue
+import io.specmatic.core.value.JSONObjectValue
+import io.specmatic.core.value.StringValue
+import io.specmatic.core.value.Value
+
+// Splits on commas that are followed by a new `key:` token, so commas inside values (e.g. regex patterns) are preserved.
+private val MATCHER_PROPERTY_SEPARATOR = Regex(""",\s*(?=[A-Za-z_][A-Za-z0-9_-]*\s*:)""")
+
+internal fun parseMatcherTokenProperties(value: String): Map<String, Value> {
+    if (value.isBlank()) return emptyMap()
+
+    return value
+        .trim()
+        .split(MATCHER_PROPERTY_SEPARATOR)
+        .associate(::toMatcherPropertyPair)
+}
+
+private fun toMatcherPropertyPair(rawProperty: String): Pair<String, Value> {
+    val separatorIndex = rawProperty.indexOf(':')
+    if (separatorIndex < 0) throw IllegalArgumentException("Invalid matcher token property '$rawProperty'")
+
+    val key = rawProperty.substring(0, separatorIndex).trim()
+    if (key.isBlank()) throw IllegalArgumentException("Invalid matcher token property '$rawProperty'")
+
+    val rawValue = rawProperty.substring(separatorIndex + 1).trim()
+    return key to parseMatcherPropertyValue(key, rawValue)
+}
+
+private fun parseMatcherPropertyValue(key: String, rawValue: String): Value {
+    if (key == RegexMatcher.PATTERN_PROPERTY_KEY) {
+        return StringValue(rawValue)
+    }
+
+    val parsed = yamlStringToValue("value: $rawValue")
+    return if (parsed is JSONObjectValue) parsed.jsonObject["value"] ?: StringValue(rawValue) else StringValue(rawValue)
+}

--- a/core/src/main/kotlin/io/specmatic/core/matchers/PatternMatcher.kt
+++ b/core/src/main/kotlin/io/specmatic/core/matchers/PatternMatcher.kt
@@ -68,7 +68,7 @@ class PatternMatcher(
     companion object : MatcherFactory {
         private const val DATA_TYPE_KEY = "dataType"
         private const val PARTIAL_KEY = "partial"
-        override val matcherKey: String = "pattern"
+        override val matcherKey: String = RegexMatcher.PATTERN_PROPERTY_KEY
 
         override fun parse(path: BreadCrumb, value: Value, context: MatcherContext): ReturnValue<PatternMatcher> {
             if (value !is StringValue) return HasFailure("Invalid '$DATA_TYPE_KEY', expected String got ${value.displayableValue()}", path.value)

--- a/core/src/main/kotlin/io/specmatic/core/matchers/RegexMatcher.kt
+++ b/core/src/main/kotlin/io/specmatic/core/matchers/RegexMatcher.kt
@@ -49,7 +49,7 @@ data class RegexMatcher(val path: BreadCrumb, val regex: String) : Matcher {
     }
 
     companion object : MatcherFactory {
-        private const val PATTERN_KEY = "pattern"
+        const val PATTERN_PROPERTY_KEY = "pattern"
         override val matcherKey: String = "regex"
 
         override fun parse(path: BreadCrumb, value: Value, context: MatcherContext): ReturnValue<RegexMatcher> {
@@ -62,13 +62,14 @@ data class RegexMatcher(val path: BreadCrumb, val regex: String) : Matcher {
         }
 
         override fun canParseFrom(path: BreadCrumb, properties: Map<String, Value>): Boolean {
-            return PATTERN_KEY in properties
+            return PATTERN_PROPERTY_KEY in properties
         }
 
         override fun parseFrom(path: BreadCrumb, properties: Map<String, Value>, context: MatcherContext): ReturnValue<RegexMatcher> {
-            val patternValue = properties[PATTERN_KEY] ?: return HasFailure("Expected key '$PATTERN_KEY' to be present", path.value)
+            val patternValue = properties[PATTERN_PROPERTY_KEY]
+                ?: return HasFailure("Expected key '$PATTERN_PROPERTY_KEY' to be present", path.value)
             if (patternValue !is StringValue) return HasFailure(
-                "Expected key '$PATTERN_KEY' to be a string",
+                "Expected key '$PATTERN_PROPERTY_KEY' to be a string",
                 path.value,
             )
 

--- a/core/src/main/kotlin/io/specmatic/core/utilities/YAMLSerialisation.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/YAMLSerialisation.kt
@@ -42,11 +42,3 @@ fun toValue(any: Any?): Value {
         else -> StringValue(rawValue.toString())
     }
 }
-
-fun fromYamlProperties(value: String): Map<String, Value> {
-    val yamlFormat = value.split(",").joinToString("\n") { it.trim().replace(Regex(":(?! )"), ": ") }
-    return when (val parsed = yamlStringToValue(yamlFormat)) {
-        is JSONObjectValue -> parsed.jsonObject
-        else -> emptyMap()
-    }
-}

--- a/core/src/test/kotlin/io/specmatic/core/matchers/MatcherTokenParserTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/matchers/MatcherTokenParserTest.kt
@@ -1,0 +1,46 @@
+package io.specmatic.core.matchers
+
+import io.specmatic.core.value.NumberValue
+import io.specmatic.core.value.StringValue
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+class MatcherTokenParserTest {
+    @Test
+    fun `should return empty map for blank input`() {
+        val properties = parseMatcherTokenProperties("   ")
+
+        assertThat(properties).isEmpty()
+    }
+
+    @Test
+    fun `should parse matcher token properties`() {
+        val properties = parseMatcherTokenProperties("exact: test, times: 2")
+
+        assertThat(properties).containsEntry("exact", StringValue("test"))
+        assertThat(properties).containsEntry("times", NumberValue(2))
+    }
+
+    @Test
+    fun `should preserve regex pattern with commas and colons`() {
+        val properties = parseMatcherTokenProperties("pattern: ^https?://[A-Za-z0-9, :/.?-]+$, dataType: string")
+
+        assertThat(properties).containsEntry(RegexMatcher.PATTERN_PROPERTY_KEY, StringValue("^https?://[A-Za-z0-9, :/.?-]+$"))
+        assertThat(properties).containsEntry("dataType", StringValue("string"))
+    }
+
+    @Test
+    fun `should fail for malformed property token with no colon`() {
+        assertThatThrownBy { parseMatcherTokenProperties("invalid-token") }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Invalid matcher token property 'invalid-token'")
+    }
+
+    @Test
+    fun `should fail for property token with blank key`() {
+        assertThatThrownBy { parseMatcherTokenProperties(": ignored, exact: test") }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Invalid matcher token property ': ignored'")
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/matchers/MatcherTokenParserTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/matchers/MatcherTokenParserTest.kt
@@ -5,6 +5,8 @@ import io.specmatic.core.value.StringValue
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 
 class MatcherTokenParserTest {
     @Test
@@ -22,11 +24,19 @@ class MatcherTokenParserTest {
         assertThat(properties).containsEntry("times", NumberValue(2))
     }
 
-    @Test
-    fun `should preserve regex pattern with commas and colons`() {
-        val properties = parseMatcherTokenProperties("pattern: ^https?://[A-Za-z0-9, :/.?-]+$, dataType: string")
+    @ParameterizedTest
+    @ValueSource(
+        strings = [
+            "^https?://[A-Za-z0-9, :/.?-]+$",
+            "^[A-Z][a-z0-9 ,]+$",
+            "^[A-Z],[a-z]+,[0-9]*$",
+            "[A-C],[D-F],[0-9]",
+        ]
+    )
+    fun `should preserve regex pattern with commas and colons`(regexMatcherValue: String) {
+        val properties = parseMatcherTokenProperties("pattern: $regexMatcherValue, dataType: string")
 
-        assertThat(properties).containsEntry(RegexMatcher.PATTERN_PROPERTY_KEY, StringValue("^https?://[A-Za-z0-9, :/.?-]+$"))
+        assertThat(properties).containsEntry(RegexMatcher.PATTERN_PROPERTY_KEY, StringValue(regexMatcherValue))
         assertThat(properties).containsEntry("dataType", StringValue("string"))
     }
 

--- a/core/src/test/kotlin/io/specmatic/core/utilities/YAMLSerialisationKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/utilities/YAMLSerialisationKtTest.kt
@@ -1,6 +1,5 @@
 package io.specmatic.core.utilities
 
-import io.specmatic.core.pattern.*
 import io.specmatic.core.value.*
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow


### PR DESCRIPTION
Reason for change -
The existing matcher token parsing logic was behaving incorrectly where there is a regex matcher where the regex contained a comma character.

Fix -
Rewrite the matcher token parsing logic to make it more solid.