### PR TITLE
Make `fixValue` in ListPattern respect the minItems and maxItems constraints

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/Resolver.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Resolver.kt
@@ -7,7 +7,6 @@ import io.specmatic.core.value.True
 import io.specmatic.core.value.Value
 import io.specmatic.test.ExampleProcessor
 import io.specmatic.test.asserts.WILDCARD_INDEX
-import kotlin.random.Random
 
 val actualMatch: (resolver: Resolver, factKey: String?, pattern: Pattern, sampleValue: Value) -> Result = { resolver: Resolver, factKey: String?, pattern: Pattern, sampleValue: Value ->
     resolver.actualPatternMatch(factKey, pattern, sampleValue)
@@ -341,12 +340,7 @@ data class Resolver(
     }
 
     private fun generateRandomList(listPattern: ListPattern): Value {
-        val size = when {
-            listPattern.minItems != null && listPattern.maxItems != null -> Random.nextInt(listPattern.minItems, listPattern.maxItems + 1)
-            listPattern.minItems != null -> Random.nextInt(listPattern.minItems, listPattern.minItems + 3)
-            listPattern.maxItems != null -> Random.nextInt(0, listPattern.maxItems + 1)
-            else -> randomNumber(3)
-        }
+        val size = listPattern.listSizeForGeneration()
         return listPattern.pattern.listOf(0.until(size).mapIndexed{ index, _ ->
             attempt(breadCrumb = "[$index (random)]") { generate(listPattern.pattern) }
         }, this)

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
@@ -3,6 +3,7 @@ package io.specmatic.core.pattern
 import io.specmatic.core.*
 import io.specmatic.core.pattern.config.NegativePatternConfiguration
 import io.specmatic.core.value.*
+import kotlin.random.Random
 
 const val LIST_BREAD_CRUMB = "[]"
 
@@ -37,13 +38,27 @@ data class ListPattern(
     override fun fixValue(value: Value, resolver: Resolver): Value {
         if (resolver.matchesPattern(null, this, value).isSuccess()) return value
         val updatedResolver = resolver.addPatternAsSeen(this).updateLookupPath(this, this.pattern)
+
         if (value !is JSONArrayValue || (value.list.isEmpty() && resolver.allPatternsAreMandatory && !resolver.hasPartialKeyCheck())) {
-            return pattern.listOf(0.until(randomNumber(3)).mapIndexed { index, _ ->
+            val listSize = listSizeForGeneration()
+            return pattern.listOf(0.until(listSize).mapIndexed { index, _ ->
                 attempt(breadCrumb = "[$index (random)]") { pattern.fixValue(NullValue, updatedResolver) }
             }, resolver)
         }
 
-        return JSONArrayValue(value.list.map { pattern.fixValue(it, updatedResolver) })
+        val listSize = if (minItems == null && maxItems == null) value.list.size else listSizeForGeneration()
+
+        val fixedItems = value.list.map { pattern.fixValue(it, updatedResolver) }.take(listSize)
+        val noOfMissingItems = (listSize - fixedItems.size).coerceAtLeast(0)
+
+        if (noOfMissingItems == 0) return JSONArrayValue(fixedItems)
+
+        val missingItems = run {
+            val sampleValue = fixedItems.firstOrNull() ?: pattern.generate(updatedResolver)
+            List(noOfMissingItems) { sampleValue }
+        }
+
+        return JSONArrayValue(fixedItems + missingItems)
     }
 
     override fun eliminateOptionalKey(value: Value, resolver: Resolver): Value {
@@ -311,6 +326,15 @@ data class ListPattern(
                 else -> emptyList()
             }
         }.toSet()
+    }
+
+    fun listSizeForGeneration(): Int {
+        return when {
+            minItems != null && maxItems != null -> Random.nextInt(minItems, maxItems + 1)
+            minItems != null -> Random.nextInt(minItems, minItems + 3)
+            maxItems != null -> Random.nextInt(0, maxItems + 1)
+            else -> randomNumber(3)
+        }
     }
 
     private fun listPatternsWithNegativePatternsWithin(

--- a/core/src/test/kotlin/io/specmatic/core/pattern/ListPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/ListPatternTest.kt
@@ -678,6 +678,137 @@ Feature: Recursive test
             val fixedValue = pattern.fixValue(partialValue, resolver)
             assertThat(fixedValue).isEqualTo(partialValue)
         }
+
+        @Test
+        fun `should fix an invalid json array value and while doing so make sure minItems constraint is enforced`() {
+            val minItems = 3
+            val pattern = ListPattern(
+                pattern = StringPattern(),
+                minItems = minItems
+            )
+
+            val invalidValue = JSONArrayValue(
+                list = listOf(NumberValue(1))
+            )
+
+            val fixedValue = pattern.fixValue(invalidValue, Resolver()) as JSONArrayValue
+
+            assertThat(fixedValue.list.all { it is StringValue }).isTrue
+            assertThat(fixedValue.list.size).isGreaterThanOrEqualTo(minItems)
+        }
+
+        @Test
+        fun `should fix an invalid json array value and while doing so make sure maxItems constraint is enforced`() {
+            val maxItems = 2
+            val pattern = ListPattern(
+                pattern = StringPattern(),
+                maxItems = maxItems
+            )
+
+            val invalidValue = JSONArrayValue(
+                list = listOf(StringValue("a"), StringValue("b"), StringValue("c"))
+            )
+
+            val fixedValue = pattern.fixValue(invalidValue, Resolver()) as JSONArrayValue
+
+            assertThat(fixedValue.list.all { it is StringValue }).isTrue
+            assertThat(fixedValue.list.size).isLessThanOrEqualTo(maxItems)
+        }
+
+        @Test
+        fun `should fix an invalid json array value and while doing so make sure minItems and maxItems constraint is enforced`() {
+            val pattern = ListPattern(
+                pattern = StringPattern(),
+                minItems = 3,
+                maxItems = 3
+            )
+
+            val invalidValue = JSONArrayValue(
+                list = listOf(NumberValue(1), NumberValue(2), NumberValue(3), NumberValue(4))
+            )
+
+            val fixedValue = pattern.fixValue(invalidValue, Resolver()) as JSONArrayValue
+
+            assertThat(fixedValue.list.all { it is StringValue }).isTrue
+            assertThat(fixedValue.list.size).isEqualTo(3)
+        }
+
+        @Test
+        fun `should fix an invalid non json array value and while doing so make sure minItems constraint is enforced`() {
+            val minItems = 3
+            val pattern = ListPattern(
+                pattern = StringPattern(),
+                minItems = minItems,
+            )
+
+            val fixedValue = pattern.fixValue(StringValue(), Resolver()) as JSONArrayValue
+
+            assertThat(fixedValue.list.all { it is StringValue }).isTrue
+            assertThat(fixedValue.list.size).isGreaterThanOrEqualTo(minItems)
+        }
+
+        @Test
+        fun `should fix an invalid non json array value and while doing so make sure maxItems constraint is enforced`() {
+            val maxItems = 0
+            val pattern = ListPattern(
+                pattern = StringPattern(),
+                maxItems = maxItems,
+            )
+
+            val fixedValue = pattern.fixValue(StringValue(), Resolver()) as JSONArrayValue
+
+            assertThat(fixedValue.list.all { it is StringValue }).isTrue
+            assertThat(fixedValue.list.size).isLessThanOrEqualTo(maxItems)
+        }
+
+        @Test
+        fun `should fix an invalid non json array value and while doing so make sure minItems and maxItems constraint is enforced`() {
+            val pattern = ListPattern(
+                pattern = StringPattern(),
+                minItems = 3,
+                maxItems = 3
+            )
+
+            val fixedValue = pattern.fixValue(StringValue(), Resolver()) as JSONArrayValue
+
+            assertThat(fixedValue.list.all { it is StringValue }).isTrue
+            assertThat(fixedValue.list.size).isEqualTo(3)
+        }
+
+        @Test
+        fun `should not fix an already valid value that satisfies the minItems, maxItems constraints`() {
+            val pattern = ListPattern(
+                pattern = StringPattern(),
+                minItems = 3,
+                maxItems = 3
+            )
+
+            val validValue = JSONArrayValue(
+                list = listOf(
+                    StringValue("a"),
+                    StringValue("b"),
+                    StringValue("c"),
+                )
+            )
+
+            val fixedValue = pattern.fixValue(validValue, Resolver()) as JSONArrayValue
+
+            assertThat(fixedValue).isEqualTo(validValue)
+        }
+
+        @Test
+        fun `should return fixed array of size same as that of given invalid json array value when no minItems, maxItems constraints are set`() {
+            val pattern = ListPattern(pattern = StringPattern())
+
+            val invalidValue = JSONArrayValue(
+                list = listOf(NumberValue(1))
+            )
+
+            val fixedValue = pattern.fixValue(invalidValue, Resolver()) as JSONArrayValue
+
+            assertThat(fixedValue.list.all { it is StringValue }).isTrue
+            assertThat(fixedValue.list.size).isEqualTo(1)
+        }
     }
 
     @Nested


### PR DESCRIPTION
Recently, support for `minItems` and `maxItems` constraints was added in `ListPattern` but unfortunately we missed to cover `fixValue` in that change.

This PR fixes that by making sure `fixValue` always returns a list of valid size as per the specified constraints.
If no constraints are specified, the existing behaviour kicks in.

See the tests added in `ListPatternTest` to understand what all cases are covered. 
