### PR TITLE
Fix flaky createStub timeout test by stubbing timeout helper

### DIFF
--- a/core/src/test/kotlin/io/specmatic/stub/CreateStubTimeoutTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/CreateStubTimeoutTest.kt
@@ -1,12 +1,14 @@
 package io.specmatic.stub
 
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.assertThrows
-import io.specmatic.stub.createStub
 import io.specmatic.core.pattern.ContractException
-import org.junit.jupiter.api.condition.DisabledOnOs
-import org.junit.jupiter.api.condition.OS
+import io.specmatic.core.utilities.runWithTimeout
 import java.io.File
 
 internal class CreateStubTimeoutTest {
@@ -29,15 +31,24 @@ internal class CreateStubTimeoutTest {
     }
 
     @Test
-    @DisabledOnOs(OS.LINUX)
-    fun `createStub should throw ContractException when stub start timeout is 0`() {
+    fun `createStub should use configured stub start timeout and fatal timeout message`() {
         // Use the test resource config that sets stub.startTimeoutInMilliseconds to 0
         val configFile = File(javaClass.getResource("/create_stub_timeout/specmatic.json").toURI())
+        val timeoutMessage = "FATAL: Specmatic stub failed to start within 0 milliseconds. You can configure the stub start timeout from Specmatic configuration. The default timeout is 20 seconds."
+        val sentinelException = ContractException("sentinel timeout")
 
-        val exception = assertThrows(ContractException::class.java) {
-            createStub(host = "localhost", port = 9001, timeoutMillis = 0L, givenConfigFileName = configFile.path).use {}
+        mockkStatic("io.specmatic.core.utilities.Utilities")
+        try {
+            every { runWithTimeout<Any>(0L, timeoutMessage, any()) } throws sentinelException
+
+            val exception = assertThrows(ContractException::class.java) {
+                createStub(host = "localhost", port = 9001, timeoutMillis = 0L, givenConfigFileName = configFile.path).use {}
+            }
+
+            assertThat(exception).isSameAs(sentinelException)
+            verify(exactly = 1) { runWithTimeout<Any>(0L, timeoutMessage, any()) }
+        } finally {
+            unmockkStatic("io.specmatic.core.utilities.Utilities")
         }
-
-        assertThat(exception.message).contains("FATAL: Specmatic stub failed to start within 0 milliseconds")
     }
 }

--- a/core/src/test/kotlin/utilities/UtilitiesTest.kt
+++ b/core/src/test/kotlin/utilities/UtilitiesTest.kt
@@ -10,6 +10,7 @@ import io.specmatic.core.git.GitCommand
 import io.specmatic.core.git.SystemGit
 import io.specmatic.core.git.checkout
 import io.specmatic.core.git.clone
+import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.pattern.parsedJSON
 import io.specmatic.core.pattern.parsedJSONObject
 import io.specmatic.core.utilities.*
@@ -34,11 +35,29 @@ import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.MethodSource
 import java.io.File
 import java.net.ServerSocket
+import java.util.concurrent.Callable
+import kotlin.system.measureTimeMillis
 import java.util.stream.Stream
 
 private const val testSystemProperty = "THIS_PROPERTY_EXISTS"
 
 internal class UtilitiesTest {
+    @Test
+    fun `runWithTimeout should throw ContractException without waiting for task completion`() {
+        val elapsedTime = measureTimeMillis {
+            val exception = assertThrows<ContractException> {
+                runWithTimeout(0, "timed out", Callable {
+                    Thread.sleep(5000)
+                    "completed"
+                })
+            }
+
+            assertThat(exception.message).contains("timed out")
+        }
+
+        assertThat(elapsedTime).isLessThan(2000)
+    }
+
     @Test
     fun `parsing multiline xml`() {
         val xml = """<line1>


### PR DESCRIPTION
## What
- Stabilize `CreateStubTimeoutTest` by verifying `createStub` passes the configured fatal timeout message into `runWithTimeout`.
- Add coverage for `runWithTimeout` to confirm it fails fast instead of waiting for task completion.

## Why
- The timeout test was flaky and OS-dependent because it exercised real timing behavior.
- Verifying the timeout helper directly makes the test deterministic and protects the intended failure path.

## How
- Mock `runWithTimeout` in the `createStub` timeout test and assert the configured timeout message is used.
- Add a focused unit test for `runWithTimeout` to validate it throws `ContractException` immediately on timeout.
- Remove the Linux-specific test skip so the behavior is covered consistently across environments.