### PR TITLE
Fix issue related to loading and aggregating external examples

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/examples/source/DirectoryExampleSource.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/source/DirectoryExampleSource.kt
@@ -12,15 +12,13 @@ import java.io.File
 class DirectoryExampleSource(val exampleDirs: List<String>, val strictMode: Boolean, val specmaticConfig: SpecmaticConfig) : ExampleSource {
     override val examples: Map<OpenApiSpecification.OperationIdentifier, List<Row>>
         get() {
-            return exampleDirs.flatMap { directory ->
-                loadExternalisedJSONExamples(File(directory)).entries
-            }.associate { it.toPair() }
+            return exampleDirs.map(::File).distinctBy { it.normalizedPath() }
+                .flatMap { directory -> loadExternalisedJSONExamples(directory).entries }
+                .groupBy(keySelector = { it.key }, valueTransform = { it.value })
+                .mapValues { (_, lists) -> lists.flatten() }
         }
 
-    private fun loadExternalisedJSONExamples(testsDirectory: File?): Map<OpenApiSpecification.OperationIdentifier, List<Row>> {
-        if (testsDirectory == null)
-            return emptyMap()
-
+    private fun loadExternalisedJSONExamples(testsDirectory: File): Map<OpenApiSpecification.OperationIdentifier, List<Row>> {
         if (!testsDirectory.exists())
             return emptyMap()
 
@@ -30,17 +28,10 @@ class DirectoryExampleSource(val exampleDirs: List<String>, val strictMode: Bool
 
         if (files.isEmpty()) return emptyMap()
 
-        val examplesInSubdirectories: Map<OpenApiSpecification.OperationIdentifier, List<Row>> =
-            files.filter {
-                it.isDirectory
-            }.fold(emptyMap()) { acc, item ->
-                acc + loadExternalisedJSONExamples(item)
-            }
-
         logger.log("Loading externalised examples in ${testsDirectory.path}: ")
         logger.boundary()
 
-        return examplesInSubdirectories + files.asSequence()
+        return files.asSequence()
             .filterNot { it.isDirectory }
             .mapNotNull { exampleFile ->
                 runCatching { ExampleFromFile(exampleFile) }.getOrElse { e ->
@@ -53,5 +44,9 @@ class DirectoryExampleSource(val exampleDirs: List<String>, val strictMode: Bool
             }.map { example -> OpenApiSpecification.OperationIdentifier(example) to example.toRow(specmaticConfig) }
             .groupBy { (operationIdentifier, _) -> operationIdentifier }
             .mapValues { (_, value) -> value.map { it.second } }
+    }
+
+    private fun File.normalizedPath(): String {
+        return runCatching { canonicalPath }.getOrElse { absolutePath }
     }
 }

--- a/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
+++ b/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
@@ -6,6 +6,9 @@ import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.core.*
+import io.specmatic.core.examples.source.CombinedSource
+import io.specmatic.core.examples.source.DirectoryExampleSource
+import io.specmatic.core.examples.source.PreLoadedExampleObjects
 import io.specmatic.core.examples.module.ExampleValidationModule
 import io.specmatic.core.log.*
 import io.specmatic.core.pattern.ContractException
@@ -39,6 +42,8 @@ private val XML_ONEOF_EXTERNAL_EXAMPLES_DIR = XML_ONEOF_RESOURCE_DIR.resolve("ap
 private val XML_ONEOF_INVALID_INVOICE_EXAMPLE = XML_ONEOF_RESOURCE_DIR.resolve("invalid_examples/invoice.json")
 
 class LoadTestsFromExternalisedFiles {
+    @TempDir
+    lateinit var tempDir: File
 
     @BeforeEach
     fun setup() {
@@ -115,6 +120,80 @@ class LoadTestsFromExternalisedFiles {
         println(results.report())
         assertThat(results.successCount).isEqualTo(2)
         assertThat(results.failureCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `should load examples from spec _examples and explicit example directories`() {
+        val specDir = tempDir.resolve("contract").apply { mkdirs() }
+        val specFile = specDir.resolve("order.yaml")
+        specFile.writeText("""
+        openapi: 3.0.0
+        info:
+          title: Order API
+          version: 1.0.0
+        paths:
+          /orders:
+            post:
+              requestBody:
+                required: true
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      properties:
+                        source:
+                          type: string
+                      required:
+                        - source
+              responses:
+                '200':
+                  description: ok
+        """.trimIndent())
+
+        val implicitExamplesDir = specDir.resolve("order_examples").apply { mkdirs() }
+        implicitExamplesDir.resolve("implicit.json").writeText("""
+        {
+          "http-request": {
+            "method": "POST",
+            "path": "/orders",
+            "body": { "source": "implicit" }
+          },
+          "http-response": { "status": 200 }
+        }
+        """.trimIndent())
+
+        val explicitExamplesDir = tempDir.resolve("explicit_examples").apply { mkdirs() }
+        explicitExamplesDir.resolve("explicit.json").writeText("""
+        {
+          "http-request": {
+            "method": "POST",
+            "path": "/orders",
+            "body": { "source": "explicit" }
+          },
+          "http-response": { "status": 200 }
+        }
+        """.trimIndent())
+
+        val feature = parseContractFileToFeature(specFile, exampleDirPaths = listOf(implicitExamplesDir.canonicalPath))
+        val (loadedFeature, unusedExamples) = feature.loadExternalisedExamplesAndListUnloadableExamples(
+            exampleSource = CombinedSource(
+                sources = listOf(
+                    DirectoryExampleSource(
+                        strictMode = true,
+                        exampleDirs = listOf(implicitExamplesDir.canonicalPath),
+                        specmaticConfig = feature.specmaticConfig
+                    ),
+                    PreLoadedExampleObjects(
+                        specmaticConfig = feature.specmaticConfig,
+                        examples = listOf(ScenarioStub.readFromFile(explicitExamplesDir.resolve("explicit.json"))),
+                    )
+                )
+            )
+        )
+
+        assertThat(loadedFeature.scenarios).hasSize(1)
+        assertThat(loadedFeature.scenarios.single().examples.single().rows).hasSize(2)
+        assertThat(unusedExamples).isEmpty()
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/core/examples/source/CombinedSourceTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/examples/source/CombinedSourceTest.kt
@@ -1,0 +1,41 @@
+package io.specmatic.core.examples.source
+
+import io.specmatic.core.SpecmaticConfigV1V2Common
+import io.specmatic.mock.ScenarioStub
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class CombinedSourceTest {
+    @Test
+    fun `should merge same operation from multiple preloaded sources`(@TempDir tempDir: File) {
+        val firstExample = tempDir.resolve("first.json").apply { writeText(exampleFile("first")) }
+        val secondExample = tempDir.resolve("second.json").apply { writeText(exampleFile("second")) }
+        val combinedSource = CombinedSource(
+            sources = listOf(
+                PreLoadedExampleObjects(listOf(ScenarioStub.readFromFile(firstExample)), SpecmaticConfigV1V2Common()),
+                PreLoadedExampleObjects(listOf(ScenarioStub.readFromFile(secondExample)), SpecmaticConfigV1V2Common())
+            )
+        )
+
+        val examples = combinedSource.examples
+        val rows = examples.values.single()
+        assertThat(examples).hasSize(1)
+        assertThat(rows).hasSize(2)
+        assertThat(rows.map { it.fileSource }).containsExactlyInAnyOrder(
+            firstExample.canonicalPath,
+            secondExample.canonicalPath
+        )
+    }
+
+    private fun exampleFile(source: String): String = """{
+      "name": "$source",
+      "http-request": {
+        "path": "/test",
+        "method": "GET",
+        "body": { "source": "$source" }
+      },
+      "http-response": { "status": 200 }
+    }""".trimIndent()
+}

--- a/core/src/test/kotlin/io/specmatic/core/examples/source/DirectoryExampleSourceTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/examples/source/DirectoryExampleSourceTest.kt
@@ -1,0 +1,64 @@
+package io.specmatic.core.examples.source
+
+import io.specmatic.core.SpecmaticConfigV1V2Common
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class DirectoryExampleSourceTest {
+    @Test
+    fun `should load examples from multiple directories without overwriting same operation`(@TempDir tempDir: File) {
+        val firstDir = tempDir.resolve("first_examples").apply { mkdirs() }
+        firstDir.resolve("first.json").writeText(exampleFile("first"))
+
+        val secondDir = tempDir.resolve("second_examples").apply { mkdirs() }
+        secondDir.resolve("second.json").writeText(exampleFile("second"))
+
+        val exampleSource = DirectoryExampleSource(
+            strictMode = true,
+            exampleDirs = listOf(firstDir.canonicalPath, secondDir.canonicalPath),
+            specmaticConfig = SpecmaticConfigV1V2Common()
+        )
+
+        val examples = exampleSource.examples
+        val operationIdentifier = examples.keys.single()
+        val rows = examples[operationIdentifier].orEmpty()
+        assertThat(examples).hasSize(1)
+        assertThat(rows).hasSize(2)
+        assertThat(rows.map { it.fileSource }).containsExactlyInAnyOrder(
+            firstDir.resolve("first.json").canonicalPath,
+            secondDir.resolve("second.json").canonicalPath
+        )
+    }
+
+    @Test
+    fun `should load nested examples multi levels deep`(@TempDir tempDir: File) {
+        val rootDir = tempDir.resolve("root_examples").apply { mkdirs() }
+        val levelOne = rootDir.resolve("level_one").apply { mkdirs() }
+        val levelTwo = levelOne.resolve("level_two").apply { mkdirs() }
+        val levelThree = levelTwo.resolve("level_three").apply { mkdirs() }
+        val deepExample = levelThree.resolve("deep.json")
+
+        deepExample.writeText(exampleFile("deep"))
+        val exampleSource = DirectoryExampleSource(
+            strictMode = true,
+            exampleDirs = listOf(rootDir.canonicalPath),
+            specmaticConfig = SpecmaticConfigV1V2Common()
+        )
+
+        val rows = exampleSource.examples.values.single()
+        assertThat(rows).hasSize(1)
+        assertThat(rows.single().fileSource).isEqualTo(deepExample.canonicalPath)
+    }
+
+    private fun exampleFile(source: String): String = """{
+      "name": "$source",
+      "http-request": {
+        "path": "/test",
+        "method": "GET",
+        "body": { "source": "$source" }
+      },
+      "http-response": { "status": 200 }
+    }""".trimIndent()
+}


### PR DESCRIPTION
**What**: Fix issue related to loading and aggregating external examples

**Why**: The use of `.associate { it.toPair() }` resulted in the loss of examples, as the last key would overwrite all previous entries. Consequently, some examples with identical identifiers from different directories were being lost

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
