### PR TITLE
chore: rename matchesResult to matchResponseValue so that it explicitly calls out that this method is only to be used for response matching

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/matchers/MatcherEngine.kt
+++ b/core/src/main/kotlin/io/specmatic/core/matchers/MatcherEngine.kt
@@ -9,7 +9,7 @@ import java.util.ServiceLoader
 
 interface MatcherEngine {
     fun patternFrom(value: ScalarValue, originalPattern: Pattern, resolver: Resolver): Pattern
-    fun matchesResult(expectedValue: Value, actualValue: Value, resolver: Resolver): Result
+    fun matchResponseValue(expectedValue: Value, actualValue: Value, resolver: Resolver): Result
 
     companion object {
         fun load(): MatcherEngine? {

--- a/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
@@ -137,7 +137,7 @@ data class ScenarioAsTest(
 
             if(responseBodyFromExample != null) {
                 matcherEngine?.let {
-                    val matchesResult = it.matchesResult(
+                    val matchesResult = it.matchResponseValue(
                         responseBodyFromExample,
                         response.body,
                         testScenario.resolver


### PR DESCRIPTION
Reason for change -
Want to be explicit about the function 'matchesResult' which is supposed to be only used for response matching so that it does not get used at wrong places e.g. request matching.