### PR TITLE
Speed up tests by rapidly shutting down mock

### DIFF
--- a/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/DockerCompose.kt
+++ b/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/DockerCompose.kt
@@ -42,6 +42,10 @@ class DockerCompose(
         mustRun(buildCommand("down", "--volumes", "--timeout", "10"), 120, TimeUnit.SECONDS)
     }
 
+    fun stopInTheBackground() {
+        buildCommand("down", "--volumes", "--timeout", "0").start()
+    }
+
     private fun run(command: ProcessBuilder, timeout: Long, timeUnit: TimeUnit): CommandResult {
         val commandString = command.command().joinToString(" ")
 

--- a/conformance-tests/src/test/kotlin/io/specmatic/conformance_tests/AbstractConformanceTest.kt
+++ b/conformance-tests/src/test/kotlin/io/specmatic/conformance_tests/AbstractConformanceTest.kt
@@ -50,7 +50,7 @@ abstract class AbstractConformanceTest(
 
     @AfterAll
     fun tearDown() {
-        dockerCompose.mustStop()
+        dockerCompose.stopInTheBackground()
     }
 
     @Test

--- a/conformance-tests/src/test/resources/docker-compose.yaml
+++ b/conformance-tests/src/test/resources/docker-compose.yaml
@@ -4,6 +4,7 @@ services:
       - SPECMATIC_TELEMETRY_EXTRA_LABELS=${SPECMATIC_TELEMETRY_EXTRA_LABELS:?error}
     image: specmatic/specmatic:${SPECMATIC_VERSION:?error}
     command: mock /service.yaml --port 9000
+    stop_signal: SIGKILL
     expose:
       - "9000"
     volumes:

--- a/conformance-tests/src/test/resources/docker-compose.yaml
+++ b/conformance-tests/src/test/resources/docker-compose.yaml
@@ -17,6 +17,7 @@ services:
 
   mitm:
     image: mitmproxy/mitmproxy:${MITM_PROXY_VERSION:?error}
+    stop_signal: SIGKILL
     depends_on:
       mock:
         condition: service_healthy

--- a/conformance-tests/src/test/resources/junit-platform.properties
+++ b/conformance-tests/src/test/resources/junit-platform.properties
@@ -2,5 +2,5 @@ junit.jupiter.execution.parallel.enabled=true
 junit.jupiter.execution.parallel.mode.default=same_thread
 junit.jupiter.execution.parallel.mode.classes.default=concurrent
 junit.jupiter.execution.parallel.config.strategy=fixed
-junit.jupiter.execution.parallel.config.fixed.parallelism=4
+junit.jupiter.execution.parallel.config.fixed.parallelism=8
 junit.jupiter.testclass.order.default=org.junit.jupiter.api.ClassOrderer$DisplayName


### PR DESCRIPTION
We don't need to wait for a graceful shutdown because
our tests have exited by the time we ask for the mock to
shutdown.
