### PR TITLE
Add support for validating form request bodies in conformance tests

### DIFF
--- a/conformance-tests/build.gradle.kts
+++ b/conformance-tests/build.gradle.kts
@@ -29,7 +29,9 @@ tasks.test {
 
     if (enableConformanceTests?.toBoolean() == true) {
         dependsOn(":specmatic-executable:dockerBuild")
-        systemProperty("specmaticVersionForConformanceTests", specmaticVersionForConformanceTests)
+        if(specmaticVersionForConformanceTests != null) {
+            systemProperty("specmaticVersionForConformanceTests", specmaticVersionForConformanceTests.toString())
+        }
     } else {
         exclude("io/specmatic/conformance_tests/")
     }

--- a/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/OpenApiSpec.kt
+++ b/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/OpenApiSpec.kt
@@ -194,6 +194,11 @@ class OpenApiSpec(private val specFile: File) {
         return obj
     }
 
+    // Form data is all strings on the wire, but the JSON Schema validator needs correctly-typed
+    // JsonNodes (e.g. IntNode, not TextNode("42")). We coerce the four primitive types explicitly;
+    // "string" needs its own branch to prevent the `else` fallback from parsing values like "true"
+    // or "42" as JSON literals. All other types (array, object, unknown) fall through to `readTree`
+    // which handles JSON-encoded values, with a string fallback for plain scalars.
     private fun parseFormValue(value: String, schemaType: String?): JsonNode =
         when (schemaType) {
             "string" -> jsonMapper.valueToTree(value)

--- a/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/OpenApiSpec.kt
+++ b/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/OpenApiSpec.kt
@@ -169,18 +169,26 @@ class OpenApiSpec(private val specFile: File) {
             val schema = properties[key]
             val schemaType = schema?.type ?: schema?.types?.firstOrNull()
             val parsedValue = parseFormValue(value, schemaType)
-            if (schemaType == "array") {
-                if (parsedValue.isArray) {
-                    // Array sent as a single JSON-encoded value e.g. tags=["foo","bar"]
-                    obj.set<JsonNode>(key, parsedValue)
-                } else {
-                    // Array sent as repeated fields e.g. tags=foo&tags=bar.
-                    // Specmatic currently sends arrays as JSON-encoded single values,
-                    // but this handles the repeated-field encoding if it's ever used.
-                    obj.withArray(key).add(parsedValue)
+            when (schemaType) {
+                "array" -> {
+                    when {
+                        parsedValue.isArray -> {
+                            // Array sent as a single JSON-encoded value e.g. tags=["foo","bar"]
+                            obj.set<JsonNode>(key, parsedValue)
+                        }
+
+                        else -> {
+                            // Array sent as repeated fields e.g. tags=foo&tags=bar.
+                            // Specmatic currently sends arrays as JSON-encoded single values,
+                            // but this handles the repeated-field encoding if it's ever used.
+                            obj.withArray(key).add(parsedValue)
+                        }
+                    }
                 }
-            } else {
-                obj.set<JsonNode>(key, parsedValue)
+
+                else -> {
+                    obj.set(key, parsedValue)
+                }
             }
         }
         return obj

--- a/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/OpenApiSpec.kt
+++ b/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/OpenApiSpec.kt
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.models.SpecVersion
 import io.swagger.v3.parser.core.models.ParseOptions
 import org.slf4j.LoggerFactory
 import java.io.File
+import java.net.URLDecoder
 import io.swagger.v3.oas.models.Operation as SwaggerOperation
 
 data class Operation(
@@ -27,6 +28,9 @@ data class Operation(
     fun isJsonContent(): Boolean = hasRequestContentType() && requestContentType!!.lowercase().contains("json")
 
     fun isYamlContent(): Boolean = hasRequestContentType() && requestContentType!!.lowercase().contains("yaml")
+
+    fun isFormUrlEncodedContent(): Boolean =
+        hasRequestContentType() && requestContentType!!.lowercase() == "application/x-www-form-urlencoded"
 }
 
 class OpenApiSpec(private val specFile: File) {
@@ -108,19 +112,13 @@ class OpenApiSpec(private val specFile: File) {
     fun validateRequestBody(body: String, operation: Operation): List<Error> {
         require(operation.hasRequestContentType())
 
-        return when {
-            operation.isJsonContent() || operation.isYamlContent() -> {
-                val requestBodyPath =
-                    "/paths/${operation.path.escapeJsonPointer()}/${operation.method.lowercase()}/requestBody"
-                val basePath = resolveRef(requestBodyPath)
-                val pointer = "$basePath/content/${operation.requestContentType!!.escapeJsonPointer()}/schema"
-                validate(pointer, body)
-            }
-
-            else -> {
-                error("no support for validating requests of type:${operation.requestContentType}\nbody=${body}")
-            }
+        val jsonNode = when {
+            operation.isJsonContent() || operation.isYamlContent() -> yamlMapper.readTree(body)
+            operation.isFormUrlEncodedContent() -> formUrlEncodedToJson(body, operation)
+            else -> error("no support for validating requests of type:${operation.requestContentType}\nbody=${body}")
         }
+
+        return requestBodySchema(operation).validate(jsonNode)
     }
 
     fun validateResponseBody(
@@ -131,6 +129,14 @@ class OpenApiSpec(private val specFile: File) {
         val basePath = resolveRef(responsePath)
         val pointer = "$basePath/content/${responseContentType.escapeJsonPointer()}/schema"
         return validate(pointer, body)
+    }
+
+    private fun requestBodySchema(operation: Operation): Schema {
+        val requestBodyPath =
+            "/paths/${operation.path.escapeJsonPointer()}/${operation.method.lowercase()}/requestBody"
+        val basePath = resolveRef(requestBodyPath)
+        val pointer = "$basePath/content/${operation.requestContentType!!.escapeJsonPointer()}/schema"
+        return documentSchema.getRefSchema(SchemaLocation.Fragment.of(pointer))
     }
 
     // Since rootNode preserves the raw YAML (see comment above), a node at a given path may be
@@ -144,6 +150,56 @@ class OpenApiSpec(private val specFile: File) {
             path
         }
     }
+
+    private fun requestBodyProperties(operation: Operation): Map<String, io.swagger.v3.oas.models.media.Schema<*>> {
+        val pathItem = openApi.paths[operation.path] ?: return emptyMap()
+        val swaggerOp = pathItem.readOperationsMap()[PathItem.HttpMethod.valueOf(operation.method.uppercase())]
+            ?: return emptyMap()
+        val schema = swaggerOp.requestBody?.content?.get(operation.requestContentType)?.schema
+            ?: return emptyMap()
+        return schema.properties.orEmpty()
+    }
+
+    private fun formUrlEncodedToJson(body: String, operation: Operation): JsonNode {
+        val properties = requestBodyProperties(operation)
+
+        val obj = jsonMapper.createObjectNode()
+        body.split("&").forEach { pair ->
+            val (key, value) = pair.split("=", limit = 2).map { URLDecoder.decode(it, Charsets.UTF_8) }
+            val schemaType = schemaTypeOf(properties[key])
+            val parsedValue = parseFormValue(value, schemaType)
+            if (schemaType == "array") {
+                if (parsedValue.isArray) {
+                    // Array sent as a single JSON-encoded value e.g. tags=["foo","bar"]
+                    obj.set<JsonNode>(key, parsedValue)
+                } else {
+                    // Array sent as repeated fields e.g. tags=foo&tags=bar.
+                    // Specmatic currently sends arrays as JSON-encoded single values,
+                    // but this handles the repeated-field encoding if it's ever used.
+                    obj.withArray(key).add(parsedValue)
+                }
+            } else {
+                obj.set<JsonNode>(key, parsedValue)
+            }
+        }
+        return obj
+    }
+
+    private fun schemaTypeOf(schema: io.swagger.v3.oas.models.media.Schema<*>?): String? =
+        schema?.type ?: schema?.types?.firstOrNull()
+
+    private fun parseFormValue(value: String, schemaType: String?): JsonNode =
+        when (schemaType) {
+            "string" -> jsonMapper.valueToTree(value)
+            "integer" -> jsonMapper.valueToTree(value.toLong())
+            "number" -> jsonMapper.valueToTree(value.toDouble())
+            "boolean" -> jsonMapper.valueToTree(value.toBoolean())
+            else -> try {
+                jsonMapper.readTree(value)
+            } catch (_: Exception) {
+                jsonMapper.valueToTree(value)
+            }
+        }
 
     private fun validate(pointer: String, body: String): List<Error> {
         val subSchema = documentSchema.getRefSchema(SchemaLocation.Fragment.of(pointer))
@@ -171,5 +227,6 @@ class OpenApiSpec(private val specFile: File) {
             SchemaRegistry.withDialect(Dialects.getOpenApi31())
 
         private val yamlMapper = ObjectMapper(YAMLFactory())
+        private val jsonMapper = ObjectMapper()
     }
 }

--- a/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/OpenApiSpec.kt
+++ b/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/OpenApiSpec.kt
@@ -166,7 +166,8 @@ class OpenApiSpec(private val specFile: File) {
         val obj = jsonMapper.createObjectNode()
         body.split("&").forEach { pair ->
             val (key, value) = pair.split("=", limit = 2).map { URLDecoder.decode(it, Charsets.UTF_8) }
-            val schemaType = schemaTypeOf(properties[key])
+            val schema = properties[key]
+            val schemaType = schema?.type ?: schema?.types?.firstOrNull()
             val parsedValue = parseFormValue(value, schemaType)
             if (schemaType == "array") {
                 if (parsedValue.isArray) {
@@ -184,9 +185,6 @@ class OpenApiSpec(private val specFile: File) {
         }
         return obj
     }
-
-    private fun schemaTypeOf(schema: io.swagger.v3.oas.models.media.Schema<*>?): String? =
-        schema?.type ?: schema?.types?.firstOrNull()
 
     private fun parseFormValue(value: String, schemaType: String?): JsonNode =
         when (schemaType) {

--- a/conformance-tests/src/test/kotlin/io/specmatic/conformance_tests/AbstractConformanceTest.kt
+++ b/conformance-tests/src/test/kotlin/io/specmatic/conformance_tests/AbstractConformanceTest.kt
@@ -54,7 +54,7 @@ abstract class AbstractConformanceTest(
     @Order(1)
     fun `loop tests should succeed`() {
         assertThat(loopTestsResult.isSuccessful())
-            .withFailMessage { "$loopTestsResult.output\n\n$allLogs" }
+            .withFailMessage { allLogs }
             .isTrue
     }
 

--- a/conformance-tests/src/test/resources/specs/009-forms-and-multipart/016-urlencoded-with-enum.yaml
+++ b/conformance-tests/src/test/resources/specs/009-forms-and-multipart/016-urlencoded-with-enum.yaml
@@ -1,0 +1,40 @@
+openapi: 3.0.3
+info:
+  title: "URL-encoded form with enum field"
+  version: "1.0"
+paths:
+  /feedback:
+    post:
+      operationId: submitFeedback
+      summary: Submit feedback with a rating enum
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required:
+                - rating
+                - comment
+              properties:
+                rating:
+                  type: string
+                  enum:
+                    - excellent
+                    - good
+                    - average
+                    - poor
+                comment:
+                  type: string
+      responses:
+        '201':
+          description: Feedback submitted
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                properties:
+                  id:
+                    type: integer

--- a/conformance-tests/src/test/resources/specs/009-forms-and-multipart/017-urlencoded-integer-enum.yaml
+++ b/conformance-tests/src/test/resources/specs/009-forms-and-multipart/017-urlencoded-integer-enum.yaml
@@ -1,0 +1,41 @@
+openapi: 3.0.3
+info:
+  title: "URL-encoded form with integer enum field"
+  version: "1.0"
+paths:
+  /priority-tickets:
+    post:
+      operationId: createPriorityTicket
+      summary: Create a ticket with an integer priority enum
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required:
+                - title
+                - priority
+              properties:
+                title:
+                  type: string
+                priority:
+                  type: integer
+                  enum:
+                    - 1
+                    - 2
+                    - 3
+                    - 4
+                    - 5
+      responses:
+        '201':
+          description: Ticket created
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                properties:
+                  id:
+                    type: integer

--- a/conformance-tests/src/test/resources/specs/009-forms-and-multipart/018-urlencoded-with-constraints.yaml
+++ b/conformance-tests/src/test/resources/specs/009-forms-and-multipart/018-urlencoded-with-constraints.yaml
@@ -1,0 +1,43 @@
+openapi: 3.0.3
+info:
+  title: "URL-encoded form with field constraints"
+  version: "1.0"
+paths:
+  /products:
+    post:
+      operationId: createProduct
+      summary: Create a product with constrained fields
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required:
+                - name
+                - price
+                - quantity
+              properties:
+                name:
+                  type: string
+                  minLength: 1
+                  maxLength: 100
+                price:
+                  type: number
+                  minimum: 0
+                quantity:
+                  type: integer
+                  minimum: 1
+                  maximum: 10000
+      responses:
+        '201':
+          description: Product created
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                properties:
+                  id:
+                    type: integer

--- a/conformance-tests/src/test/resources/specs/009-forms-and-multipart/019-urlencoded-optional-fields.yaml
+++ b/conformance-tests/src/test/resources/specs/009-forms-and-multipart/019-urlencoded-optional-fields.yaml
@@ -1,0 +1,40 @@
+openapi: 3.0.3
+info:
+  title: "URL-encoded form with optional fields"
+  version: "1.0"
+paths:
+  /contacts:
+    post:
+      operationId: createContact
+      summary: Create a contact with required and optional fields
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required:
+                - name
+                - email
+              properties:
+                name:
+                  type: string
+                email:
+                  type: string
+                  format: email
+                phone:
+                  type: string
+                company:
+                  type: string
+      responses:
+        '201':
+          description: Contact created
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                properties:
+                  id:
+                    type: integer

--- a/conformance-tests/src/test/resources/specs/009-forms-and-multipart/020-urlencoded-string-pattern.yaml
+++ b/conformance-tests/src/test/resources/specs/009-forms-and-multipart/020-urlencoded-string-pattern.yaml
@@ -1,0 +1,37 @@
+openapi: 3.0.3
+info:
+  title: "URL-encoded form with string pattern constraints"
+  version: "1.0"
+paths:
+  /verifications:
+    post:
+      operationId: submitVerification
+      summary: Submit a phone verification with pattern-constrained fields
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required:
+                - phoneNumber
+                - code
+              properties:
+                phoneNumber:
+                  type: string
+                  pattern: '^\+[1-9]\d{1,14}$'
+                code:
+                  type: string
+                  pattern: '^\d{6}$'
+      responses:
+        '200':
+          description: Verification result
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - verified
+                properties:
+                  verified:
+                    type: boolean

--- a/conformance-tests/src/test/resources/specs/009-forms-and-multipart/021-urlencoded-with-repeated-array.yaml
+++ b/conformance-tests/src/test/resources/specs/009-forms-and-multipart/021-urlencoded-with-repeated-array.yaml
@@ -1,0 +1,37 @@
+openapi: 3.0.3
+info:
+  title: "URL-encoded form with repeated array field"
+  version: "1.0"
+paths:
+  /tags:
+    post:
+      operationId: addTags
+      summary: Add tags to a resource using repeated form fields
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required:
+                - resource
+                - tags
+              properties:
+                resource:
+                  type: string
+                tags:
+                  type: array
+                  items:
+                    type: string
+      responses:
+        '201':
+          description: Tags added
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                properties:
+                  id:
+                    type: integer

--- a/conformance-tests/src/test/resources/specs/009-forms-and-multipart/022-urlencoded-boolean-fields.yaml
+++ b/conformance-tests/src/test/resources/specs/009-forms-and-multipart/022-urlencoded-boolean-fields.yaml
@@ -1,0 +1,38 @@
+openapi: 3.0.3
+info:
+  title: "URL-encoded form with boolean fields"
+  version: "1.0"
+paths:
+  /notifications:
+    post:
+      operationId: updateNotifications
+      summary: Update notification preferences with boolean fields
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required:
+                - userId
+                - emailEnabled
+                - smsEnabled
+              properties:
+                userId:
+                  type: string
+                emailEnabled:
+                  type: boolean
+                smsEnabled:
+                  type: boolean
+      responses:
+        '200':
+          description: Preferences updated
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - updated
+                properties:
+                  updated:
+                    type: boolean


### PR DESCRIPTION
So that we can validate that Specmatic sends valid form data (as per the OpenAPI spec) when POSTing from tests. I've added more tests for form uploads. The latest report is attached.
[report.html](https://github.com/user-attachments/files/26293224/report.html)
