### PR TITLE
feat: add support to store and replace variables across before and after fixtures using generic ExecutionVariableContext

### DIFF
--- a/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
@@ -11,6 +11,7 @@ import io.specmatic.license.core.SpecmaticProtocol
 import io.specmatic.reporter.model.SpecType
 import io.specmatic.stub.SPECMATIC_RESPONSE_CODE_HEADER
 import io.specmatic.test.fixtures.OpenAPIFixtureExecutor
+import io.specmatic.test.variables.ExecutionVariableContext
 import io.specmatic.test.handlers.ResponseHandler
 import io.specmatic.test.handlers.ResponseHandlerRegistry
 import io.specmatic.test.handlers.ResponseHandlingResult
@@ -119,8 +120,9 @@ data class ScenarioAsTest(
         testExecutor: TestExecutor,
         flagsBased: FlagsBased
     ): ContractTestExecutionResult {
+        val executionVariableContext = ExecutionVariableContext()
         try {
-            val beforeFixtureExecutionResult = fixtureExecutionResult(BEFORE_FIXTURE_DISCRIMINATOR_KEY)
+            val beforeFixtureExecutionResult = fixtureExecutionResult(BEFORE_FIXTURE_DISCRIMINATOR_KEY, executionVariableContext)
             if (beforeFixtureExecutionResult.isSuccess().not()) {
                 return ContractTestExecutionResult(result = beforeFixtureExecutionResult)
             }
@@ -154,7 +156,7 @@ data class ScenarioAsTest(
             val validatorResult = validators.asSequence().mapNotNull { it.validate(scenario, response) }.firstOrNull()
 
             if(validatorResult !is Result.Failure) {
-                val afterFixtureExecutionResult = fixtureExecutionResult(AFTER_FIXTURE_DISCRIMINATOR_KEY)
+                val afterFixtureExecutionResult = fixtureExecutionResult(AFTER_FIXTURE_DISCRIMINATOR_KEY, executionVariableContext)
                 if (afterFixtureExecutionResult.isSuccess().not()) {
                     return ContractTestExecutionResult(
                         result = afterFixtureExecutionResult,
@@ -218,7 +220,7 @@ data class ScenarioAsTest(
         }
     }
 
-    private fun fixtureExecutionResult(fixtureDiscriminatorKey: String): Result {
+    private fun fixtureExecutionResult(fixtureDiscriminatorKey: String, executionVariableContext: ExecutionVariableContext): Result {
         val row = scenario.exampleRow ?: return Result.Success()
         val scenarioStub = row.scenarioStub ?: return Result.Success()
         val id = scenarioStub.id.orEmpty()
@@ -227,7 +229,7 @@ data class ScenarioAsTest(
             else -> scenarioStub.afterFixtures
         }
         return ServiceLoader.load(OpenAPIFixtureExecutor::class.java)
-            .firstOrNull()?.execute(id, fixtures, fixtureDiscriminatorKey) ?: Result.Success()
+            .firstOrNull()?.execute(id, fixtures, fixtureDiscriminatorKey, executionVariableContext) ?: Result.Success()
     }
 
     private fun testResult(

--- a/core/src/main/kotlin/io/specmatic/test/fixtures/OpenAPIFixtureExecutor.kt
+++ b/core/src/main/kotlin/io/specmatic/test/fixtures/OpenAPIFixtureExecutor.kt
@@ -2,7 +2,8 @@ package io.specmatic.test.fixtures
 
 import io.specmatic.core.Result
 import io.specmatic.core.value.Value
+import io.specmatic.test.variables.ExecutionVariableContext
 
 interface OpenAPIFixtureExecutor {
-    fun execute(id: String, fixtures: List<Value>, fixtureDiscriminatorKey: String): Result
+    fun execute(id: String, fixtures: List<Value>, fixtureDiscriminatorKey: String, executionVariableContext: ExecutionVariableContext): Result
 }

--- a/core/src/main/kotlin/io/specmatic/test/variables/ExecutionVariableContext.kt
+++ b/core/src/main/kotlin/io/specmatic/test/variables/ExecutionVariableContext.kt
@@ -1,0 +1,90 @@
+package io.specmatic.test.variables
+
+import io.specmatic.core.pattern.ContractException
+import io.specmatic.core.value.JSONArrayValue
+import io.specmatic.core.value.JSONObjectValue
+import io.specmatic.core.value.StringValue
+import io.specmatic.core.value.Value
+import io.specmatic.test.ExampleProcessor.toFactStore
+
+// Matches a string that is exactly one substitution token, e.g. `$(FIXTURE.BEFORE.1.RESPONSE.id)`.
+private val EXACT_SUBSTITUTION_PATTERN = Regex("""^\$\((.*)\)$""")
+// Matches substitution tokens embedded inside a larger string, e.g. `/orders/$(FIXTURE.BEFORE.1.RESPONSE.id)`.
+private val INLINE_SUBSTITUTION_PATTERN = Regex("""\$\((.*?)\)""")
+
+/**
+ * Stores values captured during a single execution flow and resolves `$(...)` lookups against them.
+ * Stored values are flattened so nested JSON fields can be referenced using dotted paths.
+ */
+class ExecutionVariableContext {
+    private val values = linkedMapOf<String, Value>()
+
+    fun store(key: String, value: Value) {
+        values[key] = value
+        values.putAll(value.toFactStore(key))
+    }
+
+    fun getValue(key: String): Value =
+        values[key] ?: throw ContractException(
+            breadCrumb = key,
+            errorMessage = "Could not resolve \"$key\", key does not exist in execution variable context"
+        )
+
+    fun allValues(): Map<String, Value> = values.toMap()
+
+    fun resolveString(value: String): String =
+        resolveSubstitutions(
+            value = value,
+            convertExactMatchValue = Value::toStringLiteral,
+            convertInterpolatedString = { it }
+        )
+
+    fun resolveValue(value: Value): Value =
+        when (value) {
+            is StringValue -> resolveStringValue(value)
+            is JSONObjectValue -> JSONObjectValue(value.jsonObject.mapValues { (_, childValue) -> resolveValue(childValue) })
+            is JSONArrayValue -> JSONArrayValue(value.list.map(::resolveValue))
+            else -> value
+        }
+
+    fun resolveAny(value: Any?): Any? =
+        when (value) {
+            is String -> resolveStringOrNativeValue(value)
+            is Map<*, *> -> value.entries.associate { (key, childValue) ->
+                key.toString() to resolveAny(childValue)
+            }
+            is List<*> -> value.map(::resolveAny)
+            else -> value
+        }
+
+    private fun resolveStringValue(value: StringValue): Value =
+        resolveSubstitutions(
+            value = value.string,
+            convertExactMatchValue = { it },
+            convertInterpolatedString = ::StringValue
+        )
+
+    private fun resolveStringOrNativeValue(value: String): Any? =
+        resolveSubstitutions(
+            value = value,
+            convertExactMatchValue = Value::toNativeValue,
+            convertInterpolatedString = { it }
+        )
+
+    private fun <T> resolveSubstitutions(
+        value: String,
+        convertExactMatchValue: (Value) -> T,
+        convertInterpolatedString: (String) -> T
+    ): T {
+        lookupExactValue(value)?.let { return convertExactMatchValue(it) }
+
+        val resolved = INLINE_SUBSTITUTION_PATTERN.replace(value) { match ->
+            getValue(match.groupValues[1]).toStringLiteral()
+        }
+
+        return convertInterpolatedString(resolved)
+    }
+
+    private fun lookupExactValue(value: String): Value? =
+        EXACT_SUBSTITUTION_PATTERN.matchEntire(value)?.groupValues?.get(1)?.let(::getValue)
+}

--- a/core/src/test/kotlin/io/specmatic/test/ScenarioAsTestTest.kt
+++ b/core/src/test/kotlin/io/specmatic/test/ScenarioAsTestTest.kt
@@ -18,6 +18,7 @@ import io.specmatic.license.core.SpecmaticProtocol
 import io.specmatic.mock.ScenarioStub
 import io.specmatic.reporter.model.SpecType
 import io.specmatic.test.fixtures.OpenAPIFixtureExecutor
+import io.specmatic.test.variables.ExecutionVariableContext
 import io.specmatic.test.matchers.MatcherExecutor
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
@@ -112,6 +113,32 @@ class ScenarioAsTestTest {
 
             assertThat(result).isInstanceOf(Result.Success::class.java)
             assertThat(ServiceLoaderTestFixtureExecutor.calls).containsExactly("before", "after")
+            assertThat(ServiceLoaderTestFixtureExecutor.contexts).hasSize(2)
+            assertThat(ServiceLoaderTestFixtureExecutor.contexts[0]).isSameAs(ServiceLoaderTestFixtureExecutor.contexts[1])
+        }
+
+        @Test
+        fun `shares fixture variable context across before and after fixture execution`() {
+            ServiceLoaderTestFixtureExecutor.reset()
+
+            val scenario = scenario(
+                Row(
+                    scenarioStub = ScenarioStub(
+                        id = "fixture-id",
+                        beforeFixtures = listOf(StringValue("before")),
+                        afterFixtures = listOf(StringValue("after"))
+                    )
+                )
+            )
+
+            val result = withServiceLoaderEntries(
+                mapOf(OpenAPIFixtureExecutor::class.java to ServiceLoaderTestFixtureExecutor::class.java.name)
+            ) {
+                scenarioAsTest(scenario).runTest(fixedResponseExecutor("anything")).result
+            }
+
+            assertThat(result).isInstanceOf(Result.Success::class.java)
+            assertThat(ServiceLoaderTestFixtureExecutor.afterSawStoredValue).isTrue()
         }
 
         @Test
@@ -214,16 +241,30 @@ class ServiceLoaderTestMatcherExecutor : MatcherExecutor {
 }
 
 class ServiceLoaderTestFixtureExecutor : OpenAPIFixtureExecutor {
-    override fun execute(id: String, fixtures: List<Value>, fixtureDiscriminatorKey: String): Result {
+    override fun execute(id: String, fixtures: List<Value>, fixtureDiscriminatorKey: String, executionVariableContext: ExecutionVariableContext): Result {
         calls.add(fixtureDiscriminatorKey)
+        contexts.add(executionVariableContext)
+
+        if (fixtureDiscriminatorKey == "before") {
+            executionVariableContext.store("FIXTURE.BEFORE.1.RESPONSE", StringValue("stored"))
+        }
+
+        if (fixtureDiscriminatorKey == "after") {
+            afterSawStoredValue = executionVariableContext.getValue("FIXTURE.BEFORE.1.RESPONSE") == StringValue("stored")
+        }
+
         return Result.Success()
     }
 
     companion object {
         val calls: MutableList<String> = mutableListOf()
+        val contexts: MutableList<ExecutionVariableContext> = mutableListOf()
+        var afterSawStoredValue: Boolean = false
 
         fun reset() {
             calls.clear()
+            contexts.clear()
+            afterSawStoredValue = false
         }
     }
 }

--- a/core/src/test/kotlin/io/specmatic/test/variables/ExecutionVariableContextTest.kt
+++ b/core/src/test/kotlin/io/specmatic/test/variables/ExecutionVariableContextTest.kt
@@ -1,0 +1,145 @@
+package io.specmatic.test.variables
+
+import io.specmatic.core.pattern.ContractException
+import io.specmatic.core.value.JSONArrayValue
+import io.specmatic.core.value.BooleanValue
+import io.specmatic.core.value.JSONObjectValue
+import io.specmatic.core.value.NumberValue
+import io.specmatic.core.value.StringValue
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class ExecutionVariableContextTest {
+    @Test
+    fun `should flatten stored json values for lookup`() {
+        val context = ExecutionVariableContext()
+
+        context.store(
+            "FIXTURE.BEFORE.1.RESPONSE",
+            JSONObjectValue(
+                mapOf(
+                    "id" to NumberValue(10),
+                    "name" to StringValue("Jane")
+                )
+            )
+        )
+
+        assertThat(context.getValue("FIXTURE.BEFORE.1.RESPONSE.id")).isEqualTo(NumberValue(10))
+        assertThat(context.getValue("FIXTURE.BEFORE.1.RESPONSE.name")).isEqualTo(StringValue("Jane"))
+        assertThat(context.allValues()).containsKeys(
+            "FIXTURE.BEFORE.1.RESPONSE",
+            "FIXTURE.BEFORE.1.RESPONSE.id",
+            "FIXTURE.BEFORE.1.RESPONSE.name"
+        )
+    }
+
+    @Test
+    fun `should resolve exact substitution to original typed value`() {
+        val context = ExecutionVariableContext()
+        context.store(
+            "FIXTURE.BEFORE.1.RESPONSE",
+            JSONObjectValue(mapOf("id" to NumberValue(10)))
+        )
+
+        val resolvedValue = context.resolveValue(StringValue("$(FIXTURE.BEFORE.1.RESPONSE)"))
+
+        assertThat(resolvedValue).isEqualTo(JSONObjectValue(mapOf("id" to NumberValue(10))))
+    }
+
+    @Test
+    fun `should resolve inline substitutions inside strings`() {
+        val context = ExecutionVariableContext()
+        context.store("FIXTURE.BEFORE.1.RESPONSE.id", NumberValue(10))
+
+        assertThat(context.resolveString("/orders/$(FIXTURE.BEFORE.1.RESPONSE.id)"))
+            .isEqualTo("/orders/10")
+    }
+
+    @Test
+    fun `should resolve nested maps and lists preserving json types`() {
+        val context = ExecutionVariableContext()
+        context.store(
+            "FIXTURE.BEFORE.1.RESPONSE",
+            JSONObjectValue(
+                mapOf(
+                    "id" to NumberValue(10),
+                    "tags" to JSONArrayValue(listOf(StringValue("a"), StringValue("b")))
+                )
+            )
+        )
+
+        val resolved = context.resolveAny(
+            mapOf(
+                "id" to "$(FIXTURE.BEFORE.1.RESPONSE.id)",
+                "nested" to listOf("$(FIXTURE.BEFORE.1.RESPONSE.tags)")
+            )
+        ) as Map<*, *>
+
+        assertThat(resolved["id"]).isEqualTo(10)
+        assertThat(resolved["nested"]).isEqualTo(listOf(listOf("a", "b")))
+    }
+
+    @Test
+    fun `should preserve non string values while resolving Value trees`() {
+        val context = ExecutionVariableContext()
+
+        val resolved = context.resolveValue(
+            JSONObjectValue(
+                mapOf(
+                    "flag" to BooleanValue(true),
+                    "count" to NumberValue(2),
+                    "list" to JSONArrayValue(listOf(NumberValue(3)))
+                )
+            )
+        )
+
+        assertThat(resolved).isEqualTo(
+            JSONObjectValue(
+                mapOf(
+                    "flag" to BooleanValue(true),
+                    "count" to NumberValue(2),
+                    "list" to JSONArrayValue(listOf(NumberValue(3)))
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `should leave plain strings unchanged when no substitutions are present`() {
+        val context = ExecutionVariableContext()
+
+        assertThat(context.resolveString("/orders/static")).isEqualTo("/orders/static")
+        assertThat(context.resolveAny("plain-value")).isEqualTo("plain-value")
+    }
+
+    @Test
+    fun `should return native values for exact substitutions in resolveAny`() {
+        val context = ExecutionVariableContext()
+        context.store("FIXTURE.BEFORE.1.RESPONSE.id", NumberValue(10))
+        context.store("FIXTURE.BEFORE.1.RESPONSE.active", BooleanValue(true))
+
+        assertThat(context.resolveAny("$(FIXTURE.BEFORE.1.RESPONSE.id)")).isEqualTo(10)
+        assertThat(context.resolveAny("$(FIXTURE.BEFORE.1.RESPONSE.active)")).isEqualTo(true)
+    }
+
+    @Test
+    fun `should leave non collection values unchanged in resolveAny`() {
+        val context = ExecutionVariableContext()
+
+        assertThat(context.resolveAny(10)).isEqualTo(10)
+        assertThat(context.resolveAny(true)).isEqualTo(true)
+        assertThat(context.resolveAny(null)).isNull()
+    }
+
+    @Test
+    fun `should fail with a clear error when key is missing`() {
+        val context = ExecutionVariableContext()
+
+        val exception = assertThrows<ContractException> {
+            context.resolveString("$(FIXTURE.BEFORE.1.RESPONSE.id)")
+        }
+
+        assertThat(exception.message).contains("Could not resolve \"FIXTURE.BEFORE.1.RESPONSE.id\"")
+    }
+}


### PR DESCRIPTION
Reason for change -
Add ability to store and replace variables across the fixtures.
With this change we will be able to capture the response and access the fields from the response using the substitution token syntax e.g. ("$(FIXTURE.BEFORE.1.RESPONSE.id)")