### PR TITLE
Preserve partial failure state in HasFailure

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/pattern/HasFailure.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/HasFailure.kt
@@ -49,7 +49,7 @@ data class HasFailure<T>(val failure: Result.Failure, val message: String = "") 
     }
 
     override fun toFailure(): Result.Failure {
-        return Result.Failure(message, failure).updateScenario(failure.scenario) as Result.Failure
+        return Result.Failure(message, failure, isPartial = failure.isPartial).updateScenario(failure.scenario)
     }
 
     override fun breadCrumb(breadCrumb: String?, message: String?): ReturnFailure {
@@ -58,7 +58,7 @@ data class HasFailure<T>(val failure: Result.Failure, val message: String = "") 
     }
 
     override fun addDetails(message: String, breadCrumb: String): HasFailure<T> {
-        return HasFailure(Result.Failure(message, this.toFailure(), breadCrumb))
+        return HasFailure(Result.Failure(message, this.toFailure(), breadCrumb, isPartial = failure.isPartial))
     }
 
     override fun <U> realise(hasValue: (T, String?) -> U, orFailure: (HasFailure<T>) -> U, orException: (HasException<T>) -> U): U {


### PR DESCRIPTION
**What**:

Preserve the `isPartial` flag when `HasFailure` reconstructs `Result.Failure` instances.

**Why**:

Partial failures were losing their partial status when a failure was rewrapped with a new message or breadcrumb, which could make warnings behave like full failures downstream.

**How**:

Updated `HasFailure.toFailure()` and `HasFailure.addDetails()` to pass through `failure.isPartial` while rebuilding `Result.Failure`. The obsolete cast in `toFailure()` was also removed.

**Checklist**:

- [x] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate N/A
- [ ] Security scans don't report any vulnerabilities N/A
- [ ] Documentation added/updated (share link) N/A
- [ ] Sample Project added/updated (share link) N/A
- [ ] Demo video (share link) N/A
- [ ] Article on Website (share link) N/A
- [ ] Roadmpap updated (share link) N/A
- [ ] Conference Talk (share link) N/A

**Issue ID**:
Closes: N/A

Validation:
- Ran `./gradlew :specmatic-core:test --tests "io.specmatic.core.FuzzyKeyCheckTest"`
