### PR TITLE
feat: Add config-backed spec loading to validate

### DIFF
--- a/application/src/main/kotlin/application/validate/ConfigBackedSpecificationLoader.kt
+++ b/application/src/main/kotlin/application/validate/ConfigBackedSpecificationLoader.kt
@@ -5,6 +5,7 @@ import io.specmatic.core.getConfigFilePath
 import io.specmatic.core.log.logger
 import io.specmatic.core.utilities.ContractSource
 import io.specmatic.core.utilities.ContractsSelectorPredicate
+import io.specmatic.core.utilities.GitRepo
 import io.specmatic.loader.RecursiveSpecificationAndExampleClassifier
 import io.specmatic.loader.SpecificationWithExamples
 import java.io.File
@@ -22,8 +23,9 @@ class ConfigBackedSpecificationLoader(
         logger.boundary()
         logger.log("Loading specifications declared in ${configFile.path}")
 
-        val workingDirectory = configFile.parentFile?.canonicalFile ?: File(".").canonicalFile
-        val loadedSpecifications = loadSpecifications(configFile, workingDirectory)
+        val classificationWorkingDirectory = configFile.parentFile?.canonicalFile ?: File(".").canonicalFile
+        val contractLoadingBaseDir = classificationWorkingDirectory.resolve(".specmatic").canonicalFile
+        val loadedSpecifications = loadSpecifications(configFile, classificationWorkingDirectory, contractLoadingBaseDir)
             .distinctBy { it.specFile.normalizedPath() }
 
         logger.log("Resolved ${loadedSpecifications.size} specifications from config")
@@ -32,11 +34,17 @@ class ConfigBackedSpecificationLoader(
         return loadedSpecifications
     }
 
-    private fun loadSpecifications(configFile: File, workingDirectory: File): List<SpecificationWithExamples> {
+    private fun loadSpecifications(
+        configFile: File,
+        classificationWorkingDirectory: File,
+        contractLoadingBaseDir: File
+    ): List<SpecificationWithExamples> {
         return loadSources().flatMap { source ->
+            val contractLoadingWorkingDirectory =
+                if (source is GitRepo) contractLoadingBaseDir.canonicalPath else classificationWorkingDirectory.canonicalPath
             val contractPathDataList = source.loadContracts(
                 ContractsSelectorPredicate { contractSource -> contractSource.testContracts + contractSource.stubContracts },
-                workingDirectory.canonicalPath,
+                contractLoadingWorkingDirectory,
                 configFile.canonicalPath
             )
 
@@ -51,7 +59,7 @@ class ConfigBackedSpecificationLoader(
                 }
 
                 logger.log("Using specification declared in config: $descriptor -> ${specificationFile.path}")
-                classifier.load(specificationFile, workingDirectory)
+                classifier.load(specificationFile, classificationWorkingDirectory)
             }
         }
     }

--- a/application/src/main/kotlin/application/validate/ConfigBackedSpecificationLoader.kt
+++ b/application/src/main/kotlin/application/validate/ConfigBackedSpecificationLoader.kt
@@ -1,0 +1,62 @@
+package application.validate
+
+import io.specmatic.core.SpecmaticConfig
+import io.specmatic.core.getConfigFilePath
+import io.specmatic.core.log.logger
+import io.specmatic.core.utilities.ContractSource
+import io.specmatic.core.utilities.ContractsSelectorPredicate
+import io.specmatic.loader.RecursiveSpecificationAndExampleClassifier
+import io.specmatic.loader.SpecificationWithExamples
+import java.io.File
+
+class ConfigBackedSpecificationLoader(
+    private val specmaticConfig: SpecmaticConfig,
+    private val classifier: RecursiveSpecificationAndExampleClassifier,
+    private val loadSources: () -> List<ContractSource> = { specmaticConfig.loadSources() },
+    private val configFileProvider: () -> File = { File(getConfigFilePath()).canonicalFile }
+) {
+    fun load(): List<SpecificationWithExamples> {
+        val configFile = configFileProvider().canonicalFile
+        if (!configFile.exists()) return emptyList()
+
+        logger.boundary()
+        logger.log("Loading specifications declared in ${configFile.path}")
+
+        val workingDirectory = configFile.parentFile?.canonicalFile ?: File(".").canonicalFile
+        val loadedSpecifications = loadSpecifications(configFile, workingDirectory)
+            .distinctBy { it.specFile.normalizedPath() }
+
+        logger.log("Resolved ${loadedSpecifications.size} specifications from config")
+        logger.boundary()
+
+        return loadedSpecifications
+    }
+
+    private fun loadSpecifications(configFile: File, workingDirectory: File): List<SpecificationWithExamples> {
+        return loadSources().flatMap { source ->
+            val contractPathDataList = source.loadContracts(
+                ContractsSelectorPredicate { contractSource -> contractSource.testContracts + contractSource.stubContracts },
+                workingDirectory.canonicalPath,
+                configFile.canonicalPath
+            )
+
+            contractPathDataList.mapNotNull { contractPathData ->
+                val specificationFile = File(contractPathData.path).canonicalFile
+                val configuredPath = contractPathData.specificationPath ?: contractPathData.path
+                val descriptor = source.pathDescriptor(configuredPath).ifBlank { configuredPath }
+
+                if (!specificationFile.exists()) {
+                    logger.log("WARNING: Specification '$descriptor' from config '${configFile.canonicalPath}' could not be found at '${contractPathData.path}'. It will be ignored.")
+                    return@mapNotNull null
+                }
+
+                logger.log("Using specification declared in config: $descriptor -> ${specificationFile.path}")
+                classifier.load(specificationFile, workingDirectory)
+            }
+        }
+    }
+
+    private fun File.normalizedPath(): String {
+        return runCatching { canonicalPath }.getOrElse { absolutePath }
+    }
+}

--- a/application/src/main/kotlin/application/validate/ConfigBackedSpecificationLoader.kt
+++ b/application/src/main/kotlin/application/validate/ConfigBackedSpecificationLoader.kt
@@ -43,7 +43,7 @@ class ConfigBackedSpecificationLoader(
             val contractLoadingWorkingDirectory =
                 if (source is GitRepo) contractLoadingBaseDir.canonicalPath else classificationWorkingDirectory.canonicalPath
             val contractPathDataList = source.loadContracts(
-                ContractsSelectorPredicate { contractSource -> contractSource.testContracts + contractSource.stubContracts },
+                { contractSource -> contractSource.testContracts + contractSource.stubContracts },
                 contractLoadingWorkingDirectory,
                 configFile.canonicalPath
             )

--- a/application/src/main/kotlin/application/validate/ValidateCommand.kt
+++ b/application/src/main/kotlin/application/validate/ValidateCommand.kt
@@ -1,13 +1,18 @@
 package application.validate
 
+import io.specmatic.core.CONTRACT_EXTENSIONS
+import io.specmatic.core.OPENAPI_FILE_EXTENSIONS
 import io.specmatic.core.config.LoggingConfiguration
+import io.specmatic.core.getConfigFilePath
 import io.specmatic.core.loadSpecmaticConfigIfAvailableElseDefault
 import io.specmatic.core.log.configureLogging
 import io.specmatic.core.pattern.ContractException
+import io.specmatic.core.utilities.ContractsSelectorPredicate
 import io.specmatic.loader.OpenApiSpecCompatibilityChecker
 import io.specmatic.loader.RecursiveSpecificationAndExampleClassifier
 import io.specmatic.loader.SpecCompatibilityChecker
 import io.specmatic.loader.SpecificationWithExamples
+import org.yaml.snakeyaml.Yaml
 import picocli.CommandLine
 import picocli.CommandLine.Command
 import java.io.File
@@ -16,7 +21,10 @@ import java.util.concurrent.Callable
 @Command(name = "validate", hidden = true, mixinStandardHelpOptions = true, description = ["Lint & Validate specification and external examples"])
 class ValidateCommand(
     private val validator: Validator<out Any?> = OpenApiValidator(),
-    specCompatibilityChecker: SpecCompatibilityChecker = OpenApiSpecCompatibilityChecker()
+    specCompatibilityChecker: SpecCompatibilityChecker = OpenApiSpecCompatibilityChecker(),
+    private val specmaticConfig: io.specmatic.core.SpecmaticConfig = loadSpecmaticConfigIfAvailableElseDefault(),
+    private val configBackedSpecificationLoader: ConfigBackedSpecificationLoader? = null,
+    private val currentDirectoryProvider: () -> File = { File(".").canonicalFile }
 ) : Callable<Int> {
     @CommandLine.Option(names = ["--debug"], description = ["Enable debug logs"])
     var debug: Boolean? = null
@@ -27,33 +35,113 @@ class ValidateCommand(
     @CommandLine.Option(names = ["--spec-file"], description = ["Specification to validate, along with respective examples"])
     var file: File? = null
 
-    private val specmaticConfig = loadSpecmaticConfigIfAvailableElseDefault()
     private val recursiveSpecificationAndExampleClassifier = RecursiveSpecificationAndExampleClassifier(specmaticConfig, specCompatibilityChecker)
+    private val effectiveConfigBackedSpecificationLoader =
+        configBackedSpecificationLoader ?: ConfigBackedSpecificationLoader(specmaticConfig, recursiveSpecificationAndExampleClassifier)
 
     override fun call(): Int {
         configureLogging(LoggingConfiguration.Companion.LoggingFromOpts(debug = debug))
+        validateArguments()
+
+        val invalidSpecifications = findInvalidSpecificationCandidates()
         val data = loadSpecificationData()
+
+        if (invalidSpecifications.isNotEmpty()) {
+            println("Failed to parse ${invalidSpecifications.size} specification(s):")
+            invalidSpecifications.forEach { println(it.path) }
+        }
+
         if (data.isEmpty()) {
             println("No specifications found to validate.")
-            return 0
+            return if (invalidSpecifications.isNotEmpty()) 1 else 0
         }
 
         val processor = ValidationProcessor(validator)
         val summary = processor.processValidation(data)
-        return if (summary.isSuccess) 0 else 1
+        return if (summary.isSuccess && invalidSpecifications.isEmpty()) 0 else 1
     }
 
     private fun loadSpecificationData(): List<SpecificationWithExamples> {
-        validateArguments()
-
         if (file != null) {
             val specification = file ?: return emptyList()
             val loadedData = recursiveSpecificationAndExampleClassifier.load(specification) ?: return emptyList()
             return listOf(loadedData)
         }
 
-        val resolvedDirectory = directory ?: File(".").canonicalFile
-        return recursiveSpecificationAndExampleClassifier.loadAll(resolvedDirectory)
+        if (directory != null) {
+            val resolvedDirectory = directory ?: return emptyList()
+            return recursiveSpecificationAndExampleClassifier.loadAll(resolvedDirectory)
+        }
+
+        val resolvedDirectory = currentDirectoryProvider()
+        val discoveredSpecifications = recursiveSpecificationAndExampleClassifier.loadAll(resolvedDirectory)
+        val configSpecifications = if (File(getConfigFilePath()).exists()) effectiveConfigBackedSpecificationLoader.load() else emptyList()
+
+        return (discoveredSpecifications + configSpecifications)
+            .distinctBy { specificationWithExamples -> specificationWithExamples.specFile.normalizedPath() }
+    }
+
+    private fun findInvalidSpecificationCandidates(): List<File> {
+        return when {
+            file != null -> listOfNotNull(file).filter(::isMalformedOpenApiSpecification)
+            directory != null -> findInvalidSpecificationsInDirectory(directory ?: return emptyList())
+            else -> {
+                val resolvedDirectory = currentDirectoryProvider()
+                (findInvalidSpecificationsInDirectory(resolvedDirectory) + findInvalidConfigSpecifications())
+                    .distinctBy { it.normalizedPath() }
+            }
+        }
+    }
+
+    private fun findInvalidSpecificationsInDirectory(directory: File): List<File> {
+        return findContractCandidates(directory)
+            .filter(::isMalformedOpenApiSpecification)
+            .distinctBy { it.normalizedPath() }
+    }
+
+    private fun findInvalidConfigSpecifications(): List<File> {
+        val configFile = File(getConfigFilePath()).canonicalFile
+        if (!configFile.exists()) return emptyList()
+
+        val workingDirectory = configFile.parentFile?.canonicalFile ?: currentDirectoryProvider()
+
+        return specmaticConfig.loadSources().flatMap { source ->
+            source.loadContracts(
+                ContractsSelectorPredicate { contractSource -> contractSource.testContracts + contractSource.stubContracts },
+                workingDirectory.canonicalPath,
+                configFile.canonicalPath
+            )
+        }.map { contractPathData ->
+            File(contractPathData.path).canonicalFile
+        }.filter { specificationFile ->
+            specificationFile.exists() && isMalformedOpenApiSpecification(specificationFile)
+        }.distinctBy { it.normalizedPath() }
+    }
+
+    private fun findContractCandidates(directory: File): List<File> {
+        if (!directory.isDirectory) return emptyList()
+
+        return directory.listFiles()?.flatMap { file ->
+            when {
+                file.isDirectory -> findContractCandidates(file)
+                file.isFile && file.extension.lowercase() in CONTRACT_EXTENSIONS -> listOf(file.canonicalFile)
+                else -> emptyList()
+            }
+        }.orEmpty()
+    }
+
+    private fun isMalformedOpenApiSpecification(specificationFile: File): Boolean {
+        if (!specificationFile.isFile) return false
+        if (specificationFile.extension.lowercase() !in OPENAPI_FILE_EXTENSIONS) return false
+
+        return try {
+            specificationFile.reader().use { reader ->
+                Yaml().load<Any?>(reader)
+            }
+            false
+        } catch (_: Throwable) {
+            true
+        }
     }
 
     private fun validateArguments() {
@@ -69,5 +157,9 @@ class ValidateCommand(
             if (!directory.isDirectory)  throw ContractException("${directory.path} is not a directory")
             if (!directory.exists()) throw ContractException("Directory ${directory.path} does not exist")
         }
+    }
+
+    private fun File.normalizedPath(): String {
+        return runCatching { canonicalPath }.getOrElse { absolutePath }
     }
 }

--- a/application/src/main/kotlin/application/validate/ValidateCommand.kt
+++ b/application/src/main/kotlin/application/validate/ValidateCommand.kt
@@ -19,8 +19,8 @@ import java.util.concurrent.Callable
 class ValidateCommand(
     private val validator: Validator<out Any?> = OpenApiValidator(),
     specCompatibilityChecker: SpecCompatibilityChecker = OpenApiSpecCompatibilityChecker(),
-    private val specmaticConfig: io.specmatic.core.SpecmaticConfig = loadSpecmaticConfigIfAvailableElseDefault(),
-    private val configBackedSpecificationLoader: ConfigBackedSpecificationLoader? = null,
+    specmaticConfig: io.specmatic.core.SpecmaticConfig = loadSpecmaticConfigIfAvailableElseDefault(),
+    configBackedSpecificationLoader: ConfigBackedSpecificationLoader? = null,
     private val currentDirectoryProvider: () -> File = { File(".").canonicalFile }
 ) : Callable<Int> {
     @CommandLine.Option(names = ["--debug"], description = ["Enable debug logs"])

--- a/application/src/main/kotlin/application/validate/ValidateCommand.kt
+++ b/application/src/main/kotlin/application/validate/ValidateCommand.kt
@@ -8,6 +8,7 @@ import io.specmatic.core.loadSpecmaticConfigIfAvailableElseDefault
 import io.specmatic.core.log.configureLogging
 import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.utilities.ContractsSelectorPredicate
+import io.specmatic.core.utilities.GitRepo
 import io.specmatic.loader.OpenApiSpecCompatibilityChecker
 import io.specmatic.loader.RecursiveSpecificationAndExampleClassifier
 import io.specmatic.loader.SpecCompatibilityChecker
@@ -103,12 +104,15 @@ class ValidateCommand(
         val configFile = File(getConfigFilePath()).canonicalFile
         if (!configFile.exists()) return emptyList()
 
-        val workingDirectory = configFile.parentFile?.canonicalFile ?: currentDirectoryProvider()
+        val classificationWorkingDirectory = configFile.parentFile?.canonicalFile ?: currentDirectoryProvider()
+        val contractLoadingBaseDir = classificationWorkingDirectory.resolve(".specmatic").canonicalFile
 
         return specmaticConfig.loadSources().flatMap { source ->
+            val contractLoadingWorkingDirectory =
+                if (source is GitRepo) contractLoadingBaseDir.canonicalPath else classificationWorkingDirectory.canonicalPath
             source.loadContracts(
                 ContractsSelectorPredicate { contractSource -> contractSource.testContracts + contractSource.stubContracts },
-                workingDirectory.canonicalPath,
+                contractLoadingWorkingDirectory,
                 configFile.canonicalPath
             )
         }.map { contractPathData ->

--- a/application/src/main/kotlin/application/validate/ValidateCommand.kt
+++ b/application/src/main/kotlin/application/validate/ValidateCommand.kt
@@ -36,7 +36,8 @@ class ValidateCommand(
     @CommandLine.Option(names = ["--spec-file"], description = ["Specification to validate, along with respective examples"])
     var file: File? = null
 
-    private val recursiveSpecificationAndExampleClassifier = RecursiveSpecificationAndExampleClassifier(specmaticConfig, specCompatibilityChecker)
+    private val recursiveSpecificationAndExampleClassifier =
+        RecursiveSpecificationAndExampleClassifier(specmaticConfig, specCompatibilityChecker, setOf(".specmatic"))
     private val effectiveConfigBackedSpecificationLoader =
         configBackedSpecificationLoader ?: ConfigBackedSpecificationLoader(specmaticConfig, recursiveSpecificationAndExampleClassifier)
 
@@ -124,10 +125,11 @@ class ValidateCommand(
 
     private fun findContractCandidates(directory: File): List<File> {
         if (!directory.isDirectory) return emptyList()
+        if (directory.isExcludedScanDirectory()) return emptyList()
 
         return directory.listFiles()?.flatMap { file ->
             when {
-                file.isDirectory -> findContractCandidates(file)
+                file.isDirectory && !file.isExcludedScanDirectory() -> findContractCandidates(file)
                 file.isFile && file.extension.lowercase() in CONTRACT_EXTENSIONS -> listOf(file.canonicalFile)
                 else -> emptyList()
             }
@@ -165,5 +167,9 @@ class ValidateCommand(
 
     private fun File.normalizedPath(): String {
         return runCatching { canonicalPath }.getOrElse { absolutePath }
+    }
+
+    private fun File.isExcludedScanDirectory(): Boolean {
+        return isDirectory && name == ".specmatic"
     }
 }

--- a/application/src/main/kotlin/application/validate/ValidateCommand.kt
+++ b/application/src/main/kotlin/application/validate/ValidateCommand.kt
@@ -1,19 +1,15 @@
 package application.validate
 
 import io.specmatic.core.CONTRACT_EXTENSIONS
-import io.specmatic.core.OPENAPI_FILE_EXTENSIONS
 import io.specmatic.core.config.LoggingConfiguration
 import io.specmatic.core.getConfigFilePath
 import io.specmatic.core.loadSpecmaticConfigIfAvailableElseDefault
 import io.specmatic.core.log.configureLogging
 import io.specmatic.core.pattern.ContractException
-import io.specmatic.core.utilities.ContractsSelectorPredicate
-import io.specmatic.core.utilities.GitRepo
 import io.specmatic.loader.OpenApiSpecCompatibilityChecker
 import io.specmatic.loader.RecursiveSpecificationAndExampleClassifier
 import io.specmatic.loader.SpecCompatibilityChecker
 import io.specmatic.loader.SpecificationWithExamples
-import org.yaml.snakeyaml.Yaml
 import picocli.CommandLine
 import picocli.CommandLine.Command
 import java.io.File
@@ -45,22 +41,16 @@ class ValidateCommand(
         configureLogging(LoggingConfiguration.Companion.LoggingFromOpts(debug = debug))
         validateArguments()
 
-        val invalidSpecifications = findInvalidSpecificationCandidates()
         val data = loadSpecificationData()
-
-        if (invalidSpecifications.isNotEmpty()) {
-            println("Failed to parse ${invalidSpecifications.size} specification(s):")
-            invalidSpecifications.forEach { println(it.path) }
-        }
 
         if (data.isEmpty()) {
             println("No specifications found to validate.")
-            return if (invalidSpecifications.isNotEmpty()) 1 else 0
+            return 0
         }
 
         val processor = ValidationProcessor(validator)
         val summary = processor.processValidation(data)
-        return if (summary.isSuccess && invalidSpecifications.isEmpty()) 0 else 1
+        return if (summary.isSuccess) 0 else 1
     }
 
     private fun loadSpecificationData(): List<SpecificationWithExamples> {
@@ -83,73 +73,6 @@ class ValidateCommand(
             .distinctBy { specificationWithExamples -> specificationWithExamples.specFile.normalizedPath() }
     }
 
-    private fun findInvalidSpecificationCandidates(): List<File> {
-        return when {
-            file != null -> listOfNotNull(file).filter(::isMalformedOpenApiSpecification)
-            directory != null -> findInvalidSpecificationsInDirectory(directory ?: return emptyList())
-            else -> {
-                val resolvedDirectory = currentDirectoryProvider()
-                (findInvalidSpecificationsInDirectory(resolvedDirectory) + findInvalidConfigSpecifications())
-                    .distinctBy { it.normalizedPath() }
-            }
-        }
-    }
-
-    private fun findInvalidSpecificationsInDirectory(directory: File): List<File> {
-        return findContractCandidates(directory)
-            .filter(::isMalformedOpenApiSpecification)
-            .distinctBy { it.normalizedPath() }
-    }
-
-    private fun findInvalidConfigSpecifications(): List<File> {
-        val configFile = File(getConfigFilePath()).canonicalFile
-        if (!configFile.exists()) return emptyList()
-
-        val classificationWorkingDirectory = configFile.parentFile?.canonicalFile ?: currentDirectoryProvider()
-        val contractLoadingBaseDir = classificationWorkingDirectory.resolve(".specmatic").canonicalFile
-
-        return specmaticConfig.loadSources().flatMap { source ->
-            val contractLoadingWorkingDirectory =
-                if (source is GitRepo) contractLoadingBaseDir.canonicalPath else classificationWorkingDirectory.canonicalPath
-            source.loadContracts(
-                ContractsSelectorPredicate { contractSource -> contractSource.testContracts + contractSource.stubContracts },
-                contractLoadingWorkingDirectory,
-                configFile.canonicalPath
-            )
-        }.map { contractPathData ->
-            File(contractPathData.path).canonicalFile
-        }.filter { specificationFile ->
-            specificationFile.exists() && isMalformedOpenApiSpecification(specificationFile)
-        }.distinctBy { it.normalizedPath() }
-    }
-
-    private fun findContractCandidates(directory: File): List<File> {
-        if (!directory.isDirectory) return emptyList()
-        if (directory.isExcludedScanDirectory()) return emptyList()
-
-        return directory.listFiles()?.flatMap { file ->
-            when {
-                file.isDirectory && !file.isExcludedScanDirectory() -> findContractCandidates(file)
-                file.isFile && file.extension.lowercase() in CONTRACT_EXTENSIONS -> listOf(file.canonicalFile)
-                else -> emptyList()
-            }
-        }.orEmpty()
-    }
-
-    private fun isMalformedOpenApiSpecification(specificationFile: File): Boolean {
-        if (!specificationFile.isFile) return false
-        if (specificationFile.extension.lowercase() !in OPENAPI_FILE_EXTENSIONS) return false
-
-        return try {
-            specificationFile.reader().use { reader ->
-                Yaml().load<Any?>(reader)
-            }
-            false
-        } catch (_: Throwable) {
-            true
-        }
-    }
-
     private fun validateArguments() {
         if (file != null) {
             val specification = file ?: return
@@ -167,9 +90,5 @@ class ValidateCommand(
 
     private fun File.normalizedPath(): String {
         return runCatching { canonicalPath }.getOrElse { absolutePath }
-    }
-
-    private fun File.isExcludedScanDirectory(): Boolean {
-        return isDirectory && name == ".specmatic"
     }
 }

--- a/application/src/test/kotlin/application/ValidateCommandTest.kt
+++ b/application/src/test/kotlin/application/ValidateCommandTest.kt
@@ -100,6 +100,47 @@ class ValidateCommandTest {
     }
 
     @Test
+    fun `when validate scans directories it omits specs under dot specmatic`(@TempDir tempDir: File) {
+        val scannedSpec = writeOpenApiFile(tempDir.resolve("contracts/kept.yaml"))
+        writeOpenApiFile(tempDir.resolve(".specmatic/repos/ignored.yaml"))
+
+        val validator = TrackingValidator()
+        val exitCode = CommandLine(commandWithCurrentConfig(tempDir, validator)).execute()
+
+        assertThat(exitCode).isZero()
+        assertThat(validator.validatedSpecifications).containsExactly(scannedSpec.canonicalPath)
+    }
+
+    @Test
+    fun `when config references spec under dot specmatic validate still includes it`(@TempDir tempDir: File) {
+        val scannedSpec = writeOpenApiFile(tempDir.resolve("contracts/kept.yaml"))
+        val configSpec = writeOpenApiFile(tempDir.resolve(".specmatic/repos/service.yaml"))
+        writeSpecmaticYaml(tempDir, "version: 3")
+        val configBackedLoader = mockk<ConfigBackedSpecificationLoader>()
+        every { configBackedLoader.load() } returns listOf(
+            RecursiveSpecificationAndExampleClassifier(loadedConfig(tempDir), OpenApiSpecCompatibilityChecker())
+                .load(configSpec, tempDir)
+                ?: error("Expected config spec to be loadable")
+        )
+        val validator = TrackingValidator()
+        val exitCode = CommandLine(
+            ValidateCommand(
+                validator = validator,
+                specmaticConfig = loadedConfig(tempDir),
+                configBackedSpecificationLoader = configBackedLoader,
+                currentDirectoryProvider = { tempDir.canonicalFile }
+            )
+        ).execute()
+
+        assertThat(exitCode).isZero()
+        assertThat(validator.validatedSpecifications).containsExactlyInAnyOrder(
+            scannedSpec.canonicalPath,
+            configSpec.canonicalPath
+        )
+        verify(exactly = 1) { configBackedLoader.load() }
+    }
+
+    @Test
     fun `when config derived spec fails validate returns non zero and mentions the spec`(@TempDir tempDir: File) {
         val failingSpec = writeOpenApiFile(tempDir.resolve("contracts/dependencies/broken.yaml"))
         writeSpecmaticYaml(tempDir, """
@@ -218,6 +259,37 @@ class ValidateCommandTest {
         assertThat(exitCode).isEqualTo(1)
         assertThat(output).contains("Failed to parse 1 specification(s):")
         assertThat(output).contains(malformedSpec.canonicalPath)
+    }
+
+    @Test
+    fun `when malformed spec exists only under dot specmatic scan does not report it`(@TempDir tempDir: File) {
+        val scannedSpec = writeOpenApiFile(tempDir.resolve("contracts/kept.yaml"))
+        val malformedSpec = tempDir.resolve(".specmatic/repos/broken.yaml")
+        malformedSpec.parentFile.mkdirs()
+        malformedSpec.writeText(
+            """
+            openapi: 3.0.1
+            info:
+              title: Broken API
+              version: "1"
+            paths:
+              /pets:
+                get:
+                  responses:
+                    '200'
+                      description: OK
+            """.trimIndent()
+        )
+
+        val validator = TrackingValidator()
+        val (output, exitCode) = captureStandardOutput(redirectStdErrToStdout = true) {
+            CommandLine(commandWithCurrentConfig(tempDir, validator)).execute()
+        }
+
+        assertThat(exitCode).isZero()
+        assertThat(output).doesNotContain("Failed to parse 1 specification(s):")
+        assertThat(output).doesNotContain(malformedSpec.canonicalPath)
+        assertThat(validator.validatedSpecifications).containsExactly(scannedSpec.canonicalPath)
     }
 
     private fun commandWithCurrentConfig(baseDir: File, validator: TrackingValidator): ValidateCommand {

--- a/application/src/test/kotlin/application/ValidateCommandTest.kt
+++ b/application/src/test/kotlin/application/ValidateCommandTest.kt
@@ -1,0 +1,270 @@
+package application
+
+import application.validate.ConfigBackedSpecificationLoader
+import application.validate.ExampleValidationResult
+import application.validate.SpecValidationResult
+import application.validate.ValidateCommand
+import application.validate.Validator
+import io.mockk.every
+import io.mockk.mockk
+import io.specmatic.core.Result
+import io.specmatic.core.SpecmaticConfig
+import io.specmatic.core.utilities.Flags.Companion.CONFIG_FILE_PATH
+import io.specmatic.loader.OpenApiSpecCompatibilityChecker
+import io.specmatic.loader.RecursiveSpecificationAndExampleClassifier
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import picocli.CommandLine
+import java.io.File
+
+class ValidateCommandTest {
+    @AfterEach
+    fun cleanup() {
+        System.clearProperty(CONFIG_FILE_PATH)
+    }
+
+    @Test
+    fun `when validate runs without args it validates scanned and config filesystem specs`(@TempDir tempDir: File) {
+        val scannedSpec = writeOpenApiFile(tempDir.resolve("scanned/pets.yaml"))
+        val systemSpec = writeOpenApiFile(tempDir.resolve("contracts/service/service.yaml"))
+        val dependencySpec = writeOpenApiFile(tempDir.resolve("contracts/dependencies/dependency.yaml"))
+        writeSpecmaticYaml(tempDir, """
+            version: 3
+            systemUnderTest:
+              service:
+                definitions:
+                - definition:
+                    source:
+                      filesystem:
+                        directory: contracts/service
+                    specs:
+                    - service.yaml
+            dependencies:
+              services:
+              - service:
+                  definitions:
+                  - definition:
+                      source:
+                        filesystem:
+                          directory: contracts/dependencies
+                      specs:
+                      - dependency.yaml
+        """.trimIndent())
+
+        val validator = TrackingValidator()
+        val exitCode = CommandLine(commandWithCurrentConfig(tempDir, validator)).execute()
+
+        assertThat(exitCode).isZero()
+        assertThat(validator.validatedSpecifications).containsExactlyInAnyOrder(
+            scannedSpec.canonicalPath,
+            systemSpec.canonicalPath,
+            dependencySpec.canonicalPath
+        )
+    }
+
+    @Test
+    fun `when same spec is in scan and config it is validated once`(@TempDir tempDir: File) {
+        val sharedSpec = writeOpenApiFile(tempDir.resolve("contracts/shared.yaml"))
+        writeSpecmaticYaml(tempDir, """
+            version: 3
+            systemUnderTest:
+              service:
+                definitions:
+                - definition:
+                    source:
+                      filesystem:
+                        directory: contracts
+                    specs:
+                    - shared.yaml
+            dependencies:
+              services:
+              - service:
+                  definitions:
+                  - definition:
+                      source:
+                        filesystem:
+                          directory: contracts
+                      specs:
+                      - shared.yaml
+        """.trimIndent())
+
+        val validator = TrackingValidator()
+        val exitCode = CommandLine(commandWithCurrentConfig(tempDir, validator)).execute()
+
+        assertThat(exitCode).isZero()
+        assertThat(validator.validatedSpecifications).containsExactly(sharedSpec.canonicalPath)
+    }
+
+    @Test
+    fun `when config derived spec fails validate returns non zero and mentions the spec`(@TempDir tempDir: File) {
+        val failingSpec = writeOpenApiFile(tempDir.resolve("contracts/dependencies/broken.yaml"))
+        writeSpecmaticYaml(tempDir, """
+            version: 3
+            dependencies:
+              services:
+              - service:
+                  definitions:
+                  - definition:
+                      source:
+                        filesystem:
+                          directory: contracts/dependencies
+                      specs:
+                      - broken.yaml
+        """.trimIndent())
+
+        val validator = TrackingValidator(invalidSpecifications = setOf(failingSpec.canonicalPath))
+        val (output, exitCode) = captureStandardOutput(redirectStdErrToStdout = true) {
+            CommandLine(commandWithCurrentConfig(tempDir, validator)).execute()
+        }
+
+        assertThat(exitCode).isEqualTo(1)
+        assertThat(output).contains(failingSpec.canonicalPath)
+    }
+
+    @Test
+    fun `when no config file exists validate falls back to scanning current directory`(@TempDir tempDir: File) {
+        val scannedSpec = writeOpenApiFile(tempDir.resolve("fallback/only-scanned.yaml"))
+
+        val validator = TrackingValidator()
+        val exitCode = CommandLine(
+            ValidateCommand(
+                validator = validator,
+                currentDirectoryProvider = { tempDir.canonicalFile }
+            )
+        ).execute()
+
+        assertThat(exitCode).isZero()
+        assertThat(validator.validatedSpecifications).containsExactly(scannedSpec.canonicalPath)
+    }
+
+    @Test
+    fun `config backed specification loader resolves non filesystem specs via contract sources`(@TempDir tempDir: File) {
+        val downloadedSpec = writeOpenApiFile(tempDir.resolve("downloads/remote.yaml"))
+        writeSpecmaticYaml(tempDir, "version: 3")
+        val classifier = RecursiveSpecificationAndExampleClassifier(loadedConfig(tempDir), OpenApiSpecCompatibilityChecker())
+        val loader = ConfigBackedSpecificationLoader(
+            specmaticConfig = loadedConfig(tempDir),
+            classifier = classifier,
+            loadSources = {
+                val remoteSource = mockk<io.specmatic.core.utilities.ContractSource>()
+                every { remoteSource.loadContracts(any(), any(), any()) } returns listOf(
+                    io.specmatic.core.utilities.ContractPathData(
+                        baseDir = tempDir.canonicalPath,
+                        path = downloadedSpec.canonicalPath,
+                        provider = "git",
+                        specificationPath = "apis/remote.yaml"
+                    )
+                )
+                every { remoteSource.pathDescriptor("apis/remote.yaml") } returns "remote-repo:apis/remote.yaml"
+                listOf(
+                    remoteSource
+                )
+            },
+            configFileProvider = { tempDir.resolve("specmatic.yaml") }
+        )
+
+        val specifications = loader.load()
+
+        assertThat(specifications.map { it.specFile.canonicalPath }).containsExactly(downloadedSpec.canonicalPath)
+    }
+
+    @Test
+    fun `when config derived spec cannot be parsed validate returns non zero`(@TempDir tempDir: File) {
+        val malformedSpec = tempDir.resolve("contracts/dependencies/broken.yaml")
+        malformedSpec.parentFile.mkdirs()
+        malformedSpec.writeText(
+            """
+            openapi: 3.0.1
+            info:
+              title: Broken API
+              version: "1"
+            paths:
+              /pets:
+                get:
+                  responses:
+                    '200'
+                      description: OK
+            """.trimIndent()
+        )
+        writeSpecmaticYaml(tempDir, """
+            version: 3
+            dependencies:
+              services:
+              - service:
+                  definitions:
+                  - definition:
+                      source:
+                        filesystem:
+                          directory: contracts/dependencies
+                      specs:
+                      - broken.yaml
+        """.trimIndent())
+
+        val (output, exitCode) = captureStandardOutput(redirectStdErrToStdout = true) {
+            CommandLine(commandWithCurrentConfig(tempDir, TrackingValidator())).execute()
+        }
+
+        assertThat(exitCode).isEqualTo(1)
+        assertThat(output).contains("Failed to parse 1 specification(s):")
+        assertThat(output).contains(malformedSpec.canonicalPath)
+    }
+
+    private fun commandWithCurrentConfig(baseDir: File, validator: TrackingValidator): ValidateCommand {
+        return ValidateCommand(
+            validator = validator,
+            specmaticConfig = loadedConfig(baseDir),
+            currentDirectoryProvider = { baseDir.canonicalFile }
+        )
+    }
+
+    private fun loadedConfig(baseDir: File): io.specmatic.core.SpecmaticConfig {
+        val configFile = baseDir.resolve("specmatic.yaml")
+        System.setProperty(CONFIG_FILE_PATH, configFile.canonicalPath)
+        return io.specmatic.core.loadSpecmaticConfigIfAvailableElseDefault(configFile.canonicalPath)
+    }
+
+    private fun writeSpecmaticYaml(dir: File, content: String): File {
+        return dir.resolve("specmatic.yaml").also { it.writeText(content) }
+    }
+
+    private fun writeOpenApiFile(file: File): File {
+        file.parentFile.mkdirs()
+        file.writeText(
+            """
+            openapi: 3.0.1
+            info:
+              title: Test API
+              version: "1"
+            paths: {}
+            """.trimIndent()
+        )
+        return file
+    }
+
+    private class TrackingValidator(
+        private val invalidSpecifications: Set<String> = emptySet()
+    ) : Validator<String> {
+        val validatedSpecifications = mutableListOf<String>()
+
+        override fun validateSpecification(specification: File, specmaticConfig: SpecmaticConfig): SpecValidationResult<String> {
+            val canonicalPath = specification.canonicalPath
+            validatedSpecifications.add(canonicalPath)
+            val result = if (canonicalPath in invalidSpecifications) Result.Failure("Invalid specification") else Result.Success()
+            return SpecValidationResult.ValidationResult(canonicalPath, result)
+        }
+
+        override fun validateInlineExamples(specification: File, feature: String, specmaticConfig: SpecmaticConfig): Map<String, ExampleValidationResult> {
+            return emptyMap()
+        }
+
+        override fun validateExample(feature: String, file: File, specmaticConfig: SpecmaticConfig): ExampleValidationResult {
+            return ExampleValidationResult.ValidationResult(file, Result.Success())
+        }
+
+        override fun validateExamples(feature: String, files: List<File>, specmaticConfig: SpecmaticConfig): Result {
+            return Result.Success()
+        }
+    }
+}

--- a/application/src/test/kotlin/application/ValidateCommandTest.kt
+++ b/application/src/test/kotlin/application/ValidateCommandTest.kt
@@ -7,9 +7,11 @@ import application.validate.ValidateCommand
 import application.validate.Validator
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import io.specmatic.core.Result
 import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.utilities.Flags.Companion.CONFIG_FILE_PATH
+import io.specmatic.core.utilities.GitRepo
 import io.specmatic.loader.OpenApiSpecCompatibilityChecker
 import io.specmatic.loader.RecursiveSpecificationAndExampleClassifier
 import org.assertj.core.api.Assertions.assertThat
@@ -144,20 +146,20 @@ class ValidateCommandTest {
         val downloadedSpec = writeOpenApiFile(tempDir.resolve("downloads/remote.yaml"))
         writeSpecmaticYaml(tempDir, "version: 3")
         val classifier = RecursiveSpecificationAndExampleClassifier(loadedConfig(tempDir), OpenApiSpecCompatibilityChecker())
+        val remoteSource = mockk<GitRepo>()
+        every { remoteSource.loadContracts(any(), any(), any()) } returns listOf(
+            io.specmatic.core.utilities.ContractPathData(
+                baseDir = tempDir.canonicalPath,
+                path = downloadedSpec.canonicalPath,
+                provider = "git",
+                specificationPath = "apis/remote.yaml"
+            )
+        )
+        every { remoteSource.pathDescriptor("apis/remote.yaml") } returns "remote-repo:apis/remote.yaml"
         val loader = ConfigBackedSpecificationLoader(
             specmaticConfig = loadedConfig(tempDir),
             classifier = classifier,
             loadSources = {
-                val remoteSource = mockk<io.specmatic.core.utilities.ContractSource>()
-                every { remoteSource.loadContracts(any(), any(), any()) } returns listOf(
-                    io.specmatic.core.utilities.ContractPathData(
-                        baseDir = tempDir.canonicalPath,
-                        path = downloadedSpec.canonicalPath,
-                        provider = "git",
-                        specificationPath = "apis/remote.yaml"
-                    )
-                )
-                every { remoteSource.pathDescriptor("apis/remote.yaml") } returns "remote-repo:apis/remote.yaml"
                 listOf(
                     remoteSource
                 )
@@ -167,6 +169,13 @@ class ValidateCommandTest {
 
         val specifications = loader.load()
 
+        verify {
+            remoteSource.loadContracts(
+                any(),
+                tempDir.resolve(".specmatic").canonicalPath,
+                tempDir.resolve("specmatic.yaml").canonicalPath
+            )
+        }
         assertThat(specifications.map { it.specFile.canonicalPath }).containsExactly(downloadedSpec.canonicalPath)
     }
 

--- a/application/src/test/kotlin/application/ValidateCommandTest.kt
+++ b/application/src/test/kotlin/application/ValidateCommandTest.kt
@@ -221,7 +221,7 @@ class ValidateCommandTest {
     }
 
     @Test
-    fun `when config derived spec cannot be parsed validate returns non zero`(@TempDir tempDir: File) {
+    fun `when config derived spec cannot be parsed validate ignores it`(@TempDir tempDir: File) {
         val malformedSpec = tempDir.resolve("contracts/dependencies/broken.yaml")
         malformedSpec.parentFile.mkdirs()
         malformedSpec.writeText(
@@ -256,9 +256,8 @@ class ValidateCommandTest {
             CommandLine(commandWithCurrentConfig(tempDir, TrackingValidator())).execute()
         }
 
-        assertThat(exitCode).isEqualTo(1)
-        assertThat(output).contains("Failed to parse 1 specification(s):")
-        assertThat(output).contains(malformedSpec.canonicalPath)
+        assertThat(exitCode).isZero()
+        assertThat(output).contains("No specifications found to validate.")
     }
 
     @Test
@@ -287,7 +286,6 @@ class ValidateCommandTest {
         }
 
         assertThat(exitCode).isZero()
-        assertThat(output).doesNotContain("Failed to parse 1 specification(s):")
         assertThat(output).doesNotContain(malformedSpec.canonicalPath)
         assertThat(validator.validatedSpecifications).containsExactly(scannedSpec.canonicalPath)
     }

--- a/core/src/main/kotlin/io/specmatic/core/utilities/WebSource.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/WebSource.kt
@@ -11,7 +11,7 @@ import java.net.URL
 class WebSource(override val testContracts: List<ContractSourceEntry>, override val stubContracts: List<ContractSourceEntry>) : ContractSource {
     override val type: String = "web"
     override fun pathDescriptor(path: String): String {
-        return ""
+        return path
     }
 
     override fun install(workingDirectory: File) {

--- a/core/src/main/kotlin/io/specmatic/loader/RecursiveSpecificationAndExampleClassifier.kt
+++ b/core/src/main/kotlin/io/specmatic/loader/RecursiveSpecificationAndExampleClassifier.kt
@@ -4,7 +4,11 @@ import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.log.logger
 import java.io.File
 
-class RecursiveSpecificationAndExampleClassifier(private val specmaticConfig: SpecmaticConfig, private val strategy: SpecCompatibilityChecker) {
+class RecursiveSpecificationAndExampleClassifier(
+    private val specmaticConfig: SpecmaticConfig,
+    private val strategy: SpecCompatibilityChecker,
+    private val excludedDirectoryNames: Set<String> = emptySet()
+) {
     fun loadAll(directory: File): List<SpecificationWithExamples> {
         logger.boundary()
         logger.log("Scanning for specification and examples in entry directory ${directory.path}")
@@ -42,7 +46,7 @@ class RecursiveSpecificationAndExampleClassifier(private val specmaticConfig: Sp
         logger.debug("Scanning directory ${directory.path}")
         return directory.listFiles()?.flatMap { file ->
             when {
-                file.isDirectory -> findAllSpecifications(file)
+                file.isDirectory && file.name !in excludedDirectoryNames -> findAllSpecifications(file)
                 file.isFile && strategy.isCompatibleSpecification(file, specmaticConfig) -> {
                     logger.log("Specification found at ${file.path}")
                     listOf(file)

--- a/core/src/test/kotlin/io/specmatic/loader/RecursiveSpecificationAndExampleClassifierTest.kt
+++ b/core/src/test/kotlin/io/specmatic/loader/RecursiveSpecificationAndExampleClassifierTest.kt
@@ -497,6 +497,36 @@ class RecursiveSpecificationAndExampleClassifierTest {
     }
 
     @Test
+    fun `loadAll should skip excluded directories when configured`() {
+        directoryStructure {
+            spec("kept.spec")
+            dir(".specmatic") {
+                spec("ignored.spec")
+            }
+        }
+
+        val loader = createLoader(excludedDirectoryNames = setOf(".specmatic"))
+        val results = loader.loadAll(rootDir)
+
+        assertThat(results.map { it.specFile.name }).containsExactly("kept.spec")
+    }
+
+    @Test
+    fun `loadAll should scan dot specmatic by default`() {
+        directoryStructure {
+            spec("kept.spec")
+            dir(".specmatic") {
+                spec("included.spec")
+            }
+        }
+
+        val loader = createLoader()
+        val results = loader.loadAll(rootDir)
+
+        assertThat(results.map { it.specFile.name }).containsExactlyInAnyOrder("kept.spec", "included.spec")
+    }
+
+    @Test
     fun `should correctly isolate examples for multiple specs`() {
         val structure = directoryStructure {
             dir("common") {
@@ -731,10 +761,12 @@ class RecursiveSpecificationAndExampleClassifierTest {
         assertThat(adminSpec.examples.sharedExamples).hasSize(3)
     }
 
-    private fun createLoader(): RecursiveSpecificationAndExampleClassifier = RecursiveSpecificationAndExampleClassifier(
-        specmaticConfig = config.toSpecmaticConfig(),
-        strategy = strategy
-    )
+    private fun createLoader(excludedDirectoryNames: Set<String> = emptySet()): RecursiveSpecificationAndExampleClassifier =
+        RecursiveSpecificationAndExampleClassifier(
+            specmaticConfig = config.toSpecmaticConfig(),
+            strategy = strategy,
+            excludedDirectoryNames = excludedDirectoryNames
+        )
 
     private fun directoryStructure(builder: DirectoryBuilder.() -> Unit): DirectoryBuilder {
         val dirBuilder = DirectoryBuilder(rootDir)


### PR DESCRIPTION
## What

When the validate command is called, it didn't validate specs that are in the central repo. We need it to do that as well if no params are provided.

## Why

It's not right to ignore info in specmatic.yaml. So ideally this command should validate everything that it can, and if specmatic.yaml exists, it should load the specs configured in it. Config from specmatic.yaml should also taken into account in the design of all commands going forward.

## How
- load specs from `specmatic.yaml` when `validate` runs without `--dir` or `--spec-file`
- include both scanned local specs and config-backed sources, with path-based deduplication
- fail validation when discovered OpenAPI specs are malformed instead of silently skipping them
- add clearer config-source logging and return web source descriptors in logs
