### PR TITLE
OpenAPI Spec Conformance Tests: Part 1

### DIFF
--- a/conformance-tests/README.md
+++ b/conformance-tests/README.md
@@ -1,0 +1,34 @@
+# Conformance Tests
+
+## Running
+
+```
+ ./gradlew :conformance-tests:check -PenableConformanceTests=true
+```
+
+Requires `Docker Compose`
+
+```
+echo 'enableConformanceTests=true' >> ~/.gradle/gradle.properties
+```
+
+## What
+
+Introduce OpenAPI Spec conformance tests. In part 1 we validate and document that Specmatic supports 001-http-methods and 002-path-parameters features from the OpenAPI specification (version 3.0.x) by running a loop test. For example a loop test of the specification 002-path-parameters/007-two-params-with-separator.yaml starts a Specmatic mock for this specification and then points a Specmatic test at it. A successful test validates that Specmatic can load, parse, mock and test such a specification.
+
+## Why
+
+This ensures and documents that Specmatic is and remains compliant with the OpenAPI specification.
+
+## Design
+
+- All of Specmatic is the System Under Test and is treated as a block box. Only the public interface (exit code and request/responses) are used to validate Specmatic's behaviour.
+- Since these are long running black box tests it's necessary to run them in parallel. We intend to add several hundreds of tests to this suite in follow up PRs. The tests depend on the docker image of Specmatic only.
+- The tests live in an independent gradle project. To run the tests please run ./gradlew :conformance-tests:check -PenableConformanceTests=true. These tests will be wired up to the main build in subsequent PRs.
+
+## Follow up features
+
+- Wire up in the main build and documentation.
+- Detailed request/response validation.
+- Header and Content-Type validations.
+- More features of OpenAPI will be exercised.

--- a/conformance-tests/build.gradle.kts
+++ b/conformance-tests/build.gradle.kts
@@ -29,3 +29,57 @@ if (enableConformanceTests?.toBoolean() == true) {
         enabled = false
     }
 }
+
+val generateConformanceTests by tasks.registering {
+    val specsDir = file("src/test/resources/specs")
+    val outputDir = file("build/generated/sources/conformance/kotlin")
+
+    inputs.dir(specsDir)
+    outputs.dir(outputDir)
+
+    doLast {
+        outputDir.deleteRecursively()
+        outputDir.mkdirs()
+
+        val specFiles = specsDir.walkTopDown()
+            .filter { it.isFile && it.extension in listOf("yaml", "yml") }
+            .map { it.relativeTo(specsDir).path.replace("\\", "/") }
+            .sorted()
+            .toList()
+
+        val header = "package conformance_tests\nimport org.junit.jupiter.api.DisplayName\n"
+
+        val classes = specFiles.joinToString("\n") { relativePath ->
+            val segments = relativePath.split("/")
+            val className = "S" + segments.joinToString("_") { segment ->
+                segment.removeSuffix(".yaml").removeSuffix(".yml")
+                    .split("-")
+                    .joinToString("") { part -> part.replaceFirstChar { it.uppercase() } }
+            } + "Test"
+
+            val displayName = relativePath.substringBefore(".")
+
+            """
+                |@DisplayName("$displayName")
+                |class $className : AbstractConformanceTest("$relativePath")
+                |""".trimMargin()
+        }
+
+        outputDir.resolve("ConformanceTests.kt").writeText(header + "\n" + classes)
+
+        println("Generated ${specFiles.size} conformance test classes")
+    }
+}
+
+kotlin {
+    sourceSets {
+        test {
+            kotlin.srcDir("build/generated/sources/conformance/kotlin")
+        }
+    }
+}
+
+tasks.named("compileTestKotlin") {
+    dependsOn(generateConformanceTests)
+}
+

--- a/conformance-tests/build.gradle.kts
+++ b/conformance-tests/build.gradle.kts
@@ -1,0 +1,31 @@
+plugins {
+    kotlin("jvm")
+}
+
+dependencies {
+    implementation("ch.qos.logback:logback-core:1.5.32")
+    implementation("org.slf4j:slf4j-api:2.0.17")
+    implementation("org.junit.platform:junit-platform-launcher:1.14.3")
+    runtimeOnly("ch.qos.logback:logback-classic:1.5.32")
+
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.14.3")
+    testImplementation("org.assertj:assertj-core:3.27.7")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.14.3")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:5.14.3")
+    testImplementation("org.assertj:assertj-core:3.27.7")
+
+}
+
+val enableConformanceTests: String? by project
+
+if (enableConformanceTests?.toBoolean() == true) {
+    tasks.test {
+        dependsOn(":specmatic-executable:dockerBuild")
+        useJUnitPlatform()
+        systemProperty("specmatic.version", project.version)
+    }
+} else {
+    tasks.test {
+        enabled = false
+    }
+}

--- a/conformance-tests/src/test/kotlin/conformance_tests/AbstractConformanceTest.kt
+++ b/conformance-tests/src/test/kotlin/conformance_tests/AbstractConformanceTest.kt
@@ -2,7 +2,6 @@ package conformance_tests
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import java.io.File
 
 abstract class AbstractConformanceTest(
     private val openAPISpecFile: String

--- a/conformance-tests/src/test/kotlin/conformance_tests/AbstractConformanceTest.kt
+++ b/conformance-tests/src/test/kotlin/conformance_tests/AbstractConformanceTest.kt
@@ -4,12 +4,14 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.io.File
 
-class ConformanceTest {
+abstract class AbstractConformanceTest(
+    private val openAPISpecFile: String
+) {
     @Test
     fun `loop test`() {
         val dockerCompose = DockerCompose(
             specmaticVersion = System.getProperty("specmatic.version"),
-            pathToOpenAPISpecFile = File("001-http-methods/001-get.yaml")
+            pathToOpenAPISpecFile = openAPISpecFile
         )
 
         try {

--- a/conformance-tests/src/test/kotlin/conformance_tests/ConformanceTest.kt
+++ b/conformance-tests/src/test/kotlin/conformance_tests/ConformanceTest.kt
@@ -1,0 +1,24 @@
+package conformance_tests
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class ConformanceTest {
+    @Test
+    fun `loop test`() {
+        val dockerCompose = DockerCompose(
+            specmaticVersion = System.getProperty("specmatic.version"),
+            pathToOpenAPISpecFile = File("001-http-methods/001-get.yaml")
+        )
+
+        try {
+            val loopTestsResult = dockerCompose.runLoopTests()
+            assertThat(loopTestsResult.isSuccessful())
+                .withFailMessage { loopTestsResult.output }
+                .isTrue
+        } finally {
+            dockerCompose.stopAsync()
+        }
+    }
+}

--- a/conformance-tests/src/test/kotlin/conformance_tests/DockerCompose.kt
+++ b/conformance-tests/src/test/kotlin/conformance_tests/DockerCompose.kt
@@ -23,7 +23,7 @@ class DockerCompose(
     fun runLoopTests(): CommandResult {
         val command = buildCommand("up", "--exit-code-from", "test")
         val process = command.start()
-        process.waitFor(30, TimeUnit.SECONDS)
+        process.waitFor(60, TimeUnit.SECONDS)
 
         return CommandResult(
             exitCode = process.exitValue(),

--- a/conformance-tests/src/test/kotlin/conformance_tests/DockerCompose.kt
+++ b/conformance-tests/src/test/kotlin/conformance_tests/DockerCompose.kt
@@ -1,0 +1,51 @@
+package conformance_tests
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+class DockerCompose(
+    private val specmaticVersion: String,
+    private val pathToOpenAPISpecFile: String,
+    private val composeProjectName: String = pathToOpenAPISpecFile
+        .substringBefore(".")
+        .replace(Regex("[^a-zA-Z0-9]"), "-")
+) {
+    val logger: Logger = LoggerFactory.getLogger(DockerCompose::class.java)
+
+    data class CommandResult(
+        val exitCode: Int, val output: String
+    ) {
+        fun isSuccessful(): Boolean = exitCode == 0
+    }
+
+    fun runLoopTests(): CommandResult {
+        val command = buildCommand("up", "--exit-code-from", "test")
+        val process = command.start()
+        process.waitFor(30, TimeUnit.SECONDS)
+
+        return CommandResult(
+            exitCode = process.exitValue(),
+            output = process.inputReader(Charsets.UTF_8).use { it.readText() }
+        ).also { logger.debug("Loop tests result: {}", it) }
+    }
+
+    fun stopAsync() {
+        buildCommand("down", "--volumes").start()
+    }
+
+    private fun buildCommand(vararg args: String): ProcessBuilder {
+        return ProcessBuilder("docker", "compose", "--project-name", composeProjectName, *args)
+            .redirectErrorStream(true)
+            .directory(File("build/resources/test"))
+            .also {
+                it.environment().putAll(
+                    mapOf(
+                        "SPECMATIC_VERSION" to specmaticVersion,
+                        "PATH_TO_OPEN_API_SPEC_FILE" to "./specs/${pathToOpenAPISpecFile}"
+                    )
+                )
+            }
+    }
+}

--- a/conformance-tests/src/test/resources/docker-compose.yaml
+++ b/conformance-tests/src/test/resources/docker-compose.yaml
@@ -16,7 +16,7 @@ services:
     image: specmatic/specmatic:${SPECMATIC_VERSION:?error}
     depends_on:
       mock:
-        condition: service_started
+        condition: service_healthy
     command: test /service.yaml --testBaseURL=http://mock:9000
     volumes:
       - ${PATH_TO_OPEN_API_SPEC_FILE:?error}:/service.yaml:ro

--- a/conformance-tests/src/test/resources/docker-compose.yaml
+++ b/conformance-tests/src/test/resources/docker-compose.yaml
@@ -1,0 +1,22 @@
+services:
+  mock:
+    image: specmatic/specmatic:${SPECMATIC_VERSION:?error}
+    command: mock /service.yaml --port 9000
+    expose:
+      - "9000"
+    volumes:
+      - ${PATH_TO_OPEN_API_SPEC_FILE:?error}:/service.yaml:ro
+    healthcheck:
+      test: [ "CMD", "wget", "-q", "--spider", "http://mock:9000/actuator/health" ]
+      interval: 2s
+      timeout: 5s
+      retries: 10
+
+  test:
+    image: specmatic/specmatic:${SPECMATIC_VERSION:?error}
+    depends_on:
+      mock:
+        condition: service_started
+    command: test /service.yaml --testBaseURL=http://mock:9000
+    volumes:
+      - ${PATH_TO_OPEN_API_SPEC_FILE:?error}:/service.yaml:ro

--- a/conformance-tests/src/test/resources/junit-platform.properties
+++ b/conformance-tests/src/test/resources/junit-platform.properties
@@ -1,0 +1,5 @@
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent
+junit.jupiter.execution.parallel.config.strategy=dynamic
+junit.jupiter.testclass.order.default=org.junit.jupiter.api.ClassOrderer$DisplayName

--- a/conformance-tests/src/test/resources/logback.xml
+++ b/conformance-tests/src/test/resources/logback.xml
@@ -1,0 +1,13 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="conformance_tests" level="debug"/>
+
+    <root level="info">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/conformance-tests/src/test/resources/specs/001-http-methods/001-get.yaml
+++ b/conformance-tests/src/test/resources/specs/001-http-methods/001-get.yaml
@@ -1,0 +1,21 @@
+openapi: 3.0.3
+info:
+  title: "GET with JSON response"
+  version: "1.0"
+paths:
+  /items:
+    get:
+      operationId: listItems
+      summary: List items
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - name
+                properties:
+                  name:
+                    type: string

--- a/conformance-tests/src/test/resources/specs/001-http-methods/002-post.yaml
+++ b/conformance-tests/src/test/resources/specs/001-http-methods/002-post.yaml
@@ -1,0 +1,32 @@
+openapi: 3.0.3
+info:
+  title: "POST with request body"
+  version: "1.0"
+paths:
+  /items:
+    post:
+      operationId: createItem
+      summary: Create an item
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+      responses:
+        '201':
+          description: Item created
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                properties:
+                  id:
+                    type: integer

--- a/conformance-tests/src/test/resources/specs/001-http-methods/003-put.yaml
+++ b/conformance-tests/src/test/resources/specs/001-http-methods/003-put.yaml
@@ -1,0 +1,41 @@
+openapi: 3.0.3
+info:
+  title: "PUT with request body"
+  version: "1.0"
+paths:
+  /items/{id}:
+    put:
+      operationId: updateItem
+      summary: Replace an item
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+      responses:
+        '200':
+          description: Item updated
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                  - name
+                properties:
+                  id:
+                    type: integer
+                  name:
+                    type: string

--- a/conformance-tests/src/test/resources/specs/001-http-methods/004-patch.yaml
+++ b/conformance-tests/src/test/resources/specs/001-http-methods/004-patch.yaml
@@ -1,0 +1,42 @@
+openapi: 3.0.3
+info:
+  title: "PATCH with partial update body"
+  version: "1.0"
+paths:
+  /items/{id}:
+    patch:
+      operationId: patchItem
+      summary: Partially update an item
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                description:
+                  type: string
+      responses:
+        '200':
+          description: Item patched
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                properties:
+                  id:
+                    type: integer
+                  name:
+                    type: string
+                  description:
+                    type: string

--- a/conformance-tests/src/test/resources/specs/001-http-methods/005-delete.yaml
+++ b/conformance-tests/src/test/resources/specs/001-http-methods/005-delete.yaml
@@ -1,0 +1,18 @@
+openapi: 3.0.3
+info:
+  title: "DELETE resource"
+  version: "1.0"
+paths:
+  /items/{id}:
+    delete:
+      operationId: deleteItem
+      summary: Delete an item
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '204':
+          description: Item deleted

--- a/conformance-tests/src/test/resources/specs/002-path-parameters/001-integer.yaml
+++ b/conformance-tests/src/test/resources/specs/002-path-parameters/001-integer.yaml
@@ -1,0 +1,55 @@
+openapi: 3.0.3
+info:
+  title: "Path parameter - integer type"
+  version: "1.0"
+paths:
+  /orders/{orderId}:
+    get:
+      operationId: getOrder
+      summary: Get order by integer ID
+      parameters:
+        - name: orderId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Order found
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - orderId
+                  - status
+                properties:
+                  orderId:
+                    type: integer
+                  status:
+                    type: string
+    post:
+      operationId: createOrder
+      parameters:
+        - name: orderId
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - orderId
+                - status
+              properties:
+                orderId:
+                  type: integer
+                status:
+                  type: string
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/002-path-parameters/002-string.yaml
+++ b/conformance-tests/src/test/resources/specs/002-path-parameters/002-string.yaml
@@ -1,0 +1,55 @@
+openapi: 3.0.3
+info:
+  title: "Path parameter - string type"
+  version: "1.0"
+paths:
+  /users/{username}:
+    get:
+      operationId: getUser
+      summary: Get user by username
+      parameters:
+        - name: username
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: User found
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - username
+                  - email
+                properties:
+                  username:
+                    type: string
+                  email:
+                    type: string
+    post:
+      operationId: createUser
+      parameters:
+        - name: username
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - username
+                - email
+              properties:
+                username:
+                  type: string
+                email:
+                  type: string
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/002-path-parameters/003-multiple.yaml
+++ b/conformance-tests/src/test/resources/specs/002-path-parameters/003-multiple.yaml
@@ -1,0 +1,71 @@
+openapi: 3.0.3
+info:
+  title: "Multiple path parameters"
+  version: "1.0"
+paths:
+  /stores/{storeId}/products/{productId}:
+    get:
+      operationId: getStoreProduct
+      summary: Get a product within a store
+      parameters:
+        - name: storeId
+          in: path
+          required: true
+          schema:
+            type: integer
+        - name: productId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Product found
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - storeId
+                  - productId
+                  - name
+                properties:
+                  storeId:
+                    type: integer
+                  productId:
+                    type: integer
+                  name:
+                    type: string
+    post:
+      operationId: createStoreProduct
+      parameters:
+        - name: storeId
+          in: path
+          required: true
+          schema:
+            type: integer
+        - name: productId
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - storeId
+                - productId
+                - name
+              properties:
+                storeId:
+                  type: integer
+                productId:
+                  type: integer
+                name:
+                  type: string
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/002-path-parameters/004-nested-resource.yaml
+++ b/conformance-tests/src/test/resources/specs/002-path-parameters/004-nested-resource.yaml
@@ -1,0 +1,67 @@
+openapi: 3.0.3
+info:
+  title: "Nested resource path"
+  version: "1.0"
+paths:
+  /organizations/{orgId}/teams/{teamId}/members:
+    get:
+      operationId: listTeamMembers
+      summary: List members of a team in an organization
+      parameters:
+        - name: orgId
+          in: path
+          required: true
+          schema:
+            type: integer
+        - name: teamId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: List of team members
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - id
+                    - name
+                  properties:
+                    id:
+                      type: integer
+                    name:
+                      type: string
+    post:
+      operationId: createTeamMembers
+      parameters:
+        - name: orgId
+          in: path
+          required: true
+          schema:
+            type: integer
+        - name: teamId
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - id
+                - name
+              properties:
+                id:
+                  type: integer
+                name:
+                  type: string
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/002-path-parameters/005-suffix-after-param.yaml
+++ b/conformance-tests/src/test/resources/specs/002-path-parameters/005-suffix-after-param.yaml
@@ -1,0 +1,61 @@
+openapi: 3.0.3
+info:
+  title: "Path parameter - suffix after parameter"
+  version: "1.0"
+paths:
+  /images/{imageId}.png:
+    get:
+      operationId: getImage
+      summary: Get image by ID with .png extension
+      parameters:
+        - name: imageId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Image metadata
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - imageId
+                  - width
+                  - height
+                properties:
+                  imageId:
+                    type: string
+                  width:
+                    type: integer
+                  height:
+                    type: integer
+    post:
+      operationId: createImage
+      parameters:
+        - name: imageId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - imageId
+                - width
+                - height
+              properties:
+                imageId:
+                  type: string
+                width:
+                  type: integer
+                height:
+                  type: integer
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/002-path-parameters/006-prefix-before-param.yaml
+++ b/conformance-tests/src/test/resources/specs/002-path-parameters/006-prefix-before-param.yaml
@@ -1,0 +1,55 @@
+openapi: 3.0.3
+info:
+  title: "Path parameter - prefix before parameter"
+  version: "1.0"
+paths:
+  /items/item-{itemId}:
+    get:
+      operationId: getItem
+      summary: Get item with prefixed path segment
+      parameters:
+        - name: itemId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Item found
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - itemId
+                  - name
+                properties:
+                  itemId:
+                    type: integer
+                  name:
+                    type: string
+    post:
+      operationId: createItem
+      parameters:
+        - name: itemId
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - itemId
+                - name
+              properties:
+                itemId:
+                  type: integer
+                name:
+                  type: string
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/002-path-parameters/007-two-params-with-separator.yaml
+++ b/conformance-tests/src/test/resources/specs/002-path-parameters/007-two-params-with-separator.yaml
@@ -1,0 +1,71 @@
+openapi: 3.0.3
+info:
+  title: "Path parameter - two parameters with dash separator"
+  version: "1.0"
+paths:
+  /widgets/{id}-v{version}:
+    get:
+      operationId: getWidgetVersion
+      summary: Get a specific version of a widget
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+        - name: version
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Widget version found
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                  - version
+                  - name
+                properties:
+                  id:
+                    type: integer
+                  version:
+                    type: integer
+                  name:
+                    type: string
+    post:
+      operationId: createWidgetVersion
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+        - name: version
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - id
+                - version
+                - name
+              properties:
+                id:
+                  type: integer
+                version:
+                  type: integer
+                name:
+                  type: string
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/002-path-parameters/008-two-params-with-comma.yaml
+++ b/conformance-tests/src/test/resources/specs/002-path-parameters/008-two-params-with-comma.yaml
@@ -1,0 +1,71 @@
+openapi: 3.0.3
+info:
+  title: "Path parameter - two parameters with comma separator"
+  version: "1.0"
+paths:
+  /files/{f1},{f2}:
+    get:
+      operationId: compareFiles
+      summary: Compare two files
+      parameters:
+        - name: f1
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: f2
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: File comparison result
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - f1
+                  - f2
+                  - identical
+                properties:
+                  f1:
+                    type: string
+                  f2:
+                    type: string
+                  identical:
+                    type: boolean
+    post:
+      operationId: createFileComparison
+      parameters:
+        - name: f1
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: f2
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - f1
+                - f2
+                - identical
+              properties:
+                f1:
+                  type: string
+                f2:
+                  type: string
+                identical:
+                  type: boolean
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/002-path-parameters/009-param-with-prefix-and-suffix.yaml
+++ b/conformance-tests/src/test/resources/specs/002-path-parameters/009-param-with-prefix-and-suffix.yaml
@@ -1,0 +1,61 @@
+openapi: 3.0.3
+info:
+  title: "Path parameter - prefix and suffix around parameter"
+  version: "1.0"
+paths:
+  /reports/report-{reportId}-summary:
+    get:
+      operationId: getReportSummary
+      summary: Get report summary with prefix and suffix in path
+      parameters:
+        - name: reportId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Report summary
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - reportId
+                  - title
+                  - total
+                properties:
+                  reportId:
+                    type: integer
+                  title:
+                    type: string
+                  total:
+                    type: number
+    post:
+      operationId: createReportSummary
+      parameters:
+        - name: reportId
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - reportId
+                - title
+                - total
+              properties:
+                reportId:
+                  type: integer
+                title:
+                  type: string
+                total:
+                  type: number
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/002-path-parameters/010-three-params-interpolated.yaml
+++ b/conformance-tests/src/test/resources/specs/002-path-parameters/010-three-params-interpolated.yaml
@@ -1,0 +1,87 @@
+openapi: 3.0.3
+info:
+  title: "Path parameter - three interpolated parameters"
+  version: "1.0"
+paths:
+  /coordinates/{lat}:{lon}:{alt}:
+    get:
+      operationId: getLocation
+      summary: Get location by colon-separated coordinates
+      parameters:
+        - name: lat
+          in: path
+          required: true
+          schema:
+            type: number
+        - name: lon
+          in: path
+          required: true
+          schema:
+            type: number
+        - name: alt
+          in: path
+          required: true
+          schema:
+            type: number
+      responses:
+        '200':
+          description: Location info
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - lat
+                  - lon
+                  - alt
+                  - label
+                properties:
+                  lat:
+                    type: number
+                  lon:
+                    type: number
+                  alt:
+                    type: number
+                  label:
+                    type: string
+    post:
+      operationId: createLocation
+      parameters:
+        - name: lat
+          in: path
+          required: true
+          schema:
+            type: number
+        - name: lon
+          in: path
+          required: true
+          schema:
+            type: number
+        - name: alt
+          in: path
+          required: true
+          schema:
+            type: number
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - lat
+                - lon
+                - alt
+                - label
+              properties:
+                lat:
+                  type: number
+                lon:
+                  type: number
+                alt:
+                  type: number
+                label:
+                  type: string
+      responses:
+        '201':
+          description: Created

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,6 +24,7 @@ include("specmatic-executable")
 include("specmatic-core")
 include("junit5-support")
 include("specmatic-mcp")
+include("conformance-tests")
 
 project(":specmatic-executable").projectDir = file("application")
 project(":specmatic-core").projectDir = file("core")


### PR DESCRIPTION
**What**:

Introduce OpenAPI Spec conformance tests. In part 1 we validate and document that Specmatic supports `001-http-methods` and `002-path-parameters` features from the OpenAPI specification (version 3.0.x) by running a loop test. For example a loop test of the specification `002-path-parameters/007-two-params-with-separator.yaml` starts a Specmatic mock for this specification and then points a Specmatic test at it. A successful test validates that Specmatic can load, parse, mock and test such a specification. 

**Why**:

This ensures and documents that Specmatic is and remains compliant with the OpenAPI specification.

**Design**:

1. All of Specmatic is the System Under Test and is treated as a block box. Only the public interface (exit code and request/responses) are used to validate Specmatic's behaviour.
2. Since these are long running black box tests it's necessary to run them in parallel. We intend to add several hundreds of tests to this suite in follow up PRs. The tests depend on the docker image of Specmatic only.
3. The tests live in an independent gradle project. To run the tests please run `./gradlew :conformance-tests:check -PenableConformanceTests=true`. These tests will be wired up to the main build in subsequent PRs.

**Follow up PRs**:
1. Wire up in the main build and documentation.
1. Detailed request/response validation.
1. Header and Content-Type validations.
1. More features of OpenAPI will be exercised.

- [X] Unit Tests
- [X] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
