### PR TITLE
Make specmatic version configurable in conformance tests

### DIFF
--- a/conformance-tests/README.md
+++ b/conformance-tests/README.md
@@ -1,23 +1,30 @@
 # Conformance Tests
 
-## Running
+## Running (requires Docker Compose)
 
-### Run only the conformance tests (Docker-based, requires Docker running)
-./gradlew :conformance-tests:test -PenableConformanceTests=true --tests "io.specmatic.conformance_tests.*"
+By default the tests depend on the docker image produced by the build.
 
-### Run only the support code unit tests (no Docker needed, no flag needed)
-./gradlew :conformance-tests:test --tests "io.specmatic.conformance_test_support.*"
+### All tests
+```
+./gradlew :conformance-tests:check -P enableConformanceTests=true
+```
 
-### Run ALL tests in the conformance-tests project
-./gradlew :conformance-tests:test -PenableConformanceTests=true
+### A subset of tests
+This runs the suite `001-http-methods` in `conformance-tests/src/test/resources/specs`
 
 ```
-echo 'enableConformanceTests=true' >> ~/.gradle/gradle.properties
+./gradlew :conformance-tests:test --tests "io.specmatic.conformance_tests.S001*" -P enableConformanceTests=true
+```
+
+### All tests against a specific version of specmatic
+
+```
+./gradlew :conformance-tests:check -P enableConformanceTests=true -P specmaticVersionForConformanceTests=2.39.4
 ```
 
 ## What
 
-Introduce OpenAPI Spec conformance tests. In part 1 we validate and document that Specmatic supports 001-http-methods and 002-path-parameters features from the OpenAPI specification (version 3.0.x) by running a loop test. For example a loop test of the specification 002-path-parameters/007-two-params-with-separator.yaml starts a Specmatic mock for this specification and then points a Specmatic test at it. A successful test validates that Specmatic can load, parse, mock and test such a specification.
+OpenAPI Spec conformance tests that validate the Specmatic can load, test and mock OpenAPI with spec compliant requests and responses.
 
 ## Why
 
@@ -26,12 +33,4 @@ This ensures and documents that Specmatic is and remains compliant with the Open
 ## Design
 
 - All of Specmatic is the System Under Test and is treated as a block box. Only the public interface (exit code and request/responses) are used to validate Specmatic's behaviour.
-- Since these are long running black box tests it's necessary to run them in parallel. We intend to add several hundreds of tests to this suite in follow up PRs. The tests depend on the docker image of Specmatic only.
-- The tests live in an independent gradle project. To run the tests please run ./gradlew :conformance-tests:check -PenableConformanceTests=true. These tests will be wired up to the main build in subsequent PRs.
-
-## Follow up features
-
-- Wire up in the main build and documentation.
-- Detailed request/response validation.
-- Header and Content-Type validations.
-- More features of OpenAPI will be exercised.
+- Since these are long running black box tests it's necessary to run them in parallel. We intend to add several hundreds of tests to this suite. The tests depend on the docker image of Specmatic only.

--- a/conformance-tests/build.gradle.kts
+++ b/conformance-tests/build.gradle.kts
@@ -22,12 +22,14 @@ dependencies {
 }
 
 val enableConformanceTests: String? by project
+val specmaticVersionForConformanceTests: String? by project
 
 tasks.test {
     useJUnitPlatform()
 
     if (enableConformanceTests?.toBoolean() == true) {
         dependsOn(":specmatic-executable:dockerBuild")
+        systemProperty("specmaticVersionForConformanceTests", specmaticVersionForConformanceTests)
     } else {
         exclude("io/specmatic/conformance_tests/")
     }

--- a/conformance-tests/src/test/kotlin/io/specmatic/conformance_tests/AbstractConformanceTest.kt
+++ b/conformance-tests/src/test/kotlin/io/specmatic/conformance_tests/AbstractConformanceTest.kt
@@ -27,8 +27,12 @@ abstract class AbstractConformanceTest(
 
     @BeforeAll
     fun setup() {
+        val specmaticVersionForConformanceTests = System.getProperty("specmaticVersionForConformanceTests")
         dockerCompose = DockerCompose(
-            specmaticVersion = VersionInfo.version,
+            specmaticVersion = when {
+                specmaticVersionForConformanceTests.isNullOrBlank() -> VersionInfo.version
+                else -> specmaticVersionForConformanceTests
+            },
             mitmProxyVersion = "12.2.1",
             pathToOpenAPISpecFile = openAPISpecFile,
             workDir = workDir,
@@ -50,7 +54,7 @@ abstract class AbstractConformanceTest(
     @Order(1)
     fun `loop tests should succeed`() {
         assertThat(loopTestsResult.isSuccessful())
-            .withFailMessage { allLogs }
+            .withFailMessage { "$loopTestsResult.output\n\n$allLogs" }
             .isTrue
     }
 


### PR DESCRIPTION
So that we can target specific versions for tests.