### PR TITLE
Use coverage status to determine missed and not-implemented operation counts

### DIFF
--- a/core/src/main/kotlin/io/specmatic/test/TestResultRecord.kt
+++ b/core/src/main/kotlin/io/specmatic/test/TestResultRecord.kt
@@ -107,22 +107,26 @@ data class TestResultRecord(
         const val CONTRACT_TEST_TEST_TYPE = "ContractTest"
 
         fun List<TestResultRecord>.getCoverageStatus(): CoverageStatus {
-            if(this.any { it.isWip }) return CoverageStatus.WIP
-
-            if (this.any { it.isExercised }) {
-                return when (this.first().result) {
-                    TestResult.NotImplemented -> CoverageStatus.NOT_IMPLEMENTED
-                    else -> CoverageStatus.COVERED
-                }
-            }
-
-            return when (val result = this.first().result) {
-                TestResult.NotCovered -> CoverageStatus.NOT_COVERED
-                TestResult.MissingInSpec -> CoverageStatus.MISSING_IN_SPEC
-                else -> throw ContractException("Cannot determine remarks for unknown test result: $result")
-            }
+            val areAnyOfTheTestsWip = this.any { it.isWip }
+            val areAnyOfTheTestsExercised = this.any { it.isExercised }
+            return this.first().toCoverageStatus(areAnyOfTheTestsWip, areAnyOfTheTestsExercised)
         }
     }
+
+    private fun toCoverageStatus(
+        isWip: Boolean,
+        isExercised: Boolean
+    ): CoverageStatus =
+        when {
+            isWip -> CoverageStatus.WIP
+            this.result == TestResult.NotImplemented -> CoverageStatus.NOT_IMPLEMENTED
+            isExercised -> CoverageStatus.COVERED
+            this.result == TestResult.NotCovered -> CoverageStatus.NOT_COVERED
+            this.result == TestResult.MissingInSpec -> CoverageStatus.MISSING_IN_SPEC
+            else -> throw ContractException(
+                "Cannot determine coverage status for API operation ${this.testName()} with unknown test result: ${this.result}"
+            )
+        }
 }
 
 fun CoverageStatus.isPresentInSpecForApiCoverage(): Boolean =

--- a/core/src/test/kotlin/io/specmatic/test/TestResultRecordTest.kt
+++ b/core/src/test/kotlin/io/specmatic/test/TestResultRecordTest.kt
@@ -2,12 +2,11 @@ package io.specmatic.test
 
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpResponse
-import io.specmatic.license.core.SpecmaticProtocol
+import io.specmatic.reporter.internal.dto.coverage.CoverageStatus
 import io.specmatic.reporter.model.SpecType
 import io.specmatic.reporter.model.TestResult
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertTrue
+import io.specmatic.test.TestResultRecord.Companion.getCoverageStatus
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import java.time.Instant
 
@@ -130,4 +129,58 @@ class TestResultRecordTest {
         assertEquals(0L, meta.inputTime)
         assertEquals(0L, meta.outputTime)
     }
+
+    @Test
+    fun `getCoverageStatus should return COVERED for exercised test results`() {
+        listOf(TestResult.Success, TestResult.Error, TestResult.Failed).forEach { result ->
+            val coverageStatus = listOf(testResultRecord(result = result)).getCoverageStatus()
+
+            assertEquals(CoverageStatus.COVERED, coverageStatus)
+        }
+    }
+
+    @Test
+    fun `getCoverageStatus should return NOT_IMPLEMENTED for not implemented results`() {
+        val coverageStatus = listOf(testResultRecord(result = TestResult.NotImplemented)).getCoverageStatus()
+
+        assertEquals(CoverageStatus.NOT_IMPLEMENTED, coverageStatus)
+    }
+
+    @Test
+    fun `getCoverageStatus should return NOT_COVERED for not covered results`() {
+        val coverageStatus = listOf(testResultRecord(result = TestResult.NotCovered)).getCoverageStatus()
+
+        assertEquals(CoverageStatus.NOT_COVERED, coverageStatus)
+    }
+
+    @Test
+    fun `getCoverageStatus should return MISSING_IN_SPEC for missing in spec results`() {
+        val coverageStatus = listOf(testResultRecord(result = TestResult.MissingInSpec)).getCoverageStatus()
+
+        assertEquals(CoverageStatus.MISSING_IN_SPEC, coverageStatus)
+    }
+
+    @Test
+    fun `getCoverageStatus should return WIP when any test is work in progress`() {
+        val coverageStatus = listOf(
+            testResultRecord(result = TestResult.Success),
+            testResultRecord(result = TestResult.Success, isWip = true)
+        ).getCoverageStatus()
+
+        assertEquals(CoverageStatus.WIP, coverageStatus)
+    }
+
+    private fun testResultRecord(
+        result: TestResult,
+        isWip: Boolean = false
+    ) = TestResultRecord(
+        path = "/example/path",
+        method = "GET",
+        responseStatus = 200,
+        request = null,
+        response = null,
+        result = result,
+        isWip = isWip,
+        specType = SpecType.OPENAPI
+    )
 }

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
@@ -8,6 +8,7 @@ import io.specmatic.reporter.ctrf.model.CtrfSpecConfig
 import io.specmatic.reporter.generated.dto.coverage.CoverageEntry
 import io.specmatic.reporter.generated.dto.coverage.OpenAPICoverageOperation
 import io.specmatic.reporter.generated.dto.coverage.SpecmaticCoverageReport
+import io.specmatic.reporter.internal.dto.coverage.CoverageStatus
 import io.specmatic.reporter.model.OpenAPIOperation
 import io.specmatic.reporter.model.SpecType
 import io.specmatic.reporter.model.TestResult
@@ -197,11 +198,11 @@ class OpenApiCoverageReportInput(
         val testsGroupedByOperation = allTests.groupByOperation()
 
         val missedOperations = testsGroupedByOperation.count { (_, tests) ->
-            tests.all { it.result == TestResult.MissingInSpec }
+            tests.getCoverageStatus() == CoverageStatus.MISSING_IN_SPEC
         }
 
         val notImplementedOperations = testsGroupedByOperation.count { (_, tests) ->
-            tests.all { it.result == TestResult.NotImplemented }
+            tests.getCoverageStatus() == CoverageStatus.NOT_IMPLEMENTED
         }
 
         return OpenAPICoverageConsoleReport(

--- a/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInputTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInputTest.kt
@@ -842,6 +842,54 @@ class OpenApiCoverageReportInputTest {
     }
 
     @Test
+    fun `should not count wip missing in spec operations as missed operations`() {
+        val allEndpoints = mutableListOf(
+            Endpoint(
+                path = "/orders", method = "GET", responseStatus = 200,
+                protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI
+            )
+        )
+
+        val testResultRecords = mutableListOf(
+            TestResultRecord(
+                "/orders",
+                "GET",
+                200,
+                request = null,
+                response = null,
+                result = TestResult.Failed,
+                actualResponseStatus = 405,
+                specType = SpecType.OPENAPI,
+                isWip = true
+            )
+        )
+
+        val reportInput = OpenApiCoverageReportInput(
+            testResultRecords = testResultRecords,
+            configFilePath = "",
+            endpointsAPISet = true,
+            applicationAPIs = mutableListOf(API("GET", "/orders")),
+            allEndpoints = allEndpoints,
+            filteredEndpoints = allEndpoints.toMutableList()
+        )
+
+        val report = reportInput.generate()
+        val wipRow = report.coverageRows.single { it.responseStatus == "405" }
+        val exercisedWipRow = report.coverageRows.single { it.responseStatus == "200" }
+
+        assertThat(report.missedOperations).isEqualTo(0)
+        assertThat(exercisedWipRow.path).isEqualTo("/orders")
+        assertThat(exercisedWipRow.method).isEqualTo("GET")
+        assertThat(exercisedWipRow.remarks).isEqualTo(CoverageStatus.WIP)
+        assertThat(exercisedWipRow.count).isEqualTo("1")
+        assertThat(wipRow.path).isEqualTo("/orders")
+        assertThat(wipRow.method).isEqualTo("GET")
+        assertThat(wipRow.responseStatus).isEqualTo("405")
+        assertThat(wipRow.remarks).isEqualTo(CoverageStatus.WIP)
+        assertThat(wipRow.count).isEqualTo("0")
+    }
+
+    @Test
     fun `should not add synthetic missing in spec record for failed tests classified as not implemented`() {
         val allEndpoints = mutableListOf(
             Endpoint(
@@ -886,6 +934,49 @@ class OpenApiCoverageReportInputTest {
         assertThat(resultRecord.responseStatus).isEqualTo(200)
         assertThat(resultRecord.result).isEqualTo(TestResult.NotImplemented)
         assertThat(report.testResultRecords).noneMatch { it.result == TestResult.MissingInSpec }
+    }
+
+    @Test
+    fun `should not count wip not implemented operations as not implemented operations`() {
+        val allEndpoints = mutableListOf(
+            Endpoint(
+                path = "/pets/search", method = "GET", responseStatus = 200,
+                protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI
+            )
+        )
+
+        val testResultRecords = mutableListOf(
+            TestResultRecord(
+                "/pets/search",
+                "GET",
+                200,
+                request = null,
+                response = null,
+                result = TestResult.Failed,
+                actualResponseStatus = 0,
+                specType = SpecType.OPENAPI,
+                isWip = true
+            )
+        )
+
+        val reportInput = OpenApiCoverageReportInput(
+            testResultRecords = testResultRecords,
+            configFilePath = "",
+            applicationAPIs = mutableListOf(API("GET", "/pets")),
+            endpointsAPISet = true,
+            allEndpoints = allEndpoints,
+            filteredEndpoints = mutableListOf(allEndpoints.first())
+        )
+
+        val report = reportInput.generate()
+        val row = report.coverageRows.single { it.path == "/pets/search" }
+
+        assertThat(report.notImplementedOperations).isEqualTo(0)
+        assertThat(row.path).isEqualTo("/pets/search")
+        assertThat(row.method).isEqualTo("GET")
+        assertThat(row.responseStatus).isEqualTo("200")
+        assertThat(row.remarks).isEqualTo(CoverageStatus.WIP)
+        assertThat(row.count).isEqualTo("1")
     }
 
     @Test


### PR DESCRIPTION
**What**:

Use coverage status, rather than raw test results, when computing missed and not-implemented operation counts in the OpenAPI coverage report.

**Why**:

WIP operations were being rendered as `WIP` in console and CTRF reports, but still counted as missed or not implemented because the aggregate counters were based on raw `MissingInSpec` / `NotImplemented` results. This made governance counts inconsistent with the final reported coverage status.

**How**:

Update coverage aggregation to derive both `missedOperations` and `notImplementedOperations` from `getCoverageStatus()`. Add regression tests covering WIP missing-in-spec and WIP not-implemented scenarios, including cases with discovered application APIs and documented spec endpoints.

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate N/A
- [ ] Security scans don't report any vulnerabilities N/A
- [ ] Documentation added/updated (share link) N/A
- [ ] Sample Project added/updated (share link) N/A
- [ ] Demo video (share link) N/A
- [ ] Article on Website (share link) N/A
- [ ] Roadmpap updated (share link) N/A
- [ ] Conference Talk (share link) N/A

**Issue ID**:
Closes: N/A
