### PR TITLE
In BCC CTRF JSON spec paths must be relative to the repo root

### DIFF
--- a/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckBaseCommand.kt
+++ b/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckBaseCommand.kt
@@ -270,7 +270,7 @@ abstract class BackwardCompatibilityCheckBaseCommand(
 
                     val repoDirFile = File(effectiveRepoDir).absoluteFile
                     val olderFileExists =
-                        gitCommand.exists(baseBranch, File(specFilePath).relativeTo(repoDirFile).path)
+                        gitCommand.exists(baseBranch, File(specFilePath).relativeTo(repoDirFile).invariantSeparatorsPath)
 
                     if (!olderFileExists) {
                         // new file: mark as passed immediately
@@ -366,7 +366,7 @@ abstract class BackwardCompatibilityCheckBaseCommand(
                         hook.check(
                             processed.backwardCompatibilityResult,
                             gitCommand.getRemoteUrl(),
-                            File(processed.specFilePath).relativeTo(repoDirFile).path
+                            File(processed.specFilePath).relativeTo(repoDirFile).invariantSeparatorsPath
                         )
                     } catch (e: Throwable) {
                         logger.log(e)

--- a/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckCommandV2.kt
+++ b/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckCommandV2.kt
@@ -98,7 +98,7 @@ class BackwardCompatibilityCheckCommandV2(options: BackwardCompatibilityCheckOpt
         return try {
             val feature = OpenApiSpecification.fromFile(path).toFeature()
             val specificationPath = File(path).canonicalFile
-                .relativeTo(File(effectiveRepoDir).canonicalFile).path
+                .relativeTo(File(effectiveRepoDir).canonicalFile).invariantSeparatorsPath
             feature.copy(
                 specification = specificationPath,
                 scenarios = feature.scenarios.map { it.copy(specification = specificationPath) },

--- a/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckCommandV2.kt
+++ b/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckCommandV2.kt
@@ -95,7 +95,15 @@ class BackwardCompatibilityCheckCommandV2(options: BackwardCompatibilityCheckOpt
 
     override fun getFeatureFromSpecPath(path: String): Feature {
         logger.disableInfoLogging()
-        return OpenApiSpecification.fromFile(path).toFeature().also {
+        return try {
+            val feature = OpenApiSpecification.fromFile(path).toFeature()
+            val specificationPath = File(path).canonicalFile
+                .relativeTo(File(effectiveRepoDir).canonicalFile).path
+            feature.copy(
+                specification = specificationPath,
+                scenarios = feature.scenarios.map { it.copy(specification = specificationPath) },
+            )
+        } finally {
             logger.enableInfoLogging()
         }
     }

--- a/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
+++ b/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
@@ -1752,10 +1752,11 @@ class BackwardCompatibilityCheckCommandV2Test {
                 }
             }
 
+            // The report records the spec path relative to the repo root, not the absolute path.
             assertThat(operationsBySpec).containsOnly(
-                entry(compatibleSpecPath, "GET /compatible -> compatible"),
-                entry(hookPassedSpecPath, "GET /hook-passed -> incompatible"),
-                entry(hookFailedSpecPath, "GET /hook-failed -> incompatible")
+                entry("compatible.yaml", "GET /compatible -> compatible"),
+                entry(MixedResultBackwardCompatibilityCheckHook.PASSED_SPEC, "GET /hook-passed -> incompatible"),
+                entry(MixedResultBackwardCompatibilityCheckHook.FAILED_SPEC, "GET /hook-failed -> incompatible")
             )
         }
 
@@ -1912,9 +1913,10 @@ class BackwardCompatibilityCheckCommandV2Test {
                     "${it.path("method").asText()} ${it.path("path").asText()} -> ${it.path("status").asText()}"
                 }
             }
+            // The report records the spec path relative to the repo root, not the absolute path.
             assertThat(operationsBySpec).containsOnly(
-                entry(spec1Path, "GET /a -> incompatible"),
-                entry(spec2Path, "GET /b -> incompatible")
+                entry("spec1.yaml", "GET /a -> incompatible"),
+                entry("spec2.yaml", "GET /b -> incompatible")
             )
 
             // The breadcrumbs in the CTRF report carry the same source locations that appear in
@@ -2052,8 +2054,82 @@ class BackwardCompatibilityCheckCommandV2Test {
                 }
             }
             assertThat(operationsBySpec).containsOnly(
-                entry(specPath, "GET /a -> incompatible")
+                entry("spec.yaml", "GET /a -> incompatible")
             )
+        }
+
+        @Test
+        fun `report records every spec path relative to the repo root`() {
+            fun spec(path: String, type: String) = """
+                openapi: 3.0.0
+                info: { title: API, version: 1.0.0 }
+                paths:
+                  $path:
+                    get:
+                      responses:
+                        '200':
+                          description: ok
+                          content:
+                            application/json:
+                              schema:
+                                type: object
+                                required: [value]
+                                properties: { value: { type: $type } }
+            """.trimIndent()
+
+            // Three specs at increasing depths under the repo root.
+            val rootSpec = tempDir.resolve("orders.yaml")
+            val nestedSpec = tempDir.resolve("api/products.yaml").apply { parentFile.mkdirs() }
+            val deeplyNestedSpec = tempDir.resolve("internal/v2/payments.yaml").apply { parentFile.mkdirs() }
+
+            rootSpec.writeText(spec("/orders", "string"))
+            nestedSpec.writeText(spec("/products", "string"))
+            deeplyNestedSpec.writeText(spec("/payments", "string"))
+            commit(tempDir, "Initial contracts")
+            val baseBranch = SystemGit(tempDir.absolutePath).currentBranch()
+
+            ProcessBuilder("git", "switch", "-c", "breaking-change")
+                .directory(tempDir)
+                .inheritIO()
+                .start()
+                .waitFor()
+
+            // Each spec changes its response body type from string to integer (a breaking change),
+            // so every spec shows up in the report.
+            rootSpec.writeText(spec("/orders", "integer"))
+            nestedSpec.writeText(spec("/products", "integer"))
+            deeplyNestedSpec.writeText(spec("/payments", "integer"))
+            commit(tempDir, "Make every spec breaking")
+
+            val configFile = remoteDir.resolve("specmatic.yaml").apply {
+                writeText(
+                    """
+                    version: 2
+                    reportDirPath: ${tempDir.resolve("reports").canonicalPath}
+                    """.trimIndent()
+                )
+            }
+
+            captureStandardOutput(redirectStdErrToStdout = true) {
+                using(CONFIG_FILE_PATH to configFile.canonicalPath) {
+                    BackwardCompatibilityCheckCommandV2().apply {
+                        options.repoDir = tempDir.canonicalPath
+                        options.baseBranch = baseBranch
+                    }.call()
+                }
+            }
+
+            val recordedSpecPaths = bccReportJson(tempDir.resolve("reports/backward_compatibility"))
+                .path("results").path("summary").path("extra").path("executionDetails")
+                .map { it.path("specification").asText().replace('\\', '/') }
+                .toSet()
+
+            // The report records each spec as its path relative to the repo root (tempDir),
+            // never as an absolute path: orders.yaml, api/products.yaml, internal/v2/payments.yaml.
+            val repoRoot = tempDir.canonicalFile
+            assertThat(recordedSpecPaths).contains(rootSpec.canonicalFile.relativeTo(repoRoot).invariantSeparatorsPath)
+            assertThat(recordedSpecPaths).contains(nestedSpec.canonicalFile.relativeTo(repoRoot).invariantSeparatorsPath)
+            assertThat(recordedSpecPaths).contains(deeplyNestedSpec.canonicalFile.relativeTo(repoRoot).invariantSeparatorsPath)
         }
     }
 


### PR DESCRIPTION
## What

The backward-compatibility-check (BCC) CTRF report recorded the spec path as an **absolute** filesystem path, whereas the mock/test coverage CTRF reports record it **relative to the repo root**. This PR makes the BCC report consistent with them.

## Why

In the BCC flow, features were loaded via `getFeatureFromSpecPath` → `OpenApiSpecification.fromFile(path)` without a `specificationPath`, so the scenarios had no `specification` and the record fell back to `feature.path` — the canonical/absolute path. Mock/test coverage never hit that fallback because they load specs through the specmatic config sources, which carry the relative path.

## How

`getFeatureFromSpecPath` now stamps the **repo-root-relative** path onto the loaded feature and its scenarios, mirroring the relativization already used for the hook call (`File(path).canonicalFile.relativeTo(File(effectiveRepoDir).canonicalFile)`). Because the record computes `specification = scenario.specification ?: feature.path`, populating `scenario.specification` yields the relative path.

The `feature.path` fallback is intentionally left in place for non-command callers of the checker (e.g. features built inline in core unit tests), keeping the change minimal — the guarantee that the command always sets the relative path is documented through the command tests.

## Tests

- New `report records every spec path relative to the repo root` test: three specs at increasing depths (`orders.yaml`, `api/products.yaml`, `internal/v2/payments.yaml`), each asserted to be recorded relative to the repo root.
- Updated the existing `BccReportTests` assertions that previously expected absolute spec paths to expect the relative names (console-output assertions, which use `feature.path`, remain absolute).

Verified: `:specmatic-executable:test --tests 'application.BackwardCompatibilityCheckCommandV2Test'` and the related core BCC tests all pass.