### PR TITLE
Fix empty reasoning in negative multi-response tests

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -1,6 +1,5 @@
 package io.specmatic.core
 
-import io.ktor.http.HttpStatusCode
 import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.conversions.OperationMetadata
 import io.specmatic.core.discriminator.DiscriminatorBasedItem
@@ -842,27 +841,27 @@ data class Scenario(
     fun newBasedOnWithDecision(suggestions: List<Scenario> = emptyList(), strictMode: Boolean, resiliencyTestSuite: ResiliencyTestSuite): Decision<Scenario, Scenario>? {
         val hasExamples = hasExamples()
         val negativeGenerationEnabled = resiliencyTestSuite == ResiliencyTestSuite.all
-        val badRequestHasNoExample = !isGherkinScenario && status == HttpStatusCode.BadRequest.value && !hasExamples
+        val noExamples4xxResponse = !isGherkinScenario && status in 400..499 && !hasExamples
 
-        if (badRequestHasNoExample && negativeGenerationEnabled) {
+        if (noExamples4xxResponse && negativeGenerationEnabled) {
             if (!strictMode) return null
-            val ruleViolation = TestSkipReason.noExamples2xxAnd400(true)
+            val ruleViolation = TestSkipReason.noExamples2xxAnd4xx(true)
             return Decision.Skip(context = this, reasoning = Reasoning(mainReason = ruleViolation))
         }
 
-        if (badRequestHasNoExample) {
-            val otherReasons = listOf(TestSkipReason.noExamples2xxAnd400(strictMode))
+        if (noExamples4xxResponse) {
+            val otherReasons = listOf(TestSkipReason.noExamples2xxAnd4xx(strictMode))
             val reason = Reasoning(mainReason = TestSkipReason.GENERATIVE_DISABLED, otherReasons = otherReasons)
             return Decision.Skip(context = this, reasoning = reason)
         }
 
         if (!isGherkinScenario && !isA2xxScenario() && !hasExamples) {
-            val ruleViolation = TestSkipReason.noExamplesNon2xxAndNon400()
+            val ruleViolation = TestSkipReason.noExamplesNon2xxAndNon4xx()
             return Decision.Skip(context = this, reasoning = Reasoning(mainReason = ruleViolation))
         }
 
         if (strictMode && !hasExamples) {
-            val ruleViolation = TestSkipReason.noExamples2xxAnd400(true)
+            val ruleViolation = TestSkipReason.noExamples2xxAnd4xx(true)
             return Decision.Skip(context = this, reasoning = Reasoning(mainReason = ruleViolation))
         }
 

--- a/core/src/main/kotlin/io/specmatic/core/utilities/Decision.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/Decision.kt
@@ -12,6 +12,11 @@ sealed interface Decision<out Item, out Ctx> {
     }
 }
 
+inline fun <Item, Ctx, NewCtx> Decision<Item, Ctx>.flatMapCtx(fn: (Ctx) -> NewCtx): Decision<Item, NewCtx> = when (this) {
+    is Decision.Execute -> Decision.Execute(value, fn(context), reasoning)
+    is Decision.Skip -> Decision.Skip(fn(context), reasoning)
+}
+
 inline fun <Item, Ctx, NewItem> Decision<Item, Ctx>.flatMap(fn: (Item, Ctx, Reasoning) -> Decision<NewItem, Ctx>): Decision<NewItem, Ctx> = when (this) {
     is Decision.Execute -> fn(value, context, reasoning)
     is Decision.Skip -> Decision.Skip(context, reasoning)

--- a/core/src/main/kotlin/io/specmatic/test/TestSkipReason.kt
+++ b/core/src/main/kotlin/io/specmatic/test/TestSkipReason.kt
@@ -35,7 +35,7 @@ enum class TestSkipReason(override val id: String, override val title: String, o
     );
 
     companion object {
-        fun noExamplesNon2xxAndNon400(): TestSkipReason = EXAMPLES_REQUIRED
-        fun noExamples2xxAnd400(strictMode: Boolean): TestSkipReason = if (strictMode) EXAMPLES_REQUIRED_STRICT_MODE else EXAMPLES_REQUIRED
+        fun noExamplesNon2xxAndNon4xx(): TestSkipReason = EXAMPLES_REQUIRED
+        fun noExamples2xxAnd4xx(strictMode: Boolean): TestSkipReason = if (strictMode) EXAMPLES_REQUIRED_STRICT_MODE else EXAMPLES_REQUIRED
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/FeatureDecisionMatrixTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FeatureDecisionMatrixTest.kt
@@ -219,7 +219,7 @@ class FeatureDecisionMatrixTest {
 
             assertThat(generated).hasSize(1)
             val skip = generated.single() as Decision.Skip
-            assertThat(skip.reasoning.mainReason).isEqualTo(TestSkipReason.noExamples2xxAnd400(true))
+            assertThat(skip.reasoning.mainReason).isEqualTo(TestSkipReason.noExamples2xxAnd4xx(true))
             assertThat(skip.reasoning.otherReasons).isEmpty()
         }
 
@@ -235,11 +235,11 @@ class FeatureDecisionMatrixTest {
             assertThat(generated).hasSize(1)
             val skip = generated.single() as Decision.Skip<*>
             assertThat(skip.reasoning.mainReason).isEqualTo(TestSkipReason.GENERATIVE_DISABLED)
-            assertThat(skip.reasoning.otherReasons).containsExactly(TestSkipReason.noExamples2xxAnd400(true))
+            assertThat(skip.reasoning.otherReasons).containsExactly(TestSkipReason.noExamples2xxAnd4xx(true))
         }
 
         @Test
-        fun `strict mode should keep non-2xx non-400 no-example skips as no-examples violation`() {
+        fun `strict mode should keep non-2xx non-4xx no-example skips as no-examples violation`() {
             val feature = featureFromResourceOpenapi("feature_decision_matrix.yaml").copy(strictMode = true)
             val scenario = firstScenario(feature, 500, hasExamples = false)
             val secondScenario = firstScenario(feature, 404, hasExamples = false)
@@ -248,10 +248,16 @@ class FeatureDecisionMatrixTest {
                 scenarios = sequenceOf(Decision.execute(scenario), Decision.execute(secondScenario))
             ).toList()
 
-            assertThat(generated).hasSize(2).allSatisfy {
+            assertThat(generated.filter { it.context.status == 500 }).hasSize(1).allSatisfy {
                 assertThat(it).isInstanceOf(Decision.Skip::class.java); it as Decision.Skip
-                assertThat(it.reasoning.mainReason).isEqualTo(TestSkipReason.noExamplesNon2xxAndNon400())
+                assertThat(it.reasoning.mainReason).isEqualTo(TestSkipReason.noExamplesNon2xxAndNon4xx())
                 assertThat(it.reasoning.otherReasons).isEmpty()
+            }
+
+            assertThat(generated.filter { it.context.status == 404 }).hasSize(1).allSatisfy {
+                assertThat(it).isInstanceOf(Decision.Skip::class.java); it as Decision.Skip
+                assertThat(it.reasoning.mainReason).isEqualTo(TestSkipReason.GENERATIVE_DISABLED)
+                assertThat(it.reasoning.otherReasons).contains(TestSkipReason.noExamples2xxAnd4xx(strictMode = true))
             }
         }
     }
@@ -337,7 +343,7 @@ class FeatureDecisionMatrixTest {
         }
 
         @Test
-        fun `non-2xx non-400 scenarios without examples should be skipped with no-examples violation`() {
+        fun `non-2xx non-4xx scenarios without examples should be skipped with no-examples violation`() {
             val feature = featureFromResourceOpenapi("feature_decision_matrix.yaml")
             val scenario = firstScenario(feature, 500, hasExamples = false)
             val secondScenario = firstScenario(feature, 404, hasExamples = false)
@@ -346,10 +352,16 @@ class FeatureDecisionMatrixTest {
                 scenarios = sequenceOf(Decision.execute(scenario), Decision.execute(secondScenario))
             ).toList()
 
-            assertThat(generated).hasSize(2).allSatisfy {
+            assertThat(generated.filter { it.context.status == 500 }).hasSize(1).allSatisfy {
                 assertThat(it).isInstanceOf(Decision.Skip::class.java); it as Decision.Skip
-                assertThat(it.reasoning.mainReason).isEqualTo(TestSkipReason.noExamplesNon2xxAndNon400())
+                assertThat(it.reasoning.mainReason).isEqualTo(TestSkipReason.noExamplesNon2xxAndNon4xx())
                 assertThat(it.reasoning.otherReasons).isEmpty()
+            }
+
+            assertThat(generated.filter { it.context.status == 404 }).hasSize(1).allSatisfy {
+                assertThat(it).isInstanceOf(Decision.Skip::class.java); it as Decision.Skip
+                assertThat(it.reasoning.mainReason).isEqualTo(TestSkipReason.GENERATIVE_DISABLED)
+                assertThat(it.reasoning.otherReasons).contains(TestSkipReason.noExamples2xxAnd4xx(false))
             }
         }
     }
@@ -409,7 +421,7 @@ class FeatureDecisionMatrixTest {
             val generated = feature.negativeTestScenariosWithDecision(
                 originalScenarios = listOf(successScenario, badRequestScenario),
                 scenarios = sequenceOf(
-                    Decision.Skip(context = successScenario, reasoning = Reasoning(mainReason = TestSkipReason.noExamples2xxAnd400(true))),
+                    Decision.Skip(context = successScenario, reasoning = Reasoning(mainReason = TestSkipReason.noExamples2xxAnd4xx(true))),
                     Decision.execute(badRequestScenario)
                 ),
             ).toList()
@@ -434,11 +446,11 @@ class FeatureDecisionMatrixTest {
                 scenarios = sequenceOf(
                     Decision.Skip(
                         context = successScenario,
-                        reasoning = Reasoning(mainReason = TestSkipReason.noExamples2xxAnd400(true))
+                        reasoning = Reasoning(mainReason = TestSkipReason.noExamples2xxAnd4xx(true))
                     ),
                     Decision.Skip(
                         context = badRequestScenario,
-                        reasoning = Reasoning(mainReason = TestSkipReason.noExamples2xxAnd400(true))
+                        reasoning = Reasoning(mainReason = TestSkipReason.noExamples2xxAnd4xx(true))
                     )
                 ),
             ).toList()

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -466,8 +466,8 @@ open class SpecmaticJUnitSupport {
 
         startTime = Instant.now()
         return testScenarios.mapNotNull { contractTestDecision ->
-            openApiCoverage.onContractTestDecision(contractTestDecision)
             if (contractTestDecision !is Decision.Execute) {
+                openApiCoverage.onContractTestDecision(contractTestDecision)
                 logger.boundary()
                 logger.log(LOG_SEPARATOR)
                 logger.log(buildString {
@@ -541,6 +541,7 @@ open class SpecmaticJUnitSupport {
                 } finally {
                     if (testResult != null) {
                         contractTest.testResultRecord(testResult)?.let { testResultRecord ->
+                            openApiCoverage.onContractTestDecision(contractTestDecision.flatMapCtx { testResultRecord.scenarioResult?.scenario as? Scenario ?: it })
                             openApiCoverage.addTestReportRecords(testResultRecord)
                         }
                     }

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/TestHooks.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/TestHooks.kt
@@ -6,8 +6,8 @@ import io.specmatic.core.Result
 import io.specmatic.core.Scenario
 import io.specmatic.core.log.HttpLogMessage
 import io.specmatic.core.utilities.Decision
+import io.specmatic.reporter.model.OpenAPIOperation
 import io.specmatic.test.API
-import io.specmatic.test.ContractTest
 import io.specmatic.test.TestResultRecord
 import io.specmatic.test.reports.coverage.Endpoint
 
@@ -34,7 +34,7 @@ interface TestReportListener {
     fun onCoverageCalculated(coverage: Int, absoluteCoverage: Int)
     fun onPathCoverageCalculated(path: String, pathCoverage: Int)
     fun onGovernance(result: Result)
-    fun onTestDecision(decision: Decision<ContractTest, Scenario>)
+    fun onTestDecision(decision: Decision<*, OpenAPIOperation>)
 }
 
 internal fun List<TestReportListener>.onEachListener(block: TestReportListener.() -> Unit) {

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/CoverageContext.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/CoverageContext.kt
@@ -1,6 +1,5 @@
 package io.specmatic.test.reports.coverage
 
-import io.specmatic.core.Scenario
 import io.specmatic.core.report.closestMatchingEndpointFor
 import io.specmatic.core.utilities.Decision
 import io.specmatic.core.utilities.Reasoning
@@ -8,7 +7,6 @@ import io.specmatic.license.core.SpecmaticProtocol
 import io.specmatic.reporter.ctrf.model.CtrfOperationMetrics
 import io.specmatic.reporter.model.OpenAPIOperation
 import io.specmatic.test.API
-import io.specmatic.test.ContractTest
 import io.specmatic.test.TestResultRecord
 
 data class CoverageContext(
@@ -16,12 +14,12 @@ data class CoverageContext(
     val allSpecEndpoints: List<Endpoint>,
     val applicationEndpoints: List<API> = emptyList(),
     val endpointsApiAvailable: Boolean = false,
-    val decisions: Map<Endpoint, List<Decision<ContractTest, Scenario>>> = emptyMap(),
+    val decisions: Map<Endpoint, List<Decision<*, OpenAPIOperation>>> = emptyMap(),
     val previousCoverageMetrics: Map<OpenAPIOperation, CtrfOperationMetrics> = emptyMap(),
 ) {
     private val skipDecisionsByOperation: Map<OpenAPIOperation, Sequence<Reasoning>> by lazy(LazyThreadSafetyMode.NONE) {
         decisions.entries.associate { (endpoint, endpointDecisions) ->
-            val snapshots = endpointDecisions.asSequence().filterIsInstance<Decision.Skip<Scenario>>().map { it.reasoning }
+            val snapshots = endpointDecisions.asSequence().filterIsInstance<Decision.Skip<OpenAPIOperation>>().map { it.reasoning }
             endpoint.toOpenApiOperation() to snapshots
         }
     }

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverage.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverage.kt
@@ -4,7 +4,8 @@ import io.specmatic.core.Scenario
 import io.specmatic.core.filters.ExpressionStandardizer
 import io.specmatic.core.filters.TestRecordFilter
 import io.specmatic.core.utilities.Decision
-import io.specmatic.core.utilities.mapValue
+import io.specmatic.core.utilities.Reasoning
+import io.specmatic.core.utilities.flatMapCtx
 import io.specmatic.license.core.SpecmaticProtocol
 import io.specmatic.reporter.ctrf.model.CtrfOperationMetrics
 import io.specmatic.reporter.model.OpenAPIOperation
@@ -14,6 +15,7 @@ import io.specmatic.test.API
 import io.specmatic.test.ContractTest
 import io.specmatic.test.HttpInteractionsLog
 import io.specmatic.test.TestResultRecord
+import io.specmatic.test.TestSkipReason
 import io.specmatic.test.reports.TestReportListener
 import io.specmatic.test.reports.onEachListener
 import io.specmatic.test.reports.onTestResult
@@ -25,13 +27,15 @@ class OpenApiCoverage(
     private val previousRunCoverageMetrics: Map<OpenAPIOperation, CtrfOperationMetrics> = emptyMap(),
     private val httpInteractionsLog: HttpInteractionsLog = HttpInteractionsLog(),
     private val coverageReportGenerator: CoverageReportGenerator = CoverageReportGenerator(),
+    private val defaultSkipReasoning: Reasoning = Reasoning(mainReason = TestSkipReason.EXAMPLES_REQUIRED)
 ) {
     private val testResultRecords: MutableList<TestResultRecord> = mutableListOf()
     private val applicationAPIs: MutableList<API> = mutableListOf()
     private val excludedAPIs: MutableList<String> = mutableListOf()
     private val allSpecEndpoints: MutableList<Endpoint> = mutableListOf()
     private val specEndpointsInScope: MutableList<Endpoint> = mutableListOf()
-    private val contractTestDecisions: MutableMap<Endpoint, List<Decision<ContractTest, Scenario>>> = mutableMapOf()
+    private val contractTestDecisions: MutableMap<Endpoint, List<Decision<*, OpenAPIOperation>>> = mutableMapOf()
+    private val defaultContractTestDecisions: MutableMap<Endpoint, Decision.Skip<OpenAPIOperation>> = mutableMapOf()
     private var endpointsAPISet: Boolean = false
 
     fun addTestReportRecords(testResultRecord: TestResultRecord) {
@@ -61,6 +65,7 @@ class OpenApiCoverage(
     }
 
     fun addEndpoints(allEndpoints: List<Endpoint> = emptyList(), filteredEndpoints: List<Endpoint> = emptyList()) {
+        seedDefaultSkipDecisions(allEndpoints)
         this.allSpecEndpoints.addAll(allEndpoints)
         this.specEndpointsInScope.addAll(filteredEndpoints)
         val excludedEndpoints = allEndpoints.toSet().minus(filteredEndpoints.toSet()).toList()
@@ -76,7 +81,7 @@ class OpenApiCoverage(
 
     fun onContractTestDecision(contractTestDecision: Decision<Pair<ContractTest, String>, Scenario>) {
         val key = Endpoint(contractTestDecision.context)
-        val decision = contractTestDecision.mapValue { it.first }
+        val decision = contractTestDecision.flatMapCtx { scenario -> scenario.toOpenApiOperation() }
         coverageHooks.onEachListener { onTestDecision(decision) }
         contractTestDecisions[key] = contractTestDecisions.getOrDefault(key, emptyList()).plus(decision)
     }
@@ -94,6 +99,7 @@ class OpenApiCoverage(
     }
 
     fun generate(): OpenApiCoverageReport {
+        notifyDefaultDecisionsToHooks()
         return generateInternal(coverageHooks)
     }
 
@@ -123,13 +129,32 @@ class OpenApiCoverage(
 
     private fun coverageContext(): CoverageContext {
         return CoverageContext(
-            decisions = contractTestDecisions,
+            decisions = getMergedDecisions(),
             endpointsApiAvailable = endpointsAPISet,
             allSpecEndpoints = allSpecEndpoints.toList(),
             applicationEndpoints = filteredApplicationEndpoints(),
             previousCoverageMetrics = previousRunCoverageMetrics,
             tests = filteredTestResultRecords(),
         )
+    }
+
+    private fun getMergedDecisions(): Map<Endpoint, List<Decision<*, OpenAPIOperation>>> {
+        return buildMap {
+            putAll(defaultContractTestDecisions.mapValues { (_, decision) -> listOf(decision) })
+            putAll(contractTestDecisions)
+        }
+    }
+
+    private fun notifyDefaultDecisionsToHooks() {
+        defaultContractTestDecisions.filterKeys { it !in contractTestDecisions }.values.forEach { defaultDecision ->
+            coverageHooks.onEachListener { onTestDecision(defaultDecision) }
+        }
+    }
+
+    private fun seedDefaultSkipDecisions(endpoints: List<Endpoint>) {
+        defaultContractTestDecisions.putAll(from = endpoints.associateWith {
+            Decision.Skip(context = it.toOpenApiOperation(), reasoning = defaultSkipReasoning)
+        })
     }
 
     private fun filteredTestResultRecords(): List<TestResultRecord> {
@@ -162,5 +187,9 @@ class OpenApiCoverage(
         )
 
         return projectedFilterExpression.with("context", TestRecordFilter(missingInSpecRecord)).evaluate().booleanValue
+    }
+
+    private fun Scenario.toOpenApiOperation(): OpenAPIOperation {
+        return Endpoint(this).toOpenApiOperation()
     }
 }

--- a/junit5-support/src/test/kotlin/io/specmatic/test/CtrfApiCoverageReportIntegrationTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/CtrfApiCoverageReportIntegrationTest.kt
@@ -370,7 +370,7 @@ class CtrfApiCoverageReportIntegrationTest {
                 decisions = mapOf(
                     endpoint to listOf(
                         Decision.Skip(
-                            context = parseContractFileToFeature(specFile, sourceProvider = SourceProvider.filesystem.name).scenarios.first(),
+                            context = OpenAPIOperation(path = endpoint.path, method = endpoint.method, contentType = endpoint.requestContentType, responseCode = endpoint.responseStatus, protocol = endpoint.protocol, responseContentType = endpoint.responseContentType),
                             reasoning = Reasoning(mainReason = TestSkipReason.EXCLUDED, otherReasons = listOf(TestSkipReason.EXAMPLES_REQUIRED))
                         )
                     )

--- a/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
@@ -4,7 +4,6 @@ import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpResponse
 import io.specmatic.core.Result
 import io.specmatic.core.ResiliencyTestSuite
-import io.specmatic.core.Scenario
 import io.specmatic.core.SPECMATIC_STUB_DICTIONARY
 import io.specmatic.core.SpecmaticConfigV1V2Common
 import io.specmatic.core.TestConfig
@@ -1280,8 +1279,8 @@ paths:
             exampleErrorsCalls.add(resultsBySpecFile)
         }
 
-        val decisions = mutableListOf<Decision<ContractTest, Scenario>>()
-        override fun onTestDecision(decision: Decision<ContractTest, Scenario>) {
+        val decisions = mutableListOf<Decision<*, OpenAPIOperation>>()
+        override fun onTestDecision(decision: Decision<*, OpenAPIOperation>) {
             decisions.add(decision)
         }
 

--- a/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
@@ -819,7 +819,7 @@ paths:
         createAlphaBetaServer().use { server ->
             try {
                 SpecmaticJUnitSupport.settingsStaging.set(ContractTestSettings(testBaseURL = server.baseUrl, contractPaths = specFile.canonicalPath, coverageHooks = listOf(listener)))
-                SpecmaticJUnitSupport().contractTest().toList()
+                SpecmaticJUnitSupport().contractTest().toList().forEach { it.executable.execute() }
                 assertThat(listener.decisions).isNotEmpty.allSatisfy { assertThat(it).isInstanceOf(Decision.Execute::class.java) }
             } finally {
                 SpecmaticJUnitSupport.settingsStaging.remove()

--- a/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/CoverageContextTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/CoverageContextTest.kt
@@ -9,7 +9,6 @@ import io.specmatic.reporter.model.OpenAPIOperation
 import io.specmatic.reporter.model.SpecType
 import io.specmatic.reporter.model.TestResult
 import io.specmatic.test.API
-import io.specmatic.test.ContractTest
 import io.specmatic.test.TestSkipReason
 import io.specmatic.test.TestResultRecord
 import org.assertj.core.api.Assertions.assertThat
@@ -102,8 +101,8 @@ class CoverageContextTest {
     }
 
     @Suppress("UNCHECKED_CAST")
-    private fun skipDecision(reasoning: Reasoning): Decision<ContractTest, Scenario> {
-        return Decision.Skip(context = Any(), reasoning = reasoning) as Decision<ContractTest, Scenario>
+    private fun skipDecision(reasoning: Reasoning): Decision<Scenario, OpenAPIOperation> {
+        return Decision.Skip(context = Any(), reasoning = reasoning) as Decision<Scenario, OpenAPIOperation>
     }
 
     private fun endpoint(

--- a/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/CoverageReportGeneratorTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/CoverageReportGeneratorTest.kt
@@ -12,7 +12,6 @@ import io.specmatic.reporter.model.OpenAPIOperation
 import io.specmatic.reporter.model.SpecType
 import io.specmatic.reporter.model.TestResult
 import io.specmatic.test.API
-import io.specmatic.test.ContractTest
 import io.specmatic.test.TestExecutionReason
 import io.specmatic.test.TestSkipReason
 import io.specmatic.test.TestResultRecord
@@ -226,8 +225,8 @@ class CoverageReportGeneratorTest {
     }
 
     @Suppress("UNCHECKED_CAST")
-    private fun skipDecision(reasoning: Reasoning): Decision<ContractTest, Scenario> {
-        return Decision.Skip(context = Any(), reasoning = reasoning) as Decision<ContractTest, Scenario>
+    private fun skipDecision(reasoning: Reasoning): Decision<Scenario, OpenAPIOperation> {
+        return Decision.Skip(context = Any(), reasoning = reasoning) as Decision<Scenario, OpenAPIOperation>
     }
 
     private fun endpoint(

--- a/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageIntegrationTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageIntegrationTest.kt
@@ -4,6 +4,7 @@ import io.ktor.http.HttpStatusCode
 import io.specmatic.core.HttpResponse
 import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.pattern.parsedJsonValue
+import io.specmatic.core.utilities.Reasoning
 import io.specmatic.core.value.StringValue
 import io.specmatic.core.value.toXML
 import io.specmatic.license.core.SpecmaticProtocol
@@ -12,6 +13,7 @@ import io.specmatic.reporter.ctrf.model.CtrfTestQualifiers
 import io.specmatic.reporter.model.SpecType
 import io.specmatic.reporter.internal.dto.coverage.CoverageStatus
 import io.specmatic.reporter.model.TestResult
+import io.specmatic.test.TestSkipReason
 import io.specmatic.test.utils.ContractTestScope
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -250,6 +252,84 @@ class OpenApiCoverageIntegrationTest {
                 assertThat(test.result).isEqualTo(TestResult.Success)
                 assertThat(test.protocol).isEqualTo(SpecmaticProtocol.SOAP)
                 assertThat(test.specType).isEqualTo(SpecType.WSDL)
+            }
+        }
+    }
+
+    @Test
+    fun `should only include operation level reasons for operation that have been truly skipped for -ve generation scenarios`(@TempDir tempDir: File) {
+        val specYaml = """
+        openapi: 3.0.0
+        info:
+          title: Reporting generative
+          version: 1.0.0
+        paths:
+          /orders:
+            get:
+              parameters:
+                - in: header
+                  name: X-Header
+                  required: true
+                  schema:
+                    type: integer
+              responses:
+                '200':
+                  description: OK
+                '400':
+                  description: Bad request
+                  content:
+                    text/plain:
+                      schema:
+                        type: string
+                    application/json:
+                      schema:
+                        type: object
+                        properties:
+                          message:
+                            type: string
+                '422':
+                  description: Unprocessable request
+                  content:
+                    text/plain:
+                      schema:
+                        type: string
+                    application/json:
+                      schema:
+                        type: object
+                        properties:
+                          message:
+                            type: string
+        """.trimIndent()
+
+        ContractTestScope.from(specYaml, tempDir).execute(SpecmaticConfig().enableResiliencyTests()) { server ->
+            server.on("/orders", "GET") {
+                header("X-Header", "(number)")
+                respond(200)
+                otherwise(HttpResponse(status = 422, body = parsedJsonValue("""{"message": "application/json"}""")))
+            }
+        }.verifyOpenApiCoverage {
+            assertThat(totalOperations).isEqualTo(5)
+            assertThat(operations).hasSize(5)
+
+            val badReqAppJson = single("GET", "/orders", 400, responseType = "application/json")
+            assertThat(badReqAppJson.operation.reasons).isEqualTo(Reasoning(TestSkipReason.EXAMPLES_REQUIRED).toCtrfSnapshots())
+            assertThat(badReqAppJson.operation.coverageStatus).isEqualTo(CoverageStatus.NOT_TESTED)
+            assertThat(badReqAppJson.tests).isEmpty()
+
+            val badReqPlainText = single("GET", "/orders", 400, responseType = "text/plain")
+            assertThat(badReqPlainText.operation.reasons).isEqualTo(Reasoning(TestSkipReason.EXAMPLES_REQUIRED).toCtrfSnapshots())
+            assertThat(badReqPlainText.operation.coverageStatus).isEqualTo(CoverageStatus.NOT_TESTED)
+            assertThat(badReqAppJson.tests).isEmpty()
+
+            val unprocessablePlainText = single("GET", "/orders", 422, responseType = "text/plain")
+            assertThat(unprocessablePlainText.operation.reasons).isEqualTo(Reasoning(TestSkipReason.EXAMPLES_REQUIRED).toCtrfSnapshots())
+            assertThat(unprocessablePlainText.operation.coverageStatus).isEqualTo(CoverageStatus.NOT_TESTED)
+
+            val unprocessableAppJson = single("GET", "/orders", 422, responseType = "application/json")
+            assertThat(unprocessableAppJson.operation.reasons).isEmpty()
+            assertThat(unprocessableAppJson.operation.coverageStatus).isEqualTo(CoverageStatus.COVERED)
+            assertThat(unprocessableAppJson.tests).hasSize(3).allSatisfy { test ->
+                assertThat(test.result).isEqualTo(TestResult.Success)
             }
         }
     }

--- a/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInputTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInputTest.kt
@@ -1,17 +1,16 @@
 package io.specmatic.test.reports.coverage
 
 import io.specmatic.core.Result
-import io.specmatic.core.Scenario
 import io.specmatic.core.loadSpecmaticConfig
 import io.specmatic.core.utilities.Decision
 import io.specmatic.core.utilities.Reasoning
 import io.specmatic.license.core.SpecmaticProtocol
 import io.specmatic.reporter.internal.dto.coverage.CoverageStatus
 import io.specmatic.reporter.internal.dto.coverage.OmittedStatus
+import io.specmatic.reporter.model.OpenAPIOperation
 import io.specmatic.reporter.model.SpecType
 import io.specmatic.reporter.model.TestResult
 import io.specmatic.test.API
-import io.specmatic.test.ContractTest
 import io.specmatic.test.TestResultRecord
 import io.specmatic.test.TestSkipReason
 import io.specmatic.test.reports.OpenApiCoverageReportProcessor
@@ -1304,6 +1303,6 @@ class OpenApiCoverageReportInputTest {
         override fun onTestsComplete() = Unit
         override fun onExampleErrors(resultsBySpecFile: Map<String, Result>) = Unit
         override fun onEnd() = Unit
-        override fun onTestDecision(decision: Decision<ContractTest, Scenario>) = Unit
+        override fun onTestDecision(decision: Decision<*, OpenAPIOperation>) = Unit
     }
 }

--- a/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageTest.kt
@@ -1,8 +1,15 @@
 package io.specmatic.test.reports.coverage
 
+import io.specmatic.core.utilities.Reasoning
 import io.specmatic.reporter.ctrf.model.CtrfOperationQualifiers
 import io.specmatic.reporter.internal.dto.coverage.CoverageStatus
+import io.specmatic.reporter.internal.dto.coverage.OmittedStatus
+import io.specmatic.reporter.model.OpenAPIOperation
 import io.specmatic.reporter.model.TestResult
+import io.specmatic.test.TestExecutionReason
+import io.specmatic.test.TestSkipReason
+import io.specmatic.test.reports.TestExecutionResult
+import io.specmatic.test.reports.TestReportListener
 import io.specmatic.test.utils.OpenApiCoverageBuilder
 import io.specmatic.test.utils.OpenApiCoverageVerifier.Companion.verify
 import org.assertj.core.api.Assertions.assertThat
@@ -186,6 +193,103 @@ class OpenApiCoverageTest {
             assertThat(missingInSpecView.apiOperation.responseContentType).isNull()
             assertThat(missingInSpecView.operation.coverageStatus).isEqualTo(CoverageStatus.MISSING_IN_SPEC)
         }
+    }
+
+    @Test
+    fun `should keep default skip reasoning in report when generative 4xx scenario has no decision`() {
+        val coverage = OpenApiCoverageBuilder.buildCoverage {
+            specEndpoint(method = "POST", path = "/orders", responseCode = 400, responseType = "application/json")
+        }
+
+        val report = coverage.generate()
+        report.verify {
+            val badRequestView = single("POST", "/orders", 400)
+            assertThat(badRequestView.operation.coverageStatus).isEqualTo(CoverageStatus.NOT_TESTED)
+            assertThat(badRequestView.operation.eligibleForCoverage).isTrue()
+            assertThat(badRequestView.operation.reasons.map { it.id }).containsExactly(TestSkipReason.EXAMPLES_REQUIRED.id)
+            assertThat(badRequestView.tests).isEmpty()
+        }
+    }
+
+    @Test
+    fun `should prefer explicit decision over default skip decision during report generation`() {
+        val coverage = OpenApiCoverageBuilder.buildCoverage {
+            specEndpoint(method = "POST", path = "/orders", responseCode = 400, responseType = "application/json")
+            decisionSkip(
+                path = "/orders",
+                method = "POST",
+                responseCode = 400,
+                responseType = "application/json",
+                reasoning = Reasoning(mainReason = TestSkipReason.EXAMPLES_REQUIRED_STRICT_MODE)
+            )
+        }
+
+        val report = coverage.generate()
+        report.verify {
+            val badRequestView = single("POST", "/orders", 400)
+            assertThat(badRequestView.operation.reasons.map { it.id }).containsExactly(TestSkipReason.EXAMPLES_REQUIRED_STRICT_MODE.id)
+            assertThat(badRequestView.operation.coverageStatus).isEqualTo(CoverageStatus.NOT_TESTED)
+        }
+    }
+
+    @Test
+    fun `should prefer explicit decision over default skip decision during report generation with path parameters`() {
+        val coverage = OpenApiCoverageBuilder.buildCoverage {
+            specEndpoint(method = "POST", path = "/orders/{id}", responseCode = 400, responseType = "application/json")
+            decisionSkip(
+                path = "/orders/(id:number)",
+                method = "POST",
+                responseCode = 400,
+                responseType = "application/json",
+                reasoning = Reasoning(mainReason = TestSkipReason.EXAMPLES_REQUIRED_STRICT_MODE)
+            )
+        }
+
+        val report = coverage.generate()
+        report.verify {
+            val badRequestView = single("POST", "/orders/{id}", 400)
+            assertThat(badRequestView.operation.reasons.map { it.id }).containsExactly(TestSkipReason.EXAMPLES_REQUIRED_STRICT_MODE.id)
+            assertThat(badRequestView.operation.coverageStatus).isEqualTo(CoverageStatus.NOT_TESTED)
+        }
+    }
+
+    @Test
+    fun `should not add default skip decision when explicit execution reasoning exists`() {
+        val coverage = OpenApiCoverageBuilder.buildCoverage {
+            specEndpoint(method = "POST", path = "/orders", responseCode = 400, responseType = "application/json")
+            testResult(path = "/orders", method = "POST", responseCode = 400, responseType = "application/json", result = TestResult.Success)
+            decisionExecute(
+                path = "/orders",
+                method = "POST",
+                responseCode = 400,
+                responseType = "application/json",
+                reasoning = Reasoning(mainReason = TestExecutionReason.HAS_EXAMPLE)
+            )
+        }
+
+        val report = coverage.generate()
+        report.verify {
+            val badRequestView = single("POST", "/orders", 400)
+            assertThat(badRequestView.operation.reasons).isEmpty()
+            assertThat(badRequestView.operation.omittedStatus).isEqualTo(OmittedStatus.NONE)
+            assertThat(badRequestView.operation.coverageStatus).isEqualTo(CoverageStatus.COVERED)
+        }
+    }
+
+    @Test
+    fun `should call onTestDecision for default decision only during generate`() {
+        val listener = RecordingTestDecisionListener()
+        val coverage = OpenApiCoverageBuilder.buildCoverage {
+            addListener(listener)
+            specEndpoint(method = "POST", path = "/orders", responseCode = 400, responseType = "application/json")
+        }
+
+        coverage.generateWithoutHooks()
+        assertThat(listener.decisions).isEmpty()
+
+        coverage.generate()
+        assertThat(listener.decisions).hasSize(1)
+        assertThat(listener.decisions.single().reasoning.mainReason).isEqualTo(TestSkipReason.EXAMPLES_REQUIRED)
     }
 
     @Test
@@ -380,4 +484,22 @@ class OpenApiCoverageTest {
             assertThat(single(method = "GET", path = "/orders", responseCode = 200).apiOperation.path).isEqualTo("/orders")
         }
     }
+}
+
+private class RecordingTestDecisionListener : TestReportListener {
+    val decisions = mutableListOf<io.specmatic.core.utilities.Decision<*, OpenAPIOperation>>()
+    override fun onTestDecision(decision: io.specmatic.core.utilities.Decision<*, OpenAPIOperation>) {
+        decisions += decision
+    }
+
+    override fun onActuator(enabled: Boolean) = Unit
+    override fun onActuatorApis(apisNotExcluded: List<io.specmatic.test.API>, apisExcluded: List<io.specmatic.test.API>) = Unit
+    override fun onEndpointApis(endpointsNotExcluded: List<Endpoint>, endpointsExcluded: List<Endpoint>) = Unit
+    override fun onTestResult(result: TestExecutionResult) = Unit
+    override fun onExampleErrors(resultsBySpecFile: Map<String, io.specmatic.core.Result>) = Unit
+    override fun onTestsComplete() = Unit
+    override fun onEnd() = Unit
+    override fun onCoverageCalculated(coverage: Int, absoluteCoverage: Int) = Unit
+    override fun onPathCoverageCalculated(path: String, pathCoverage: Int) = Unit
+    override fun onGovernance(result: io.specmatic.core.Result) = Unit
 }

--- a/junit5-support/src/test/kotlin/io/specmatic/test/utils/ContractTestScope.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/utils/ContractTestScope.kt
@@ -1,7 +1,6 @@
 package io.specmatic.test.utils
 
 import io.specmatic.core.JSON
-import io.specmatic.core.Scenario
 import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.SpecmaticConfigV1V2Common
 import io.specmatic.core.YAML
@@ -10,12 +9,12 @@ import io.specmatic.core.config.v3.SpecmaticConfigV3Impl
 import io.specmatic.core.utilities.Decision
 import io.specmatic.core.utilities.yamlMapper
 import io.specmatic.test.API
-import io.specmatic.test.ContractTest
 import io.specmatic.test.ContractTestSettings
 import io.specmatic.test.SpecmaticJUnitSupport
 import io.specmatic.test.reports.TestExecutionResult
 import io.specmatic.test.reports.TestReportListener
 import io.specmatic.test.reports.coverage.Endpoint
+import io.specmatic.reporter.model.OpenAPIOperation
 import org.junit.jupiter.api.DynamicTest
 import java.io.File
 import java.util.UUID
@@ -117,5 +116,5 @@ class RecordingTestReportListener : TestReportListener {
     override fun onCoverageCalculated(coverage: Int, absoluteCoverage: Int) = Unit
     override fun onPathCoverageCalculated(path: String, pathCoverage: Int) = Unit
     override fun onGovernance(result: io.specmatic.core.Result) = Unit
-    override fun onTestDecision(decision: Decision<ContractTest, Scenario>) = Unit
+    override fun onTestDecision(decision: Decision<*, OpenAPIOperation>) = Unit
 }

--- a/junit5-support/src/test/kotlin/io/specmatic/test/utils/OpenApiCoverageDsl.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/utils/OpenApiCoverageDsl.kt
@@ -1,5 +1,7 @@
 package io.specmatic.test.utils
 
+import io.specmatic.core.DefaultStrategies
+import io.specmatic.core.Feature
 import io.specmatic.core.HttpHeadersPattern
 import io.specmatic.core.HttpPathPattern
 import io.specmatic.core.HttpRequestPattern
@@ -18,6 +20,7 @@ import io.specmatic.reporter.model.SpecType
 import io.specmatic.reporter.model.TestResult
 import io.specmatic.test.API
 import io.specmatic.test.ContractTest
+import io.specmatic.test.ScenarioAsTest
 import io.specmatic.test.TestResultRecord
 import io.specmatic.test.reports.TestReportListener
 import io.specmatic.test.reports.coverage.Endpoint
@@ -107,6 +110,30 @@ class OpenApiCoverageBuilder {
 
     fun outOfScopeSpecEndpoint(endpoint: Endpoint) {
         allSpecEndpoints += endpoint
+    }
+
+    fun decisionExecute(
+        path: String,
+        method: String,
+        responseCode: Int,
+        requestType: String? = null,
+        responseType: String? = null,
+        reasoning: Reasoning,
+        protocol: SpecmaticProtocol = SpecmaticProtocol.HTTP,
+        specType: SpecType = SpecType.OPENAPI,
+    ) {
+        val scenario = Scenario(
+            ScenarioInfo(
+                protocol = protocol,
+                specType = specType,
+                httpRequestPattern = HttpRequestPattern(httpPathPattern = HttpPathPattern.from(path), method = method, headersPattern = HttpHeadersPattern(contentType = requestType)),
+                httpResponsePattern = HttpResponsePattern(status = responseCode, headersPattern = HttpHeadersPattern(contentType = responseType)),
+            )
+        )
+
+        val feature = Feature(name = "test", scenarios = listOf(scenario), protocol = protocol)
+        val contractTest = ScenarioAsTest(feature = feature, scenario = scenario, protocol = protocol, specType = specType, flagsBased = DefaultStrategies, originalScenario = scenario)
+        decisions += Decision.Execute(contractTest, scenario, reasoning)
     }
 
     fun decisionSkip(


### PR DESCRIPTION
**What:** Fix empty skip reasoning for negative contract tests in multi-response scenario

**Why:**
When contract tests run with generative tests enabled, 4xx operations without examples are not immediately marked with a missing-example reason because negative test generation may still cover them.

However, for operations with multiple 4xx scenarios, such as 400 and 422, or multiple response content types under the same 4xx response, the System Under Test may not return every generated case. In those cases, reporting had no fallback reason, so the operation was marked as skipped without an explanation.

**How:**
- Use default skip reasons for unmatched negative scenarios where examples are required.
- Fix `Scenario.newBasedOnWithDecision` being hard-coded to only consider 400 status for negative case 
- Fix `OpenApiCoverage.onContractTestDecision` call-site to use resolved scenario

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)