### PR TITLE
Alternative 1 for change tracking of reference schemas: Go in and collect refs

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
@@ -25,6 +25,11 @@ data class HttpHeadersPattern(
 
     val headerNames = pattern.keys
 
+    fun collectReferences(references: ReferencedPatterns) {
+        references.addAll(pattern.values)
+        ancestorHeaders?.values?.let(references::addAll)
+    }
+
     fun isEmpty(): Boolean {
         return pattern.isEmpty()
     }

--- a/core/src/main/kotlin/io/specmatic/core/HttpPathPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpPathPattern.kt
@@ -25,6 +25,10 @@ data class HttpPathPattern(
         .map { SegmentCounts.segmentCounts(it, internalPathRegex) }
         .fold(SegmentCounts()) { acc, counts -> acc + counts }
 
+    fun collectReferences(references: ReferencedPatterns) {
+        references.addAll(pathSegmentPatterns)
+    }
+
     fun encompasses(otherHttpPathPattern: HttpPathPattern, thisResolver: Resolver, otherResolver: Resolver): Result {
         if (this.matches(URI.create(otherHttpPathPattern.path), resolver = thisResolver) is Success)
             return Success()

--- a/core/src/main/kotlin/io/specmatic/core/HttpQueryParamPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpQueryParamPattern.kt
@@ -25,6 +25,11 @@ data class HttpQueryParamPattern(
 
     val queryKeyNames = queryPatterns.keys
 
+    fun collectReferences(references: ReferencedPatterns) {
+        references.addAll(queryPatterns.values)
+        additionalProperties?.let(references::add)
+    }
+
     fun generate(resolver: Resolver): List<Pair<String, String>> {
         val updatedResolver = resolver.updateLookupPath(BreadCrumb.PARAMETERS.value).updateLookupForParam(BreadCrumb.QUERY.value)
         return attempt(breadCrumb = BreadCrumb.PARAM_QUERY.value) {

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
@@ -19,6 +19,7 @@ import io.specmatic.core.pattern.Pattern
 import io.specmatic.core.pattern.QueryParameterArrayPattern
 import io.specmatic.core.pattern.QueryParameterScalarPattern
 import io.specmatic.core.pattern.REQUEST_BODY_FIELD
+import io.specmatic.core.pattern.ReferencedPatterns
 import io.specmatic.core.pattern.ReturnValue
 import io.specmatic.core.pattern.Row
 import io.specmatic.core.pattern.ValueDetails
@@ -62,6 +63,15 @@ data class HttpRequestPattern(
     val multiPartFormDataPattern: List<MultiPartFormDataPattern> = emptyList(),
     val securitySchemes: List<OpenAPISecurityScheme> = listOf(NoSecurityScheme())
 ) {
+    fun collectReferences(references: ReferencedPatterns) {
+        headersPattern.collectReferences(references)
+        httpPathPattern?.collectReferences(references)
+        httpQueryParamPattern.collectReferences(references)
+        references.add(body)
+        references.addAll(formFieldsPattern.values)
+        multiPartFormDataPattern.forEach { it.collectReferences(references) }
+    }
+
     fun getHeaderKeys() = headersPattern.headerNames
 
     fun getQueryParamKeys() = httpQueryParamPattern.queryKeyNames

--- a/core/src/main/kotlin/io/specmatic/core/HttpResponsePattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpResponsePattern.kt
@@ -19,6 +19,12 @@ data class HttpResponsePattern(
 ) {
     constructor(response: HttpResponse) : this(HttpHeadersPattern(response.headers.mapValues { stringToPattern(it.value, it.key) }), response.status, response.body.exactMatchElseType())
 
+    fun collectReferences(references: ReferencedPatterns) {
+        headersPattern.collectReferences(references)
+        references.add(body)
+        responseValueAssertion.collectReferences(references)
+    }
+
     fun fillInTheBlanks(resolver: Resolver, resultHeaderValue: String = "success"): HttpResponse {
         return generateResponseWith(
             value = resolver.withCyclePrevention(body, body::generate),

--- a/core/src/main/kotlin/io/specmatic/core/MultiPartFormDataPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/MultiPartFormDataPattern.kt
@@ -7,6 +7,7 @@ import io.specmatic.core.value.StringValue
 import java.io.File
 
 sealed class MultiPartFormDataPattern(open val name: String, open val contentType: String?) {
+    abstract fun collectReferences(references: ReferencedPatterns)
     abstract fun newBasedOn(row: Row, resolver: Resolver): Sequence<MultiPartFormDataPattern?>
     abstract fun generate(resolver: Resolver): MultiPartFormDataValue
     abstract fun matches(value: MultiPartFormDataValue, resolver: Resolver): Result
@@ -14,6 +15,10 @@ sealed class MultiPartFormDataPattern(open val name: String, open val contentTyp
 }
 
 data class MultiPartContentPattern(override val name: String, val content: Pattern, override val contentType: String? = null) : MultiPartFormDataPattern(name, contentType) {
+    override fun collectReferences(references: ReferencedPatterns) {
+        references.add(content)
+    }
+
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<MultiPartContentPattern?> =
         newPatternsBasedOn(row, withoutOptionality(name), content, resolver).map { it.value }.map { newContent: Pattern ->
             MultiPartContentPattern(
@@ -84,6 +89,10 @@ data class MultiPartContentPattern(override val name: String, val content: Patte
 }
 
 data class MultiPartFilePattern(override val name: String, val filename: Pattern, override val contentType: String? = null, val contentEncoding: String? = null) : MultiPartFormDataPattern(name, contentType) {
+    override fun collectReferences(references: ReferencedPatterns) {
+        references.add(filename)
+    }
+
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<MultiPartFormDataPattern?> {
         val rowKey = "${name}_filename"
         return sequenceOf(this.copy(filename = if(row.containsField(rowKey)) ExactValuePattern(StringValue(row.getField(rowKey))) else filename))

--- a/core/src/main/kotlin/io/specmatic/core/ResponseValueAssertion.kt
+++ b/core/src/main/kotlin/io/specmatic/core/ResponseValueAssertion.kt
@@ -1,5 +1,8 @@
 package io.specmatic.core
 
+import io.specmatic.core.pattern.ReferencedPatterns
+
 interface ResponseValueAssertion {
+    fun collectReferences(references: ReferencedPatterns) {}
     fun matches(response: HttpResponse, resolver: Resolver): Result
 }

--- a/core/src/main/kotlin/io/specmatic/core/ScenarioFingerprint.kt
+++ b/core/src/main/kotlin/io/specmatic/core/ScenarioFingerprint.kt
@@ -1,5 +1,7 @@
 package io.specmatic.core
 
+import io.specmatic.core.pattern.Pattern
+import io.specmatic.core.pattern.ReferencedPatterns
 import io.specmatic.reporter.internal.dto.bcc.ChangeStatus
 
 data class ScenarioFingerprint(
@@ -8,6 +10,7 @@ data class ScenarioFingerprint(
     val responseContentType: String?,
     val httpRequestPattern: HttpRequestPattern,
     val httpResponsePattern: HttpResponsePattern,
+    val referencedPatterns: Map<String, Pattern>,
 ) {
     companion object {
         fun from(scenario: Scenario): ScenarioFingerprint = ScenarioFingerprint(
@@ -16,6 +19,7 @@ data class ScenarioFingerprint(
             responseContentType = scenario.responseContentType,
             httpRequestPattern = scenario.httpRequestPattern,
             httpResponsePattern = scenario.httpResponsePattern,
+            referencedPatterns = referencedPatternDefinitions(scenario),
         )
 
         fun changeStatusBetween(
@@ -25,6 +29,13 @@ data class ScenarioFingerprint(
             val oldFingerprints = oldScenarios.map(::from).toSet()
             val newFingerprints = newScenarios.map(::from).toSet()
             return if (oldFingerprints == newFingerprints) ChangeStatus.UNCHANGED else ChangeStatus.CHANGED
+        }
+
+        private fun referencedPatternDefinitions(scenario: Scenario): Map<String, Pattern> {
+            val referencedPatterns = ReferencedPatterns(scenario.patterns)
+            scenario.httpRequestPattern.collectReferences(referencedPatterns)
+            scenario.httpResponsePattern.collectReferences(referencedPatterns)
+            return referencedPatterns.toMap()
         }
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/URLPathSegmentPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/URLPathSegmentPattern.kt
@@ -8,6 +8,10 @@ import io.specmatic.core.value.StringValue
 import io.specmatic.core.value.Value
 
 data class URLPathSegmentPattern(override val pattern: Pattern, override val key: String? = null, override val typeAlias: String? = null) : Pattern, Keyed {
+    override fun collectReferences(references: ReferencedPatterns) {
+        references.add(pattern)
+    }
+
     override fun matches(sampleData: Value?, resolver: Resolver): Result {
         return resolver.matchesPattern(key, pattern, sampleData ?: NullValue)
     }

--- a/core/src/main/kotlin/io/specmatic/core/ValueAssertion.kt
+++ b/core/src/main/kotlin/io/specmatic/core/ValueAssertion.kt
@@ -1,6 +1,12 @@
 package io.specmatic.core
 
+import io.specmatic.core.pattern.ReferencedPatterns
+
 data class ValueAssertion(val expectedExactResponsePattern: HttpResponsePattern) : ResponseValueAssertion {
+    override fun collectReferences(references: ReferencedPatterns) {
+        expectedExactResponsePattern.collectReferences(references)
+    }
+
     override fun matches(response: HttpResponse, resolver: Resolver): Result {
         return expectedExactResponsePattern.matchesResponse(response, resolver)
     }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/AnyNonNullJSONValue.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/AnyNonNullJSONValue.kt
@@ -9,6 +9,10 @@ import io.specmatic.core.value.Value
 import io.specmatic.core.valueMismatchResult
 
 data class AnyNonNullJSONValue(override val pattern: Pattern = AnythingPattern): Pattern by pattern{
+    override fun collectReferences(references: ReferencedPatterns) {
+        references.add(pattern)
+    }
+
     override fun matches(sampleData: Value?, resolver: Resolver): Result {
         if (sampleData is NullValue) return valueMismatchResult("non-null value", sampleData, resolver.mismatchMessages)
         return Result.Success()

--- a/core/src/main/kotlin/io/specmatic/core/pattern/AnyOfPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/AnyOfPattern.kt
@@ -29,6 +29,10 @@ data class AnyOfPattern(
     HasDefaultExample by delegate,
     PossibleJsonObjectPatternContainer by delegate,
     SubSchemaCompositePattern by delegate {
+    override fun collectReferences(references: ReferencedPatterns) {
+        delegate.collectReferences(references)
+    }
+
     override fun matches(
         sampleData: Value?,
         resolver: Resolver,

--- a/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
@@ -42,6 +42,10 @@ data class AnyPattern(
         emptyMap()
     ), pattern.extractCombinedExtensions())
 
+    override fun collectReferences(references: ReferencedPatterns) {
+        references.addAll(pattern)
+    }
+
     data class AnyPatternMatch(val pattern: Pattern, val result: Result)
 
     private fun extractDiscriminatorValue(value: Value): String? {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/CsvPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/CsvPattern.kt
@@ -10,6 +10,10 @@ import io.specmatic.core.value.StringValue
 import io.specmatic.core.value.Value
 
 class CsvPattern(override val pattern: Pattern) : Pattern {
+    override fun collectReferences(references: ReferencedPatterns) {
+        references.add(pattern)
+    }
+
     override fun matches(sampleData: Value?, resolver: Resolver): Result {
         if (sampleData !is StringValue) return dataTypeMismatchResult(this, sampleData, resolver.mismatchMessages)
         val results: List<Result> = sampleData.string.split(",").mapIndexed { index, value ->

--- a/core/src/main/kotlin/io/specmatic/core/pattern/DeferredPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/DeferredPattern.kt
@@ -134,6 +134,10 @@ data class DeferredPattern(
         return resolvePattern(resolver).patternFrom(value, resolver, parseValueToType)
     }
 
+    override fun collectReferences(references: ReferencedPatterns) {
+        references.addReference(pattern)
+    }
+
     override fun toString() = pattern
 }
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/DictionaryPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/DictionaryPattern.kt
@@ -8,6 +8,10 @@ import io.specmatic.core.value.StringValue
 import io.specmatic.core.value.Value
 
 data class DictionaryPattern(val keyPattern: Pattern, val valuePattern: Pattern, override val typeAlias: String? = null) : Pattern {
+    override fun collectReferences(references: ReferencedPatterns) {
+        references.add(keyPattern)
+        references.add(valuePattern)
+    }
 
     override fun eliminateOptionalKey(value: Value, resolver: Resolver): Value {
         return JSONObjectValue()

--- a/core/src/main/kotlin/io/specmatic/core/pattern/EnumPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/EnumPattern.kt
@@ -50,6 +50,10 @@ data class EnumPattern(override val pattern: AnyPattern, val nullable: Boolean) 
         multiType: Boolean = false
     ) : this (validEnumValues(values, key, typeAlias, example, nullable, multiType), nullable)
 
+    override fun collectReferences(references: ReferencedPatterns) {
+        references.add(pattern)
+    }
+
     override fun resolveSubstitutions(
         substitution: Substitution,
         value: Value,

--- a/core/src/main/kotlin/io/specmatic/core/pattern/JSONArrayPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/JSONArrayPattern.kt
@@ -32,6 +32,10 @@ data class JSONArrayPattern(override val pattern: List<Pattern> = emptyList(), o
 
     constructor(jsonString: String, typeAlias: String?) : this(stringTooPatternArray(jsonString), typeAlias = typeAlias)
 
+    override fun collectReferences(references: ReferencedPatterns) {
+        references.addAll(pattern)
+    }
+
     @Throws(Exception::class)
     override fun matches(sampleData: Value?, resolver: Resolver): Result {
         if (sampleData !is JSONArrayValue) return dataTypeMismatchResult(this, sampleData, resolver.mismatchMessages)

--- a/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
@@ -137,6 +137,13 @@ data class JSONObjectPattern(
         )
     }
 
+    override fun collectReferences(references: ReferencedPatterns) {
+        references.addAll(pattern.values)
+        if (additionalProperties is AdditionalProperties.PatternConstrained) {
+            references.add(additionalProperties.pattern)
+        }
+    }
+
     override fun fillInTheBlanks(value: Value, resolver: Resolver, removeExtraKeys: Boolean): ReturnValue<Value> {
         val patternToConsider = when (val resolvedPattern = resolveToPattern(value, resolver, this)) {
             is ReturnFailure -> return resolvedPattern.cast()

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
@@ -15,6 +15,10 @@ data class ListPattern(
     override val memberList: MemberList
         get() = MemberList(emptyList(), pattern)
 
+    override fun collectReferences(references: ReferencedPatterns) {
+        references.add(pattern)
+    }
+
     override fun fixValue(value: Value, resolver: Resolver): Value {
         if (resolver.matchesPattern(null, this, value).isSuccess()) return value
         val updatedResolver = resolver.addPatternAsSeen(this).updateLookupPath(this, this.pattern)

--- a/core/src/main/kotlin/io/specmatic/core/pattern/LookupRowPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/LookupRowPattern.kt
@@ -10,6 +10,10 @@ data class LookupRowPattern(override val pattern: Pattern, override val key: Str
     override fun equals(other: Any?): Boolean = other is LookupRowPattern && resolvedHop(other.pattern, Resolver()) == resolvedHop(pattern, Resolver())
     override fun hashCode(): Int = pattern.hashCode()
 
+    override fun collectReferences(references: ReferencedPatterns) {
+        references.add(pattern)
+    }
+
     override fun addTypeAliasesToConcretePattern(concretePattern: Pattern, resolver: Resolver, typeAlias: String?): Pattern {
         return pattern.addTypeAliasesToConcretePattern(concretePattern, resolver, typeAlias)
     }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/Pattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/Pattern.kt
@@ -33,6 +33,8 @@ interface Pattern {
 
     fun patternSet(resolver: Resolver): List<Pattern> = listOf(this)
 
+    fun collectReferences(references: ReferencedPatterns) {}
+
     fun parseToType(valueString: String, resolver: Resolver): Pattern {
         return parse(valueString, resolver).exactMatchElseType()
     }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/PatternInStringPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/PatternInStringPattern.kt
@@ -10,6 +10,10 @@ import io.specmatic.core.value.StringValue
 import io.specmatic.core.value.Value
 
 data class PatternInStringPattern(override val pattern: Pattern = StringPattern(), override val typeAlias: String? = null): Pattern {
+    override fun collectReferences(references: ReferencedPatterns) {
+        references.add(pattern)
+    }
+
     override fun matches(sampleData: Value?, resolver: Resolver): Result {
         if (sampleData !is StringValue) return dataTypeMismatchResult(pattern, sampleData, resolver.mismatchMessages)
         return resultOf(ruleViolation = StandardRuleViolation.VALUE_MISMATCH) {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/QueryParameterArrayPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/QueryParameterArrayPattern.kt
@@ -11,6 +11,10 @@ import io.specmatic.core.value.StringValue
 import io.specmatic.core.value.Value
 
 data class QueryParameterArrayPattern(override val pattern: List<Pattern>, val parameterName: String): Pattern {
+    override fun collectReferences(references: ReferencedPatterns) {
+        references.addAll(pattern)
+    }
+
     override fun matches(sampleData: Value?, resolver: Resolver): Result {
         if (sampleData !is ListValue) return dataTypeMismatchResult("list of ${pattern.first().typeName}", sampleData)
         val requestValues = sampleData.list.map { it.toString() }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/QueryParameterScalarPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/QueryParameterScalarPattern.kt
@@ -8,6 +8,10 @@ import io.specmatic.core.dataTypeMismatchResult
 import io.specmatic.core.value.*
 
 data class QueryParameterScalarPattern(override val pattern: Pattern): Pattern by pattern, ScalarType {
+    override fun collectReferences(references: ReferencedPatterns) {
+        references.add(pattern)
+    }
+
     override fun resolveSubstitutions(
         substitution: Substitution,
         value: Value,

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ReferencedPatterns.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ReferencedPatterns.kt
@@ -1,0 +1,29 @@
+package io.specmatic.core.pattern
+
+import java.util.Collections
+import java.util.IdentityHashMap
+
+class ReferencedPatterns(private val availablePatterns: Map<String, Pattern>) {
+    private val references = linkedMapOf<String, Pattern>()
+    private val visitedReferences = mutableSetOf<String>()
+    private val visitedPatterns = Collections.newSetFromMap(IdentityHashMap<Pattern, Boolean>())
+
+    fun add(pattern: Pattern) {
+        if (visitedPatterns.add(pattern)) pattern.collectReferences(this)
+    }
+
+    fun addAll(patterns: Iterable<Pattern>) {
+        patterns.forEach(::add)
+    }
+
+    fun addReference(patternName: String) {
+        val normalizedPatternName = patternName.trim()
+        if (!visitedReferences.add(normalizedPatternName)) return
+
+        val referencedPattern = availablePatterns[normalizedPatternName] ?: return
+        references[normalizedPatternName] = referencedPattern
+        add(referencedPattern)
+    }
+
+    fun toMap(): Map<String, Pattern> = references.toMap()
+}

--- a/core/src/main/kotlin/io/specmatic/core/pattern/RegexConstrainedPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/RegexConstrainedPattern.kt
@@ -18,6 +18,10 @@ data class RegexConstrainedPattern(
         if (eagerRegexValidation) this.validateRegexAgainstBasePattern()
     }
 
+    override fun collectReferences(references: ReferencedPatterns) {
+        references.add(basePattern)
+    }
+
     override fun matches(sampleData: Value?, resolver: Resolver): Result {
         if (sampleData?.hasSupportedTemplate() == true) return Result.Success()
         val baseResult = basePattern.matches(sampleData, resolver)

--- a/core/src/main/kotlin/io/specmatic/core/pattern/RestPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/RestPattern.kt
@@ -9,6 +9,10 @@ import io.specmatic.core.value.Value
 data class RestPattern(override val pattern: Pattern, override val typeAlias: String? = null) : Pattern {
     private val listPattern = ListPattern(pattern)
 
+    override fun collectReferences(references: ReferencedPatterns) {
+        references.add(pattern)
+    }
+
     override fun matches(sampleData: Value?, resolver: Resolver): Result =
             listPattern.matches(sampleData, resolver)
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/TabularPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/TabularPattern.kt
@@ -35,6 +35,10 @@ data class TabularPattern(
     private val unexpectedKeyCheck: UnexpectedKeyCheck = ValidateUnexpectedKeys,
     override val typeAlias: String? = null
 ) : Pattern {
+    override fun collectReferences(references: ReferencedPatterns) {
+        references.addAll(pattern.values)
+    }
+
     override fun matches(sampleData: Value?, resolver: Resolver): Result {
         if (sampleData !is JSONObjectValue) return dataTypeMismatchResult("JSON object", sampleData, resolver.mismatchMessages)
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLChoiceGroupPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLChoiceGroupPattern.kt
@@ -26,6 +26,11 @@ data class XMLChoiceGroupPattern(
     override val memberList: MemberList
         get() = MemberList(concreteSequence?.flatten() ?: choices.firstOrNull() ?: emptyList(), null)
 
+    override fun collectReferences(references: ReferencedPatterns) {
+        references.addAll(choices.flatten())
+        concreteSequence?.flatten()?.let(references::addAll)
+    }
+
     override fun matches(sampleData: Value?, resolver: Resolver): Result {
         return when (sampleData) {
             is XMLNode -> matches(sampleData.childNodes, resolver).result

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLPattern.kt
@@ -91,6 +91,12 @@ data class XMLPattern(
         isSOAPHeader: Boolean = false
     ) : this(toXMLNode(parseXML(xmlString)), typeAlias, isSOAP, isSOAPHeader)
 
+    override fun collectReferences(references: ReferencedPatterns) {
+        referredType?.let { references.addReference(withPatternDelimiters(it)) }
+        references.addAll(pattern.attributes.values)
+        references.addAll(pattern.nodes)
+    }
+
     fun toPrettyString(): String {
         return pattern.toGherkinishNode().toPrettyStringValue()
     }

--- a/core/src/test/kotlin/io/specmatic/core/ScenarioFingerprintTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ScenarioFingerprintTest.kt
@@ -33,6 +33,33 @@ class ScenarioFingerprintTest {
                   description: created
     """.trimIndent()
 
+    private val componentRefSpec = """
+        openapi: 3.0.0
+        info:
+          title: Orders API
+          version: 1.0.0
+        paths:
+          /orders:
+            post:
+              requestBody:
+                required: true
+                content:
+                  application/json:
+                    schema:
+                      ${'$'}ref: '#/components/schemas/Order'
+              responses:
+                '201':
+                  description: created
+        components:
+          schemas:
+            Order:
+              type: object
+              required: [id]
+              properties:
+                id:
+                  type: string
+    """.trimIndent()
+
     @Test
     fun `from copies identifying fields and patterns off the scenario`() {
         val scenario = singleScenarioFrom(baseSpec)
@@ -113,6 +140,39 @@ class ScenarioFingerprintTest {
         """.trimIndent()))
 
         assertThat(ScenarioFingerprint.changeStatusBetween(old, new)).isEqualTo(ChangeStatus.CHANGED)
+    }
+
+    @Test
+    fun `changeStatusBetween returns CHANGED when a referenced component schema changes`() {
+        val old = scenariosFrom(componentRefSpec)
+        val new = scenariosFrom(componentRefSpec.applyJsonPatch("""
+            - op: replace
+              path: /components/schemas/Order/properties/id/type
+              value: integer
+        """.trimIndent()))
+
+        assertThat(ScenarioFingerprint.changeStatusBetween(old, new)).isEqualTo(ChangeStatus.CHANGED)
+    }
+
+    @Test
+    fun `changeStatusBetween returns UNCHANGED when an unused component schema changes`() {
+        val specWithUnusedComponent = componentRefSpec.applyJsonPatch("""
+            - op: add
+              path: /components/schemas/Unused
+              value:
+                type: object
+                properties:
+                  name:
+                    type: string
+        """.trimIndent())
+        val old = scenariosFrom(specWithUnusedComponent)
+        val new = scenariosFrom(specWithUnusedComponent.applyJsonPatch("""
+            - op: replace
+              path: /components/schemas/Unused/properties/name/type
+              value: integer
+        """.trimIndent()))
+
+        assertThat(ScenarioFingerprint.changeStatusBetween(old, new)).isEqualTo(ChangeStatus.UNCHANGED)
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
@@ -5225,7 +5225,47 @@ paths:
                 """,
             ),
             ChangeStatusCase(
-                name = "31. required array and properties reordered",
+                name = "31. schema referenced via same \$ref has component schema changed",
+                path = "/orders", method = "POST",
+                expected = ChangeStatus.CHANGED,
+                oldPatch = """
+                    - op: add
+                      path: /components
+                      value:
+                        schemas:
+                          Order:
+                            type: object
+                            required: [id]
+                            properties:
+                              id:
+                                type: string
+                    - op: replace
+                      path: /paths/~1orders/post/requestBody/content/application~1json/schema
+                      value:
+                        ${'$'}ref: '#/components/schemas/Order'
+                """,
+                newPatch = """
+                    - op: add
+                      path: /components
+                      value:
+                        schemas:
+                          Order:
+                            type: object
+                            required: [id]
+                            properties:
+                              id:
+                                type: string
+                    - op: replace
+                      path: /paths/~1orders/post/requestBody/content/application~1json/schema
+                      value:
+                        ${'$'}ref: '#/components/schemas/Order'
+                    - op: replace
+                      path: /components/schemas/Order/properties/id/type
+                      value: integer
+                """,
+            ),
+            ChangeStatusCase(
+                name = "32. required array and properties reordered",
                 path = "/orders", method = "POST",
                 expected = ChangeStatus.UNCHANGED,
                 oldPatch = """


### PR DESCRIPTION
https://github.com/specmatic/specmatic/pull/2505 doesn't handle refs. If a ref in a component is changed (see tests in here) than it's reported as unchanged. This PR fixes this by collecting all the refs.