### PR TITLE
build: bump specmatic reporter to 0.3.29

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 group=io.specmatic
 version=2.46.4-SNAPSHOT
 specmaticGradlePluginVersion=0.15.12
-specmaticReporterVersion=0.3.27
+specmaticReporterVersion=0.3.29
 swaggerParserVersion=2.1.35
 kotlin.daemon.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=384m
 org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=384m


### PR DESCRIPTION
## What
- bump `specmaticReporterVersion` from `0.3.27` to `0.3.29` in `gradle.properties`

## Validation
- not run (version bump only)