### PR TITLE
chore: update patternFrom signature so that either deep pattern or exact pattern can be derived using the same method

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -775,7 +775,7 @@ data class Feature(
                 match = { scenario -> scenario.matchesMock(request = request, response = response, mismatchMessages = mismatchMessages, keyCheck = keyCheck) },
                 onSuccess = { scenario ->
                     scenario.resolverAndResponseForExpectation(response).let { (resolver, resolvedResponse) ->
-                        val newRequestType = scenario.httpRequestPattern.generate(request, resolver)
+                        val newRequestType = scenario.httpRequestPattern.generateExactHttpRequestPatternFrom(request, resolver)
                         HttpStubData(
                             requestType = newRequestType,
                             response = resolvedResponse.adjustPayloadForContentType().copy(externalisedResponseCommand = response.externalisedResponseCommand),

--- a/core/src/main/kotlin/io/specmatic/core/HttpPathPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpPathPattern.kt
@@ -6,6 +6,7 @@ import io.specmatic.core.Result.Failure
 import io.specmatic.core.Result.Success
 import io.specmatic.core.pattern.*
 import io.specmatic.core.value.StringValue
+import io.specmatic.core.value.Value
 import java.net.URI
 
 val OMIT = listOf("(OMIT)", "(omit)")
@@ -378,12 +379,13 @@ data class HttpPathPattern(
         }
     }
 
-    fun patternFrom(path: String, resolver: Resolver): HttpPathPattern {
+    fun patternFrom(path: String, resolver: Resolver, parseValueToType: (Value) -> Pattern): HttpPathPattern {
         val pathSegments = path.split("/".toRegex()).filter { it.isNotEmpty() }
         val pathSegmentPatternsFromPathTokens = pathSegmentPatterns.zip(pathSegments).map { (urlPathPattern, token) ->
             urlPathPattern.patternFrom(
                 StringValue(removeKeyFromParameterToken(token)),
-                resolver
+                resolver,
+                parseValueToType
             )
         }
         return this.copy(pathSegmentPatterns = pathSegmentPatternsFromPathTokens)

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
@@ -38,6 +38,7 @@ import io.specmatic.core.value.EmptyString
 import io.specmatic.core.value.JSONArrayValue
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.StringValue
+import io.specmatic.core.value.Value
 import io.specmatic.core.value.XMLNode
 
 private const val MULTIPART_FORMDATA_BREADCRUMB = "MULTIPART-FORMDATA"
@@ -354,8 +355,9 @@ data class HttpRequestPattern(
             MatchSuccess(parameters)
     }
 
-    fun generate(request: HttpRequest, resolver: Resolver): HttpRequestPattern {
+    fun generateExactHttpRequestPatternFrom(request: HttpRequest, resolver: Resolver): HttpRequestPattern {
         var requestPattern = HttpRequestPattern()
+        val parseValueToType: (Value) -> Pattern = { it.exactMatchElseType() }
 
         return attempt(breadCrumb = "REQUEST") {
             if (method == null) {
@@ -369,8 +371,8 @@ data class HttpRequestPattern(
 
             requestPattern = attempt(breadCrumb = "URL") {
                 val path = request.path ?: ""
-                val pathTypes = this.httpPathPattern.patternFrom(path, resolver).pathSegmentPatterns
-                val queryParamTypes = toTypeMapForQueryParameters(request.queryParams, httpQueryParamPattern, resolver)
+                val pathTypes = this.httpPathPattern.patternFrom(path, resolver, parseValueToType).pathSegmentPatterns
+                val queryParamTypes = toExactTypeMapForQueryParameters(request.queryParams, httpQueryParamPattern, resolver)
                 requestPattern.copy(
                     httpPathPattern = HttpPathPattern(pathTypes, path),
                     httpQueryParamPattern = HttpQueryParamPattern(
@@ -388,7 +390,7 @@ data class HttpRequestPattern(
                         headersPattern.removeContentType(it)
                     }
 
-                val headersFromRequest = toTypeMap(
+                val headersFromRequest = toExactTypeMap(
                     toLowerCaseKeys(headersWithRelevantFields),
                     toLowerCaseKeys(headersPattern.pattern),
                     resolver,
@@ -408,14 +410,14 @@ data class HttpRequestPattern(
                     body = when (request.body) {
                         EmptyString -> EmptyStringPattern
                         NoBodyValue -> NoBodyPattern
-                        is StringValue -> encompassedType(request.bodyString, null, body, resolver)
-                        else -> this.body.patternFrom(request.body, resolver)
+                        is StringValue -> exactEncompassedType(request.bodyString, null, body, resolver)
+                        else -> this.body.patternFrom(request.body, resolver, parseValueToType)
                     }
                 )
             }
 
             requestPattern = attempt(breadCrumb = "FORM FIELDS") {
-                requestPattern.copy(formFieldsPattern = toTypeMap(request.formFields, formFieldsPattern, resolver))
+                requestPattern.copy(formFieldsPattern = toExactTypeMap(request.formFields, formFieldsPattern, resolver))
             }
 
             val multiPartFormDataRequestMap =
@@ -437,7 +439,7 @@ data class HttpRequestPattern(
     private fun <ValueType> toLowerCaseKeys(map: Map<String, ValueType>) =
         map.map { (key, value) -> key.toLowerCasePreservingASCIIRules() to value }.toMap()
 
-    private fun toTypeMap(
+    private fun toExactTypeMap(
         values: Map<String, String>,
         types: Map<String, Pattern>,
         resolver: Resolver
@@ -445,12 +447,12 @@ data class HttpRequestPattern(
         val withoutOptionality = types.mapKeys { withoutOptionality(it.key) }
         return values.mapValues { (key, value) ->
             withoutOptionality[key]?.let { type ->
-                attempt(breadCrumb = key) { encompassedType(value, key, type, resolver) }
+                attempt(breadCrumb = key) { exactEncompassedType(value, key, type, resolver) }
             } ?: parsedPattern(value)
         }
     }
 
-    private fun toTypeMapForQueryParameters(
+    private fun toExactTypeMapForQueryParameters(
         queryParams: QueryParameters,
         httpQueryParamPattern: HttpQueryParamPattern,
         resolver: Resolver
@@ -466,14 +468,14 @@ data class HttpRequestPattern(
                 when (pattern) {
                     is QueryParameterArrayPattern -> {
                         val queryParameterValuePatterns = values.map { value ->
-                            encompassedType(value, key, pattern.pattern.first(), resolver)
+                            exactEncompassedType(value, key, pattern.pattern.first(), resolver)
                         }
                         key to QueryParameterArrayPattern(queryParameterValuePatterns, key)
                     }
 
                     is QueryParameterScalarPattern -> {
                         key to QueryParameterScalarPattern(
-                            encompassedType(
+                            exactEncompassedType(
                                 values.single(),
                                 key,
                                 pattern.pattern,
@@ -529,10 +531,10 @@ data class HttpRequestPattern(
             name to pattern
         }.toMap()
 
-    private fun encompassedType(valueString: String, key: String?, type: Pattern, resolver: Resolver): Pattern {
+    private fun exactEncompassedType(valueString: String, key: String?, type: Pattern, resolver: Resolver): Pattern {
         return when {
             isPatternToken(valueString) -> resolvedHop(parsedPattern(valueString, key), resolver)
-            isMatcherToken(valueString) -> type.patternFrom(StringValue(valueString), resolver)
+            isMatcherToken(valueString) -> type.patternFrom(StringValue(valueString), resolver) { it.exactMatchElseType() }
             else -> runCatching { type.parseToType(valueString, resolver) }.getOrElse { StringValue(valueString).exactMatchElseType() }
         }
     }

--- a/core/src/main/kotlin/io/specmatic/core/URLPathSegmentPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/URLPathSegmentPattern.kt
@@ -65,8 +65,8 @@ data class URLPathSegmentPattern(override val pattern: Pattern, override val key
         return JSONArrayValue(valueList)
     }
 
-    override fun patternFrom(value: Value, resolver: Resolver): URLPathSegmentPattern {
-        return this.copy(pattern = pattern.patternFrom(value, resolver))
+    override fun patternFrom(value: Value, resolver: Resolver, parseValueToType: (Value) -> Pattern): URLPathSegmentPattern {
+        return this.copy(pattern = pattern.patternFrom(value, resolver, parseValueToType))
     }
 
     fun tryParse(token: String, resolver: Resolver): Value {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
@@ -599,9 +599,9 @@ data class AnyPattern(
         return setOf("{[$matchingPatternIndex]}")
     }
 
-    override fun patternFrom(value: Value, resolver: Resolver): Pattern {
+    override fun patternFrom(value: Value, resolver: Resolver, parseValueToType: (Value) -> Pattern): Pattern {
         val selectedPattern = selectPattern(value, resolver)
-        return selectedPattern.patternFrom(value, resolver)
+        return selectedPattern.patternFrom(value, resolver, parseValueToType)
     }
 
     private fun allValuesAreScalar() = pattern.all { it is ExactValuePattern && it.pattern is ScalarValue }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/DeferredPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/DeferredPattern.kt
@@ -130,8 +130,8 @@ data class DeferredPattern(
 
     override fun patternSet(resolver: Resolver): List<Pattern> = resolvePattern(resolver).patternSet(resolver)
 
-    override fun patternFrom(value: Value, resolver: Resolver): Pattern {
-        return resolvePattern(resolver).patternFrom(value, resolver)
+    override fun patternFrom(value: Value, resolver: Resolver, parseValueToType: (Value) -> Pattern): Pattern {
+        return resolvePattern(resolver).patternFrom(value, resolver, parseValueToType)
     }
 
     override fun toString() = pattern

--- a/core/src/main/kotlin/io/specmatic/core/pattern/EmailPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/EmailPattern.kt
@@ -64,8 +64,8 @@ class EmailPattern (private val stringPatternDelegate: StringPattern, val exampl
         return resolver.provideString(this) ?: StringValue("$localPart@$domain.com")
     }
 
-    override fun patternFrom(value: Value, resolver: Resolver): Pattern {
-        return patternFromValueUsing(this, value, resolver)
+    override fun patternFrom(value: Value, resolver: Resolver, parseValueToType: (Value) -> Pattern): Pattern {
+        return patternFromValueUsing(this, value, resolver, parseValueToType)
     }
 
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/JSONArrayPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/JSONArrayPattern.kt
@@ -124,12 +124,12 @@ data class JSONArrayPattern(override val pattern: List<Pattern> = emptyList(), o
         }
     }
 
-    override fun patternFrom(value: Value, resolver: Resolver): Pattern {
-        if(value !is JSONArrayValue) return value.exactMatchElseType()
+    override fun patternFrom(value: Value, resolver: Resolver, parseValueToType: (Value) -> Pattern): Pattern {
+        if(value !is JSONArrayValue) return parseValueToType(value)
         return JSONArrayPattern(
             value.list.mapIndexed { index, indexedValue ->
-                val patternAtIndex = pattern.getOrElse(index) { indexedValue.exactMatchElseType() }
-                patternAtIndex.patternFrom(indexedValue, resolver)
+                val patternAtIndex = pattern.getOrElse(index) { parseValueToType(indexedValue) }
+                patternAtIndex.patternFrom(indexedValue, resolver, parseValueToType)
             }
         )
     }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
@@ -512,12 +512,12 @@ data class JSONObjectPattern(
 
     override val typeName: String = "json object"
 
-    override fun patternFrom(value: Value, resolver: Resolver): Pattern {
-        if (value !is JSONObjectValue) return value.exactMatchElseType()
+    override fun patternFrom(value: Value, resolver: Resolver, parseValueToType: (Value) -> Pattern): Pattern {
+        if (value !is JSONObjectValue) return parseValueToType(value)
         return toJSONObjectPattern(
             value.jsonObject.mapValues {
-                val keyPattern = this.patternForKey(it.key) ?: it.value.exactMatchElseType()
-                keyPattern.patternFrom(it.value, resolver)
+                val keyPattern = this.patternForKey(it.key) ?: parseValueToType(it.value)
+                keyPattern.patternFrom(it.value, resolver, parseValueToType)
             },
             typeAlias
         )

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
@@ -250,10 +250,10 @@ data class ListPattern(
         return this.copy(pattern = pattern.ensureAdditionalProperties(resolver))
     }
 
-    override fun patternFrom(value: Value, resolver: Resolver): Pattern {
-        if (value !is JSONArrayValue) return value.exactMatchElseType()
+    override fun patternFrom(value: Value, resolver: Resolver, parseValueToType: (Value) -> Pattern): Pattern {
+        if (value !is JSONArrayValue) return parseValueToType(value)
         return JSONArrayPattern(
-            value.list.map { this.pattern.patternFrom(it, resolver) }
+            value.list.map { this.pattern.patternFrom(it, resolver, parseValueToType) }
         )
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/Pattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/Pattern.kt
@@ -98,16 +98,25 @@ interface Pattern {
         return fixValue(value, this, resolver)
     }
 
-    fun patternFrom(value: Value, resolver: Resolver): Pattern =
-        patternFromValueUsing(this, value, resolver)
+    fun patternFrom(
+        value: Value,
+        resolver: Resolver,
+        parseValueToType: (Value) -> Pattern = { it.deepPattern() }
+    ): Pattern =
+        patternFromValueUsing(this, value, resolver, parseValueToType)
 
     val typeAlias: String?
     val typeName: String
     val pattern: Any
 }
 
-fun patternFromValueUsing(originalPattern: Pattern, value: Value, resolver: Resolver): Pattern {
-    if(value !is StringValue) return value.exactMatchElseType()
+fun patternFromValueUsing(
+    originalPattern: Pattern,
+    value: Value,
+    resolver: Resolver,
+    parseValueToType: (Value) -> Pattern
+): Pattern {
+    if(value !is StringValue) return parseValueToType(value)
     if(isPatternToken(value)) return DeferredPattern(value.string)
     if(isMatcherToken(value)) {
         return Matcher.patternFrom(
@@ -116,7 +125,7 @@ fun patternFromValueUsing(originalPattern: Pattern, value: Value, resolver: Reso
             resolver = resolver,
         )
     }
-    return value.exactMatchElseType()
+    return parseValueToType(value)
 }
 
 fun fillInTheBlanksWithPattern(value: Value, resolver: Resolver, self: Pattern): ReturnValue<Value> {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/RegexConstrainedPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/RegexConstrainedPattern.kt
@@ -55,8 +55,8 @@ data class RegexConstrainedPattern(
         }
     }
 
-    override fun patternFrom(value: Value, resolver: Resolver): Pattern {
-        return RegexConstrainedPattern(basePattern.patternFrom(value, resolver), this.regex, resolver)
+    override fun patternFrom(value: Value, resolver: Resolver, parseValueToType: (Value) -> Pattern): Pattern {
+        return RegexConstrainedPattern(basePattern.patternFrom(value, resolver, parseValueToType), this.regex, resolver)
     }
 
     private fun validateRegexAgainstBasePattern() {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/TabularPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/TabularPattern.kt
@@ -79,12 +79,12 @@ data class TabularPattern(
         })
     }
 
-    override fun patternFrom(value: Value, resolver: Resolver): Pattern {
-        if (value !is JSONObjectValue) return value.exactMatchElseType()
+    override fun patternFrom(value: Value, resolver: Resolver, parseValueToType: (Value) -> Pattern): Pattern {
+        if (value !is JSONObjectValue) return parseValueToType(value)
 
         val updatedPattern = value.jsonObject.mapValues { (key, value) ->
-            val keyPattern = patternForKey(key) ?: value.exactMatchElseType()
-            keyPattern.patternFrom(value, resolver)
+            val keyPattern = patternForKey(key) ?: parseValueToType(value)
+            keyPattern.patternFrom(value, resolver, parseValueToType)
         }
 
         return this.copy(pattern = updatedPattern)

--- a/core/src/main/kotlin/io/specmatic/stub/ThreadSafeListOfStubs.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/ThreadSafeListOfStubs.kt
@@ -183,7 +183,7 @@ class ThreadSafeListOfStubs(
             }.map { (stubData, partial) ->
                 val (requestPattern, _, resolver) = stubData
                 val partialResolver = resolver.withUnexpectedKeyCheck(IgnoreUnexpectedKeys)
-                val partialResult = requestPattern.generate(partial.request, resolver)
+                val partialResult = requestPattern.generateExactHttpRequestPatternFrom(partial.request, resolver)
                     .matches(httpRequest, partialResolver, partialResolver)
 
                 if (!partialResult.isSuccess()) return@map partialResult to stubData

--- a/core/src/test/kotlin/io/specmatic/core/HttpRequestPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpRequestPatternTest.kt
@@ -447,7 +447,7 @@ internal class HttpRequestPatternTest {
     @Test
     fun `should generate a stub request pattern from an http request in which the query params are not optional`() {
         val requestType = HttpRequestPattern(method = "GET", httpPathPattern = HttpPathPattern(pathToPattern("/"), "/"), httpQueryParamPattern = HttpQueryParamPattern(mapOf("status" to QueryParameterScalarPattern(StringPattern()))))
-        val newRequestType = requestType.generate(HttpRequest("GET", "/", queryParametersMap = mapOf("status" to "available")), Resolver())
+        val newRequestType = requestType.generateExactHttpRequestPatternFrom(HttpRequest("GET", "/", queryParametersMap = mapOf("status" to "available")), Resolver())
 
         assertThat(newRequestType.httpQueryParamPattern.queryPatterns.keys.sorted()).isEqualTo(listOf("status"))
 
@@ -462,7 +462,7 @@ internal class HttpRequestPatternTest {
             method = "POST",
             httpPathPattern = HttpPathPattern(emptyList(), "/"),
             formFieldsPattern = mapOf("Customer" to PatternInStringPattern(customerType, "(customer)"))
-        ).generate(request, Resolver()).let { requestType ->
+        ).generateExactHttpRequestPatternFrom(request, Resolver()).let { requestType ->
             val customerFieldType = requestType.formFieldsPattern.getValue("Customer")
             assertThat(customerFieldType).isInstanceOf(PatternInStringPattern::class.java)
 
@@ -503,7 +503,7 @@ internal class HttpRequestPatternTest {
         val type = HttpRequestPattern(method = "POST", httpPathPattern = buildHttpPathPattern("http://helloworld.com/data"), headersPattern = HttpHeadersPattern(mapOf("x-data" to StringPattern())), body = JSONObjectPattern(mapOf("id" to NumberPattern())))
         val request = HttpRequest("POST", "/data", headers = mapOf("X-Data" to "abc123"), body = parsedJSON("""{"id": "abc123"}"""))
 
-        val httpRequestPattern = type.generate(request, Resolver())
+        val httpRequestPattern = type.generateExactHttpRequestPatternFrom(request, Resolver())
         assertThat(httpRequestPattern.headersPattern.pattern["x-data"].toString()).isEqualTo("abc123")
     }
 
@@ -737,7 +737,7 @@ internal class HttpRequestPatternTest {
             headers = mapOf("X-Test-Header" to "abc123", "X-Extra-Header" to "def456"),
             body = JSONObjectValue(mapOf("key" to StringValue("value")))
         )
-        val newRequestPattern = originalRequestPattern.generate(httpRequest, Resolver())
+        val newRequestPattern = originalRequestPattern.generateExactHttpRequestPatternFrom(httpRequest, Resolver())
         val requestBodyPattern = newRequestPattern.body as JSONObjectPattern
 
         assertThat(newRequestPattern.headersPattern.pattern).isEqualTo(mapOf(
@@ -760,7 +760,7 @@ internal class HttpRequestPatternTest {
             ))
         )
 
-        val newRequestPattern = originalRequestPattern.generate(httpRequest, Resolver())
+        val newRequestPattern = originalRequestPattern.generateExactHttpRequestPatternFrom(httpRequest, Resolver())
         val requestBodyPattern = newRequestPattern.body as JSONObjectPattern
 
         assertThat(requestBodyPattern.pattern.getValue("id"))
@@ -779,7 +779,7 @@ internal class HttpRequestPatternTest {
         val httpRequest = HttpRequest(
             headers = mapOf("X-Test-Header" to "abc123", "X-Extra-Header" to "def456", AUTHORIZATION to "1234")
         )
-        val newRequestPattern = originalRequestPattern.generate(httpRequest, Resolver())
+        val newRequestPattern = originalRequestPattern.generateExactHttpRequestPatternFrom(httpRequest, Resolver())
 
         assertThat(newRequestPattern.headersPattern.pattern).isEqualTo(mapOf(
             "x-test-header" to ExactValuePattern(StringValue("abc123")),
@@ -794,7 +794,7 @@ internal class HttpRequestPatternTest {
             headersPattern = HttpHeadersPattern(contentType = "application/json"),
         )
         val httpRequest = HttpRequest(headers = mapOf("Content-Type" to "application/json", "X-Extra-Header" to "def456"))
-        val newRequestPattern = originalRequestPattern.generate(httpRequest, Resolver())
+        val newRequestPattern = originalRequestPattern.generateExactHttpRequestPatternFrom(httpRequest, Resolver())
 
         assertThat(newRequestPattern.headersPattern.pattern).isEqualTo(mapOf(
             "x-extra-header" to ExactValuePattern(StringValue("def456"))
@@ -912,7 +912,7 @@ internal class HttpRequestPatternTest {
             queryParams = QueryParameters(mapOf("key" to "invalidDateTime")),
             body = JSONObjectValue(mapOf("key" to StringValue("invalidEmail")))
         )
-        val newRequestPattern = httpRequestPattern.generate(httpRequest, Resolver())
+        val newRequestPattern = httpRequestPattern.generateExactHttpRequestPatternFrom(httpRequest, Resolver())
 
         assertThat(newRequestPattern.httpPathPattern).isEqualTo(
             HttpPathPattern(
@@ -937,7 +937,7 @@ internal class HttpRequestPatternTest {
             body = JSONObjectPattern(mapOf("key" to EmailPattern()))
         )
         val httpRequest = HttpRequest(path = "/", method = "GET")
-        val newRequestPattern = httpRequestPattern.generate(httpRequest, Resolver())
+        val newRequestPattern = httpRequestPattern.generateExactHttpRequestPatternFrom(httpRequest, Resolver())
 
         assertThat(newRequestPattern.body).isEqualTo(EmptyStringPattern)
     }

--- a/core/src/test/kotlin/io/specmatic/core/pattern/AnyPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/AnyPatternTest.kt
@@ -1336,7 +1336,7 @@ internal class AnyPatternTest {
         }
 
         @Test
-        fun `patternFrom should return the discriminator based pattern`() {
+        fun `patternFrom should return the discriminator based pattern when exactMatchElseType parser is overridden`() {
             val pattern = AnyPattern(
                 listOf(
                     JSONObjectPattern(
@@ -1360,7 +1360,7 @@ internal class AnyPatternTest {
                     )
                 ),
                 Resolver()
-            )
+            ) { it.exactMatchElseType() }
 
             assertThat(result).isInstanceOf(JSONObjectPattern::class.java)
 
@@ -1375,7 +1375,7 @@ internal class AnyPatternTest {
         }
 
         @Test
-        fun `patternFrom should return the correct discriminator pattern on wrong or invalid discriminator value`() {
+        fun `patternFrom should return the correct discriminator pattern on wrong or invalid discriminator value when exactMatchElseType parser is overridden`() {
             val pattern = AnyPattern(
                 listOf(
                     JSONObjectPattern(mapOf("type" to ExactValuePattern(StringValue("sub1")), "prop" to StringPattern(), "extra" to StringPattern()), typeAlias = "(Sub1)"),
@@ -1389,7 +1389,7 @@ internal class AnyPatternTest {
             )
 
             val invalidValue = JSONObjectValue(mapOf("type" to StringValue("notExists"), "prop" to NumberValue(999)))
-            val result = pattern.patternFrom(invalidValue, Resolver())
+            val result = pattern.patternFrom(invalidValue, Resolver()) { it.exactMatchElseType() }
 
             assertThat(result).isInstanceOf(JSONObjectPattern::class.java)
 
@@ -1404,7 +1404,7 @@ internal class AnyPatternTest {
         }
 
         @Test
-        fun `patternFrom should return the pattern with least failures when discriminator key is missing from value`() {
+        fun `patternFrom should return the pattern with least failures when discriminator key is missing from value and exactMatchElseType parser is overridden`() {
             val pattern = AnyPattern(
                 listOf(
                     JSONObjectPattern(mapOf("type" to ExactValuePattern(StringValue("sub1")), "prop" to StringPattern(), "extra" to StringPattern()), typeAlias = "(Sub1)"),
@@ -1418,7 +1418,7 @@ internal class AnyPatternTest {
             )
 
             val valueWithoutDiscriminator = JSONObjectValue(mapOf("prop" to NumberValue(999)))
-            val result = pattern.patternFrom(valueWithoutDiscriminator, Resolver())
+            val result = pattern.patternFrom(valueWithoutDiscriminator, Resolver()) { it.exactMatchElseType() }
 
             assertThat(result).isInstanceOf(JSONObjectPattern::class.java)
             assertThat(result).isEqualTo(
@@ -1431,7 +1431,7 @@ internal class AnyPatternTest {
         }
 
         @Test
-        fun `patternFrom should return the pattern with least failures when no discriminator is present in the pattern`() {
+        fun `patternFrom should return the pattern with least failures when no discriminator is present in the pattern and exactMatchElseType parser is overridden`() {
             val pattern = AnyPattern(
                 listOf(
                     JSONObjectPattern(mapOf("type" to ExactValuePattern(StringValue("sub1")), "prop" to StringPattern(), "extra" to StringPattern()), typeAlias = "(Sub1)"),
@@ -1441,7 +1441,7 @@ internal class AnyPatternTest {
             )
 
             val value = JSONObjectValue(mapOf("prop" to NumberValue(999)))
-            val result = pattern.patternFrom(value, Resolver())
+            val result = pattern.patternFrom(value, Resolver()) { it.exactMatchElseType() }
 
             assertThat(result).isInstanceOf(JSONObjectPattern::class.java)
             assertThat(result).isEqualTo(
@@ -1454,7 +1454,7 @@ internal class AnyPatternTest {
         }
 
         @Test
-        fun `patternFrom should retain pattern token if it matches when resolver is in mock mode`() {
+        fun `patternFrom should retain pattern token if it matches when resolver is in mock mode and exactMatchElseType parser is overridden`() {
             val objectPattern = JSONObjectPattern(mapOf("type" to "object".toDiscriminator(), "number" to NumberPattern(), "string" to StringPattern()), typeAlias = "(Object)")
             val pattern = AnyPattern(
                 pattern = listOf(objectPattern), typeAlias = "(AnyPattern)",
@@ -1464,13 +1464,13 @@ internal class AnyPatternTest {
             val validValues = listOf(StringValue("(Object)"), StringValue("(AnyPattern)"))
 
             assertThat(validValues).allSatisfy {
-                val result = pattern.patternFrom(it, resolver)
+                val result = pattern.patternFrom(it, resolver) { value -> value.exactMatchElseType() }
                 assertThat(result).isEqualTo(DeferredPattern(it.string))
             }
         }
 
         @Test
-        fun `patternFrom should generate pattern when pattern token does not match when resolver is in mock mode`() {
+        fun `patternFrom should generate pattern when pattern token does not match when resolver is in mock mode and exactMatchElseType parser is overridden`() {
             val objectPattern = JSONObjectPattern(mapOf("type" to "object".toDiscriminator(), "number" to NumberPattern(), "string" to StringPattern()), typeAlias = "(Object)")
             val pattern = AnyPattern(
                 pattern = listOf(objectPattern), typeAlias = "(AnyPattern)",
@@ -1480,13 +1480,13 @@ internal class AnyPatternTest {
             val invalidValues = listOf(StringValue("(string)"), StringValue("(number)"))
 
             assertThat(invalidValues).allSatisfy {
-                val result = pattern.patternFrom(it, resolver)
+                val result = pattern.patternFrom(it, resolver) { value -> value.exactMatchElseType() }
                 assertThat(result).isEqualTo(DeferredPattern(it.string))
             }
         }
 
         @Test
-        fun `patternFrom should generate pattern even if pattern token matches but resolver is not in mock mode`() {
+        fun `patternFrom should generate pattern even if pattern token matches but resolver is not in mock mode and exactMatchElseType parser is overridden`() {
             val objectPattern = JSONObjectPattern(mapOf("type" to "object".toDiscriminator(), "number" to NumberPattern(), "string" to StringPattern()), typeAlias = "(Object)")
             val pattern = AnyPattern(
                 pattern = listOf(objectPattern), typeAlias = "(AnyPattern)",
@@ -1496,44 +1496,44 @@ internal class AnyPatternTest {
             val values = listOf(StringValue("(Object)"), StringValue("(AnyPattern)"))
 
             assertThat(values).allSatisfy {
-                val result = pattern.patternFrom(it, resolver)
+                val result = pattern.patternFrom(it, resolver) { value -> value.exactMatchElseType() }
                 assertThat(result).isEqualTo(DeferredPattern(it.string))
             }
         }
 
         @Test
-        fun `patternFrom should work when pattern is scalar based of nullable type`() {
+        fun `patternFrom should work when pattern is scalar based of nullable type and exactMatchElseType parser is overridden`() {
             val pattern = AnyPattern(listOf(NullPattern, NumberPattern()), extensions = emptyMap())
             val resolver = Resolver()
             val value = NumberValue(999)
-            val result = pattern.patternFrom(value, resolver)
+            val result = pattern.patternFrom(value, resolver) { it.exactMatchElseType() }
 
             assertThat(result).isEqualTo(ExactValuePattern(NumberValue(999)))
         }
 
         @Test
-        fun `patternFrom scalar pattern should be created when pattern has typeAlias`() {
+        fun `patternFrom scalar pattern should be created when pattern has typeAlias and exactMatchElseType parser is overridden`() {
             val pattern = AnyPattern(listOf(NullPattern, NumberPattern()), typeAlias = "(NumberOrEmpty)", extensions = emptyMap())
             val resolver = Resolver()
             val value = NumberValue(999)
-            val result = pattern.patternFrom(value, resolver)
+            val result = pattern.patternFrom(value, resolver) { it.exactMatchElseType() }
 
             assertThat(result).isEqualTo(ExactValuePattern(NumberValue(999)))
         }
 
         @Test
-        fun `patternFrom should not throw an exception for a nullable pattern`() {
+        fun `patternFrom should not throw an exception for a nullable pattern when exactMatchElseType parser is overridden`() {
             val pattern = AnyPattern(listOf(NullPattern, NumberPattern()), extensions = emptyMap())
             val resolver = Resolver()
 
             val value = NumberValue(999)
-            val result = assertDoesNotThrow { pattern.patternFrom(value, resolver) }
+            val result = assertDoesNotThrow { pattern.patternFrom(value, resolver) { it.exactMatchElseType() } }
 
             assertThat(result).isEqualTo(ExactValuePattern(NumberValue(999)))
         }
 
         @Test
-        fun `patternFrom should be able to create pattern from values with a partial resolver`() {
+        fun `patternFrom should be able to create pattern from values with a partial resolver when exactMatchElseType parser is overridden`() {
             val pattern = AnyPattern(
                 listOf(
                     JSONObjectPattern(mapOf("type" to "sub1".toDiscriminator(), "prop" to StringPattern(), "extra" to NumberPattern()), typeAlias = "(Sub1)"),
@@ -1547,7 +1547,7 @@ internal class AnyPatternTest {
             )
             val resolver = Resolver().partializeKeyCheck()
             val partialValue = JSONObjectValue(mapOf("extra" to NumberValue(999)))
-            val result = pattern.patternFrom(partialValue, resolver)
+            val result = pattern.patternFrom(partialValue, resolver) { it.exactMatchElseType() }
 
             assertThat(result).isEqualTo(
                 JSONObjectPattern(
@@ -1556,6 +1556,39 @@ internal class AnyPatternTest {
                     )
                 )
             )
+        }
+
+        @Test
+        fun `patternFrom should fallback to deepPattern when no discriminator is present in the pattern by default`() {
+            val pattern = AnyPattern(
+                listOf(
+                    JSONObjectPattern(mapOf("type" to ExactValuePattern(StringValue("sub1")), "prop" to StringPattern(), "extra" to StringPattern()), typeAlias = "(Sub1)"),
+                    JSONObjectPattern(mapOf("type" to ExactValuePattern(StringValue("sub2")), "prop" to NumberPattern()), typeAlias = "(Sub2)")
+                ),
+                typeAlias = "(Base)",
+                discriminator = null
+            )
+
+            val value = JSONObjectValue(mapOf("prop" to NumberValue(999)))
+            val result = pattern.patternFrom(value, Resolver())
+
+            assertThat(result).isEqualTo(
+                JSONObjectPattern(
+                    mapOf("prop" to NumberPattern()),
+                    typeAlias = "(Sub2)"
+                )
+            )
+        }
+
+        @Test
+        fun `patternFrom should fallback to deepPattern for scalar nullable AnyPattern by default`() {
+            val pattern = AnyPattern(listOf(NullPattern, NumberPattern()), extensions = emptyMap())
+            val resolver = Resolver()
+            val value = NumberValue(999)
+
+            val result = pattern.patternFrom(value, resolver)
+
+            assertThat(result).isEqualTo(NumberPattern())
         }
     }
 

--- a/core/src/test/kotlin/io/specmatic/core/pattern/JSONArrayPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/JSONArrayPatternTest.kt
@@ -104,17 +104,28 @@ internal class JSONArrayPatternTest {
     }
 
     @Test
-    fun `patternFrom should use existing patterns and fallback to value types for extra elements`() {
+    fun `patternFrom should use existing patterns and fallback to exactMatchElseType for extra elements when parser is overridden`() {
         val pattern = JSONArrayPattern(listOf(NumberPattern()))
         val value = JSONArrayValue(listOf(
             StringValue("(number)"),
             StringValue("alpha")
         ))
 
-        val result = pattern.patternFrom(value, Resolver()) as JSONArrayPattern
+        val result = pattern.patternFrom(value, Resolver()) { it.exactMatchElseType() } as JSONArrayPattern
 
         assertThat(result.pattern[0]).isEqualTo(DeferredPattern("(number)"))
         assertThat(result.pattern[1]).isEqualTo(ExactValuePattern(StringValue("alpha")))
+    }
+
+    @Test
+    fun `patternFrom should fallback to deepPattern for extra elements by default`() {
+        val pattern = JSONArrayPattern(listOf(NumberPattern()))
+        val value = JSONArrayValue(listOf(StringValue("(number)"), StringValue("alpha")))
+
+        val result = pattern.patternFrom(value, Resolver()) as JSONArrayPattern
+
+        assertThat(result.pattern[0]).isEqualTo(DeferredPattern("(number)"))
+        assertThat(result.pattern[1]).isEqualTo(StringPattern())
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/core/pattern/ListPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/ListPatternTest.kt
@@ -73,17 +73,28 @@ internal class ListPatternTest {
     }
 
     @Test
-    fun `patternFrom should retain matcher tokens in list elements`() {
+    fun `patternFrom should retain matcher tokens and use exactMatchElseType in list elements when parser is overridden`() {
         val pattern = ListPattern(StringPattern())
         val value = JSONArrayValue(listOf(
             StringValue("${'$'}match(pattern: POSITIVE_REGEX)"),
             NumberValue(10)
         ))
 
-        val result = pattern.patternFrom(value, Resolver()) as JSONArrayPattern
+        val result = pattern.patternFrom(value, Resolver()) { it.exactMatchElseType() } as JSONArrayPattern
 
         assertThat(result.pattern[0]).isEqualTo(RegexConstrainedPattern(StringPattern(), "POSITIVE_REGEX", Resolver()))
         assertThat(result.pattern[1]).isEqualTo(ExactValuePattern(NumberValue(10)))
+    }
+
+    @Test
+    fun `patternFrom should fallback to deepPattern in list elements by default`() {
+        val pattern = ListPattern(StringPattern())
+        val value = JSONArrayValue(listOf(StringValue("${'$'}match(pattern: POSITIVE_REGEX)"), NumberValue(10)))
+
+        val result = pattern.patternFrom(value, Resolver()) as JSONArrayPattern
+
+        assertThat(result.pattern[0]).isEqualTo(RegexConstrainedPattern(StringPattern(), "POSITIVE_REGEX", Resolver()))
+        assertThat(result.pattern[1]).isEqualTo(NumberPattern())
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/core/pattern/PatternKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/PatternKtTest.kt
@@ -1,0 +1,37 @@
+package io.specmatic.core.pattern
+
+import io.specmatic.core.Resolver
+import io.specmatic.core.value.NumberValue
+import io.specmatic.core.value.StringValue
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class PatternKtTest {
+    @Test
+    fun `patternFromValueUsing should fallback to parseValueToType for non-string values`() {
+        val result = patternFromValueUsing(StringPattern(), NumberValue(10), Resolver()) { it.deepPattern() }
+
+        assertThat(result).isEqualTo(NumberPattern())
+    }
+
+    @Test
+    fun `patternFromValueUsing should fallback to parseValueToType for non-token strings`() {
+        val result = patternFromValueUsing(StringPattern(), StringValue("hello"), Resolver()) { it.deepPattern() }
+
+        assertThat(result).isEqualTo(StringPattern())
+    }
+
+    @Test
+    fun `patternFromValueUsing should allow exactMatchElseType override for non-string values`() {
+        val result = patternFromValueUsing(StringPattern(), NumberValue(10), Resolver()) { it.exactMatchElseType() }
+
+        assertThat(result).isEqualTo(ExactValuePattern(NumberValue(10)))
+    }
+
+    @Test
+    fun `patternFromValueUsing should allow exactMatchElseType override for non-token strings`() {
+        val result = patternFromValueUsing(StringPattern(), StringValue("hello"), Resolver()) { it.exactMatchElseType() }
+
+        assertThat(result).isEqualTo(ExactValuePattern(StringValue("hello")))
+    }
+}


### PR DESCRIPTION
Reason for change -
The existing patternFrom implementation always returns an exact value pattern if there is no matcher or pattern token involved. This is desirable on the mock side but on the test side during matching we'd want to match using the deep pattern and not the exact pattern.
This change parameterises patternFrom so that it can return both exact pattern and deep pattern based on our need.