### PR TITLE
Add configurable health endpoint for contract test preflight

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -221,6 +221,9 @@ interface SpecmaticConfig {
     fun getTestSwaggerUIBaseUrl(): String?
 
     @JsonIgnore
+    fun getTestHealthEndpoint(): String?
+
+    @JsonIgnore
     fun getTestJunitReportDir(): String?
 
     @JsonIgnore

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfigV1V2Common.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfigV1V2Common.kt
@@ -897,6 +897,11 @@ data class SpecmaticConfigV1V2Common(
     }
 
     @JsonIgnore
+    override fun getTestHealthEndpoint(): String? {
+        return if (getVersion() == VERSION_2) test?.healthEndpoint else null
+    }
+
+    @JsonIgnore
     override fun getTestJunitReportDir(): String? {
         return if (getVersion() == VERSION_2) test?.junitReportDir else null
     }
@@ -1453,6 +1458,7 @@ data class TestConfiguration(
     val testsDirectory: String? = null,
     val swaggerUrl: String? = null,
     val swaggerUIBaseURL: String? = null,
+    val healthEndpoint: String? = null,
     val actuatorUrl: String? = null,
     val filter: String? = null,
     val baseUrl: String? = null,

--- a/core/src/main/kotlin/io/specmatic/core/config/OpenAPITestConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/OpenAPITestConfig.kt
@@ -9,6 +9,8 @@ import io.specmatic.core.ResiliencyTestsConfig
 data class OpenAPITestConfig(
     @JsonProperty("baseUrl")
     val baseUrl: String,
+    @JsonProperty("healthEndpoint")
+    val healthEndpoint: String? = null,
     @JsonProperty("resiliencyTests")
     val resiliencyTests: ResiliencyTestsConfig? = null,
     @JsonProperty("examples")
@@ -41,4 +43,3 @@ data class OpenAPITestConfig(
         }
     }
 }
-

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3Impl.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3Impl.kt
@@ -441,6 +441,10 @@ data class SpecmaticConfigV3Impl(val file: File? = null, private val specmaticCo
         return specmaticConfig.systemUnderTest?.getOpenApiTestConfig(resolver)?.swaggerUiBaseUrl
     }
 
+    override fun getTestHealthEndpoint(): String? {
+        return specmaticConfig.systemUnderTest?.getOpenApiTestConfig(resolver)?.healthEndpoint
+    }
+
     override fun getTestJunitReportDir(): String? {
         return testSettings.junitReportDir
     }

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/OpenApiRunOptions.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/OpenApiRunOptions.kt
@@ -17,6 +17,7 @@ sealed interface OpenApiRunOptions : IRunOptions { val type: RunOptionType? }
 data class OpenApiTestConfig(
     override val type: RunOptionType? = null,
     val baseUrl: String? = null,
+    val healthEndpoint: String? = null,
     val host: String? = null,
     val port: Int? = null,
     val filter: String? = null,

--- a/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigKtTest.kt
@@ -537,6 +537,26 @@ internal class SpecmaticConfigKtTest {
         }
     }
 
+    @Test
+    fun `should read v2 test health endpoint from config`() {
+        val config = SpecmaticConfigV1V2Common(
+            version = SpecmaticConfigVersion.VERSION_2,
+            test = TestConfiguration(healthEndpoint = "/_specmatic/health")
+        )
+
+        assertThat(config.getTestHealthEndpoint()).isEqualTo("/_specmatic/health")
+    }
+
+    @Test
+    fun `should return null for v2 test health endpoint when not configured`() {
+        val config = SpecmaticConfigV1V2Common(
+            version = SpecmaticConfigVersion.VERSION_2,
+            test = TestConfiguration()
+        )
+
+        assertThat(config.getTestHealthEndpoint()).isNull()
+    }
+
     @ParameterizedTest
     @MethodSource("testFilterPropertyCases")
     fun `should prefer v2 test config over system properties for test filter fields`(case: TestFilterPropertyCase) {

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -387,12 +387,14 @@ open class SpecmaticJUnitSupport {
 
         settings.coverageHooks.forEach { it.onExampleErrors(testBuildResult.exampleValidationResults) }
         testBuildResult.baseUrls.forEach { baseUrl ->
-            if (isBaseURLReachable(baseUrl, keyData = keyDataFor(baseUrl))) return@forEach
+            val preflightURL = preflightConnectivityURL(baseUrl)
+            if (isReachable(preflightURL, keyData = keyDataFor(preflightURL))) return@forEach
             return loadExceptionAsTestError(e = ContractException("""
             Cannot connect to server at: $baseUrl
             Please check:
             - Is the server running?
             - Is the testBaseURL correct?
+            - If the application does not support HEAD on the base URL, configure runOptions.openapi.healthEndpoint in specmatic.yaml
             """.trimIndent()))
         }
 
@@ -772,6 +774,16 @@ open class SpecmaticJUnitSupport {
 
         return keyDataRegistry.get(host, port)
     }
+
+    private fun preflightConnectivityURL(baseUrl: String): String {
+        val healthEndpoint = specmaticConfig.getTestHealthEndpoint()?.takeIf { it.isNotBlank() }
+            ?: return canonicalBaseUrl(baseUrl)
+
+        return when {
+            healthEndpoint.startsWith("http://") || healthEndpoint.startsWith("https://") -> healthEndpoint
+            else -> URI(canonicalBaseUrl(baseUrl)).resolve(healthEndpoint).toString()
+        }
+    }
 }
 
 data class LoadedTestScenarios(
@@ -835,8 +847,15 @@ fun <T> selectTestsToRun(
 
 
 fun isBaseURLReachable(baseUrl: String, timeOutMs: Int = 3000, keyData: KeyData? = null): Boolean {
+    return isReachable(canonicalBaseUrl(baseUrl), timeOutMs, keyData)
+}
+
+private fun canonicalBaseUrl(baseUrl: String): String {
+    return if (baseUrl.endsWith("/")) baseUrl else "$baseUrl/"
+}
+
+private fun isReachable(url: String, timeOutMs: Int = 3000, keyData: KeyData? = null): Boolean {
     return try {
-        val url = if (baseUrl.endsWith("/")) baseUrl else "$baseUrl/"
         val connection = URL(url).openConnection() as HttpURLConnection
 
         if (connection is HttpsURLConnection) {

--- a/junit5-support/src/test/kotlin/io/specmatic/test/ContractTestSettingsTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/ContractTestSettingsTest.kt
@@ -78,6 +78,26 @@ class ContractTestSettingsTest {
     }
 
     @Test
+    fun `getSpecmaticConfig should read preflight connectivity health endpoint from config`(@TempDir tempDir: File) {
+        val configFile = writeSpecmaticConfig(
+            tempDir,
+            baseUrl = "http://config.example:9000",
+            healthEndpoint = "/_specmatic/health"
+        )
+        val settings = ContractTestSettings(configFile = configFile.absolutePath)
+
+        assertThat(settings.getSpecmaticConfig().getTestHealthEndpoint()).isEqualTo("/_specmatic/health")
+    }
+
+    @Test
+    fun `getSpecmaticConfig should expose null preflight connectivity health endpoint when config is missing it`(@TempDir tempDir: File) {
+        val configFile = writeSpecmaticConfig(tempDir, baseUrl = "http://config.example:9000")
+        val settings = ContractTestSettings(configFile = configFile.absolutePath)
+
+        assertThat(settings.getSpecmaticConfig().getTestHealthEndpoint()).isNull()
+    }
+
+    @Test
     fun `getSpecmaticConfig should override resiliency config to all when generative is true`(@TempDir tempDir: File) {
         val configFile = writeSpecmaticConfig(tempDir, resiliency = ResiliencyTestSuite.positiveOnly)
         val settings = ContractTestSettings(configFile = configFile.absolutePath, generative = true)
@@ -107,7 +127,12 @@ class ContractTestSettingsTest {
         assertThat(copied.lenientMode).isNull()
     }
 
-    private fun writeSpecmaticConfig(tempDir: File, baseUrl: String? = null, resiliency: ResiliencyTestSuite? = null): File {
+    private fun writeSpecmaticConfig(
+        tempDir: File,
+        baseUrl: String? = null,
+        healthEndpoint: String? = null,
+        resiliency: ResiliencyTestSuite? = null
+    ): File {
         val configFile = tempDir.resolve("specmatic.yaml")
         val config = SpecmaticConfigV3(
             version = SpecmaticConfigVersion.VERSION_3,
@@ -115,7 +140,7 @@ class ContractTestSettingsTest {
                 service = RefOrValue.Value(
                     CommonServiceConfig(
                         definitions = emptyList(),
-                        runOptions = RefOrValue.Value(TestRunOptions(openapi = OpenApiTestConfig(baseUrl = baseUrl))),
+                        runOptions = RefOrValue.Value(TestRunOptions(openapi = OpenApiTestConfig(baseUrl = baseUrl, healthEndpoint = healthEndpoint))),
                         settings = RefOrValue.Value(TestSettings(schemaResiliencyTests = resiliency))
                     )
                 )

--- a/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
@@ -1,5 +1,6 @@
 package io.specmatic.test
 
+import com.sun.net.httpserver.HttpServer
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpResponse
 import io.specmatic.core.Result
@@ -51,7 +52,10 @@ import org.junit.platform.launcher.TestExecutionListener
 import org.opentest4j.TestAbortedException
 import java.io.File
 import java.io.PrintStream
+import java.net.InetSocketAddress
 import java.util.*
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
 
 class SpecmaticJunitSupportTest {
     companion object {
@@ -168,6 +172,188 @@ class SpecmaticJunitSupportTest {
             assertThat(url).isEqualTo("http://override.example:8080")
         } finally {
             SpecmaticJUnitSupport.settingsStaging.remove()
+        }
+    }
+
+    @Test
+    fun `should use configured health endpoint for preflight connectivity check when available`(@TempDir tempDir: File) {
+        val specFile = writeSimpleSpec(tempDir)
+
+        localHttpTestServer(
+            mapOf(
+                "/" to mapOf(
+                    "HEAD" to ResponseSpec(500),
+                    "*" to ResponseSpec(404)
+                ),
+                "/_specmatic/health" to mapOf(
+                    "*" to ResponseSpec(200, "ok")
+                ),
+                "/hello" to mapOf(
+                    "*" to ResponseSpec(200)
+                )
+            )
+        ).use { server ->
+            val baseUrl = "http://localhost:${server.port}"
+            val configFile = writeSpecmaticConfig(
+                tempDir,
+                baseUrl = baseUrl,
+                healthEndpoint = "/_specmatic/health"
+            )
+
+            SpecmaticJUnitSupport.settingsStaging.set(
+                ContractTestSettings(
+                    contractPaths = specFile.absolutePath,
+                    configFile = configFile.absolutePath,
+                    filter = ""
+                )
+            )
+
+            try {
+                val tests = SpecmaticJUnitSupport().contractTest().toList()
+
+                assertThat(tests).isNotEmpty
+                tests.forEach { test ->
+                    assertDoesNotThrow {
+                        test.executable.execute()
+                    }
+                }
+            } finally {
+                SpecmaticJUnitSupport.settingsStaging.remove()
+            }
+        }
+    }
+
+    @Test
+    fun `should stop test execution when configured health endpoint preflight check fails`(@TempDir tempDir: File) {
+        val specFile = writeSimpleSpec(tempDir)
+
+        localHttpTestServer(
+            mapOf(
+                "/" to mapOf(
+                    "HEAD" to ResponseSpec(200),
+                    "*" to ResponseSpec(404)
+                ),
+                "/_specmatic/health" to mapOf(
+                    "*" to ResponseSpec(500)
+                ),
+                "/hello" to mapOf(
+                    "*" to ResponseSpec(200)
+                )
+            )
+        ).use { server ->
+            val baseUrl = "http://localhost:${server.port}"
+            val configFile = writeSpecmaticConfig(
+                tempDir,
+                baseUrl = baseUrl,
+                healthEndpoint = "/_specmatic/health"
+            )
+
+            SpecmaticJUnitSupport.settingsStaging.set(
+                ContractTestSettings(
+                    contractPaths = specFile.absolutePath,
+                    configFile = configFile.absolutePath,
+                    filter = ""
+                )
+            )
+
+            try {
+                val tests = SpecmaticJUnitSupport().contractTest().toList()
+
+                assertThat(tests).hasSize(1)
+                val exception = assertThrows<AssertionError> {
+                    tests.single().executable.execute()
+                }
+
+                assertThat(exception.message).contains("Cannot connect to server at: $baseUrl")
+            } finally {
+                SpecmaticJUnitSupport.settingsStaging.remove()
+            }
+        }
+    }
+
+    @Test
+    fun `should use base URL HEAD for preflight connectivity check and continue test execution when health endpoint is not configured`(@TempDir tempDir: File) {
+        val specFile = writeSimpleSpec(tempDir)
+
+        localHttpTestServer(
+            mapOf(
+                "/" to mapOf(
+                    "HEAD" to ResponseSpec(200),
+                    "*" to ResponseSpec(404)
+                ),
+                "/hello" to mapOf(
+                    "*" to ResponseSpec(200)
+                )
+            )
+        ).use { server ->
+            val baseUrl = "http://localhost:${server.port}"
+            val configFile = writeSpecmaticConfig(tempDir, baseUrl = baseUrl)
+
+            SpecmaticJUnitSupport.settingsStaging.set(
+                ContractTestSettings(
+                    contractPaths = specFile.absolutePath,
+                    configFile = configFile.absolutePath,
+                    filter = ""
+                )
+            )
+
+            try {
+                val tests = SpecmaticJUnitSupport().contractTest().toList()
+
+                assertThat(tests).isNotEmpty
+                tests.forEach { test ->
+                    assertDoesNotThrow {
+                        test.executable.execute()
+                    }
+                }
+            } finally {
+                SpecmaticJUnitSupport.settingsStaging.remove()
+            }
+        }
+    }
+
+    @Test
+    fun `should use base URL HEAD for preflight connectivity check and if it fails stop test execution with health endpoint guidance`(@TempDir tempDir: File) {
+        val specFile = writeSimpleSpec(tempDir)
+
+        localHttpTestServer(
+            mapOf(
+                "/" to mapOf(
+                    "HEAD" to ResponseSpec(500),
+                    "*" to ResponseSpec(404)
+                ),
+                "/_specmatic/health" to mapOf(
+                    "*" to ResponseSpec(200, "ok")
+                ),
+                "/hello" to mapOf(
+                    "*" to ResponseSpec(200)
+                )
+            )
+        ).use { server ->
+            val baseUrl = "http://localhost:${server.port}"
+            val configFile = writeSpecmaticConfig(tempDir, baseUrl = baseUrl)
+
+            SpecmaticJUnitSupport.settingsStaging.set(
+                ContractTestSettings(
+                    contractPaths = specFile.absolutePath,
+                    configFile = configFile.absolutePath,
+                    filter = ""
+                )
+            )
+
+            try {
+                val tests = SpecmaticJUnitSupport().contractTest().toList()
+
+                assertThat(tests).hasSize(1)
+                val exception = assertThrows<AssertionError> {
+                    tests.single().executable.execute()
+                }
+
+                assertThat(exception.message).contains("Cannot connect to server at: $baseUrl")
+                assertThat(exception.message).contains("runOptions.openapi.healthEndpoint")
+            } finally {
+                SpecmaticJUnitSupport.settingsStaging.remove()
+            }
         }
     }
 
@@ -1005,7 +1191,7 @@ paths:
             .isEqualTo(0)
     }
 
-    private fun writeSpecmaticConfig(tempDir: File, baseUrl: String? = null): File {
+    private fun writeSpecmaticConfig(tempDir: File, baseUrl: String? = null, healthEndpoint: String? = null): File {
         val configFile = tempDir.resolve("specmatic.yaml")
         val config = SpecmaticConfigV3(
             version = SpecmaticConfigVersion.VERSION_3,
@@ -1013,7 +1199,7 @@ paths:
                 service = RefOrValue.Value(
                     CommonServiceConfig(
                         definitions = emptyList(),
-                        runOptions = RefOrValue.Value(TestRunOptions(openapi = OpenApiTestConfig(baseUrl = baseUrl))),
+                        runOptions = RefOrValue.Value(TestRunOptions(openapi = OpenApiTestConfig(baseUrl = baseUrl, healthEndpoint = healthEndpoint))),
                         settings = RefOrValue.Value(TestSettings())
                     )
                 )
@@ -1021,6 +1207,71 @@ paths:
         )
         configFile.writeText(yamlMapper.writeValueAsString(config))
         return configFile
+    }
+
+    private fun writeSimpleSpec(tempDir: File): File {
+        val specFile = tempDir.resolve("openapi.yaml")
+        specFile.writeText(
+            """
+            openapi: 3.0.0
+            info:
+              title: Reachability Test API
+              version: 1.0.0
+            paths:
+              /hello:
+                get:
+                  responses:
+                    '200':
+                      description: ok
+            """.trimIndent()
+        )
+        return specFile
+    }
+
+    private fun localHttpTestServer(
+        responsesByPath: Map<String, Map<String, ResponseSpec>>
+    ): LocalHttpTestServer {
+        val server = HttpServer.create(InetSocketAddress("localhost", 0), 0)
+
+        responsesByPath.forEach { (path, responsesByMethod) ->
+            server.createContext(path) { exchange ->
+                val response = responsesByMethod[exchange.requestMethod.uppercase()]
+                    ?: responsesByMethod["*"]
+                    ?: ResponseSpec(404)
+
+                if (response.body == null) {
+                    exchange.sendResponseHeaders(response.status, -1)
+                } else {
+                    val responseBytes = response.body.toByteArray()
+                    exchange.sendResponseHeaders(response.status, responseBytes.size.toLong())
+                    exchange.responseBody.use { outputStream -> outputStream.write(responseBytes) }
+                }
+                exchange.close()
+            }
+        }
+
+        val executor = Executors.newSingleThreadExecutor()
+        server.executor = executor
+        server.start()
+
+        return LocalHttpTestServer(server, executor)
+    }
+
+    private data class ResponseSpec(
+        val status: Int,
+        val body: String? = null
+    )
+
+    private data class LocalHttpTestServer(
+        val server: HttpServer,
+        val executor: ExecutorService
+    ) : AutoCloseable {
+        val port: Int get() = server.address.port
+
+        override fun close() {
+            server.stop(0)
+            executor.shutdownNow()
+        }
     }
 
     private class RecordingExampleErrorsListener : TestReportListener {


### PR DESCRIPTION
**What**:

- add a configurable health endpoint for contract-test preflight connectivity checks
- support reading `healthEndpoint` from both v2 and v3 Specmatic config
- add tests for config resolution and preflight behavior

**Why**:

Some applications do not expose `HEAD` on the base URL, which makes the current hard-coded preflight check too rigid. Allowing an explicit health endpoint keeps preflight validation in place without requiring services to support `HEAD /`.

**How**:

- add `healthEndpoint` to OpenAPI test configuration
- read `healthEndpoint` from v2 and v3 config models
- use the configured health endpoint for preflight connectivity checks when present
- fall back to `HEAD` on the base URL when no health endpoint is configured
- improve the preflight failure message to explain how to configure `runOptions.openapi.healthEndpoint`
- add focused tests for configured-endpoint behavior, fallback behavior, and config parsing

**Checklist**:

- [x] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link) N/A
- [ ] Sample Project added/updated (share link) N/A
- [ ] Demo video (share link) N/A
- [ ] Article on Website (share link) N/A
- [ ] Roadmpap updated (share link) N/A
- [ ] Conference Talk (share link) N/A

Build passing locally is unchecked because final local verification was blocked by a Gradle/Kotlin daemon cache issue in this environment after the v2 support change.

**Issue ID**:
Closes: N/A
