### PR TITLE
Handle missing-in-spec spec association for API coverage report

### DIFF
--- a/core/src/main/kotlin/io/specmatic/test/TestResultRecord.kt
+++ b/core/src/main/kotlin/io/specmatic/test/TestResultRecord.kt
@@ -125,6 +125,19 @@ data class TestResultRecord(
     }
 }
 
+fun CoverageStatus.isPresentInSpecForApiCoverage(): Boolean =
+    this != CoverageStatus.MISSING_IN_SPEC
+
+fun CoverageStatus.countsAsCoveredForApiCoverage(): Boolean =
+    this == CoverageStatus.COVERED || this == CoverageStatus.WIP
+
+fun List<TestResultRecord>.countsAsCoveredForApiCoverage(): Boolean =
+    when {
+        any { it.isWip } -> true
+        any { it.isExercised } -> first().result != TestResult.NotImplemented
+        else -> false
+    }
+
 private fun durationFrom(requestTime: Instant?, responseTime: Instant?) =
     if (requestTime != null && responseTime != null)
         Duration.between(requestTime, responseTime).toMillis()

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -20,7 +20,6 @@ import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.Value
 import io.specmatic.license.core.*
 import io.specmatic.license.core.util.LicenseConfig
-import io.specmatic.reporter.ctrf.model.CtrfSpecConfig
 import io.specmatic.reporter.model.SpecType
 import io.specmatic.stub.hasOpenApiFileExtension
 import io.specmatic.stub.isOpenAPI
@@ -205,22 +204,7 @@ open class SpecmaticJUnitSupport {
         val start = startTime?.toEpochMilli() ?: 0L
         val end = startTime?.let { Instant.now().toEpochMilli() } ?: 0L
 
-        val specConfigs = openApiCoverageReportInput.endpoints()
-            .plus(openApiCoverageReportInput.missingInSpecEndpoints())
-            .groupBy {
-                it.specification.orEmpty()
-            }.flatMap { (_, groupedEndpoints) ->
-                groupedEndpoints.map {
-                    CtrfSpecConfig(
-                        protocol = it.protocol.key,
-                        specType = it.specType.value,
-                        specification = it.specification.orEmpty(),
-                        sourceProvider = it.sourceProvider,
-                        repository = it.sourceRepository,
-                        branch = it.sourceRepositoryBranch ?: "main"
-                    )
-                }
-            }
+        val specConfigs = openApiCoverageReportInput.ctrfSpecConfigs()
 
         val reportDirPath = specmaticConfig.getReportDirPath()
         ReportGenerator.generateReport(

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -204,18 +204,23 @@ open class SpecmaticJUnitSupport {
         val report = openApiCoverageReportInput.generateCoverageReport(emptyList())
         val start = startTime?.toEpochMilli() ?: 0L
         val end = startTime?.let { Instant.now().toEpochMilli() } ?: 0L
-        val specConfigs = openApiCoverageReportInput.endpoints().groupBy { it.specification.orEmpty() }.flatMap { (_, groupedEndpoints) ->
-            groupedEndpoints.map {
-                CtrfSpecConfig(
-                    protocol = it.protocol.key,
-                    specType = it.specType.value,
-                    specification = it.specification.orEmpty(),
-                    sourceProvider = it.sourceProvider,
-                    repository = it.sourceRepository,
-                    branch = it.sourceRepositoryBranch ?: "main"
-                )
+
+        val specConfigs = openApiCoverageReportInput.endpoints()
+            .plus(openApiCoverageReportInput.missingInSpecEndpoints())
+            .groupBy {
+                it.specification.orEmpty()
+            }.flatMap { (_, groupedEndpoints) ->
+                groupedEndpoints.map {
+                    CtrfSpecConfig(
+                        protocol = it.protocol.key,
+                        specType = it.specType.value,
+                        specification = it.specification.orEmpty(),
+                        sourceProvider = it.sourceProvider,
+                        repository = it.sourceRepository,
+                        branch = it.sourceRepositoryBranch ?: "main"
+                    )
+                }
             }
-        }
 
         val reportDirPath = specmaticConfig.getReportDirPath()
         ReportGenerator.generateReport(

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
@@ -4,6 +4,7 @@ import io.specmatic.core.filters.ExpressionStandardizer
 import io.specmatic.core.filters.TestRecordFilter
 import io.specmatic.core.log.HttpLogMessage
 import io.specmatic.license.core.SpecmaticProtocol
+import io.specmatic.reporter.ctrf.model.CtrfSpecConfig
 import io.specmatic.reporter.generated.dto.coverage.CoverageEntry
 import io.specmatic.reporter.generated.dto.coverage.OpenAPICoverageOperation
 import io.specmatic.reporter.generated.dto.coverage.SpecmaticCoverageReport
@@ -49,6 +50,24 @@ class OpenApiCoverageReportInput(
                 specification = it.specification
             )
         }
+    }
+
+    fun ctrfSpecConfigs(): List<CtrfSpecConfig> {
+        return endpoints()
+            .plus(missingInSpecEndpoints())
+            .groupBy { it.specification.orEmpty() }
+            .flatMap { (_, groupedEndpoints) ->
+                groupedEndpoints.map {
+                    CtrfSpecConfig(
+                        protocol = it.protocol.key,
+                        specType = it.specType.value,
+                        specification = it.specification.orEmpty(),
+                        sourceProvider = it.sourceProvider,
+                        repository = it.sourceRepository,
+                        branch = it.sourceRepositoryBranch ?: "main"
+                    )
+                }
+            }
     }
 
     fun onProcessingComplete() = coverageHooks.onEachListener { onEnd() }

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
@@ -325,7 +325,6 @@ class OpenApiCoverageReportInput(
     }
 
     private fun missingInSpecTestResultRecords(): List<TestResultRecord> {
-        val specToAssociateToMissingInSpecTestResultRecords = allEndpoints.firstNotNullOfOrNull { it.specification }
         return applicationAPIs.filter { api ->
             val noTestResultFoundForThisAPI = allEndpoints.none { it.path == api.path && it.method == api.method }
             val isNotExcluded = api.path !in excludedAPIs
@@ -348,9 +347,38 @@ class OpenApiCoverageReportInput(
                         protocol = SpecmaticProtocol.HTTP
                     )
                 ),
-                specification = specToAssociateToMissingInSpecTestResultRecords
+                specification = closestMatchingSpecificationFor(api)
             )
         }
+    }
+
+    private fun closestMatchingSpecificationFor(api: API): String? {
+        val endpointsWithSpecs = allEndpoints.filter { it.specification != null }
+        if (endpointsWithSpecs.isEmpty()) {
+            return null
+        }
+
+        val methodMatchedEndpoints = endpointsWithSpecs.filter { it.method == api.method }
+        val candidateEndpoints = methodMatchedEndpoints.ifEmpty { endpointsWithSpecs }
+
+        return candidateEndpoints
+            .maxWithOrNull(
+                compareBy<Endpoint> { commonPathPrefixSegments(api.path, it.path) }
+                    .thenBy { normalizedPathSegments(it.path).size }
+            )
+            ?.specification
+            ?: endpointsWithSpecs.first().specification
+    }
+
+    private fun commonPathPrefixSegments(leftPath: String, rightPath: String): Int {
+        val leftSegments = normalizedPathSegments(leftPath)
+        val rightSegments = normalizedPathSegments(rightPath)
+
+        return leftSegments.zip(rightSegments).takeWhile { (left, right) -> left == right }.count()
+    }
+
+    private fun normalizedPathSegments(path: String): List<String> {
+        return path.trim('/').split('/').filter { it.isNotBlank() }
     }
 
     private fun calculateTotalCoveragePercentage(methodMap: Map<String, Map<String?, Map<String, List<TestResultRecord>>>>): Int {

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
@@ -396,7 +396,9 @@ class OpenApiCoverageReportInput(
         val responseMaps = methodMap.values.flatMap { it.values }
         val totalResponseGroupCount = responseMaps.sumOf { it.size }
         val coveredResponseGroupCount = responseMaps.sumOf { responseMap ->
-            responseMap.values.count { testResults -> testResults.any { it.isCovered } }
+            responseMap.values.count { testResults ->
+                testResults.any { it.isCovered && it.result != TestResult.NotImplemented }
+            }
         }
 
         return totalResponseGroupCount to coveredResponseGroupCount

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
@@ -45,6 +45,9 @@ class OpenApiCoverageReportInput(
                 path = it.path,
                 method = it.method,
                 responseStatus =  it.responseStatus,
+                sourceProvider = it.sourceProvider,
+                sourceRepository = it.repository,
+                sourceRepositoryBranch = it.branch,
                 protocol = SpecmaticProtocol.HTTP,
                 specType = SpecType.OPENAPI,
                 specification = it.specification
@@ -330,6 +333,7 @@ class OpenApiCoverageReportInput(
             val isNotExcluded = api.path !in excludedAPIs
             noTestResultFoundForThisAPI && isNotExcluded
         }.map { api ->
+            val closestMatchingEndpoint = closestMatchingEndpointFor(api.path, api.method)
             TestResultRecord(
                 path = api.path,
                 method = api.method,
@@ -337,6 +341,9 @@ class OpenApiCoverageReportInput(
                 request = null,
                 response = null,
                 result = TestResult.MissingInSpec,
+                sourceProvider = closestMatchingEndpoint?.sourceProvider,
+                repository = closestMatchingEndpoint?.sourceRepository,
+                branch = closestMatchingEndpoint?.sourceRepositoryBranch,
                 specType = SpecType.OPENAPI,
                 operations = setOf(
                     OpenAPIOperation(
@@ -347,27 +354,26 @@ class OpenApiCoverageReportInput(
                         protocol = SpecmaticProtocol.HTTP
                     )
                 ),
-                specification = closestMatchingSpecificationFor(api)
+                specification = closestMatchingEndpoint?.specification
             )
         }
     }
 
-    private fun closestMatchingSpecificationFor(api: API): String? {
+    private fun closestMatchingEndpointFor(path: String, method: String): Endpoint? {
         val endpointsWithSpecs = allEndpoints.filter { it.specification != null }
         if (endpointsWithSpecs.isEmpty()) {
             return null
         }
 
-        val methodMatchedEndpoints = endpointsWithSpecs.filter { it.method == api.method }
+        val methodMatchedEndpoints = endpointsWithSpecs.filter { it.method == method }
         val candidateEndpoints = methodMatchedEndpoints.ifEmpty { endpointsWithSpecs }
 
         return candidateEndpoints
             .maxWithOrNull(
-                compareBy<Endpoint> { commonPathPrefixSegments(api.path, it.path) }
+                compareBy<Endpoint> { commonPathPrefixSegments(path, it.path) }
                     .thenBy { normalizedPathSegments(it.path).size }
             )
-            ?.specification
-            ?: endpointsWithSpecs.first().specification
+            ?: endpointsWithSpecs.first()
     }
 
     private fun commonPathPrefixSegments(leftPath: String, rightPath: String): Int {

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
@@ -38,6 +38,19 @@ class OpenApiCoverageReportInput(
 ) {
     fun endpoints() = allEndpoints.toList()
 
+    fun missingInSpecEndpoints(): List<Endpoint> {
+        return missingInSpecTestResultRecords().map {
+            Endpoint(
+                path = it.path,
+                method = it.method,
+                responseStatus =  it.responseStatus,
+                protocol = SpecmaticProtocol.HTTP,
+                specType = SpecType.OPENAPI,
+                specification = it.specification
+            )
+        }
+    }
+
     fun onProcessingComplete() = coverageHooks.onEachListener { onEnd() }
 
     fun totalDuration(): Long {
@@ -281,7 +294,20 @@ class OpenApiCoverageReportInput(
         if (!endpointsAPISet)
             return testResults
 
-        val testResultsForMissingAPIs = applicationAPIs.filter { api ->
+        val projectedFilterExpression = ExpressionStandardizer.filterToEvalExForSupportedKeys(filterExpression) {
+            TestRecordFilter.supportsFilterKey(it)
+        }
+
+        val filteredMissingApiResults = missingInSpecTestResultRecords().filter { missingTestResult ->
+            projectedFilterExpression.with("context", TestRecordFilter(missingTestResult)).evaluate().booleanValue
+        }
+
+        return testResults + filteredMissingApiResults
+    }
+
+    private fun missingInSpecTestResultRecords(): List<TestResultRecord> {
+        val specToAssociateToMissingInSpecTestResultRecords = allEndpoints.firstNotNullOfOrNull { it.specification }
+        return applicationAPIs.filter { api ->
             val noTestResultFoundForThisAPI = allEndpoints.none { it.path == api.path && it.method == api.method }
             val isNotExcluded = api.path !in excludedAPIs
             noTestResultFoundForThisAPI && isNotExcluded
@@ -302,20 +328,10 @@ class OpenApiCoverageReportInput(
                         responseCode = 0,
                         protocol = SpecmaticProtocol.HTTP
                     )
-                )
+                ),
+                specification = specToAssociateToMissingInSpecTestResultRecords
             )
         }
-
-
-        val projectedFilterExpression = ExpressionStandardizer.filterToEvalExForSupportedKeys(filterExpression) {
-            TestRecordFilter.supportsFilterKey(it)
-        }
-
-        val filteredMissingApiResults = testResultsForMissingAPIs.filter { missingTestResult ->
-            projectedFilterExpression.with("context", TestRecordFilter(missingTestResult)).evaluate().booleanValue
-        }
-
-        return testResults + filteredMissingApiResults
     }
 
     private fun calculateTotalCoveragePercentage(methodMap: Map<String, Map<String?, Map<String, List<TestResultRecord>>>>): Int {

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
@@ -15,6 +15,7 @@ import io.specmatic.test.API
 import io.specmatic.test.HttpInteractionsLog
 import io.specmatic.test.TestResultRecord
 import io.specmatic.test.TestResultRecord.Companion.getCoverageStatus
+import io.specmatic.test.countsAsCoveredForApiCoverage
 import io.specmatic.test.reports.TestReportListener
 import io.specmatic.test.reports.coverage.console.GroupedTestResultRecords
 import io.specmatic.test.reports.coverage.console.OpenAPICoverageConsoleReport
@@ -396,9 +397,7 @@ class OpenApiCoverageReportInput(
         val responseMaps = methodMap.values.flatMap { it.values }
         val totalResponseGroupCount = responseMaps.sumOf { it.size }
         val coveredResponseGroupCount = responseMaps.sumOf { responseMap ->
-            responseMap.values.count { testResults ->
-                testResults.any { it.isCovered && it.result != TestResult.NotImplemented }
-            }
+            responseMap.values.count { testResults -> testResults.countsAsCoveredForApiCoverage() }
         }
 
         return totalResponseGroupCount to coveredResponseGroupCount

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
@@ -403,18 +403,16 @@ class OpenApiCoverageReportInput(
     }
 
     private fun identifyFailedTestsDueToUnimplementedEndpointsAddMissingTests(testResults: List<TestResultRecord>): List<TestResultRecord> {
-        return testResults.map { testResult ->
-            when {
-                testResult.hasFailedAndEndpointIsNotImplemented() -> testResult.copy(result = TestResult.NotImplemented)
-                else -> testResult
-            }
-        }.flatMap { testResult ->
-            when {
-                testResult.testedEndpointIsMissingInSpec() -> {
-                    createMissingInSpecRecordAndIncludeOriginalRecordIfApplicable(testResult)
-                }
-                else -> listOf(testResult)
-            }
+        return testResults.flatMap { testResult ->
+            val updated = if (testResult.hasFailedAndEndpointIsNotImplemented())
+                testResult.copy(result = TestResult.NotImplemented)
+            else
+                testResult
+
+            if (updated.testedEndpointIsMissingInSpec())
+                createMissingInSpecRecordAndIncludeOriginalRecordIfApplicable(updated)
+            else
+                listOf(updated)
         }
     }
 
@@ -440,12 +438,17 @@ class OpenApiCoverageReportInput(
 
     private fun TestResultRecord.hasFailedAndEndpointIsNotImplemented(): Boolean {
         return this.result == TestResult.Failed && endpointsAPISet &&
+                applicationAPIs.isNotEmpty() &&
                 applicationAPIs.none {
                     it.path == this.path && it.method == this.method
                 }
     }
 
     private fun TestResultRecord.testedEndpointIsMissingInSpec(): Boolean {
+        if (this.result == TestResult.NotImplemented) {
+            return false
+        }
+
         val endpointExistsInSpecification = allEndpoints.any {
             it.path == this.path && it.method == this.method && it.responseStatus == this.actualResponseStatus
         }

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/console/OpenAPICoverageConsoleReport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/console/OpenAPICoverageConsoleReport.kt
@@ -1,7 +1,8 @@
 package io.specmatic.test.reports.coverage.console
 
-import io.specmatic.reporter.internal.dto.coverage.CoverageStatus
 import io.specmatic.test.TestResultRecord
+import io.specmatic.test.countsAsCoveredForApiCoverage
+import io.specmatic.test.isPresentInSpecForApiCoverage
 import io.specmatic.test.reports.TestReportListener
 import io.specmatic.test.reports.onEachListener
 import kotlin.math.roundToInt
@@ -31,14 +32,13 @@ data class OpenAPICoverageConsoleReport(
         if (totalEndpointsCount == 0) return 0
 
         val countOfEndpointsPresentInSpec =
-            coverageRows.count { it.remarks != CoverageStatus.MISSING_IN_SPEC }
+            coverageRows.count { it.remarks.isPresentInSpecForApiCoverage() }
 
         if(countOfEndpointsPresentInSpec == 0 ) return 0
 
         val countOfEndpointsHitThatArePresentInSpec = coverageRows.count {
             it.count.toInt() > 0 &&
-                it.remarks != CoverageStatus.MISSING_IN_SPEC &&
-                it.remarks != CoverageStatus.NOT_IMPLEMENTED
+                it.remarks.countsAsCoveredForApiCoverage()
         }
 
         return ((countOfEndpointsHitThatArePresentInSpec * 100) / countOfEndpointsPresentInSpec.toDouble()).roundToInt()

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/console/OpenAPICoverageConsoleReport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/console/OpenAPICoverageConsoleReport.kt
@@ -35,7 +35,11 @@ data class OpenAPICoverageConsoleReport(
 
         if(countOfEndpointsPresentInSpec == 0 ) return 0
 
-        val countOfEndpointsHitThatArePresentInSpec = coverageRows.count { it.count.toInt() > 0 && it.remarks != CoverageStatus.MISSING_IN_SPEC }
+        val countOfEndpointsHitThatArePresentInSpec = coverageRows.count {
+            it.count.toInt() > 0 &&
+                it.remarks != CoverageStatus.MISSING_IN_SPEC &&
+                it.remarks != CoverageStatus.NOT_IMPLEMENTED
+        }
 
         return ((countOfEndpointsHitThatArePresentInSpec * 100) / countOfEndpointsPresentInSpec.toDouble()).roundToInt()
     }

--- a/junit5-support/src/test/kotlin/io/specmatic/test/ApiCoverageReportInputTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/ApiCoverageReportInputTest.kt
@@ -228,8 +228,8 @@ class ApiCoverageReportInputTest {
                 listOf(
                     OpenApiCoverageConsoleRow("GET", "/route1", 200, 1, 100, CoverageStatus.COVERED),
                     OpenApiCoverageConsoleRow("POST", "/route1", 200, 1, 100, CoverageStatus.COVERED, showPath = false),
-                    OpenApiCoverageConsoleRow("GET", "/route2", 200, 1, 100, CoverageStatus.NOT_IMPLEMENTED),
-                    OpenApiCoverageConsoleRow("POST", "/route2", 200, 1, 100, CoverageStatus.NOT_IMPLEMENTED, showPath = false)
+                    OpenApiCoverageConsoleRow("GET", "/route2", 200, 1, 0, CoverageStatus.NOT_IMPLEMENTED),
+                    OpenApiCoverageConsoleRow("POST", "/route2", 200, 1, 0, CoverageStatus.NOT_IMPLEMENTED, showPath = false)
                 ),
                 apiCoverageReport.testResultRecords,
                 totalEndpointsCount = 2, missedEndpointsCount = 0, notImplementedAPICount = 1, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 0
@@ -268,8 +268,8 @@ class ApiCoverageReportInputTest {
                 listOf(
                     OpenApiCoverageConsoleRow("GET", "/route1", 200, 1, 100, CoverageStatus.COVERED),
                     OpenApiCoverageConsoleRow("POST", "/route1", 200, 1, 100, CoverageStatus.COVERED, showPath = false),
-                    OpenApiCoverageConsoleRow("GET", "/route2", 200, 1, 100, CoverageStatus.COVERED),
-                    OpenApiCoverageConsoleRow("POST", "/route2", 200, 1, 100, CoverageStatus.NOT_IMPLEMENTED, showPath = false),
+                    OpenApiCoverageConsoleRow("GET", "/route2", 200, 1, 50, CoverageStatus.COVERED),
+                    OpenApiCoverageConsoleRow("POST", "/route2", 200, 1, 50, CoverageStatus.NOT_IMPLEMENTED, showPath = false),
                     OpenApiCoverageConsoleRow("GET", "/route3/{route_id}", 0, 0, 0, CoverageStatus.MISSING_IN_SPEC),
                     OpenApiCoverageConsoleRow("POST", "/route3/{route_id}", 0, 0, 0, CoverageStatus.MISSING_IN_SPEC, showPath = false)
                 ),

--- a/junit5-support/src/test/kotlin/io/specmatic/test/ApiCoverageReportInputTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/ApiCoverageReportInputTest.kt
@@ -228,13 +228,11 @@ class ApiCoverageReportInputTest {
                 listOf(
                     OpenApiCoverageConsoleRow("GET", "/route1", 200, 1, 100, CoverageStatus.COVERED),
                     OpenApiCoverageConsoleRow("POST", "/route1", 200, 1, 100, CoverageStatus.COVERED, showPath = false),
-                    OpenApiCoverageConsoleRow("GET", "/route2", 200, 1, 50, CoverageStatus.NOT_IMPLEMENTED),
-                    OpenApiCoverageConsoleRow("GET", "/route2", 404, 0, 50, CoverageStatus.MISSING_IN_SPEC, showPath = false, showMethod = false),
-                    OpenApiCoverageConsoleRow("POST", "/route2", 200, 1, 50, CoverageStatus.NOT_IMPLEMENTED, showPath = false),
-                    OpenApiCoverageConsoleRow("POST", "/route2", 404, 0, 50, CoverageStatus.MISSING_IN_SPEC, showPath = false, showMethod = false)
+                    OpenApiCoverageConsoleRow("GET", "/route2", 200, 1, 100, CoverageStatus.NOT_IMPLEMENTED),
+                    OpenApiCoverageConsoleRow("POST", "/route2", 200, 1, 100, CoverageStatus.NOT_IMPLEMENTED, showPath = false)
                 ),
                 apiCoverageReport.testResultRecords,
-                totalEndpointsCount = 2, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 1, partiallyNotImplementedAPICount = 1
+                totalEndpointsCount = 2, missedEndpointsCount = 0, notImplementedAPICount = 1, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 0
             )
         )
     }
@@ -270,14 +268,13 @@ class ApiCoverageReportInputTest {
                 listOf(
                     OpenApiCoverageConsoleRow("GET", "/route1", 200, 1, 100, CoverageStatus.COVERED),
                     OpenApiCoverageConsoleRow("POST", "/route1", 200, 1, 100, CoverageStatus.COVERED, showPath = false),
-                    OpenApiCoverageConsoleRow("GET", "/route2", 200, 1, 67, CoverageStatus.COVERED),
-                    OpenApiCoverageConsoleRow("POST", "/route2", 200, 1, 67, CoverageStatus.NOT_IMPLEMENTED, showPath = false),
-                    OpenApiCoverageConsoleRow("POST", "/route2", 404, 0, 67, CoverageStatus.MISSING_IN_SPEC, showPath = false, showMethod = false),
+                    OpenApiCoverageConsoleRow("GET", "/route2", 200, 1, 100, CoverageStatus.COVERED),
+                    OpenApiCoverageConsoleRow("POST", "/route2", 200, 1, 100, CoverageStatus.NOT_IMPLEMENTED, showPath = false),
                     OpenApiCoverageConsoleRow("GET", "/route3/{route_id}", 0, 0, 0, CoverageStatus.MISSING_IN_SPEC),
                     OpenApiCoverageConsoleRow("POST", "/route3/{route_id}", 0, 0, 0, CoverageStatus.MISSING_IN_SPEC, showPath = false)
                 ),
                 apiCoverageReport.testResultRecords,
-                totalEndpointsCount = 3, missedEndpointsCount = 1, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 1, partiallyNotImplementedAPICount = 1
+                totalEndpointsCount = 3, missedEndpointsCount = 1, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 1
             )
         )
     }
@@ -358,7 +355,7 @@ class ApiCoverageReportInputTest {
         val openApiCoverageJsonReport = OpenApiCoverageReportInput(CONFIG_FILE_PATH, testReportRecords, applicationAPIs, allEndpoints = endpointsInSpec, endpointsAPISet = true).generateJsonReport()
         val reportJson = ObjectMapper().writeValueAsString(openApiCoverageJsonReport)
         assertThat(reportJson.trimIndent()).isEqualTo(
-            """{"specmaticConfigPath":"./specmatic.json","apiCoverage":[{"specification":"in/specmatic/examples/store/route1.yaml","type":"git","repository":"https://github.com/specmatic/specmatic-order-contracts.git","branch":"main","serviceType":"HTTP","specType":"OPENAPI","operations":[{"path":"/route1","method":"GET","responseCode":200,"coverageStatus":"covered","count":1},{"path":"/route1","method":"POST","responseCode":200,"coverageStatus":"covered","count":1}]},{"specification":"in/specmatic/examples/store/route2.yaml","type":"git","repository":"https://github.com/specmatic/specmatic-order-contracts.git","branch":"main","serviceType":"HTTP","specType":"OPENAPI","operations":[{"path":"/route2","method":"GET","responseCode":200,"coverageStatus":"covered","count":1},{"path":"/route2","method":"POST","responseCode":404,"coverageStatus":"missing in spec","count":0},{"path":"/route2","method":"POST","responseCode":200,"coverageStatus":"not implemented","count":1}]},{"type":"git","repository":"","branch":"","serviceType":"HTTP","specType":"OPENAPI","operations":[{"path":"/route3/{route_id}","method":"GET","responseCode":0,"coverageStatus":"missing in spec","count":0},{"path":"/route3/{route_id}","method":"POST","responseCode":0,"coverageStatus":"missing in spec","count":0}]}]}"""
+            """{"specmaticConfigPath":"./specmatic.json","apiCoverage":[{"specification":"in/specmatic/examples/store/route1.yaml","type":"git","repository":"https://github.com/specmatic/specmatic-order-contracts.git","branch":"main","serviceType":"HTTP","specType":"OPENAPI","operations":[{"path":"/route1","method":"GET","responseCode":200,"coverageStatus":"covered","count":1},{"path":"/route1","method":"POST","responseCode":200,"coverageStatus":"covered","count":1}]},{"specification":"in/specmatic/examples/store/route2.yaml","type":"git","repository":"https://github.com/specmatic/specmatic-order-contracts.git","branch":"main","serviceType":"HTTP","specType":"OPENAPI","operations":[{"path":"/route2","method":"GET","responseCode":200,"coverageStatus":"covered","count":1},{"path":"/route2","method":"POST","responseCode":200,"coverageStatus":"not implemented","count":1}]},{"type":"git","repository":"","branch":"","serviceType":"HTTP","specType":"OPENAPI","operations":[{"path":"/route3/{route_id}","method":"GET","responseCode":0,"coverageStatus":"missing in spec","count":0},{"path":"/route3/{route_id}","method":"POST","responseCode":0,"coverageStatus":"missing in spec","count":0}]}]}"""
         )
     }
 

--- a/junit5-support/src/test/kotlin/io/specmatic/test/ApiCoverageReportStatusTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/ApiCoverageReportStatusTest.kt
@@ -149,8 +149,56 @@ class ApiCoverageReportStatusTest {
         assertThat(apiCoverageReport.coverageRows).isEqualTo(
             listOf(
                 OpenApiCoverageConsoleRow("GET", "/route1", 200, 1, 100, CoverageStatus.COVERED),
-                OpenApiCoverageConsoleRow("GET", "/route2", 200, 1, 50, CoverageStatus.NOT_IMPLEMENTED),
-                OpenApiCoverageConsoleRow("GET", "/route2", 404, 0, 50, CoverageStatus.MISSING_IN_SPEC, showPath = false, showMethod = false)
+                OpenApiCoverageConsoleRow("GET", "/route2", 200, 1, 100, CoverageStatus.NOT_IMPLEMENTED)
+            )
+        )
+    }
+
+    @Test
+    fun `does not identify endpoint as not implemented when endpoints api is enabled but discovered endpoint list is empty`() {
+        val endpointsInSpec = mutableListOf(
+            Endpoint("/route1", "GET", 200, protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI)
+        )
+
+        val contractTestResults = mutableListOf(
+            TestResultRecord("/route1", "GET", 200, request = null, response = null, result = TestResult.Failed, actualResponseStatus = 404, specType = SpecType.OPENAPI)
+        )
+
+        val apiCoverageReport = OpenApiCoverageReportInput(
+            CONFIG_FILE_PATH,
+            contractTestResults,
+            mutableListOf(),
+            allEndpoints = endpointsInSpec,
+            endpointsAPISet = true
+        ).generate()
+        assertThat(apiCoverageReport.coverageRows).isEqualTo(
+            listOf(
+                OpenApiCoverageConsoleRow("GET", "/route1", 200, 1, 50, CoverageStatus.COVERED),
+                OpenApiCoverageConsoleRow("GET", "/route1", 404, 0, 50, CoverageStatus.MISSING_IN_SPEC, showPath = false, showMethod = false),
+            )
+        )
+    }
+
+    @Test
+    fun `does not identify endpoint as not implemented when endpoints api is enabled but discovered endpoint list is empty and connection is refused`() {
+        val endpointsInSpec = mutableListOf(
+            Endpoint("/route1", "GET", 200, protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI)
+        )
+
+        val contractTestResults = mutableListOf(
+            TestResultRecord("/route1", "GET", 200, request = null, response = null, result = TestResult.Failed, actualResponseStatus = 0, specType = SpecType.OPENAPI)
+        )
+
+        val apiCoverageReport = OpenApiCoverageReportInput(
+            CONFIG_FILE_PATH,
+            contractTestResults,
+            mutableListOf(),
+            allEndpoints = endpointsInSpec,
+            endpointsAPISet = true
+        ).generate()
+        assertThat(apiCoverageReport.coverageRows).isEqualTo(
+            listOf(
+                OpenApiCoverageConsoleRow("GET", "/route1", 200, 1, 100, CoverageStatus.COVERED)
             )
         )
     }

--- a/junit5-support/src/test/kotlin/io/specmatic/test/ApiCoverageReportStatusTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/ApiCoverageReportStatusTest.kt
@@ -149,7 +149,7 @@ class ApiCoverageReportStatusTest {
         assertThat(apiCoverageReport.coverageRows).isEqualTo(
             listOf(
                 OpenApiCoverageConsoleRow("GET", "/route1", 200, 1, 100, CoverageStatus.COVERED),
-                OpenApiCoverageConsoleRow("GET", "/route2", 200, 1, 100, CoverageStatus.NOT_IMPLEMENTED)
+                OpenApiCoverageConsoleRow("GET", "/route2", 200, 1, 0, CoverageStatus.NOT_IMPLEMENTED)
             )
         )
     }

--- a/junit5-support/src/test/kotlin/io/specmatic/test/ApiCoverageReportTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/ApiCoverageReportTest.kt
@@ -42,7 +42,7 @@ class ApiCoverageReportTest {
         val endpointsInSpec = mutableListOf(
             Endpoint("/order/{id}", "GET", 200, protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI),
         )
-        val applicationAPIs = mutableListOf<API>()
+        val applicationAPIs = mutableListOf(API("POST", "/orders"))
         val testResultRecords = mutableListOf(
             TestResultRecord("/order/{id}", "GET", 200, request = null, response = null, result = TestResult.Failed, actualResponseStatus = 404, specType = SpecType.OPENAPI)
         )
@@ -51,11 +51,15 @@ class ApiCoverageReportTest {
         assertThat(apiCoverageReport).isEqualTo(
             OpenAPICoverageConsoleReport(
                 listOf(
-                    OpenApiCoverageConsoleRow("GET", "/order/{id}", 200, 1, 50, CoverageStatus.COVERED),
-                    OpenApiCoverageConsoleRow("GET", "/order/{id}", 404, 0, 50, CoverageStatus.MISSING_IN_SPEC, showPath = false, showMethod = false),
+                    OpenApiCoverageConsoleRow("GET", "/order/{id}", 200, 1, 0, CoverageStatus.NOT_IMPLEMENTED),
+                    OpenApiCoverageConsoleRow("POST", "/orders", 0, 0, 0, CoverageStatus.MISSING_IN_SPEC),
                 ),
                 apiCoverageReport.testResultRecords,
-                totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 1, partiallyNotImplementedAPICount = 0
+                totalEndpointsCount = 2,
+                missedEndpointsCount = 1,
+                notImplementedAPICount = 1,
+                partiallyMissedEndpointsCount = 0,
+                partiallyNotImplementedAPICount = 0
             )
         )
     }
@@ -63,7 +67,13 @@ class ApiCoverageReportTest {
     @Test
     fun `POST 201 and 400 in spec not implemented with actuator`() {
         val endpointsInSpec = mutableListOf(
-            Endpoint("/order/{id}", "POST", 201, protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI), Endpoint(
+            Endpoint(
+                "/order/{id}",
+                "POST",
+                201,
+                protocol = SpecmaticProtocol.HTTP,
+                specType = SpecType.OPENAPI),
+            Endpoint(
                 "/order/{id}",
                 "POST",
                 400,
@@ -71,7 +81,7 @@ class ApiCoverageReportTest {
                 specType = SpecType.OPENAPI
             )
         )
-        val applicationAPIs = mutableListOf<API>()
+        val applicationAPIs = mutableListOf(API("POST", "/orders"))
         val testResultRecords = mutableListOf(
             TestResultRecord(
                 "/order/{id}",
@@ -97,12 +107,12 @@ class ApiCoverageReportTest {
         assertThat(apiCoverageReport).isEqualTo(
             OpenAPICoverageConsoleReport(
                 listOf(
-                    OpenApiCoverageConsoleRow("POST", "/order/{id}", 201, 1, 67, CoverageStatus.COVERED),
-                    OpenApiCoverageConsoleRow("POST", "/order/{id}", 400, 1, 67, CoverageStatus.COVERED, showPath = false, showMethod = false),
-                    OpenApiCoverageConsoleRow("POST", "/order/{id}", 404, 0, 67, CoverageStatus.MISSING_IN_SPEC, showPath = false, showMethod = false),
+                    OpenApiCoverageConsoleRow("POST", "/order/{id}", 201, 1, 0, CoverageStatus.NOT_IMPLEMENTED),
+                    OpenApiCoverageConsoleRow("POST", "/order/{id}", 400, 1, 0, CoverageStatus.NOT_IMPLEMENTED, showPath = false, showMethod = false),
+                    OpenApiCoverageConsoleRow("POST", "/orders", 0, 0, 0, CoverageStatus.MISSING_IN_SPEC, showPath = true, showMethod = true),
                 ),
                 apiCoverageReport.testResultRecords,
-                totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 1, partiallyNotImplementedAPICount = 0
+                totalEndpointsCount = 2, missedEndpointsCount = 1, notImplementedAPICount = 1, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 0
             )
         )
 
@@ -164,7 +174,14 @@ class ApiCoverageReportTest {
     @Test
     fun `GET 200 and 404 in spec not implemented with actuator`() {
         val endpointsInSpec = mutableListOf(
-            Endpoint("/order/{id}", "GET", 200, protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI), Endpoint(
+            Endpoint(
+                "/order/{id}",
+                "GET",
+                200,
+                protocol = SpecmaticProtocol.HTTP,
+                specType = SpecType.OPENAPI
+            ),
+            Endpoint(
                 "/order/{id}",
                 "GET",
                 404,
@@ -172,7 +189,7 @@ class ApiCoverageReportTest {
                 specType = SpecType.OPENAPI
             )
         )
-        val applicationAPIs = mutableListOf<API>()
+        val applicationAPIs = mutableListOf(API("GET", "/orders"))
         val testResultRecords = mutableListOf(
             TestResultRecord("/order/{id}", "GET", 200,   request = null, response = null, result = TestResult.Failed, actualResponseStatus = 404, specType = SpecType.OPENAPI)
         )
@@ -181,9 +198,10 @@ class ApiCoverageReportTest {
         assertThat(apiCoverageReport).isEqualTo(
             OpenAPICoverageConsoleReport(
                 listOf(
-                    OpenApiCoverageConsoleRow("GET", "/order/{id}", 200, 1, 50, CoverageStatus.COVERED),
-                    OpenApiCoverageConsoleRow("GET", "/order/{id}", 404, 0, 50, CoverageStatus.NOT_COVERED, showPath = false, showMethod = false),
-                ), apiCoverageReport.testResultRecords, totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 0
+                    OpenApiCoverageConsoleRow("GET", "/order/{id}", 200, 1, 0, CoverageStatus.NOT_IMPLEMENTED),
+                    OpenApiCoverageConsoleRow("GET", "/order/{id}",404, 0, 0, CoverageStatus.NOT_COVERED, showPath = false, showMethod = false),
+                    OpenApiCoverageConsoleRow("GET", "/orders", 0, 0, 0, CoverageStatus.MISSING_IN_SPEC),
+                ), apiCoverageReport.testResultRecords, totalEndpointsCount = 2, missedEndpointsCount = 1, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 1
             )
         )
     }
@@ -195,7 +213,7 @@ class ApiCoverageReportTest {
             Endpoint("/order/{id}", "POST", 400, protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI),
             Endpoint("/order/{id}", "POST", 404, protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI)
         )
-        val applicationAPIS = mutableListOf<API>()
+        val applicationAPIS = mutableListOf(API("POST", "/orders"))
         val testResultRecords = mutableListOf(
             TestResultRecord("/order/{id}", "POST", 201,   request = null, response = null, result = TestResult.Failed, actualResponseStatus = 404, specType = SpecType.OPENAPI),
             TestResultRecord("/order/{id}", "POST", 400,   request = null, response = null, result = TestResult.Failed, actualResponseStatus = 404, specType = SpecType.OPENAPI)
@@ -206,10 +224,11 @@ class ApiCoverageReportTest {
         assertThat(apiCoverageReport).isEqualTo(
             OpenAPICoverageConsoleReport(
                 listOf(
-                    OpenApiCoverageConsoleRow("POST", "/order/{id}", 201, 1, 67, CoverageStatus.COVERED),
-                    OpenApiCoverageConsoleRow("POST", "/order/{id}", 400, 1, 67, CoverageStatus.COVERED, showPath = false, showMethod = false),
-                    OpenApiCoverageConsoleRow("POST", "/order/{id}", 404, 0, 67, CoverageStatus.NOT_COVERED, showPath = false, showMethod = false),
-                ), apiCoverageReport.testResultRecords, totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 0
+                    OpenApiCoverageConsoleRow("POST", "/order/{id}", 201, 1, 0, CoverageStatus.NOT_IMPLEMENTED),
+                    OpenApiCoverageConsoleRow("POST", "/order/{id}", 400, 1, 0, CoverageStatus.NOT_IMPLEMENTED, showPath = false, showMethod = false),
+                    OpenApiCoverageConsoleRow("POST", "/order/{id}", 404, 0, 0, CoverageStatus.NOT_COVERED, showPath = false, showMethod = false),
+                    OpenApiCoverageConsoleRow("POST", "/orders", 0, 0, 0, CoverageStatus.MISSING_IN_SPEC),
+                ), apiCoverageReport.testResultRecords, totalEndpointsCount = 2, missedEndpointsCount = 1, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 1
             )
         )
     }

--- a/junit5-support/src/test/kotlin/io/specmatic/test/ApiCoverageReportTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/ApiCoverageReportTest.kt
@@ -51,11 +51,11 @@ class ApiCoverageReportTest {
         assertThat(apiCoverageReport).isEqualTo(
             OpenAPICoverageConsoleReport(
                 listOf(
-                    OpenApiCoverageConsoleRow("GET", "/order/{id}", 200, 1, 50, CoverageStatus.NOT_IMPLEMENTED),
+                    OpenApiCoverageConsoleRow("GET", "/order/{id}", 200, 1, 50, CoverageStatus.COVERED),
                     OpenApiCoverageConsoleRow("GET", "/order/{id}", 404, 0, 50, CoverageStatus.MISSING_IN_SPEC, showPath = false, showMethod = false),
                 ),
                 apiCoverageReport.testResultRecords,
-                totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 1, partiallyNotImplementedAPICount = 1
+                totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 1, partiallyNotImplementedAPICount = 0
             )
         )
     }
@@ -97,12 +97,12 @@ class ApiCoverageReportTest {
         assertThat(apiCoverageReport).isEqualTo(
             OpenAPICoverageConsoleReport(
                 listOf(
-                    OpenApiCoverageConsoleRow("POST", "/order/{id}", 201, 1, 67, CoverageStatus.NOT_IMPLEMENTED),
-                    OpenApiCoverageConsoleRow("POST", "/order/{id}", 400, 1, 67, CoverageStatus.NOT_IMPLEMENTED, showPath = false, showMethod = false),
+                    OpenApiCoverageConsoleRow("POST", "/order/{id}", 201, 1, 67, CoverageStatus.COVERED),
+                    OpenApiCoverageConsoleRow("POST", "/order/{id}", 400, 1, 67, CoverageStatus.COVERED, showPath = false, showMethod = false),
                     OpenApiCoverageConsoleRow("POST", "/order/{id}", 404, 0, 67, CoverageStatus.MISSING_IN_SPEC, showPath = false, showMethod = false),
                 ),
                 apiCoverageReport.testResultRecords,
-                totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 1, partiallyNotImplementedAPICount = 1
+                totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 1, partiallyNotImplementedAPICount = 0
             )
         )
 
@@ -181,9 +181,9 @@ class ApiCoverageReportTest {
         assertThat(apiCoverageReport).isEqualTo(
             OpenAPICoverageConsoleReport(
                 listOf(
-                    OpenApiCoverageConsoleRow("GET", "/order/{id}", 200, 1, 50, CoverageStatus.NOT_IMPLEMENTED),
+                    OpenApiCoverageConsoleRow("GET", "/order/{id}", 200, 1, 50, CoverageStatus.COVERED),
                     OpenApiCoverageConsoleRow("GET", "/order/{id}", 404, 0, 50, CoverageStatus.NOT_COVERED, showPath = false, showMethod = false),
-                ), apiCoverageReport.testResultRecords, totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 1
+                ), apiCoverageReport.testResultRecords, totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 0
             )
         )
     }
@@ -206,10 +206,10 @@ class ApiCoverageReportTest {
         assertThat(apiCoverageReport).isEqualTo(
             OpenAPICoverageConsoleReport(
                 listOf(
-                    OpenApiCoverageConsoleRow("POST", "/order/{id}", 201, 1, 67, CoverageStatus.NOT_IMPLEMENTED),
-                    OpenApiCoverageConsoleRow("POST", "/order/{id}", 400, 1, 67, CoverageStatus.NOT_IMPLEMENTED, showPath = false, showMethod = false),
+                    OpenApiCoverageConsoleRow("POST", "/order/{id}", 201, 1, 67, CoverageStatus.COVERED),
+                    OpenApiCoverageConsoleRow("POST", "/order/{id}", 400, 1, 67, CoverageStatus.COVERED, showPath = false, showMethod = false),
                     OpenApiCoverageConsoleRow("POST", "/order/{id}", 404, 0, 67, CoverageStatus.NOT_COVERED, showPath = false, showMethod = false),
-                ), apiCoverageReport.testResultRecords, totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 1
+                ), apiCoverageReport.testResultRecords, totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 0
             )
         )
     }
@@ -489,9 +489,9 @@ class ApiCoverageReportTest {
         assertThat(apiCoverageReport).isEqualTo(
             OpenAPICoverageConsoleReport(
                 listOf(
-                    OpenApiCoverageConsoleRow("GET", "/orders", 200, 1, 50, CoverageStatus.NOT_IMPLEMENTED),
+                    OpenApiCoverageConsoleRow("GET", "/orders", 200, 1, 50, CoverageStatus.COVERED),
                     OpenApiCoverageConsoleRow("GET", "/orders", 404, 0, 50, CoverageStatus.MISSING_IN_SPEC, showPath=false, showMethod=false),
-                ), apiCoverageReport.testResultRecords, totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 1, partiallyNotImplementedAPICount = 1
+                ), apiCoverageReport.testResultRecords, totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 1, partiallyNotImplementedAPICount = 0
             )
         )
     }

--- a/junit5-support/src/test/kotlin/io/specmatic/test/CtrfApiCoverageReportIntegrationTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/CtrfApiCoverageReportIntegrationTest.kt
@@ -19,13 +19,22 @@ class CtrfApiCoverageReportIntegrationTest {
     fun `ctrf html report should include swagger discovered endpoints missing in the contract`() {
         val actualSpec = File("src/test/resources/openapi/api_coverage/openapi.yaml").canonicalFile
         val applicationSpec = File("src/test/resources/openapi/api_coverage/app_generated_openapi.json").canonicalFile
+        val sourceProvider = "filesystem"
+        val sourceRepository = ""
+        val sourceRepositoryBranch = "main"
 
         val input = OpenApiCoverageReportInput(
             configFilePath = actualSpec.canonicalPath,
             endpointsAPISet = true,
         )
 
-        val endpoints = endpointsFrom(actualSpec)
+        val endpoints = endpointsFrom(actualSpec).map { endpoint ->
+            endpoint.copy(
+                sourceProvider = sourceProvider,
+                sourceRepository = sourceRepository,
+                sourceRepositoryBranch = sourceRepositoryBranch,
+            )
+        }
         input.addEndpoints(endpoints, endpoints)
         input.addAPIs(applicationApisFrom(applicationSpec))
 
@@ -69,9 +78,20 @@ class CtrfApiCoverageReportIntegrationTest {
         val reportNode = ObjectMapper().readTree(reportJson)
 
         val testNames = reportNode["results"]["tests"].map { it["name"].asText() }
-        val executionOperations = reportNode["results"]["summary"]["extra"]["executionDetails"]
-            .flatMap { it["operations"].toList() }
+        val executionDetails = reportNode["results"]["summary"]["extra"]["executionDetails"].toList()
+        val matchingExecutionDetails = executionDetails.filter { it["specification"].asText() == actualSpec.canonicalPath }
+        val executionOperations = executionDetails.flatMap { it["operations"].toList() }
         val executionOperationPaths = executionOperations.map { it["path"].asText() }
+
+        assertThat(matchingExecutionDetails)
+            .withFailMessage(
+                "Expected exactly one CTRF execution detail for spec %s, but found: %s",
+                actualSpec.canonicalPath,
+                matchingExecutionDetails
+            )
+            .hasSize(1)
+
+        assertThat(matchingExecutionDetails.single()["type"].asText()).isEqualTo(sourceProvider)
 
         assertThat(testNames)
             .withFailMessage(

--- a/junit5-support/src/test/kotlin/io/specmatic/test/CtrfApiCoverageReportIntegrationTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/CtrfApiCoverageReportIntegrationTest.kt
@@ -92,6 +92,93 @@ class CtrfApiCoverageReportIntegrationTest {
             .contains("/pets/search")
     }
 
+    @Test
+    fun `ctrf html report should associate missing in spec endpoint with closest matching spec`() {
+        val petsSpec = File("src/test/resources/openapi/api_coverage/openapi.yaml").canonicalFile
+        val ownersSpec = File("src/test/resources/openapi/api_coverage/owners.yaml").canonicalFile
+
+        val petsEndpoints = endpointsFrom(petsSpec)
+        val ownersEndpoints = listOf(
+            Endpoint(
+                path = "/owners/{ownerId}",
+                method = "GET",
+                responseStatus = 200,
+                specification = ownersSpec.canonicalPath,
+                protocol = io.specmatic.license.core.SpecmaticProtocol.HTTP,
+                specType = SpecType.OPENAPI,
+            )
+        )
+
+        val input = OpenApiCoverageReportInput(
+            configFilePath = petsSpec.canonicalPath,
+            endpointsAPISet = true,
+        )
+
+        input.addEndpoints(ownersEndpoints + petsEndpoints, ownersEndpoints + petsEndpoints)
+        input.addAPIs(listOf(
+            API(method = "GET", path = "/pets/search")
+        ))
+
+        (ownersEndpoints + petsEndpoints).forEach { endpoint ->
+            input.addTestReportRecords(
+                TestResultRecord(
+                    path = endpoint.path,
+                    method = endpoint.method,
+                    responseStatus = endpoint.responseStatus,
+                    request = null,
+                    response = null,
+                    result = TestResult.Success,
+                    specification = endpoint.specification,
+                    specType = SpecType.OPENAPI,
+                    requestContentType = endpoint.requestContentType,
+                )
+            )
+        }
+
+        val consoleReport = input.generate()
+        val ctrfReport = CtrfReportGenerator.generate(
+            testResultRecords = consoleReport.testResultRecords,
+            specConfig = input.ctrfSpecConfigs(),
+            startTime = 0L,
+            endTime = 0L,
+            extra = mapOf("apiCoverage" to "${consoleReport.totalCoveragePercentage}%"),
+            toolName = "Specmatic test",
+        ) { ctrfTestResultRecords ->
+            ctrfTestResultRecords.filterIsInstance<TestResultRecord>().getCoverageStatus()
+        }
+
+        val reportNode = ObjectMapper().readTree(ObjectMapper().writeValueAsString(ctrfReport))
+        val testNames = reportNode["results"]["tests"].map { it["name"].asText() }
+        val executionDetails = reportNode["results"]["summary"]["extra"]["executionDetails"].toList()
+        val petsExecutionDetail = executionDetails.single { it["specification"].asText() == petsSpec.canonicalPath }
+        val ownersExecutionDetail = executionDetails.single { it["specification"].asText() == ownersSpec.canonicalPath }
+        val petsOperationPaths = petsExecutionDetail["operations"].map { it["path"].asText() }
+        val ownersOperationPaths = ownersExecutionDetail["operations"].map { it["path"].asText() }
+
+        assertThat(testNames)
+            .withFailMessage(
+                "Expected raw CTRF tests to contain /pets/search, but test names were: %s",
+                testNames
+            )
+            .anyMatch { it.contains("/pets/search") }
+
+        assertThat(petsOperationPaths)
+            .withFailMessage(
+                "Expected /pets/search to be attached to pets spec execution details. Pets operations: %s. Owners operations: %s",
+                petsOperationPaths,
+                ownersOperationPaths
+            )
+            .contains("/pets/search")
+
+        assertThat(ownersOperationPaths)
+            .withFailMessage(
+                "Expected /pets/search to be absent from owners spec execution details. Pets operations: %s. Owners operations: %s",
+                petsOperationPaths,
+                ownersOperationPaths
+            )
+            .doesNotContain("/pets/search")
+    }
+
     private fun endpointsFrom(specFile: File): List<Endpoint> {
         val feature = OpenApiSpecification.fromFile(specFile.canonicalPath).toFeature()
 

--- a/junit5-support/src/test/kotlin/io/specmatic/test/CtrfApiCoverageReportIntegrationTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/CtrfApiCoverageReportIntegrationTest.kt
@@ -199,6 +199,133 @@ class CtrfApiCoverageReportIntegrationTest {
             .doesNotContain("/pets/search")
     }
 
+    @Test
+    fun `ctrf report summary coverage should match console coverage for not implemented endpoints`() {
+        val specFile = File("src/test/resources/openapi/api_coverage/openapi.yaml").canonicalFile
+        val endpoint = Endpoint(
+            path = "/pets/search",
+            method = "GET",
+            responseStatus = 200,
+            specification = specFile.canonicalPath,
+            protocol = io.specmatic.license.core.SpecmaticProtocol.HTTP,
+            specType = SpecType.OPENAPI,
+        )
+
+        val input = OpenApiCoverageReportInput(
+            configFilePath = specFile.canonicalPath,
+            endpointsAPISet = true,
+        )
+        input.addEndpoints(listOf(endpoint), listOf(endpoint))
+        input.addAPIs(listOf(API(method = "GET", path = "/pets")))
+        input.addTestReportRecords(
+            TestResultRecord(
+                path = endpoint.path,
+                method = endpoint.method,
+                responseStatus = endpoint.responseStatus,
+                request = null,
+                response = null,
+                result = TestResult.Failed,
+                actualResponseStatus = 422,
+                specification = endpoint.specification,
+                specType = SpecType.OPENAPI,
+            )
+        )
+
+        val consoleReport = input.generate()
+        val reportNode = ctrfReportNode(input, consoleReport)
+
+        assertThat(consoleReport.totalCoveragePercentage).isEqualTo(0)
+        assertThat(findTextValue(reportNode, "apiCoverage")).isEqualTo("0%")
+        assertThat(reportNode["results"]["tests"].map { it["name"].asText() }).anyMatch { it.contains("/pets/search") }
+    }
+
+    @Test
+    fun `ctrf report should preserve wip coverage semantics from console report`() {
+        val specFile = File("src/test/resources/openapi/api_coverage/openapi.yaml").canonicalFile
+        val endpoint = Endpoint(
+            path = "/pets/find",
+            method = "GET",
+            responseStatus = 200,
+            specification = specFile.canonicalPath,
+            protocol = io.specmatic.license.core.SpecmaticProtocol.HTTP,
+            specType = SpecType.OPENAPI,
+        )
+
+        val input = OpenApiCoverageReportInput(
+            configFilePath = specFile.canonicalPath,
+            endpointsAPISet = true,
+        )
+        input.addEndpoints(listOf(endpoint), listOf(endpoint))
+        input.addTestReportRecords(
+            TestResultRecord(
+                path = endpoint.path,
+                method = endpoint.method,
+                responseStatus = endpoint.responseStatus,
+                request = null,
+                response = null,
+                result = TestResult.Failed,
+                isWip = true,
+                specification = endpoint.specification,
+                specType = SpecType.OPENAPI,
+            )
+        )
+
+        val consoleReport = input.generate()
+        val reportNode = ctrfReportNode(input, consoleReport)
+        val executionOperations = reportNode["results"]["summary"]["extra"]["executionDetails"]
+            .single()
+            .get("operations")
+            .toList()
+        val tests = reportNode["results"]["tests"].toList()
+
+        assertThat(consoleReport.totalCoveragePercentage).isEqualTo(100)
+        assertThat(findTextValue(reportNode, "apiCoverage")).isEqualTo("100%")
+        assertThat(tests.single()["extra"]["wip"].asBoolean()).isTrue()
+        assertThat(executionOperations.single()["coverageStatus"].asText()).isEqualTo("WIP")
+    }
+
+    private fun findTextValue(node: com.fasterxml.jackson.databind.JsonNode, fieldName: String): String? {
+        if (node.has(fieldName)) {
+            return node[fieldName].asText()
+        }
+
+        val fields = node.fields()
+        while (fields.hasNext()) {
+            val child = fields.next().value
+            val result = findTextValue(child, fieldName)
+            if (result != null) {
+                return result
+            }
+        }
+
+        if (node.isArray) {
+            node.forEach { child ->
+                val result = findTextValue(child, fieldName)
+                if (result != null) {
+                    return result
+                }
+            }
+        }
+
+        return null
+    }
+
+    private fun ctrfReportNode(input: OpenApiCoverageReportInput, consoleReport: io.specmatic.test.reports.coverage.console.OpenAPICoverageConsoleReport) =
+        ObjectMapper().readTree(
+            ObjectMapper().writeValueAsString(
+                CtrfReportGenerator.generate(
+                    testResultRecords = consoleReport.testResultRecords,
+                    specConfig = input.ctrfSpecConfigs(),
+                    startTime = 0L,
+                    endTime = 0L,
+                    extra = mapOf("apiCoverage" to "${consoleReport.totalCoveragePercentage}%"),
+                    toolName = "Specmatic test",
+                ) { ctrfTestResultRecords ->
+                    ctrfTestResultRecords.filterIsInstance<TestResultRecord>().getCoverageStatus()
+                }
+            )
+        )
+
     private fun endpointsFrom(specFile: File): List<Endpoint> {
         val feature = OpenApiSpecification.fromFile(specFile.canonicalPath).toFeature()
 

--- a/junit5-support/src/test/kotlin/io/specmatic/test/CtrfApiCoverageReportIntegrationTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/CtrfApiCoverageReportIntegrationTest.kt
@@ -1,0 +1,138 @@
+package io.specmatic.test
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.specmatic.conversions.OpenApiSpecification
+import io.specmatic.conversions.convertPathParameterStyle
+import io.specmatic.reporter.ctrf.CtrfReportGenerator
+import io.specmatic.reporter.internal.dto.coverage.CoverageStatus
+import io.specmatic.reporter.model.SpecType
+import io.specmatic.reporter.model.TestResult
+import io.specmatic.test.TestResultRecord.Companion.getCoverageStatus
+import io.specmatic.test.reports.coverage.Endpoint
+import io.specmatic.test.reports.coverage.OpenApiCoverageReportInput
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class CtrfApiCoverageReportIntegrationTest {
+    @Test
+    fun `ctrf html report should include swagger discovered endpoints missing in the contract`() {
+        val actualSpec = File("src/test/resources/openapi/api_coverage/openapi.yaml").canonicalFile
+        val applicationSpec = File("src/test/resources/openapi/api_coverage/app_generated_openapi.json").canonicalFile
+
+        val input = OpenApiCoverageReportInput(
+            configFilePath = actualSpec.canonicalPath,
+            endpointsAPISet = true,
+        )
+
+        val endpoints = endpointsFrom(actualSpec)
+        input.addEndpoints(endpoints, endpoints)
+        input.addAPIs(applicationApisFrom(applicationSpec))
+
+        endpoints.forEach { endpoint ->
+            input.addTestReportRecords(
+                TestResultRecord(
+                    path = endpoint.path,
+                    method = endpoint.method,
+                    responseStatus = endpoint.responseStatus,
+                    request = null,
+                    response = null,
+                    result = TestResult.Success,
+                    specification = actualSpec.canonicalPath,
+                    specType = SpecType.OPENAPI,
+                    requestContentType = endpoint.requestContentType,
+                )
+            )
+        }
+
+        val consoleReport = input.generate()
+
+        assertThat(consoleReport.coverageRows).anyMatch {
+            it.path == "/pets/search" && it.remarks == CoverageStatus.MISSING_IN_SPEC
+        }
+        assertThat(consoleReport.coverageRows).anyMatch {
+            it.path == "/pets/find" && it.remarks == CoverageStatus.COVERED
+        }
+
+        val specConfigs = endpoints.groupBy { it.specification.orEmpty() }.flatMap { (_, groupedEndpoints) ->
+            groupedEndpoints.map {
+                io.specmatic.reporter.ctrf.model.CtrfSpecConfig(
+                    protocol = it.protocol.key,
+                    specType = it.specType.value,
+                    specification = it.specification.orEmpty(),
+                    sourceProvider = it.sourceProvider,
+                    repository = it.sourceRepository,
+                    branch = it.sourceRepositoryBranch ?: "main"
+                )
+            }
+        }
+
+        val ctrfReport = CtrfReportGenerator.generate(
+            testResultRecords = consoleReport.testResultRecords,
+            specConfig = specConfigs,
+            startTime = 0L,
+            endTime = 0L,
+            extra = mapOf("apiCoverage" to "${consoleReport.totalCoveragePercentage}%"),
+            toolName = "Specmatic test",
+        ) { ctrfTestResultRecords ->
+            ctrfTestResultRecords.filterIsInstance<TestResultRecord>().getCoverageStatus()
+        }
+
+        val reportJson = ObjectMapper().writeValueAsString(ctrfReport)
+        val reportNode = ObjectMapper().readTree(reportJson)
+
+        val testNames = reportNode["results"]["tests"].map { it["name"].asText() }
+        val executionOperations = reportNode["results"]["summary"]["extra"]["executionDetails"]
+            .flatMap { it["operations"].toList() }
+        val executionOperationPaths = executionOperations.map { it["path"].asText() }
+
+        assertThat(testNames)
+            .withFailMessage(
+                "Expected raw CTRF tests to contain /pets/search, but test names were: %s",
+                testNames
+            )
+            .anyMatch { it.contains("/pets/search") }
+
+        assertThat(executionOperationPaths)
+            .withFailMessage(
+                "Expected CTRF executionDetails.operations to include /pets/search because the raw CTRF tests already contain it. " +
+                    "This is the HTML-report bug: the raw tests know about /pets/search, but the summary operations used by the CTRF HTML do not. " +
+                    "Raw test names: %s. Summary operation paths: %s",
+                testNames,
+                executionOperationPaths
+            )
+            .contains("/pets/search")
+    }
+
+    private fun endpointsFrom(specFile: File): List<Endpoint> {
+        val feature = OpenApiSpecification.fromFile(specFile.canonicalPath).toFeature()
+
+        return feature.scenarios.map { scenario ->
+            Endpoint(
+                path = convertPathParameterStyle(scenario.path),
+                method = scenario.method,
+                responseStatus = scenario.httpResponsePattern.status,
+                soapAction = scenario.soapActionUnescaped,
+                sourceProvider = scenario.sourceProvider,
+                sourceRepository = scenario.sourceRepository,
+                sourceRepositoryBranch = scenario.sourceRepositoryBranch,
+                specification = specFile.canonicalPath,
+                requestContentType = scenario.requestContentType,
+                responseContentType = scenario.httpResponsePattern.headersPattern.contentType,
+                protocol = scenario.protocol,
+                specType = scenario.specType,
+            )
+        }
+    }
+
+    private fun applicationApisFrom(specFile: File): List<API> {
+        val feature = OpenApiSpecification.fromFile(specFile.canonicalPath).toFeature()
+
+        return feature.scenarios.map { scenario ->
+            API(
+                method = scenario.method,
+                path = convertPathParameterStyle(scenario.path),
+            )
+        }.distinct()
+    }
+}

--- a/junit5-support/src/test/kotlin/io/specmatic/test/CtrfApiCoverageReportIntegrationTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/CtrfApiCoverageReportIntegrationTest.kt
@@ -54,22 +54,9 @@ class CtrfApiCoverageReportIntegrationTest {
             it.path == "/pets/find" && it.remarks == CoverageStatus.COVERED
         }
 
-        val specConfigs = endpoints.groupBy { it.specification.orEmpty() }.flatMap { (_, groupedEndpoints) ->
-            groupedEndpoints.map {
-                io.specmatic.reporter.ctrf.model.CtrfSpecConfig(
-                    protocol = it.protocol.key,
-                    specType = it.specType.value,
-                    specification = it.specification.orEmpty(),
-                    sourceProvider = it.sourceProvider,
-                    repository = it.sourceRepository,
-                    branch = it.sourceRepositoryBranch ?: "main"
-                )
-            }
-        }
-
         val ctrfReport = CtrfReportGenerator.generate(
             testResultRecords = consoleReport.testResultRecords,
-            specConfig = specConfigs,
+            specConfig = input.ctrfSpecConfigs(),
             startTime = 0L,
             endTime = 0L,
             extra = mapOf("apiCoverage" to "${consoleReport.totalCoveragePercentage}%"),
@@ -95,8 +82,9 @@ class CtrfApiCoverageReportIntegrationTest {
 
         assertThat(executionOperationPaths)
             .withFailMessage(
-                "Expected CTRF executionDetails.operations to include /pets/search because the raw CTRF tests already contain it. " +
-                    "This is the HTML-report bug: the raw tests know about /pets/search, but the summary operations used by the CTRF HTML do not. " +
+                "Expected CTRF executionDetails.operations to include /pets/search after propagating missing-in-spec endpoints into CTRF spec configs. " +
+                    "The raw CTRF tests already contain /pets/search, and the HTML report reads executionDetails.operations. " +
+                    "If this fails, the missing-in-spec endpoint is still being dropped before the HTML summary is built. " +
                     "Raw test names: %s. Summary operation paths: %s",
                 testNames,
                 executionOperationPaths

--- a/junit5-support/src/test/kotlin/io/specmatic/test/OpenApiCoverageConsoleReportTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/OpenApiCoverageConsoleReportTest.kt
@@ -60,4 +60,44 @@ class OpenApiCoverageConsoleReportTest {
 
         assertThat(coverageReport.totalCoveragePercentage).isEqualTo(100)
     }
+
+    @Test
+    fun `test does not count not implemented endpoints as covered when calculating total percentage`() {
+        val rows = listOf(
+            OpenApiCoverageConsoleRow("GET", "/route1", 200, 1, 100, CoverageStatus.NOT_IMPLEMENTED),
+            OpenApiCoverageConsoleRow("GET", "/route2", 200, 1, 100, CoverageStatus.COVERED),
+        )
+
+        val coverageReport = OpenAPICoverageConsoleReport(
+            rows,
+            emptyList(),
+            totalEndpointsCount = 2,
+            missedEndpointsCount = 0,
+            notImplementedAPICount = 1,
+            partiallyMissedEndpointsCount = 0,
+            partiallyNotImplementedAPICount = 0
+        )
+
+        assertThat(coverageReport.totalCoveragePercentage).isEqualTo(50)
+    }
+
+    @Test
+    fun `test calculates zero total percentage when all exercised endpoints are not implemented`() {
+        val rows = listOf(
+            OpenApiCoverageConsoleRow("GET", "/route1", 200, 1, 0, CoverageStatus.NOT_IMPLEMENTED),
+            OpenApiCoverageConsoleRow("POST", "/route1", 400, 1, 0, CoverageStatus.NOT_IMPLEMENTED, showPath = false),
+        )
+
+        val coverageReport = OpenAPICoverageConsoleReport(
+            rows,
+            emptyList(),
+            totalEndpointsCount = 1,
+            missedEndpointsCount = 0,
+            notImplementedAPICount = 1,
+            partiallyMissedEndpointsCount = 0,
+            partiallyNotImplementedAPICount = 0
+        )
+
+        assertThat(coverageReport.totalCoveragePercentage).isEqualTo(0)
+    }
 }

--- a/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInputTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInputTest.kt
@@ -232,6 +232,46 @@ class OpenApiCoverageReportInputTest {
     }
 
     @Test
+    fun `should count wip as covered in path and total coverage calculations`() {
+        val wipEndpoint = Endpoint(
+            path = "/wip", method = "GET", responseStatus = 200,
+            protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI
+        )
+        val uncoveredEndpoint = Endpoint(
+            path = "/uncovered", method = "GET", responseStatus = 200,
+            protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI
+        )
+
+        val input = OpenApiCoverageReportInput(
+            configFilePath = "specmatic.yaml",
+            testResultRecords = mutableListOf(
+                TestResultRecord(
+                    path = "/wip",
+                    method = "GET",
+                    responseStatus = 200,
+                    request = null,
+                    response = null,
+                    result = TestResult.Failed,
+                    isWip = true,
+                    specType = SpecType.OPENAPI
+                )
+            ),
+            allEndpoints = mutableListOf(wipEndpoint, uncoveredEndpoint),
+            filteredEndpoints = mutableListOf(wipEndpoint, uncoveredEndpoint)
+        )
+
+        val report = input.generate()
+
+        assertThat(report.coverageRows).anyMatch {
+            it.path == "/wip" && it.remarks == CoverageStatus.WIP && it.coveragePercentage == 100
+        }
+        assertThat(report.coverageRows).anyMatch {
+            it.path == "/uncovered" && it.remarks == CoverageStatus.NOT_COVERED && it.coveragePercentage == 0
+        }
+        assertThat(report.totalCoveragePercentage).isEqualTo(50)
+    }
+
+    @Test
     fun `should calculate coverage percentage with only current results`() {
         val endpoint1 = Endpoint(
             path = "/current", method = "GET", responseStatus = 200,
@@ -331,6 +371,99 @@ class OpenApiCoverageReportInputTest {
         assertThat(report.coverageRows).anyMatch { it.path == "/current" && it.remarks.toString() == "covered" && it.coveragePercentage == 100 }
         assertThat(report.coverageRows).anyMatch { it.path == "/previous" && it.remarks.toString() == "covered" && it.coveragePercentage == 100 }
         assertThat(report.coverageRows).anyMatch { it.path == "/not-possible" && it.remarks.toString() == "covered" && it.coveragePercentage == 100 }
+    }
+
+    @Test
+    fun `should calculate mixed path coverage with covered not implemented and not covered responses`() {
+        val allEndpoints = mutableListOf(
+            Endpoint("/mixed", "GET", 200, protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI),
+            Endpoint("/mixed", "GET", 400, protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI),
+            Endpoint("/mixed", "GET", 500, protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI),
+        )
+
+        val input = OpenApiCoverageReportInput(
+            configFilePath = "specmatic.yaml",
+            testResultRecords = mutableListOf(
+                TestResultRecord(
+                    path = "/mixed",
+                    method = "GET",
+                    responseStatus = 200,
+                    request = null,
+                    response = null,
+                    result = TestResult.Success,
+                    specType = SpecType.OPENAPI
+                ),
+                TestResultRecord(
+                    path = "/mixed",
+                    method = "GET",
+                    responseStatus = 400,
+                    request = null,
+                    response = null,
+                    result = TestResult.Failed,
+                    actualResponseStatus = 0,
+                    specType = SpecType.OPENAPI
+                )
+            ),
+            applicationAPIs = mutableListOf(API("GET", "/other")),
+            endpointsAPISet = true,
+            allEndpoints = allEndpoints,
+            filteredEndpoints = allEndpoints
+        )
+
+        val report = input.generate()
+
+        assertThat(report.coverageRows.filter { it.path == "/mixed" }).containsExactly(
+            OpenApiCoverageConsoleRow("GET", "/mixed", 200, 1, 33, CoverageStatus.COVERED),
+            OpenApiCoverageConsoleRow("GET", "/mixed", 400, 1, 33, CoverageStatus.NOT_IMPLEMENTED, showPath = false, showMethod = false),
+            OpenApiCoverageConsoleRow("GET", "/mixed", 500, 0, 33, CoverageStatus.NOT_COVERED, showPath = false, showMethod = false),
+        )
+        assertThat(report.totalCoveragePercentage).isEqualTo(33)
+    }
+
+    @Test
+    fun `should calculate mixed path coverage with wip and not implemented responses`() {
+        val allEndpoints = mutableListOf(
+            Endpoint("/mixed", "GET", 200, protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI),
+            Endpoint("/mixed", "GET", 400, protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI),
+        )
+
+        val input = OpenApiCoverageReportInput(
+            configFilePath = "specmatic.yaml",
+            testResultRecords = mutableListOf(
+                TestResultRecord(
+                    path = "/mixed",
+                    method = "GET",
+                    responseStatus = 200,
+                    request = null,
+                    response = null,
+                    result = TestResult.Failed,
+                    isWip = true,
+                    specType = SpecType.OPENAPI
+                ),
+                TestResultRecord(
+                    path = "/mixed",
+                    method = "GET",
+                    responseStatus = 400,
+                    request = null,
+                    response = null,
+                    result = TestResult.Failed,
+                    actualResponseStatus = 0,
+                    specType = SpecType.OPENAPI
+                )
+            ),
+            applicationAPIs = mutableListOf(API("GET", "/other")),
+            endpointsAPISet = true,
+            allEndpoints = allEndpoints,
+            filteredEndpoints = allEndpoints
+        )
+
+        val report = input.generate()
+
+        assertThat(report.coverageRows.filter { it.path == "/mixed" }).containsExactly(
+            OpenApiCoverageConsoleRow("GET", "/mixed", 200, 1, 50, CoverageStatus.WIP),
+            OpenApiCoverageConsoleRow("GET", "/mixed", 400, 1, 50, CoverageStatus.NOT_IMPLEMENTED, showPath = false, showMethod = false),
+        )
+        assertThat(report.totalCoveragePercentage).isEqualTo(50)
     }
 
     @Test
@@ -546,6 +679,50 @@ class OpenApiCoverageReportInputTest {
         assertThat(report.coverageRows).anyMatch { it.path == "/test" && it.remarks == CoverageStatus.NOT_IMPLEMENTED }
         assertThat(report.testResultRecords).noneMatch { it.path == "/filtered" }
         assertThat(report.coverageRows).noneMatch { it.path == "/filtered" }
+        assertThat(report.totalCoveragePercentage).isEqualTo(0)
+    }
+
+    @Test
+    fun `should calculate zero coverage for path with multiple not implemented responses`() {
+        val allEndpoints = mutableListOf(
+            Endpoint("/pets/search", "GET", 200, protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI),
+            Endpoint("/pets/search", "GET", 404, protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI),
+        )
+
+        val report = OpenApiCoverageReportInput(
+            configFilePath = "specmatic.yaml",
+            testResultRecords = mutableListOf(
+                TestResultRecord(
+                    path = "/pets/search",
+                    method = "GET",
+                    responseStatus = 200,
+                    request = null,
+                    response = null,
+                    result = TestResult.Failed,
+                    actualResponseStatus = 0,
+                    specType = SpecType.OPENAPI
+                ),
+                TestResultRecord(
+                    path = "/pets/search",
+                    method = "GET",
+                    responseStatus = 404,
+                    request = null,
+                    response = null,
+                    result = TestResult.Failed,
+                    actualResponseStatus = 0,
+                    specType = SpecType.OPENAPI
+                )
+            ),
+            applicationAPIs = mutableListOf(API("GET", "/pets")),
+            endpointsAPISet = true,
+            allEndpoints = allEndpoints,
+            filteredEndpoints = allEndpoints
+        ).generate()
+
+        assertThat(report.coverageRows.filter { it.path == "/pets/search" }).containsExactly(
+            OpenApiCoverageConsoleRow("GET", "/pets/search", 200, 1, 0, CoverageStatus.NOT_IMPLEMENTED),
+            OpenApiCoverageConsoleRow("GET", "/pets/search", 404, 1, 0, CoverageStatus.NOT_IMPLEMENTED, showPath = false, showMethod = false),
+        )
         assertThat(report.totalCoveragePercentage).isEqualTo(0)
     }
 

--- a/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInputTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInputTest.kt
@@ -546,7 +546,7 @@ class OpenApiCoverageReportInputTest {
         assertThat(report.coverageRows).anyMatch { it.path == "/test" && it.remarks == CoverageStatus.NOT_IMPLEMENTED }
         assertThat(report.testResultRecords).noneMatch { it.path == "/filtered" }
         assertThat(report.coverageRows).noneMatch { it.path == "/filtered" }
-        assertThat(report.totalCoveragePercentage).isEqualTo(100)
+        assertThat(report.totalCoveragePercentage).isEqualTo(0)
     }
 
     @Test
@@ -701,7 +701,7 @@ class OpenApiCoverageReportInputTest {
         val report = reportInput.generate()
 
         assertThat(report.coverageRows).containsExactly(
-            OpenApiCoverageConsoleRow("GET", "/pets/search", 200, 1, 100, CoverageStatus.NOT_IMPLEMENTED)
+            OpenApiCoverageConsoleRow("GET", "/pets/search", 200, 1, 0, CoverageStatus.NOT_IMPLEMENTED)
         )
         val resultRecord = report.testResultRecords.single()
         assertThat(resultRecord.path).isEqualTo("/pets/search")
@@ -748,7 +748,7 @@ class OpenApiCoverageReportInputTest {
         val report = reportInput.generate()
 
         assertThat(report.coverageRows).containsExactly(
-            OpenApiCoverageConsoleRow("GET", "/pets/search", 200, 1, 100, CoverageStatus.NOT_IMPLEMENTED)
+            OpenApiCoverageConsoleRow("GET", "/pets/search", 200, 1, 0, CoverageStatus.NOT_IMPLEMENTED)
         )
         val resultRecord = report.testResultRecords.single()
         assertThat(resultRecord.path).isEqualTo("/pets/search")

--- a/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInputTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInputTest.kt
@@ -9,6 +9,7 @@ import io.specmatic.test.API
 import io.specmatic.test.TestResultRecord
 import io.specmatic.test.reports.TestExecutionResult
 import io.specmatic.test.reports.TestReportListener
+import io.specmatic.test.reports.coverage.console.OpenApiCoverageConsoleRow
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -534,7 +535,10 @@ class OpenApiCoverageReportInputTest {
         )
 
         val reportInput = OpenApiCoverageReportInput(
-            testResultRecords = testResultRecords, configFilePath = "", endpointsAPISet = true,
+            testResultRecords = testResultRecords,
+            configFilePath = "",
+            applicationAPIs = mutableListOf(API("POST", "/other")),
+            endpointsAPISet = true,
             allEndpoints = allEndpoints, filteredEndpoints = filtered
         )
         val report = reportInput.generate()
@@ -578,7 +582,10 @@ class OpenApiCoverageReportInputTest {
         )
 
         val reportInput = OpenApiCoverageReportInput(
-            testResultRecords = testResultRecords, configFilePath = "", endpointsAPISet = true,
+            testResultRecords = testResultRecords,
+            configFilePath = "",
+            applicationAPIs = mutableListOf(API("GET", "/current")),
+            endpointsAPISet = true,
             allEndpoints = allEndpoints
         )
         val report = reportInput.generate()
@@ -655,6 +662,101 @@ class OpenApiCoverageReportInputTest {
         assertThat(missingInSpecRow.path).isEqualTo("/current")
         assertThat(missingInSpecRow.method).isEqualTo("GET")
         assertThat(missingInSpecRow.responseStatus).isEqualTo("400")
+    }
+
+    @Test
+    fun `should not add synthetic missing in spec record for failed tests classified as not implemented`() {
+        val allEndpoints = mutableListOf(
+            Endpoint(
+                path = "/pets/search", method = "GET", responseStatus = 200,
+                protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI
+            ),
+            Endpoint(
+                path = "/pets", method = "GET", responseStatus = 200,
+                protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI
+            )
+        )
+
+        val testResultRecords = mutableListOf(
+            TestResultRecord(
+                "/pets/search",
+                "GET",
+                200,
+                request = null,
+                response = null,
+                result = TestResult.Failed,
+                actualResponseStatus = 422,
+                specType = SpecType.OPENAPI
+            )
+        )
+
+        val reportInput = OpenApiCoverageReportInput(
+            testResultRecords = testResultRecords,
+            configFilePath = "",
+            applicationAPIs = mutableListOf(API("GET", "/pets")),
+            endpointsAPISet = true,
+            allEndpoints = allEndpoints,
+            filteredEndpoints = mutableListOf(allEndpoints.first())
+        )
+        val report = reportInput.generate()
+
+        assertThat(report.coverageRows).containsExactly(
+            OpenApiCoverageConsoleRow("GET", "/pets/search", 200, 1, 100, CoverageStatus.NOT_IMPLEMENTED)
+        )
+        val resultRecord = report.testResultRecords.single()
+        assertThat(resultRecord.path).isEqualTo("/pets/search")
+        assertThat(resultRecord.method).isEqualTo("GET")
+        assertThat(resultRecord.responseStatus).isEqualTo(200)
+        assertThat(resultRecord.result).isEqualTo(TestResult.NotImplemented)
+        assertThat(report.testResultRecords).noneMatch { it.result == TestResult.MissingInSpec }
+    }
+
+    @Test
+    fun `should not add synthetic missing in spec record for connection refused when test is classified as not implemented`() {
+        val allEndpoints = mutableListOf(
+            Endpoint(
+                path = "/pets/search", method = "GET", responseStatus = 200,
+                protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI
+            ),
+            Endpoint(
+                path = "/pets", method = "GET", responseStatus = 200,
+                protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI
+            )
+        )
+
+        val testResultRecords = mutableListOf(
+            TestResultRecord(
+                "/pets/search",
+                "GET",
+                200,
+                request = null,
+                response = null,
+                result = TestResult.Failed,
+                actualResponseStatus = 0,
+                specType = SpecType.OPENAPI
+            )
+        )
+
+        val reportInput = OpenApiCoverageReportInput(
+            testResultRecords = testResultRecords,
+            configFilePath = "",
+            applicationAPIs = mutableListOf(API("GET", "/pets")),
+            endpointsAPISet = true,
+            allEndpoints = allEndpoints,
+            filteredEndpoints = mutableListOf(allEndpoints.first())
+        )
+        val report = reportInput.generate()
+
+        assertThat(report.coverageRows).containsExactly(
+            OpenApiCoverageConsoleRow("GET", "/pets/search", 200, 1, 100, CoverageStatus.NOT_IMPLEMENTED)
+        )
+        val resultRecord = report.testResultRecords.single()
+        assertThat(resultRecord.path).isEqualTo("/pets/search")
+        assertThat(resultRecord.method).isEqualTo("GET")
+        assertThat(resultRecord.responseStatus).isEqualTo(200)
+        assertThat(resultRecord.result).isEqualTo(TestResult.NotImplemented)
+        assertThat(resultRecord.actualResponseStatus).isEqualTo(0)
+        assertThat(report.testResultRecords).noneMatch { it.result == TestResult.MissingInSpec }
     }
 
     @Test

--- a/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInputTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInputTest.kt
@@ -70,6 +70,167 @@ class OpenApiCoverageReportInputTest {
     }
 
     @Test
+    fun `should associate missing in spec endpoint with closest matching spec based on path`() {
+        val petsEndpoint = Endpoint(
+            path = "/pets/{petId}",
+            method = "GET",
+            responseStatus = 200,
+            specification = "pets.yaml",
+            protocol = SpecmaticProtocol.HTTP,
+            specType = SpecType.OPENAPI
+        )
+        val ownersEndpoint = Endpoint(
+            path = "/owners/{ownerId}",
+            method = "GET",
+            responseStatus = 200,
+            specification = "owners.yaml",
+            protocol = SpecmaticProtocol.HTTP,
+            specType = SpecType.OPENAPI
+        )
+
+        val input = OpenApiCoverageReportInput(
+            configFilePath = "specmatic.yaml",
+            applicationAPIs = mutableListOf(API(method = "GET", path = "/pets/search")),
+            allEndpoints = mutableListOf(ownersEndpoint, petsEndpoint),
+            filteredEndpoints = mutableListOf(ownersEndpoint, petsEndpoint),
+            endpointsAPISet = true,
+        )
+
+        val missingInSpecEndpoint = input.missingInSpecEndpoints().single()
+
+        assertThat(missingInSpecEndpoint.path).isEqualTo("/pets/search")
+        assertThat(missingInSpecEndpoint.specification).isEqualTo("pets.yaml")
+    }
+
+    @Test
+    fun `should prefer the spec with the deeper shared path prefix`() {
+        val genericPetsEndpoint = Endpoint(
+            path = "/pets/{petId}",
+            method = "GET",
+            responseStatus = 200,
+            specification = "pets.yaml",
+            protocol = SpecmaticProtocol.HTTP,
+            specType = SpecType.OPENAPI
+        )
+        val searchEndpoint = Endpoint(
+            path = "/pets/search/{query}",
+            method = "GET",
+            responseStatus = 200,
+            specification = "pets-search.yaml",
+            protocol = SpecmaticProtocol.HTTP,
+            specType = SpecType.OPENAPI
+        )
+
+        val input = OpenApiCoverageReportInput(
+            configFilePath = "specmatic.yaml",
+            applicationAPIs = mutableListOf(API(method = "GET", path = "/pets/search/advanced")),
+            allEndpoints = mutableListOf(genericPetsEndpoint, searchEndpoint),
+            filteredEndpoints = mutableListOf(genericPetsEndpoint, searchEndpoint),
+            endpointsAPISet = true,
+        )
+
+        val missingInSpecEndpoint = input.missingInSpecEndpoints().single()
+
+        assertThat(missingInSpecEndpoint.specification).isEqualTo("pets-search.yaml")
+    }
+
+    @Test
+    fun `should prefer matching http method before path depth`() {
+        val deeperGetEndpoint = Endpoint(
+            path = "/pets/search/{query}",
+            method = "GET",
+            responseStatus = 200,
+            specification = "pets-get.yaml",
+            protocol = SpecmaticProtocol.HTTP,
+            specType = SpecType.OPENAPI
+        )
+        val shallowerPostEndpoint = Endpoint(
+            path = "/pets/{petId}",
+            method = "POST",
+            responseStatus = 202,
+            specification = "pets-post.yaml",
+            protocol = SpecmaticProtocol.HTTP,
+            specType = SpecType.OPENAPI
+        )
+
+        val input = OpenApiCoverageReportInput(
+            configFilePath = "specmatic.yaml",
+            applicationAPIs = mutableListOf(API(method = "POST", path = "/pets/search/advanced")),
+            allEndpoints = mutableListOf(deeperGetEndpoint, shallowerPostEndpoint),
+            filteredEndpoints = mutableListOf(deeperGetEndpoint, shallowerPostEndpoint),
+            endpointsAPISet = true,
+        )
+
+        val missingInSpecEndpoint = input.missingInSpecEndpoints().single()
+
+        assertThat(missingInSpecEndpoint.specification).isEqualTo("pets-post.yaml")
+    }
+
+    @Test
+    fun `should not associate a spec when no endpoints carry specification metadata`() {
+        val petsEndpoint = Endpoint(
+            path = "/pets/{petId}",
+            method = "GET",
+            responseStatus = 200,
+            specification = null,
+            protocol = SpecmaticProtocol.HTTP,
+            specType = SpecType.OPENAPI
+        )
+        val ownersEndpoint = Endpoint(
+            path = "/owners/{ownerId}",
+            method = "GET",
+            responseStatus = 200,
+            specification = null,
+            protocol = SpecmaticProtocol.HTTP,
+            specType = SpecType.OPENAPI
+        )
+
+        val input = OpenApiCoverageReportInput(
+            configFilePath = "specmatic.yaml",
+            applicationAPIs = mutableListOf(API(method = "GET", path = "/pets/search")),
+            allEndpoints = mutableListOf(ownersEndpoint, petsEndpoint),
+            filteredEndpoints = mutableListOf(ownersEndpoint, petsEndpoint),
+            endpointsAPISet = true,
+        )
+
+        val missingInSpecEndpoint = input.missingInSpecEndpoints().single()
+
+        assertThat(missingInSpecEndpoint.specification).isNull()
+    }
+
+    @Test
+    fun `should use deterministic fallback when no candidate shares a path prefix`() {
+        val invoicesEndpoint = Endpoint(
+            path = "/invoices/{invoiceId}",
+            method = "GET",
+            responseStatus = 200,
+            specification = "invoices.yaml",
+            protocol = SpecmaticProtocol.HTTP,
+            specType = SpecType.OPENAPI
+        )
+        val ownersEndpoint = Endpoint(
+            path = "/owners/{ownerId}",
+            method = "GET",
+            responseStatus = 200,
+            specification = "owners.yaml",
+            protocol = SpecmaticProtocol.HTTP,
+            specType = SpecType.OPENAPI
+        )
+
+        val input = OpenApiCoverageReportInput(
+            configFilePath = "specmatic.yaml",
+            applicationAPIs = mutableListOf(API(method = "GET", path = "/pets/search")),
+            allEndpoints = mutableListOf(invoicesEndpoint, ownersEndpoint),
+            filteredEndpoints = mutableListOf(invoicesEndpoint, ownersEndpoint),
+            endpointsAPISet = true,
+        )
+
+        val missingInSpecEndpoint = input.missingInSpecEndpoints().single()
+
+        assertThat(missingInSpecEndpoint.specification).isEqualTo("invoices.yaml")
+    }
+
+    @Test
     fun `should calculate coverage percentage with only current results`() {
         val endpoint1 = Endpoint(
             path = "/current", method = "GET", responseStatus = 200,

--- a/junit5-support/src/test/resources/openapi/api_coverage/app_generated_openapi.json
+++ b/junit5-support/src/test/resources/openapi/api_coverage/app_generated_openapi.json
@@ -1,0 +1,133 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Petstore API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/pets/search": {
+      "get": {
+        "summary": "Search Pets",
+        "operationId": "search_pets_pets_search_get",
+        "parameters": [
+          {
+            "name": "type",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Type"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pets/{petId}": {
+      "get": {
+        "summary": "Get Pet",
+        "operationId": "get_pet_pets__petId__get",
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Petid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      }
+    }
+  }
+}

--- a/junit5-support/src/test/resources/openapi/api_coverage/openapi.yaml
+++ b/junit5-support/src/test/resources/openapi/api_coverage/openapi.yaml
@@ -1,0 +1,77 @@
+openapi: 3.0.1
+info:
+  title: Contract for the petstore service
+  version: "1"
+paths:
+  /pets/{petId}:
+    get:
+      summary: Get a pet by id
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          schema:
+            type: integer
+          examples:
+            SCOOBY_200_OK:
+              value: 1
+      responses:
+        "200":
+          description: Pet details
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+              examples:
+                SCOOBY_200_OK:
+                  value:
+                    id: 1
+                    name: Scooby
+                    type: dog
+                    status: Adopted
+  /pets/find:
+    get:
+      summary: Search pets by type
+      parameters:
+        - name: type
+          in: query
+          required: true
+          schema:
+            type: string
+          examples:
+            DOG_SEARCH_200_OK:
+              value: dog
+      responses:
+        "200":
+          description: Matching pets
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Pet"
+              examples:
+                DOG_SEARCH_200_OK:
+                  value:
+                    - id: 1
+                      name: Scooby
+                      type: dog
+                      status: Adopted
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+        - type
+        - status
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        type:
+          type: string
+        status:
+          type: string


### PR DESCRIPTION
**What**:
- update missing-in-spec spec association to choose the closest matching spec by method and path prefix
- add focused tests for missing-in-spec spec association in `OpenApiCoverageReportInput`
- add a CTRF integration test for multi-spec execution details

**Why**:
- the new spec-association heuristic needed regression coverage beyond the single `/pets/search` vs `/owners/*` case
- CTRF HTML reads `executionDetails.operations`, so the multi-spec mapping needs end-to-end protection as well

**How**:
- added helper-level tests covering deeper shared path prefixes, HTTP method preference, null-spec fallback, and deterministic unrelated-path fallback
- added a multi-spec CTRF integration test that proves `/pets/search` is attached to the pets execution detail and not the owners execution detail
- reused the existing `OpenApiCoverageReportInput` and CTRF generation path to keep the tests close to production behavior

**Checklist**:
- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate N/A
- [ ] Security scans don't report any vulnerabilities N/A
- [ ] Documentation added/updated (share link) N/A
- [ ] Sample Project added/updated (share link) N/A
- [ ] Demo video (share link) N/A
- [ ] Article on Website (share link) N/A
- [ ] Roadmpap updated (share link) N/A
- [ ] Conference Talk (share link) N/A

**Issue ID**:
Closes: N/A

**Validation**:
- `./gradlew :junit5-support:test --tests "io.specmatic.test.reports.coverage.OpenApiCoverageReportInputTest"`
- `./gradlew :junit5-support:test --tests "io.specmatic.test.CtrfApiCoverageReportIntegrationTest"`
