### PR TITLE
Improve git clone error handling and remove unused contract source install

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/git/GitOperations.kt
+++ b/core/src/main/kotlin/io/specmatic/core/git/GitOperations.kt
@@ -2,22 +2,14 @@
 
 package io.specmatic.core.git
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.azure.AzureAuthCredentials
-import io.specmatic.core.loadSpecmaticConfig
 import io.specmatic.core.log.logger
 import io.specmatic.core.pattern.ContractException
-import io.specmatic.core.pattern.parsedJSON
 import io.specmatic.core.utilities.GitRepo
-import io.specmatic.core.utilities.getTransportCallingCallback
+import io.specmatic.core.utilities.exceptionCauseMessage
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.Value
-import io.ktor.http.*
-import org.eclipse.jgit.api.Git
-import org.eclipse.jgit.transport.CredentialsProvider
-import org.eclipse.jgit.transport.HttpTransport
-import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider
 import org.eclipse.jgit.transport.http.HttpConnection
 import org.eclipse.jgit.transport.http.HttpConnectionFactory
 import org.eclipse.jgit.transport.http.JDKHttpConnectionFactory
@@ -64,15 +56,57 @@ fun checkout(workingDirectory: File, branchName: String, useCurrentBranchForCent
 }
 
 private fun clone(gitRepositoryURI: String, cloneDirectory: File, specmaticConfig: SpecmaticConfig) {
-    try {
-        SystemGit(cloneDirectory.parent, "-", AzureAuthCredentials(specmaticConfig, gitRepositoryURI)).clone(gitRepositoryURI, cloneDirectory)
-    } catch(exception: Exception) {
-        logger.debug("Falling back to jgit after trying shallow clone")
-        logger.debug(exception.localizedMessage ?: exception.message ?: "")
-        logger.debug(exception.stackTraceToString())
+    val systemGit: GitCommand = SystemGit(cloneDirectory.parent, "-", AzureAuthCredentials(specmaticConfig, gitRepositoryURI))
+    clone(gitRepositoryURI, cloneDirectory, specmaticConfig, systemGit, JGitCloneCmd())
+}
 
-        jgitClone(gitRepositoryURI, cloneDirectory, specmaticConfig)
+internal fun clone(
+    gitRepositoryURI: String,
+    cloneDirectory: File,
+    specmaticConfig: SpecmaticConfig,
+    systemGit: GitCommand,
+    jGitCloneCommand: JGitCloneCmd
+) {
+    try {
+        try {
+            systemGit.clone(gitRepositoryURI, cloneDirectory)
+        } catch(exception: Exception) {
+            logger.debug("Falling back to jgit after trying shallow clone")
+            logger.debug(exception.localizedMessage ?: exception.message ?: "")
+            logger.debug(exception.stackTraceToString())
+
+            jGitCloneCommand.execute(gitRepositoryURI, cloneDirectory, specmaticConfig)
+        }
+    } catch (e: Throwable) {
+        throw enrichContractRepoAccessError(e.message ?: exceptionCauseMessage(e), gitRepositoryURI)
     }
+}
+
+private fun enrichContractRepoAccessError(originalMessage: String, gitRepositoryURI: String): ContractException {
+    if (!looksLikeContractRepoReadAccessIssue(originalMessage)) {
+        return ContractException(originalMessage)
+    }
+
+    val enrichedMessage =
+        """
+        Failed to read contract repository $gitRepositoryURI
+        Specmatic only needs read access to load contracts.
+        Check that the supplied git credentials are valid, have read access to this repository, and are authorized for the organization or SSO if required.
+        
+        Original (misleading) error from Git repository hosting service:
+        $originalMessage
+        """.trimIndent()
+
+    return ContractException(enrichedMessage)
+}
+
+private fun looksLikeContractRepoReadAccessIssue(message: String): Boolean {
+    val normalizedMessage = message.lowercase()
+
+    return "requested url returned error: 403" in normalizedMessage ||
+            "requested url returned error: 401" in normalizedMessage ||
+            "write access to repository not granted" in normalizedMessage ||
+            "authentication failed" in normalizedMessage
 }
 
 private fun resetCloneDirectory(cloneDirectory: File) {
@@ -93,41 +127,6 @@ internal class InsecureHttpConnectionFactory : HttpConnectionFactory {
         val connection: HttpConnection = JDKHttpConnectionFactory().create(url, proxy)
         HttpSupport.disableSslVerify(connection)
         return connection
-    }
-}
-
-private fun jgitClone(gitRepositoryURI: String, cloneDirectory: File, specmaticConfig: SpecmaticConfig) {
-    val preservedConnectionFactory: HttpConnectionFactory = HttpTransport.getConnectionFactory()
-
-    try {
-        HttpTransport.setConnectionFactory(InsecureHttpConnectionFactory())
-
-        val evaluatedGitRepoURI = evaluateEnvVariablesInGitRepoURI(gitRepositoryURI, System.getenv())
-
-        val cloneCommand = Git.cloneRepository().apply {
-            setTransportConfigCallback(getTransportCallingCallback())
-            setURI(evaluatedGitRepoURI)
-            setDirectory(cloneDirectory)
-        }
-
-        val accessTokenText = getPersonalAccessToken(specmaticConfig, gitRepositoryURI)
-
-        if (accessTokenText != null) {
-            val credentialsProvider: CredentialsProvider = UsernamePasswordCredentialsProvider(accessTokenText, "")
-            cloneCommand.setCredentialsProvider(credentialsProvider)
-        } else {
-            val ciBearerToken = getBearerToken(specmaticConfig, gitRepositoryURI)
-
-            if (ciBearerToken != null) {
-                cloneCommand.setTransportConfigCallback(getTransportCallingCallback(ciBearerToken.encodeOAuth()))
-            }
-        }
-
-        logger.log("Cloning: $gitRepositoryURI -> ${cloneDirectory.canonicalPath}")
-
-        cloneCommand.call()
-    } finally {
-        HttpTransport.setConnectionFactory(preservedConnectionFactory)
     }
 }
 
@@ -185,13 +184,4 @@ fun getBearerToken(specmaticConfig: SpecmaticConfig, repositoryUrl: String): Str
 
 fun getPersonalAccessToken(specmaticConfig: SpecmaticConfig, repositoryUrl: String): String? {
     return specmaticConfig.getAuthPersonalAccessToken(repositoryUrl)?.takeIf { it.isNotBlank() }
-}
-
-private fun readConfig(configFile: File): Value {
-    try {
-        val config = loadSpecmaticConfig(configFile.path)
-        return parsedJSON(ObjectMapper().writeValueAsString(config))
-    } catch(e: Throwable) {
-        throw ContractException("Error loading Specmatic configuration: ${e.message}")
-    }
 }

--- a/core/src/main/kotlin/io/specmatic/core/git/JGitCloneCmd.kt
+++ b/core/src/main/kotlin/io/specmatic/core/git/JGitCloneCmd.kt
@@ -1,0 +1,67 @@
+package io.specmatic.core.git
+
+import io.ktor.http.encodeOAuth
+import io.specmatic.core.SpecmaticConfig
+import io.specmatic.core.log.logger
+import io.specmatic.core.utilities.getTransportCallingCallback
+import org.eclipse.jgit.api.CloneCommand
+import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.transport.CredentialsProvider
+import org.eclipse.jgit.transport.HttpTransport
+import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider
+import org.eclipse.jgit.transport.http.HttpConnectionFactory
+import java.io.File
+
+internal class JGitCloneCmd(
+    private val cloneCommandFactory: () -> CloneCommand = { Git.cloneRepository() },
+    private val environmentVariables: Map<String, String> = System.getenv(),
+    private val httpTransportFactoryManager: HttpTransportFactoryManager = DefaultHttpTransportFactoryManager
+) {
+    fun execute(gitRepositoryURI: String, cloneDirectory: File, specmaticConfig: SpecmaticConfig) {
+        val preservedConnectionFactory = httpTransportFactoryManager.getConnectionFactory()
+
+        try {
+            httpTransportFactoryManager.setConnectionFactory(InsecureHttpConnectionFactory())
+
+            val evaluatedGitRepoURI = evaluateEnvVariablesInGitRepoURI(gitRepositoryURI, environmentVariables)
+
+            val cloneCommand = cloneCommandFactory().apply {
+                setTransportConfigCallback(getTransportCallingCallback())
+                setURI(evaluatedGitRepoURI)
+                setDirectory(cloneDirectory)
+            }
+
+            val accessTokenText = getPersonalAccessToken(specmaticConfig, gitRepositoryURI)
+
+            if (accessTokenText != null) {
+                val credentialsProvider: CredentialsProvider = UsernamePasswordCredentialsProvider(accessTokenText, "")
+                cloneCommand.setCredentialsProvider(credentialsProvider)
+            } else {
+                val ciBearerToken = getBearerToken(specmaticConfig, gitRepositoryURI)
+
+                if (ciBearerToken != null) {
+                    cloneCommand.setTransportConfigCallback(getTransportCallingCallback(ciBearerToken.encodeOAuth()))
+                }
+            }
+
+            logger.log("Cloning: $gitRepositoryURI -> ${cloneDirectory.canonicalPath}")
+
+            cloneCommand.call()
+        } finally {
+            httpTransportFactoryManager.setConnectionFactory(preservedConnectionFactory)
+        }
+    }
+}
+
+internal interface HttpTransportFactoryManager {
+    fun getConnectionFactory(): HttpConnectionFactory
+    fun setConnectionFactory(connectionFactory: HttpConnectionFactory)
+}
+
+internal object DefaultHttpTransportFactoryManager : HttpTransportFactoryManager {
+    override fun getConnectionFactory(): HttpConnectionFactory = HttpTransport.getConnectionFactory()
+
+    override fun setConnectionFactory(connectionFactory: HttpConnectionFactory) {
+        HttpTransport.setConnectionFactory(connectionFactory)
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/core/utilities/ContractSource.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/ContractSource.kt
@@ -18,7 +18,6 @@ sealed interface ContractSource {
     val testContracts: List<ContractSourceEntry>
     val stubContracts: List<ContractSourceEntry>
     fun pathDescriptor(path: String): String
-    fun install(workingDirectory: File)
     fun directoryRelativeTo(workingDirectory: File): File
     fun getLatest(sourceGit: SystemGit)
     fun pushUpdates(sourceGit: SystemGit)

--- a/core/src/main/kotlin/io/specmatic/core/utilities/GitMonoRepo.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/GitMonoRepo.kt
@@ -6,20 +6,6 @@ import java.io.File
 data class GitMonoRepo(override val testContracts: List<ContractSourceEntry>, override val stubContracts: List<ContractSourceEntry>,
                        override val type: String?) : ContractSource, GitSource {
     override fun pathDescriptor(path: String): String = path
-    override fun install(workingDirectory: File) {
-        println("Checking list of mono repo paths...")
-
-        val contracts = testContracts + stubContracts
-
-        for (contract in contracts) {
-            val existenceMessage = when {
-                File(contract.path).exists() -> "${contract.path} exists"
-                else -> "${contract.path} NOT FOUND!"
-            }
-
-            println(existenceMessage)
-        }
-    }
 
     override fun directoryRelativeTo(workingDirectory: File) = workingDirectory.resolve(gitRootDir())
 

--- a/core/src/main/kotlin/io/specmatic/core/utilities/GitRepo.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/GitRepo.kt
@@ -151,31 +151,4 @@ data class GitRepo(
     }
 
     private fun localRepoDir(workingDirectory: String): File = File(workingDirectory).resolve("repos")
-
-    override fun install(workingDirectory: File) {
-        val baseReposDirectory = workingDirectory.resolve("repos")
-        val sourceDir = baseReposDirectory.resolve(repoName)
-        val sourceGit = SystemGit(sourceDir.path)
-
-        try {
-            println("Checking ${sourceDir.path}")
-            if (!sourceDir.exists())
-                sourceDir.mkdirs()
-
-            if (!sourceGit.workingDirectoryIsGitRepo() || isEmptyNestedGitDirectory(sourceGit, sourceDir)) {
-                println("Found it, not a git dir, recreating...")
-                sourceDir.deleteRecursively()
-                sourceDir.mkdirs()
-                println("Cloning ${this.gitRepositoryURL} into ${sourceDir.canonicalPath}")
-                this.cloneRepoAndCheckoutBranch(sourceDir.canonicalFile.parentFile, this)
-            } else {
-                println("Git repo already exists at ${sourceDir.path}, so ignoring it and moving on")
-            }
-        } catch (e: Throwable) {
-            println("Could not clone ${this.gitRepositoryURL}\n${e.javaClass.name}: ${exceptionCauseMessage(e)}")
-        }
-    }
-
-    private fun isEmptyNestedGitDirectory(sourceGit: SystemGit, sourceDir: File) =
-        (sourceGit.workingDirectoryIsGitRepo() && sourceGit.getRemoteUrl() != this.gitRepositoryURL && sourceDir.listFiles()?.isEmpty() == true)
 }

--- a/core/src/main/kotlin/io/specmatic/core/utilities/LocalFileSystemSource.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/LocalFileSystemSource.kt
@@ -13,10 +13,6 @@ data class LocalFileSystemSource(
 
     override fun pathDescriptor(path: String): String = path
 
-    override fun install(workingDirectory: File) {
-        logger.log("No installation needed as this source is a directory on the local file system")
-    }
-
     override fun directoryRelativeTo(workingDirectory: File): File {
         if(File(directory).isAbsolute)
             return File(directory)

--- a/core/src/main/kotlin/io/specmatic/core/utilities/WebSource.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/WebSource.kt
@@ -14,10 +14,6 @@ class WebSource(override val testContracts: List<ContractSourceEntry>, override 
         return ""
     }
 
-    override fun install(workingDirectory: File) {
-        logger.log("Install is not currently supported for web sources")
-    }
-
     override fun directoryRelativeTo(workingDirectory: File): File {
         return File(".")
     }

--- a/core/src/test/kotlin/io/specmatic/core/git/GitOperationsTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/git/GitOperationsTest.kt
@@ -1,14 +1,118 @@
 package io.specmatic.core.git
 
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
 import io.specmatic.core.Auth
 import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.SpecmaticConfigV1V2Common
-import org.assertj.core.api.AssertionsForClassTypes.assertThat
+import io.specmatic.core.pattern.ContractException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.io.TempDir
+import java.io.File
 import java.nio.file.Path
 
 class GitOperationsTest {
+    @AfterEach
+    fun tearDown() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun `orchestration clone should use system git when it succeeds`(@TempDir tempDir: File) {
+        val gitRepositoryURI = "https://github.com/specmatic/enterprise.git"
+        val cloneDirectory = tempDir.resolve("enterprise")
+        val systemGit = mockk<GitCommand>()
+        val jGitCloneCommand = mockk<JGitCloneCmd>()
+
+        every { systemGit.clone(gitRepositoryURI, cloneDirectory) } returns mockk<SystemGit>()
+
+        clone(gitRepositoryURI, cloneDirectory, SpecmaticConfigV1V2Common(), systemGit, jGitCloneCommand)
+
+        verify(exactly = 1) { systemGit.clone(gitRepositoryURI, cloneDirectory) }
+        verify(exactly = 0) { jGitCloneCommand.execute(any(), any(), any()) }
+    }
+
+    @Test
+    fun `orchestration clone should fall back to jgit when system git fails`(@TempDir tempDir: File) {
+        val gitRepositoryURI = "https://github.com/specmatic/enterprise.git"
+        val cloneDirectory = tempDir.resolve("enterprise")
+        val systemGit = mockk<GitCommand>()
+        val jGitCloneCommand = mockk<JGitCloneCmd>()
+
+        every { systemGit.clone(gitRepositoryURI, cloneDirectory) } throws RuntimeException("system git failed")
+        every { jGitCloneCommand.execute(any(), any(), any()) } returns Unit
+
+        clone(gitRepositoryURI, cloneDirectory, SpecmaticConfigV1V2Common(), systemGit, jGitCloneCommand)
+
+        verify(exactly = 1) { systemGit.clone(gitRepositoryURI, cloneDirectory) }
+        verify(exactly = 1) { jGitCloneCommand.execute(any(), any(), any()) }
+    }
+
+    @Test
+    fun `orchestration clone should enrich auth related failures`(@TempDir tempDir: File) {
+        val gitRepositoryURI = "https://github.com/specmatic/enterprise.git"
+        val cloneDirectory = tempDir.resolve("enterprise")
+        val systemGit = mockk<GitCommand>()
+        val jGitCloneCommand = mockk<JGitCloneCmd>()
+        val originalMessage =
+            """
+            remote: Write access to repository not granted.
+            fatal: unable to access '$gitRepositoryURI/': The requested URL returned error: 403
+            """.trimIndent()
+
+        every { systemGit.clone(gitRepositoryURI, cloneDirectory) } throws RuntimeException("system git failed")
+        every { jGitCloneCommand.execute(any(), any(), any()) } throws RuntimeException(originalMessage)
+
+        val exception = assertThrows<ContractException> {
+            clone(gitRepositoryURI, cloneDirectory, SpecmaticConfigV1V2Common(), systemGit, jGitCloneCommand)
+        }
+
+        assertThat(exception.message).contains("Failed to read contract repository $gitRepositoryURI")
+        assertThat(exception.message).contains("Specmatic only needs read access to load contracts.")
+        assertThat(exception.message).contains("Write access to repository not granted")
+        assertThat(exception.message).contains("The requested URL returned error: 403")
+    }
+
+    @Test
+    fun `orchestration clone should preserve non auth failure messages`(@TempDir tempDir: File) {
+        val gitRepositoryURI = "https://github.com/specmatic/enterprise.git"
+        val cloneDirectory = tempDir.resolve("enterprise")
+        val systemGit = mockk<GitCommand>()
+        val jGitCloneCommand = mockk<JGitCloneCmd>()
+
+        every { systemGit.clone(gitRepositoryURI, cloneDirectory) } throws RuntimeException("system git failed")
+        every { jGitCloneCommand.execute(any(), any(), any()) } throws RuntimeException("repository unavailable")
+
+        val exception = assertThrows<ContractException> {
+            clone(gitRepositoryURI, cloneDirectory, SpecmaticConfigV1V2Common(), systemGit, jGitCloneCommand)
+        }
+
+        assertThat(exception.message).isEqualTo("repository unavailable")
+        assertThat(exception.message).doesNotContain("Specmatic only needs read access")
+    }
+
+    @Test
+    fun `orchestration clone should use cause message when throwable message is null`(@TempDir tempDir: File) {
+        val gitRepositoryURI = "https://github.com/specmatic/enterprise.git"
+        val cloneDirectory = tempDir.resolve("enterprise")
+        val systemGit = mockk<GitCommand>()
+        val jGitCloneCommand = mockk<JGitCloneCmd>()
+
+        every { systemGit.clone(gitRepositoryURI, cloneDirectory) } throws RuntimeException("system git failed")
+        every { jGitCloneCommand.execute(any(), any(), any()) } throws RuntimeException(null, IllegalStateException("deep cause"))
+
+        val exception = assertThrows<ContractException> {
+            clone(gitRepositoryURI, cloneDirectory, SpecmaticConfigV1V2Common(), systemGit, jGitCloneCommand)
+        }
+
+        assertThat(exception.message).isEqualTo("deep cause")
+    }
+
     @Test
     fun shouldNotChangeGitRepoUrlWhenThereAreNoEnvVariables() {
         val gitRepositoryURI = "https://gitlab.com/group/project.git"

--- a/core/src/test/kotlin/io/specmatic/core/git/JGitCloneCmdTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/git/JGitCloneCmdTest.kt
@@ -1,0 +1,153 @@
+package io.specmatic.core.git
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.specmatic.core.Auth
+import io.specmatic.core.SpecmaticConfigV1V2Common
+import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.jgit.api.CloneCommand
+import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.transport.http.HttpConnectionFactory
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class JGitCloneCmdTest {
+    @Test
+    fun `should configure clone command with evaluated URI and target directory`(@TempDir tempDir: File) {
+        val cloneCommand = cloneCommand()
+        val originalConnectionFactory = mockk<HttpConnectionFactory>()
+        val transportManager = FakeHttpTransportFactoryManager(originalConnectionFactory)
+        val cloneDirectory = tempDir.resolve("clone-target")
+
+        JGitCloneCmd(
+            cloneCommandFactory = { cloneCommand },
+            environmentVariables = mapOf("CI_JOB_TOKEN" to "secret"),
+            httpTransportFactoryManager = transportManager
+        ).execute(
+            gitRepositoryURI = "https://gitlab-ci-token:${'$'}{CI_JOB_TOKEN}@gitlab.com/group/project.git",
+            cloneDirectory = cloneDirectory,
+            specmaticConfig = SpecmaticConfigV1V2Common()
+        )
+
+        verify(exactly = 1) { cloneCommand.setURI("https://gitlab-ci-token:secret@gitlab.com/group/project.git") }
+        verify(exactly = 1) { cloneCommand.setDirectory(cloneDirectory) }
+        verify(exactly = 1) { cloneCommand.setTransportConfigCallback(any()) }
+        verify(exactly = 1) { cloneCommand.call() }
+        assertThat(transportManager.setFactories.first()).isInstanceOf(InsecureHttpConnectionFactory::class.java)
+        assertThat(transportManager.setFactories.last()).isSameAs(originalConnectionFactory)
+    }
+
+    @Test
+    fun `should apply personal access token credentials provider when configured`(@TempDir tempDir: File) {
+        val cloneCommand = cloneCommand()
+
+        JGitCloneCmd(
+            cloneCommandFactory = { cloneCommand },
+            httpTransportFactoryManager = FakeHttpTransportFactoryManager(mockk())
+        ).execute(
+            gitRepositoryURI = "https://github.com/specmatic/enterprise.git",
+            cloneDirectory = tempDir.resolve("clone-target"),
+            specmaticConfig = SpecmaticConfigV1V2Common(auth = Auth(personalAccessToken = "token-123"))
+        )
+
+        verify(exactly = 1) { cloneCommand.setCredentialsProvider(any()) }
+        verify(exactly = 1) { cloneCommand.setTransportConfigCallback(any()) }
+    }
+
+    @Test
+    fun `should apply bearer transport callback when bearer file is configured`(@TempDir tempDir: File) {
+        val cloneCommand = cloneCommand()
+        val bearerFile = tempDir.resolve("bearer.txt").apply {
+            writeText("bearer-token")
+        }
+
+        JGitCloneCmd(
+            cloneCommandFactory = { cloneCommand },
+            httpTransportFactoryManager = FakeHttpTransportFactoryManager(mockk())
+        ).execute(
+            gitRepositoryURI = "https://github.com/specmatic/enterprise.git",
+            cloneDirectory = tempDir.resolve("clone-target"),
+            specmaticConfig = SpecmaticConfigV1V2Common(auth = Auth(bearerFile = bearerFile.absolutePath))
+        )
+
+        verify(exactly = 2) { cloneCommand.setTransportConfigCallback(any()) }
+        verify(exactly = 0) { cloneCommand.setCredentialsProvider(any()) }
+    }
+
+    @Test
+    fun `should prefer personal access token over bearer file`(@TempDir tempDir: File) {
+        val cloneCommand = cloneCommand()
+        val bearerFile = tempDir.resolve("bearer.txt").apply {
+            writeText("bearer-token")
+        }
+
+        JGitCloneCmd(
+            cloneCommandFactory = { cloneCommand },
+            httpTransportFactoryManager = FakeHttpTransportFactoryManager(mockk())
+        ).execute(
+            gitRepositoryURI = "https://github.com/specmatic/enterprise.git",
+            cloneDirectory = tempDir.resolve("clone-target"),
+            specmaticConfig = SpecmaticConfigV1V2Common(
+                auth = Auth(
+                    bearerFile = bearerFile.absolutePath,
+                    personalAccessToken = "token-123"
+                )
+            )
+        )
+
+        verify(exactly = 1) { cloneCommand.setCredentialsProvider(any()) }
+        verify(exactly = 1) { cloneCommand.setTransportConfigCallback(any()) }
+    }
+
+    @Test
+    fun `should restore connection factory after clone failure`(@TempDir tempDir: File) {
+        val cloneCommand = cloneCommand {
+            throw RuntimeException("clone failed")
+        }
+        val originalConnectionFactory = mockk<HttpConnectionFactory>()
+        val transportManager = FakeHttpTransportFactoryManager(originalConnectionFactory)
+
+        val exception = assertThrows<RuntimeException> {
+            JGitCloneCmd(
+                cloneCommandFactory = { cloneCommand },
+                httpTransportFactoryManager = transportManager
+            ).execute(
+                gitRepositoryURI = "https://github.com/specmatic/enterprise.git",
+                cloneDirectory = tempDir.resolve("clone-target"),
+                specmaticConfig = SpecmaticConfigV1V2Common()
+            )
+        }
+
+        assertThat(exception.message).isEqualTo("clone failed")
+        assertThat(transportManager.setFactories.first()).isInstanceOf(InsecureHttpConnectionFactory::class.java)
+        assertThat(transportManager.setFactories.last()).isSameAs(originalConnectionFactory)
+    }
+
+    private fun cloneCommand(callAnswer: () -> Git = { mockk() }): CloneCommand {
+        val cloneCommand = mockk<CloneCommand>()
+
+        every { cloneCommand.setTransportConfigCallback(any()) } returns cloneCommand
+        every { cloneCommand.setURI(any()) } returns cloneCommand
+        every { cloneCommand.setDirectory(any()) } returns cloneCommand
+        every { cloneCommand.setCredentialsProvider(any()) } returns cloneCommand
+        every { cloneCommand.call() } answers { callAnswer() }
+
+        return cloneCommand
+    }
+
+    private class FakeHttpTransportFactoryManager(
+        private var currentConnectionFactory: HttpConnectionFactory
+    ) : HttpTransportFactoryManager {
+        val setFactories = mutableListOf<HttpConnectionFactory>()
+
+        override fun getConnectionFactory(): HttpConnectionFactory = currentConnectionFactory
+
+        override fun setConnectionFactory(connectionFactory: HttpConnectionFactory) {
+            currentConnectionFactory = connectionFactory
+            setFactories += connectionFactory
+        }
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/git/SystemGitTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/git/SystemGitTest.kt
@@ -1,0 +1,78 @@
+package io.specmatic.core.git
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class SystemGitTest {
+    @Test
+    fun `workingDirectoryIsGitRepo should return true for a git repository`(@TempDir tempDir: File) {
+        initialiseGitRepository(tempDir)
+
+        assertThat(SystemGit(tempDir.absolutePath).workingDirectoryIsGitRepo()).isTrue()
+    }
+
+    @Test
+    fun `currentRemoteBranch should return current branch when upstream is not configured`(@TempDir tempDir: File) {
+        initialiseGitRepository(tempDir)
+        commitFile(tempDir, "contract.spec", "openapi: 3.0.0")
+
+        val systemGit = SystemGit(tempDir.absolutePath)
+        assertThat(systemGit.currentRemoteBranch()).isEqualTo("main")
+    }
+
+    @Test
+    fun `getChangedFiles should return repository relative paths for modified files`(@TempDir tempDir: File) {
+        initialiseGitRepository(tempDir)
+        val contractFile = tempDir.resolve("apis").resolve("contract.spec")
+        commitFile(tempDir, "apis/contract.spec", "openapi: 3.0.0")
+
+        contractFile.writeText("openapi: 3.0.1")
+
+        val systemGit = SystemGit(tempDir.absolutePath)
+        assertThat(systemGit.getChangedFiles()).containsExactly("apis/contract.spec")
+    }
+
+    @Test
+    fun `getUntrackedFiles should return absolute paths for untracked files`(@TempDir tempDir: File) {
+        initialiseGitRepository(tempDir)
+        val untrackedFile = tempDir.resolve("apis").resolve("new-contract.spec")
+        untrackedFile.parentFile.mkdirs()
+        untrackedFile.writeText("openapi: 3.0.0")
+
+        val systemGit = SystemGit(tempDir.absolutePath)
+        assertThat(systemGit.getUntrackedFiles()).containsExactly(untrackedFile.absolutePath)
+    }
+
+    private fun initialiseGitRepository(directory: File) {
+        runGit(directory, "init", "-b", "main")
+        runGit(directory, "config", "user.name", "Specmatic Tests")
+        runGit(directory, "config", "user.email", "specmatic-tests@example.com")
+    }
+
+    private fun commitFile(directory: File, relativePath: String, contents: String) {
+        val file = directory.resolve(relativePath)
+        file.parentFile.mkdirs()
+        file.writeText(contents)
+
+        runGit(directory, "add", relativePath)
+        runGit(directory, "commit", "-m", "Add $relativePath")
+    }
+
+    private fun runGit(directory: File, vararg args: String): String {
+        val process = ProcessBuilder(listOf("git") + args.toList())
+            .directory(directory)
+            .redirectErrorStream(true)
+            .start()
+
+        val output = process.inputStream.bufferedReader().readText()
+        val exitCode = process.waitFor()
+
+        check(exitCode == 0) {
+            "git ${args.joinToString(" ")} failed with exit code $exitCode\n$output"
+        }
+
+        return output
+    }
+}


### PR DESCRIPTION
**What**:
- remove the unused `install()` contract source hook and its dead implementations
- enrich clone failures so auth and permission issues report a clear read-access message
- extract JGit clone behavior into `JGitCloneCmd` and add focused unit coverage for clone orchestration, JGit setup, and `SystemGit`

**Why**:
- git hosting services can return misleading write-access errors when the actual problem is missing read access or auth setup
- the removed `install()` flow was unused dead code
- the clone path needed direct unit coverage without relying on constructor mocking

**How**:
- remove `install()` from `ContractSource` and delete the unused implementations
- keep the existing clone entrypoint behavior but route fallback cloning through `JGitCloneCmd`
- wrap auth-like clone failures with a clearer `ContractException` message
- add targeted tests for `GitOperations`, `JGitCloneCmd`, and `SystemGit`

**Checklist**:
- [x] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link) N/A
- [ ] Sample Project added/updated (share link) N/A
- [ ] Demo video (share link) N/A
- [ ] Article on Website (share link) N/A
- [ ] Roadmpap updated (share link) N/A
- [ ] Conference Talk (share link) N/A

**Issue ID**:
Closes: N/A

**Validation**:
- `./gradlew :specmatic-core:test --tests "io.specmatic.core.git.GitOperationsTest" --no-daemon`
- `./gradlew :specmatic-core:test --tests "io.specmatic.core.git.JGitCloneCmdTest" --no-daemon`
- `./gradlew :specmatic-core:test --tests "io.specmatic.core.git.SystemGitTest" --no-daemon`