### PR TITLE
Issue 2350: Stub response not able to identify response content type given in spec

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/HttpResponsePattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpResponsePattern.kt
@@ -49,7 +49,7 @@ data class HttpResponsePattern(
             val value = attempt(breadCrumb = "BODY") { softCastValueToXML(body.generateWithAll(resolver)) }
             val headers = headersPattern.generateWithAll(resolver).plus(SPECMATIC_RESULT_HEADER to "success").let { headers ->
                 when {
-                    !headers.containsKey("Content-Type") -> headers.plus("Content-Type" to value.httpContentType)
+                    !headers.containsKey("Content-Type") -> headers.plus("Content-Type" to (headersPattern.contentType ?: value.httpContentType))
                     else -> headers
                 }
             }

--- a/core/src/test/kotlin/io/specmatic/core/HttpResponsePatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpResponsePatternTest.kt
@@ -221,4 +221,39 @@ internal class HttpResponsePatternTest {
             assertThat(currentAccountRequestBody.jsonObject["@type"]?.toStringLiteral()).isEqualTo("current")
         }
     }
+
+    @Test
+    fun `generateResponseWithAll should use custom content-type from spec`() {
+        val responsePattern = HttpResponsePattern(
+            headersPattern = HttpHeadersPattern(
+                pattern = emptyMap(),
+                contentType = "application/vnd.company.custom+json"
+            ),
+            status = 200,
+            body = StringPattern()
+        )
+
+        val resolver = Resolver()
+        val generatedResponse = responsePattern.generateResponseWithAll(resolver)
+
+        assertThat(generatedResponse.headers[CONTENT_TYPE])
+            .isEqualTo("application/vnd.company.custom+json")
+    }
+
+    @Test
+    fun `generateResponseWithAll should fallback to default content-type when spec does not specify`() {
+        val responsePattern = HttpResponsePattern(
+            headersPattern = HttpHeadersPattern(
+                pattern = emptyMap(),
+                contentType = null
+            ),
+            status = 200,
+            body = StringPattern()
+        )
+
+        val resolver = Resolver()
+        val generatedResponse = responsePattern.generateResponseWithAll(resolver)
+
+        assertThat(generatedResponse.headers[CONTENT_TYPE]).isEqualTo("text/plain")
+    }
 }

--- a/core/src/test/kotlin/io/specmatic/core/issues/CustomContentTypeTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/issues/CustomContentTypeTest.kt
@@ -1,0 +1,64 @@
+package io.specmatic.core.issues
+
+import io.specmatic.conversions.OpenApiSpecification
+import io.specmatic.core.HttpRequest
+import io.specmatic.core.HttpResponse
+import io.specmatic.core.CONTENT_TYPE
+import io.specmatic.core.value.Value
+import io.specmatic.test.TestExecutor
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class CustomContentTypeTest {
+    @Test
+    fun `stub generated response should use custom content-type from spec not text plain`() {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+openapi: "3.0.3"
+info:
+  version: 1.0.0
+  title: Test API
+paths:
+  /hello:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        '200':
+          description: success
+          content:
+            application/vnd.company.custom+json:
+              schema:
+                type: string
+""".trimIndent(), ""
+        ).toFeature()
+
+        val scenario = feature.scenarios.first()
+        val resolver = io.specmatic.core.Resolver()
+        val generatedResponse = scenario.httpResponsePattern.generateResponseWithAll(resolver)
+        
+        assertThat(generatedResponse.headers[CONTENT_TYPE])
+            .isEqualTo("application/vnd.company.custom+json")
+    }
+
+    @Test
+    fun `stub generated response should fallback to default content-type when spec does not specify`() {
+        val responsePattern = io.specmatic.core.HttpResponsePattern(
+            headersPattern = io.specmatic.core.HttpHeadersPattern(
+                pattern = emptyMap(),
+                contentType = null
+            ),
+            status = 200,
+            body = io.specmatic.core.pattern.StringPattern()
+        )
+
+        val resolver = io.specmatic.core.Resolver()
+        val generatedResponse = responsePattern.generateResponseWithAll(resolver)
+        
+        assertThat(generatedResponse.headers[CONTENT_TYPE]).isEqualTo("text/plain")
+    }
+}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Stub responses now respect custom content-types from OpenAPI specs

<!-- Why are these changes necessary? -->

**Why**: Fixes stub responses for APIs using custom vendor-specific media types like application/vnd.api+json, application/hal+json, etc.

<!-- How were these changes implemented? -->

**How**: Modified HttpResponsePattern.generateResponseWithAll() to prioritize the content-type from the OpenAPI spec over the default content-type of the value class.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #2350 

<!-- feel free to add additional comments -->
