### PR TITLE
Include error output in Docker commands and reduce default concurrency levels

### DIFF
--- a/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/DockerCompose.kt
+++ b/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/DockerCompose.kt
@@ -39,7 +39,7 @@ class DockerCompose(
     }
 
     fun mustStop() {
-        mustRun(buildCommand("down", "--volumes"), 30, TimeUnit.SECONDS)
+        mustRun(buildCommand("down", "--volumes", "--timeout", "10"), 30, TimeUnit.SECONDS)
     }
 
     private fun run(command: ProcessBuilder, timeout: Long, timeUnit: TimeUnit): CommandResult {

--- a/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/DockerCompose.kt
+++ b/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/DockerCompose.kt
@@ -68,6 +68,7 @@ class DockerCompose(
 
     private fun mustRun(command: ProcessBuilder, timeout: Long, timeUnit: TimeUnit): String {
         val result = run(command, timeout, timeUnit)
+
         return when {
             result.isSuccessful() -> result.output
             else -> error(

--- a/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/DockerCompose.kt
+++ b/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/DockerCompose.kt
@@ -38,8 +38,8 @@ class DockerCompose(
             }
     }
 
-    fun stopAsync() {
-        buildCommand("down", "--volumes").start()
+    fun mustStop() {
+        mustRun(buildCommand("down", "--volumes"), 30, TimeUnit.SECONDS)
     }
 
     private fun run(command: ProcessBuilder, timeout: Long, timeUnit: TimeUnit): CommandResult {

--- a/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/DockerCompose.kt
+++ b/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/DockerCompose.kt
@@ -1,6 +1,7 @@
 package io.specmatic.conformance_test_support
 
 import java.io.File
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 
 class DockerCompose(
@@ -11,7 +12,10 @@ class DockerCompose(
     private val specsDirName: String
 ) {
     data class CommandResult(
-        val exitCode: Int, val output: String
+        val command: String,
+        val exitCode: Int,
+        val output: String,
+        val errorOutput: String
     ) {
         fun isSuccessful(): Boolean = exitCode == 0
     }
@@ -40,11 +44,25 @@ class DockerCompose(
 
     private fun run(command: ProcessBuilder, timeout: Long, timeUnit: TimeUnit): CommandResult {
         val process = command.start()
-        process.waitFor(timeout, timeUnit)
+
+        val stdoutFuture = CompletableFuture.supplyAsync {
+            process.inputReader(Charsets.UTF_8).readText()
+        }
+
+        val stderrFuture = CompletableFuture.supplyAsync {
+            process.errorReader(Charsets.UTF_8).readText()
+        }
+
+        val finished = process.waitFor(timeout, timeUnit)
+        if (!finished) {
+            process.destroyForcibly()
+        }
 
         return CommandResult(
+            command = command.command().joinToString(" "),
             exitCode = process.exitValue(),
-            output = process.inputReader(Charsets.UTF_8).use { it.readText() }
+            output = stdoutFuture.get(),
+            errorOutput = stderrFuture.get()
         )
     }
 
@@ -52,7 +70,11 @@ class DockerCompose(
         val result = run(command, timeout, timeUnit)
         return when {
             result.isSuccessful() -> result.output
-            else -> error("failed to run ${command.command()}\nexit code: ${result.exitCode}\noutput: ${result.output}")
+            else -> error(
+                "failed to run ${result.command}" +
+                        "\nexit code: ${result.exitCode}" +
+                        "\noutput: ${result.errorOutput}"
+            )
         }
     }
 
@@ -62,7 +84,7 @@ class DockerCompose(
             .replace(Regex("[^a-zA-Z0-9]"), "-")
 
         return ProcessBuilder("docker", "compose", "--project-name", composeProjectName, *args)
-            .redirectErrorStream(true)
+            .redirectErrorStream(false)
             .directory(workDir)
             .also {
                 it.environment().putAll(

--- a/conformance-tests/src/test/kotlin/io/specmatic/conformance_tests/AbstractConformanceTest.kt
+++ b/conformance-tests/src/test/kotlin/io/specmatic/conformance_tests/AbstractConformanceTest.kt
@@ -43,11 +43,8 @@ abstract class AbstractConformanceTest(
         httpExchanges =
             HttpExchange.parseAll(dockerCompose.mustGetHttpTrafficLogs())
                 .filterNot(HttpExchange::isInfraRequest)
-    }
 
-    @AfterAll
-    fun tearDown() {
-        dockerCompose.stopAsync()
+        dockerCompose.mustStop()
     }
 
     @Test

--- a/conformance-tests/src/test/kotlin/io/specmatic/conformance_tests/AbstractConformanceTest.kt
+++ b/conformance-tests/src/test/kotlin/io/specmatic/conformance_tests/AbstractConformanceTest.kt
@@ -54,7 +54,7 @@ abstract class AbstractConformanceTest(
     @Order(1)
     fun `loop tests should succeed`() {
         assertThat(loopTestsResult.isSuccessful())
-            .withFailMessage { allLogs }
+            .withFailMessage { "${loopTestsResult.command}\n${loopTestsResult.errorOutput}\n\n$allLogs" }
             .isTrue
     }
 

--- a/conformance-tests/src/test/resources/junit-platform.properties
+++ b/conformance-tests/src/test/resources/junit-platform.properties
@@ -1,5 +1,6 @@
 junit.jupiter.execution.parallel.enabled=true
 junit.jupiter.execution.parallel.mode.default=same_thread
 junit.jupiter.execution.parallel.mode.classes.default=concurrent
-junit.jupiter.execution.parallel.config.strategy=dynamic
+junit.jupiter.execution.parallel.config.strategy=fixed
+junit.jupiter.execution.parallel.config.fixed.parallelism=4
 junit.jupiter.testclass.order.default=org.junit.jupiter.api.ClassOrderer$DisplayName


### PR DESCRIPTION
This helps with debugging tests. No major impact on total test run time after reducing concurrency down to a fixed level of 4. 