### PR TITLE
Refine OpenAPI coverage reporting for operation metrics

### DIFF
--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/OpenApiCoverageReportProcessor.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/OpenApiCoverageReportProcessor.kt
@@ -56,23 +56,23 @@ class OpenApiCoverageReportProcessor(private val openApiCoverageReportInput: Ope
         val successCriteria = reportConfiguration.getSuccessCriteria()
         if (successCriteria.getEnforceOrDefault()) {
             val coverageThresholdNotMetMessage =
-                "Total API coverage: ${report.totalCoveragePercentage}% is less than the specified minimum threshold of ${successCriteria.getMinThresholdPercentageOrDefault()}%. "
-            val missedEndpointsCountExceededMessage =
-                "Total missed endpoints count: ${report.missedEndpointsCount} is greater than the maximum threshold of ${successCriteria.getMaxMissedEndpointsInSpecOrDefault()}.\n(Note: Specmatic will consider an endpoint as 'covered' only if it is documented in the open api spec with at least one example for each operation and response code.\nIf it is present in the spec, but does not have an example, Specmatic will still report the particular operation and response code as 'missing in spec'.)"
+                "Total API coverage: ${report.totalCoveragePercentage}% is less than the specified minimum threshold of ${successCriteria.getMinThresholdPercentageOrDefault()}%."
+            val missedOperationsExceededMessage =
+                "Total missed operations: ${report.missedOperations} is greater than the maximum threshold of ${successCriteria.getMaxMissedEndpointsInSpecOrDefault()}."
 
             val minCoverageThresholdCriteriaMet =
                 report.totalCoveragePercentage >= successCriteria.getMinThresholdPercentageOrDefault()
-            val maxMissingEndpointsExceededCriteriaMet =
-                report.missedEndpointsCount <= successCriteria.getMaxMissedEndpointsInSpecOrDefault()
-            val coverageReportSuccessCriteriaMet = minCoverageThresholdCriteriaMet && maxMissingEndpointsExceededCriteriaMet
+            val maxMissingOperationsExceededCriteriaMet =
+                report.missedOperations <= successCriteria.getMaxMissedEndpointsInSpecOrDefault()
+            val coverageReportSuccessCriteriaMet = minCoverageThresholdCriteriaMet && maxMissingOperationsExceededCriteriaMet
             if(!coverageReportSuccessCriteriaMet){
                 logger.newLine()
                 logger.log("Failed the following API Coverage Report success criteria:")
                 if(!minCoverageThresholdCriteriaMet) {
                     logger.log(coverageThresholdNotMetMessage)
                 }
-                if(!maxMissingEndpointsExceededCriteriaMet) {
-                    logger.log(missedEndpointsCountExceededMessage)
+                if(!maxMissingOperationsExceededCriteriaMet) {
+                    logger.log(missedOperationsExceededMessage)
                 }
                 logger.newLine()
             }

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
@@ -17,9 +17,9 @@ import io.specmatic.test.TestResultRecord
 import io.specmatic.test.TestResultRecord.Companion.getCoverageStatus
 import io.specmatic.test.countsAsCoveredForApiCoverage
 import io.specmatic.test.reports.TestReportListener
-import io.specmatic.test.reports.coverage.console.GroupedTestResultRecords
 import io.specmatic.test.reports.coverage.console.OpenAPICoverageConsoleReport
 import io.specmatic.test.reports.coverage.console.OpenApiCoverageConsoleRow
+import io.specmatic.test.reports.coverage.console.groupRecords
 import io.specmatic.test.reports.onEachListener
 import io.specmatic.test.reports.onTestResult
 import kotlinx.serialization.Serializable
@@ -193,33 +193,23 @@ class OpenApiCoverageReportInput(
             apiCoverageRows.addAll(rowsForPath)
         }
 
-        val totalAPICount = groupedTestResultRecords.keys.size
-        val testsGroupedByPath = allTests.groupBy { it.path }
+        val totalOperations = groupedTestResultRecords.keys.size
+        val testsGroupedByOperation = allTests.groupByOperation()
 
-        val missedAPICount = testsGroupedByPath.count { (_, tests) ->
+        val missedOperations = testsGroupedByOperation.count { (_, tests) ->
             tests.all { it.result == TestResult.MissingInSpec }
         }
 
-        val notImplementedAPICount = testsGroupedByPath.count { (_, tests) ->
+        val notImplementedOperations = testsGroupedByOperation.count { (_, tests) ->
             tests.all { it.result == TestResult.NotImplemented }
-        }
-
-        val partiallyMissedAPICount = testsGroupedByPath.count { (_, tests) ->
-            tests.any { it.result == TestResult.MissingInSpec } && tests.any { it.result != TestResult.MissingInSpec }
-        }
-
-        val partiallyNotImplementedAPICount = testsGroupedByPath.count { (_, tests) ->
-            tests.any { it.result == TestResult.NotImplemented } && tests.any { it.result != TestResult.NotImplemented }
         }
 
         return OpenAPICoverageConsoleReport(
             apiCoverageRows,
             allTests,
-            totalAPICount,
-            missedAPICount,
-            notImplementedAPICount,
-            partiallyMissedAPICount,
-            partiallyNotImplementedAPICount,
+            totalOperations,
+            missedOperations,
+            notImplementedOperations,
             listeners,
         )
     }
@@ -303,13 +293,14 @@ class OpenApiCoverageReportInput(
         }
     }
 
-    private fun List<TestResultRecord>.groupRecords(): GroupedTestResultRecords {
-        return groupBy { it.path }.mapValues { (_, pathMap) ->
-            pathMap.groupBy { it.soapAction ?: it.method }.mapValues { (_, methodMap) ->
-                methodMap.groupBy { it.requestContentType }.mapValues { (_, contentTypeMap) ->
-                    contentTypeMap.groupBy { it.responseStatus.toString() }
-                }
-            }
+    private fun List<TestResultRecord>.groupByOperation(): Map<OperationKey, List<TestResultRecord>> {
+        return groupBy {
+            OperationKey(
+                path = it.path,
+                method = it.soapAction ?: it.method,
+                requestContentType = it.requestContentType,
+                responseStatus = it.responseStatus
+            )
         }
     }
 
@@ -468,6 +459,13 @@ class OpenApiCoverageReportInput(
         return this.minus(wipTestResults.toSet()).plus(updatedWipTestResults)
     }
 }
+
+private data class OperationKey(
+    val path: String,
+    val method: String,
+    val requestContentType: String?,
+    val responseStatus: Int
+)
 
 data class CoverageGroupKey(
     val sourceProvider: String?,

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/console/OpenAPICoverageConsoleReport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/console/OpenAPICoverageConsoleReport.kt
@@ -14,11 +14,9 @@ typealias GroupedCoverageRows = Map<String, Map<String, Map<String?, Map<String,
 data class OpenAPICoverageConsoleReport(
     val coverageRows: List<OpenApiCoverageConsoleRow>,
     val testResultRecords: List<TestResultRecord>,
-    val totalEndpointsCount: Int,
-    val missedEndpointsCount: Int,
-    val notImplementedAPICount: Int,
-    val partiallyMissedEndpointsCount: Int,
-    val partiallyNotImplementedAPICount: Int,
+    val totalOperations: Int,
+    val missedOperations: Int,
+    val notImplementedOperations: Int,
     private val coverageHooks: List<TestReportListener> = emptyList(),
 ) {
     val totalCoveragePercentage: Int = calculateTotalCoveragePercentage()
@@ -29,29 +27,23 @@ data class OpenAPICoverageConsoleReport(
     }
 
     private fun calculateTotalCoveragePercentage(): Int {
-        if (totalEndpointsCount == 0) return 0
+        if (totalOperations == 0) return 0
 
-        val countOfEndpointsPresentInSpec =
+        val countOfOperationsPresentInSpec =
             coverageRows.count { it.remarks.isPresentInSpecForApiCoverage() }
 
-        if(countOfEndpointsPresentInSpec == 0 ) return 0
+        if(countOfOperationsPresentInSpec == 0 ) return 0
 
-        val countOfEndpointsHitThatArePresentInSpec = coverageRows.count {
+        val countOfOperationsHitThatArePresentInSpec = coverageRows.count {
             it.count.toInt() > 0 &&
                 it.remarks.countsAsCoveredForApiCoverage()
         }
 
-        return ((countOfEndpointsHitThatArePresentInSpec * 100) / countOfEndpointsPresentInSpec.toDouble()).roundToInt()
+        return ((countOfOperationsHitThatArePresentInSpec * 100) / countOfOperationsPresentInSpec.toDouble()).roundToInt()
     }
 
     fun getGroupedTestResultRecords(testResultRecords: List<TestResultRecord>): GroupedTestResultRecords {
-        return testResultRecords.groupBy { it.path }.mapValues { (_, pathMap) ->
-            pathMap.groupBy { it.soapAction ?: it.method }.mapValues { (_, methodMap) ->
-                methodMap.groupBy { it.requestContentType }.mapValues { (_, contentTypeMap) ->
-                    contentTypeMap.groupBy { it.responseStatus.toString() }
-                }
-            }
-        }
+        return testResultRecords.groupRecords()
     }
 
     fun getGroupedCoverageRows(coverageRows: List<OpenApiCoverageConsoleRow>): GroupedCoverageRows {
@@ -60,6 +52,16 @@ data class OpenAPICoverageConsoleReport(
                 methodMap.groupBy { it.requestContentType }.mapValues { (_, contentTypeMap) ->
                     contentTypeMap.groupBy { it.responseStatus }
                 }
+            }
+        }
+    }
+}
+
+fun List<TestResultRecord>.groupRecords(): GroupedTestResultRecords {
+    return groupBy { it.path }.mapValues { (_, pathMap) ->
+        pathMap.groupBy { it.soapAction ?: it.method }.mapValues { (_, methodMap) ->
+            methodMap.groupBy { it.requestContentType }.mapValues { (_, contentTypeMap) ->
+                contentTypeMap.groupBy { it.responseStatus.toString() }
             }
         }
     }

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/renderers/CoverageReportTextRenderer.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/renderers/CoverageReportTextRenderer.kt
@@ -12,30 +12,20 @@ class CoverageReportTextRenderer: ReportRenderer<OpenAPICoverageConsoleReport> {
 
         val missingAndNotImplementedAPIsMessageRows:MutableList<String> = mutableListOf()
 
-        if(report.missedEndpointsCount > 0) {
-            val missedPaths = pluralisePath(report.missedEndpointsCount)
-            missingAndNotImplementedAPIsMessageRows.add("$missedPaths found in the app ${isOrAre(report.missedEndpointsCount)} not documented in the spec.")
+        if(report.missedOperations > 0) {
+            val missedOperations = pluraliseOperation(report.missedOperations)
+            missingAndNotImplementedAPIsMessageRows.add("$missedOperations found in the service ${isOrAre(report.missedOperations)} not documented in the spec.")
         }
 
-        if(report.partiallyMissedEndpointsCount > 0) {
-            val partiallyMissedPaths = pluralisePath(report.partiallyMissedEndpointsCount)
-            missingAndNotImplementedAPIsMessageRows.add("$partiallyMissedPaths found in the app ${isOrAre(report.partiallyMissedEndpointsCount)} partially documented in the spec.")
-        }
-
-        if(report.notImplementedAPICount > 0) {
-            val notImplementedPaths = pluralisePath(report.notImplementedAPICount)
-            missingAndNotImplementedAPIsMessageRows.add("$notImplementedPaths found in the spec ${isOrAre(report.notImplementedAPICount)} not implemented.")
-        }
-
-        if(report.partiallyNotImplementedAPICount > 0) {
-            val partiallyNotImplementedPaths = pluralisePath(report.partiallyNotImplementedAPICount)
-            missingAndNotImplementedAPIsMessageRows.add("$partiallyNotImplementedPaths found in the spec ${isOrAre(report.partiallyNotImplementedAPICount)} partially implemented.")
+        if(report.notImplementedOperations > 0) {
+            val notImplementedOperations = pluraliseOperation(report.notImplementedOperations)
+            missingAndNotImplementedAPIsMessageRows.add("$notImplementedOperations found in the spec ${isOrAre(report.notImplementedOperations)} not implemented.")
         }
 
         return coveredAPIsTable + System.lineSeparator()  + missingAndNotImplementedAPIsMessageRows.joinToString(System.lineSeparator()) + System.lineSeparator()
     }
-    private fun pluralisePath(count: Int): String =
-        "$count path${if (count == 1) "" else "s"}"
+    private fun pluraliseOperation(count: Int): String =
+        "$count operation${if (count == 1) "" else "s"}"
 
     private fun isOrAre(count: Int): String = if (count > 1) "are" else "is"
 
@@ -62,7 +52,6 @@ class CoverageReportTextRenderer: ReportRenderer<OpenAPICoverageConsoleReport> {
     }
 
     private fun makeFooter(report: OpenAPICoverageConsoleReport): String {
-        return "${report.totalCoveragePercentage}% API Coverage reported from ${report.totalEndpointsCount} Paths"
+        return "${report.totalCoveragePercentage}% API Coverage reported from ${report.totalOperations} Operations"
     }
-
 }

--- a/junit5-support/src/test/kotlin/io/specmatic/test/ApiCoverageReportInputTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/ApiCoverageReportInputTest.kt
@@ -53,7 +53,7 @@ class ApiCoverageReportInputTest {
                     OpenApiCoverageConsoleRow("GET", "/route2", 200, 1, 100, CoverageStatus.COVERED)
                 ),
                 apiCoverageReport.testResultRecords,
-                totalEndpointsCount = 2, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 0
+                totalOperations = 2, missedOperations = 0, notImplementedOperations = 0
             )
         )
     }
@@ -97,7 +97,7 @@ class ApiCoverageReportInputTest {
                     OpenApiCoverageConsoleRow("POST", "/route3", 0, 0, 0, CoverageStatus.MISSING_IN_SPEC, showPath = false)
                 ),
                 apiCoverageReport.testResultRecords,
-                totalEndpointsCount = 3, missedEndpointsCount = 1, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 1, partiallyNotImplementedAPICount = 0
+                totalOperations = 3, missedOperations = 3, notImplementedOperations = 0
             )
         )
     }
@@ -146,7 +146,7 @@ class ApiCoverageReportInputTest {
                     OpenApiCoverageConsoleRow("POST", "/route2", 200, 1, 100,  CoverageStatus.COVERED, showPath = false)
                 ),
                 apiCoverageReport.testResultRecords,
-                totalEndpointsCount = 2,  missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 0
+                totalOperations = 2,  missedOperations = 0, notImplementedOperations = 0
             )
         )
     }
@@ -232,7 +232,7 @@ class ApiCoverageReportInputTest {
                     OpenApiCoverageConsoleRow("POST", "/route2", 200, 1, 0, CoverageStatus.NOT_IMPLEMENTED, showPath = false)
                 ),
                 apiCoverageReport.testResultRecords,
-                totalEndpointsCount = 2, missedEndpointsCount = 0, notImplementedAPICount = 1, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 0
+                totalOperations = 2, missedOperations = 0, notImplementedOperations = 2
             )
         )
     }
@@ -274,7 +274,7 @@ class ApiCoverageReportInputTest {
                     OpenApiCoverageConsoleRow("POST", "/route3/{route_id}", 0, 0, 0, CoverageStatus.MISSING_IN_SPEC, showPath = false)
                 ),
                 apiCoverageReport.testResultRecords,
-                totalEndpointsCount = 3, missedEndpointsCount = 1, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 1
+                totalOperations = 3, missedOperations = 2, notImplementedOperations = 1
             )
         )
     }
@@ -397,7 +397,7 @@ class ApiCoverageReportInputTest {
                     OpenApiCoverageConsoleRow("POST", "/route2", 500, 1, 75, CoverageStatus.COVERED, showPath = false)
                 ),
                 apiCoverageReport.testResultRecords,
-                totalEndpointsCount = 2, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 0
+                totalOperations = 2, missedOperations = 0, notImplementedOperations = 0
             )
         )
     }

--- a/junit5-support/src/test/kotlin/io/specmatic/test/ApiCoverageReportTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/ApiCoverageReportTest.kt
@@ -55,11 +55,9 @@ class ApiCoverageReportTest {
                     OpenApiCoverageConsoleRow("POST", "/orders", 0, 0, 0, CoverageStatus.MISSING_IN_SPEC),
                 ),
                 apiCoverageReport.testResultRecords,
-                totalEndpointsCount = 2,
-                missedEndpointsCount = 1,
-                notImplementedAPICount = 1,
-                partiallyMissedEndpointsCount = 0,
-                partiallyNotImplementedAPICount = 0
+                totalOperations = 2,
+                missedOperations = 1,
+                notImplementedOperations = 1
             )
         )
     }
@@ -112,7 +110,7 @@ class ApiCoverageReportTest {
                     OpenApiCoverageConsoleRow("POST", "/orders", 0, 0, 0, CoverageStatus.MISSING_IN_SPEC, showPath = true, showMethod = true),
                 ),
                 apiCoverageReport.testResultRecords,
-                totalEndpointsCount = 2, missedEndpointsCount = 1, notImplementedAPICount = 1, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 0
+                totalOperations = 2, missedOperations = 1, notImplementedOperations = 2
             )
         )
 
@@ -138,7 +136,7 @@ class ApiCoverageReportTest {
                     OpenApiCoverageConsoleRow("GET", "/order/{id}", 404, 0, 50, CoverageStatus.MISSING_IN_SPEC, showPath = false, showMethod = false),
                 ),
                 apiCoverageReport.testResultRecords,
-                totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 1, partiallyNotImplementedAPICount = 0
+                totalOperations = 1, missedOperations = 1, notImplementedOperations = 0
             )
         )
     }
@@ -166,7 +164,7 @@ class ApiCoverageReportTest {
                     OpenApiCoverageConsoleRow("POST", "/order/{id}", 201, 1, 67, CoverageStatus.COVERED),
                     OpenApiCoverageConsoleRow("POST", "/order/{id}", 400, 1, 67, CoverageStatus.COVERED, showPath = false, showMethod = false),
                     OpenApiCoverageConsoleRow("POST", "/order/{id}", 404, 0, 67, CoverageStatus.MISSING_IN_SPEC, showPath = false, showMethod = false),
-                ), apiCoverageReport.testResultRecords, totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 1, partiallyNotImplementedAPICount = 0
+                ), apiCoverageReport.testResultRecords, totalOperations = 1, missedOperations = 1, notImplementedOperations = 0
             )
         )
     }
@@ -201,7 +199,7 @@ class ApiCoverageReportTest {
                     OpenApiCoverageConsoleRow("GET", "/order/{id}", 200, 1, 0, CoverageStatus.NOT_IMPLEMENTED),
                     OpenApiCoverageConsoleRow("GET", "/order/{id}",404, 0, 0, CoverageStatus.NOT_COVERED, showPath = false, showMethod = false),
                     OpenApiCoverageConsoleRow("GET", "/orders", 0, 0, 0, CoverageStatus.MISSING_IN_SPEC),
-                ), apiCoverageReport.testResultRecords, totalEndpointsCount = 2, missedEndpointsCount = 1, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 1
+                ), apiCoverageReport.testResultRecords, totalOperations = 2, missedOperations = 1, notImplementedOperations = 1
             )
         )
     }
@@ -228,7 +226,7 @@ class ApiCoverageReportTest {
                     OpenApiCoverageConsoleRow("POST", "/order/{id}", 400, 1, 0, CoverageStatus.NOT_IMPLEMENTED, showPath = false, showMethod = false),
                     OpenApiCoverageConsoleRow("POST", "/order/{id}", 404, 0, 0, CoverageStatus.NOT_COVERED, showPath = false, showMethod = false),
                     OpenApiCoverageConsoleRow("POST", "/orders", 0, 0, 0, CoverageStatus.MISSING_IN_SPEC),
-                ), apiCoverageReport.testResultRecords, totalEndpointsCount = 2, missedEndpointsCount = 1, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 1
+                ), apiCoverageReport.testResultRecords, totalOperations = 2, missedOperations = 1, notImplementedOperations = 2
             )
         )
     }
@@ -254,7 +252,7 @@ class ApiCoverageReportTest {
                 listOf(
                     OpenApiCoverageConsoleRow("GET", "/order/{id}", 200, 1, 50, CoverageStatus.COVERED),
                     OpenApiCoverageConsoleRow("GET", "/order/{id}", 404, 0, 50, CoverageStatus.NOT_COVERED, showPath = false, showMethod = false),
-                ), apiCoverageReport.testResultRecords, totalEndpointsCount = 1, missedEndpointsCount =  0, notImplementedAPICount =  0, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount =  0
+                ), apiCoverageReport.testResultRecords, totalOperations = 1, missedOperations =  0, notImplementedOperations =  0
             )
         )
     }
@@ -278,7 +276,7 @@ class ApiCoverageReportTest {
                     OpenApiCoverageConsoleRow("POST", "/order/{id}", 201, 1, 67, CoverageStatus.COVERED),
                     OpenApiCoverageConsoleRow("POST", "/order/{id}", 400, 1, 67, CoverageStatus.COVERED, showPath = false, showMethod = false),
                     OpenApiCoverageConsoleRow("POST", "/order/{id}", 404, 0, 67, CoverageStatus.NOT_COVERED, showPath = false, showMethod = false),
-                ), apiCoverageReport.testResultRecords, totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount =  0
+                ), apiCoverageReport.testResultRecords, totalOperations = 1, missedOperations = 0, notImplementedOperations = 0
             )
         )
     }
@@ -308,7 +306,7 @@ class ApiCoverageReportTest {
                 listOf(
                     OpenApiCoverageConsoleRow("GET", "/order/{id}", 200, 1, 50, CoverageStatus.COVERED),
                     OpenApiCoverageConsoleRow("GET", "/order/{id}", 404, 0, 50, CoverageStatus.NOT_COVERED, showPath = false, showMethod = false),
-                ), apiCoverageReport.testResultRecords, totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 0
+                ), apiCoverageReport.testResultRecords, totalOperations = 1, missedOperations = 0, notImplementedOperations = 0
             )
         )
     }
@@ -335,7 +333,7 @@ class ApiCoverageReportTest {
                     OpenApiCoverageConsoleRow("POST", "/order/{id}", 201, 1, 67, CoverageStatus.COVERED),
                     OpenApiCoverageConsoleRow("POST", "/order/{id}", 400, 1, 67, CoverageStatus.COVERED, showPath = false, showMethod = false),
                     OpenApiCoverageConsoleRow("POST", "/order/{id}", 404, 0, 67, CoverageStatus.NOT_COVERED, showPath = false, showMethod = false),
-                ), apiCoverageReport.testResultRecords, totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 0
+                ), apiCoverageReport.testResultRecords, totalOperations = 1, missedOperations = 0, notImplementedOperations = 0
             )
         )
 
@@ -362,7 +360,7 @@ class ApiCoverageReportTest {
                 listOf(
                     OpenApiCoverageConsoleRow("GET", "/order/{id}", 200, 1, 50, CoverageStatus.COVERED),
                     OpenApiCoverageConsoleRow("GET", "/order/{id}", 400, 0, 50, CoverageStatus.NOT_COVERED, showPath = false, showMethod = false),
-                ), apiCoverageReport.testResultRecords, totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 0
+                ), apiCoverageReport.testResultRecords, totalOperations = 1, missedOperations = 0, notImplementedOperations = 0
             )
         )
     }
@@ -386,7 +384,7 @@ class ApiCoverageReportTest {
                     OpenApiCoverageConsoleRow("POST", "/order/{id}", 201, 1, 67, CoverageStatus.COVERED),
                     OpenApiCoverageConsoleRow("POST", "/order/{id}", 400, 1, 67, CoverageStatus.COVERED, showPath = false, showMethod = false),
                     OpenApiCoverageConsoleRow("POST", "/order/{id}", 404, 0, 67, CoverageStatus.NOT_COVERED, showPath = false, showMethod = false),
-                ), apiCoverageReport.testResultRecords, totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 0
+                ), apiCoverageReport.testResultRecords, totalOperations = 1, missedOperations = 0, notImplementedOperations = 0
             )
         )
     }
@@ -411,7 +409,7 @@ class ApiCoverageReportTest {
                 listOf(
                     OpenApiCoverageConsoleRow("GET", "/order/{id}", 200, 1, 50, CoverageStatus.COVERED),
                     OpenApiCoverageConsoleRow("GET", "/order/{id}", 404, 0, 50, CoverageStatus.MISSING_IN_SPEC, showPath = false, showMethod = false),
-                ), apiCoverageReport.testResultRecords, totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 1, partiallyNotImplementedAPICount = 0
+                ), apiCoverageReport.testResultRecords, totalOperations = 1, missedOperations = 1, notImplementedOperations = 0
             )
         )
     }
@@ -431,7 +429,7 @@ class ApiCoverageReportTest {
                 listOf(
                     OpenApiCoverageConsoleRow("GET", "/order/{id}", 200, 1, 50, CoverageStatus.COVERED),
                     OpenApiCoverageConsoleRow("GET", "/order/{id}", 404, 0, 50, CoverageStatus.MISSING_IN_SPEC, showPath = false, showMethod = false),
-                ), apiCoverageReport.testResultRecords, totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 1, partiallyNotImplementedAPICount = 0
+                ), apiCoverageReport.testResultRecords, totalOperations = 1, missedOperations = 1, notImplementedOperations = 0
             )
         )
     }
@@ -460,7 +458,7 @@ class ApiCoverageReportTest {
                 listOf(
                     OpenApiCoverageConsoleRow("GET", "/order/{id}", 200, 1, 50, CoverageStatus.COVERED),
                     OpenApiCoverageConsoleRow("GET", "/order/{id}", 404, 0, 50, CoverageStatus.NOT_COVERED, showPath = false, showMethod = false),
-                ), apiCoverageReport.testResultRecords, totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 0
+                ), apiCoverageReport.testResultRecords, totalOperations = 1, missedOperations = 0, notImplementedOperations = 0
             )
         )
     }
@@ -486,7 +484,7 @@ class ApiCoverageReportTest {
                 listOf(
                     OpenApiCoverageConsoleRow("GET", "/order/{id}", 200, 1, 50, CoverageStatus.COVERED),
                     OpenApiCoverageConsoleRow("GET", "/order/{id}", 404, 0, 50, CoverageStatus.NOT_COVERED, showPath = false, showMethod = false),
-                ), apiCoverageReport.testResultRecords, totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 0
+                ), apiCoverageReport.testResultRecords, totalOperations = 1, missedOperations = 0, notImplementedOperations = 0
             )
         )
     }
@@ -510,7 +508,7 @@ class ApiCoverageReportTest {
                 listOf(
                     OpenApiCoverageConsoleRow("GET", "/orders", 200, 1, 50, CoverageStatus.COVERED),
                     OpenApiCoverageConsoleRow("GET", "/orders", 404, 0, 50, CoverageStatus.MISSING_IN_SPEC, showPath=false, showMethod=false),
-                ), apiCoverageReport.testResultRecords, totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 1, partiallyNotImplementedAPICount = 0
+                ), apiCoverageReport.testResultRecords, totalOperations = 1, missedOperations = 1, notImplementedOperations = 0
             )
         )
     }
@@ -534,7 +532,7 @@ class ApiCoverageReportTest {
                 listOf(
                     OpenApiCoverageConsoleRow("GET", "/orders", 200, 1, 50, CoverageStatus.COVERED),
                     OpenApiCoverageConsoleRow("GET", "/orders", 404, 0, 50, CoverageStatus.NOT_COVERED, showPath = false, showMethod = false),
-                ), apiCoverageReport.testResultRecords, totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 0
+                ), apiCoverageReport.testResultRecords, totalOperations = 1, missedOperations = 0, notImplementedOperations = 0
             )
         )
     }
@@ -561,7 +559,7 @@ class ApiCoverageReportTest {
                 listOf(
                     OpenApiCoverageConsoleRow("GET", "/orders", 200, 1, 50, CoverageStatus.COVERED),
                     OpenApiCoverageConsoleRow("GET", "/orders", 404, 0, 50, CoverageStatus.NOT_COVERED, showPath = false, showMethod = false),
-                ), apiCoverageReport.testResultRecords, totalEndpointsCount = 1, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 0
+                ), apiCoverageReport.testResultRecords, totalOperations = 1, missedOperations = 0, notImplementedOperations = 0
             )
         )
     }

--- a/junit5-support/src/test/kotlin/io/specmatic/test/OpenApiCoverageConsoleReportTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/OpenApiCoverageConsoleReportTest.kt
@@ -20,7 +20,7 @@ class OpenApiCoverageConsoleReportTest {
             OpenApiCoverageConsoleRow("GET", "/route3", 200, 0, 0, CoverageStatus.NOT_COVERED),
         )
 
-        val coverageReport = OpenAPICoverageConsoleReport(rows, emptyList(), totalEndpointsCount = 3, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 1, partiallyNotImplementedAPICount = 0)
+        val coverageReport = OpenAPICoverageConsoleReport(rows, emptyList(), totalOperations = 3, missedOperations = 0, notImplementedOperations = 0)
 
         assertThat(coverageReport.totalCoveragePercentage).isEqualTo(29)
     }
@@ -41,7 +41,7 @@ class OpenApiCoverageConsoleReportTest {
             OpenApiCoverageConsoleRow("POST", "/route3", 503, 0, 67, CoverageStatus.NOT_COVERED),
         )
 
-        val coverageReport = OpenAPICoverageConsoleReport(rows, emptyList(), totalEndpointsCount = 3, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 0)
+        val coverageReport = OpenAPICoverageConsoleReport(rows, emptyList(), totalOperations = 3, missedOperations = 0, notImplementedOperations = 0)
 
         assertThat(coverageReport.totalCoveragePercentage).isEqualTo(82)
     }
@@ -56,7 +56,7 @@ class OpenApiCoverageConsoleReportTest {
             OpenApiCoverageConsoleRow("GET", "/route3", 200, 1, 0, CoverageStatus.MISSING_IN_SPEC),
         )
 
-        val coverageReport = OpenAPICoverageConsoleReport(rows, emptyList(), totalEndpointsCount = 3, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 0)
+        val coverageReport = OpenAPICoverageConsoleReport(rows, emptyList(), totalOperations = 3, missedOperations = 0, notImplementedOperations = 0)
 
         assertThat(coverageReport.totalCoveragePercentage).isEqualTo(100)
     }
@@ -71,11 +71,9 @@ class OpenApiCoverageConsoleReportTest {
         val coverageReport = OpenAPICoverageConsoleReport(
             rows,
             emptyList(),
-            totalEndpointsCount = 2,
-            missedEndpointsCount = 0,
-            notImplementedAPICount = 1,
-            partiallyMissedEndpointsCount = 0,
-            partiallyNotImplementedAPICount = 0
+            totalOperations = 2,
+            missedOperations = 0,
+            notImplementedOperations = 1
         )
 
         assertThat(coverageReport.totalCoveragePercentage).isEqualTo(50)
@@ -91,11 +89,9 @@ class OpenApiCoverageConsoleReportTest {
         val coverageReport = OpenAPICoverageConsoleReport(
             rows,
             emptyList(),
-            totalEndpointsCount = 1,
-            missedEndpointsCount = 0,
-            notImplementedAPICount = 1,
-            partiallyMissedEndpointsCount = 0,
-            partiallyNotImplementedAPICount = 0
+            totalOperations = 1,
+            missedOperations = 0,
+            notImplementedOperations = 1
         )
 
         assertThat(coverageReport.totalCoveragePercentage).isEqualTo(0)


### PR DESCRIPTION
**What**:

Refines OpenAPI coverage reporting in `junit5-support` to use operation-level metrics consistently.

- switches missed/not-implemented counting from path-level aggregation to operation-level aggregation
- renames the runtime report fields to operation-focused names
- removes partial-operation counters that no longer make sense at operation granularity
- deduplicates grouped test-result aggregation logic

**Why**:

The report model and config terminology had drifted. The code was still carrying path/endpoint-oriented names and counters even after the behavior moved to operations, which made the coverage gate and report output harder to reason about.

**How**:

- updated `OpenApiCoverageReportInput` to aggregate summary counts by operation
- simplified `OpenAPICoverageConsoleReport` to expose only `totalOperations`, `missedOperations`, and `notImplementedOperations`
- updated processor and renderer messaging to match the operation-based model
- extracted shared `groupRecords()` logic to remove duplication between coverage report classes
- updated focused tests to reflect the simplified report model

**Checklist**:

- [x] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link) N/A
- [ ] Sample Project added/updated (share link) N/A
- [ ] Demo video (share link) N/A
- [ ] Article on Website (share link) N/A
- [ ] Roadmpap updated (share link) N/A
- [ ] Conference Talk (share link) N/A

**Issue ID**:
Closes: N/A
