### PR TITLE
BCC: emit structured breakages metadata for the grouped HTML report

### DIFF
--- a/application/build.gradle.kts
+++ b/application/build.gradle.kts
@@ -64,4 +64,13 @@ tasks.test {
 
         listOf("-javaagent:$junit5SystemExit")
     })
+
+    // Keep tests hermetic from any developer license at ~/.specmatic/specmatic-license.txt: point the
+    // home-dir license loader (its documented "for test injection" hook) at a non-existent file so the
+    // suite always resolves the OSS license, matching CI. Without this, an ENTERPRISE/TRIAL license on
+    // the machine would make BCC tests emit an extra "Generating CTRF report" line and fail.
+    systemProperty(
+        "specmatic.license.file",
+        layout.buildDirectory.file("test-no-license.txt").get().asFile.absolutePath,
+    )
 }

--- a/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckCommandV2.kt
+++ b/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckCommandV2.kt
@@ -25,7 +25,7 @@ import kotlin.io.path.pathString
 class BackwardCompatibilityCheckCommandV2(options: BackwardCompatibilityCheckOptions = BackwardCompatibilityCheckOptions()): BackwardCompatibilityCheckBaseCommand(options) {
 
     override fun checkBackwardCompatibility(oldFeature: IFeature, newFeature: IFeature): BackwardCompatibilityCheckResult {
-        val (results, records) = backwardCompatibilityRecords(oldFeature as Feature, newFeature as Feature)
+        val (results, records) = backwardCompatibilityRecords(oldFeature as Feature, newFeature as Feature, effectiveRepoDir)
         return BackwardCompatibilityCheckResult(results, records)
     }
 

--- a/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
+++ b/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
@@ -594,26 +594,26 @@ class BackwardCompatibilityCheckCommandV2Test {
                 In scenario "GET /orders. Response: bad request"
                 API: GET /orders -> 400
 
-                  >> RESPONSE.BODY.code (${spec.canonicalFile.invariantSeparatorsPath}:157:9)
+                  >> RESPONSE.BODY.code (${spec.name}:157:9)
 
                       This is number in the new specification response but string in the old specification
 
                 In scenario "GET /orders. Response: server error"
                 API: GET /orders -> 500
 
-                      This API exists in the old contract but not in the new contract (${spec.canonicalFile.invariantSeparatorsPath}:28:9)
+                      This API exists in the old contract but not in the new contract (${spec.name}:28:9)
 
                 In scenario "DELETE /orders/(id:string). Response: deleted"
                 API: DELETE /orders/(id:string) -> 204
 
-                      This API exists in the old contract but not in the new contract (${spec.canonicalFile.invariantSeparatorsPath}:87:5)
+                      This API exists in the old contract but not in the new contract (${spec.name}:87:5)
               ________________________________________
               WIP scenarios (incompatible, not breaking the check):
 
                 In scenario "GET /promotions. Response: ok"
                 API: GET /promotions -> 200
 
-                  >> RESPONSE.BODY.code (${spec.canonicalFile.invariantSeparatorsPath}:105:19)
+                  >> RESPONSE.BODY.code (${spec.name}:105:19)
 
                       This is number in the new specification response but string in the old specification
 
@@ -926,7 +926,7 @@ class BackwardCompatibilityCheckCommandV2Test {
                 In scenario "GET /b. Response: ok"
                 API: GET /b -> 200
 
-                  >> RESPONSE.BODY.code (${spec.canonicalFile.invariantSeparatorsPath}:26:31)
+                  >> RESPONSE.BODY.code (${spec.name}:26:31)
 
                       This is number in the new specification response but string in the old specification
               --------------------
@@ -1008,7 +1008,7 @@ class BackwardCompatibilityCheckCommandV2Test {
                 In scenario "GET /a. Response: ok"
                 API: GET /a -> 200
 
-                  >> RESPONSE.BODY.value (${spec.canonicalFile.invariantSeparatorsPath}:14:31)
+                  >> RESPONSE.BODY.value (${spec.name}:14:31)
 
                       This is number in the new specification response but string in the old specification
 
@@ -1120,7 +1120,7 @@ class BackwardCompatibilityCheckCommandV2Test {
                 In scenario "GET /a. Response: ok"
                 API: GET /a -> 200
 
-                  >> RESPONSE.BODY.value (${spec.canonicalFile.invariantSeparatorsPath}:14:31)
+                  >> RESPONSE.BODY.value (${spec.name}:14:31)
 
                       This is number in the new specification response but string in the old specification
 
@@ -1232,7 +1232,7 @@ class BackwardCompatibilityCheckCommandV2Test {
                 In scenario "GET /a. Response: ok"
                 API: GET /a -> 200
 
-                  >> RESPONSE.BODY.value (${spec.canonicalFile.invariantSeparatorsPath}:14:31)
+                  >> RESPONSE.BODY.value (${spec.name}:14:31)
 
                       This is number in the new specification response but string in the old specification
               ________________________________________
@@ -1241,7 +1241,7 @@ class BackwardCompatibilityCheckCommandV2Test {
                 In scenario "GET /b. Response: ok"
                 API: GET /b -> 200
 
-                  >> RESPONSE.BODY.code (${spec.canonicalFile.invariantSeparatorsPath}:26:31)
+                  >> RESPONSE.BODY.code (${spec.name}:26:31)
 
                       This is number in the new specification response but string in the old specification
 
@@ -1327,7 +1327,7 @@ class BackwardCompatibilityCheckCommandV2Test {
                 In scenario "GET /b. Response: ok"
                 API: GET /b -> 200
 
-                  >> RESPONSE.BODY.code (${spec.canonicalFile.invariantSeparatorsPath}:15:31)
+                  >> RESPONSE.BODY.code (${spec.name}:15:31)
 
                       This is number in the new specification response but string in the old specification
               --------------------
@@ -1410,7 +1410,7 @@ class BackwardCompatibilityCheckCommandV2Test {
                 In scenario "GET /a. Response: ok"
                 API: GET /a -> 200
 
-                  >> RESPONSE.BODY.value (${spec.canonicalFile.invariantSeparatorsPath}:15:31)
+                  >> RESPONSE.BODY.value (${spec.name}:15:31)
 
                       This is number in the new specification response but string in the old specification
               --------------------
@@ -1493,7 +1493,7 @@ class BackwardCompatibilityCheckCommandV2Test {
                 In scenario "GET /a. Response: ok"
                 API: GET /a -> 200
 
-                  >> RESPONSE.BODY.value (${spec.canonicalFile.invariantSeparatorsPath}:14:31)
+                  >> RESPONSE.BODY.value (${spec.name}:14:31)
 
                       This is number in the new specification response but string in the old specification
 
@@ -1710,7 +1710,7 @@ class BackwardCompatibilityCheckCommandV2Test {
                 In scenario "GET /hook-failed. Response: ok"
                 API: GET /hook-failed -> 200
 
-                  >> RESPONSE.BODY.value ($hookFailedSpecPath:14:31)
+                  >> RESPONSE.BODY.value (${hookFailedSpec.name}:14:31)
 
                       This is number in the new specification response but string in the old specification
 
@@ -1728,7 +1728,7 @@ class BackwardCompatibilityCheckCommandV2Test {
                 In scenario "GET /hook-passed. Response: ok"
                 API: GET /hook-passed -> 200
 
-                  >> RESPONSE.BODY.value ($hookPassedSpecPath:14:31)
+                  >> RESPONSE.BODY.value (${hookPassedSpec.name}:14:31)
 
                       This is number in the new specification response but string in the old specification
 
@@ -1870,7 +1870,7 @@ class BackwardCompatibilityCheckCommandV2Test {
                 In scenario "GET /a. Response: ok"
                 API: GET /a -> 200
 
-                  >> RESPONSE.BODY.value ($spec1Path:14:31)
+                  >> RESPONSE.BODY.value (${spec1.name}:14:31)
 
                       This is number in the new specification response but string in the old specification
 
@@ -1888,7 +1888,7 @@ class BackwardCompatibilityCheckCommandV2Test {
                 In scenario "GET /b. Response: ok"
                 API: GET /b -> 200
 
-                  >> RESPONSE.BODY.value ($spec2Path:14:31)
+                  >> RESPONSE.BODY.value (${spec2.name}:14:31)
 
                       This is number in the new specification response but string in the old specification
 
@@ -1924,9 +1924,9 @@ class BackwardCompatibilityCheckCommandV2Test {
             val testMessages = reportJson.path("results").path("tests")
                 .map { it.path("message").asText().replace('\\', '/') }
             assertThat(testMessages)
-                .anyMatch { it.contains("RESPONSE.BODY.value") && it.contains("$spec1Path:14:31") }
+                .anyMatch { it.contains("RESPONSE.BODY.value") && it.contains("${spec1.name}:14:31") }
             assertThat(testMessages)
-                .anyMatch { it.contains("RESPONSE.BODY.value") && it.contains("$spec2Path:14:31") }
+                .anyMatch { it.contains("RESPONSE.BODY.value") && it.contains("${spec2.name}:14:31") }
         }
 
         @Test
@@ -2028,7 +2028,7 @@ class BackwardCompatibilityCheckCommandV2Test {
                 In scenario "GET /a. Response: ok"
                 API: GET /a -> 200
 
-                  >> RESPONSE.BODY.value ($specPath:14:31)
+                  >> RESPONSE.BODY.value (${spec.name}:14:31)
 
                       This is number in the new specification response but string in the old specification
 
@@ -2266,7 +2266,6 @@ class BackwardCompatibilityCheckCommandV2Test {
             }
 
             assertThat(exitCode).isEqualTo(1)
-            val common = tempDir.resolve("common.yaml").canonicalFile.invariantSeparatorsPath
             val apiA = tempDir.resolve("apiA.yaml").canonicalFile.invariantSeparatorsPath
             val apiB = tempDir.resolve("apiB.yaml").canonicalFile.invariantSeparatorsPath
 
@@ -2277,10 +2276,11 @@ class BackwardCompatibilityCheckCommandV2Test {
             assertThat(normalizedOut).contains("Verdict for spec $apiB:")
             // Both referring specs are incompatible, each annotated at the change in the shared file.
             // The location is a chain that starts at each spec's own ref use-site and ends at the
-            // shared external change, so the tail is reached twice — once per referring spec.
-            assertThat(normalizedOut.split("-> $common:10:9)")).hasSize(3)
-            assertThat(normalizedOut).contains("($apiA:")
-            assertThat(normalizedOut).contains("($apiB:")
+            // shared external change, so the tail is reached twice — once per referring spec. Source
+            // locations are rendered relative to the repo root.
+            assertThat(normalizedOut.split("-> common.yaml:10:9)")).hasSize(3)
+            assertThat(normalizedOut).contains("(apiA.yaml:")
+            assertThat(normalizedOut).contains("(apiB.yaml:")
         }
 
         private fun productBase(type: String) = """

--- a/core/src/main/kotlin/io/specmatic/core/FailureReport.kt
+++ b/core/src/main/kotlin/io/specmatic/core/FailureReport.kt
@@ -50,7 +50,10 @@ data class FailureReport(val contractPath: String?, private val scenarioMessage:
                 breadCrumb = breadCrumbString(detail.breadCrumbs),
                 ruleViolations = detail.ruleViolationReport?.toSnapShots().orEmpty(),
                 details = errorMessagesToString(detail.errorMessages),
-                severity = if (detail.isPartial) IssueSeverity.WARNING else IssueSeverity.ERROR
+                severity = if (detail.isPartial) IssueSeverity.WARNING else IssueSeverity.ERROR,
+                sourceLocations = detail.sourceLocation?.let { loc ->
+                    (loc.via + loc).filterNot { it.filePath.isBlank() }
+                }.orEmpty()
             )
         }
     }

--- a/core/src/main/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityCheckRecord.kt
+++ b/core/src/main/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityCheckRecord.kt
@@ -3,7 +3,10 @@ package io.specmatic.core
 import io.specmatic.conversions.convertPathParameterStyle
 import io.specmatic.core.utilities.Flags
 import io.specmatic.reporter.ctrf.model.CtrfBackwardCompatibilityRecord
+import io.specmatic.reporter.ctrf.model.CtrfBreakage
 import io.specmatic.reporter.ctrf.model.CtrfOperationQualifiers
+import io.specmatic.reporter.ctrf.model.CtrfRuleSnapshot
+import io.specmatic.reporter.ctrf.model.CtrfSourceLocation
 import io.specmatic.reporter.internal.dto.operation.APIOperation
 import io.specmatic.reporter.model.BackwardCompatibilityStatus
 import io.specmatic.reporter.model.SpecType
@@ -28,6 +31,18 @@ data class OpenApiBackwardCompatibilityCheckRecord(
     // TODO: Need actual positive variation from generatedScenario
     override val name: String = scenario.fullApiDescription
     override val message: String = compatResult.reportString(addSourceLocation = Flags.getBooleanValue(SPECMATIC_BCC_REPORT_FLAG))
+    override val breakages: List<CtrfBreakage> = compatResult.toIssues().map { issue ->
+        CtrfBreakage(
+            breadcrumb = issue.breadCrumb,
+            sourceLocations = issue.sourceLocations.map { CtrfSourceLocation(it.filePath, it.line, it.column) },
+            rule = issue.ruleViolations.firstOrNull()?.let {
+                CtrfRuleSnapshot(it.id, it.title, it.documentationUrl, it.summary)
+            },
+            description = issue.details,
+            side = if (issue.breadCrumb.startsWith("RESPONSE")) "response" else "request",
+            severity = issue.severity.name.lowercase(),
+        )
+    }
     override val operations: Set<APIOperation> = toOpenApiOperation(scenario)
     override val tags: List<String> = buildList {
         if (isWip) add("wip")

--- a/core/src/main/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityCheckRecord.kt
+++ b/core/src/main/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityCheckRecord.kt
@@ -6,6 +6,7 @@ import io.specmatic.reporter.ctrf.model.CtrfBackwardCompatibilityRecord
 import io.specmatic.reporter.ctrf.model.CtrfBreakingChange
 import io.specmatic.reporter.ctrf.model.CtrfOperationQualifiers
 import io.specmatic.reporter.ctrf.model.CtrfRuleSnapshot
+import io.specmatic.reporter.ctrf.model.CtrfSeverity
 import io.specmatic.reporter.ctrf.model.CtrfSourceLocation
 import io.specmatic.reporter.internal.dto.operation.APIOperation
 import io.specmatic.reporter.model.BackwardCompatibilityStatus
@@ -42,7 +43,10 @@ data class OpenApiBackwardCompatibilityCheckRecord(
                 sourceLocations = sourceLocations,
                 rule = rule,
                 description = issue.details,
-                severity = issue.severity.name.lowercase(),
+                severity = when (issue.severity) {
+                    IssueSeverity.ERROR -> CtrfSeverity.ERROR
+                    IssueSeverity.WARNING -> CtrfSeverity.WARNING
+                },
             )
         }
     }

--- a/core/src/main/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityCheckRecord.kt
+++ b/core/src/main/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityCheckRecord.kt
@@ -31,16 +31,20 @@ data class OpenApiBackwardCompatibilityCheckRecord(
     // TODO: Need actual positive variation from generatedScenario
     override val name: String = scenario.fullApiDescription
     override val message: String = compatResult.reportString(addSourceLocation = Flags.getBooleanValue(SPECMATIC_BCC_REPORT_FLAG))
-    override val breakingChanges: List<CtrfBreakingChange> = compatResult.toIssues().map { issue ->
-        CtrfBreakingChange(
-            breadcrumb = issue.breadCrumb,
-            sourceLocations = issue.sourceLocations.map { CtrfSourceLocation(it.filePath, it.line, it.column) },
-            rule = issue.ruleViolations.firstOrNull()?.let {
-                CtrfRuleSnapshot(it.id, it.title, it.documentationUrl, it.summary)
-            },
-            description = issue.details,
-            severity = issue.severity.name.lowercase(),
-        )
+    override val breakingChanges: List<CtrfBreakingChange> = compatResult.toIssues().flatMap { issue ->
+        val sourceLocations = issue.sourceLocations.map { CtrfSourceLocation(it.filePath, it.line, it.column) }
+        val rules: List<CtrfRuleSnapshot?> = issue.ruleViolations.map {
+            CtrfRuleSnapshot(it.id, it.title, it.documentationUrl, it.summary)
+        }.ifEmpty { listOf(null) }
+        rules.map { rule ->
+            CtrfBreakingChange(
+                breadcrumb = issue.breadCrumb,
+                sourceLocations = sourceLocations,
+                rule = rule,
+                description = issue.details,
+                severity = issue.severity.name.lowercase(),
+            )
+        }
     }
     override val operations: Set<APIOperation> = toOpenApiOperation(scenario)
     override val tags: List<String> = buildList {

--- a/core/src/main/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityCheckRecord.kt
+++ b/core/src/main/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityCheckRecord.kt
@@ -3,7 +3,7 @@ package io.specmatic.core
 import io.specmatic.conversions.convertPathParameterStyle
 import io.specmatic.core.utilities.Flags
 import io.specmatic.reporter.ctrf.model.CtrfBackwardCompatibilityRecord
-import io.specmatic.reporter.ctrf.model.CtrfBreakage
+import io.specmatic.reporter.ctrf.model.CtrfBreakingChange
 import io.specmatic.reporter.ctrf.model.CtrfOperationQualifiers
 import io.specmatic.reporter.ctrf.model.CtrfRuleSnapshot
 import io.specmatic.reporter.ctrf.model.CtrfSourceLocation
@@ -31,15 +31,14 @@ data class OpenApiBackwardCompatibilityCheckRecord(
     // TODO: Need actual positive variation from generatedScenario
     override val name: String = scenario.fullApiDescription
     override val message: String = compatResult.reportString(addSourceLocation = Flags.getBooleanValue(SPECMATIC_BCC_REPORT_FLAG))
-    override val breakages: List<CtrfBreakage> = compatResult.toIssues().map { issue ->
-        CtrfBreakage(
+    override val breakingChanges: List<CtrfBreakingChange> = compatResult.toIssues().map { issue ->
+        CtrfBreakingChange(
             breadcrumb = issue.breadCrumb,
             sourceLocations = issue.sourceLocations.map { CtrfSourceLocation(it.filePath, it.line, it.column) },
             rule = issue.ruleViolations.firstOrNull()?.let {
                 CtrfRuleSnapshot(it.id, it.title, it.documentationUrl, it.summary)
             },
             description = issue.details,
-            side = if (issue.breadCrumb.startsWith("RESPONSE")) "response" else "request",
             severity = issue.severity.name.lowercase(),
         )
     }

--- a/core/src/main/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityChecker.kt
+++ b/core/src/main/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityChecker.kt
@@ -4,10 +4,15 @@ import io.specmatic.core.log.logger
 import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.pattern.IgnoreUnexpectedKeys
 import io.specmatic.test.asserts.toFailure
+import java.io.File
 import java.util.Collections
 import java.util.IdentityHashMap
 
-class OpenApiBackwardCompatibilityChecker(private val oldFeature: Feature, private val newFeature: Feature) {
+class OpenApiBackwardCompatibilityChecker(
+    private val oldFeature: Feature,
+    private val newFeature: Feature,
+    private val repoDir: String? = null,
+) {
     private val newScenariosByMethodAndReqContentType = newFeature.scenarios.groupBy { it.method to it.requestContentType }
     private val oldChangeTrackingScenariosByPathAndMethod = oldFeature.scenariosForChangeTracking()
         .groupBy { it.path to it.method }
@@ -165,12 +170,27 @@ class OpenApiBackwardCompatibilityChecker(private val oldFeature: Feature, priva
     }
 
     private fun newRecord(scenario: Scenario, result: Result, changeStatusFor: (Scenario) -> ChangeStatus): OpenApiBackwardCompatibilityCheckRecord {
+        val compatResult = result.updateScenario(scenario).withoutFailureReasons().relativizeSourceLocations()
         return OpenApiBackwardCompatibilityCheckRecord(
             feature = newFeature,
             scenario = scenario,
-            compatResult = result.updateScenario(scenario).withoutFailureReasons(),
+            compatResult = compatResult,
             changeStatus = changeStatusFor(scenario),
         )
+    }
+
+    // Make every source-location path in a failure relative to the repo root, so the console report,
+    // the CTRF message and the structured breakages all show repo-relative paths. No-op when the repo
+    // dir is unknown (e.g. in-memory checks).
+    private fun Result.relativizeSourceLocations(): Result =
+        if (this is Result.Failure && !repoDir.isNullOrBlank()) mapSourceLocations(::relativizeToRepoRoot) else this
+
+    private fun relativizeToRepoRoot(filePath: String): String {
+        val root = repoDir
+        if (root.isNullOrBlank() || filePath.isBlank()) return filePath
+        return runCatching {
+            File(filePath).canonicalFile.relativeTo(File(root).canonicalFile).invariantSeparatorsPath
+        }.getOrDefault(filePath)
     }
 
     private fun <First, Second, Item> Map<Pair<First, Second?>, List<Item>>.findExactOrSingle(

--- a/core/src/main/kotlin/io/specmatic/core/Report.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Report.kt
@@ -18,7 +18,9 @@ data class Issue(
     val path: List<String>,
     val ruleViolations: List<RuleViolationSnapshot>,
     val details: String,
-    val severity: IssueSeverity
+    val severity: IssueSeverity,
+    // Head-to-tail chain of $ref use-sites for this issue; the last element is the actual source.
+    val sourceLocations: List<SourceLocation> = emptyList()
 )
 
 interface Report {

--- a/core/src/main/kotlin/io/specmatic/core/Result.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Result.kt
@@ -5,6 +5,7 @@ import io.specmatic.core.pattern.*
 import io.specmatic.core.utilities.capitalizeFirstChar
 import io.specmatic.core.value.Value
 import io.specmatic.reporter.model.TestResult
+import kotlinx.serialization.Serializable
 
 sealed class Result {
     abstract val scenario: ScenarioDetailsForResult?
@@ -443,6 +444,7 @@ data class MatchFailureDetails(
 // `via` holds the ordered $ref use-site hops that lead to this location, head-first (the use-site in
 // the spec under check), excluding this location itself which is the tail (the actual source of the
 // breakage). Empty for locations that live directly in the entry spec.
+@Serializable
 data class SourceLocation(
     val filePath: String,
     val line: Int,

--- a/core/src/main/kotlin/io/specmatic/core/Result.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Result.kt
@@ -273,6 +273,14 @@ sealed class Result {
             }
         }
 
+        // Rewrite the file path of every source location in this failure tree (and the `via` chains),
+        // e.g. to make absolute paths relative to a repo root before they reach a report.
+        fun mapSourceLocations(transform: (String) -> String): Failure =
+            copy(
+                sourceLocation = sourceLocation?.mapFilePath(transform),
+                causes = causes.map { it.copy(cause = it.cause?.mapSourceLocations(transform)) }
+            )
+
         override fun isAnyFluffy(acceptableFluffLevel: Int): Boolean {
             return failureReason?.let { it.fluffLevel > acceptableFluffLevel } == true || causes.any { it.cause?.isAnyFluffy(acceptableFluffLevel) == true }
         }
@@ -450,7 +458,10 @@ data class SourceLocation(
     val line: Int,
     val column: Int,
     val via: List<SourceLocation> = emptyList()
-)
+) {
+    fun mapFilePath(transform: (String) -> String): SourceLocation =
+        copy(filePath = transform(filePath), via = via.map { it.mapFilePath(transform) })
+}
 
 interface MismatchMessages {
     fun mismatchMessage(expected: String, actual: String): String

--- a/core/src/main/kotlin/io/specmatic/core/TestBackwardCompatibility.kt
+++ b/core/src/main/kotlin/io/specmatic/core/TestBackwardCompatibility.kt
@@ -26,8 +26,8 @@ internal fun testBackwardCompatibilityWithReport(older: Feature, newer: Feature)
     return Pair(result, report)
 }
 
-fun backwardCompatibilityRecords(older: Feature, newer: Feature): Pair<Results, List<CtrfBackwardCompatibilityRecord>> {
-    val records = OpenApiBackwardCompatibilityChecker(older, newer).run()
+fun backwardCompatibilityRecords(older: Feature, newer: Feature, repoDir: String? = null): Pair<Results, List<CtrfBackwardCompatibilityRecord>> {
+    val records = OpenApiBackwardCompatibilityChecker(older, newer, repoDir).run()
     return records.toBackwardCompatibilityStatuses().copy(addSourceLocation = Flags.getBooleanValue(SPECMATIC_BCC_REPORT_FLAG)) to records
 }
 

--- a/core/src/test/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityCheckRecordTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityCheckRecordTest.kt
@@ -3,6 +3,7 @@ package io.specmatic.core
 import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.conversions.convertPathParameterStyle
 import io.specmatic.reporter.ctrf.model.CtrfOperationQualifiers
+import io.specmatic.reporter.ctrf.model.CtrfSourceLocation
 import io.specmatic.core.ChangeStatus
 import io.specmatic.reporter.model.BackwardCompatibilityStatus
 import io.specmatic.reporter.model.SpecType
@@ -62,6 +63,54 @@ class OpenApiBackwardCompatibilityCheckRecordTest {
         )
 
         assertThat(record.specification).isEqualTo(feature.path)
+    }
+
+    @Test
+    fun `should expose structured breakages with breadcrumb, rule and source-location chain`() {
+        val feature = openApiFeature()
+        val scenario = feature.scenarios.single()
+
+        // The actual source of the break lives in common.yaml (tail); api.yaml is the $ref use-site (via head).
+        val location = SourceLocation(
+            filePath = "/specs/common.yaml", line = 38, column = 9,
+            via = listOf(SourceLocation(filePath = "/specs/api.yaml", line = 27, column = 13))
+        )
+        val failure = Result.Failure(
+            message = "This is type number in the new specification, but type string in the old specification",
+            ruleViolation = StandardRuleViolation.TYPE_MISMATCH
+        ).breadCrumb("applicationNumber", location).breadCrumb("BODY").breadCrumb("REQUEST")
+
+        val record = OpenApiBackwardCompatibilityCheckRecord(
+            scenario = scenario,
+            compatResult = failure,
+            feature = feature.copy(scenarios = listOf(scenario)),
+        )
+
+        assertThat(record.breakages).hasSize(1)
+        val breakage = record.breakages.single()
+        assertThat(breakage.breadcrumb).isEqualTo("REQUEST.BODY.applicationNumber")
+        assertThat(breakage.rule?.id).isEqualTo("R1001")
+        assertThat(breakage.description).contains("type number in the new specification")
+        assertThat(breakage.side).isEqualTo("request")
+        assertThat(breakage.severity).isEqualTo("error")
+        assertThat(breakage.sourceLocations).containsExactly(
+            CtrfSourceLocation("/specs/api.yaml", 27, 13),
+            CtrfSourceLocation("/specs/common.yaml", 38, 9),
+        )
+    }
+
+    @Test
+    fun `should expose no breakages for a compatible scenario`() {
+        val feature = openApiFeature()
+        val scenario = feature.scenarios.single()
+
+        val record = OpenApiBackwardCompatibilityCheckRecord(
+            scenario = scenario,
+            compatResult = Result.Success(),
+            feature = feature.copy(scenarios = listOf(scenario)),
+        )
+
+        assertThat(record.breakages).isEmpty()
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityCheckRecordTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityCheckRecordTest.kt
@@ -86,12 +86,11 @@ class OpenApiBackwardCompatibilityCheckRecordTest {
             feature = feature.copy(scenarios = listOf(scenario)),
         )
 
-        assertThat(record.breakages).hasSize(1)
-        val breakage = record.breakages.single()
+        assertThat(record.breakingChanges).hasSize(1)
+        val breakage = record.breakingChanges.single()
         assertThat(breakage.breadcrumb).isEqualTo("REQUEST.BODY.applicationNumber")
         assertThat(breakage.rule?.id).isEqualTo("R1001")
         assertThat(breakage.description).contains("type number in the new specification")
-        assertThat(breakage.side).isEqualTo("request")
         assertThat(breakage.severity).isEqualTo("error")
         assertThat(breakage.sourceLocations).containsExactly(
             CtrfSourceLocation("/specs/api.yaml", 27, 13),
@@ -110,7 +109,7 @@ class OpenApiBackwardCompatibilityCheckRecordTest {
             feature = feature.copy(scenarios = listOf(scenario)),
         )
 
-        assertThat(record.breakages).isEmpty()
+        assertThat(record.breakingChanges).isEmpty()
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityCheckRecordTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityCheckRecordTest.kt
@@ -3,6 +3,7 @@ package io.specmatic.core
 import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.conversions.convertPathParameterStyle
 import io.specmatic.reporter.ctrf.model.CtrfOperationQualifiers
+import io.specmatic.reporter.ctrf.model.CtrfSeverity
 import io.specmatic.reporter.ctrf.model.CtrfSourceLocation
 import io.specmatic.core.ChangeStatus
 import io.specmatic.reporter.model.BackwardCompatibilityStatus
@@ -91,7 +92,7 @@ class OpenApiBackwardCompatibilityCheckRecordTest {
         assertThat(breakage.breadcrumb).isEqualTo("REQUEST.BODY.applicationNumber")
         assertThat(breakage.rule?.id).isEqualTo("R1001")
         assertThat(breakage.description).contains("type number in the new specification")
-        assertThat(breakage.severity).isEqualTo("error")
+        assertThat(breakage.severity).isEqualTo(CtrfSeverity.ERROR)
         assertThat(breakage.sourceLocations).containsExactly(
             CtrfSourceLocation("/specs/api.yaml", 27, 13),
             CtrfSourceLocation("/specs/common.yaml", 38, 9),

--- a/core/src/test/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityCheckRecordTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityCheckRecordTest.kt
@@ -99,6 +99,50 @@ class OpenApiBackwardCompatibilityCheckRecordTest {
     }
 
     @Test
+    fun `should expose one breakage per rule violation on an issue`() {
+        val feature = openApiFeature()
+        val scenario = feature.scenarios.single()
+
+        val failure = Result.Failure(
+            message = "type mismatch on applicationNumber",
+            ruleViolation = StandardRuleViolation.TYPE_MISMATCH
+        ).withRuleViolation(StandardRuleViolation.VALUE_MISMATCH)
+            .breadCrumb("applicationNumber").breadCrumb("BODY").breadCrumb("REQUEST")
+
+        val record = OpenApiBackwardCompatibilityCheckRecord(
+            scenario = scenario,
+            compatResult = failure,
+            feature = feature.copy(scenarios = listOf(scenario)),
+        )
+
+        assertThat(record.breakingChanges).hasSize(2)
+        assertThat(record.breakingChanges.map { it.rule?.id })
+            .containsExactlyInAnyOrder(
+                StandardRuleViolation.TYPE_MISMATCH.id,
+                StandardRuleViolation.VALUE_MISMATCH.id,
+            )
+        assertThat(record.breakingChanges.map { it.breadcrumb }.distinct())
+            .containsExactly("REQUEST.BODY.applicationNumber")
+    }
+
+    @Test
+    fun `should expose a breakage even when the issue has no rule violation`() {
+        val feature = openApiFeature()
+        val scenario = feature.scenarios.single()
+
+        val failure = Result.Failure(message = "breaking change").breadCrumb("applicationNumber")
+
+        val record = OpenApiBackwardCompatibilityCheckRecord(
+            scenario = scenario,
+            compatResult = failure,
+            feature = feature.copy(scenarios = listOf(scenario)),
+        )
+
+        assertThat(record.breakingChanges).hasSize(1)
+        assertThat(record.breakingChanges.single().rule).isNull()
+    }
+
+    @Test
     fun `should expose no breakages for a compatible scenario`() {
         val feature = openApiFeature()
         val scenario = feature.scenarios.single()

--- a/core/src/test/kotlin/io/specmatic/core/ResultTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ResultTest.kt
@@ -48,4 +48,26 @@ class ResultTest {
             )
         )
     }
+
+    @Test
+    fun `mapSourceLocations rewrites file paths across the failure tree and via chains`() {
+        val leaf = Result.Failure(
+            message = "type mismatch",
+            ruleViolation = StandardRuleViolation.TYPE_MISMATCH,
+        ).breadCrumb(
+            "name",
+            SourceLocation(
+                filePath = "/repo/common.yaml", line = 38, column = 9,
+                via = listOf(SourceLocation(filePath = "/repo/api.yaml", line = 27, column = 13)),
+            ),
+        ).breadCrumb("BODY").breadCrumb("REQUEST")
+
+        val relativized = leaf.mapSourceLocations { it.removePrefix("/repo/") }
+
+        val location = relativized.toMatchFailureDetailList().single().sourceLocation!!
+        assertThat(location.filePath).isEqualTo("common.yaml")
+        assertThat(location.via.single().filePath).isEqualTo("api.yaml")
+        // original tree is untouched
+        assertThat(leaf.toMatchFailureDetailList().single().sourceLocation!!.filePath).isEqualTo("/repo/common.yaml")
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 group=io.specmatic
 version=2.46.5-SNAPSHOT
 specmaticGradlePluginVersion=0.15.12
-specmaticReporterVersion=0.3.29
+specmaticReporterVersion=0.3.30-SNAPSHOT
 swaggerParserVersion=2.1.35
 kotlin.daemon.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=384m
 org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=384m


### PR DESCRIPTION
1. Emit structured breaking changes metadata in the CTRF.
2. Make BCC tests hermetic to local license files.
3. All output of specFile:lineNumber:columnNumber are made relative to the repository root instead of absolute paths. 

## Related PRs
1. https://github.com/specmatic/specmatic-html-reporter/pull/136
2. https://github.com/specmatic/specmatic-reporter/pull/151