### PR TITLE
Handle OpenAPI uri format as URLPattern in mocks

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -2200,6 +2200,23 @@ class OpenApiSpecification(
         return StringPattern.from(stringConstraints, schema.pattern, example, collectorContext)
     }
 
+    private fun uriPattern(schema: Schema<*>, patternName: String, collectorContext: CollectorContext, example: String? = null): Pattern {
+        val baseUriPattern = URIPattern()
+        val regex = stringPattern(schema, patternName, collectorContext, example).regex ?: return baseUriPattern
+
+        return collectorContext.at("pattern").safely(
+            fallback = { baseUriPattern },
+            message = "URI regex constraint could not be applied, defaulting to uri"
+        ) {
+            RegexConstrainedPattern(
+                basePattern = baseUriPattern,
+                regex = regex,
+                resolver = Resolver(),
+                eagerRegexValidation = false
+            )
+        }
+    }
+
     private fun numberPattern(schema: Schema<*>, collectorContext: CollectorContext, isDoubleFormat: Boolean, example: String?) : NumberPattern {
         val minSource = if (schema.exclusiveMinimumValue != null) NumericBoundSource.EXCLUSIVE_MINIMUM else if (schema.minimum != null) NumericBoundSource.MINIMUM else null
         val maxSource = if (schema.exclusiveMaximumValue != null) NumericBoundSource.EXCLUSIVE_MAXIMUM else if (schema.maximum != null) NumericBoundSource.MAXIMUM else null
@@ -2734,7 +2751,7 @@ class OpenApiSpecification(
             "string" -> when (this.format) {
                 "email" -> EmailPattern(example = example)
                 "password" -> StringPattern(example = example)
-                "uri" -> URLPattern(URLScheme.EITHER)
+                "uri" -> uriPattern(this, patternName = patternName, collectorContext = collectorContext, example = example)
                 "uuid" -> UUIDPattern
                 "date" -> DatePattern
                 "date-time" -> DateTimePattern

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -2734,6 +2734,7 @@ class OpenApiSpecification(
             "string" -> when (this.format) {
                 "email" -> EmailPattern(example = example)
                 "password" -> StringPattern(example = example)
+                "uri" -> URLPattern(URLScheme.EITHER)
                 "uuid" -> UUIDPattern
                 "date" -> DatePattern
                 "date-time" -> DateTimePattern

--- a/core/src/main/kotlin/io/specmatic/core/pattern/URIPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/URIPattern.kt
@@ -1,0 +1,56 @@
+package io.specmatic.core.pattern
+
+import io.specmatic.core.Resolver
+import io.specmatic.core.Result
+import io.specmatic.core.dataTypeMismatchResult
+import io.specmatic.core.value.JSONArrayValue
+import io.specmatic.core.value.StringValue
+import io.specmatic.core.value.Value
+import java.net.URI
+
+data class URIPattern(override val typeAlias: String? = null) : Pattern, ScalarType {
+    override val pattern: String = "(uri)"
+
+    override fun matches(sampleData: Value?, resolver: Resolver): Result {
+        return resultOf {
+            when {
+                sampleData is StringValue && parse(sampleData.string, resolver).string == sampleData.string -> Result.Success()
+                else -> dataTypeMismatchResult(this, sampleData, resolver.mismatchMessages)
+            }
+        }
+    }
+
+    override fun generate(resolver: Resolver): StringValue {
+        val providedString = resolver.provideString(this)
+        return providedString ?: StringValue("https://${randomString().lowercase()}.com/${randomString().lowercase()}")
+    }
+
+    override fun newBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> = sequenceOf(HasValue(this))
+
+    override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
+
+    override fun negativeBasedOn(
+        row: Row,
+        resolver: Resolver,
+        config: io.specmatic.core.pattern.config.NegativePatternConfiguration
+    ): Sequence<ReturnValue<Pattern>> = newBasedOn(row, resolver)
+
+    override fun parse(value: String, resolver: Resolver): StringValue =
+        attemptParse(this, value, resolver.mismatchMessages) {
+            val parsed = URI.create(value)
+            if (!parsed.isAbsolute) throw IllegalArgumentException("Expected an absolute URI")
+            StringValue(parsed.toString())
+        }
+
+    override fun encompasses(otherPattern: Pattern, thisResolver: Resolver, otherResolver: Resolver, typeStack: TypeStack): Result {
+        return when (otherPattern) {
+            this -> Result.Success()
+            is URIPattern -> Result.Success()
+            else -> Result.Failure("Expected $typeName, got ${otherPattern.typeName}")
+        }
+    }
+
+    override fun listOf(valueList: List<Value>, resolver: Resolver): Value = JSONArrayValue(valueList)
+
+    override val typeName: String = "uri"
+}

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -53,6 +53,7 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import java.io.File
 import java.math.BigDecimal
+import java.net.URI
 import java.util.*
 import java.util.function.Consumer
 import java.util.stream.Stream
@@ -9906,6 +9907,44 @@ paths:
         assertThat(petTypePattern.pattern.pattern.map { it.pattern }).containsExactlyInAnyOrder(
             StringValue("dog"), StringValue("cat")
         )
+    }
+
+    @Test
+    fun `format uri should map to URLPattern and generate URL values`() {
+        val specContent = """
+        openapi: '3.0.3'
+        info:
+          title: URI Format API
+          version: '1.0'
+        paths:
+          /links:
+            get:
+              responses:
+                '200':
+                  description: OK
+                  content:
+                    application/json:
+                      schema:
+                        type: object
+                        required:
+                          - href
+                        properties:
+                          href:
+                            type: string
+                            format: uri
+        """.trimIndent()
+
+        val feature = OpenApiSpecification.fromYAML(specContent, "").toFeature()
+        val scenario = feature.scenarios.first()
+        val responseBodyPattern = resolvedHop(scenario.httpResponsePattern.body, scenario.resolver) as JSONObjectPattern
+        val hrefPattern = resolvedHop(responseBodyPattern.pattern.getValue("href"), scenario.resolver)
+
+        assertThat(hrefPattern).isEqualTo(URLPattern(URLScheme.EITHER))
+
+        val generatedHref = (hrefPattern as URLPattern).generate(Resolver()).string
+        val generatedUri = URI.create(generatedHref)
+
+        assertThat(generatedUri.scheme).isIn("http", "https")
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -9910,7 +9910,7 @@ paths:
     }
 
     @Test
-    fun `format uri should map to URLPattern and generate URL values`() {
+    fun `format uri should map to URIPattern and generate URI values`() {
         val specContent = """
         openapi: '3.0.3'
         info:
@@ -9939,12 +9939,112 @@ paths:
         val responseBodyPattern = resolvedHop(scenario.httpResponsePattern.body, scenario.resolver) as JSONObjectPattern
         val hrefPattern = resolvedHop(responseBodyPattern.pattern.getValue("href"), scenario.resolver)
 
-        assertThat(hrefPattern).isEqualTo(URLPattern(URLScheme.EITHER))
+        assertThat(hrefPattern).isEqualTo(URIPattern())
 
-        val generatedHref = (hrefPattern as URLPattern).generate(Resolver()).string
+        val generatedHref = (hrefPattern as URIPattern).generate(Resolver()).string
         val generatedUri = URI.create(generatedHref)
 
-        assertThat(generatedUri.scheme).isIn("http", "https")
+        assertThat(generatedUri.isAbsolute).isTrue()
+    }
+
+    @Test
+    fun `format uri should support regex pattern constraints`() {
+        val specContent = """
+        openapi: '3.0.3'
+        info:
+          title: URI Format API
+          version: '1.0'
+        paths:
+          /links:
+            get:
+              responses:
+                '200':
+                  description: OK
+                  content:
+                    application/json:
+                      schema:
+                        type: object
+                        required:
+                          - href
+                        properties:
+                          href:
+                            type: string
+                            format: uri
+                            pattern: "^mqtt://.*"
+        """.trimIndent()
+
+        val feature = OpenApiSpecification.fromYAML(specContent, "").toFeature()
+        val scenario = feature.scenarios.first()
+        val responseBodyPattern = resolvedHop(scenario.httpResponsePattern.body, scenario.resolver) as JSONObjectPattern
+        val hrefPattern = resolvedHop(responseBodyPattern.pattern.getValue("href"), scenario.resolver)
+
+        assertThat(hrefPattern).isInstanceOf(RegexConstrainedPattern::class.java)
+        hrefPattern as RegexConstrainedPattern
+        assertThat(hrefPattern.basePattern).isEqualTo(URIPattern())
+
+        assertThat(hrefPattern.matches(StringValue("mqtt://example.com"), Resolver()).isSuccess()).isTrue()
+        assertThat(hrefPattern.matches(StringValue("http://example.com"), Resolver()).isSuccess()).isFalse()
+    }
+
+    @Test
+    fun `format uri should support complex mqtt URI regex constraints`() {
+        val hrefPattern = hrefPatternForUriRegex("^mqtt://[a-zA-Z0-9.-]+(:[0-9]{2,5})?/devices/[a-z0-9_-]+/events\\?qos=[0-2]$")
+
+        assertThat(hrefPattern.matches(StringValue("mqtt://broker-1.example.com:1883/devices/device_01/events?qos=1"), Resolver()).isSuccess()).isTrue()
+        assertThat(hrefPattern.matches(StringValue("mqtt://broker-1.example.com/devices/device_01/events?quality=1"), Resolver()).isSuccess()).isFalse()
+        assertThat(hrefPattern.matches(StringValue("http://broker-1.example.com/devices/device_01/events?qos=1"), Resolver()).isSuccess()).isFalse()
+    }
+
+    @Test
+    fun `format uri should support complex URN regex constraints`() {
+        val hrefPattern = hrefPatternForUriRegex("^urn:[a-z0-9][a-z0-9-]{1,31}:[A-Za-z0-9()+,\\-.:=@;${'$'}_!*%/?#]+$")
+
+        assertThat(hrefPattern.matches(StringValue("urn:example:animal:ferret:nose"), Resolver()).isSuccess()).isTrue()
+        assertThat(hrefPattern.matches(StringValue("urn::example:animal"), Resolver()).isSuccess()).isFalse()
+        assertThat(hrefPattern.matches(StringValue("https://example.com/animal/ferret/nose"), Resolver()).isSuccess()).isFalse()
+    }
+
+    @Test
+    fun `format uri should support complex websocket URI regex constraints`() {
+        val hrefPattern = hrefPatternForUriRegex("^wss://[a-z0-9.-]+(:[0-9]{2,5})?/stream/[A-Za-z0-9_-]+\\?token=[A-Za-z0-9._-]+$")
+
+        assertThat(hrefPattern.matches(StringValue("wss://realtime.example.com:443/stream/abc_123?token=t.kn-1"), Resolver()).isSuccess()).isTrue()
+        assertThat(hrefPattern.matches(StringValue("ws://realtime.example.com/stream/abc_123?token=t.kn-1"), Resolver()).isSuccess()).isFalse()
+        assertThat(hrefPattern.matches(StringValue("wss://realtime.example.com/stream/abc_123"), Resolver()).isSuccess()).isFalse()
+    }
+
+    private fun hrefPatternForUriRegex(regex: String): RegexConstrainedPattern {
+        val specContent = """
+        openapi: '3.0.3'
+        info:
+          title: URI Format API
+          version: '1.0'
+        paths:
+          /links:
+            get:
+              responses:
+                '200':
+                  description: OK
+                  content:
+                    application/json:
+                      schema:
+                        type: object
+                        required:
+                          - href
+                        properties:
+                          href:
+                            type: string
+                            format: uri
+                            pattern: '$regex'
+        """.trimIndent()
+
+        val feature = OpenApiSpecification.fromYAML(specContent, "").toFeature()
+        val scenario = feature.scenarios.first()
+        val responseBodyPattern = resolvedHop(scenario.httpResponsePattern.body, scenario.resolver) as JSONObjectPattern
+        val hrefPattern = resolvedHop(responseBodyPattern.pattern.getValue("href"), scenario.resolver)
+
+        assertThat(hrefPattern).isInstanceOf(RegexConstrainedPattern::class.java)
+        return hrefPattern as RegexConstrainedPattern
     }
 
     @Test


### PR DESCRIPTION
~~This is however missing support for a `pattern` field to be able to generate specific type of URIs (for e.g. `tcp://...` or `jdbc://...` or `mqtt://...`)~~