### PR TITLE
OpenAPI Spec Conformance Tests: New Spec Categories

### DIFF
--- a/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/DockerCompose.kt
+++ b/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/DockerCompose.kt
@@ -31,7 +31,7 @@ class DockerCompose(
     }
 
     fun mustGetAllLogs(): String {
-        val command = buildCommand("logs", "--no-color")
+        val command = buildCommand("logs", "--no-color", "--timestamps")
         val commandResult = run(command, 5, TimeUnit.SECONDS)
         return when {
             commandResult.isSuccessful() -> commandResult.output

--- a/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/DockerCompose.kt
+++ b/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/DockerCompose.kt
@@ -23,20 +23,15 @@ class DockerCompose(
 
     fun mustGetHttpTrafficLogs(): String {
         val command = buildCommand("logs", "mitm", "--no-color", "--no-log-prefix")
-        val commandResult = run(command, 5, TimeUnit.SECONDS)
-        return when {
-            commandResult.isSuccessful() -> commandResult.output
-            else -> error("failed to fetch http traffic logs")
-        }
+        return mustRun(command, 5, TimeUnit.SECONDS)
     }
 
+    // must fetch logs individually otherwise they come out of order
     fun mustGetAllLogs(): String {
-        val command = buildCommand("logs", "--no-color", "--timestamps")
-        val commandResult = run(command, 5, TimeUnit.SECONDS)
-        return when {
-            commandResult.isSuccessful() -> commandResult.output
-            else -> error("failed to fetch all logs")
-        }
+        return listOf("mock", "test", "mitm")
+            .joinToString("\n") {
+                mustRun(buildCommand("logs", it, "--no-color"), 5, TimeUnit.SECONDS)
+            }
     }
 
     fun stopAsync() {
@@ -51,6 +46,14 @@ class DockerCompose(
             exitCode = process.exitValue(),
             output = process.inputReader(Charsets.UTF_8).use { it.readText() }
         )
+    }
+
+    private fun mustRun(command: ProcessBuilder, timeout: Long, timeUnit: TimeUnit): String {
+        val result = run(command, timeout, timeUnit)
+        return when {
+            result.isSuccessful() -> result.output
+            else -> error("failed to run ${command.command()}\nexit code: ${result.exitCode}\noutput: ${result.output}")
+        }
     }
 
     private fun buildCommand(vararg args: String): ProcessBuilder {

--- a/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/HttpExchange.kt
+++ b/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/HttpExchange.kt
@@ -40,11 +40,17 @@ data class HttpExchange(
                 .toList()
     }
 
+    // Strip parameters (boundary, charset, etc.) so the media type matches the spec's bare content type.
+    // e.g. "multipart/form-data; boundary=abc123" -> "multipart/form-data"
     val requestContentType: String?
-        get() = requestHeaders.entries.firstOrNull { it.key.equals("content-type", ignoreCase = true) }?.value
+        get() = requestHeaders.entries
+            .firstOrNull { it.key.equals("content-type", ignoreCase = true) }
+            ?.value?.substringBefore(";")?.trim()
 
     val responseContentType: String?
-        get() = responseHeaders.entries.firstOrNull { it.key.equals("content-type", ignoreCase = true) }?.value
+        get() = responseHeaders.entries
+            .firstOrNull { it.key.equals("content-type", ignoreCase = true) }
+            ?.value?.substringBefore(";")?.trim()
 
     fun isInfraRequest(): Boolean {
         return when (method) {

--- a/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/HttpExchange.kt
+++ b/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/HttpExchange.kt
@@ -54,6 +54,11 @@ data class HttpExchange(
         }
     }
 
+    val isSuccessful: Boolean
+        get() {
+            return statusCode in 200..299
+        }
+
     fun toOperation(spec: OpenApiSpec): Operation {
         return spec.toOperation(method, path, requestContentType, statusCode) ?: Operation(method, path, requestContentType, statusCode)
     }

--- a/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/HttpExchange.kt
+++ b/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/HttpExchange.kt
@@ -65,13 +65,8 @@ data class HttpExchange(
             return statusCode in 200..299
         }
 
-    fun toOperation(spec: OpenApiSpec): Operation {
-        return spec.toOperation(method, path, requestContentType, statusCode) ?: Operation(
-            method,
-            path,
-            requestContentType,
-            statusCode
-        )
+    fun toOperation(spec: OpenApiSpec): Operation? {
+        return spec.toOperation(method, path, requestContentType, statusCode)
     }
 
     fun toDebugInfo(): String {

--- a/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/HttpExchange.kt
+++ b/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/HttpExchange.kt
@@ -66,7 +66,12 @@ data class HttpExchange(
         }
 
     fun toOperation(spec: OpenApiSpec): Operation {
-        return spec.toOperation(method, path, requestContentType, statusCode) ?: Operation(method, path, requestContentType, statusCode)
+        return spec.toOperation(method, path, requestContentType, statusCode) ?: Operation(
+            method,
+            path,
+            requestContentType,
+            statusCode
+        )
     }
 
     fun toDebugInfo(): String {

--- a/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/HttpExchange.kt
+++ b/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/HttpExchange.kt
@@ -65,11 +65,10 @@ data class HttpExchange(
             return statusCode in 200..299
         }
 
-    fun toOperation(spec: OpenApiSpec): Operation? {
-        return spec.toOperation(method, path, requestContentType, statusCode)
-    }
+    fun toOperation(spec: OpenApiSpec): Operation? = spec.toOperation(method, path, requestContentType, statusCode)
 
-    fun toDebugInfo(): String {
-        return "$method $path -> $statusCode (requestContentType=$requestContentType)"
-    }
+    fun toOperation(): Operation = Operation(method, path, requestContentType, statusCode)
+
+
+    fun toDebugInfo(): String = "$method $path -> $statusCode (requestContentType=$requestContentType)"
 }

--- a/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/HttpExchange.kt
+++ b/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/HttpExchange.kt
@@ -57,4 +57,8 @@ data class HttpExchange(
     fun toOperation(spec: OpenApiSpec): Operation {
         return spec.toOperation(method, path, requestContentType, statusCode) ?: Operation(method, path, requestContentType, statusCode)
     }
+
+    fun toDebugInfo(): String {
+        return "$method $path -> $statusCode (requestContentType=$requestContentType)"
+    }
 }

--- a/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/OpenApiSpec.kt
+++ b/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/OpenApiSpec.kt
@@ -25,12 +25,15 @@ class OpenApiSpec(private val specFile: File) {
     private val openApi = run {
         val options = ParseOptions().apply {
             isResolve = true
-            isResolveFully = false
+            isResolveFully = true
         }
         val result = OpenAPIParser().readLocation(specFile.absolutePath, null, options)
         result.openAPI ?: error("Failed to parse OpenAPI spec at ${specFile.absolutePath}: ${result.messages}")
     }
 
+    // We read the raw YAML (not the fully-resolved openApi model) because json-schema-validator
+    // needs $ref pointers intact to handle discriminators correctly. Serializing the fully-resolved
+    // model inlines all $refs, which breaks discriminator-based schema selection.
     private val rootNode: JsonNode = yamlMapper.readTree(specFile)
 
     private val documentSchema: Schema = schemaRegistry.getSchema(
@@ -86,8 +89,9 @@ class OpenApiSpec(private val specFile: File) {
             return emptyList()
         }
 
-        val pointer =
-            "/paths/${operation.path.escapeJsonPointer()}/${operation.method.lowercase()}/requestBody/content/${operation.requestContentType.escapeJsonPointer()}/schema"
+        val requestBodyPath = "/paths/${operation.path.escapeJsonPointer()}/${operation.method.lowercase()}/requestBody"
+        val basePath = resolveRef(requestBodyPath)
+        val pointer = "$basePath/content/${operation.requestContentType.escapeJsonPointer()}/schema"
         return validate(pointer, body)
     }
 
@@ -99,16 +103,25 @@ class OpenApiSpec(private val specFile: File) {
             return emptyList()
         }
 
-        val pointer =
-            "/paths/${operation.path.escapeJsonPointer()}/${operation.method.lowercase()}/responses/${operation.statusCode}/content/${responseContentType.escapeJsonPointer()}/schema"
+        val responsePath = "/paths/${operation.path.escapeJsonPointer()}/${operation.method.lowercase()}/responses/${operation.statusCode}"
+        val basePath = resolveRef(responsePath)
+        val pointer = "$basePath/content/${responseContentType.escapeJsonPointer()}/schema"
         return validate(pointer, body)
     }
 
-    private fun validate(pointer: String, body: String): List<Error> {
-        val schemaNode = rootNode.at(pointer)
-        if (schemaNode.isMissingNode) {
-            error("can't find schema for $pointer in $specFile")
+    // Since rootNode preserves the raw YAML (see comment above), a node at a given path may be
+    // a $ref rather than an inline definition (e.g. `requestBody: {$ref: '#/components/requestBodies/Foo'}`).
+    // In that case, we follow the $ref so the caller can continue building the pointer from the target.
+    private fun resolveRef(path: String): String {
+        val node = rootNode.at(path)
+        return if (node.has("\$ref")) {
+            node.get("\$ref").asText().removePrefix("#")
+        } else {
+            path
         }
+    }
+
+    private fun validate(pointer: String, body: String): List<Error> {
         val subSchema = documentSchema.getRefSchema(SchemaLocation.Fragment.of(pointer))
         return subSchema.validate(yamlMapper.readTree(body))
     }

--- a/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/OpenApiSpec.kt
+++ b/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/OpenApiSpec.kt
@@ -11,6 +11,7 @@ import com.networknt.schema.dialect.Dialects
 import io.swagger.parser.OpenAPIParser
 import io.swagger.v3.oas.models.PathItem
 import io.swagger.v3.parser.core.models.ParseOptions
+import org.slf4j.LoggerFactory
 import java.io.File
 import io.swagger.v3.oas.models.Operation as SwaggerOperation
 
@@ -19,9 +20,17 @@ data class Operation(
     val path: String,
     val requestContentType: String?,
     val statusCode: Int
-)
+) {
+    fun hasRequestContentType(): Boolean = requestContentType != null
+
+    fun isJsonContent(): Boolean = hasRequestContentType() && requestContentType!!.lowercase().contains("json")
+
+    fun isYamlContent(): Boolean = hasRequestContentType() && requestContentType!!.lowercase().contains("yaml")
+}
 
 class OpenApiSpec(private val specFile: File) {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
     private val openApi = run {
         val options = ParseOptions().apply {
             isResolve = true
@@ -82,28 +91,29 @@ class OpenApiSpec(private val specFile: File) {
         }?.key
 
     fun validateRequestBody(body: String, operation: Operation): List<Error> {
-        // No request body because this operation does not have request content
-        // We verify that all valid request bodies have been sent because we check that all valid operations have been exercised
-        // in the conformance tests
-        if (operation.requestContentType == null) {
-            return emptyList()
-        }
+        require(operation.hasRequestContentType())
 
-        val requestBodyPath = "/paths/${operation.path.escapeJsonPointer()}/${operation.method.lowercase()}/requestBody"
-        val basePath = resolveRef(requestBodyPath)
-        val pointer = "$basePath/content/${operation.requestContentType.escapeJsonPointer()}/schema"
-        return validate(pointer, body)
+        return when {
+            operation.isJsonContent() || operation.isYamlContent() -> {
+                val requestBodyPath =
+                    "/paths/${operation.path.escapeJsonPointer()}/${operation.method.lowercase()}/requestBody"
+                val basePath = resolveRef(requestBodyPath)
+                val pointer = "$basePath/content/${operation.requestContentType!!.escapeJsonPointer()}/schema"
+                validate(pointer, body)
+            }
+
+            else -> {
+                logger.warn("no support for validating requests of type ${operation.requestContentType}\nbody=${body}")
+                emptyList()
+            }
+        }
     }
 
     fun validateResponseBody(
-        body: String, operation: Operation, responseContentType: String?
+        body: String, operation: Operation, responseContentType: String
     ): List<Error> {
-        // See comment in validateRequestBody for details
-        if (responseContentType == null) {
-            return emptyList()
-        }
-
-        val responsePath = "/paths/${operation.path.escapeJsonPointer()}/${operation.method.lowercase()}/responses/${operation.statusCode}"
+        val responsePath =
+            "/paths/${operation.path.escapeJsonPointer()}/${operation.method.lowercase()}/responses/${operation.statusCode}"
         val basePath = resolveRef(responsePath)
         val pointer = "$basePath/content/${responseContentType.escapeJsonPointer()}/schema"
         return validate(pointer, body)
@@ -114,8 +124,8 @@ class OpenApiSpec(private val specFile: File) {
     // In that case, we follow the $ref so the caller can continue building the pointer from the target.
     private fun resolveRef(path: String): String {
         val node = rootNode.at(path)
-        return if (node.has("\$ref")) {
-            node.get("\$ref").asText().removePrefix("#")
+        return if (node.has($$"$ref")) {
+            node.get($$"$ref").asText().removePrefix("#")
         } else {
             path
         }
@@ -140,7 +150,8 @@ class OpenApiSpec(private val specFile: File) {
     private fun String.escapeJsonPointer(): String = replace("~", "~0").replace("/", "~1")
 
     companion object {
-        private val schemaRegistry = SchemaRegistry.withDialect(Dialects.getOpenApi30()) // TODO: Make this configurable when we add OpenAPI 3.1 specs
+        private val schemaRegistry =
+            SchemaRegistry.withDialect(Dialects.getOpenApi30()) // TODO: Make this configurable when we add OpenAPI 3.1 specs
         private val yamlMapper = ObjectMapper(YAMLFactory())
     }
 }

--- a/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/OpenApiSpec.kt
+++ b/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/OpenApiSpec.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.networknt.schema.Error
 import com.networknt.schema.SchemaRegistry
 import com.networknt.schema.SpecificationVersion
+import com.networknt.schema.dialect.Dialects
 import io.swagger.parser.OpenAPIParser
 import io.swagger.v3.oas.models.PathItem
 import io.swagger.v3.parser.core.models.ParseOptions
@@ -122,7 +123,7 @@ class OpenApiSpec(private val specFile: File) {
     private fun String.escapeJsonPointer(): String = replace("~", "~0").replace("/", "~1")
 
     companion object {
-        private val schemaRegistry = SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_7)
+        private val schemaRegistry = SchemaRegistry.withDialect(Dialects.getOpenApi30()) // TODO: Make this configurable when we add OpenAPI 3.1 specs
         private val yamlMapper = ObjectMapper(YAMLFactory())
     }
 }

--- a/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/OpenApiSpec.kt
+++ b/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/OpenApiSpec.kt
@@ -4,13 +4,13 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.networknt.schema.Error
+import com.networknt.schema.Schema
+import com.networknt.schema.SchemaLocation
 import com.networknt.schema.SchemaRegistry
-import com.networknt.schema.SpecificationVersion
 import com.networknt.schema.dialect.Dialects
 import io.swagger.parser.OpenAPIParser
 import io.swagger.v3.oas.models.PathItem
 import io.swagger.v3.parser.core.models.ParseOptions
-import io.swagger.v3.core.util.Json
 import java.io.File
 import io.swagger.v3.oas.models.Operation as SwaggerOperation
 
@@ -25,13 +25,17 @@ class OpenApiSpec(private val specFile: File) {
     private val openApi = run {
         val options = ParseOptions().apply {
             isResolve = true
-            isResolveFully = true
+            isResolveFully = false
         }
         val result = OpenAPIParser().readLocation(specFile.absolutePath, null, options)
         result.openAPI ?: error("Failed to parse OpenAPI spec at ${specFile.absolutePath}: ${result.messages}")
     }
 
-    private val rootNode: JsonNode = Json.mapper().valueToTree(openApi)
+    private val rootNode: JsonNode = yamlMapper.readTree(specFile)
+
+    private val documentSchema: Schema = schemaRegistry.getSchema(
+        SchemaLocation.of(specFile.toURI().toString()), rootNode
+    )
 
     val operations: Set<Operation> = openApi.paths.orEmpty().flatMap { (path, item) ->
         item.readOperationsMap().flatMap { (swaggerMethod: PathItem.HttpMethod, swaggerOperation: SwaggerOperation) ->
@@ -105,8 +109,8 @@ class OpenApiSpec(private val specFile: File) {
         if (schemaNode.isMissingNode) {
             error("can't find schema for $pointer in $specFile")
         }
-        val jsonSchema = schemaRegistry.getSchema(schemaNode)
-        return jsonSchema.validate(yamlMapper.readTree(body))
+        val subSchema = documentSchema.getRefSchema(SchemaLocation.Fragment.of(pointer))
+        return subSchema.validate(yamlMapper.readTree(body))
     }
 
 

--- a/conformance-tests/src/test/kotlin/io/specmatic/conformance_tests/AbstractConformanceTest.kt
+++ b/conformance-tests/src/test/kotlin/io/specmatic/conformance_tests/AbstractConformanceTest.kt
@@ -7,7 +7,6 @@ import io.specmatic.conformance_test_support.OpenApiSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation
-import org.slf4j.LoggerFactory
 import java.io.File
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -17,8 +16,6 @@ abstract class AbstractConformanceTest(
     private val workDir: File = File("build/resources/test"),
     private val specsDirName: String = "specs"
 ) {
-    private val logger = LoggerFactory.getLogger(this::class.java)
-
     private lateinit var dockerCompose: DockerCompose
     private lateinit var loopTestsResult: DockerCompose.CommandResult
     private lateinit var allLogs: String
@@ -87,11 +84,11 @@ abstract class AbstractConformanceTest(
             .filter(HttpExchange::isSuccessful)
             // requests without a requestContentType cannot have bodies
             // In the previous test we have validated that all requests are valid so we can safely skip these here
-            .filter { it.toOperation(spec).hasRequestContentType() }
+            .filter { it.toOperation(spec)?.hasRequestContentType() == true }
             .flatMap {
                 spec.validateRequestBody(
                     body = it.requestBody,
-                    operation = it.toOperation(spec)
+                    operation = it.toOperation(spec)!!
                 )
             }
 
@@ -105,13 +102,19 @@ abstract class AbstractConformanceTest(
     @Test
     @Order(5)
     fun `should return valid response bodies`() {
-        val errors = httpExchanges.flatMap {
-            spec.validateResponseBody(
-                body = it.responseBody,
-                operation = it.toOperation(spec),
-                responseContentType = it.responseContentType
-            )
-        }
+        val errors = httpExchanges
+            // Only validate responses for operations defined in the spec.
+            // When Specmatic's mock rejects a request, it returns a 400 text/plain error that isn't
+            // in the spec — attempting to resolve its schema pointer would throw InvalidSchemaRefException.
+            // Those failures are already caught by the "loop tests should succeed" test.
+            .filterNot { it.toOperation(spec) == null }
+            .flatMap {
+                spec.validateResponseBody(
+                    body = it.responseBody,
+                    operation = it.toOperation(spec)!!,
+                    responseContentType = it.responseContentType!!
+                )
+            }
 
         assertThat(errors)
             .withFailMessage {

--- a/conformance-tests/src/test/kotlin/io/specmatic/conformance_tests/AbstractConformanceTest.kt
+++ b/conformance-tests/src/test/kotlin/io/specmatic/conformance_tests/AbstractConformanceTest.kt
@@ -62,13 +62,14 @@ abstract class AbstractConformanceTest(
         debugInfoBuilder.appendLine("Operations defined in spec (${specOps.size}): $specOps")
         debugInfoBuilder.appendLine("HTTP exchanges captured (${httpExchanges.size}): ${httpExchanges.joinToString("\n") { it.toDebugInfo() }}")
 
-        val exchangeOps = httpExchanges.map { it.toOperation(spec) }.toSet()
+        val exchangeOps = httpExchanges.map { it.toOperation(spec) ?: it.toOperation() }.toSet()
         debugInfoBuilder.appendLine("HTTP exchanges mapped to operations (${httpExchanges.size} exchanges -> ${exchangeOps.size} unique operations): $exchangeOps")
 
         assertThat(specOps)
             .withFailMessage {
                 debugInfoBuilder
-                    .appendLine("specOps - exchangeOps: ${specOps - exchangeOps}")
+                    .appendLine("Missing Operations: ${specOps - exchangeOps}")
+                    .appendLine("Extra Operations: ${exchangeOps - specOps}")
                     .appendLine()
                     .appendLine(allLogs)
                     .toString()
@@ -94,7 +95,7 @@ abstract class AbstractConformanceTest(
 
         assertThat(errors)
             .withFailMessage {
-                "error=$errors\n\nrequests=${httpExchanges.joinToString("\n") { it.requestBody }}\n\nallLogs=$allLogs"
+                "error=$errors\n\nrequests=${httpExchanges.joinToString("\n") { it.requestBody }}\n\n$allLogs"
             }
             .isEmpty()
     }
@@ -121,7 +122,7 @@ abstract class AbstractConformanceTest(
 
         assertThat(errors)
             .withFailMessage {
-                "errors=$errors\n\nresponses=${httpExchanges.joinToString("\n") { it.responseBody }}\n\nallLogs=$allLogs"
+                "errors=$errors\n\nresponses=${httpExchanges.joinToString("\n") { it.responseBody }}\n\n$allLogs"
             }
             .isEmpty()
     }

--- a/conformance-tests/src/test/kotlin/io/specmatic/conformance_tests/AbstractConformanceTest.kt
+++ b/conformance-tests/src/test/kotlin/io/specmatic/conformance_tests/AbstractConformanceTest.kt
@@ -72,6 +72,7 @@ abstract class AbstractConformanceTest(
             .withFailMessage {
                 debugInfoBuilder
                     .appendLine("specOps - exchangeOps: ${specOps - exchangeOps}")
+                    .appendLine()
                     .appendLine(allLogs)
                     .toString()
             }

--- a/conformance-tests/src/test/kotlin/io/specmatic/conformance_tests/AbstractConformanceTest.kt
+++ b/conformance-tests/src/test/kotlin/io/specmatic/conformance_tests/AbstractConformanceTest.kt
@@ -108,6 +108,9 @@ abstract class AbstractConformanceTest(
             // in the spec — attempting to resolve its schema pointer would throw InvalidSchemaRefException.
             // Those failures are already caught by the "loop tests should succeed" test.
             .filterNot { it.toOperation(spec) == null }
+            // http exchanges without a response are excluded from this validation.
+            // In the test number 2 (@Order = 2) we have validated that all requests are spec compliant
+            .filterNot { it.responseContentType == null }
             .flatMap {
                 spec.validateResponseBody(
                     body = it.responseBody,

--- a/conformance-tests/src/test/kotlin/io/specmatic/conformance_tests/AbstractConformanceTest.kt
+++ b/conformance-tests/src/test/kotlin/io/specmatic/conformance_tests/AbstractConformanceTest.kt
@@ -81,7 +81,10 @@ abstract class AbstractConformanceTest(
     @Test
     @Order(4)
     fun `should send valid request bodies`() {
-        val errors = httpExchanges.flatMap {
+        val errors = httpExchanges
+            // requests in the test that produce 4xx, 5xx may contain invalid request bodies by design
+            .filter(HttpExchange::isSuccessful)
+            .flatMap {
             spec.validateRequestBody(
                 body = it.requestBody,
                 operation = it.toOperation(spec)

--- a/conformance-tests/src/test/kotlin/io/specmatic/conformance_tests/AbstractConformanceTest.kt
+++ b/conformance-tests/src/test/kotlin/io/specmatic/conformance_tests/AbstractConformanceTest.kt
@@ -85,16 +85,19 @@ abstract class AbstractConformanceTest(
         val errors = httpExchanges
             // requests in the test that produce 4xx, 5xx may contain invalid request bodies by design
             .filter(HttpExchange::isSuccessful)
+            // requests without a requestContentType cannot have bodies
+            // In the previous test we have validated that all requests are valid so we can safely skip these here
+            .filter { it.toOperation(spec).hasRequestContentType() }
             .flatMap {
-            spec.validateRequestBody(
-                body = it.requestBody,
-                operation = it.toOperation(spec)
-            )
-        }
+                spec.validateRequestBody(
+                    body = it.requestBody,
+                    operation = it.toOperation(spec)
+                )
+            }
 
         assertThat(errors)
             .withFailMessage {
-                "error=$errors requests=${httpExchanges.joinToString("\n") { it.requestBody }}\nallLogs=$allLogs"
+                "error=$errors\n\nrequests=${httpExchanges.joinToString("\n") { it.requestBody }}\n\nallLogs=$allLogs"
             }
             .isEmpty()
     }
@@ -112,7 +115,7 @@ abstract class AbstractConformanceTest(
 
         assertThat(errors)
             .withFailMessage {
-                "errors=$errors responses=${httpExchanges.joinToString("\n") { it.responseBody }}\nallLogs=$allLogs"
+                "errors=$errors\n\nresponses=${httpExchanges.joinToString("\n") { it.responseBody }}\n\nallLogs=$allLogs"
             }
             .isEmpty()
     }

--- a/conformance-tests/src/test/kotlin/io/specmatic/conformance_tests/AbstractConformanceTest.kt
+++ b/conformance-tests/src/test/kotlin/io/specmatic/conformance_tests/AbstractConformanceTest.kt
@@ -61,20 +61,20 @@ abstract class AbstractConformanceTest(
     @Order(2)
     fun `should only exercise all operations in the openAPI spec and not make any additional non-compliant requests`() {
         val specOps = spec.operations
-
-        logger.info("Operations defined in spec (${specOps.size}):")
-        specOps.forEach { logger.info("  $it") }
-
-        logger.info("HTTP exchanges captured (${httpExchanges.size}):")
-        httpExchanges.forEach { logger.info("  ${it.method} ${it.path} -> ${it.statusCode} (requestContentType=${it.requestContentType})") }
+        val debugInfoBuilder = StringBuilder()
+        debugInfoBuilder.appendLine("Operations defined in spec (${specOps.size}): $specOps")
+        debugInfoBuilder.appendLine("HTTP exchanges captured (${httpExchanges.size}): ${httpExchanges.joinToString("\n") { it.toDebugInfo() }}")
 
         val exchangeOps = httpExchanges.map { it.toOperation(spec) }.toSet()
-
-        logger.info("HTTP exchanges mapped to operations (${httpExchanges.size} exchanges -> ${exchangeOps.size} unique operations):")
-        exchangeOps.forEach { logger.info("  $it") }
+        debugInfoBuilder.appendLine("HTTP exchanges mapped to operations (${httpExchanges.size} exchanges -> ${exchangeOps.size} unique operations): $exchangeOps")
 
         assertThat(specOps)
-            .withFailMessage { allLogs }
+            .withFailMessage {
+                debugInfoBuilder
+                    .appendLine("specOps - exchangeOps: ${specOps - exchangeOps}")
+                    .appendLine(allLogs)
+                    .toString()
+            }
             .isEqualTo(exchangeOps)
     }
 

--- a/conformance-tests/src/test/resources/logback.xml
+++ b/conformance-tests/src/test/resources/logback.xml
@@ -6,6 +6,7 @@
     </appender>
 
     <logger name="conformance_tests" level="debug"/>
+    <logger name="com.networknt.schema.keyword.UnknownKeywordFactory" level="error"/>
 
     <root level="info">
         <appender-ref ref="STDOUT"/>

--- a/conformance-tests/src/test/resources/specs/008-constraints/001-string-minlength.yaml
+++ b/conformance-tests/src/test/resources/specs/008-constraints/001-string-minlength.yaml
@@ -1,0 +1,46 @@
+openapi: 3.0.3
+info:
+  title: "Constraint - string minLength"
+  version: "1.0"
+paths:
+  /usernames:
+    get:
+      operationId: listUsernames
+      responses:
+        '200':
+          description: Username list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - id
+                    - username
+                  properties:
+                    id:
+                      type: integer
+                    username:
+                      type: string
+                      minLength: 3
+    post:
+      operationId: createUsername
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - id
+                - username
+              properties:
+                id:
+                  type: integer
+                username:
+                  type: string
+                  minLength: 3
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/008-constraints/002-string-maxlength.yaml
+++ b/conformance-tests/src/test/resources/specs/008-constraints/002-string-maxlength.yaml
@@ -1,0 +1,46 @@
+openapi: 3.0.3
+info:
+  title: "Constraint - string maxLength"
+  version: "1.0"
+paths:
+  /tags:
+    get:
+      operationId: listTags
+      responses:
+        '200':
+          description: Tag list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - id
+                    - label
+                  properties:
+                    id:
+                      type: integer
+                    label:
+                      type: string
+                      maxLength: 20
+    post:
+      operationId: createTag
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - id
+                - label
+              properties:
+                id:
+                  type: integer
+                label:
+                  type: string
+                  maxLength: 20
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/008-constraints/003-string-minlength-maxlength.yaml
+++ b/conformance-tests/src/test/resources/specs/008-constraints/003-string-minlength-maxlength.yaml
@@ -1,0 +1,48 @@
+openapi: 3.0.3
+info:
+  title: "Constraint - string minLength and maxLength"
+  version: "1.0"
+paths:
+  /slugs:
+    get:
+      operationId: listSlugs
+      responses:
+        '200':
+          description: Slug list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - id
+                    - slug
+                  properties:
+                    id:
+                      type: integer
+                    slug:
+                      type: string
+                      minLength: 2
+                      maxLength: 30
+    post:
+      operationId: createSlug
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - id
+                - slug
+              properties:
+                id:
+                  type: integer
+                slug:
+                  type: string
+                  minLength: 2
+                  maxLength: 30
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/008-constraints/004-string-pattern.yaml
+++ b/conformance-tests/src/test/resources/specs/008-constraints/004-string-pattern.yaml
@@ -1,0 +1,46 @@
+openapi: 3.0.3
+info:
+  title: "Constraint - string pattern (regex)"
+  version: "1.0"
+paths:
+  /postcodes:
+    get:
+      operationId: listPostcodes
+      responses:
+        '200':
+          description: Postcode list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - city
+                    - postcode
+                  properties:
+                    city:
+                      type: string
+                    postcode:
+                      type: string
+                      pattern: "^[A-Z]{1,2}[0-9]{1,2}[A-Z]? [0-9][A-Z]{2}$"
+    post:
+      operationId: createPostcode
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - city
+                - postcode
+              properties:
+                city:
+                  type: string
+                postcode:
+                  type: string
+                  pattern: "^[A-Z]{1,2}[0-9]{1,2}[A-Z]? [0-9][A-Z]{2}$"
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/008-constraints/005-integer-minimum.yaml
+++ b/conformance-tests/src/test/resources/specs/008-constraints/005-integer-minimum.yaml
@@ -1,0 +1,46 @@
+openapi: 3.0.3
+info:
+  title: "Constraint - integer minimum"
+  version: "1.0"
+paths:
+  /scores:
+    get:
+      operationId: listScores
+      responses:
+        '200':
+          description: Score list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - player
+                    - score
+                  properties:
+                    player:
+                      type: string
+                    score:
+                      type: integer
+                      minimum: 0
+    post:
+      operationId: createScore
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - player
+                - score
+              properties:
+                player:
+                  type: string
+                score:
+                  type: integer
+                  minimum: 0
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/008-constraints/006-integer-maximum.yaml
+++ b/conformance-tests/src/test/resources/specs/008-constraints/006-integer-maximum.yaml
@@ -1,0 +1,46 @@
+openapi: 3.0.3
+info:
+  title: "Constraint - integer maximum"
+  version: "1.0"
+paths:
+  /ratings:
+    get:
+      operationId: listRatings
+      responses:
+        '200':
+          description: Rating list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - item
+                    - rating
+                  properties:
+                    item:
+                      type: string
+                    rating:
+                      type: integer
+                      maximum: 5
+    post:
+      operationId: createRating
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - item
+                - rating
+              properties:
+                item:
+                  type: string
+                rating:
+                  type: integer
+                  maximum: 5
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/008-constraints/007-integer-minimum-maximum.yaml
+++ b/conformance-tests/src/test/resources/specs/008-constraints/007-integer-minimum-maximum.yaml
@@ -1,0 +1,48 @@
+openapi: 3.0.3
+info:
+  title: "Constraint - integer minimum and maximum"
+  version: "1.0"
+paths:
+  /percentages:
+    get:
+      operationId: listPercentages
+      responses:
+        '200':
+          description: Percentage list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - label
+                    - value
+                  properties:
+                    label:
+                      type: string
+                    value:
+                      type: integer
+                      minimum: 0
+                      maximum: 100
+    post:
+      operationId: createPercentage
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - label
+                - value
+              properties:
+                label:
+                  type: string
+                value:
+                  type: integer
+                  minimum: 0
+                  maximum: 100
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/008-constraints/008-integer-exclusive-min-max.yaml
+++ b/conformance-tests/src/test/resources/specs/008-constraints/008-integer-exclusive-min-max.yaml
@@ -1,0 +1,48 @@
+openapi: 3.0.3
+info:
+  title: "Constraint - integer exclusiveMinimum and exclusiveMaximum"
+  version: "1.0"
+paths:
+  /temperatures:
+    get:
+      operationId: listTemperatures
+      responses:
+        '200':
+          description: Temperature list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - sensor
+                    - celsius
+                  properties:
+                    sensor:
+                      type: string
+                    celsius:
+                      type: integer
+                      exclusiveMinimum: -273
+                      exclusiveMaximum: 1000
+    post:
+      operationId: createTemperature
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - sensor
+                - celsius
+              properties:
+                sensor:
+                  type: string
+                celsius:
+                  type: integer
+                  exclusiveMinimum: -273
+                  exclusiveMaximum: 1000
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/008-constraints/009-integer-multipleof.yaml
+++ b/conformance-tests/src/test/resources/specs/008-constraints/009-integer-multipleof.yaml
@@ -1,0 +1,46 @@
+openapi: 3.0.3
+info:
+  title: "Constraint - integer multipleOf"
+  version: "1.0"
+paths:
+  /quantities:
+    get:
+      operationId: listQuantities
+      responses:
+        '200':
+          description: Quantity list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - product
+                    - quantity
+                  properties:
+                    product:
+                      type: string
+                    quantity:
+                      type: integer
+                      multipleOf: 6
+    post:
+      operationId: createQuantity
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - product
+                - quantity
+              properties:
+                product:
+                  type: string
+                quantity:
+                  type: integer
+                  multipleOf: 6
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/008-constraints/010-number-minimum-maximum.yaml
+++ b/conformance-tests/src/test/resources/specs/008-constraints/010-number-minimum-maximum.yaml
@@ -1,0 +1,48 @@
+openapi: 3.0.3
+info:
+  title: "Constraint - number minimum and maximum"
+  version: "1.0"
+paths:
+  /measurements:
+    get:
+      operationId: listMeasurements
+      responses:
+        '200':
+          description: Measurement list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - label
+                    - value
+                  properties:
+                    label:
+                      type: string
+                    value:
+                      type: number
+                      minimum: 0.0
+                      maximum: 999.99
+    post:
+      operationId: createMeasurement
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - label
+                - value
+              properties:
+                label:
+                  type: string
+                value:
+                  type: number
+                  minimum: 0.0
+                  maximum: 999.99
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/008-constraints/011-number-multipleof.yaml
+++ b/conformance-tests/src/test/resources/specs/008-constraints/011-number-multipleof.yaml
@@ -1,0 +1,46 @@
+openapi: 3.0.3
+info:
+  title: "Constraint - number multipleOf (decimal)"
+  version: "1.0"
+paths:
+  /prices:
+    get:
+      operationId: listPrices
+      responses:
+        '200':
+          description: Price list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - item
+                    - price
+                  properties:
+                    item:
+                      type: string
+                    price:
+                      type: number
+                      multipleOf: 0.01
+    post:
+      operationId: createPrice
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - item
+                - price
+              properties:
+                item:
+                  type: string
+                price:
+                  type: number
+                  multipleOf: 0.01
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/008-constraints/012-array-minitems.yaml
+++ b/conformance-tests/src/test/resources/specs/008-constraints/012-array-minitems.yaml
@@ -1,0 +1,50 @@
+openapi: 3.0.3
+info:
+  title: "Constraint - array minItems"
+  version: "1.0"
+paths:
+  /teams:
+    get:
+      operationId: listTeams
+      responses:
+        '200':
+          description: Team list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - name
+                    - members
+                  properties:
+                    name:
+                      type: string
+                    members:
+                      type: array
+                      minItems: 1
+                      items:
+                        type: string
+    post:
+      operationId: createTeam
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+                - members
+              properties:
+                name:
+                  type: string
+                members:
+                  type: array
+                  minItems: 1
+                  items:
+                    type: string
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/008-constraints/013-array-maxitems.yaml
+++ b/conformance-tests/src/test/resources/specs/008-constraints/013-array-maxitems.yaml
@@ -1,0 +1,50 @@
+openapi: 3.0.3
+info:
+  title: "Constraint - array maxItems"
+  version: "1.0"
+paths:
+  /polls:
+    get:
+      operationId: listPolls
+      responses:
+        '200':
+          description: Poll list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - question
+                    - choices
+                  properties:
+                    question:
+                      type: string
+                    choices:
+                      type: array
+                      maxItems: 5
+                      items:
+                        type: string
+    post:
+      operationId: createPoll
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - question
+                - choices
+              properties:
+                question:
+                  type: string
+                choices:
+                  type: array
+                  maxItems: 5
+                  items:
+                    type: string
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/008-constraints/014-array-uniqueitems.yaml
+++ b/conformance-tests/src/test/resources/specs/008-constraints/014-array-uniqueitems.yaml
@@ -1,0 +1,50 @@
+openapi: 3.0.3
+info:
+  title: "Constraint - array uniqueItems"
+  version: "1.0"
+paths:
+  /tag-sets:
+    get:
+      operationId: listTagSets
+      responses:
+        '200':
+          description: Tag set list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - name
+                    - tags
+                  properties:
+                    name:
+                      type: string
+                    tags:
+                      type: array
+                      uniqueItems: true
+                      items:
+                        type: string
+    post:
+      operationId: createTagSet
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+                - tags
+              properties:
+                name:
+                  type: string
+                tags:
+                  type: array
+                  uniqueItems: true
+                  items:
+                    type: string
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/008-constraints/015-object-minproperties.yaml
+++ b/conformance-tests/src/test/resources/specs/008-constraints/015-object-minproperties.yaml
@@ -1,0 +1,50 @@
+openapi: 3.0.3
+info:
+  title: "Constraint - object minProperties"
+  version: "1.0"
+paths:
+  /profiles:
+    get:
+      operationId: listProfiles
+      responses:
+        '200':
+          description: Profile list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - id
+                    - attributes
+                  properties:
+                    id:
+                      type: integer
+                    attributes:
+                      type: object
+                      minProperties: 1
+                      additionalProperties:
+                        type: string
+    post:
+      operationId: createProfile
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - id
+                - attributes
+              properties:
+                id:
+                  type: integer
+                attributes:
+                  type: object
+                  minProperties: 1
+                  additionalProperties:
+                    type: string
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/008-constraints/016-object-maxproperties.yaml
+++ b/conformance-tests/src/test/resources/specs/008-constraints/016-object-maxproperties.yaml
@@ -1,0 +1,50 @@
+openapi: 3.0.3
+info:
+  title: "Constraint - object maxProperties"
+  version: "1.0"
+paths:
+  /configs:
+    get:
+      operationId: listConfigs
+      responses:
+        '200':
+          description: Config list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - name
+                    - settings
+                  properties:
+                    name:
+                      type: string
+                    settings:
+                      type: object
+                      maxProperties: 5
+                      additionalProperties:
+                        type: string
+    post:
+      operationId: createConfig
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+                - settings
+              properties:
+                name:
+                  type: string
+                settings:
+                  type: object
+                  maxProperties: 5
+                  additionalProperties:
+                    type: string
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/008-constraints/017-readonly-writeonly.yaml
+++ b/conformance-tests/src/test/resources/specs/008-constraints/017-readonly-writeonly.yaml
@@ -1,0 +1,52 @@
+openapi: 3.0.3
+info:
+  title: "Constraint - readOnly and writeOnly"
+  version: "1.0"
+paths:
+  /accounts:
+    get:
+      operationId: listAccounts
+      responses:
+        '200':
+          description: Account list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - id
+                    - email
+                  properties:
+                    id:
+                      type: integer
+                      readOnly: true
+                    email:
+                      type: string
+                    password:
+                      type: string
+                      writeOnly: true
+    post:
+      operationId: createAccount
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - email
+                - password
+              properties:
+                id:
+                  type: integer
+                  readOnly: true
+                email:
+                  type: string
+                password:
+                  type: string
+                  writeOnly: true
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/008-constraints/018-combined-string-constraints.yaml
+++ b/conformance-tests/src/test/resources/specs/008-constraints/018-combined-string-constraints.yaml
@@ -1,0 +1,50 @@
+openapi: 3.0.3
+info:
+  title: "Constraint - combined string constraints (minLength + maxLength + pattern)"
+  version: "1.0"
+paths:
+  /product-codes:
+    get:
+      operationId: listProductCodes
+      responses:
+        '200':
+          description: Product code list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - name
+                    - code
+                  properties:
+                    name:
+                      type: string
+                    code:
+                      type: string
+                      minLength: 6
+                      maxLength: 10
+                      pattern: "^[A-Z]{2}-[0-9]+$"
+    post:
+      operationId: createProductCode
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+                - code
+              properties:
+                name:
+                  type: string
+                code:
+                  type: string
+                  minLength: 6
+                  maxLength: 10
+                  pattern: "^[A-Z]{2}-[0-9]+$"
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/008-constraints/019-combined-numeric-constraints.yaml
+++ b/conformance-tests/src/test/resources/specs/008-constraints/019-combined-numeric-constraints.yaml
@@ -1,0 +1,50 @@
+openapi: 3.0.3
+info:
+  title: "Constraint - combined numeric constraints (minimum + maximum + multipleOf)"
+  version: "1.0"
+paths:
+  /discounts:
+    get:
+      operationId: listDiscounts
+      responses:
+        '200':
+          description: Discount list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - label
+                    - percent
+                  properties:
+                    label:
+                      type: string
+                    percent:
+                      type: integer
+                      minimum: 5
+                      maximum: 50
+                      multipleOf: 5
+    post:
+      operationId: createDiscount
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - label
+                - percent
+              properties:
+                label:
+                  type: string
+                percent:
+                  type: integer
+                  minimum: 5
+                  maximum: 50
+                  multipleOf: 5
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/008-constraints/020-combined-array-constraints.yaml
+++ b/conformance-tests/src/test/resources/specs/008-constraints/020-combined-array-constraints.yaml
@@ -1,0 +1,54 @@
+openapi: 3.0.3
+info:
+  title: "Constraint - combined array constraints (minItems + maxItems + uniqueItems)"
+  version: "1.0"
+paths:
+  /playlists:
+    get:
+      operationId: listPlaylists
+      responses:
+        '200':
+          description: Playlist list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - name
+                    - tracks
+                  properties:
+                    name:
+                      type: string
+                    tracks:
+                      type: array
+                      minItems: 1
+                      maxItems: 50
+                      uniqueItems: true
+                      items:
+                        type: string
+    post:
+      operationId: createPlaylist
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+                - tracks
+              properties:
+                name:
+                  type: string
+                tracks:
+                  type: array
+                  minItems: 1
+                  maxItems: 50
+                  uniqueItems: true
+                  items:
+                    type: string
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/008-constraints/021-object-minproperties-with-additional.yaml
+++ b/conformance-tests/src/test/resources/specs/008-constraints/021-object-minproperties-with-additional.yaml
@@ -1,0 +1,34 @@
+openapi: 3.0.3
+info:
+  title: "Object minProperties with additionalProperties typed"
+  version: "1.0"
+paths:
+  /tags:
+    get:
+      operationId: listTags
+      responses:
+        '200':
+          description: Tag list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  minProperties: 2
+                  additionalProperties:
+                    type: string
+    post:
+      operationId: createTag
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              minProperties: 2
+              additionalProperties:
+                type: string
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/008-constraints/022-number-multipleof-decimal.yaml
+++ b/conformance-tests/src/test/resources/specs/008-constraints/022-number-multipleof-decimal.yaml
@@ -1,0 +1,46 @@
+openapi: 3.0.3
+info:
+  title: "Number multipleOf with decimal value"
+  version: "1.0"
+paths:
+  /amounts:
+    get:
+      operationId: listAmounts
+      responses:
+        '200':
+          description: Amount list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - label
+                    - amount
+                  properties:
+                    label:
+                      type: string
+                    amount:
+                      type: number
+                      multipleOf: 0.25
+    post:
+      operationId: createAmount
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - label
+                - amount
+              properties:
+                label:
+                  type: string
+                amount:
+                  type: number
+                  multipleOf: 0.25
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/008-constraints/023-maxproperties-with-required.yaml
+++ b/conformance-tests/src/test/resources/specs/008-constraints/023-maxproperties-with-required.yaml
@@ -1,0 +1,52 @@
+openapi: 3.0.3
+info:
+  title: "maxProperties lower than total defined properties"
+  version: "1.0"
+paths:
+  /entries:
+    get:
+      operationId: listEntries
+      responses:
+        '200':
+          description: Entry list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - id
+                  maxProperties: 2
+                  properties:
+                    id:
+                      type: integer
+                    name:
+                      type: string
+                    description:
+                      type: string
+                    tags:
+                      type: string
+    post:
+      operationId: createEntry
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - id
+              maxProperties: 2
+              properties:
+                id:
+                  type: integer
+                name:
+                  type: string
+                description:
+                  type: string
+                tags:
+                  type: string
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/008-constraints/024-minproperties-three.yaml
+++ b/conformance-tests/src/test/resources/specs/008-constraints/024-minproperties-three.yaml
@@ -1,0 +1,44 @@
+openapi: 3.0.3
+info:
+  title: "Object minProperties 3 with fixed and additional properties"
+  version: "1.0"
+paths:
+  /labels:
+    get:
+      operationId: listLabels
+      responses:
+        '200':
+          description: Label list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - id
+                  minProperties: 3
+                  properties:
+                    id:
+                      type: integer
+                  additionalProperties:
+                    type: string
+    post:
+      operationId: createLabel
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - id
+              minProperties: 3
+              properties:
+                id:
+                  type: integer
+              additionalProperties:
+                type: string
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/009-forms-and-multipart/001-urlencoded-form.yaml
+++ b/conformance-tests/src/test/resources/specs/009-forms-and-multipart/001-urlencoded-form.yaml
@@ -1,0 +1,35 @@
+openapi: 3.0.3
+info:
+  title: "URL-encoded form submission"
+  version: "1.0"
+paths:
+  /login:
+    post:
+      operationId: loginUser
+      summary: Submit login credentials via URL-encoded form
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required:
+                - username
+                - password
+              properties:
+                username:
+                  type: string
+                password:
+                  type: string
+      responses:
+        '200':
+          description: Login successful
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - token
+                properties:
+                  token:
+                    type: string

--- a/conformance-tests/src/test/resources/specs/009-forms-and-multipart/002-urlencoded-multiple-fields.yaml
+++ b/conformance-tests/src/test/resources/specs/009-forms-and-multipart/002-urlencoded-multiple-fields.yaml
@@ -1,0 +1,42 @@
+openapi: 3.0.3
+info:
+  title: "URL-encoded form with multiple field types"
+  version: "1.0"
+paths:
+  /registrations:
+    post:
+      operationId: registerUser
+      summary: Register with various field types via URL-encoded form
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required:
+                - name
+                - email
+                - age
+                - subscribe
+              properties:
+                name:
+                  type: string
+                email:
+                  type: string
+                  format: email
+                age:
+                  type: integer
+                subscribe:
+                  type: boolean
+      responses:
+        '201':
+          description: Registration created
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                properties:
+                  id:
+                    type: integer

--- a/conformance-tests/src/test/resources/specs/009-forms-and-multipart/003-multipart-basic.yaml
+++ b/conformance-tests/src/test/resources/specs/009-forms-and-multipart/003-multipart-basic.yaml
@@ -1,0 +1,37 @@
+openapi: 3.0.3
+info:
+  title: "Multipart form data - basic fields"
+  version: "1.0"
+paths:
+  /profiles:
+    post:
+      operationId: createProfile
+      summary: Create a profile with multipart form data
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - firstName
+                - lastName
+              properties:
+                firstName:
+                  type: string
+                lastName:
+                  type: string
+                bio:
+                  type: string
+      responses:
+        '201':
+          description: Profile created
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                properties:
+                  id:
+                    type: integer

--- a/conformance-tests/src/test/resources/specs/009-forms-and-multipart/004-multipart-file-upload.yaml
+++ b/conformance-tests/src/test/resources/specs/009-forms-and-multipart/004-multipart-file-upload.yaml
@@ -1,0 +1,36 @@
+openapi: 3.0.3
+info:
+  title: "Multipart single file upload"
+  version: "1.0"
+paths:
+  /documents:
+    post:
+      operationId: uploadDocument
+      summary: Upload a single file
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - file
+              properties:
+                file:
+                  type: string
+                  format: binary
+      responses:
+        '201':
+          description: Document uploaded
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                  - filename
+                properties:
+                  id:
+                    type: integer
+                  filename:
+                    type: string

--- a/conformance-tests/src/test/resources/specs/009-forms-and-multipart/005-multipart-file-with-metadata.yaml
+++ b/conformance-tests/src/test/resources/specs/009-forms-and-multipart/005-multipart-file-with-metadata.yaml
@@ -1,0 +1,48 @@
+openapi: 3.0.3
+info:
+  title: "Multipart file upload with metadata fields"
+  version: "1.0"
+paths:
+  /attachments:
+    post:
+      operationId: uploadAttachment
+      summary: Upload a file with additional metadata
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - file
+                - description
+              properties:
+                file:
+                  type: string
+                  format: binary
+                description:
+                  type: string
+                category:
+                  type: string
+                  enum:
+                    - report
+                    - invoice
+                    - receipt
+      responses:
+        '201':
+          description: Attachment uploaded
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                  - filename
+                  - description
+                properties:
+                  id:
+                    type: integer
+                  filename:
+                    type: string
+                  description:
+                    type: string

--- a/conformance-tests/src/test/resources/specs/009-forms-and-multipart/006-multipart-image-upload.yaml
+++ b/conformance-tests/src/test/resources/specs/009-forms-and-multipart/006-multipart-image-upload.yaml
@@ -1,0 +1,39 @@
+openapi: 3.0.3
+info:
+  title: "Multipart image upload with content type"
+  version: "1.0"
+paths:
+  /avatars:
+    post:
+      operationId: uploadAvatar
+      summary: Upload an image with explicit content type encoding
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - image
+              properties:
+                image:
+                  type: string
+                  format: binary
+            encoding:
+              image:
+                contentType: image/png, image/jpeg
+      responses:
+        '201':
+          description: Avatar uploaded
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                  - url
+                properties:
+                  id:
+                    type: integer
+                  url:
+                    type: string

--- a/conformance-tests/src/test/resources/specs/009-forms-and-multipart/007-multipart-multiple-files.yaml
+++ b/conformance-tests/src/test/resources/specs/009-forms-and-multipart/007-multipart-multiple-files.yaml
@@ -1,0 +1,38 @@
+openapi: 3.0.3
+info:
+  title: "Multipart multiple file upload via array"
+  version: "1.0"
+paths:
+  /galleries:
+    post:
+      operationId: uploadGalleryImages
+      summary: Upload multiple files as an array
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - files
+              properties:
+                files:
+                  type: array
+                  items:
+                    type: string
+                    format: binary
+      responses:
+        '201':
+          description: Gallery created
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                  - count
+                properties:
+                  id:
+                    type: integer
+                  count:
+                    type: integer

--- a/conformance-tests/src/test/resources/specs/009-forms-and-multipart/008-multipart-binary-octet-stream.yaml
+++ b/conformance-tests/src/test/resources/specs/009-forms-and-multipart/008-multipart-binary-octet-stream.yaml
@@ -1,0 +1,42 @@
+openapi: 3.0.3
+info:
+  title: "Multipart binary with octet-stream encoding"
+  version: "1.0"
+paths:
+  /uploads:
+    post:
+      operationId: uploadBinaryFile
+      summary: Upload a binary file with octet-stream content type
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - file
+                - filename
+              properties:
+                file:
+                  type: string
+                  format: binary
+                filename:
+                  type: string
+            encoding:
+              file:
+                contentType: application/octet-stream
+      responses:
+        '201':
+          description: File uploaded
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                  - size
+                properties:
+                  id:
+                    type: integer
+                  size:
+                    type: integer

--- a/conformance-tests/src/test/resources/specs/009-forms-and-multipart/009-multipart-with-json-part.yaml
+++ b/conformance-tests/src/test/resources/specs/009-forms-and-multipart/009-multipart-with-json-part.yaml
@@ -1,0 +1,47 @@
+openapi: 3.0.3
+info:
+  title: "Multipart with JSON-encoded part"
+  version: "1.0"
+paths:
+  /reports:
+    post:
+      operationId: uploadReport
+      summary: Upload a file with a JSON metadata part
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - metadata
+                - file
+              properties:
+                metadata:
+                  type: object
+                  required:
+                    - title
+                    - author
+                  properties:
+                    title:
+                      type: string
+                    author:
+                      type: string
+                file:
+                  type: string
+                  format: binary
+            encoding:
+              metadata:
+                contentType: application/json
+      responses:
+        '201':
+          description: Report created
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                properties:
+                  id:
+                    type: integer

--- a/conformance-tests/src/test/resources/specs/009-forms-and-multipart/010-raw-binary-body.yaml
+++ b/conformance-tests/src/test/resources/specs/009-forms-and-multipart/010-raw-binary-body.yaml
@@ -1,0 +1,31 @@
+openapi: 3.0.3
+info:
+  title: "Raw binary request body (octet-stream)"
+  version: "1.0"
+paths:
+  /files:
+    post:
+      operationId: uploadRawFile
+      summary: Upload raw binary content directly
+      requestBody:
+        required: true
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+      responses:
+        '201':
+          description: File stored
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                  - size
+                properties:
+                  id:
+                    type: integer
+                  size:
+                    type: integer

--- a/conformance-tests/src/test/resources/specs/009-forms-and-multipart/011-raw-image-body.yaml
+++ b/conformance-tests/src/test/resources/specs/009-forms-and-multipart/011-raw-image-body.yaml
@@ -1,0 +1,31 @@
+openapi: 3.0.3
+info:
+  title: "Raw image request body (image/png)"
+  version: "1.0"
+paths:
+  /thumbnails:
+    post:
+      operationId: uploadThumbnail
+      summary: Upload a PNG image as raw body
+      requestBody:
+        required: true
+        content:
+          image/png:
+            schema:
+              type: string
+              format: binary
+      responses:
+        '201':
+          description: Thumbnail stored
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                  - url
+                properties:
+                  id:
+                    type: integer
+                  url:
+                    type: string

--- a/conformance-tests/src/test/resources/specs/009-forms-and-multipart/012-multipart-optional-file.yaml
+++ b/conformance-tests/src/test/resources/specs/009-forms-and-multipart/012-multipart-optional-file.yaml
@@ -1,0 +1,39 @@
+openapi: 3.0.3
+info:
+  title: "Multipart with optional file upload"
+  version: "1.0"
+paths:
+  /contacts:
+    post:
+      operationId: createContact
+      summary: Create a contact with an optional photo
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - name
+                - email
+              properties:
+                name:
+                  type: string
+                email:
+                  type: string
+                  format: email
+                photo:
+                  type: string
+                  format: binary
+      responses:
+        '201':
+          description: Contact created
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                properties:
+                  id:
+                    type: integer

--- a/conformance-tests/src/test/resources/specs/009-forms-and-multipart/013-urlencoded-with-array.yaml
+++ b/conformance-tests/src/test/resources/specs/009-forms-and-multipart/013-urlencoded-with-array.yaml
@@ -1,0 +1,37 @@
+openapi: 3.0.3
+info:
+  title: "URL-encoded form with array field"
+  version: "1.0"
+paths:
+  /surveys:
+    post:
+      operationId: submitSurvey
+      summary: Submit a survey with multiple selected options
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required:
+                - respondent
+                - answers
+              properties:
+                respondent:
+                  type: string
+                answers:
+                  type: array
+                  items:
+                    type: string
+      responses:
+        '201':
+          description: Survey submitted
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                properties:
+                  id:
+                    type: integer

--- a/conformance-tests/src/test/resources/specs/009-forms-and-multipart/014-multipart-pdf-upload.yaml
+++ b/conformance-tests/src/test/resources/specs/009-forms-and-multipart/014-multipart-pdf-upload.yaml
@@ -1,0 +1,39 @@
+openapi: 3.0.3
+info:
+  title: "Multipart PDF file upload with content type"
+  version: "1.0"
+paths:
+  /invoices:
+    post:
+      operationId: uploadInvoice
+      summary: Upload a PDF invoice
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - invoice
+                - invoiceNumber
+              properties:
+                invoice:
+                  type: string
+                  format: binary
+                invoiceNumber:
+                  type: string
+            encoding:
+              invoice:
+                contentType: application/pdf
+      responses:
+        '201':
+          description: Invoice uploaded
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                properties:
+                  id:
+                    type: integer

--- a/conformance-tests/src/test/resources/specs/009-forms-and-multipart/015-multipart-multiple-named-files.yaml
+++ b/conformance-tests/src/test/resources/specs/009-forms-and-multipart/015-multipart-multiple-named-files.yaml
@@ -1,0 +1,40 @@
+openapi: 3.0.3
+info:
+  title: "Multipart with multiple named file fields"
+  version: "1.0"
+paths:
+  /applications:
+    post:
+      operationId: submitApplication
+      summary: Submit an application with separate file fields
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - name
+                - resume
+                - coverLetter
+              properties:
+                name:
+                  type: string
+                resume:
+                  type: string
+                  format: binary
+                coverLetter:
+                  type: string
+                  format: binary
+      responses:
+        '201':
+          description: Application submitted
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                properties:
+                  id:
+                    type: integer

--- a/conformance-tests/src/test/resources/specs/010-status-codes/001-200-ok.yaml
+++ b/conformance-tests/src/test/resources/specs/010-status-codes/001-200-ok.yaml
@@ -1,0 +1,26 @@
+openapi: 3.0.3
+info:
+  title: "Status code - 200 OK"
+  version: "1.0"
+paths:
+  /items:
+    get:
+      operationId: listItems
+      summary: List items returning 200
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - id
+                    - name
+                  properties:
+                    id:
+                      type: integer
+                    name:
+                      type: string

--- a/conformance-tests/src/test/resources/specs/010-status-codes/002-201-created.yaml
+++ b/conformance-tests/src/test/resources/specs/010-status-codes/002-201-created.yaml
@@ -1,0 +1,35 @@
+openapi: 3.0.3
+info:
+  title: "Status code - 201 Created"
+  version: "1.0"
+paths:
+  /items:
+    post:
+      operationId: createItem
+      summary: Create an item returning 201
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+      responses:
+        '201':
+          description: Item created
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                  - name
+                properties:
+                  id:
+                    type: integer
+                  name:
+                    type: string

--- a/conformance-tests/src/test/resources/specs/010-status-codes/003-202-accepted.yaml
+++ b/conformance-tests/src/test/resources/specs/010-status-codes/003-202-accepted.yaml
@@ -1,0 +1,35 @@
+openapi: 3.0.3
+info:
+  title: "Status code - 202 Accepted"
+  version: "1.0"
+paths:
+  /jobs:
+    post:
+      operationId: submitJob
+      summary: Submit a job returning 202
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - task
+              properties:
+                task:
+                  type: string
+      responses:
+        '202':
+          description: Job accepted for processing
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - jobId
+                  - status
+                properties:
+                  jobId:
+                    type: string
+                  status:
+                    type: string

--- a/conformance-tests/src/test/resources/specs/010-status-codes/004-204-no-content.yaml
+++ b/conformance-tests/src/test/resources/specs/010-status-codes/004-204-no-content.yaml
@@ -1,0 +1,18 @@
+openapi: 3.0.3
+info:
+  title: "Status code - 204 No Content"
+  version: "1.0"
+paths:
+  /items/{itemId}:
+    delete:
+      operationId: deleteItem
+      summary: Delete an item returning 204
+      parameters:
+        - name: itemId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '204':
+          description: Item deleted

--- a/conformance-tests/src/test/resources/specs/010-status-codes/005-400-bad-request.yaml
+++ b/conformance-tests/src/test/resources/specs/010-status-codes/005-400-bad-request.yaml
@@ -1,0 +1,43 @@
+openapi: 3.0.3
+info:
+  title: "Status code - 400 Bad Request"
+  version: "1.0"
+paths:
+  /items:
+    post:
+      operationId: createItem
+      summary: Create item with possible 400 response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+      responses:
+        '201':
+          description: Item created
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                properties:
+                  id:
+                    type: integer
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                properties:
+                  error:
+                    type: string

--- a/conformance-tests/src/test/resources/specs/010-status-codes/005-400-bad-request.yaml
+++ b/conformance-tests/src/test/resources/specs/010-status-codes/005-400-bad-request.yaml
@@ -18,6 +18,10 @@ paths:
               properties:
                 name:
                   type: string
+            examples:
+              ERROR:
+                value:
+                  something: else
       responses:
         '201':
           description: Item created
@@ -41,3 +45,7 @@ paths:
                 properties:
                   error:
                     type: string
+              examples:
+                ERROR:
+                  value:
+                    error: "Invalid request body"

--- a/conformance-tests/src/test/resources/specs/010-status-codes/006-401-unauthorized.yaml
+++ b/conformance-tests/src/test/resources/specs/010-status-codes/006-401-unauthorized.yaml
@@ -1,0 +1,43 @@
+openapi: 3.0.3
+info:
+  title: "Status code - 401 Unauthorized"
+  version: "1.0"
+paths:
+  /secrets:
+    get:
+      operationId: listSecrets
+      summary: List secrets with possible 401
+      parameters:
+        - name: X-Api-Key
+          in: header
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Secrets list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - id
+                    - value
+                  properties:
+                    id:
+                      type: integer
+                    value:
+                      type: string
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                properties:
+                  error:
+                    type: string

--- a/conformance-tests/src/test/resources/specs/010-status-codes/006-401-unauthorized.yaml
+++ b/conformance-tests/src/test/resources/specs/010-status-codes/006-401-unauthorized.yaml
@@ -13,6 +13,9 @@ paths:
           required: true
           schema:
             type: string
+          examples:
+            ERROR:
+              value: "invalid-key"
       responses:
         '200':
           description: Secrets list
@@ -41,3 +44,7 @@ paths:
                 properties:
                   error:
                     type: string
+              examples:
+                ERROR:
+                  value:
+                    error: "Invalid API key"

--- a/conformance-tests/src/test/resources/specs/010-status-codes/007-403-forbidden.yaml
+++ b/conformance-tests/src/test/resources/specs/010-status-codes/007-403-forbidden.yaml
@@ -1,0 +1,38 @@
+openapi: 3.0.3
+info:
+  title: "Status code - 403 Forbidden"
+  version: "1.0"
+paths:
+  /admin/settings:
+    get:
+      operationId: getAdminSettings
+      summary: Get admin settings with possible 403
+      parameters:
+        - name: X-Api-Key
+          in: header
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Admin settings
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - maintenanceMode
+                properties:
+                  maintenanceMode:
+                    type: boolean
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                properties:
+                  error:
+                    type: string

--- a/conformance-tests/src/test/resources/specs/010-status-codes/007-403-forbidden.yaml
+++ b/conformance-tests/src/test/resources/specs/010-status-codes/007-403-forbidden.yaml
@@ -13,6 +13,9 @@ paths:
           required: true
           schema:
             type: string
+          examples:
+            ERROR:
+              value: "unauthorized-key"
       responses:
         '200':
           description: Admin settings
@@ -36,3 +39,7 @@ paths:
                 properties:
                   error:
                     type: string
+              examples:
+                ERROR:
+                  value:
+                    error: "Access denied"

--- a/conformance-tests/src/test/resources/specs/010-status-codes/008-404-not-found.yaml
+++ b/conformance-tests/src/test/resources/specs/010-status-codes/008-404-not-found.yaml
@@ -13,6 +13,9 @@ paths:
           required: true
           schema:
             type: integer
+          examples:
+            ERROR:
+              value: 0
       responses:
         '200':
           description: Item found
@@ -39,3 +42,7 @@ paths:
                 properties:
                   error:
                     type: string
+              examples:
+                ERROR:
+                  value:
+                    error: "Item not found"

--- a/conformance-tests/src/test/resources/specs/010-status-codes/008-404-not-found.yaml
+++ b/conformance-tests/src/test/resources/specs/010-status-codes/008-404-not-found.yaml
@@ -1,0 +1,41 @@
+openapi: 3.0.3
+info:
+  title: "Status code - 404 Not Found"
+  version: "1.0"
+paths:
+  /items/{itemId}:
+    get:
+      operationId: getItem
+      summary: Get item with possible 404
+      parameters:
+        - name: itemId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Item found
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                  - name
+                properties:
+                  id:
+                    type: integer
+                  name:
+                    type: string
+        '404':
+          description: Item not found
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                properties:
+                  error:
+                    type: string

--- a/conformance-tests/src/test/resources/specs/010-status-codes/009-409-conflict.yaml
+++ b/conformance-tests/src/test/resources/specs/010-status-codes/009-409-conflict.yaml
@@ -1,0 +1,47 @@
+openapi: 3.0.3
+info:
+  title: "Status code - 409 Conflict"
+  version: "1.0"
+paths:
+  /users:
+    post:
+      operationId: createUser
+      summary: Create user with possible 409 conflict
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - email
+                - name
+              properties:
+                email:
+                  type: string
+                  format: email
+                name:
+                  type: string
+      responses:
+        '201':
+          description: User created
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                properties:
+                  id:
+                    type: integer
+        '409':
+          description: Conflict - user already exists
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                properties:
+                  error:
+                    type: string

--- a/conformance-tests/src/test/resources/specs/010-status-codes/009-409-conflict.yaml
+++ b/conformance-tests/src/test/resources/specs/010-status-codes/009-409-conflict.yaml
@@ -22,6 +22,11 @@ paths:
                   format: email
                 name:
                   type: string
+            examples:
+              ERROR:
+                value:
+                  email: "existing@example.com"
+                  name: "Existing User"
       responses:
         '201':
           description: User created
@@ -45,3 +50,7 @@ paths:
                 properties:
                   error:
                     type: string
+              examples:
+                ERROR:
+                  value:
+                    error: "User already exists"

--- a/conformance-tests/src/test/resources/specs/010-status-codes/010-422-unprocessable.yaml
+++ b/conformance-tests/src/test/resources/specs/010-status-codes/010-422-unprocessable.yaml
@@ -21,6 +21,11 @@ paths:
                   type: integer
                 quantity:
                   type: integer
+            examples:
+              ERROR:
+                value:
+                  productId: 1
+                  quantity: -5
       responses:
         '201':
           description: Order created
@@ -54,3 +59,9 @@ paths:
                           type: string
                         message:
                           type: string
+              examples:
+                ERROR:
+                  value:
+                    errors:
+                      - field: "quantity"
+                        message: "Must be greater than zero"

--- a/conformance-tests/src/test/resources/specs/010-status-codes/010-422-unprocessable.yaml
+++ b/conformance-tests/src/test/resources/specs/010-status-codes/010-422-unprocessable.yaml
@@ -1,0 +1,56 @@
+openapi: 3.0.3
+info:
+  title: "Status code - 422 Unprocessable Entity"
+  version: "1.0"
+paths:
+  /orders:
+    post:
+      operationId: createOrder
+      summary: Create order with possible 422 validation error
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - productId
+                - quantity
+              properties:
+                productId:
+                  type: integer
+                quantity:
+                  type: integer
+      responses:
+        '201':
+          description: Order created
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                properties:
+                  id:
+                    type: integer
+        '422':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - errors
+                properties:
+                  errors:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - field
+                        - message
+                      properties:
+                        field:
+                          type: string
+                        message:
+                          type: string

--- a/conformance-tests/src/test/resources/specs/010-status-codes/011-multiple-success-codes.yaml
+++ b/conformance-tests/src/test/resources/specs/010-status-codes/011-multiple-success-codes.yaml
@@ -1,0 +1,52 @@
+openapi: 3.0.3
+info:
+  title: "Multiple success status codes on one endpoint"
+  version: "1.0"
+paths:
+  /tasks:
+    post:
+      operationId: createTask
+      summary: Create task returning 200 or 201
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - title
+              properties:
+                title:
+                  type: string
+      responses:
+        '200':
+          description: Task already existed
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                  - title
+                  - existed
+                properties:
+                  id:
+                    type: integer
+                  title:
+                    type: string
+                  existed:
+                    type: boolean
+        '201':
+          description: Task created
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                  - title
+                properties:
+                  id:
+                    type: integer
+                  title:
+                    type: string

--- a/conformance-tests/src/test/resources/specs/010-status-codes/012-multiple-error-codes.yaml
+++ b/conformance-tests/src/test/resources/specs/010-status-codes/012-multiple-error-codes.yaml
@@ -1,0 +1,74 @@
+openapi: 3.0.3
+info:
+  title: "Multiple error status codes on one endpoint"
+  version: "1.0"
+paths:
+  /accounts/{accountId}:
+    put:
+      operationId: updateAccount
+      summary: Update account with multiple possible errors
+      parameters:
+        - name: accountId
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+      responses:
+        '200':
+          description: Account updated
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                  - name
+                properties:
+                  id:
+                    type: integer
+                  name:
+                    type: string
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                properties:
+                  error:
+                    type: string
+        '404':
+          description: Account not found
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                properties:
+                  error:
+                    type: string
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                properties:
+                  error:
+                    type: string

--- a/conformance-tests/src/test/resources/specs/010-status-codes/012-multiple-error-codes.yaml
+++ b/conformance-tests/src/test/resources/specs/010-status-codes/012-multiple-error-codes.yaml
@@ -13,6 +13,13 @@ paths:
           required: true
           schema:
             type: integer
+          examples:
+            NOT_FOUND:
+              value: 9999
+            BAD_REQUEST:
+              value: 1
+            CONFLICT:
+              value: 1
       requestBody:
         required: true
         content:
@@ -24,6 +31,16 @@ paths:
               properties:
                 name:
                   type: string
+            examples:
+              NOT_FOUND:
+                value:
+                  name: "Valid Name"
+              BAD_REQUEST:
+                value:
+                  invalid: "field"
+              CONFLICT:
+                value:
+                  name: "Existing Name"
       responses:
         '200':
           description: Account updated
@@ -50,6 +67,10 @@ paths:
                 properties:
                   error:
                     type: string
+              examples:
+                BAD_REQUEST:
+                  value:
+                    error: "Invalid request body"
         '404':
           description: Account not found
           content:
@@ -61,6 +82,10 @@ paths:
                 properties:
                   error:
                     type: string
+              examples:
+                NOT_FOUND:
+                  value:
+                    error: "Account not found"
         '409':
           description: Conflict
           content:
@@ -72,3 +97,7 @@ paths:
                 properties:
                   error:
                     type: string
+              examples:
+                CONFLICT:
+                  value:
+                    error: "Account name already taken"

--- a/conformance-tests/src/test/resources/specs/011-refs-and-components/001-ref-schema.yaml
+++ b/conformance-tests/src/test/resources/specs/011-refs-and-components/001-ref-schema.yaml
@@ -1,0 +1,40 @@
+openapi: 3.0.3
+info:
+  title: "$ref to component schema"
+  version: "1.0"
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+    post:
+      operationId: createPet
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+      responses:
+        '201':
+          description: Created
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - name
+        - species
+      properties:
+        name:
+          type: string
+        species:
+          type: string

--- a/conformance-tests/src/test/resources/specs/011-refs-and-components/002-ref-shared-across-endpoints.yaml
+++ b/conformance-tests/src/test/resources/specs/011-refs-and-components/002-ref-shared-across-endpoints.yaml
@@ -1,0 +1,59 @@
+openapi: 3.0.3
+info:
+  title: "$ref shared across multiple endpoints"
+  version: "1.0"
+paths:
+  /orders:
+    get:
+      operationId: listOrders
+      responses:
+        '200':
+          description: Order list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Order'
+    post:
+      operationId: createOrder
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Order'
+      responses:
+        '201':
+          description: Created
+  /orders/{orderId}:
+    get:
+      operationId: getOrder
+      parameters:
+        - name: orderId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Order found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Order'
+components:
+  schemas:
+    Order:
+      type: object
+      required:
+        - id
+        - product
+        - quantity
+      properties:
+        id:
+          type: integer
+        product:
+          type: string
+        quantity:
+          type: integer

--- a/conformance-tests/src/test/resources/specs/011-refs-and-components/003-ref-nested-object.yaml
+++ b/conformance-tests/src/test/resources/specs/011-refs-and-components/003-ref-nested-object.yaml
@@ -1,0 +1,55 @@
+openapi: 3.0.3
+info:
+  title: "$ref to nested object within schema"
+  version: "1.0"
+paths:
+  /invoices:
+    get:
+      operationId: listInvoices
+      responses:
+        '200':
+          description: Invoice list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Invoice'
+    post:
+      operationId: createInvoice
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Invoice'
+      responses:
+        '201':
+          description: Created
+components:
+  schemas:
+    Address:
+      type: object
+      required:
+        - street
+        - city
+      properties:
+        street:
+          type: string
+        city:
+          type: string
+        zipCode:
+          type: string
+    Invoice:
+      type: object
+      required:
+        - id
+        - amount
+        - billingAddress
+      properties:
+        id:
+          type: integer
+        amount:
+          type: number
+        billingAddress:
+          $ref: '#/components/schemas/Address'

--- a/conformance-tests/src/test/resources/specs/011-refs-and-components/004-ref-in-array-items.yaml
+++ b/conformance-tests/src/test/resources/specs/011-refs-and-components/004-ref-in-array-items.yaml
@@ -1,0 +1,52 @@
+openapi: 3.0.3
+info:
+  title: "$ref in array items"
+  version: "1.0"
+paths:
+  /classrooms:
+    get:
+      operationId: listClassrooms
+      responses:
+        '200':
+          description: Classroom list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Classroom'
+    post:
+      operationId: createClassroom
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Classroom'
+      responses:
+        '201':
+          description: Created
+components:
+  schemas:
+    Student:
+      type: object
+      required:
+        - name
+        - grade
+      properties:
+        name:
+          type: string
+        grade:
+          type: integer
+    Classroom:
+      type: object
+      required:
+        - roomNumber
+        - students
+      properties:
+        roomNumber:
+          type: string
+        students:
+          type: array
+          items:
+            $ref: '#/components/schemas/Student'

--- a/conformance-tests/src/test/resources/specs/011-refs-and-components/005-ref-parameter.yaml
+++ b/conformance-tests/src/test/resources/specs/011-refs-and-components/005-ref-parameter.yaml
@@ -1,0 +1,58 @@
+openapi: 3.0.3
+info:
+  title: "$ref to component parameter"
+  version: "1.0"
+paths:
+  /items:
+    get:
+      operationId: listItems
+      parameters:
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/PageNumber'
+      responses:
+        '200':
+          description: Items list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - id
+                    - name
+                  properties:
+                    id:
+                      type: integer
+                    name:
+                      type: string
+    post:
+      operationId: createItem
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+      responses:
+        '201':
+          description: Created
+components:
+  parameters:
+    PageSize:
+      name: pageSize
+      in: query
+      required: false
+      schema:
+        type: integer
+    PageNumber:
+      name: page
+      in: query
+      required: false
+      schema:
+        type: integer

--- a/conformance-tests/src/test/resources/specs/011-refs-and-components/006-ref-request-body.yaml
+++ b/conformance-tests/src/test/resources/specs/011-refs-and-components/006-ref-request-body.yaml
@@ -1,0 +1,52 @@
+openapi: 3.0.3
+info:
+  title: "$ref to component request body"
+  version: "1.0"
+paths:
+  /tickets:
+    post:
+      operationId: createTicket
+      requestBody:
+        $ref: '#/components/requestBodies/TicketBody'
+      responses:
+        '201':
+          description: Ticket created
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                properties:
+                  id:
+                    type: integer
+  /tickets/{ticketId}:
+    put:
+      operationId: updateTicket
+      parameters:
+        - name: ticketId
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        $ref: '#/components/requestBodies/TicketBody'
+      responses:
+        '200':
+          description: Ticket updated
+components:
+  requestBodies:
+    TicketBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - title
+              - priority
+            properties:
+              title:
+                type: string
+              priority:
+                type: string

--- a/conformance-tests/src/test/resources/specs/011-refs-and-components/007-ref-response.yaml
+++ b/conformance-tests/src/test/resources/specs/011-refs-and-components/007-ref-response.yaml
@@ -23,20 +23,26 @@ paths:
                       type: integer
                     name:
                       type: string
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-  /widgets/{widgetId}:
-    get:
-      operationId: getWidget
-      parameters:
-        - name: widgetId
-          in: path
-          required: true
-          schema:
-            type: integer
+    post:
+      operationId: createWidget
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+            examples:
+              ERROR:
+                value:
+                  something: else
       responses:
-        '200':
-          description: Widget found
+        '201':
+          description: Widget created
           content:
             application/json:
               schema:
@@ -49,12 +55,12 @@ paths:
                     type: integer
                   name:
                     type: string
-        '401':
-          $ref: '#/components/responses/Unauthorized'
+        '400':
+          $ref: '#/components/responses/BadRequest'
 components:
   responses:
-    Unauthorized:
-      description: Authentication required
+    BadRequest:
+      description: Bad request
       content:
         application/json:
           schema:
@@ -64,3 +70,7 @@ components:
             properties:
               error:
                 type: string
+          examples:
+            ERROR:
+              value:
+                error: "Invalid request body"

--- a/conformance-tests/src/test/resources/specs/011-refs-and-components/007-ref-response.yaml
+++ b/conformance-tests/src/test/resources/specs/011-refs-and-components/007-ref-response.yaml
@@ -1,0 +1,66 @@
+openapi: 3.0.3
+info:
+  title: "$ref to component response"
+  version: "1.0"
+paths:
+  /widgets:
+    get:
+      operationId: listWidgets
+      responses:
+        '200':
+          description: Widget list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - id
+                    - name
+                  properties:
+                    id:
+                      type: integer
+                    name:
+                      type: string
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+  /widgets/{widgetId}:
+    get:
+      operationId: getWidget
+      parameters:
+        - name: widgetId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Widget found
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                  - name
+                properties:
+                  id:
+                    type: integer
+                  name:
+                    type: string
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+components:
+  responses:
+    Unauthorized:
+      description: Authentication required
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - error
+            properties:
+              error:
+                type: string

--- a/conformance-tests/src/test/resources/specs/011-refs-and-components/008-ref-deeply-nested.yaml
+++ b/conformance-tests/src/test/resources/specs/011-refs-and-components/008-ref-deeply-nested.yaml
@@ -1,0 +1,63 @@
+openapi: 3.0.3
+info:
+  title: "$ref deeply nested - multiple levels"
+  version: "1.0"
+paths:
+  /companies:
+    get:
+      operationId: listCompanies
+      responses:
+        '200':
+          description: Company list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Company'
+    post:
+      operationId: createCompany
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Company'
+      responses:
+        '201':
+          description: Created
+components:
+  schemas:
+    Country:
+      type: object
+      required:
+        - name
+        - code
+      properties:
+        name:
+          type: string
+        code:
+          type: string
+    Address:
+      type: object
+      required:
+        - street
+        - city
+        - country
+      properties:
+        street:
+          type: string
+        city:
+          type: string
+        country:
+          $ref: '#/components/schemas/Country'
+    Company:
+      type: object
+      required:
+        - name
+        - headquarters
+      properties:
+        name:
+          type: string
+        headquarters:
+          $ref: '#/components/schemas/Address'

--- a/conformance-tests/src/test/resources/specs/012-content-negotiation/001-json-response.yaml
+++ b/conformance-tests/src/test/resources/specs/012-content-negotiation/001-json-response.yaml
@@ -1,0 +1,41 @@
+openapi: 3.0.3
+info:
+  title: "Content negotiation - JSON only"
+  version: "1.0"
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        '200':
+          description: Items as JSON
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - id
+                    - name
+                  properties:
+                    id:
+                      type: integer
+                    name:
+                      type: string
+    post:
+      operationId: createItem
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/012-content-negotiation/002-xml-response.yaml
+++ b/conformance-tests/src/test/resources/specs/012-content-negotiation/002-xml-response.yaml
@@ -1,0 +1,39 @@
+openapi: 3.0.3
+info:
+  title: "Content negotiation - XML response"
+  version: "1.0"
+paths:
+  /reports:
+    get:
+      operationId: listReports
+      responses:
+        '200':
+          description: Reports as XML
+          content:
+            application/xml:
+              schema:
+                type: object
+                required:
+                  - id
+                  - title
+                properties:
+                  id:
+                    type: integer
+                  title:
+                    type: string
+    post:
+      operationId: createReport
+      requestBody:
+        required: true
+        content:
+          application/xml:
+            schema:
+              type: object
+              required:
+                - title
+              properties:
+                title:
+                  type: string
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/012-content-negotiation/003-multiple-response-types.yaml
+++ b/conformance-tests/src/test/resources/specs/012-content-negotiation/003-multiple-response-types.yaml
@@ -1,0 +1,38 @@
+openapi: 3.0.3
+info:
+  title: "Content negotiation - multiple response content types"
+  version: "1.0"
+paths:
+  /documents:
+    get:
+      operationId: listDocuments
+      responses:
+        '200':
+          description: Documents in JSON or XML
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - id
+                    - title
+                  properties:
+                    id:
+                      type: integer
+                    title:
+                      type: string
+            application/xml:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - id
+                    - title
+                  properties:
+                    id:
+                      type: integer
+                    title:
+                      type: string

--- a/conformance-tests/src/test/resources/specs/012-content-negotiation/004-multiple-request-types.yaml
+++ b/conformance-tests/src/test/resources/specs/012-content-negotiation/004-multiple-request-types.yaml
@@ -1,0 +1,40 @@
+openapi: 3.0.3
+info:
+  title: "Content negotiation - multiple request content types"
+  version: "1.0"
+paths:
+  /messages:
+    post:
+      operationId: createMessage
+      summary: Accept message as JSON or XML
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - text
+              properties:
+                text:
+                  type: string
+          application/xml:
+            schema:
+              type: object
+              required:
+                - text
+              properties:
+                text:
+                  type: string
+      responses:
+        '201':
+          description: Message created
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                properties:
+                  id:
+                    type: integer

--- a/conformance-tests/src/test/resources/specs/012-content-negotiation/005-plain-text-response.yaml
+++ b/conformance-tests/src/test/resources/specs/012-content-negotiation/005-plain-text-response.yaml
@@ -1,0 +1,16 @@
+openapi: 3.0.3
+info:
+  title: "Content negotiation - plain text response"
+  version: "1.0"
+paths:
+  /health:
+    get:
+      operationId: healthCheck
+      summary: Health check returning plain text
+      responses:
+        '200':
+          description: Health status
+          content:
+            text/plain:
+              schema:
+                type: string

--- a/conformance-tests/src/test/resources/specs/012-content-negotiation/006-different-request-response-types.yaml
+++ b/conformance-tests/src/test/resources/specs/012-content-negotiation/006-different-request-response-types.yaml
@@ -1,0 +1,32 @@
+openapi: 3.0.3
+info:
+  title: "Content negotiation - different request and response types"
+  version: "1.0"
+paths:
+  /transforms:
+    post:
+      operationId: transformData
+      summary: Accept XML request, return JSON response
+      requestBody:
+        required: true
+        content:
+          application/xml:
+            schema:
+              type: object
+              required:
+                - input
+              properties:
+                input:
+                  type: string
+      responses:
+        '200':
+          description: Transformed result
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - output
+                properties:
+                  output:
+                    type: string

--- a/conformance-tests/src/test/resources/specs/013-discriminator/001-oneof-with-discriminator.yaml
+++ b/conformance-tests/src/test/resources/specs/013-discriminator/001-oneof-with-discriminator.yaml
@@ -1,0 +1,62 @@
+openapi: 3.0.3
+info:
+  title: "Discriminator with oneOf"
+  version: "1.0"
+paths:
+  /notifications:
+    get:
+      operationId: listNotifications
+      responses:
+        '200':
+          description: Notification list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Notification'
+    post:
+      operationId: createNotification
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Notification'
+      responses:
+        '201':
+          description: Created
+components:
+  schemas:
+    Notification:
+      oneOf:
+        - $ref: '#/components/schemas/EmailNotification'
+        - $ref: '#/components/schemas/SmsNotification'
+      discriminator:
+        propertyName: type
+    EmailNotification:
+      type: object
+      required:
+        - type
+        - emailAddress
+        - subject
+      properties:
+        type:
+          type: string
+        emailAddress:
+          type: string
+        subject:
+          type: string
+    SmsNotification:
+      type: object
+      required:
+        - type
+        - phoneNumber
+        - message
+      properties:
+        type:
+          type: string
+        phoneNumber:
+          type: string
+        message:
+          type: string

--- a/conformance-tests/src/test/resources/specs/013-discriminator/002-oneof-with-mapping.yaml
+++ b/conformance-tests/src/test/resources/specs/013-discriminator/002-oneof-with-mapping.yaml
@@ -1,0 +1,65 @@
+openapi: 3.0.3
+info:
+  title: "Discriminator with oneOf and mapping"
+  version: "1.0"
+paths:
+  /payments:
+    get:
+      operationId: listPayments
+      responses:
+        '200':
+          description: Payment list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Payment'
+    post:
+      operationId: createPayment
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Payment'
+      responses:
+        '201':
+          description: Created
+components:
+  schemas:
+    Payment:
+      oneOf:
+        - $ref: '#/components/schemas/CreditCardPayment'
+        - $ref: '#/components/schemas/BankTransferPayment'
+      discriminator:
+        propertyName: method
+        mapping:
+          credit_card: '#/components/schemas/CreditCardPayment'
+          bank_transfer: '#/components/schemas/BankTransferPayment'
+    CreditCardPayment:
+      type: object
+      required:
+        - method
+        - cardNumber
+        - amount
+      properties:
+        method:
+          type: string
+        cardNumber:
+          type: string
+        amount:
+          type: number
+    BankTransferPayment:
+      type: object
+      required:
+        - method
+        - accountNumber
+        - amount
+      properties:
+        method:
+          type: string
+        accountNumber:
+          type: string
+        amount:
+          type: number

--- a/conformance-tests/src/test/resources/specs/013-discriminator/003-anyof-with-discriminator.yaml
+++ b/conformance-tests/src/test/resources/specs/013-discriminator/003-anyof-with-discriminator.yaml
@@ -1,0 +1,56 @@
+openapi: 3.0.3
+info:
+  title: "Discriminator with anyOf"
+  version: "1.0"
+paths:
+  /vehicles:
+    get:
+      operationId: listVehicles
+      responses:
+        '200':
+          description: Vehicle list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Vehicle'
+    post:
+      operationId: createVehicle
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Vehicle'
+      responses:
+        '201':
+          description: Created
+components:
+  schemas:
+    Vehicle:
+      anyOf:
+        - $ref: '#/components/schemas/Car'
+        - $ref: '#/components/schemas/Truck'
+      discriminator:
+        propertyName: vehicleType
+    Car:
+      type: object
+      required:
+        - vehicleType
+        - seats
+      properties:
+        vehicleType:
+          type: string
+        seats:
+          type: integer
+    Truck:
+      type: object
+      required:
+        - vehicleType
+        - payloadTons
+      properties:
+        vehicleType:
+          type: string
+        payloadTons:
+          type: number

--- a/conformance-tests/src/test/resources/specs/013-discriminator/004-allof-with-discriminator.yaml
+++ b/conformance-tests/src/test/resources/specs/013-discriminator/004-allof-with-discriminator.yaml
@@ -1,0 +1,67 @@
+openapi: 3.0.3
+info:
+  title: "Discriminator with allOf inheritance"
+  version: "1.0"
+paths:
+  /shapes:
+    get:
+      operationId: listShapes
+      responses:
+        '200':
+          description: Shape list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Shape'
+    post:
+      operationId: createShape
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Shape'
+      responses:
+        '201':
+          description: Created
+components:
+  schemas:
+    Shape:
+      oneOf:
+        - $ref: '#/components/schemas/Circle'
+        - $ref: '#/components/schemas/Rectangle'
+      discriminator:
+        propertyName: shapeType
+    ShapeBase:
+      type: object
+      required:
+        - shapeType
+        - color
+      properties:
+        shapeType:
+          type: string
+        color:
+          type: string
+    Circle:
+      allOf:
+        - $ref: '#/components/schemas/ShapeBase'
+        - type: object
+          required:
+            - radius
+          properties:
+            radius:
+              type: number
+    Rectangle:
+      allOf:
+        - $ref: '#/components/schemas/ShapeBase'
+        - type: object
+          required:
+            - width
+            - height
+          properties:
+            width:
+              type: number
+            height:
+              type: number

--- a/conformance-tests/src/test/resources/specs/013-discriminator/005-three-variants.yaml
+++ b/conformance-tests/src/test/resources/specs/013-discriminator/005-three-variants.yaml
@@ -1,0 +1,74 @@
+openapi: 3.0.3
+info:
+  title: "Discriminator with three variants"
+  version: "1.0"
+paths:
+  /events:
+    get:
+      operationId: listEvents
+      responses:
+        '200':
+          description: Event list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Event'
+    post:
+      operationId: createEvent
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Event'
+      responses:
+        '201':
+          description: Created
+components:
+  schemas:
+    Event:
+      oneOf:
+        - $ref: '#/components/schemas/ClickEvent'
+        - $ref: '#/components/schemas/ViewEvent'
+        - $ref: '#/components/schemas/PurchaseEvent'
+      discriminator:
+        propertyName: eventType
+        mapping:
+          click: '#/components/schemas/ClickEvent'
+          view: '#/components/schemas/ViewEvent'
+          purchase: '#/components/schemas/PurchaseEvent'
+    ClickEvent:
+      type: object
+      required:
+        - eventType
+        - elementId
+      properties:
+        eventType:
+          type: string
+        elementId:
+          type: string
+    ViewEvent:
+      type: object
+      required:
+        - eventType
+        - pageUrl
+      properties:
+        eventType:
+          type: string
+        pageUrl:
+          type: string
+    PurchaseEvent:
+      type: object
+      required:
+        - eventType
+        - productId
+        - amount
+      properties:
+        eventType:
+          type: string
+        productId:
+          type: string
+        amount:
+          type: number

--- a/conformance-tests/src/test/resources/specs/014-nullable-and-optional/001-nullable-string.yaml
+++ b/conformance-tests/src/test/resources/specs/014-nullable-and-optional/001-nullable-string.yaml
@@ -1,0 +1,46 @@
+openapi: 3.0.3
+info:
+  title: "Nullable string property"
+  version: "1.0"
+paths:
+  /contacts:
+    get:
+      operationId: listContacts
+      responses:
+        '200':
+          description: Contact list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - name
+                    - nickname
+                  properties:
+                    name:
+                      type: string
+                    nickname:
+                      type: string
+                      nullable: true
+    post:
+      operationId: createContact
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+                - nickname
+              properties:
+                name:
+                  type: string
+                nickname:
+                  type: string
+                  nullable: true
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/014-nullable-and-optional/002-nullable-integer.yaml
+++ b/conformance-tests/src/test/resources/specs/014-nullable-and-optional/002-nullable-integer.yaml
@@ -1,0 +1,46 @@
+openapi: 3.0.3
+info:
+  title: "Nullable integer property"
+  version: "1.0"
+paths:
+  /employees:
+    get:
+      operationId: listEmployees
+      responses:
+        '200':
+          description: Employee list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - name
+                    - managerId
+                  properties:
+                    name:
+                      type: string
+                    managerId:
+                      type: integer
+                      nullable: true
+    post:
+      operationId: createEmployee
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+                - managerId
+              properties:
+                name:
+                  type: string
+                managerId:
+                  type: integer
+                  nullable: true
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/014-nullable-and-optional/003-nullable-object.yaml
+++ b/conformance-tests/src/test/resources/specs/014-nullable-and-optional/003-nullable-object.yaml
@@ -1,0 +1,60 @@
+openapi: 3.0.3
+info:
+  title: "Nullable object property"
+  version: "1.0"
+paths:
+  /profiles:
+    get:
+      operationId: listProfiles
+      responses:
+        '200':
+          description: Profile list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - name
+                    - address
+                  properties:
+                    name:
+                      type: string
+                    address:
+                      nullable: true
+                      type: object
+                      required:
+                        - city
+                      properties:
+                        city:
+                          type: string
+                        zipCode:
+                          type: string
+    post:
+      operationId: createProfile
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+                - address
+              properties:
+                name:
+                  type: string
+                address:
+                  nullable: true
+                  type: object
+                  required:
+                    - city
+                  properties:
+                    city:
+                      type: string
+                    zipCode:
+                      type: string
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/014-nullable-and-optional/004-nullable-array.yaml
+++ b/conformance-tests/src/test/resources/specs/014-nullable-and-optional/004-nullable-array.yaml
@@ -1,0 +1,50 @@
+openapi: 3.0.3
+info:
+  title: "Nullable array property"
+  version: "1.0"
+paths:
+  /teams:
+    get:
+      operationId: listTeams
+      responses:
+        '200':
+          description: Team list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - name
+                    - members
+                  properties:
+                    name:
+                      type: string
+                    members:
+                      type: array
+                      nullable: true
+                      items:
+                        type: string
+    post:
+      operationId: createTeam
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+                - members
+              properties:
+                name:
+                  type: string
+                members:
+                  type: array
+                  nullable: true
+                  items:
+                    type: string
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/014-nullable-and-optional/005-optional-property.yaml
+++ b/conformance-tests/src/test/resources/specs/014-nullable-and-optional/005-optional-property.yaml
@@ -1,0 +1,46 @@
+openapi: 3.0.3
+info:
+  title: "Optional (not required) property"
+  version: "1.0"
+paths:
+  /users:
+    get:
+      operationId: listUsers
+      responses:
+        '200':
+          description: User list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    name:
+                      type: string
+                    bio:
+                      type: string
+                    age:
+                      type: integer
+    post:
+      operationId: createUser
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+                bio:
+                  type: string
+                age:
+                  type: integer
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/014-nullable-and-optional/006-optional-and-nullable.yaml
+++ b/conformance-tests/src/test/resources/specs/014-nullable-and-optional/006-optional-and-nullable.yaml
@@ -1,0 +1,52 @@
+openapi: 3.0.3
+info:
+  title: "Optional and nullable combined"
+  version: "1.0"
+paths:
+  /records:
+    get:
+      operationId: listRecords
+      responses:
+        '200':
+          description: Record list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - id
+                  properties:
+                    id:
+                      type: integer
+                    notes:
+                      type: string
+                      nullable: true
+                    deletedAt:
+                      type: string
+                      format: date-time
+                      nullable: true
+    post:
+      operationId: createRecord
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - id
+              properties:
+                id:
+                  type: integer
+                notes:
+                  type: string
+                  nullable: true
+                deletedAt:
+                  type: string
+                  format: date-time
+                  nullable: true
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/014-nullable-and-optional/007-nullable-enum.yaml
+++ b/conformance-tests/src/test/resources/specs/014-nullable-and-optional/007-nullable-enum.yaml
@@ -1,0 +1,54 @@
+openapi: 3.0.3
+info:
+  title: "Nullable enum property"
+  version: "1.0"
+paths:
+  /tasks:
+    get:
+      operationId: listTasks
+      responses:
+        '200':
+          description: Task list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - title
+                    - priority
+                  properties:
+                    title:
+                      type: string
+                    priority:
+                      type: string
+                      nullable: true
+                      enum:
+                        - low
+                        - medium
+                        - high
+    post:
+      operationId: createTask
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - title
+                - priority
+              properties:
+                title:
+                  type: string
+                priority:
+                  type: string
+                  nullable: true
+                  enum:
+                    - low
+                    - medium
+                    - high
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/015-additional-properties/001-additional-properties-true.yaml
+++ b/conformance-tests/src/test/resources/specs/015-additional-properties/001-additional-properties-true.yaml
@@ -1,0 +1,40 @@
+openapi: 3.0.3
+info:
+  title: "additionalProperties true"
+  version: "1.0"
+paths:
+  /configs:
+    get:
+      operationId: listConfigs
+      responses:
+        '200':
+          description: Config list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    name:
+                      type: string
+                  additionalProperties: true
+    post:
+      operationId: createConfig
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+              additionalProperties: true
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/015-additional-properties/002-additional-properties-false.yaml
+++ b/conformance-tests/src/test/resources/specs/015-additional-properties/002-additional-properties-false.yaml
@@ -1,0 +1,44 @@
+openapi: 3.0.3
+info:
+  title: "additionalProperties false"
+  version: "1.0"
+paths:
+  /settings:
+    get:
+      operationId: getSettings
+      responses:
+        '200':
+          description: Settings
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - theme
+                  - language
+                properties:
+                  theme:
+                    type: string
+                  language:
+                    type: string
+                additionalProperties: false
+    post:
+      operationId: updateSettings
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - theme
+                - language
+              properties:
+                theme:
+                  type: string
+                language:
+                  type: string
+              additionalProperties: false
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/015-additional-properties/003-additional-properties-typed.yaml
+++ b/conformance-tests/src/test/resources/specs/015-additional-properties/003-additional-properties-typed.yaml
@@ -1,0 +1,40 @@
+openapi: 3.0.3
+info:
+  title: "additionalProperties with typed schema"
+  version: "1.0"
+paths:
+  /labels:
+    get:
+      operationId: getLabels
+      responses:
+        '200':
+          description: Labels map
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                properties:
+                  id:
+                    type: integer
+                additionalProperties:
+                  type: string
+    post:
+      operationId: createLabels
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - id
+              properties:
+                id:
+                  type: integer
+              additionalProperties:
+                type: string
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/015-additional-properties/004-additional-properties-object-schema.yaml
+++ b/conformance-tests/src/test/resources/specs/015-additional-properties/004-additional-properties-object-schema.yaml
@@ -1,0 +1,46 @@
+openapi: 3.0.3
+info:
+  title: "additionalProperties with object schema"
+  version: "1.0"
+paths:
+  /catalogs:
+    get:
+      operationId: getCatalog
+      responses:
+        '200':
+          description: Catalog
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: object
+                  required:
+                    - price
+                    - stock
+                  properties:
+                    price:
+                      type: number
+                    stock:
+                      type: integer
+    post:
+      operationId: createCatalog
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+                required:
+                  - price
+                  - stock
+                properties:
+                  price:
+                    type: number
+                  stock:
+                    type: integer
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/015-additional-properties/005-free-form-object.yaml
+++ b/conformance-tests/src/test/resources/specs/015-additional-properties/005-free-form-object.yaml
@@ -1,0 +1,26 @@
+openapi: 3.0.3
+info:
+  title: "Free-form object (no properties defined)"
+  version: "1.0"
+paths:
+  /metadata:
+    get:
+      operationId: getMetadata
+      responses:
+        '200':
+          description: Free-form metadata
+          content:
+            application/json:
+              schema:
+                type: object
+    post:
+      operationId: createMetadata
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/015-additional-properties/006-additional-properties-integer.yaml
+++ b/conformance-tests/src/test/resources/specs/015-additional-properties/006-additional-properties-integer.yaml
@@ -1,0 +1,30 @@
+openapi: 3.0.3
+info:
+  title: "additionalProperties with integer values"
+  version: "1.0"
+paths:
+  /scores:
+    get:
+      operationId: getScores
+      responses:
+        '200':
+          description: Score map
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: integer
+    post:
+      operationId: createScores
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: integer
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/016-default-values/001-default-string-property.yaml
+++ b/conformance-tests/src/test/resources/specs/016-default-values/001-default-string-property.yaml
@@ -1,0 +1,44 @@
+openapi: 3.0.3
+info:
+  title: "Default value - string property"
+  version: "1.0"
+paths:
+  /tickets:
+    get:
+      operationId: listTickets
+      responses:
+        '200':
+          description: Ticket list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - title
+                  properties:
+                    title:
+                      type: string
+                    status:
+                      type: string
+                      default: open
+    post:
+      operationId: createTicket
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - title
+              properties:
+                title:
+                  type: string
+                status:
+                  type: string
+                  default: open
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/016-default-values/002-default-integer-property.yaml
+++ b/conformance-tests/src/test/resources/specs/016-default-values/002-default-integer-property.yaml
@@ -1,0 +1,44 @@
+openapi: 3.0.3
+info:
+  title: "Default value - integer property"
+  version: "1.0"
+paths:
+  /products:
+    get:
+      operationId: listProducts
+      responses:
+        '200':
+          description: Product list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    name:
+                      type: string
+                    quantity:
+                      type: integer
+                      default: 0
+    post:
+      operationId: createProduct
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+                quantity:
+                  type: integer
+                  default: 0
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/016-default-values/003-default-boolean-property.yaml
+++ b/conformance-tests/src/test/resources/specs/016-default-values/003-default-boolean-property.yaml
@@ -1,0 +1,44 @@
+openapi: 3.0.3
+info:
+  title: "Default value - boolean property"
+  version: "1.0"
+paths:
+  /features:
+    get:
+      operationId: listFeatures
+      responses:
+        '200':
+          description: Feature list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    name:
+                      type: string
+                    enabled:
+                      type: boolean
+                      default: false
+    post:
+      operationId: createFeature
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+                enabled:
+                  type: boolean
+                  default: false
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/016-default-values/004-default-enum.yaml
+++ b/conformance-tests/src/test/resources/specs/016-default-values/004-default-enum.yaml
@@ -1,0 +1,52 @@
+openapi: 3.0.3
+info:
+  title: "Default value - enum property"
+  version: "1.0"
+paths:
+  /alerts:
+    get:
+      operationId: listAlerts
+      responses:
+        '200':
+          description: Alert list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - message
+                  properties:
+                    message:
+                      type: string
+                    severity:
+                      type: string
+                      enum:
+                        - info
+                        - warning
+                        - error
+                      default: info
+    post:
+      operationId: createAlert
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - message
+              properties:
+                message:
+                  type: string
+                severity:
+                  type: string
+                  enum:
+                    - info
+                    - warning
+                    - error
+                  default: info
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/016-default-values/005-default-query-parameter.yaml
+++ b/conformance-tests/src/test/resources/specs/016-default-values/005-default-query-parameter.yaml
@@ -1,0 +1,41 @@
+openapi: 3.0.3
+info:
+  title: "Default value - query parameter"
+  version: "1.0"
+paths:
+  /items:
+    get:
+      operationId: listItems
+      parameters:
+        - name: sort
+          in: query
+          required: false
+          schema:
+            type: string
+            default: createdAt
+        - name: order
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - asc
+              - desc
+            default: desc
+      responses:
+        '200':
+          description: Sorted items
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - id
+                    - name
+                  properties:
+                    id:
+                      type: integer
+                    name:
+                      type: string

--- a/conformance-tests/src/test/resources/specs/016-default-values/006-default-number-property.yaml
+++ b/conformance-tests/src/test/resources/specs/016-default-values/006-default-number-property.yaml
@@ -1,0 +1,44 @@
+openapi: 3.0.3
+info:
+  title: "Default value - number property"
+  version: "1.0"
+paths:
+  /discounts:
+    get:
+      operationId: listDiscounts
+      responses:
+        '200':
+          description: Discount list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - code
+                  properties:
+                    code:
+                      type: string
+                    percentage:
+                      type: number
+                      default: 10.0
+    post:
+      operationId: createDiscount
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - code
+              properties:
+                code:
+                  type: string
+                percentage:
+                  type: number
+                  default: 10.0
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/017-security-schemes/001-api-key-header.yaml
+++ b/conformance-tests/src/test/resources/specs/017-security-schemes/001-api-key-header.yaml
@@ -1,0 +1,51 @@
+openapi: 3.0.3
+info:
+  title: "Security scheme - API key in header"
+  version: "1.0"
+paths:
+  /items:
+    get:
+      operationId: listItems
+      security:
+        - apiKey: []
+      responses:
+        '200':
+          description: Items list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - id
+                    - name
+                  properties:
+                    id:
+                      type: integer
+                    name:
+                      type: string
+    post:
+      operationId: createItem
+      security:
+        - apiKey: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+      responses:
+        '201':
+          description: Created
+components:
+  securitySchemes:
+    apiKey:
+      type: apiKey
+      in: header
+      name: X-Api-Key

--- a/conformance-tests/src/test/resources/specs/017-security-schemes/002-api-key-query.yaml
+++ b/conformance-tests/src/test/resources/specs/017-security-schemes/002-api-key-query.yaml
@@ -1,0 +1,46 @@
+openapi: 3.0.3
+info:
+  title: "Security scheme - API key in query"
+  version: "1.0"
+paths:
+  /data:
+    get:
+      operationId: getData
+      security:
+        - apiKeyQuery: []
+      responses:
+        '200':
+          description: Data
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - value
+                properties:
+                  value:
+                    type: string
+    post:
+      operationId: createData
+      security:
+        - apiKeyQuery: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - value
+              properties:
+                value:
+                  type: string
+      responses:
+        '201':
+          description: Created
+components:
+  securitySchemes:
+    apiKeyQuery:
+      type: apiKey
+      in: query
+      name: api_key

--- a/conformance-tests/src/test/resources/specs/017-security-schemes/003-http-bearer.yaml
+++ b/conformance-tests/src/test/resources/specs/017-security-schemes/003-http-bearer.yaml
@@ -1,0 +1,51 @@
+openapi: 3.0.3
+info:
+  title: "Security scheme - HTTP bearer token"
+  version: "1.0"
+paths:
+  /accounts:
+    get:
+      operationId: listAccounts
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Account list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - id
+                    - name
+                  properties:
+                    id:
+                      type: integer
+                    name:
+                      type: string
+    post:
+      operationId: createAccount
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+      responses:
+        '201':
+          description: Created
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT

--- a/conformance-tests/src/test/resources/specs/017-security-schemes/004-http-basic.yaml
+++ b/conformance-tests/src/test/resources/specs/017-security-schemes/004-http-basic.yaml
@@ -1,0 +1,53 @@
+openapi: 3.0.3
+info:
+  title: "Security scheme - HTTP basic auth"
+  version: "1.0"
+paths:
+  /secrets:
+    get:
+      operationId: listSecrets
+      security:
+        - basicAuth: []
+      responses:
+        '200':
+          description: Secrets list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - id
+                    - key
+                  properties:
+                    id:
+                      type: integer
+                    key:
+                      type: string
+    post:
+      operationId: createSecret
+      security:
+        - basicAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - key
+                - value
+              properties:
+                key:
+                  type: string
+                value:
+                  type: string
+      responses:
+        '201':
+          description: Created
+components:
+  securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic

--- a/conformance-tests/src/test/resources/specs/017-security-schemes/005-global-security.yaml
+++ b/conformance-tests/src/test/resources/specs/017-security-schemes/005-global-security.yaml
@@ -1,0 +1,48 @@
+openapi: 3.0.3
+info:
+  title: "Security scheme - global security"
+  version: "1.0"
+security:
+  - bearerAuth: []
+paths:
+  /projects:
+    get:
+      operationId: listProjects
+      responses:
+        '200':
+          description: Project list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - id
+                    - name
+                  properties:
+                    id:
+                      type: integer
+                    name:
+                      type: string
+    post:
+      operationId: createProject
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+      responses:
+        '201':
+          description: Created
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer

--- a/conformance-tests/src/test/resources/specs/017-security-schemes/006-per-operation-override.yaml
+++ b/conformance-tests/src/test/resources/specs/017-security-schemes/006-per-operation-override.yaml
@@ -1,0 +1,45 @@
+openapi: 3.0.3
+info:
+  title: "Security scheme - per-operation override"
+  version: "1.0"
+security:
+  - bearerAuth: []
+paths:
+  /public/health:
+    get:
+      operationId: healthCheck
+      summary: Public endpoint overriding global security
+      security: []
+      responses:
+        '200':
+          description: Health status
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - status
+                properties:
+                  status:
+                    type: string
+  /private/data:
+    get:
+      operationId: getPrivateData
+      summary: Uses global bearer auth
+      responses:
+        '200':
+          description: Private data
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - secret
+                properties:
+                  secret:
+                    type: string
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer

--- a/conformance-tests/src/test/resources/specs/018-pagination/001-offset-limit.yaml
+++ b/conformance-tests/src/test/resources/specs/018-pagination/001-offset-limit.yaml
@@ -1,0 +1,51 @@
+openapi: 3.0.3
+info:
+  title: "Pagination - offset and limit"
+  version: "1.0"
+paths:
+  /items:
+    get:
+      operationId: listItems
+      summary: List items with offset/limit pagination
+      parameters:
+        - name: offset
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 0
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 20
+      responses:
+        '200':
+          description: Paginated items
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - items
+                  - total
+                properties:
+                  items:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - id
+                        - name
+                      properties:
+                        id:
+                          type: integer
+                        name:
+                          type: string
+                  total:
+                    type: integer
+                  offset:
+                    type: integer
+                  limit:
+                    type: integer

--- a/conformance-tests/src/test/resources/specs/018-pagination/002-page-number.yaml
+++ b/conformance-tests/src/test/resources/specs/018-pagination/002-page-number.yaml
@@ -1,0 +1,52 @@
+openapi: 3.0.3
+info:
+  title: "Pagination - page number and size"
+  version: "1.0"
+paths:
+  /products:
+    get:
+      operationId: listProducts
+      summary: List products with page number pagination
+      parameters:
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 1
+        - name: pageSize
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 10
+      responses:
+        '200':
+          description: Paginated products
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                  - page
+                  - totalPages
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - id
+                        - name
+                      properties:
+                        id:
+                          type: integer
+                        name:
+                          type: string
+                  page:
+                    type: integer
+                  pageSize:
+                    type: integer
+                  totalPages:
+                    type: integer

--- a/conformance-tests/src/test/resources/specs/018-pagination/003-cursor-based.yaml
+++ b/conformance-tests/src/test/resources/specs/018-pagination/003-cursor-based.yaml
@@ -1,0 +1,48 @@
+openapi: 3.0.3
+info:
+  title: "Pagination - cursor-based"
+  version: "1.0"
+paths:
+  /events:
+    get:
+      operationId: listEvents
+      summary: List events with cursor-based pagination
+      parameters:
+        - name: cursor
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 25
+      responses:
+        '200':
+          description: Paginated events
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                  - hasMore
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - id
+                        - name
+                      properties:
+                        id:
+                          type: string
+                        name:
+                          type: string
+                  hasMore:
+                    type: boolean
+                  nextCursor:
+                    type: string

--- a/conformance-tests/src/test/resources/specs/018-pagination/004-pagination-with-sorting.yaml
+++ b/conformance-tests/src/test/resources/specs/018-pagination/004-pagination-with-sorting.yaml
@@ -1,0 +1,70 @@
+openapi: 3.0.3
+info:
+  title: "Pagination with sorting parameters"
+  version: "1.0"
+paths:
+  /users:
+    get:
+      operationId: listUsers
+      summary: List users with pagination and sorting
+      parameters:
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 1
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 20
+        - name: sortBy
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - name
+              - createdAt
+              - email
+            default: createdAt
+        - name: order
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - asc
+              - desc
+            default: desc
+      responses:
+        '200':
+          description: Paginated and sorted users
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                  - total
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - id
+                        - name
+                        - email
+                      properties:
+                        id:
+                          type: integer
+                        name:
+                          type: string
+                        email:
+                          type: string
+                          format: email
+                  total:
+                    type: integer

--- a/conformance-tests/src/test/resources/specs/019-examples/001-example-on-property.yaml
+++ b/conformance-tests/src/test/resources/specs/019-examples/001-example-on-property.yaml
@@ -1,0 +1,50 @@
+openapi: 3.0.3
+info:
+  title: "Example on schema properties"
+  version: "1.0"
+paths:
+  /users:
+    get:
+      operationId: listUsers
+      responses:
+        '200':
+          description: User list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - name
+                    - email
+                  properties:
+                    name:
+                      type: string
+                      example: Jane Doe
+                    email:
+                      type: string
+                      format: email
+                      example: jane@example.com
+    post:
+      operationId: createUser
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+                - email
+              properties:
+                name:
+                  type: string
+                  example: Jane Doe
+                email:
+                  type: string
+                  format: email
+                  example: jane@example.com
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/019-examples/002-example-on-schema.yaml
+++ b/conformance-tests/src/test/resources/specs/019-examples/002-example-on-schema.yaml
@@ -1,0 +1,50 @@
+openapi: 3.0.3
+info:
+  title: "Example on schema object"
+  version: "1.0"
+paths:
+  /products:
+    get:
+      operationId: listProducts
+      responses:
+        '200':
+          description: Product list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - name
+                    - price
+                  properties:
+                    name:
+                      type: string
+                    price:
+                      type: number
+                  example:
+                    name: Widget
+                    price: 9.99
+    post:
+      operationId: createProduct
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+                - price
+              properties:
+                name:
+                  type: string
+                price:
+                  type: number
+              example:
+                name: Widget
+                price: 9.99
+      responses:
+        '201':
+          description: Created

--- a/conformance-tests/src/test/resources/specs/019-examples/003-example-on-parameter.yaml
+++ b/conformance-tests/src/test/resources/specs/019-examples/003-example-on-parameter.yaml
@@ -1,0 +1,30 @@
+openapi: 3.0.3
+info:
+  title: "Example on parameter"
+  version: "1.0"
+paths:
+  /orders/{orderId}:
+    get:
+      operationId: getOrder
+      parameters:
+        - name: orderId
+          in: path
+          required: true
+          schema:
+            type: integer
+          example: 42
+      responses:
+        '200':
+          description: Order found
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                  - status
+                properties:
+                  id:
+                    type: integer
+                  status:
+                    type: string

--- a/conformance-tests/src/test/resources/specs/019-examples/004-examples-on-media-type.yaml
+++ b/conformance-tests/src/test/resources/specs/019-examples/004-examples-on-media-type.yaml
@@ -1,0 +1,46 @@
+openapi: 3.0.3
+info:
+  title: "Examples on media type"
+  version: "1.0"
+paths:
+  /events:
+    post:
+      operationId: createEvent
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+                - date
+              properties:
+                name:
+                  type: string
+                date:
+                  type: string
+                  format: date
+            examples:
+              conference:
+                summary: A conference event
+                value:
+                  name: Tech Summit
+                  date: "2025-06-15"
+              workshop:
+                summary: A workshop event
+                value:
+                  name: Kotlin Workshop
+                  date: "2025-07-01"
+      responses:
+        '201':
+          description: Event created
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                properties:
+                  id:
+                    type: integer

--- a/conformance-tests/src/test/resources/specs/019-examples/005-example-on-query-parameter.yaml
+++ b/conformance-tests/src/test/resources/specs/019-examples/005-example-on-query-parameter.yaml
@@ -1,0 +1,38 @@
+openapi: 3.0.3
+info:
+  title: "Example on query parameter"
+  version: "1.0"
+paths:
+  /search:
+    get:
+      operationId: searchItems
+      parameters:
+        - name: q
+          in: query
+          required: true
+          schema:
+            type: string
+          example: specmatic
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+          example: 10
+      responses:
+        '200':
+          description: Search results
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - id
+                    - title
+                  properties:
+                    id:
+                      type: integer
+                    title:
+                      type: string

--- a/conformance-tests/src/test/resources/specs/019-examples/006-example-on-header-parameter.yaml
+++ b/conformance-tests/src/test/resources/specs/019-examples/006-example-on-header-parameter.yaml
@@ -1,0 +1,33 @@
+openapi: 3.0.3
+info:
+  title: "Example on header parameter"
+  version: "1.0"
+paths:
+  /resources:
+    get:
+      operationId: listResources
+      parameters:
+        - name: X-Request-Id
+          in: header
+          required: true
+          schema:
+            type: string
+            format: uuid
+          example: 550e8400-e29b-41d4-a716-446655440000
+      responses:
+        '200':
+          description: Resource list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - id
+                    - name
+                  properties:
+                    id:
+                      type: integer
+                    name:
+                      type: string


### PR DESCRIPTION
Add new spec categories to the conformance tests:
1. 008-constraints
2. 009-forms-and-multipart
3. 010-status-codes
4. 011-refs-and-components
5. 012-content-negotiation
6. 013-discriminator
7. 014-nullable-and-optional
8. 015-additional-properties
9. 016-default-values
10. 017-security-schemes
11. 018-pagination
12. 019-examples
