### PR TITLE
Update netty-codec-http dependencies to resolve security vulnerabilities

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -5,8 +5,8 @@ plugins {
 }
 
 dependencies {
-    implementation("io.netty:netty-codec-http:4.2.9.Final")
-    implementation("io.netty:netty-codec-http2:4.2.9.Final")
+    implementation("io.netty:netty-codec-http:4.2.11.Final")
+    implementation("io.netty:netty-codec-http2:4.2.11.Final")
 
     implementation("io.specmatic.build-reporter:specmatic-reporter-min:${project.property("specmaticReporterVersion")}") {
         exclude(group = "commons-logging", module = "commons-logging")


### PR DESCRIPTION
**What**:
- Both netty-codec-http and netty-codec-http2 version 4.2.9.Final have been reported to have a HIGH vulnerability
- Update both dependencies to the next safest version, 4.2.11.Final

**Checklist**:

- [ ] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
