### PR TITLE
Annotate BCC source locations as a chain through external $refs

### DIFF
--- a/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
+++ b/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
@@ -2200,7 +2200,11 @@ class BackwardCompatibilityCheckCommandV2Test {
             assertThat(normalizedOut).contains("Verdict for spec $apiA:")
             assertThat(normalizedOut).contains("Verdict for spec $apiB:")
             // Both referring specs are incompatible, each annotated at the change in the shared file.
-            assertThat(normalizedOut.split(">> REQUEST.BODY.name ($common:10:9)")).hasSize(3)
+            // The location is a chain that starts at each spec's own ref use-site and ends at the
+            // shared external change, so the tail is reached twice — once per referring spec.
+            assertThat(normalizedOut.split("-> $common:10:9)")).hasSize(3)
+            assertThat(normalizedOut).contains("($apiA:")
+            assertThat(normalizedOut).contains("($apiB:")
         }
 
         private fun productBase(type: String) = """

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -2213,18 +2213,28 @@ class OpenApiSpecification(
     private data class ProjectedExternalRefUse(
         val refUse: ExternalRefUse,
         val modelPointer: String,
+        // The $ref use-site hops taken to reach this ref, head-first (entry spec first), including
+        // this ref's own use-site. Becomes the `via` chain of every location under its projection.
+        val via: List<SourceLocation>,
     )
 
-    // Recovers where each external source subtree appears in the resolved parser model.
-    // External schemas may be imported as renamed internal refs (Payload -> Payload_1), while
-    // whole-file PathItem/response/requestBody refs are usually inlined at the use site.
-    private val externalSourceProjections: Set<ExternalSourceProjection> by lazy {
-        val projections = linkedSetOf<ExternalSourceProjection>()
+    private fun useSiteLocation(file: String, pointer: String): SourceLocation? {
+        val node = sourceMapFor(file)[pointer] ?: return null
+        return SourceLocation(File(file).invariantSeparatorsPath, node.line, node.column)
+    }
+
+    // Recovers where each external source subtree appears in the resolved parser model, along with
+    // the chain of $ref use-sites that led there (first-seen wins, so the chain is the shortest path
+    // discovered by the BFS). External schemas may be imported as renamed internal refs
+    // (Payload -> Payload_1), while whole-file PathItem/response/requestBody refs are usually
+    // inlined at the use site.
+    private val externalSourceProjections: Map<ExternalSourceProjection, List<SourceLocation>> by lazy {
+        val projections = LinkedHashMap<ExternalSourceProjection, List<SourceLocation>>()
         val refUsesBySourceFile = externalRefUses.groupBy { it.sourceFile }
         val queue = ArrayDeque(
             externalRefUses
                 .filter { it.sourceFile == entryFileKey }
-                .map { ProjectedExternalRefUse(it, it.sourcePointer) }
+                .map { ProjectedExternalRefUse(it, it.sourcePointer, listOfNotNull(useSiteLocation(it.sourceFile, it.sourcePointer))) }
         )
 
         while (queue.isNotEmpty()) {
@@ -2239,10 +2249,17 @@ class OpenApiSpecification(
                     targetPointer = targetPointer,
                 )
 
-                if (projections.add(projection)) {
+                if (projection !in projections) {
+                    projections[projection] = projectedRefUse.via
                     refUsesBySourceFile[projection.sourceFile].orEmpty()
                         .filter { projection.contains(it.sourceFile, it.sourcePointer) }
-                        .mapTo(queue) { ProjectedExternalRefUse(it, projection.targetPointerFor(it.sourcePointer)) }
+                        .mapTo(queue) { childRefUse ->
+                            ProjectedExternalRefUse(
+                                childRefUse,
+                                projection.targetPointerFor(childRefUse.sourcePointer),
+                                projectedRefUse.via + listOfNotNull(useSiteLocation(childRefUse.sourceFile, childRefUse.sourcePointer)),
+                            )
+                        }
                 }
             }
         }
@@ -2270,11 +2287,11 @@ class OpenApiSpecification(
         entryMap.forEach { (pointer, node) ->
             locations[pointer] = SourceLocation(entryFileKey, node.line, node.column)
         }
-        externalSourceProjections.forEach { projection ->
+        externalSourceProjections.forEach { (projection, via) ->
             val displayPath = File(projection.sourceFile).invariantSeparatorsPath
             sourceMapFor(projection.sourceFile).forEach { (pointer, node) ->
                 if (projection.contains(projection.sourceFile, pointer)) {
-                    locations[projection.targetPointerFor(pointer)] = SourceLocation(displayPath, node.line, node.column)
+                    locations[projection.targetPointerFor(pointer)] = SourceLocation(displayPath, node.line, node.column, via = via)
                 }
             }
         }

--- a/core/src/main/kotlin/io/specmatic/core/FailureReport.kt
+++ b/core/src/main/kotlin/io/specmatic/core/FailureReport.kt
@@ -67,8 +67,11 @@ data class FailureReport(val contractPath: String?, private val scenarioMessage:
         val crumbs = breadCrumbString(matchFailureDetails.breadCrumbs)
         val locationSuffix = if (addSourceLocation) {
             matchFailureDetails.sourceLocation?.let { loc ->
-                if (loc.filePath.isBlank()) null
-                else "(${loc.filePath}:${loc.line}:${loc.column})"
+                val chain = (loc.via + loc).filterNot { it.filePath.isBlank() }
+                if (chain.isEmpty()) null
+                else chain.joinToString(separator = " -> ", prefix = "(", postfix = ")") {
+                    "${it.filePath}:${it.line}:${it.column}"
+                }
             }
         } else null
         val crumbsWithLocation = when {

--- a/core/src/main/kotlin/io/specmatic/core/Result.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Result.kt
@@ -440,7 +440,15 @@ data class MatchFailureDetails(
     val sourceLocation: SourceLocation? = null
 )
 
-data class SourceLocation(val filePath: String, val line: Int, val column: Int)
+// `via` holds the ordered $ref use-site hops that lead to this location, head-first (the use-site in
+// the spec under check), excluding this location itself which is the tail (the actual source of the
+// breakage). Empty for locations that live directly in the entry spec.
+data class SourceLocation(
+    val filePath: String,
+    val line: Int,
+    val column: Int,
+    val via: List<SourceLocation> = emptyList()
+)
 
 interface MismatchMessages {
     fun mismatchMessage(expected: String, actual: String): String

--- a/core/src/test/kotlin/io/specmatic/core/FailureReportTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FailureReportTest.kt
@@ -218,6 +218,37 @@ internal class FailureReportTest {
         """.trimIndent().trimmedLinesString())
     }
 
+    @Nested
+    inner class SourceLocationChainRendering {
+        private fun reportFor(sourceLocation: SourceLocation?, addSourceLocation: Boolean): String {
+            val details = MatchFailureDetails(listOf("REQUEST", "BODY", "name"), listOf("error"), sourceLocation = sourceLocation)
+            return FailureReport(null, null, null, listOf(details), addSourceLocation = addSourceLocation).toText()
+        }
+
+        @Test
+        fun `a chain renders every hop joined head to tail`() {
+            val location = SourceLocation(
+                "common.yaml", 10, 9,
+                via = listOf(SourceLocation("api.yaml", 10, 13), SourceLocation("commonA.yaml", 10, 9))
+            )
+            assertThat(reportFor(location, addSourceLocation = true))
+                .contains(">> REQUEST.BODY.name (api.yaml:10:13 -> commonA.yaml:10:9 -> common.yaml:10:9)")
+        }
+
+        @Test
+        fun `a location with no via renders as a single hop with no arrow`() {
+            assertThat(reportFor(SourceLocation("api.yaml", 7, 11), addSourceLocation = true))
+                .contains(">> REQUEST.BODY.name (api.yaml:7:11)")
+        }
+
+        @Test
+        fun `the chain is omitted when source locations are disabled`() {
+            val location = SourceLocation("common.yaml", 10, 9, via = listOf(SourceLocation("api.yaml", 10, 13)))
+            assertThat(reportFor(location, addSourceLocation = false))
+                .contains(">> REQUEST.BODY.name").doesNotContain("->").doesNotContain("common.yaml")
+        }
+    }
+
     @Test
     fun `mergeMatchFailureDetailsFrom should append match failure details from the other report`() {
         val firstDetail = MatchFailureDetails(listOf("person", "id"), listOf("first error"))

--- a/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
@@ -5742,8 +5742,8 @@ paths:
                 assertThat(results.success()).isFalse()
                 val commonA = at("path-item-same-fragment-collision", "new/commonA.yaml")
                 val commonB = at("path-item-same-fragment-collision", "new/commonB.yaml")
-                assertThat(results.report()).contains(">> RESPONSE.BODY.state ($commonA:17:21)")
-                assertThat(results.report()).contains(">> RESPONSE.BODY.state ($commonB:18:21)")
+                assertThat(results.report()).contains("-> $commonA:17:21)")
+                assertThat(results.report()).contains("-> $commonB:18:21)")
             }
 
             // The entry spec owns #/components/pathItems/Status AND also refs an external file's
@@ -5755,8 +5755,10 @@ paths:
                 assertThat(results.success()).isFalse()
                 val api = at("entry-owns-path-item-fragment", "new/api.yaml")
                 val common = at("entry-owns-path-item-fragment", "new/common.yaml")
+                // The entry owns this path item, so the change is anchored directly in the entry spec:
+                // a single-hop chain with no `->`, not relocated into the external file.
                 assertThat(results.report()).contains(">> RESPONSE.BODY.state ($api:21:21)")
-                assertThat(results.report()).doesNotContain(">> RESPONSE.BODY.state ($common:18:21)")
+                assertThat(results.report()).doesNotContain("$common:18:21)")
             }
 
             @Test
@@ -5765,8 +5767,8 @@ paths:
                 assertThat(results.success()).isFalse()
                 val commonA = at("requestbody-same-fragment-collision", "new/commonA.yaml")
                 val commonB = at("requestbody-same-fragment-collision", "new/commonB.yaml")
-                assertThat(results.report()).contains(">> REQUEST.BODY.name ($commonA:14:15)")
-                assertThat(results.report()).contains(">> REQUEST.BODY.name ($commonB:15:15)")
+                assertThat(results.report()).contains("-> $commonA:14:15)")
+                assertThat(results.report()).contains("-> $commonB:15:15)")
             }
 
             @Test
@@ -5775,13 +5777,35 @@ paths:
                 assertThat(results.success()).isFalse()
                 val commonA = at("response-same-fragment-collision", "new/commonA.yaml")
                 val commonB = at("response-same-fragment-collision", "new/commonB.yaml")
-                assertThat(results.report()).contains(">> RESPONSE.BODY.name ($commonA:14:15)")
-                assertThat(results.report()).contains(">> RESPONSE.BODY.name ($commonB:15:15)")
+                assertThat(results.report()).contains("-> $commonA:14:15)")
+                assertThat(results.report()).contains("-> $commonB:15:15)")
             }
 
             @Test
             fun `the change is two ref hops away in a transitive chain`() =
                 assertLocated("transitive-chain", ">> REQUEST.BODY.detail.value", "new/commonB.yaml:10:9")
+
+            // The full source-location chain is rendered head -> ... -> tail: the use-site in the entry
+            // spec, each intermediate $ref use-site, then the actual source of the change. This pins the
+            // whole rendering so the chain can be reduced to a single root downstream.
+            @Test
+            fun `a single external hop renders the entry use-site then the external source`() {
+                val results = compare("request-body")
+                val api = at("request-body", "new/api.yaml")
+                val common = at("request-body", "new/common.yaml")
+                assertThat(locationChainFor(results.report(), ">> REQUEST.BODY.name"))
+                    .isEqualTo("$api:10:13 -> $common:10:9")
+            }
+
+            @Test
+            fun `a transitive chain renders every ref hop from the entry spec to the source`() {
+                val results = compare("transitive-chain")
+                val api = at("transitive-chain", "new/api.yaml")
+                val commonA = at("transitive-chain", "new/commonA.yaml")
+                val commonB = at("transitive-chain", "new/commonB.yaml")
+                assertThat(locationChainFor(results.report(), ">> REQUEST.BODY.detail.value"))
+                    .isEqualTo("$api:10:13 -> $commonA:10:9 -> $commonB:10:9")
+            }
 
             @Test
             fun `a transitive ref renamed during import keeps its external source location`() =
@@ -5825,8 +5849,8 @@ paths:
                 assertThat(results.success()).isFalse()
                 val commonA = at("same-fragment-collision", "new/commonA.yaml")
                 val commonB = at("same-fragment-collision", "new/commonB.yaml")
-                assertThat(results.report()).contains(">> REQUEST.BODY.name ($commonA:10:9)")
-                assertThat(results.report()).contains(">> REQUEST.BODY.name ($commonB:12:9)")
+                assertThat(results.report()).contains("-> $commonA:10:9)")
+                assertThat(results.report()).contains("-> $commonB:12:9)")
             }
 
             @Test
@@ -5876,12 +5900,25 @@ paths:
             fun `a header parameter whose schema is an external ref is annotated at its declaration in the entry spec`() =
                 assertLocated("header-param-schema", ">> REQUEST.PARAMETERS.HEADER.X-Tenant", "new/api.yaml:7:11")
 
+            // The breadcrumb now carries a source-location chain `head -> ... -> tail`, where the tail
+            // is the actual source of the change. These cases assert tail correctness; the chain's
+            // head-to-tail rendering is pinned separately below.
             private fun assertLocated(case: String, breadcrumb: String, fileLineCol: String) {
                 val results = compare(case)
                 assertThat(results.success()).isFalse()
                 val file = at(case, fileLineCol.substringBefore(":"))
                 val lineCol = fileLineCol.substringAfter(":")
-                assertThat(results.report()).contains("$breadcrumb ($file:$lineCol)")
+                assertThat(locationChainFor(results.report(), breadcrumb)).endsWith("$file:$lineCol")
+            }
+
+            // Returns the source-location chain rendered inside the parentheses after `breadcrumb`,
+            // e.g. "/a/api.yaml:10:13 -> /a/common.yaml:10:9". Chains contain no nested parens.
+            private fun locationChainFor(report: String, breadcrumb: String): String {
+                val marker = "$breadcrumb ("
+                val start = report.indexOf(marker)
+                require(start >= 0) { "Located breadcrumb '$breadcrumb' not found in report:\n$report" }
+                val open = start + marker.length
+                return report.substring(open, report.indexOf(')', open))
             }
 
             private fun compare(case: String): Results {


### PR DESCRIPTION
Stacked on top of #2533.

Annotates BCC source locations so that they form a chain through external $refs, making it possible to trace a breadcrumb's source location across referenced external files.

## Changes
- `OpenApiSpecification.kt` — build the source-location chain through external $refs
- `Result.kt` / `FailureReport.kt` — carry and render the chained source locations
- Tests in `FailureReportTest`, `TestBackwardCompatibilityKtTest`, `BackwardCompatibilityCheckCommandV2Test`