### PR TITLE
Ensure additional query parameters are preserved for mock

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
@@ -33,7 +33,6 @@ import io.specmatic.core.pattern.parsedPattern
 import io.specmatic.core.pattern.resolvedHop
 import io.specmatic.core.pattern.returnValue
 import io.specmatic.core.pattern.singleLineDescription
-import io.specmatic.core.pattern.withOptionality
 import io.specmatic.core.pattern.withoutOptionality
 import io.specmatic.core.utilities.toStringMap
 import io.specmatic.core.value.EmptyString
@@ -496,26 +495,23 @@ data class HttpRequestPattern(
             name
         }
 
-        val paramsOutsidePattern = if(httpQueryParamPattern.additionalProperties != null) {
-            val results = paramsUnaccountedFor.map { (name, values) ->
-                values.map { (_, rawValue) ->
-                    val value = httpQueryParamPattern.additionalProperties.parse(rawValue, resolver)
-                    httpQueryParamPattern.additionalProperties.matches(value, resolver)
-                }
-            }.flatten()
-
-            val matchResult = Result.fromResults(results)
-
-            if (matchResult is Failure)
-                throw ContractException(matchResult.toFailureReport())
-
-            unaccountedQueryParamsToMap(paramsUnaccountedFor)
-        } else if (httpQueryParamPattern.extensibleQueryParams) {
-            unaccountedQueryParamsToMap(paramsUnaccountedFor)
-        } else {
-            emptyMap()
+        if (httpQueryParamPattern.additionalProperties == null) {
+            val paramsOutsidePattern = unaccountedQueryParamsToMap(paramsUnaccountedFor)
+            return paramsWithinPattern + paramsOutsidePattern
         }
 
+        val additionalPropertiesResult = paramsUnaccountedFor.map { (_, values) ->
+            values.map { (_, rawValue) ->
+                val value = httpQueryParamPattern.additionalProperties.parse(rawValue, resolver)
+                httpQueryParamPattern.additionalProperties.matches(value, resolver)
+            }
+        }.flatten()
+
+        val matchResult = Result.fromResults(additionalPropertiesResult)
+        if (matchResult is Failure)
+            throw ContractException(matchResult.toFailureReport())
+
+        val paramsOutsidePattern = unaccountedQueryParamsToMap(paramsUnaccountedFor)
         return paramsWithinPattern + paramsOutsidePattern
     }
 

--- a/core/src/test/kotlin/io/specmatic/core/HttpRequestPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpRequestPatternTest.kt
@@ -10,9 +10,11 @@ import io.specmatic.core.value.JSONArrayValue
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.NumberValue
 import io.specmatic.core.value.StringValue
+import io.specmatic.toViolationReportString
 import org.apache.http.HttpHeaders.AUTHORIZATION
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import java.net.URI
@@ -451,6 +453,57 @@ internal class HttpRequestPatternTest {
 
         assertThat(newRequestType.httpQueryParamPattern.queryPatterns.keys.sorted()).isEqualTo(listOf("status"))
 
+    }
+
+    @Test
+    fun `should preserve additional query params when generating an exact request pattern`() {
+        val requestType = HttpRequestPattern(
+            method = "GET",
+            httpPathPattern = HttpPathPattern(pathToPattern("/"), "/"),
+            httpQueryParamPattern = HttpQueryParamPattern(mapOf("status" to QueryParameterScalarPattern(StringPattern())))
+        )
+
+        val request = HttpRequest(
+            path = "/",
+            method = "GET",
+            queryParametersMap = mapOf("status" to "available", "extra" to "extra-value")
+        )
+
+        val newRequestType = requestType.generateExactHttpRequestPatternFrom(request, Resolver())
+        assertThat(newRequestType.httpQueryParamPattern.queryPatterns).containsKeys("status", "extra")
+        assertThat(newRequestType.httpQueryParamPattern.queryPatterns["extra"])
+            .isEqualTo(QueryParameterScalarPattern(ExactValuePattern(StringValue("extra-value"))))
+    }
+
+    @Test
+    fun `should complain for additional query params when generating an exact request pattern and value does not match additional properties`() {
+        val requestType = HttpRequestPattern(
+            method = "GET",
+            httpPathPattern = HttpPathPattern(pathToPattern("/"), "/"),
+            httpQueryParamPattern = HttpQueryParamPattern(
+                additionalProperties = NumberPattern(),
+                queryPatterns = mapOf("status" to QueryParameterScalarPattern(StringPattern())),
+            )
+        )
+
+        val request = HttpRequest(
+            path = "/",
+            method = "GET",
+            queryParametersMap = mapOf("status" to "available", "extra" to "not-a-number")
+        )
+
+        val exception = assertThrows<ContractException> {
+            requestType.generateExactHttpRequestPatternFrom(request, Resolver())
+        }
+
+        assertThat(exception.report()).isEqualToNormalizingWhitespace(toViolationReportString(
+            breadCrumb = "REQUEST.URL",
+            details = """
+            Expected type number, actual was value "not-a-number" of type string
+            Expected number, actual was "not-a-number"
+            """.trimIndent(),
+            StandardRuleViolation.TYPE_MISMATCH
+        ))
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
@@ -1075,6 +1075,81 @@ components:
     }
 
     @Test
+    fun `should load a get stub with headers and query params including extra query params`() {
+        val feature = OpenApiSpecification.fromYAML("""
+        openapi: 3.0.0
+        info:
+          title: Query Stub
+          version: 1.0.0
+        paths:
+          /data:
+            get:
+              summary: query stub
+              parameters:
+                - name: id
+                  in: query
+                  required: true
+                  schema:
+                    type: string
+                - name: X-Mode
+                  in: header
+                  required: true
+                  schema:
+                    type: string
+              responses:
+                '200':
+                  description: Success
+                  content:
+                    application/json:
+                      schema:
+                        type: object
+                        properties:
+                          message:
+                            type: string
+                '422':
+                  description: Unprocessable
+                  content:
+                    application/json:
+                      schema:
+                        type: object
+                        properties:
+                          message:
+                            type: string
+        """.trimIndent(), "").toFeature()
+
+        val invalid422Request = HttpRequest(
+            method = "GET",
+            path = "/data",
+            headers = mapOf("X-Mode" to "422"),
+            queryParametersMap = mapOf("id" to "123", "extra" to "abc")
+        )
+
+
+        val valid200Request = HttpRequest(
+            method = "GET",
+            path = "/data",
+            headers = mapOf("X-Mode" to "200"),
+            queryParametersMap = mapOf("id" to "123")
+        )
+
+        val invalid422RespBody = parsedJSONObject("""{"message":"unprocessable"}""")
+        val invalid422Example = ScenarioStub(invalid422Request, HttpResponse(422, body = invalid422RespBody))
+
+        val valid200RespBody = parsedJSONObject("""{"message":"valid"}""")
+        val valid200Example = ScenarioStub(valid200Request, HttpResponse(200, body = valid200RespBody))
+
+        HttpStub(feature, listOf(invalid422Example, valid200Example)).use { stub ->
+            val validResponse = stub.client.execute(valid200Request)
+            assertThat(validResponse.status).isEqualTo(200)
+            assertThat(validResponse.body).isEqualTo(valid200RespBody)
+
+            val invalidResponse = stub.client.execute(invalid422Request)
+            assertThat(invalidResponse.status).isEqualTo(422)
+            assertThat(invalidResponse.body).isEqualTo(invalid422RespBody)
+        }
+    }
+
+    @Test
     fun `stub should load an example for a spec with pattern as a path param`() {
         createStubFromContracts(listOf(("src/test/resources/openapi/spec_with_path_param.yaml")), timeoutMillis = 0).use { stub ->
             val request = HttpRequest("GET", "/users/abc123", queryParametersMap = mapOf("item" to "10"))


### PR DESCRIPTION
What: Preserve additional query parameters in mock request patterns

How: When converting an HttpRequest to an HttpRequestPattern, retain additional query parameters in the final request pattern regardless of whether extensible query params is enabled.

Previously, additional query parameters were preserved only when extensible query params was enabled. With this change, they are always carried forward into the generated HttpRequestPattern, so the mock has access to the complete query parameter set from the example

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
