### PR TITLE
fix: fix the logic in list pattern's pattern from so that it works as expected when deep pattern is expected from an example

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
@@ -252,9 +252,14 @@ data class ListPattern(
 
     override fun patternFrom(value: Value, resolver: Resolver, parseValueToType: (Value) -> Pattern): Pattern {
         if (value !is JSONArrayValue) return parseValueToType(value)
-        return JSONArrayPattern(
-            value.list.map { this.pattern.patternFrom(it, resolver, parseValueToType) }
-        )
+        if (usesExactMatchStrategy(parseValueToType)) {
+            return JSONArrayPattern(
+                value.list.map { this.pattern.patternFrom(it, resolver, parseValueToType) }
+            )
+        }
+
+        val firstValue = value.list.firstOrNull() ?: return parseValueToType(value)
+        return this.copy(pattern = this.pattern.patternFrom(firstValue, resolver, parseValueToType))
     }
 
     fun calculatePath(value: Value, resolver: Resolver): Set<String> {
@@ -289,6 +294,10 @@ data class ListPattern(
             }
         }.toSet()
     }
+}
+
+private fun usesExactMatchStrategy(parseValueToType: (Value) -> Pattern): Boolean {
+    return parseValueToType(NumberValue(0)) is ExactValuePattern
 }
 
 private fun withEmptyType(pattern: Pattern, resolver: Resolver): Resolver {

--- a/core/src/test/kotlin/io/specmatic/core/pattern/ListPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/ListPatternTest.kt
@@ -91,10 +91,39 @@ internal class ListPatternTest {
         val pattern = ListPattern(StringPattern())
         val value = JSONArrayValue(listOf(StringValue("${'$'}match(pattern: POSITIVE_REGEX)"), NumberValue(10)))
 
-        val result = pattern.patternFrom(value, Resolver()) as JSONArrayPattern
+        val result = pattern.patternFrom(value, Resolver()) as ListPattern
 
-        assertThat(result.pattern[0]).isEqualTo(RegexConstrainedPattern(StringPattern(), "POSITIVE_REGEX", Resolver()))
-        assertThat(result.pattern[1]).isEqualTo(NumberPattern())
+        assertThat(result.pattern).isEqualTo(RegexConstrainedPattern(StringPattern(), "POSITIVE_REGEX", Resolver()))
+    }
+
+    @Test
+    fun `patternFrom should fallback to parseValueToType when list is empty in deepPattern mode`() {
+        val pattern = ListPattern(StringPattern())
+
+        val result = pattern.patternFrom(JSONArrayValue(emptyList()), Resolver())
+
+        assertThat(result).isEqualTo(ListPattern(AnythingPattern))
+    }
+
+    @Test
+    fun `patternFrom should derive deepPattern from the first list value`() {
+        val pattern = ListPattern(StringPattern())
+        val value = JSONArrayValue(listOf(NumberValue(10), StringValue("second-value")))
+
+        val result = pattern.patternFrom(value, Resolver())
+
+        assertThat(result).isEqualTo(ListPattern(NumberPattern()))
+    }
+
+    @Test
+    fun `patternFrom should derive exact patterns for each list value when exact parser is used`() {
+        val pattern = ListPattern(StringPattern())
+        val value = JSONArrayValue(listOf(NumberValue(10), StringValue("second-value")))
+
+        val result = pattern.patternFrom(value, Resolver()) { it.exactMatchElseType() } as JSONArrayPattern
+
+        assertThat(result.pattern[0]).isEqualTo(ExactValuePattern(NumberValue(10)))
+        assertThat(result.pattern[1]).isEqualTo(ExactValuePattern(StringValue("second-value")))
     }
 
     @Test


### PR DESCRIPTION
Reason for change -
The deep pattern derived from an example containing a list is currently mandating that the length of the array should be same as that of the value in the example. This is not expected behaviour. This PR fixes it so that the appropriate deep pattern is computed.