### PR TITLE
fix: filter proxy transport headers from recorded artifacts

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
@@ -624,6 +624,7 @@ val HTTP_REQUEST_TRANSPORT_HEADERS: Set<String> =
 
 val HTTP_RESPONSE_TRANSPORT_HEADERS: Set<String> =
     listOf(
+        HttpHeaders.ContentLength,
         HttpHeaders.Date,
         HttpHeaders.Server,
         HttpHeaders.Expires,

--- a/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
@@ -576,8 +576,8 @@ private fun parseOrString(pattern: Pattern, sampleValue: String, resolver: Resol
         StringValue(sampleValue)
     }
 
-fun Map<String, String>.withoutTransportHeaders(): Map<String, String> =
-    this.filterKeys { key -> key.lowercase() !in HTTP_TRANSPORT_HEADERS }
+fun Map<String, String>.withoutTransportHeaders(headersToExclude: Set<String> = HTTP_TRANSPORT_HEADERS): Map<String, String> =
+    this.filterKeys { key -> key.lowercase() !in headersToExclude }
 
 fun <T> Map<String, T>.getCaseInsensitive(key: String): Map.Entry<String, T>? = this.entries.find { it.key.equals(key, ignoreCase = true) }
 
@@ -596,7 +596,7 @@ fun Map<String, Pattern>.addIfNotExistCaseInsensitiveCheckOptional(key: String, 
     return this.plus(key to value)
 }
 
-val HTTP_TRANSPORT_HEADERS: Set<String> =
+val HTTP_REQUEST_TRANSPORT_HEADERS: Set<String> =
     listOf(
         HttpHeaders.Authorization,
         HttpHeaders.UserAgent,
@@ -606,9 +606,24 @@ val HTTP_TRANSPORT_HEADERS: Set<String> =
         HttpHeaders.IfModifiedSince,
         HttpHeaders.IfNoneMatch,
         HttpHeaders.CacheControl,
+        "DNT",
         HttpHeaders.ContentLength,
         HttpHeaders.Range,
+        HttpHeaders.Forwarded,
         HttpHeaders.XForwardedFor,
+        HttpHeaders.XForwardedHost,
+        HttpHeaders.XForwardedPort,
+        HttpHeaders.XForwardedProto,
+        "Sec-Fetch-Site",
+        "Sec-Fetch-Mode",
+        "Sec-Fetch-Dest",
+        "Sec-GPC",
+    ).map {
+        it.lowercase()
+    }.toSet()
+
+val HTTP_RESPONSE_TRANSPORT_HEADERS: Set<String> =
+    listOf(
         HttpHeaders.Date,
         HttpHeaders.Server,
         HttpHeaders.Expires,
@@ -621,6 +636,11 @@ val HTTP_TRANSPORT_HEADERS: Set<String> =
         HttpHeaders.AccessControlRequestMethod,
     ).map {
         it.lowercase()
-    }.plus(listOfExcludedHeaders())
+    }.toSet()
+
+val HTTP_TRANSPORT_HEADERS: Set<String> =
+    HTTP_REQUEST_TRANSPORT_HEADERS
+        .plus(HTTP_RESPONSE_TRANSPORT_HEADERS)
+        .plus(listOfExcludedHeaders())
         .toSet()
         .minus(HttpHeaders.ContentType.lowercase())

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
@@ -383,7 +383,7 @@ data class HttpRequest(
 
     fun dropIrrelevantHeaders(): HttpRequest = withoutTransportHeaders().withoutConversionHeaders().withoutSpecmaticHeaders()
 
-    fun withoutTransportHeaders(): HttpRequest = copy(headers = headers.withoutTransportHeaders())
+    fun withoutTransportHeaders(): HttpRequest = copy(headers = headers.withoutTransportHeaders(HTTP_REQUEST_TRANSPORT_HEADERS))
 
     fun withoutSpecmaticHeaders(): HttpRequest = copy(headers = dropSpecmaticHeaders(headers))
 

--- a/core/src/main/kotlin/io/specmatic/core/HttpResponse.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpResponse.kt
@@ -203,7 +203,7 @@ data class HttpResponse(
 
     fun dropIrrelevantHeaders(): HttpResponse = withoutTransportHeaders().withoutConversionHeaders().withoutSpecmaticHeaders()
 
-    fun withoutTransportHeaders(): HttpResponse = copy(headers = headers.withoutTransportHeaders())
+    fun withoutTransportHeaders(): HttpResponse = copy(headers = headers.withoutTransportHeaders(HTTP_RESPONSE_TRANSPORT_HEADERS))
 
     fun withoutSpecmaticHeaders(): HttpResponse = copy(headers = dropSpecmaticHeaders(headers))
 

--- a/core/src/test/kotlin/io/specmatic/proxy/ProxyTest.kt
+++ b/core/src/test/kotlin/io/specmatic/proxy/ProxyTest.kt
@@ -4,11 +4,14 @@ import io.ktor.http.*
 import io.specmatic.Waiter
 import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.core.HttpResponse
+import io.specmatic.core.HttpRequest
+import io.specmatic.core.HTTP_REQUEST_TRANSPORT_HEADERS
 import io.specmatic.core.YAML
 import io.specmatic.core.parseGherkinStringToFeature
 import io.specmatic.core.pattern.parsedJSON
 import io.specmatic.core.pattern.parsedJSONObject
 import io.specmatic.core.value.JSONObjectValue
+import io.specmatic.core.value.StringValue
 import io.specmatic.stub.HttpStub
 import io.ktor.util.*
 import io.specmatic.core.pattern.QueryParameterScalarPattern
@@ -29,21 +32,6 @@ import java.net.InetSocketAddress
 import java.nio.file.Files
 
 internal class ProxyTest {
-    private val dynamicHttpHeaders =
-        listOf(
-            HttpHeaders.Authorization,
-            HttpHeaders.UserAgent,
-            HttpHeaders.Referrer,
-            HttpHeaders.AcceptLanguage,
-            HttpHeaders.Host,
-            HttpHeaders.IfModifiedSince,
-            HttpHeaders.IfNoneMatch,
-            HttpHeaders.CacheControl,
-            HttpHeaders.ContentLength,
-            HttpHeaders.Range,
-            HttpHeaders.XForwardedFor,
-        )
-
     private val simpleFeature =
         parseGherkinStringToFeature(
             """
@@ -307,11 +295,57 @@ internal class ProxyTest {
 
         assertThat(fakeFileWriter.receivedContract?.trim()).startsWith("openapi:")
 
-        dynamicHttpHeaders.forEach {
+        HTTP_REQUEST_TRANSPORT_HEADERS.forEach {
             assertThat(fakeFileWriter.receivedContract)
                 .withFailMessage("Specification should not have contained $it")
                 .doesNotContainIgnoringCase("name: $it")
             assertThat(fakeFileWriter.receivedStub).withFailMessage("Stub should not have contained $it")
+        }
+    }
+
+    @Test
+    fun `should not include transport and browser metadata headers in recorded proxy artifacts`() {
+        HttpStub(simpleFeature).use {
+            Proxy(host = "localhost", port = 9001, "http://localhost:9000", fakeFileWriter).use {
+                HttpClient("http://localhost:9001").use { client ->
+                    val response = client.execute(
+                        HttpRequest(
+                            method = "POST",
+                            path = "/",
+                            headers = mapOf(
+                                "DNT" to "1",
+                                HttpHeaders.Forwarded to "for=192.0.2.60;proto=https;host=example.com",
+                                HttpHeaders.XForwardedHost to "example.com",
+                                HttpHeaders.XForwardedPort to "443",
+                                HttpHeaders.XForwardedProto to "https",
+                                "Sec-Fetch-Site" to "cross-site",
+                                "Sec-Fetch-Mode" to "cors",
+                                "Sec-Fetch-Dest" to "empty",
+                                "Sec-GPC" to "1",
+                                HttpHeaders.ContentType to "text/plain"
+                            ),
+                            body = StringValue("10")
+                        )
+                    )
+
+                    assertThat(response.status).isEqualTo(200)
+                }
+            }
+        }
+
+        listOf(
+            "DNT",
+            HttpHeaders.Forwarded,
+            HttpHeaders.XForwardedHost,
+            HttpHeaders.XForwardedPort,
+            HttpHeaders.XForwardedProto,
+            "Sec-Fetch-Site",
+            "Sec-Fetch-Mode",
+            "Sec-Fetch-Dest",
+            "Sec-GPC",
+        ).forEach { headerName ->
+            assertThat(fakeFileWriter.receivedContract).doesNotContainIgnoringCase("name: $headerName")
+            assertThat(fakeFileWriter.receivedStub).doesNotContainIgnoringCase("\"$headerName\"")
         }
     }
 


### PR DESCRIPTION
**What**:

Filter transport and browser metadata request headers out of proxy-recorded contracts and stubs.

**Why**:

These headers are connection or browser context metadata rather than contract-relevant inputs. Recording them in generated proxy artifacts creates noisy and brittle specifications.

**How**:

- Split transport header exclusions into request and response sets.
- Use the request-specific set when filtering `HttpRequest` headers and the response-specific set when filtering `HttpResponse` headers.
- Reuse the request transport header set from `ProxyTest` instead of maintaining a duplicate test list.
- Add proxy regression coverage for `DNT`, `Forwarded`, `X-Forwarded-*`, and selected `Sec-*` headers to ensure they are not written into recorded contracts or stubs.

**Checklist**:

- [x] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link) N/A
- [ ] Sample Project added/updated (share link) N/A
- [ ] Demo video (share link) N/A
- [ ] Article on Website (share link) N/A
- [ ] Roadmpap updated (share link) N/A
- [ ] Conference Talk (share link) N/A

**Issue ID**:
Closes: N/A
