### PR TITLE
Preserve Content-Type specificity in header matching

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/ExampleFromFile.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/ExampleFromFile.kt
@@ -75,12 +75,12 @@ class ExampleFromFile(private val scenarioStub: ScenarioStub, val file: File) {
     val requestPath: String? = request.path?.let(::URI)?.path
     val requestMethod: String? = request.method
     val queryParams: Map<String, String> = request.queryParams.asValueMap().mapValues { it.value.toStringLiteral() }
-    val requestContentType: String? = request.headers.getCaseInsensitive(CONTENT_TYPE)?.split(";")?.firstOrNull()
+    val requestContentType: String? = request.headers.getCaseInsensitive(CONTENT_TYPE)
     val requestBody: Value? = request.body.takeUnless { it === EmptyString }
 
     val response: HttpResponse = scenarioStub.responseElsePartialResponse()
     val responseStatus: Int? = response.status.takeUnless { it == 0 }
-    val responseContentType: String? = response.headers.getCaseInsensitive(CONTENT_TYPE)?.split(";")?.firstOrNull()
+    val responseContentType: String? = response.headers.getCaseInsensitive(CONTENT_TYPE)
     val responseBody: Value? = response.body.takeUnless { it === EmptyString }
 
     fun isPartial(): Boolean = scenarioStub.isPartial()

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -1339,6 +1339,8 @@ class OpenApiSpecification(
 
         val contentTypeHeader = headersMap.entries.find { it.key.lowercase() in listOf("content-type", "content-type?") }?.value
         val contentContext = collectorContext.at("content")
+        val allMediaTypes = response.content.keys.toSet()
+        val baseHeadersPattern = HttpHeadersPattern(headersMap.mapValues { it.value.first }, preferEscapedSoapAction = preferEscapedSoapAction)
         return response.content.map { (contentType, mediaType) ->
             logger.debug("Processing response with content type $contentType")
             val mediaTypeContext = contentContext.at(contentType)
@@ -1349,12 +1351,9 @@ class OpenApiSpecification(
                 contentType
             }
 
+            val otherHttpHeadersPattern = allMediaTypes.minus(contentType).map { baseHeadersPattern.copy(contentType = it) }
             val responsePattern = HttpResponsePattern(
-                headersPattern = HttpHeadersPattern(
-                    headersMap.mapValues { it.value.first },
-                    contentType = contentType,
-                    preferEscapedSoapAction = preferEscapedSoapAction
-                ),
+                headersPattern = baseHeadersPattern.copy(contentType = contentType, otherHttpHeadersPattern = otherHttpHeadersPattern),
                 status = if (status == "default") 1000 else status.toInt(),
                 body = when (contentType) {
                     "application/xml" -> toXMLPattern(mediaType, mediaTypeContext)
@@ -1499,9 +1498,11 @@ class OpenApiSpecification(
         }
 
         val contentContext = requestBodyContext.at("content")
+        val allMediaTypes = requestBody.content.keys.toSet()
         return requestBody.content.map { (contentType, mediaType) ->
             logger.debug("Processing request payload with media type $contentType")
             val mediaTypeContext = contentContext.at(contentType)
+            val otherHttpHeadersPattern = allMediaTypes.minus(contentType).map { headersPattern.copy(contentType = it) }
             when (contentType.lowercase()) {
                 "multipart/form-data" -> {
                     val partSchemas = resolveSchemaIfRef(mediaType.schema, collectorContext = mediaTypeContext)
@@ -1532,7 +1533,10 @@ class OpenApiSpecification(
                     Pair(
                         requestPattern.copy(
                             multiPartFormDataPattern = parts,
-                            headersPattern = headersPatternWithContentType(requestPattern, contentType)
+                            headersPattern = headersPattern.copy(
+                                contentType = contentType,
+                                otherHttpHeadersPattern = otherHttpHeadersPattern
+                            )
                         ), emptyMap()
                     )
                 }
@@ -1540,14 +1544,20 @@ class OpenApiSpecification(
                 "application/x-www-form-urlencoded" -> Pair(
                     requestPattern.copy(
                         formFieldsPattern = toFormFields(mediaType, mediaTypeContext),
-                        headersPattern = headersPatternWithContentType(requestPattern, contentType)
+                        headersPattern = headersPattern.copy(
+                            contentType = contentType,
+                            otherHttpHeadersPattern = otherHttpHeadersPattern
+                        )
                     ), emptyMap()
                 )
 
                 "application/xml" -> Pair(
                     requestPattern.copy(
                         body = toXMLPattern(mediaType, collectorContext = mediaTypeContext),
-                        headersPattern = headersPatternWithContentType(requestPattern, contentType)
+                        headersPattern = headersPattern.copy(
+                            contentType = contentType,
+                            otherHttpHeadersPattern = otherHttpHeadersPattern
+                        )
                     ), emptyMap()
                 )
 
@@ -1582,7 +1592,10 @@ class OpenApiSpecification(
                     Pair(
                         requestPattern.copy(
                             body = body,
-                            headersPattern = headersPatternWithContentType(requestPattern, contentType)
+                            headersPattern = headersPattern.copy(
+                                contentType = contentType,
+                                otherHttpHeadersPattern = otherHttpHeadersPattern
+                            )
                         ), allExamples
                     )
                 }
@@ -1676,13 +1689,6 @@ class OpenApiSpecification(
             }
         }
     }
-
-    private fun headersPatternWithContentType(
-        requestPattern: HttpRequestPattern,
-        contentType: String
-    ) = requestPattern.headersPattern.copy(
-        contentType = contentType
-    )
 
     private inline fun <reified T : Parameter> namedExampleParams(parameters: List<Parameter>): Map<String, Map<String, String>> {
         if (specmaticConfig.getIgnoreInlineExamples()) return emptyMap()

--- a/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
@@ -14,7 +14,8 @@ data class HttpHeadersPattern(
     val pattern: Map<String, Pattern> = emptyMap(),
     val ancestorHeaders: Map<String, Pattern>? = null,
     val contentType: String? = null,
-    val preferEscapedSoapAction: Boolean = false
+    val preferEscapedSoapAction: Boolean = false,
+    val otherHttpHeadersPattern: Collection<HttpHeadersPattern> = emptyList(),
 ) {
     init {
         val uniqueHeaders = pattern.keys.map { it.lowercase() }.distinct()
@@ -93,7 +94,6 @@ data class HttpHeadersPattern(
 
         return MatchSuccess(parameters)
     }
-
 
     private fun matchEach(parameters: Pair<Map<String, String>, Resolver>): MatchingResult<Pair<Map<String, String>, Resolver>> {
         val (headers, resolver) = parameters

--- a/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
@@ -56,43 +56,64 @@ data class HttpHeadersPattern(
 
     fun matchContentType(parameters: Pair<Map<String, String>, Resolver>):  MatchingResult<Pair<Map<String, String>, Resolver>> {
         val (headers, resolver) = parameters
+        val contentTypeFromRequest = headers.getCaseInsensitive(CONTENT_TYPE)?.value
+        val contentTypeMatchingSource = contentTypeMatchingSource(contentTypeFromRequest, resolver)
 
-        val contentTypeHeaderValueFromRequest = headers.entries.find { it.key.lowercase() == "content-type" }?.value
-        val contentTypePattern = pattern.entries.find { it.key.lowercase() in listOf("content-type", "content-type?") }?.value
+        val contentTypeMatchResult = matchContentTypeAgainstSource(contentTypeFromRequest, contentTypeMatchingSource, resolver)
+        if (contentTypeMatchResult is Result.Failure) return MatchFailure(contentTypeMatchResult)
 
-        val isContentTypeNotAsPerPattern = isContentTypeAsPerPattern(contentTypePattern, resolver).not()
-
-        if (contentTypePattern != null && isContentTypeNotAsPerPattern) {
-            val contentTypeMatchResult = contentTypePattern.matches(
-                parsedValue(contentTypeHeaderValueFromRequest),
-                resolver
-            )
-
-            if (contentTypeMatchResult is Result.Failure) {
-                val matchFailure: Result.Failure =
-                    contentTypeMatchResult
-                        .withFailureReason(FailureReason.ContentTypeMismatch)
-                        .breadCrumb(CONTENT_TYPE)
-
-                return MatchFailure(matchFailure)
-            }
-        } else if (contentType != null && contentTypeHeaderValueFromRequest != null) {
-            val parsedContentType = simplifiedContentType(contentType.lowercase())
-            val parsedContentTypeHeaderValue = simplifiedContentType(contentTypeHeaderValueFromRequest.lowercase())
-
-            if (parsedContentType != parsedContentTypeHeaderValue) {
-                return MatchFailure(
-                    Result.Failure(
-                        resolver.mismatchMessages.mismatchMessage(contentType, contentTypeHeaderValueFromRequest),
-                        breadCrumb = CONTENT_TYPE,
-                        failureReason = FailureReason.ContentTypeMismatch,
-                        ruleViolation = StandardRuleViolation.VALUE_MISMATCH
-                    )
+        val conflictingPattern = conflictingContentTypePattern(contentTypeFromRequest, contentTypeMatchingSource, resolver)
+        if (conflictingPattern != null) {
+            return MatchFailure(
+                Result.Failure(
+                    breadCrumb = CONTENT_TYPE,
+                    failureReason = FailureReason.ContentTypeMatchButConflict,
+                    message = "Content type $contentTypeFromRequest matches a more specific pattern: ${conflictingPattern.first}",
                 )
-            }
+            )
         }
 
         return MatchSuccess(parameters)
+    }
+
+    private fun matchContentTypeAgainstSource(contentTypeFromRequest: String?, contentTypeMatchingSource: ContentTypeMatchingSource?, resolver: Resolver): Result {
+        return when (contentTypeMatchingSource) {
+            is ContentTypeMatchingSource.Pattern -> matchContentTypePattern(contentTypeFromRequest, contentTypeMatchingSource.pattern, resolver)
+            is ContentTypeMatchingSource.MediaType -> matchContentTypeMediaType(contentTypeFromRequest, contentTypeMatchingSource.contentType, resolver)
+            null -> Result.Success()
+        }
+    }
+
+    private fun matchContentTypePattern(contentTypeFromRequest: String?, contentTypePattern: Pattern, resolver: Resolver): Result {
+        val contentTypeMatchResult = contentTypePattern.matches(parsedValue(contentTypeFromRequest), resolver)
+        return contentTypeMatchResult.withFailureReason(FailureReason.ContentTypeMismatch).breadCrumb(CONTENT_TYPE)
+    }
+
+    private fun matchContentTypeMediaType(contentTypeFromRequest: String?, expectedContentTypeText: String, resolver: Resolver): Result {
+        if (contentTypeFromRequest == null) return Result.Success()
+        val actualContentType = runCatching { ContentType.parse(contentTypeFromRequest) }.getOrNull()
+        val expectedContentType = runCatching { ContentType.parse(expectedContentTypeText) }.getOrNull()
+        if (actualContentType != null && expectedContentType != null && actualContentType.match(expectedContentType)) {
+            return Result.Success()
+        }
+
+        return Result.Failure(
+            breadCrumb = CONTENT_TYPE,
+            failureReason = FailureReason.ContentTypeMismatch,
+            ruleViolation = StandardRuleViolation.VALUE_MISMATCH,
+            message = resolver.mismatchMessages.mismatchMessage(expectedContentTypeText, contentTypeFromRequest),
+        )
+    }
+
+    private fun conflictingContentTypePattern(contentTypeFromRequest: String?, contentTypeMatchingSource: ContentTypeMatchingSource?, resolver: Resolver): Pair<HttpHeadersPattern, Int>? {
+        val actualContentType = contentTypeFromRequest?.let(::StringValue) ?: return null
+        val currentSpecificity = calculateSpecificity(actualContentType, contentTypeMatchingSource, resolver)
+        return otherHttpHeadersPattern.firstNotNullOfOrNull { otherPattern ->
+            val otherContentTypeMatchingSource = otherPattern.contentTypeMatchingSource(contentTypeFromRequest, resolver)
+            if (otherPattern.matchContentTypeAgainstSource(contentTypeFromRequest, otherContentTypeMatchingSource, resolver) is Result.Failure) return@firstNotNullOfOrNull null
+            val otherSpecificity = otherPattern.calculateSpecificity(actualContentType, otherContentTypeMatchingSource, resolver)
+            otherSpecificity.takeIf { it > currentSpecificity }?.let { otherPattern to it }
+        }
     }
 
     private fun matchEach(parameters: Pair<Map<String, String>, Resolver>): MatchingResult<Pair<Map<String, String>, Resolver>> {
@@ -169,16 +190,6 @@ data class HttpHeadersPattern(
             MatchFailure(Result.Failure.fromFailures(failures))
         else
             MatchSuccess(parameters)
-    }
-
-    private fun simplifiedContentType(contentType: String): String {
-        return try {
-            ContentType.parse(contentType).let {
-                "${it.contentType}/${it.contentSubtype}"
-            }
-        } catch (e: Throwable) {
-            contentType
-        }
     }
 
     private fun highlightIfSOAPActionMismatch(missingKey: String): FailureReason? =
@@ -471,9 +482,9 @@ data class HttpHeadersPattern(
         )
 
         return runCatching {
-            val specContentType = simplifiedContentType(contentTypeFromSpec.lowercase())
-            val valueContentType = simplifiedContentType(contentTypeEntry.value.toUnformattedString().lowercase())
-            if (specContentType.equals(valueContentType, ignoreCase = true)) return headers
+            val specContentType = ContentType.parse(contentTypeFromSpec)
+            val valueContentType = ContentType.parse(contentTypeEntry.value.toUnformattedString())
+            if (valueContentType.match(specContentType)) return headers
             headers.plus(contentTypeEntry.key to StringValue(contentTypeFromSpec))
         }.getOrElse { e ->
             logger.debug(e, "Failed to fix $CONTENT_TYPE for entry \"${contentTypeEntry.key}\" with value ${contentTypeEntry.value}")
@@ -564,8 +575,59 @@ data class HttpHeadersPattern(
         return false
     }
 
+    private fun calculateSpecificity(actualContentType: Value, source: ContentTypeMatchingSource?, resolver: Resolver): Int {
+        return when (source) {
+            is ContentTypeMatchingSource.Pattern -> {
+                val resolvedPattern = resolveContentTypePattern(source.pattern, actualContentType, resolver) ?: source.pattern
+                val generatedContentType = runCatching { resolvedPattern.generate(resolver) }.getOrDefault(actualContentType)
+                contentTypeSpecificity(generatedContentType.toUnformattedString())
+            }
+            is ContentTypeMatchingSource.MediaType -> contentTypeSpecificity(source.contentType)
+            null -> 0
+        }
+    }
+
+    private fun contentTypeSpecificity(contentType: String): Int {
+        val wildcardSpecificity = runCatching { ContentType.parse(contentType) }.getOrNull().let { parsedContentType ->
+            when {
+                parsedContentType?.contentType == "*" && parsedContentType.contentSubtype == "*" -> -2
+                parsedContentType?.contentType == "*" || parsedContentType?.contentSubtype == "*" -> -1
+                else -> 0
+            }
+        }
+
+        val parametersSpecificity = runCatching { ContentType.parse(contentType).parameters.size }.getOrElse {
+            contentType.split(';').drop(1).count(String::isNotBlank)
+        }
+
+        return parametersSpecificity.plus(wildcardSpecificity)
+    }
+
+    private fun contentTypeMatchingSource(contentTypeFromRequest: String?, resolver: Resolver): ContentTypeMatchingSource? {
+        val contentTypePattern = pattern.getCaseInsensitiveCheckOptional(CONTENT_TYPE)?.value
+        val isContentTypeNotAsPerPattern = isContentTypeAsPerPattern(contentTypePattern, resolver).not()
+        return when {
+            contentTypePattern != null && isContentTypeNotAsPerPattern -> ContentTypeMatchingSource.Pattern(contentTypePattern)
+            contentType != null && contentTypeFromRequest != null -> ContentTypeMatchingSource.MediaType(contentType)
+            else -> null
+        }
+    }
+
+    private fun resolveContentTypePattern(contentTypePattern: Pattern, contentType: Value, resolver: Resolver): Pattern? {
+        if (contentTypePattern is EnumPattern) return resolveContentTypePattern(contentTypePattern.pattern, contentType, resolver)
+        if (contentTypePattern !is SubSchemaCompositePattern) return contentTypePattern
+        return contentTypePattern.pattern.firstNotNullOfOrNull { nestedPattern ->
+            val resolvedPattern = resolveContentTypePattern(nestedPattern, contentType, resolver) ?: return@firstNotNullOfOrNull null
+            resolvedPattern.takeIf { it.matches(contentType, resolver).isSuccess() }
+        }
+    }
+
     companion object {
         private const val HEADER_KEY_ID_IN_TEST_DETAILS = "header"
+        private sealed interface ContentTypeMatchingSource {
+            data class Pattern(val pattern: io.specmatic.core.pattern.Pattern) : ContentTypeMatchingSource
+            data class MediaType(val contentType: String) : ContentTypeMatchingSource
+        }
     }
 }
 
@@ -587,17 +649,13 @@ fun Map<String, String>.withoutTransportHeaders(
     }
 
 fun <T> Map<String, T>.getCaseInsensitive(key: String): Map.Entry<String, T>? = this.entries.find { it.key.equals(key, ignoreCase = true) }
-
-fun Map<String, Pattern>.containsCaseInsensitiveCheckOptional(key: String): Boolean {
+fun <T> Map<String, T>.getCaseInsensitiveCheckOptional(key: String): Map.Entry<String, T>? {
     val mandatoryEntry = this.getCaseInsensitive(withoutOptionality(key))
-    if (mandatoryEntry != null) return true
-
-    val optionalEntry = this.getCaseInsensitive(withOptionality(key))
-    if (optionalEntry != null) return true
-
-    return false
+    if (mandatoryEntry != null) return mandatoryEntry
+    return getCaseInsensitive(withOptionality(key))
 }
 
+fun Map<String, Pattern>.containsCaseInsensitiveCheckOptional(key: String): Boolean = this.getCaseInsensitiveCheckOptional(key) != null
 fun Map<String, Pattern>.addIfNotExistCaseInsensitiveCheckOptional(key: String, value: Pattern): Map<String, Pattern> {
     if (this.containsCaseInsensitiveCheckOptional(key)) return this
     return this.plus(key to value)

--- a/core/src/main/kotlin/io/specmatic/core/Result.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Result.kt
@@ -407,6 +407,7 @@ enum class FailureReason(val fluffLevel: Int, val objectMatchOccurred: Boolean) 
     URLPathMisMatch(2, false),
     URLPathParamMismatchButSameStructure(1, false),
     URLPathParamMatchButConflict(2, false),
+    ContentTypeMatchButConflict(2, false),
     SOAPActionMismatch(2, false),
     DiscriminatorMismatch(0, true),
     FailedButDiscriminatorMatched(0, true),

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -990,17 +990,13 @@ data class Scenario(
 
 
     private fun matchesResponseContentType(operationId: OpenApiSpecification.OperationIdentifier): Boolean {
-        val exampleResponseContentType = operationId.responseContentType ?: return true
-        val patternResponseContentType = httpResponsePattern.headersPattern.contentType ?: return true
-
-        return exampleResponseContentType == patternResponseContentType
+        val headers = operationId.responseContentType?.let { mapOf(CONTENT_TYPE to it) }.orEmpty()
+        return httpResponsePattern.headersPattern.matchContentType(headers to resolver).toResult { it }.isSuccess()
     }
 
     private fun matchesRequestContentType(operationId: OpenApiSpecification.OperationIdentifier): Boolean {
-        val exampleRequestContentType = operationId.requestContentType ?: return true
-        val patternRequestContentType = httpRequestPattern.headersPattern.contentType ?: return true
-
-        return exampleRequestContentType == patternRequestContentType
+        val headers = operationId.requestContentType?.let { mapOf(CONTENT_TYPE to it) }.orEmpty()
+        return httpRequestPattern.headersPattern.matchContentType(headers to resolver).toResult { it }.isSuccess()
     }
 
     fun resolveSubstitutions(

--- a/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
+++ b/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
@@ -1772,8 +1772,7 @@ class LoadTestsFromExternalisedFiles {
         }
 
         @Test
-        @Disabled // TODO: Test expected to fail
-        fun `externalized tests should load matching examples for versioned content types`() {
+        fun `externalized tests should load matching examples for content types with attributes`() {
             val specFile = File("src/test/resources/versioned_content_type/specification.yaml")
             val feature = OpenApiSpecification.fromFile(specFile.canonicalPath).toFeature().loadExternalisedExamples()
 
@@ -1803,11 +1802,41 @@ class LoadTestsFromExternalisedFiles {
                 assertThat(row.responseExample?.headers?.get("Content-Type"))
                     .isEqualTo(contentType)
 
-                assertThat(row.requestExample?.body?.toStringLiteral())
-                    .isEqualTo("""{"id": 1, "message": "RequestContentType: $contentType"}""")
+                assertThat(row.requestExample?.body)
+                    .isEqualTo(parsedJSONObject("""{"id": 1, "message": "RequestContentType: $contentType"}"""))
 
-                assertThat(row.responseExample?.body?.toStringLiteral())
-                    .isEqualTo("""{"id": 1, "message": "ResponseContentType: $contentType"}""")
+                assertThat(row.responseExample?.body)
+                    .isEqualTo(parsedJSONObject("""{"id": 1, "message": "ResponseContentType: $contentType"}"""))
+            }
+        }
+
+        @Test
+        fun `externalized tests should load matching examples for overridden content types`() {
+            val specFile = File("src/test/resources/versioned_overridden_content_type/specification.yaml")
+            val feature = OpenApiSpecification.fromFile(specFile.canonicalPath).toFeature().loadExternalisedExamples()
+
+            assertThat(feature.scenarios).hasSize(4)
+            val expectedExamples = listOf(
+                "/widgets/json" to "application/json",
+                "/widgets/vendor-json" to "application/vnd.widget.json",
+                "/widgets/versioned-json" to "application/json; version=2026-12-31",
+                "/widgets/versioned-vendor-json" to "application/vnd.widget.json; version=2026-12-31",
+            )
+
+            assertThat(feature.scenarios).allSatisfy { scenario ->
+                val rows = scenario.examples.flatMap { example -> example.rows }
+                assertThat(rows).hasSize(1)
+
+                val row = rows.single()
+                val (expectedPath, contentType) = expectedExamples.single { (path, contentType) ->
+                    row.requestExample?.path == path && row.requestExample.contentType() == contentType
+                }
+
+                assertThat(row.requestExample?.path).isEqualTo(expectedPath)
+                assertThat(row.requestExample?.headers?.get("Content-Type")).isEqualTo(contentType)
+                assertThat(row.responseExample?.headers?.get("Content-Type")).isEqualTo(contentType)
+                assertThat(row.requestExample?.body).isEqualTo(parsedJSONObject("""{"id": 1, "message": "RequestContentType: $contentType"}"""))
+                assertThat(row.responseExample?.body).isEqualTo(parsedJSONObject("""{"id": 1, "message": "ResponseContentType: $contentType"}"""))
             }
         }
     }

--- a/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
+++ b/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
@@ -1737,4 +1737,78 @@ class LoadTestsFromExternalisedFiles {
             }
         }
     }
+
+    @Nested
+    inner class ParameterizedHeaders {
+        @Test
+        fun `externalized tests should load examples with extra content type parameters`() {
+            val specificationFilePath = "src/test/resources/openapi/spec_with_simple_request_body.yaml"
+            val feature = OpenApiSpecification.fromFile(specificationFilePath).toFeature().loadExternalisedExamples()
+
+            val row = feature.scenarios.single().examples.single().rows.single()
+            assertThat(row.requestExample?.headers?.get("Content-Type"))
+                .isEqualTo("application/json; charset=utf-8")
+            assertThat(row.responseExample?.headers?.get("Content-Type"))
+                .isEqualTo("application/json; charset=utf-8")
+            assertThat(row.requestExample?.body)
+                .isEqualTo(parsedJSONObject("""{"productId": 10, "status": "fulfilled", "quantity": 100}"""))
+            assertThat(row.responseExample?.body)
+                .isEqualTo(parsedJSONObject("""{"id": 1}"""))
+        }
+
+        @Test
+        fun `externalized tests should load examples without content type parameters`() {
+            val specificationFilePath = "src/test/resources/openapi/simple_products_spec.yaml"
+            val feature = OpenApiSpecification.fromFile(specificationFilePath).toFeature().loadExternalisedExamples()
+
+            val exampleRows = feature.scenarios.single().examples.single().rows
+            assertThat(exampleRows).hasSize(2)
+
+            val noContentTypeRow = exampleRows.single { it.name == "no_content_type" }
+            assertThat(noContentTypeRow.requestExample?.contentType()).isNull()
+            assertThat(noContentTypeRow.responseExample?.contentType()).isNull()
+            assertThat(noContentTypeRow.requestExample?.body).isSameAs(EmptyString)
+            assertThat(noContentTypeRow.responseExample?.body).isEqualTo(StringValue("Another Sample Product"))
+        }
+
+        @Test
+        @Disabled // TODO: Test expected to fail
+        fun `externalized tests should load matching examples for versioned content types`() {
+            val specFile = File("src/test/resources/versioned_content_type/specification.yaml")
+            val feature = OpenApiSpecification.fromFile(specFile.canonicalPath).toFeature().loadExternalisedExamples()
+
+            assertThat(feature.scenarios).hasSize(4)
+            val scenariosByContentTypes = feature.scenarios.associateBy {
+                it.requestContentType to it.responseContentType
+            }
+
+            val expectedContentTypes = listOf(
+                "application/json",
+                "application/vnd.widget.json",
+                "application/json; version=2026-12-31",
+                "application/vnd.widget.json; version=2026-12-31",
+            )
+
+            assertThat(expectedContentTypes).allSatisfy { contentType ->
+                val scenario = scenariosByContentTypes.getValue(contentType to contentType)
+                val rows = scenario.examples.flatMap { it.rows }
+                assertThat(rows)
+                    .withFailMessage("Expected only $contentType example to be loaded, found ${rows.joinToString(separator = " AND ", transform = { it.requestExample?.contentType().orEmpty() })}")
+                    .hasSize(1)
+
+                val row = rows.singleOrNull() ?: return@allSatisfy
+                assertThat(row.requestExample?.headers?.get("Content-Type"))
+                    .isEqualTo(contentType)
+
+                assertThat(row.responseExample?.headers?.get("Content-Type"))
+                    .isEqualTo(contentType)
+
+                assertThat(row.requestExample?.body?.toStringLiteral())
+                    .isEqualTo("""{"id": 1, "message": "RequestContentType: $contentType"}""")
+
+                assertThat(row.responseExample?.body?.toStringLiteral())
+                    .isEqualTo("""{"id": 1, "message": "ResponseContentType: $contentType"}""")
+            }
+        }
+    }
 }

--- a/core/src/test/kotlin/io/specmatic/conversions/ExampleFromFileTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/ExampleFromFileTest.kt
@@ -73,6 +73,38 @@ class ExampleFromFileTest {
     }
 
     @Test
+    fun `should preserve content type parameters in request and response`() {
+        val jsonContent = """{
+        "name": "content-type-params",
+        "http-request": {
+            "method": "POST",
+            "path": "/api/users",
+            "headers": {
+                "Content-Type": "application/json; charset=utf-8"
+            }
+        },
+        "http-response": {
+            "status": 200,
+            "headers": {
+                "Content-Type": "application/problem+json; charset=utf-8"
+            },
+            "body": "ok"
+        }
+        }""".trimIndent()
+
+        val file = createTempFile(jsonContent)
+        val example = ExampleFromFile.fromFile(file)
+
+        assertThat(example).isInstanceOf(HasValue::class.java)
+        val exampleFromFile = (example as HasValue).value
+
+        assertThat(exampleFromFile.requestContentType).isEqualTo("application/json; charset=utf-8")
+        assertThat(exampleFromFile.responseContentType).isEqualTo("application/problem+json; charset=utf-8")
+        assertThat(exampleFromFile.request.headers).containsEntry("Content-Type", "application/json; charset=utf-8")
+        assertThat(exampleFromFile.response.headers).containsEntry("Content-Type", "application/problem+json; charset=utf-8")
+    }
+
+    @Test
     fun `should handle partial example`() {
         val jsonContent = """
             {

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationParseTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationParseTest.kt
@@ -5,12 +5,16 @@ import io.specmatic.core.HttpRequest
 import io.specmatic.core.QueryParameters
 import io.specmatic.core.Resolver
 import io.specmatic.core.Result
+import io.specmatic.core.CONTENT_TYPE
 import io.specmatic.core.pattern.AnythingPattern
+import io.specmatic.core.HttpHeadersPattern
 import io.specmatic.core.pattern.BooleanPattern
 import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.pattern.DeferredPattern
 import io.specmatic.core.pattern.NumberPattern
 import io.specmatic.core.pattern.QueryParameterScalarPattern
+import io.specmatic.core.getCaseInsensitive
+import io.specmatic.core.pattern.Pattern
 import io.specmatic.core.pattern.StringPattern
 import io.specmatic.core.pattern.XMLPattern
 import io.specmatic.core.pattern.XMLTypeData
@@ -815,6 +819,70 @@ class OpenApiSpecificationParseTest {
                     '200':
                       description: OK
         """.trimIndent()
+    }
+
+    @Test
+    fun `should load other media types into headers pattern when parsing specification`() {
+        val specFile = File("src/test/resources/versioned_content_type/specification.yaml")
+        val feature = OpenApiSpecification.fromFile(specFile.canonicalPath).toFeature()
+
+        assertThat(feature.scenarios).isNotEmpty
+        feature.scenarios.forEach { scenario ->
+            assertThat(scenario.httpRequestPattern.headersPattern.otherHttpHeadersPattern).allSatisfy { otherHeadersPattern ->
+                assertThat(otherHeadersPattern).isInstanceOf(HttpHeadersPattern::class.java)
+                assertThat(otherHeadersPattern.contentType).isNotBlank
+            }
+
+            assertThat(scenario.httpRequestPattern.headersPattern.otherHttpHeadersPattern)
+                .extracting<String?> { it.contentType }
+                .doesNotContain(scenario.requestContentType)
+
+            assertThat(scenario.httpResponsePattern.headersPattern.otherHttpHeadersPattern).allSatisfy { otherHeadersPattern ->
+                assertThat(otherHeadersPattern).isInstanceOf(HttpHeadersPattern::class.java)
+                assertThat(otherHeadersPattern.contentType).isNotBlank
+            }
+
+            assertThat(scenario.httpResponsePattern.headersPattern.otherHttpHeadersPattern)
+                .extracting<String?> { it.contentType }
+                .doesNotContain(scenario.responseContentType)
+        }
+    }
+
+    @Test
+    fun `should load other media types into headers pattern when parsing specification with overrides`() {
+        val specFile = File("src/test/resources/versioned_overridden_content_type/specification.yaml")
+        val feature = OpenApiSpecification.fromFile(specFile.canonicalPath).toFeature()
+
+        assertThat(feature.scenarios).isNotEmpty
+        feature.scenarios.forEach { scenario ->
+            assertThat(scenario.httpRequestPattern.headersPattern.otherHttpHeadersPattern).allSatisfy { otherHeadersPattern ->
+                assertThat(otherHeadersPattern).isInstanceOf(HttpHeadersPattern::class.java)
+                assertThat(otherHeadersPattern.pattern.getCaseInsensitive(CONTENT_TYPE)).isNotNull
+                assertThat(otherHeadersPattern.contentType).isNotBlank
+            }
+
+            assertThat(scenario.httpRequestPattern.headersPattern.otherHttpHeadersPattern)
+                .extracting<String?> { it.contentType }
+                .doesNotContain(scenario.requestContentType)
+
+            assertThat(scenario.httpRequestPattern.headersPattern.otherHttpHeadersPattern)
+                .extracting<Pattern?> { it.pattern.getCaseInsensitive(CONTENT_TYPE)?.value }
+                .contains(scenario.httpRequestPattern.headersPattern.pattern.getCaseInsensitive(CONTENT_TYPE)?.value)
+
+            assertThat(scenario.httpResponsePattern.headersPattern.otherHttpHeadersPattern).allSatisfy { otherHeadersPattern ->
+                assertThat(otherHeadersPattern).isInstanceOf(HttpHeadersPattern::class.java)
+                assertThat(otherHeadersPattern.pattern.getCaseInsensitive(CONTENT_TYPE)).isNotNull
+                assertThat(otherHeadersPattern.contentType).isNotBlank
+            }
+
+            assertThat(scenario.httpResponsePattern.headersPattern.otherHttpHeadersPattern)
+                .extracting<String?> { it.contentType }
+                .doesNotContain(scenario.responseContentType)
+
+            assertThat(scenario.httpResponsePattern.headersPattern.otherHttpHeadersPattern)
+                .extracting<Pattern?> { it.pattern.getCaseInsensitive(CONTENT_TYPE)?.value }
+                .doesNotContain(scenario.httpResponsePattern.headersPattern.pattern.getCaseInsensitive(CONTENT_TYPE)?.value)
+        }
     }
 
     companion object {

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationParseTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationParseTest.kt
@@ -849,39 +849,13 @@ class OpenApiSpecificationParseTest {
     }
 
     @Test
-    fun `should load other media types into headers pattern when parsing specification with overrides`() {
+    fun `should not load other media types into headers pattern when parsing specification when operation differs`() {
         val specFile = File("src/test/resources/versioned_overridden_content_type/specification.yaml")
         val feature = OpenApiSpecification.fromFile(specFile.canonicalPath).toFeature()
 
-        assertThat(feature.scenarios).isNotEmpty
-        feature.scenarios.forEach { scenario ->
-            assertThat(scenario.httpRequestPattern.headersPattern.otherHttpHeadersPattern).allSatisfy { otherHeadersPattern ->
-                assertThat(otherHeadersPattern).isInstanceOf(HttpHeadersPattern::class.java)
-                assertThat(otherHeadersPattern.pattern.getCaseInsensitive(CONTENT_TYPE)).isNotNull
-                assertThat(otherHeadersPattern.contentType).isNotBlank
-            }
-
-            assertThat(scenario.httpRequestPattern.headersPattern.otherHttpHeadersPattern)
-                .extracting<String?> { it.contentType }
-                .doesNotContain(scenario.requestContentType)
-
-            assertThat(scenario.httpRequestPattern.headersPattern.otherHttpHeadersPattern)
-                .extracting<Pattern?> { it.pattern.getCaseInsensitive(CONTENT_TYPE)?.value }
-                .contains(scenario.httpRequestPattern.headersPattern.pattern.getCaseInsensitive(CONTENT_TYPE)?.value)
-
-            assertThat(scenario.httpResponsePattern.headersPattern.otherHttpHeadersPattern).allSatisfy { otherHeadersPattern ->
-                assertThat(otherHeadersPattern).isInstanceOf(HttpHeadersPattern::class.java)
-                assertThat(otherHeadersPattern.pattern.getCaseInsensitive(CONTENT_TYPE)).isNotNull
-                assertThat(otherHeadersPattern.contentType).isNotBlank
-            }
-
-            assertThat(scenario.httpResponsePattern.headersPattern.otherHttpHeadersPattern)
-                .extracting<String?> { it.contentType }
-                .doesNotContain(scenario.responseContentType)
-
-            assertThat(scenario.httpResponsePattern.headersPattern.otherHttpHeadersPattern)
-                .extracting<Pattern?> { it.pattern.getCaseInsensitive(CONTENT_TYPE)?.value }
-                .doesNotContain(scenario.httpResponsePattern.headersPattern.pattern.getCaseInsensitive(CONTENT_TYPE)?.value)
+        assertThat(feature.scenarios).isNotEmpty.allSatisfy { scenario ->
+            assertThat(scenario.httpRequestPattern.headersPattern.otherHttpHeadersPattern).isEmpty()
+            assertThat(scenario.httpResponsePattern.headersPattern.otherHttpHeadersPattern).isEmpty()
         }
     }
 

--- a/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
@@ -2169,7 +2169,7 @@ components:
         val result = contractTest.runTest(object : TestExecutor {
             override fun execute(request: HttpRequest): HttpResponse {
                 assertThat(request.headers.getCaseInsensitive(ACCEPT)?.value).isEqualTo("application/json")
-                return HttpResponse(200, body = parsedJSONObject("{}"), headers = mapOf(CONTENT_TYPE to "application/json"))
+                return HttpResponse(200, body = parsedJSONObject("{}"), headers = mapOf(CONTENT_TYPE to "application/json; charset=utf-8"))
             }
         })
 

--- a/core/src/test/kotlin/io/specmatic/core/HttpHeadersPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpHeadersPatternTest.kt
@@ -9,7 +9,6 @@ import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.core.value.*
 import io.specmatic.test.TestExecutor
 import io.specmatic.toViolationReportString
-import org.assertj.core.api.Assertions.assertThatCode
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Nested
@@ -18,8 +17,10 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.MethodSource
 import java.util.function.Consumer
 import kotlin.collections.HashMap
+import java.util.stream.Stream
 
 internal class HttpHeadersPatternTest {
     @Test
@@ -898,6 +899,51 @@ internal class HttpHeadersPatternTest {
     }
 
     @Nested
+    inner class ContentTypeMatchingTests {
+        @ParameterizedTest(name = "{0} vs {1}")
+        @CsvSource(
+            "application/json, application/json",
+            "Application/JSON, application/json",
+            "application/json; charset=utf-8, application/json",
+            "application/json; charset=utf-8; version=2026-12-31, application/json; charset=utf-8",
+        )
+        fun `should match content type by base type and parameters`(actualContentType: String, expectedContentType: String) {
+            val httpHeaders = HttpHeadersPattern(emptyMap(), contentType = expectedContentType)
+            val actualHeaders = mapOf("Content-Type" to actualContentType)
+            val result = httpHeaders.matches(actualHeaders, Resolver())
+            assertThat(result).isInstanceOf(Result.Success::class.java)
+        }
+
+        @ParameterizedTest(name = "{0} vs {1}")
+        @CsvSource(
+            "application/xml, application/json",
+            "application/json, application/json; version=2026-12-31",
+            "application/json; charset=utf-8, application/json; charset=utf-16",
+        )
+        fun `should not match content type where base type or parameters differ`(actualContentType: String, expectedContentType: String) {
+            val httpHeaders = HttpHeadersPattern(emptyMap(), contentType = expectedContentType)
+            val actualHeaders = mapOf("Content-Type" to actualContentType)
+            val result = httpHeaders.matches(actualHeaders, Resolver())
+            assertThat(result).isInstanceOf(Result.Failure::class.java)
+        }
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("io.specmatic.core.HttpHeadersPatternTest#conflictingContentTypeCases")
+        fun `should not match content type when more specific versioned pattern exists`(case: ContentTypeCase) {
+            val result = case.toPattern().matches(mapOf("Content-Type" to case.actualContentType), Resolver())
+            assertThat(result).isInstanceOf(Result.Failure::class.java); result as Result.Failure
+            assertThat(result.hasReason(FailureReason.ContentTypeMatchButConflict)).isTrue
+        }
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("io.specmatic.core.HttpHeadersPatternTest#nonConflictingContentTypeCases")
+        fun `should match content type when more specific versioned pattern does not exists`(case: ContentTypeCase) {
+            val result = case.toPattern().matches(mapOf("Content-Type" to case.actualContentType), Resolver())
+            assertThat(result).isInstanceOf(Result.Success::class.java)
+        }
+    }
+
+    @Nested
     inner class FillInTheBlanksTests {
         @Test
         fun `should generate values for missing mandatory keys and pattern tokens`() {
@@ -1050,5 +1096,111 @@ internal class HttpHeadersPatternTest {
             val value = assertDoesNotThrow { httpHeaders.fillInTheBlanks(headers, Resolver()).value }
             assertThat(value).isEqualTo(headers)
         }
+    }
+
+    companion object {
+        data class ContentTypePatternSpec(val contentType: String, val contentTypeOverride: Pattern? = null) {
+            fun toPattern(): HttpHeadersPattern {
+                val pattern = contentTypeOverride?.let { mapOf(CONTENT_TYPE to it) }.orEmpty()
+                return HttpHeadersPattern(pattern = pattern, contentType = contentType, )
+            }
+        }
+
+        data class ContentTypeCase(val name: String, val actualContentType: String, val thisSpec: ContentTypePatternSpec, val otherSpecs: List<ContentTypePatternSpec>) {
+            override fun toString() = name
+            fun toPattern(): HttpHeadersPattern = thisSpec.toPattern().copy(otherHttpHeadersPattern = otherSpecs.map { it.toPattern() })
+        }
+
+        @JvmStatic
+        fun conflictingContentTypeCases(): Stream<ContentTypeCase> = Stream.of(
+            ContentTypeCase(
+                name = "base media type should conflict with matching versioned override",
+                actualContentType = "application/json; version=2026-12-31",
+                thisSpec = ContentTypePatternSpec("application/json"),
+                otherSpecs = listOf(ContentTypePatternSpec("application/json; version=2026-12-31"))
+            ),
+            ContentTypeCase(
+                name = "specific media type should outrank wildcard content type",
+                actualContentType = "application/json",
+                thisSpec = ContentTypePatternSpec("*/json"),
+                otherSpecs = listOf(ContentTypePatternSpec("application/json"))
+            ),
+            ContentTypeCase(
+                name = "specific media type should outrank wildcard content sub type",
+                actualContentType = "application/json",
+                thisSpec = ContentTypePatternSpec("application/*"),
+                otherSpecs = listOf(ContentTypePatternSpec("application/json"))
+            ),
+            ContentTypeCase(
+                name = "specific media type should outrank wildcard content and content sub type",
+                actualContentType = "application/json",
+                thisSpec = ContentTypePatternSpec("*/*"),
+                otherSpecs = listOf(ContentTypePatternSpec("application/json"))
+            ),
+            ContentTypeCase(
+                name = "base media type should conflict with exact content-type override",
+                actualContentType = "text/plain; version=2026-12-31",
+                thisSpec = ContentTypePatternSpec("text/plain"),
+                otherSpecs = listOf(ContentTypePatternSpec("text/plain", ExactValuePattern(StringValue("text/plain; version=2026-12-31"))))
+            ),
+            ContentTypeCase(
+                name = "base media type should conflict with exact override on parameterized content-type",
+                actualContentType = "application/xml; charset=utf-8; version=2026-12-31",
+                thisSpec = ContentTypePatternSpec("application/xml; charset=utf-8"),
+                otherSpecs = listOf(ContentTypePatternSpec("application/xml; charset=utf-8", ExactValuePattern(StringValue("application/xml; charset=utf-8; version=2026-12-31"))))
+            ),
+            ContentTypeCase(
+                name = "base media type should conflict with regex string override",
+                actualContentType = "application/json; version=2026-12-31",
+                thisSpec = ContentTypePatternSpec("application/json"),
+                otherSpecs = listOf(ContentTypePatternSpec("application/json", StringPattern(example = "application/json; version=2026-12-31", regex = "application/json; version=\\d{4}-\\d{2}-\\d{2}")))
+            ),
+            ContentTypeCase(
+                name = "base media type should conflict with enum override",
+                actualContentType = "text/csv; version=2026-12-31",
+                thisSpec = ContentTypePatternSpec("text/csv"),
+                otherSpecs = listOf(ContentTypePatternSpec("text/csv", EnumPattern(listOf(StringValue("text/csv; version=2026-12-31"), StringValue("text/csv; version=2030-12-31")))))
+            ),
+            ContentTypeCase(
+                name = "base media type should conflict with subschema override",
+                actualContentType = "application/xml; version=2026-12-31",
+                thisSpec = ContentTypePatternSpec("application/xml"),
+                otherSpecs = listOf(ContentTypePatternSpec("application/xml", AnyOfPattern(listOf(ExactValuePattern(StringValue("application/json")), ExactValuePattern(StringValue("application/xml; version=2026-12-31"))))))
+            )
+        )
+
+        @JvmStatic
+        fun nonConflictingContentTypeCases(): Stream<ContentTypeCase> = Stream.of(
+            ContentTypeCase(
+                name = "base media type should not conflict when versioned override fails",
+                actualContentType = "application/json; version=2030-12-31",
+                thisSpec = ContentTypePatternSpec("application/json"),
+                otherSpecs = listOf(ContentTypePatternSpec("application/json; version=2026-12-31"))
+            ),
+            ContentTypeCase(
+                name = "base media type should not conflict with exact override when actual version differs",
+                actualContentType = "text/plain; version=2030-12-31",
+                thisSpec = ContentTypePatternSpec("text/plain"),
+                otherSpecs = listOf(ContentTypePatternSpec("text/plain", ExactValuePattern(StringValue("text/plain; version=2026-12-31"))))
+            ),
+            ContentTypeCase(
+                name = "base media type should not conflict with regex override when actual version differs",
+                actualContentType = "application/json; version=2030-12-31",
+                thisSpec = ContentTypePatternSpec("application/json"),
+                otherSpecs = listOf(ContentTypePatternSpec("application/json", StringPattern(example = "application/json; version=2026-12-31", regex = "application/json; version=2026-12-31")))
+            ),
+            ContentTypeCase(
+                name = "base media type should not conflict with enum override when actual value is outside enum",
+                actualContentType = "text/csv; version=2030-12-31",
+                thisSpec = ContentTypePatternSpec("text/csv"),
+                otherSpecs = listOf(ContentTypePatternSpec("text/csv", EnumPattern(listOf(StringValue("text/csv; version=2026-12-31"), StringValue("text/csv; version=2027-12-31")))))
+            ),
+            ContentTypeCase(
+                name = "base media type should not conflict with subschema override when no branch matches",
+                actualContentType = "application/xml; version=2030-12-31",
+                thisSpec = ContentTypePatternSpec("application/xml"),
+                otherSpecs = listOf(ContentTypePatternSpec("application/xml", AnyOfPattern(listOf(ExactValuePattern(StringValue("application/json")), ExactValuePattern(StringValue("application/xml; version=2026-12-31"))))))
+            )
+        )
     }
 }

--- a/core/src/test/resources/openapi/simple_products_spec_examples/no_content_type.json
+++ b/core/src/test/resources/openapi/simple_products_spec_examples/no_content_type.json
@@ -1,0 +1,10 @@
+{
+  "http-request": {
+    "method": "GET",
+    "path": "/products/(id:number)"
+  },
+  "http-response": {
+    "status": 200,
+    "body": "Another Sample Product"
+  }
+}

--- a/core/src/test/resources/openapi/spec_with_simple_request_body_examples/charset_json.json
+++ b/core/src/test/resources/openapi/spec_with_simple_request_body_examples/charset_json.json
@@ -1,0 +1,23 @@
+{
+  "http-request": {
+    "method": "POST",
+    "path": "/orders",
+    "headers": {
+      "Content-Type": "application/json; charset=utf-8"
+    },
+    "body": {
+      "productId": 10,
+      "status": "fulfilled",
+      "quantity": 100
+    }
+  },
+  "http-response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json; charset=utf-8"
+    },
+    "body": {
+      "id": 1
+    }
+  }
+}

--- a/core/src/test/resources/openapi/specs_for_additional_headers_in_examples/additional_headers_test_content_type_examples/content_type_with_charset.json
+++ b/core/src/test/resources/openapi/specs_for_additional_headers_in_examples/additional_headers_test_content_type_examples/content_type_with_charset.json
@@ -1,0 +1,22 @@
+{
+  "http-request": {
+    "method": "POST",
+    "path": "/products",
+    "headers": {
+      "X-Req-ID": "1",
+      "Content-Type": "application/json; charset=utf-8"
+    },
+    "body": {
+      "name": "iPhone"
+    }
+  },
+  "http-response": {
+    "status": 201,
+    "headers": {
+      "Content-Type": "application/json; charset=utf-8"
+    },
+    "body": {
+      "id": 1
+    }
+  }
+}

--- a/core/src/test/resources/versioned_content_type/specification.yaml
+++ b/core/src/test/resources/versioned_content_type/specification.yaml
@@ -1,0 +1,51 @@
+openapi: "3.0.0"
+info:
+  title: "Widgets API"
+  version: "1.0.0"
+paths:
+  /widgets:
+    post:
+      summary: "Create Widget"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SimpleSchema"
+          application/json; version=2026-12-31:
+            schema:
+              $ref: "#/components/schemas/SimpleSchema"
+          application/vnd.widget.json:
+            schema:
+              $ref: "#/components/schemas/SimpleSchema"
+          application/vnd.widget.json; version=2026-12-31:
+            schema:
+              $ref: "#/components/schemas/SimpleSchema"
+      responses:
+        "201":
+          description: "Widget created"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SimpleSchema"
+            application/json; version=2026-12-31:
+              schema:
+                $ref: "#/components/schemas/SimpleSchema"
+            application/vnd.widget.json:
+              schema:
+                $ref: "#/components/schemas/SimpleSchema"
+            application/vnd.widget.json; version=2026-12-31:
+              schema:
+                $ref: "#/components/schemas/SimpleSchema"
+components:
+  schemas:
+    SimpleSchema:
+      type: object
+      required:
+        - id
+        - message
+      properties:
+        id:
+          type: integer
+        message:
+          type: string

--- a/core/src/test/resources/versioned_content_type/specification_examples/json_to_json.json
+++ b/core/src/test/resources/versioned_content_type/specification_examples/json_to_json.json
@@ -1,0 +1,24 @@
+{
+    "http-request": {
+        "path": "/widgets",
+        "method": "POST",
+        "headers": {
+            "Content-Type": "application/json"
+        },
+        "body": {
+            "id": 1,
+            "message": "RequestContentType: application/json"
+        }
+    },
+    "http-response": {
+        "status": 201,
+        "body": {
+            "id": 1,
+            "message": "ResponseContentType: application/json"
+        },
+        "status-text": "Created",
+        "headers": {
+            "Content-Type": "application/json"
+        }
+    }
+}

--- a/core/src/test/resources/versioned_content_type/specification_examples/versioned_json_to_versioned_json.json
+++ b/core/src/test/resources/versioned_content_type/specification_examples/versioned_json_to_versioned_json.json
@@ -1,0 +1,24 @@
+{
+    "http-request": {
+        "path": "/widgets",
+        "method": "POST",
+        "headers": {
+            "Content-Type": "application/json; version=2026-12-31"
+        },
+        "body": {
+            "id": 1,
+            "message": "RequestContentType: application/json; version=2026-12-31"
+        }
+    },
+    "http-response": {
+        "status": 201,
+        "body": {
+            "id": 1,
+            "message": "ResponseContentType: application/json; version=2026-12-31"
+        },
+        "status-text": "Created",
+        "headers": {
+            "Content-Type": "application/json; version=2026-12-31"
+        }
+    }
+}

--- a/core/src/test/resources/versioned_content_type/specification_examples/versioned_widget_to_versioned_widget.json
+++ b/core/src/test/resources/versioned_content_type/specification_examples/versioned_widget_to_versioned_widget.json
@@ -1,0 +1,24 @@
+{
+    "http-request": {
+        "path": "/widgets",
+        "method": "POST",
+        "headers": {
+            "Content-Type": "application/vnd.widget.json; version=2026-12-31"
+        },
+        "body": {
+            "id": 1,
+            "message": "RequestContentType: application/vnd.widget.json; version=2026-12-31"
+        }
+    },
+    "http-response": {
+        "status": 201,
+        "body": {
+            "id": 1,
+            "message": "ResponseContentType: application/vnd.widget.json; version=2026-12-31"
+        },
+        "status-text": "Created",
+        "headers": {
+            "Content-Type": "application/vnd.widget.json; version=2026-12-31"
+        }
+    }
+}

--- a/core/src/test/resources/versioned_content_type/specification_examples/widget_to_widget.json
+++ b/core/src/test/resources/versioned_content_type/specification_examples/widget_to_widget.json
@@ -1,0 +1,24 @@
+{
+    "http-request": {
+        "path": "/widgets",
+        "method": "POST",
+        "headers": {
+            "Content-Type": "application/vnd.widget.json"
+        },
+        "body": {
+            "id": 1,
+            "message": "RequestContentType: application/vnd.widget.json"
+        }
+    },
+    "http-response": {
+        "status": 201,
+        "body": {
+            "id": 1,
+            "message": "ResponseContentType: application/vnd.widget.json"
+        },
+        "status-text": "Created",
+        "headers": {
+            "Content-Type": "application/vnd.widget.json"
+        }
+    }
+}

--- a/core/src/test/resources/versioned_overridden_content_type/specification.yaml
+++ b/core/src/test/resources/versioned_overridden_content_type/specification.yaml
@@ -2,25 +2,94 @@ openapi: "3.0.0"
 info:
   title: "Widgets API"
   version: "1.0.0"
+
 paths:
-  /widgets:
+  /widgets/json:
     post:
-      summary: "Create Widget"
+      summary: "Create Widget - JSON"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SimpleSchema"
+      responses:
+        "201":
+          description: "Base JSON response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SimpleSchema"
+
+  /widgets/versioned-json:
+    post:
+      summary: "Create Widget - Versioned JSON override"
+      parameters:
+        - name: Content-Type
+          in: header
+          required: true
+          schema:
+            type: string
+            enum:
+              - application/json; version=2026-12-31
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SimpleSchema"
+      responses:
+        "202":
+          description: "Enum Content-Type response override"
+          headers:
+            Content-Type:
+              schema:
+                type: string
+                enum:
+                  - application/json; version=2026-12-31
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SimpleSchema"
+
+  /widgets/vendor-json:
+    post:
+      summary: "Create Widget - Vendor JSON override"
+      parameters:
+        - name: Content-Type
+          in: header
+          required: true
+          schema:
+            type: string
+            pattern: "^application/vnd\\.widget\\.json$"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SimpleSchema"
+      responses:
+        "203":
+          description: "Pattern Content-Type response override"
+          headers:
+            Content-Type:
+              schema:
+                type: string
+                pattern: "^application/vnd\\.widget\\.json$"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SimpleSchema"
+
+  /widgets/versioned-vendor-json:
+    post:
+      summary: "Create Widget - Versioned Vendor JSON override"
       parameters:
         - name: Content-Type
           in: header
           required: true
           schema:
             oneOf:
-              - type: string
-                enum:
-                  - application/json
-              - type: string
-                enum:
-                  - application/json; version=2026-12-31
-              - type: string
-                enum:
-                  - application/vnd.widget.json
               - type: string
                 enum:
                   - application/vnd.widget.json; version=2026-12-31
@@ -30,51 +99,9 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/SimpleSchema"
-          application/json; version=2026-12-31:
-            schema:
-              $ref: "#/components/schemas/SimpleSchema"
-          application/vnd.widget.json:
-            schema:
-              $ref: "#/components/schemas/SimpleSchema"
-          application/vnd.widget.json; version=2026-12-31:
-            schema:
-              $ref: "#/components/schemas/SimpleSchema"
       responses:
-        "201":
-          description: "String Content-Type response"
-          headers:
-            Content-Type:
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/SimpleSchema"
-        "202":
-          description: "Enum Content-Type response"
-          headers:
-            Content-Type:
-              schema:
-                type: string
-                enum:
-                  - application/json; version=2026-12-31
-          content:
-            application/json; version=2026-12-31:
-              schema:
-                $ref: "#/components/schemas/SimpleSchema"
-        "203":
-          description: "Pattern Content-Type response"
-          headers:
-            Content-Type:
-              schema:
-                type: string
-                pattern: "^application/vnd\\.widget\\.json$"
-          content:
-            application/vnd.widget.json:
-              schema:
-                $ref: "#/components/schemas/SimpleSchema"
         "204":
-          description: "oneOf Content-Type response"
+          description: "oneOf Content-Type response override"
           headers:
             Content-Type:
               schema:
@@ -83,9 +110,10 @@ paths:
                     enum:
                       - application/vnd.widget.json; version=2026-12-31
           content:
-            application/vnd.widget.json; version=2026-12-31:
+            application/json:
               schema:
                 $ref: "#/components/schemas/SimpleSchema"
+
 components:
   schemas:
     SimpleSchema:

--- a/core/src/test/resources/versioned_overridden_content_type/specification.yaml
+++ b/core/src/test/resources/versioned_overridden_content_type/specification.yaml
@@ -1,0 +1,100 @@
+openapi: "3.0.0"
+info:
+  title: "Widgets API"
+  version: "1.0.0"
+paths:
+  /widgets:
+    post:
+      summary: "Create Widget"
+      parameters:
+        - name: Content-Type
+          in: header
+          required: true
+          schema:
+            oneOf:
+              - type: string
+                enum:
+                  - application/json
+              - type: string
+                enum:
+                  - application/json; version=2026-12-31
+              - type: string
+                enum:
+                  - application/vnd.widget.json
+              - type: string
+                enum:
+                  - application/vnd.widget.json; version=2026-12-31
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SimpleSchema"
+          application/json; version=2026-12-31:
+            schema:
+              $ref: "#/components/schemas/SimpleSchema"
+          application/vnd.widget.json:
+            schema:
+              $ref: "#/components/schemas/SimpleSchema"
+          application/vnd.widget.json; version=2026-12-31:
+            schema:
+              $ref: "#/components/schemas/SimpleSchema"
+      responses:
+        "201":
+          description: "String Content-Type response"
+          headers:
+            Content-Type:
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SimpleSchema"
+        "202":
+          description: "Enum Content-Type response"
+          headers:
+            Content-Type:
+              schema:
+                type: string
+                enum:
+                  - application/json; version=2026-12-31
+          content:
+            application/json; version=2026-12-31:
+              schema:
+                $ref: "#/components/schemas/SimpleSchema"
+        "203":
+          description: "Pattern Content-Type response"
+          headers:
+            Content-Type:
+              schema:
+                type: string
+                pattern: "^application/vnd\\.widget\\.json$"
+          content:
+            application/vnd.widget.json:
+              schema:
+                $ref: "#/components/schemas/SimpleSchema"
+        "204":
+          description: "oneOf Content-Type response"
+          headers:
+            Content-Type:
+              schema:
+                oneOf:
+                  - type: string
+                    enum:
+                      - application/vnd.widget.json; version=2026-12-31
+          content:
+            application/vnd.widget.json; version=2026-12-31:
+              schema:
+                $ref: "#/components/schemas/SimpleSchema"
+components:
+  schemas:
+    SimpleSchema:
+      type: object
+      required:
+        - id
+        - message
+      properties:
+        id:
+          type: integer
+        message:
+          type: string

--- a/core/src/test/resources/versioned_overridden_content_type/specification_examples/json_to_json.json
+++ b/core/src/test/resources/versioned_overridden_content_type/specification_examples/json_to_json.json
@@ -1,0 +1,24 @@
+{
+    "http-request": {
+        "path": "/widgets",
+        "method": "POST",
+        "headers": {
+            "Content-Type": "application/json"
+        },
+        "body": {
+            "id": 1,
+            "message": "RequestContentType: application/json"
+        }
+    },
+    "http-response": {
+        "status": 201,
+        "body": {
+            "id": 1,
+            "message": "ResponseContentType: application/json"
+        },
+        "status-text": "Created",
+        "headers": {
+            "Content-Type": "application/json"
+        }
+    }
+}

--- a/core/src/test/resources/versioned_overridden_content_type/specification_examples/json_to_json.json
+++ b/core/src/test/resources/versioned_overridden_content_type/specification_examples/json_to_json.json
@@ -1,6 +1,6 @@
 {
     "http-request": {
-        "path": "/widgets",
+        "path": "/widgets/json",
         "method": "POST",
         "headers": {
             "Content-Type": "application/json"

--- a/core/src/test/resources/versioned_overridden_content_type/specification_examples/versioned_json_to_versioned_json.json
+++ b/core/src/test/resources/versioned_overridden_content_type/specification_examples/versioned_json_to_versioned_json.json
@@ -1,0 +1,24 @@
+{
+    "http-request": {
+        "path": "/widgets",
+        "method": "POST",
+        "headers": {
+            "Content-Type": "application/json; version=2026-12-31"
+        },
+        "body": {
+            "id": 1,
+            "message": "RequestContentType: application/json; version=2026-12-31"
+        }
+    },
+    "http-response": {
+        "status": 201,
+        "body": {
+            "id": 1,
+            "message": "ResponseContentType: application/json; version=2026-12-31"
+        },
+        "status-text": "Created",
+        "headers": {
+            "Content-Type": "application/json; version=2026-12-31"
+        }
+    }
+}

--- a/core/src/test/resources/versioned_overridden_content_type/specification_examples/versioned_json_to_versioned_json.json
+++ b/core/src/test/resources/versioned_overridden_content_type/specification_examples/versioned_json_to_versioned_json.json
@@ -1,6 +1,6 @@
 {
     "http-request": {
-        "path": "/widgets",
+        "path": "/widgets/versioned-json",
         "method": "POST",
         "headers": {
             "Content-Type": "application/json; version=2026-12-31"
@@ -11,12 +11,12 @@
         }
     },
     "http-response": {
-        "status": 201,
+        "status": 202,
         "body": {
             "id": 1,
             "message": "ResponseContentType: application/json; version=2026-12-31"
         },
-        "status-text": "Created",
+        "status-text": "Accepted",
         "headers": {
             "Content-Type": "application/json; version=2026-12-31"
         }

--- a/core/src/test/resources/versioned_overridden_content_type/specification_examples/versioned_widget_to_versioned_widget.json
+++ b/core/src/test/resources/versioned_overridden_content_type/specification_examples/versioned_widget_to_versioned_widget.json
@@ -1,6 +1,6 @@
 {
     "http-request": {
-        "path": "/widgets",
+        "path": "/widgets/versioned-vendor-json",
         "method": "POST",
         "headers": {
             "Content-Type": "application/vnd.widget.json; version=2026-12-31"
@@ -11,12 +11,12 @@
         }
     },
     "http-response": {
-        "status": 201,
+        "status": 204,
         "body": {
             "id": 1,
             "message": "ResponseContentType: application/vnd.widget.json; version=2026-12-31"
         },
-        "status-text": "Created",
+        "status-text": "No Content",
         "headers": {
             "Content-Type": "application/vnd.widget.json; version=2026-12-31"
         }

--- a/core/src/test/resources/versioned_overridden_content_type/specification_examples/versioned_widget_to_versioned_widget.json
+++ b/core/src/test/resources/versioned_overridden_content_type/specification_examples/versioned_widget_to_versioned_widget.json
@@ -1,0 +1,24 @@
+{
+    "http-request": {
+        "path": "/widgets",
+        "method": "POST",
+        "headers": {
+            "Content-Type": "application/vnd.widget.json; version=2026-12-31"
+        },
+        "body": {
+            "id": 1,
+            "message": "RequestContentType: application/vnd.widget.json; version=2026-12-31"
+        }
+    },
+    "http-response": {
+        "status": 201,
+        "body": {
+            "id": 1,
+            "message": "ResponseContentType: application/vnd.widget.json; version=2026-12-31"
+        },
+        "status-text": "Created",
+        "headers": {
+            "Content-Type": "application/vnd.widget.json; version=2026-12-31"
+        }
+    }
+}

--- a/core/src/test/resources/versioned_overridden_content_type/specification_examples/widget_to_widget.json
+++ b/core/src/test/resources/versioned_overridden_content_type/specification_examples/widget_to_widget.json
@@ -1,6 +1,6 @@
 {
     "http-request": {
-        "path": "/widgets",
+        "path": "/widgets/vendor-json",
         "method": "POST",
         "headers": {
             "Content-Type": "application/vnd.widget.json"
@@ -11,12 +11,12 @@
         }
     },
     "http-response": {
-        "status": 201,
+        "status": 203,
         "body": {
             "id": 1,
             "message": "ResponseContentType: application/vnd.widget.json"
         },
-        "status-text": "Created",
+        "status-text": "Non-Authoritative Information",
         "headers": {
             "Content-Type": "application/vnd.widget.json"
         }

--- a/core/src/test/resources/versioned_overridden_content_type/specification_examples/widget_to_widget.json
+++ b/core/src/test/resources/versioned_overridden_content_type/specification_examples/widget_to_widget.json
@@ -1,0 +1,24 @@
+{
+    "http-request": {
+        "path": "/widgets",
+        "method": "POST",
+        "headers": {
+            "Content-Type": "application/vnd.widget.json"
+        },
+        "body": {
+            "id": 1,
+            "message": "RequestContentType: application/vnd.widget.json"
+        }
+    },
+    "http-response": {
+        "status": 201,
+        "body": {
+            "id": 1,
+            "message": "ResponseContentType: application/vnd.widget.json"
+        },
+        "status-text": "Created",
+        "headers": {
+            "Content-Type": "application/vnd.widget.json"
+        }
+    }
+}


### PR DESCRIPTION
**What**: Preserve Content-Type specificity in header matching

**Why**:
Before this, `Content-Type` parameters were being stripped in example extraction, and OpenAPI operations with multiple content-type variants could be matched too loosely or against the wrong header variant. This caused externalized examples and request/response matching to lose media-type specificity

**How**:
- Stop dropping `Content-Type` parameters in `ExampleFromFile`.
- Carry all media-type variants into `HttpHeadersPattern` during OpenAPI parsing via `otherHttpHeadersPattern`.
- Update `Scenario` example matching to use content-type-aware header matching.
- Revise `HttpHeadersPattern.matchContentType` to compare against parsed media types, support wildcard precedence, and detect more specific conflicting variants.

**Checklist**:
- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link) N/A
- [ ] Sample Project added/updated (share link) N/A
- [ ] Demo video (share link) N/A
- [ ] Article on Website (share link) N/A
- [ ] Roadmpap updated (share link) N/A
- [ ] Conference Talk (share link) N/A