### PR TITLE
feat: add ability to hook a before each hook per test

### DIFF
--- a/application/src/main/kotlin/application/TestCommand.kt
+++ b/application/src/main/kotlin/application/TestCommand.kt
@@ -13,6 +13,7 @@ import io.specmatic.core.utilities.xmlToString
 import io.specmatic.license.core.cli.Category
 import io.specmatic.test.ContractTestSettings
 import io.specmatic.test.DeprecatedArguments
+import io.specmatic.test.SpecmaticContractTestImpl
 import io.specmatic.test.SpecmaticJUnitSupport
 import io.specmatic.test.listeners.ContractExecutionListener
 import org.junit.platform.engine.discovery.DiscoverySelectors.selectClass
@@ -148,7 +149,7 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
         setTestThreadLocalSettings()
 
         val request: LauncherDiscoveryRequest = LauncherDiscoveryRequestBuilder.request()
-                .selectors(selectClass(SpecmaticJUnitSupport::class.java))
+                .selectors(selectClass(SpecmaticContractTestImpl::class.java))
                 .build()
 
         junitLauncher.discover(request)

--- a/junit5-support/src/main/kotlin/io/specmatic/test/BeforeEachTestHook.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/BeforeEachTestHook.kt
@@ -1,0 +1,5 @@
+package io.specmatic.test
+
+interface BeforeEachTestHook {
+    fun execute()
+}

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticContractTest.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticContractTest.kt
@@ -2,7 +2,6 @@ package io.specmatic.test
 
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.DynamicTest
-import org.junit.jupiter.api.TestFactory
 import java.util.stream.Stream
 
 interface SpecmaticContractTest : SpecmaticContractTestRunner {
@@ -16,7 +15,6 @@ interface SpecmaticContractTest : SpecmaticContractTestRunner {
         }
     }
 
-    @TestFactory
     override fun testStream(): Stream<DynamicTest> {
         return instance.contractTest()
     }
@@ -26,3 +24,4 @@ interface SpecmaticContractTest : SpecmaticContractTestRunner {
     }
 }
 
+class SpecmaticContractTestImpl : SpecmaticContractTest

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticContractTestRunner.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticContractTestRunner.kt
@@ -2,10 +2,22 @@ package io.specmatic.test
 
 import org.junit.jupiter.api.DynamicTest
 import org.junit.jupiter.api.TestFactory
+import java.util.ServiceLoader
 import java.util.stream.Stream
 
 interface SpecmaticContractTestRunner {
+
     @TestFactory
+    fun contractTest(): Stream<DynamicTest> {
+        val beforeEachHooks = ServiceLoader.load(BeforeEachTestHook::class.java).mapNotNull { it }
+        return testStream().map { dynamicTest ->
+            DynamicTest.dynamicTest(dynamicTest.displayName) {
+                beforeEachHooks.forEach { it.execute() }
+                dynamicTest.executable.execute()
+            }
+        }
+    }
+
     fun testStream(): Stream<DynamicTest>
 
     fun generateReports()


### PR DESCRIPTION
Reason for change -
We needed an ability to run a before each hook prior to any kind of test (be it openapi/grpc/async, etc.)