### PR TITLE
fix: filter browser metadata headers from proxy recordings

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
@@ -614,6 +614,7 @@ val HTTP_REQUEST_TRANSPORT_HEADERS: Set<String> =
         HttpHeaders.UserAgent,
         HttpHeaders.Referrer,
         HttpHeaders.AcceptLanguage,
+        HttpHeaders.AcceptEncoding,
         HttpHeaders.Host,
         HttpHeaders.IfModifiedSince,
         HttpHeaders.IfNoneMatch,

--- a/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
@@ -576,8 +576,15 @@ private fun parseOrString(pattern: Pattern, sampleValue: String, resolver: Resol
         StringValue(sampleValue)
     }
 
-fun Map<String, String>.withoutTransportHeaders(headersToExclude: Set<String> = HTTP_TRANSPORT_HEADERS): Map<String, String> =
-    this.filterKeys { key -> key.lowercase() !in headersToExclude }
+fun Map<String, String>.withoutTransportHeaders(
+    headersToExclude: Set<String> = HTTP_TRANSPORT_HEADERS,
+    headerPrefixesToExclude: Set<String> = emptySet()
+): Map<String, String> =
+    this.filterKeys { key ->
+        val lowercasedKey = key.lowercase()
+        lowercasedKey !in headersToExclude &&
+            headerPrefixesToExclude.none { prefix -> lowercasedKey.startsWith(prefix) }
+    }
 
 fun <T> Map<String, T>.getCaseInsensitive(key: String): Map.Entry<String, T>? = this.entries.find { it.key.equals(key, ignoreCase = true) }
 
@@ -596,6 +603,11 @@ fun Map<String, Pattern>.addIfNotExistCaseInsensitiveCheckOptional(key: String, 
     return this.plus(key to value)
 }
 
+private val COMMON_HTTP_EXCLUDED_HEADERS: Set<String> =
+    listOfExcludedHeaders()
+        .toSet()
+        .minus(HttpHeaders.ContentType.lowercase())
+
 val HTTP_REQUEST_TRANSPORT_HEADERS: Set<String> =
     listOf(
         HttpHeaders.Authorization,
@@ -606,7 +618,6 @@ val HTTP_REQUEST_TRANSPORT_HEADERS: Set<String> =
         HttpHeaders.IfModifiedSince,
         HttpHeaders.IfNoneMatch,
         HttpHeaders.CacheControl,
-        "DNT",
         HttpHeaders.ContentLength,
         HttpHeaders.Range,
         HttpHeaders.Forwarded,
@@ -614,13 +625,20 @@ val HTTP_REQUEST_TRANSPORT_HEADERS: Set<String> =
         HttpHeaders.XForwardedHost,
         HttpHeaders.XForwardedPort,
         HttpHeaders.XForwardedProto,
-        "Sec-Fetch-Site",
-        "Sec-Fetch-Mode",
-        "Sec-Fetch-Dest",
+        "DNT",
         "Sec-GPC",
+        "Save-Data",
+        "Priority",
     ).map {
         it.lowercase()
     }.toSet()
+        .plus(COMMON_HTTP_EXCLUDED_HEADERS)
+
+val HTTP_REQUEST_TRANSPORT_HEADER_PREFIXES: Set<String> =
+    setOf(
+        "sec-ch-",
+        "sec-fetch-"
+    )
 
 val HTTP_RESPONSE_TRANSPORT_HEADERS: Set<String> =
     listOf(
@@ -638,10 +656,9 @@ val HTTP_RESPONSE_TRANSPORT_HEADERS: Set<String> =
     ).map {
         it.lowercase()
     }.toSet()
+        .plus(COMMON_HTTP_EXCLUDED_HEADERS)
 
 val HTTP_TRANSPORT_HEADERS: Set<String> =
     HTTP_REQUEST_TRANSPORT_HEADERS
         .plus(HTTP_RESPONSE_TRANSPORT_HEADERS)
-        .plus(listOfExcludedHeaders())
         .toSet()
-        .minus(HttpHeaders.ContentType.lowercase())

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
@@ -383,7 +383,13 @@ data class HttpRequest(
 
     fun dropIrrelevantHeaders(): HttpRequest = withoutTransportHeaders().withoutConversionHeaders().withoutSpecmaticHeaders()
 
-    fun withoutTransportHeaders(): HttpRequest = copy(headers = headers.withoutTransportHeaders(HTTP_REQUEST_TRANSPORT_HEADERS))
+    fun withoutTransportHeaders(): HttpRequest =
+        copy(
+            headers = headers.withoutTransportHeaders(
+                headersToExclude = HTTP_REQUEST_TRANSPORT_HEADERS,
+                headerPrefixesToExclude = HTTP_REQUEST_TRANSPORT_HEADER_PREFIXES
+            )
+        )
 
     fun withoutSpecmaticHeaders(): HttpRequest = copy(headers = dropSpecmaticHeaders(headers))
 

--- a/core/src/test/kotlin/io/specmatic/core/HttpRequestTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpRequestTest.kt
@@ -190,8 +190,8 @@ internal class HttpRequestTest {
             "POST",
             path = "/",
             headers = mapOf(
+                HttpHeaders.AcceptEncoding to "gzip, deflate, br",
                 "Authorization" to "Bearer DummyToken",
-                "Accept-Encoding" to "gzip, deflate, br",
                 "Sec-CH-UA-Platform" to "\"macOS\"",
                 "Sec-Fetch-User" to "?1",
                 "Save-Data" to "on",

--- a/core/src/test/kotlin/io/specmatic/core/HttpRequestTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpRequestTest.kt
@@ -189,7 +189,13 @@ internal class HttpRequestTest {
         HttpRequest(
             "POST",
             path = "/",
-            headers = mapOf("Authorization" to "Bearer DummyToken")
+            headers = mapOf(
+                "Authorization" to "Bearer DummyToken",
+                "Sec-CH-UA-Platform" to "\"macOS\"",
+                "Sec-Fetch-User" to "?1",
+                "Save-Data" to "on",
+                "Priority" to "u=1, i"
+            )
         ).withoutTransportHeaders().headers.let {
             assertThat(it).isEmpty()
         }

--- a/core/src/test/kotlin/io/specmatic/core/HttpRequestTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpRequestTest.kt
@@ -191,6 +191,7 @@ internal class HttpRequestTest {
             path = "/",
             headers = mapOf(
                 "Authorization" to "Bearer DummyToken",
+                "Accept-Encoding" to "gzip, deflate, br",
                 "Sec-CH-UA-Platform" to "\"macOS\"",
                 "Sec-Fetch-User" to "?1",
                 "Save-Data" to "on",

--- a/core/src/test/kotlin/io/specmatic/core/HttpResponseTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpResponseTest.kt
@@ -155,8 +155,23 @@ internal class HttpResponseTest {
 
     @Test
     fun `should exclude dynamic headers`() {
-        HttpResponse.OK.copy(headers = mapOf("Content-Length" to "10").withoutTransportHeaders()).let {
+        HttpResponse.OK.copy(
+            headers = mapOf(
+                "Content-Length" to "10",
+                "Transfer-Encoding" to "chunked"
+            )
+        ).withoutTransportHeaders().let {
             assertThat(it.headers).isEmpty()
+        }
+    }
+
+    @Test
+    fun `map helper should exclude common transport headers`() {
+        mapOf(
+            "Content-Length" to "10",
+            "Transfer-Encoding" to "chunked"
+        ).withoutTransportHeaders().let {
+            assertThat(it).isEmpty()
         }
     }
 

--- a/core/src/test/kotlin/io/specmatic/proxy/ProxyTest.kt
+++ b/core/src/test/kotlin/io/specmatic/proxy/ProxyTest.kt
@@ -320,6 +320,7 @@ internal class ProxyTest {
                             path = "/",
                             headers = mapOf(
                                 "DNT" to "1",
+                                "Accept-Encoding" to "gzip, deflate, br, zstd",
                                 HttpHeaders.Forwarded to "for=192.0.2.60;proto=https;host=example.com",
                                 HttpHeaders.XForwardedHost to "example.com",
                                 HttpHeaders.XForwardedPort to "443",
@@ -347,6 +348,7 @@ internal class ProxyTest {
 
         listOf(
             "DNT",
+            "Accept-Encoding",
             HttpHeaders.Forwarded,
             HttpHeaders.XForwardedHost,
             HttpHeaders.XForwardedPort,

--- a/core/src/test/kotlin/io/specmatic/proxy/ProxyTest.kt
+++ b/core/src/test/kotlin/io/specmatic/proxy/ProxyTest.kt
@@ -230,6 +230,9 @@ internal class ProxyTest {
                                 Content-Length:
                                   schema:
                                     type: string
+                                Transfer-Encoding:
+                                  schema:
+                                    type: string
                               content:
                                 text/plain:
                                   schema:
@@ -253,14 +256,15 @@ internal class ProxyTest {
                     "method": "GET",
                     "path": "/info"
                   },
-                  "http-response": {
-                    "status": 200,
-                    "headers": {
-                      "Content-Type": "text/plain",
-                      "Content-Length": "${bodyWithBaseURL.length}"
-                    },
-                    "body": "$bodyWithBaseURL"
-                  }
+                      "http-response": {
+                        "status": 200,
+                        "headers": {
+                          "Content-Type": "text/plain",
+                          "Content-Length": "${bodyWithBaseURL.length}",
+                          "Transfer-Encoding": "chunked"
+                        },
+                        "body": "$bodyWithBaseURL"
+                      }
                 }
                 """.trimIndent()
 
@@ -279,6 +283,8 @@ internal class ProxyTest {
         val observedResponse = recordedResponse ?: fail("Expected recorded response to be captured")
         assertThat(observedResponse.body.toStringLiteral()).isEqualTo("Visit /info")
         assertThat(observedResponse.getHeader(HttpHeaders.ContentLength)).isEqualTo("Visit /info".length.toString())
+        assertThat(fakeFileWriter.receivedContract).doesNotContainIgnoringCase(HttpHeaders.TransferEncoding)
+        assertThat(fakeFileWriter.receivedStub).doesNotContainIgnoringCase(HttpHeaders.TransferEncoding)
     }
 
     @Test
@@ -318,10 +324,16 @@ internal class ProxyTest {
                                 HttpHeaders.XForwardedHost to "example.com",
                                 HttpHeaders.XForwardedPort to "443",
                                 HttpHeaders.XForwardedProto to "https",
+                                "Sec-CH-UA" to "\"Brave\";v=\"135\", \"Chromium\";v=\"135\"",
+                                "Sec-CH-UA-Mobile" to "?0",
+                                "Sec-CH-UA-Platform" to "\"macOS\"",
                                 "Sec-Fetch-Site" to "cross-site",
                                 "Sec-Fetch-Mode" to "cors",
                                 "Sec-Fetch-Dest" to "empty",
+                                "Sec-Fetch-User" to "?1",
                                 "Sec-GPC" to "1",
+                                "Save-Data" to "on",
+                                "Priority" to "u=1, i",
                                 HttpHeaders.ContentType to "text/plain"
                             ),
                             body = StringValue("10")
@@ -339,10 +351,16 @@ internal class ProxyTest {
             HttpHeaders.XForwardedHost,
             HttpHeaders.XForwardedPort,
             HttpHeaders.XForwardedProto,
+            "Sec-CH-UA",
+            "Sec-CH-UA-Mobile",
+            "Sec-CH-UA-Platform",
             "Sec-Fetch-Site",
             "Sec-Fetch-Mode",
             "Sec-Fetch-Dest",
+            "Sec-Fetch-User",
             "Sec-GPC",
+            "Save-Data",
+            "Priority",
         ).forEach { headerName ->
             assertThat(fakeFileWriter.receivedContract).doesNotContainIgnoringCase("name: $headerName")
             assertThat(fakeFileWriter.receivedStub).doesNotContainIgnoringCase("\"$headerName\"")

--- a/core/src/test/kotlin/io/specmatic/proxy/ProxyTest.kt
+++ b/core/src/test/kotlin/io/specmatic/proxy/ProxyTest.kt
@@ -320,7 +320,7 @@ internal class ProxyTest {
                             path = "/",
                             headers = mapOf(
                                 "DNT" to "1",
-                                "Accept-Encoding" to "gzip, deflate, br, zstd",
+                                HttpHeaders.AcceptEncoding to "gzip, deflate, br, zstd",
                                 HttpHeaders.Forwarded to "for=192.0.2.60;proto=https;host=example.com",
                                 HttpHeaders.XForwardedHost to "example.com",
                                 HttpHeaders.XForwardedPort to "443",

--- a/core/src/test/kotlin/io/specmatic/proxy/ProxyTest.kt
+++ b/core/src/test/kotlin/io/specmatic/proxy/ProxyTest.kt
@@ -319,12 +319,12 @@ internal class ProxyTest {
                             method = "POST",
                             path = "/",
                             headers = mapOf(
-                                "DNT" to "1",
                                 HttpHeaders.AcceptEncoding to "gzip, deflate, br, zstd",
                                 HttpHeaders.Forwarded to "for=192.0.2.60;proto=https;host=example.com",
                                 HttpHeaders.XForwardedHost to "example.com",
                                 HttpHeaders.XForwardedPort to "443",
                                 HttpHeaders.XForwardedProto to "https",
+                                "DNT" to "1",
                                 "Sec-CH-UA" to "\"Brave\";v=\"135\", \"Chromium\";v=\"135\"",
                                 "Sec-CH-UA-Mobile" to "?0",
                                 "Sec-CH-UA-Platform" to "\"macOS\"",
@@ -347,12 +347,12 @@ internal class ProxyTest {
         }
 
         listOf(
-            "DNT",
-            "Accept-Encoding",
+            HttpHeaders.AcceptEncoding,
             HttpHeaders.Forwarded,
             HttpHeaders.XForwardedHost,
             HttpHeaders.XForwardedPort,
             HttpHeaders.XForwardedProto,
+            "DNT",
             "Sec-CH-UA",
             "Sec-CH-UA-Mobile",
             "Sec-CH-UA-Platform",


### PR DESCRIPTION
**What**:

Filter browser-generated metadata headers out of proxy-recorded contracts and stubs so recordings are portable across browsers.

**Why**:

Proxy recordings made from Chromium-based browsers could capture browser-specific request metadata such as `Sec-CH-UA*`. Those headers were then recorded as mandatory headers, which caused replay failures when the generated mock was used from a different browser such as Safari.

**How**:

- Extend request transport-header filtering to exclude browser metadata by prefix for `Sec-CH-*` and `Sec-Fetch-*` headers.
- Add `Save-Data` and `Priority` to the request transport-header exclusion set.
- Restore common excluded transport headers for both request and response filtering so shared transport headers like `Transfer-Encoding` are filtered consistently.
- Add regression coverage for request cleanup and proxy-recorded artifacts.

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link) N/A
- [ ] Sample Project added/updated (share link) N/A
- [ ] Demo video (share link) N/A
- [ ] Article on Website (share link) N/A
- [ ] Roadmpap updated (share link) N/A
- [ ] Conference Talk (share link) N/A

Validated locally with:
- `./gradlew :specmatic-core:test --tests "io.specmatic.core.HttpRequestTest"`
- `./gradlew :specmatic-core:test --tests "io.specmatic.core.HttpResponseTest"`
- `./gradlew :specmatic-core:test --tests "io.specmatic.proxy.ProxyTest"`

**Issue ID**:
Closes: N/A
