### PR TITLE
Fix stash detection when git stash list is empty

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/git/SystemGit.kt
+++ b/core/src/main/kotlin/io/specmatic/core/git/SystemGit.kt
@@ -256,7 +256,8 @@ class SystemGit(override val workingDirectory: String = ".", private val prefix:
     }
 
     private fun getStashListSize(): Int {
-        return execute(Configuration.gitCommand, "stash", "list").trim().lines().size
+        val output = execute(Configuration.gitCommand, "stash", "list").trim()
+        return if (output.isBlank()) 0 else output.lines().size
     }
 
     override fun detachedHEAD(): String {

--- a/core/src/test/kotlin/io/specmatic/core/git/SystemGitTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/git/SystemGitTest.kt
@@ -45,6 +45,21 @@ class SystemGitTest {
         assertThat(systemGit.getUntrackedFiles()).containsExactly(untrackedFile.absolutePath)
     }
 
+    @Test
+    fun `stash should report true when local changes are stashed from an empty stash list`(@TempDir tempDir: File) {
+        initialiseGitRepository(tempDir)
+        val fileName = "openapi.yaml"
+        commitFile(tempDir, fileName, "openapi: 3.0.0")
+
+        tempDir.resolve(fileName).writeText("openapi: 3.0.1")
+
+        val systemGit = SystemGit(tempDir.absolutePath)
+        assertThat(runGit(tempDir, "stash", "list")).isBlank()
+
+        assertThat(systemGit.stash()).isTrue()
+        assertThat(runGit(tempDir, "stash", "list")).contains("tmp")
+    }
+
     private fun initialiseGitRepository(directory: File) {
         runGit(directory, "init", "-b", "main")
         runGit(directory, "config", "user.name", "Specmatic Tests")


### PR DESCRIPTION
## Summary
- Handle an empty `git stash list` output as zero stashes instead of counting it as one line
- Add a regression test covering stashing local changes when the stash list starts empty

## Testing
- Added a focused unit test in `SystemGitTest` for the empty-stash case
- Not run (not requested)