### PR TITLE
chore(deps): Remove mozilla-rhino "dependency"

### DIFF
--- a/application/build.gradle.kts
+++ b/application/build.gradle.kts
@@ -39,10 +39,7 @@ dependencies {
     implementation(project(":specmatic-mcp"))
 
     implementation("io.ktor:ktor-client-cio-jvm:2.3.13")
-    implementation("io.swagger.parser.v3:swagger-parser:2.1.37") {
-        exclude(group = "org.mozilla", module = "rhino")
-    }
-    implementation("org.mozilla:rhino:1.9.0")
+    implementation("io.swagger.parser.v3:swagger-parser:2.1.37")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.10.0")
 
     implementation("org.jetbrains.kotlin:kotlin-reflect:2.3.0")


### PR DESCRIPTION
This was upgraded to work around some vulnerability issues that do not exist as of today.
