### PR TITLE
Fix stubBaseUrls in Config V3 generating unparseable URLs

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/CertRegistry.kt
+++ b/core/src/main/kotlin/io/specmatic/core/CertRegistry.kt
@@ -1,6 +1,7 @@
 package io.specmatic.core
 
 import io.specmatic.core.config.HttpsConfiguration
+import io.specmatic.core.config.v3.ServerOrigin
 import io.specmatic.stub.normalizeHost
 import java.net.URI
 
@@ -42,6 +43,13 @@ class CertRegistry private constructor(private val certificates: List<Pair<HostP
                 is HostPortIdentifier.Matching -> acc.plus(identifier.host, identifier.port, cert.isMtlsEnabled())
                 else -> acc.plusWildCard(cert.isMtlsEnabled())
             }
+        }
+    }
+
+    fun plus(serverOrigin: ServerOrigin, cert: HttpsConfiguration): CertRegistry {
+        return when (serverOrigin) {
+            is ServerOrigin.BaseUrl -> plus(serverOrigin.baseUrl, cert)
+            is ServerOrigin.NetworkAddress -> plus(serverOrigin.host, serverOrigin.port, cert)
         }
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -34,6 +34,7 @@ data class SpecificationSource(
 data class SpecificationSourceEntry(
     val specFile: File,
     val specPathInConfig: String,
+    val host: String?,
     val port: Int?,
     val baseUrl: String?,
     val webSourceUrl: String? = null,
@@ -49,9 +50,10 @@ data class SpecificationSourceEntry(
         return ContractSourceEntry(specPathInConfig, baseUrl, resiliencyTestSuite, exampleDirs)
     }
 
-    constructor(source: Source, specFile: File, specPathInConfig: String, baseUrl: String?, port: Int?, resiliencyTestSuite: ResiliencyTestSuite?) : this(
+    constructor(source: Source, specFile: File, specPathInConfig: String, baseUrl: String?, host: String?, port: Int?, resiliencyTestSuite: ResiliencyTestSuite?) : this(
         specFile = specFile,
         specPathInConfig = specPathInConfig,
+        host = host,
         port = port,
         baseUrl = baseUrl,
         webSourceUrl = source.webBaseUrl,

--- a/core/src/main/kotlin/io/specmatic/core/config/SpecmaticSpecConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/SpecmaticSpecConfig.kt
@@ -1,20 +1,20 @@
 package io.specmatic.core.config
 
+import io.specmatic.core.config.v3.ServerOrigin
 import io.specmatic.core.config.v3.components.runOptions.IRunOptionSpecification
 
 class RawRunOptionSpecification(private val config: Map<String, Any>): IRunOptionSpecification {
     override fun getId(): String? = null
-    override fun getBaseUrl(defaultHost: String): String? = null
     override fun getOverlayFilePath(): String? = null
     override fun getConfig(): Map<String, Any> = config
     override fun isNoOpOverride(): Boolean = config.isEmpty()
+    override fun getServerOrigin(defaultHost: String): ServerOrigin? = extractServerOriginFromMap(config, defaultHost)
 }
 
 class SpecmaticSpecConfig(val baseUrl: String? = null, val spec: IRunOptionSpecification? = null, val config: Map<String, Any> = emptyMap()) {
     constructor(raw: Map<String, Any>): this(spec = RawRunOptionSpecification(raw))
 
     fun resolvedConfig(): Map<String, Any> {
-        return if(spec?.getConfig().isNullOrEmpty()) config
-        else spec?.getConfig().orEmpty()
+        return if (spec?.getConfig().isNullOrEmpty()) config else spec.getConfig()
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/config/v2/SpecExecutionConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v2/SpecExecutionConfig.kt
@@ -26,7 +26,7 @@ sealed class SpecExecutionConfig {
 
         override fun createSpecificationEntriesFrom(source: Source, baseDir: File, resiliencyTestSuite: ResiliencyTestSuite?): List<SpecificationSourceEntry> {
             val specFile = resolveSpecFile(source, baseDir, value)
-            return listOf(SpecificationSourceEntry(source, specFile, value, null, null, resiliencyTestSuite))
+            return listOf(SpecificationSourceEntry(source, specFile, value, null, null, null, resiliencyTestSuite))
         }
 
         override fun use(baseUrl: String, resiliencyTestsConfig: ResiliencyTestsConfig): SpecExecutionConfig {
@@ -68,7 +68,7 @@ sealed class SpecExecutionConfig {
                 val resiliency = resiliencyTests?.enable ?: resiliencyTestSuite
                 return specs().map { spec ->
                     val specFile = resolveSpecFile(source, baseDir, spec)
-                    SpecificationSourceEntry(source, specFile, spec, baseUrl, null, resiliency)
+                    SpecificationSourceEntry(source, specFile, spec, baseUrl, null, null, resiliency)
                 }
             }
 
@@ -109,7 +109,7 @@ sealed class SpecExecutionConfig {
                 val resiliency = resiliencyTests?.enable ?: resiliencyTestSuite
                 return specs().map { spec ->
                     val specFile = resolveSpecFile(source, baseDir, spec)
-                    SpecificationSourceEntry(source, specFile, spec, baseUrl, port, resiliency)
+                    SpecificationSourceEntry(source, specFile, spec, baseUrl, host, port, resiliency)
                 }
             }
 
@@ -139,7 +139,7 @@ sealed class SpecExecutionConfig {
         override fun createSpecificationEntriesFrom(source: Source, baseDir: File, resiliencyTestSuite: ResiliencyTestSuite?): List<SpecificationSourceEntry> {
             return specs().map { spec ->
                 val specFile = resolveSpecFile(source, baseDir, spec)
-                SpecificationSourceEntry(source, specFile, spec, null, null, resiliencyTestSuite)
+                SpecificationSourceEntry(source, specFile, spec, null, null, null, resiliencyTestSuite)
             }
         }
 

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3Impl.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3Impl.kt
@@ -432,7 +432,7 @@ data class SpecmaticConfigV3Impl(val file: File? = null, val specmaticConfig: Sp
 
     override fun getTestBaseUrl(specType: SpecType): String? {
         val runOptions = specmaticConfig.systemUnderTest?.getRunOptions(resolver, specType)
-        return runOptions?.getBaseUrlIfExists()
+        return runOptions?.gerServerOrigin()?.baseUrl
     }
 
     override fun getCoverageReportBaseUrl(specType: SpecType): String? {
@@ -510,13 +510,13 @@ data class SpecmaticConfigV3Impl(val file: File? = null, val specmaticConfig: Sp
 
     override fun getStubHttpsConfiguration(): CertRegistry {
         val registry = CertRegistry.empty()
-        val certificates: List<Pair<String, HttpsConfiguration>> = specmaticConfig.dependencies?.getCerts(resolver).orEmpty()
+        val certificates: List<Pair<ServerOrigin, HttpsConfiguration>> = specmaticConfig.dependencies?.getCerts(resolver).orEmpty()
         return certificates.fold(registry) { acc, (baseUrl, cert) -> acc.plus(baseUrl, cert) }
     }
 
     override fun getTestHttpsConfiguration(): CertRegistry {
         val registry = CertRegistry.empty()
-        val certificates: List<Pair<String, HttpsConfiguration>> = specmaticConfig.systemUnderTest?.getCerts(resolver).orEmpty()
+        val certificates: List<Pair<ServerOrigin, HttpsConfiguration>> = specmaticConfig.systemUnderTest?.getCerts(resolver).orEmpty()
         return certificates.fold(registry) { acc, (baseUrl, cert) -> acc.plus(baseUrl, cert) }
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/AsyncApiRunOptions.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/AsyncApiRunOptions.kt
@@ -1,6 +1,7 @@
 package io.specmatic.core.config.v3.components.runOptions
 
 import com.fasterxml.jackson.annotation.*
+import io.specmatic.core.config.v3.ServerOrigin
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 @JsonSubTypes(JsonSubTypes.Type(AsyncApiTestConfig::class, name = "test"), JsonSubTypes.Type(AsyncApiMockConfig::class, name = "mock"))
@@ -8,9 +9,9 @@ sealed interface AsyncApiRunOptions : IRunOptions {
     val type: RunOptionType?
 
     @JsonIgnore
-    override fun getBaseUrlIfExists(): String? {
+    override fun gerServerOrigin(): ServerOrigin? {
         val brokerConfig = config["inMemoryBroker"] as? Map<*, *> ?: return null
-        return extractBaseUrlFromMap(brokerConfig, defaultHost = "localhost")
+        return extractServerOriginFromMap(brokerConfig, defaultHost = "localhost")
     }
 }
 

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/GraphQLSdlRunOptions.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/GraphQLSdlRunOptions.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
+import io.specmatic.core.config.v3.ServerOrigin
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 @JsonSubTypes(JsonSubTypes.Type(GraphQLSdlTestConfig::class, name = "test"), JsonSubTypes.Type(GraphQLSdlMockConfig::class, name = "mock"))
@@ -13,9 +14,9 @@ sealed interface GraphQLSdlRunOptions : IRunOptions {
     val type: RunOptionType?
 
     @JsonIgnore
-    override fun getBaseUrlIfExists(): String? {
+    override fun gerServerOrigin(): ServerOrigin? {
         val defaultHost = if (this is GraphQLSdlTestConfig) "localhost" else "0.0.0.0"
-        return extractBaseUrlFromMap(config, defaultHost)
+        return extractServerOriginFromMap(config, defaultHost)
     }
 }
 

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/OpenApiRunOptions.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/OpenApiRunOptions.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo
 import io.specmatic.core.WorkflowConfiguration
 import io.specmatic.core.config.HttpsConfiguration
 import io.specmatic.core.config.v3.RefOrValue
+import io.specmatic.core.config.v3.ServerOrigin
 
 interface ConfigWithCert { val cert: RefOrValue<HttpsConfiguration>? }
 
@@ -30,10 +31,10 @@ data class OpenApiTestConfig(
     override val config: Map<String, Any> = emptyMap()
 
     @JsonIgnore
-    override fun getBaseUrlIfExists(): String? {
-        if (baseUrl != null) return baseUrl
+    override fun gerServerOrigin(): ServerOrigin? {
+        if (baseUrl != null) return ServerOrigin.from(baseUrl)
         if (port == null) return null
-        return "http://${host ?: "localhost"}:$port"
+        return ServerOrigin.from("http", host ?: "localhost", port)
     }
 
     init {
@@ -58,11 +59,11 @@ data class OpenApiMockConfig(
     override val config: Map<String, Any> = emptyMap()
 
     @JsonIgnore
-    override fun getBaseUrlIfExists(): String? {
-        if (baseUrl != null) return baseUrl
+    override fun gerServerOrigin(): ServerOrigin? {
+        if (baseUrl != null) return ServerOrigin.from(baseUrl)
         if (port == null) return null
         val scheme = if (cert == null) "http" else "https"
-        return "$scheme://${host ?: "0.0.0.0"}:$port"
+        return ServerOrigin.from(scheme, host ?: "0.0.0.0", port)
     }
 
     init {

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/ProtobufRunOptions.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/ProtobufRunOptions.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
+import io.specmatic.core.config.v3.ServerOrigin
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 @JsonSubTypes(JsonSubTypes.Type(ProtobufTestConfig::class, name = "test"), JsonSubTypes.Type(ProtobufMockConfig::class, name = "mock"))
@@ -13,9 +14,9 @@ sealed interface ProtobufRunOptions : IRunOptions {
     val type: RunOptionType?
 
     @JsonIgnore
-    override fun getBaseUrlIfExists(): String? {
+    override fun gerServerOrigin(): ServerOrigin? {
         val defaultHost = if (this is ProtobufTestConfig) "localhost" else "0.0.0.0"
-        return extractBaseUrlFromMap(config, defaultHost)
+        return extractServerOriginFromMap(config, defaultHost)
     }
 }
 

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/RunOptions.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/RunOptions.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonAnySetter
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonIgnore
 import io.specmatic.core.config.SpecmaticSpecConfig
+import io.specmatic.core.config.v3.ServerOrigin
 import io.specmatic.reporter.model.SpecType
 
 interface IRunOptions {
@@ -12,7 +13,7 @@ interface IRunOptions {
     val config: Map<String, Any>
 
     @JsonIgnore
-    fun getBaseUrlIfExists(): String?
+    fun gerServerOrigin(): ServerOrigin?
 
     @JsonIgnore
     fun getMatchingSpecification(id: String): IRunOptionSpecification? {
@@ -21,13 +22,13 @@ interface IRunOptions {
 
     fun toSpecmaticSpecConfig(specId: String?): SpecmaticSpecConfig {
         val matching = if (specId != null) getMatchingSpecification(specId) else null
-        return SpecmaticSpecConfig(getBaseUrlIfExists(), matching, config)
+        return SpecmaticSpecConfig(gerServerOrigin()?.baseUrl, matching, config)
     }
 
-    fun extractBaseUrlFromMap(map: Map<*, *>, defaultHost: String): String? {
+    fun extractServerOriginFromMap(map: Map<*, *>, defaultHost: String): ServerOrigin? {
         val host = map["host"]?.toString() ?: defaultHost
         val port = map["port"]?.toString()?.toIntOrNull() ?: return null
-        return "$host:$port"
+        return ServerOrigin.from(host = host, port = port)
     }
 }
 

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/RunOptionsSpecifications.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/RunOptionsSpecifications.kt
@@ -3,21 +3,22 @@ package io.specmatic.core.config.v3.components.runOptions
 import com.fasterxml.jackson.annotation.JsonAnyGetter
 import com.fasterxml.jackson.annotation.JsonAnySetter
 import com.fasterxml.jackson.annotation.JsonIgnore
+import io.specmatic.core.config.v3.ServerOrigin
 import io.specmatic.core.config.v3.components.SecuritySchemeConfigurationV3
 import kotlin.String
 
 interface IRunOptionSpecification {
     fun getId(): String?
-    fun getBaseUrl(defaultHost: String): String?
+    fun getServerOrigin(defaultHost: String): ServerOrigin?
     fun getConfig(): Map<String, Any>
     fun getOverlayFilePath(): String?
     fun isNoOpOverride(): Boolean
 
-    fun extractBaseUrlFromMap(map: Map<*, *>?, defaultHost: String): String? {
-        if (map.isNullOrEmpty()) return null
-        val host = map["host"]?.toString() ?: defaultHost
-        val port = map["port"]?.toString()?.toIntOrNull() ?: return null
-        return "$host:$port"
+    @JsonIgnore
+    fun extractServerOriginFromMap(map: Map<*, *>?, defaultHost: String): ServerOrigin? {
+        val host = map?.get("host")?.toString() ?: defaultHost
+        val port = map?.get("port")?.toString()?.toIntOrNull() ?: return null
+        return ServerOrigin.from(host = host, port = port)
     }
 }
 
@@ -33,9 +34,9 @@ data class RunOptionsSpecifications(val spec: Value) : IRunOptionSpecification {
     }
 
     @JsonIgnore
-    override fun getBaseUrl(defaultHost: String): String? {
-        if (spec.port == null) return extractBaseUrlFromMap(spec.config["inMemoryBroker"] as? Map<*, *>, "localhost")
-        return "${spec.host ?: defaultHost}:${spec.port}"
+    override fun getServerOrigin(defaultHost: String): ServerOrigin? {
+        if (spec.port == null) return extractServerOriginFromMap(spec.config["inMemoryBroker"] as? Map<*, *>, defaultHost)
+        return ServerOrigin.from(host = spec.host ?: defaultHost, port = spec.port)
     }
 
     @JsonIgnore
@@ -94,10 +95,10 @@ data class WsdlRunOptionsSpecifications(val spec: Value) : IRunOptionSpecificati
     }
 
     @JsonIgnore
-    override fun getBaseUrl(defaultHost: String): String? {
-        if (spec.baseUrl != null) return spec.baseUrl
+    override fun getServerOrigin(defaultHost: String): ServerOrigin? {
+        if (spec.baseUrl != null) return ServerOrigin.from(spec.baseUrl)
         if (spec.port == null) return null
-        return "http://${spec.host ?: defaultHost}:${spec.port}"
+        return ServerOrigin.from("http", spec.host ?: defaultHost, spec.port)
     }
 
     data class Value(
@@ -135,10 +136,10 @@ data class OpenApiRunOptionsSpecifications(val spec: Value) : IRunOptionSpecific
     }
 
     @JsonIgnore
-    override fun getBaseUrl(defaultHost: String): String? {
-        if (spec.baseUrl != null) return spec.baseUrl
+    override fun getServerOrigin(defaultHost: String): ServerOrigin? {
+        if (spec.baseUrl != null) return ServerOrigin.from(spec.baseUrl)
         if (spec.port == null) return null
-        return "http://${spec.host ?: defaultHost}:${spec.port}"
+        return ServerOrigin.from("http", spec.host ?: defaultHost, spec.port)
     }
 
     data class Value(

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/WsdlRunOptions.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/WsdlRunOptions.kt
@@ -3,6 +3,7 @@ package io.specmatic.core.config.v3.components.runOptions
 import com.fasterxml.jackson.annotation.*
 import io.specmatic.core.config.HttpsConfiguration
 import io.specmatic.core.config.v3.RefOrValue
+import io.specmatic.core.config.v3.ServerOrigin
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 @JsonSubTypes(JsonSubTypes.Type(WsdlTestConfig::class, name = "test"), JsonSubTypes.Type(WsdlMockConfig::class, name = "mock"))
@@ -19,10 +20,10 @@ data class WsdlTestConfig(
     private val _config: MutableMap<String, Any> = linkedMapOf()
 
     @JsonIgnore
-    override fun getBaseUrlIfExists(): String? {
-        if (baseUrl != null) return baseUrl
-        if (port != null) return "http://${host ?: "localhost"}:$port"
-        return null
+    override fun gerServerOrigin(): ServerOrigin? {
+        if (baseUrl != null) return ServerOrigin.from(baseUrl)
+        if (port == null) return null
+        return ServerOrigin.from("http", host ?: "localhost", port)
     }
 
     @JsonIgnore
@@ -55,11 +56,11 @@ data class WsdlMockConfig(
     private val _config: MutableMap<String, Any> = linkedMapOf()
 
     @JsonIgnore
-    override fun getBaseUrlIfExists(): String? {
-        if (baseUrl != null) return baseUrl
+    override fun gerServerOrigin(): ServerOrigin? {
+        if (baseUrl != null) return ServerOrigin.from(baseUrl)
         if (port == null) return null
         val scheme = if (cert == null) "http" else "https"
-        return "$scheme://${host ?: "0.0.0.0"}:$port"
+        return ServerOrigin.from(scheme, host ?: "0.0.0.0", port)
     }
 
     @JsonIgnore

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/MockServiceConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/MockServiceConfig.kt
@@ -7,6 +7,7 @@ import io.specmatic.core.config.nonNullElse
 import io.specmatic.core.config.v3.Data
 import io.specmatic.core.config.v3.RefOrValue
 import io.specmatic.core.config.v3.RefOrValueResolver
+import io.specmatic.core.config.v3.ServerOrigin
 import io.specmatic.core.config.v3.SpecmaticConfigV3Resolver
 import io.specmatic.core.config.v3.components.ExampleDirectories
 import io.specmatic.core.config.v3.components.runOptions.ConfigWithCert
@@ -78,11 +79,11 @@ data class MockServiceConfig(val services: List<Value>, val data: Data? = null, 
             service.definitions.flatMap { defRef ->
                 val definition = defRef.definition
                 val source = definition.source.resolveElseThrow(resolver)
-                val serviceExamples = service?.data?.toExampleDirs(resolver)
+                val serviceExamples = service.data?.toExampleDirs(resolver)
                 val examples = mergeExamples(dependencyExamples, serviceExamples)
                 definition.specs.map {
                     it.toSpecificationSource(source, null, examples) { specId, file ->
-                        getFirstBaseUrlFromRunOpts(specId, file , service, resolver)
+                        getServerOrigin(specId, file, service, resolver)
                     }
                 }.map { spec -> source to spec }
             }
@@ -114,12 +115,12 @@ data class MockServiceConfig(val services: List<Value>, val data: Data? = null, 
     }
 
     @JsonIgnore
-    private fun getFirstBaseUrlFromRunOpts(specId: String?, specFile: File, service: CommonServiceConfig<MockRunOptions, MockSettings>, resolver: RefOrValueResolver): String? {
+    private fun getServerOrigin(specId: String?, specFile: File, service: CommonServiceConfig<MockRunOptions, MockSettings>, resolver: RefOrValueResolver): ServerOrigin? {
         val specTypesToCheck = determineSpecTypeFor(specFile)
         return specTypesToCheck.firstNotNullOfOrNull {
             val runOptions = getRunOptions(service, resolver, it) ?: return@firstNotNullOfOrNull null
             val runOptionSpecOverride = specId?.let(runOptions::getMatchingSpecification)
-            runOptionSpecOverride?.getBaseUrl("0.0.0.0") ?: runOptions.getBaseUrlIfExists()
+            runOptionSpecOverride?.getServerOrigin("0.0.0.0") ?: runOptions.gerServerOrigin()
         }
     }
 
@@ -136,7 +137,7 @@ data class MockServiceConfig(val services: List<Value>, val data: Data? = null, 
     }
 
     @JsonIgnore
-    fun getCerts(resolver: RefOrValueResolver): List<Pair<String, HttpsConfiguration>> {
+    fun getCerts(resolver: RefOrValueResolver): List<Pair<ServerOrigin, HttpsConfiguration>> {
         return services.map { it.service.resolveElseThrow(resolver) }.flatMap { service ->
             service.definitions.map { it.definition }.flatMap { definition ->
                 definition.specs.mapNotNull { specDefinition ->
@@ -146,7 +147,7 @@ data class MockServiceConfig(val services: List<Value>, val data: Data? = null, 
                     val runCert = (runOptions as? ConfigWithCert)?.cert?.resolveElseThrow(resolver) ?: return@mapNotNull null
                     val specId = specDefinition.getSpecificationId()
                     val runOptionSpecOverride = specId?.let(runOptions::getMatchingSpecification)
-                    val baseUrl = runOptionSpecOverride?.getBaseUrl("0.0.0.0") ?: runOptions.getBaseUrlIfExists() ?: return@mapNotNull null
+                    val baseUrl = runOptionSpecOverride?.getServerOrigin("0.0.0.0") ?: runOptions.gerServerOrigin() ?: return@mapNotNull null
                     Pair(baseUrl, runCert)
                 }
             }

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/SpecificationDefinition.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/SpecificationDefinition.kt
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonValue
 import io.specmatic.core.Configuration.Companion.DEFAULT_BASE_URL
 import io.specmatic.core.ResiliencyTestSuite
 import io.specmatic.core.SpecificationSourceEntry
+import io.specmatic.core.config.v3.ServerOrigin
 import io.specmatic.core.config.v3.components.sources.SourceV3
 import io.specmatic.core.utilities.Flags
 import java.io.File
@@ -34,11 +35,11 @@ sealed interface SpecificationDefinition {
             source: SourceV3,
             resiliencyTestSuite: ResiliencyTestSuite?,
             examples: List<String>?,
-            getBaseUrl: (String?, File) -> String?
+            getServerOrigin: (String?, File) -> ServerOrigin?
         ): SpecificationSourceEntry {
             val specFile = source.resolveSpecification(File(spec.path))
-            val baseUrl = getBaseUrl(getSpecificationId(), specFile).let(::getBaseUrlWithSuffixPath)
-            return source.toSpecificationSource(specFile, spec.path, baseUrl, resiliencyTestSuite, examples)
+            val serverOrigin = getServerOrigin(getSpecificationId(), specFile).let(::getServerOriginWithBasePath)
+            return source.toSpecificationSource(specFile, spec.path, serverOrigin, resiliencyTestSuite, examples)
         }
 
         fun hasNoData(): Boolean = spec.urlPathPrefix == null && spec.config.isEmpty()
@@ -61,11 +62,11 @@ sealed interface SpecificationDefinition {
             source: SourceV3,
             resiliencyTestSuite: ResiliencyTestSuite?,
             examples: List<String>?,
-            getBaseUrl: (String?, File) -> String?
+            getServerOrigin: (String?, File) -> ServerOrigin?
         ): SpecificationSourceEntry {
             val specFile = source.resolveSpecification(File(specification))
-            val baseUrl = getBaseUrl(getSpecificationId(), specFile).let(::getBaseUrlWithSuffixPath)
-            return source.toSpecificationSource(specFile, specification, baseUrl, resiliencyTestSuite, examples)
+            val serverOrigin = getServerOrigin(getSpecificationId(), specFile).let(::getServerOriginWithBasePath)
+            return source.toSpecificationSource(specFile, specification, serverOrigin, resiliencyTestSuite, examples)
         }
 
         companion object {
@@ -82,11 +83,11 @@ sealed interface SpecificationDefinition {
     }
 
     @JsonIgnore
-    fun getBaseUrlWithSuffixPath(baseUrl: String?): String? {
-        val prefix = (this as? ObjectValue)?.spec?.urlPathPrefix?.trim('/')
-        if (prefix.isNullOrEmpty()) return baseUrl
-        val effectiveBaseUrl = baseUrl ?: Flags.getStringValue(Flags.SPECMATIC_BASE_URL) ?: DEFAULT_BASE_URL
-        return "${effectiveBaseUrl.removeSuffix("/")}/$prefix"
+    fun getServerOriginWithBasePath(serverOrigin: ServerOrigin?): ServerOrigin? {
+        val basePath = (this as? ObjectValue)?.spec?.urlPathPrefix?.trim('/')
+        if (basePath.isNullOrEmpty()) return serverOrigin
+        val effectiveBaseUrl = serverOrigin ?: ServerOrigin.from(Flags.getStringValue(Flags.SPECMATIC_BASE_URL) ?: DEFAULT_BASE_URL)
+        return effectiveBaseUrl.withPath(basePath)
     }
 
     @JsonIgnore
@@ -112,6 +113,6 @@ sealed interface SpecificationDefinition {
         source: SourceV3,
         resiliencyTestSuite: ResiliencyTestSuite?,
         examples: List<String>?,
-        getBaseUrl: (String?, File) -> String?
+        getServerOrigin: (String?, File) -> ServerOrigin?
     ): SpecificationSourceEntry
 }

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/TestServiceConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/TestServiceConfig.kt
@@ -8,6 +8,7 @@ import io.specmatic.core.config.nonNullElse
 import io.specmatic.core.config.v3.Data
 import io.specmatic.core.config.v3.RefOrValue
 import io.specmatic.core.config.v3.RefOrValueResolver
+import io.specmatic.core.config.v3.ServerOrigin
 import io.specmatic.core.config.v3.SpecmaticConfigV3Resolver
 import io.specmatic.core.config.v3.components.ExampleDirectories
 import io.specmatic.core.config.v3.components.runOptions.IRunOptions
@@ -78,7 +79,7 @@ data class TestServiceConfig(val service: RefOrValue<CommonServiceConfig<TestRun
             val source = definition.source.resolveElseThrow(resolver)
             definition.specs.map {
                 it.toSpecificationSource(source, resilientSuite, examples) { specId, file ->
-                    getFirstBaseUrlFromRunOpts(specId, file, resolver)
+                    getServerOrigin(specId, file, resolver)
                 }
             }.map { spec -> source to spec }
         }.groupBy(keySelector = { it.first }, valueTransform = { it.second })
@@ -109,7 +110,7 @@ data class TestServiceConfig(val service: RefOrValue<CommonServiceConfig<TestRun
     }
 
     @JsonIgnore
-    fun getCerts(resolver: RefOrValueResolver): List<Pair<String, HttpsConfiguration>> {
+    fun getCerts(resolver: RefOrValueResolver): List<Pair<ServerOrigin, HttpsConfiguration>> {
         val serviceConfig = service.resolveElseThrow(resolver)
         return serviceConfig.definitions.map { it.definition }.flatMap { definition ->
             definition.specs.mapNotNull { specDefinition ->
@@ -119,7 +120,7 @@ data class TestServiceConfig(val service: RefOrValue<CommonServiceConfig<TestRun
                 val runCert = (runOptions as? ConfigWithCert)?.cert?.resolveElseThrow(resolver) ?: return@mapNotNull null
                 val specId = specDefinition.getSpecificationId()
                 val runOptionSpecOverride = specId?.let(runOptions::getMatchingSpecification)
-                val baseUrl = runOptionSpecOverride?.getBaseUrl("localhost") ?: runOptions.getBaseUrlIfExists() ?: return@mapNotNull null
+                val baseUrl = runOptionSpecOverride?.getServerOrigin("localhost") ?: runOptions.gerServerOrigin() ?: return@mapNotNull null
                 Pair(baseUrl, runCert)
             }
         }
@@ -186,12 +187,12 @@ data class TestServiceConfig(val service: RefOrValue<CommonServiceConfig<TestRun
     }
 
     @JsonIgnore
-    private fun getFirstBaseUrlFromRunOpts(specId: String?, specFile: File, resolver: RefOrValueResolver): String? {
+    private fun getServerOrigin(specId: String?, specFile: File, resolver: RefOrValueResolver): ServerOrigin? {
         val specTypesToCheck = determineSpecTypeFor(specFile)
         return specTypesToCheck.firstNotNullOfOrNull {
             val runOptions = getRunOptions(resolver, it) ?: return@firstNotNullOfOrNull null
             val runOptionSpecOverride = specId?.let(runOptions::getMatchingSpecification)
-            runOptionSpecOverride?.getBaseUrl("localhost") ?: runOptions.getBaseUrlIfExists()
+            runOptionSpecOverride?.getServerOrigin("localhost") ?: runOptions.gerServerOrigin()
         }
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/sources/SourceV3.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/sources/SourceV3.kt
@@ -8,11 +8,11 @@ import io.specmatic.core.ResiliencyTestSuite
 import io.specmatic.core.SourceProvider
 import io.specmatic.core.SpecificationSourceEntry
 import io.specmatic.core.WorkingDirectory
+import io.specmatic.core.config.v3.ServerOrigin
 import io.specmatic.core.getConfigFilePath
 import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.utilities.applyIf
 import io.specmatic.core.utilities.ResolvedWebSource
-import io.specmatic.stub.extractPort
 import java.io.File
 
 data class SourceV3(private val git: Git?, private val fileSystem: FileSystem?, private val web: Web?) {
@@ -50,12 +50,13 @@ data class SourceV3(private val git: Git?, private val fileSystem: FileSystem?, 
         else -> SourceProvider.filesystem
     }
 
-    fun toSpecificationSource(specFile: File, specPathInConfig: String, baseUrl: String?, resiliencyTestSuite: ResiliencyTestSuite?, examples: List<String>?): SpecificationSourceEntry {
+    fun toSpecificationSource(specFile: File, specPathInConfig: String, serverOrigin: ServerOrigin?, resiliencyTestSuite: ResiliencyTestSuite?, examples: List<String>?): SpecificationSourceEntry {
         val type = when {
             git != null -> SourceProvider.git
             web != null -> SourceProvider.web
             else -> SourceProvider.filesystem
         }
+
         return SpecificationSourceEntry(
             specFile = specFile,
             specPathInConfig = specPathInConfig,
@@ -64,9 +65,10 @@ data class SourceV3(private val git: Git?, private val fileSystem: FileSystem?, 
             directory = fileSystem?.directory,
             branch = git?.branch,
             matchBranch = git?.matchBranch,
-            baseUrl = baseUrl,
             webSourceUrl = web?.url,
-            port = baseUrl?.let(::extractPort),
+            host = serverOrigin?.host,
+            port = serverOrigin?.port,
+            baseUrl = serverOrigin?.baseUrl,
             resiliencyTestSuite = resiliencyTestSuite,
             exampleDirs = examples,
         )

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/utils.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/utils.kt
@@ -7,6 +7,39 @@ import org.yaml.snakeyaml.Yaml
 import java.io.File
 import kotlin.collections.contains
 
+sealed interface ServerOrigin {
+    val port: Int? get() = null
+    val host: String? get() = null
+    val scheme: String? get() = null
+    val baseUrl: String? get() = null
+
+    fun toBaseUrl(defaultScheme: String = "http"): String
+
+    data class BaseUrl(override val baseUrl: String) : ServerOrigin {
+        override fun toBaseUrl(defaultScheme: String): String = baseUrl
+    }
+
+    data class NetworkAddress(override val scheme: String? = null, override val host: String, override val port: Int) : ServerOrigin {
+        override fun toBaseUrl(defaultScheme: String): String {
+            return "${scheme ?: defaultScheme}://$host:$port"
+        }
+    }
+
+    fun withPath(path: String, defaultScheme: String = "http"): ServerOrigin {
+        val cleanPath = path.removePrefix("/")
+        val cleanBaseUrl = toBaseUrl(defaultScheme).removeSuffix("/")
+        return BaseUrl(if (cleanPath.isBlank()) cleanBaseUrl else "$cleanBaseUrl/$cleanPath")
+    }
+
+    companion object {
+        fun from(url: String): ServerOrigin = BaseUrl(url)
+        fun from(scheme: String? = null, host: String, port: Int): ServerOrigin {
+            if (scheme == null) return NetworkAddress(host = host, port = port)
+            return BaseUrl("$scheme://$host:$port")
+        }
+    }
+}
+
 internal fun determineSpecTypeFor(specFile: File): List<SpecType> {
     return when(specFile.extension.lowercase()) {
         "wsdl" ->

--- a/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigKtTest.kt
@@ -142,6 +142,7 @@ internal class SpecmaticConfigKtTest {
         val sourceEntry = SpecificationSourceEntry(
             specFile = specFile,
             specPathInConfig = "contracts/petstore.yaml",
+            host = null,
             port = null,
             baseUrl = "http://localhost:9000",
             webSourceUrl = null,

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/UtilsTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/UtilsTest.kt
@@ -1,0 +1,18 @@
+package io.specmatic.core.config.v3
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class UtilsTest {
+    @Test
+    fun `ServerOrigin withPath should append path to base url`() {
+        val origin = ServerOrigin.from("http://example.com")
+        assertThat(origin.withPath("/api/v1")).isEqualTo(ServerOrigin.from("http://example.com/api/v1"))
+    }
+
+    @Test
+    fun `ServerOrigin withPath should build base url from network address`() {
+        val origin = ServerOrigin.NetworkAddress(host = "localhost", port = 8080)
+        assertThat(origin.withPath("api/v1")).isEqualTo(ServerOrigin.from("http://localhost:8080/api/v1"))
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/components/runOptions/RunOptionsSpecificationsTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/components/runOptions/RunOptionsSpecificationsTest.kt
@@ -1,48 +1,49 @@
 package io.specmatic.core.config.v3.components.runOptions
 
+import io.specmatic.core.config.v3.ServerOrigin
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class RunOptionsSpecificationsTest {
     @Test
-    fun `openapi getBaseUrl should return baseUrl when present`() {
+    fun `openapi getServerOrigin should return baseUrl when present`() {
         val runOptions = OpenApiRunOptionsSpecifications(OpenApiRunOptionsSpecifications.Value(baseUrl = "http://example.com"))
-        assertEquals("http://example.com", runOptions.getBaseUrl("localhost"))
+        assertEquals(ServerOrigin.from("http://example.com"), runOptions.getServerOrigin("localhost"))
     }
 
     @Test
-    fun `openapi getBaseUrl should return host and port when baseUrl is absent`() {
+    fun `openapi getServerOrigin should return http origin when baseUrl is absent`() {
         val runOptions = OpenApiRunOptionsSpecifications(OpenApiRunOptionsSpecifications.Value(host = "localhost", port = 8080))
-        assertEquals("http://localhost:8080", runOptions.getBaseUrl("localhost"))
+        assertEquals(ServerOrigin.from("http", "localhost", 8080), runOptions.getServerOrigin("localhost"))
 
         val portOnly = OpenApiRunOptionsSpecifications(OpenApiRunOptionsSpecifications.Value(port = 9000))
-        assertEquals("http://0.0.0.0:9000", portOnly.getBaseUrl("0.0.0.0"))
+        assertEquals(ServerOrigin.from("http", "0.0.0.0", 9000), portOnly.getServerOrigin("0.0.0.0"))
     }
 
     @Test
-    fun `wsdl getBaseUrl should return baseUrl when present`() {
+    fun `wsdl getServerOrigin should return baseUrl when present`() {
         val runOptions = WsdlRunOptionsSpecifications(WsdlRunOptionsSpecifications.Value(baseUrl = "http://example.com"))
-        assertEquals("http://example.com", runOptions.getBaseUrl("localhost"))
+        assertEquals(ServerOrigin.from("http://example.com"), runOptions.getServerOrigin("localhost"))
     }
 
     @Test
-    fun `wsdl getBaseUrl should return host and port when baseUrl is absent`() {
+    fun `wsdl getServerOrigin should return http origin when baseUrl is absent`() {
         val runOptions = WsdlRunOptionsSpecifications(WsdlRunOptionsSpecifications.Value(host = "localhost", port = 9000))
-        assertEquals("http://localhost:9000", runOptions.getBaseUrl("localhost"))
+        assertEquals(ServerOrigin.from("http", "localhost", 9000), runOptions.getServerOrigin("localhost"))
 
         val portOnly = WsdlRunOptionsSpecifications(WsdlRunOptionsSpecifications.Value(port = 9000))
-        assertEquals("http://0.0.0.0:9000", portOnly.getBaseUrl("0.0.0.0"))
+        assertEquals(ServerOrigin.from("http", "0.0.0.0", 9000), portOnly.getServerOrigin("0.0.0.0"))
     }
 
     @Test
-    fun `for other specs getBaseUrl should return host and port and for async use inMemoryBroker`() {
+    fun `for other specs getServerOrigin should keep host and port only`() {
         val otherSpec = RunOptionsSpecifications(RunOptionsSpecifications.Value(host = "localhost", port = 9090))
-        assertEquals("localhost:9090", otherSpec.getBaseUrl("localhost"))
+        assertEquals(ServerOrigin.NetworkAddress(host = "localhost", port = 9090), otherSpec.getServerOrigin("localhost"))
 
         val otherPortOnly = RunOptionsSpecifications(RunOptionsSpecifications.Value(port = 9090))
-        assertEquals("0.0.0.0:9090", otherPortOnly.getBaseUrl("0.0.0.0"))
+        assertEquals(ServerOrigin.NetworkAddress(host = "0.0.0.0", port = 9090), otherPortOnly.getServerOrigin("0.0.0.0"))
 
         val asyncSpec = RunOptionsSpecifications(RunOptionsSpecifications.Value().withConfig(mapOf("inMemoryBroker" to mapOf("host" to "localhost", "port" to 5672))))
-        assertEquals("localhost:5672", asyncSpec.getBaseUrl("localhost"))
+        assertEquals(ServerOrigin.NetworkAddress(host = "localhost", port = 5672), asyncSpec.getServerOrigin("localhost"))
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/components/services/MockServiceConfigTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/components/services/MockServiceConfigTest.kt
@@ -93,7 +93,7 @@ class MockServiceConfigTest {
     }
 
     @Test
-    fun `getSpecificationSources should use asyncapi inMemoryBroker for async runOptions`(@TempDir tempDir: File) {
+    fun `getSpecificationSources should use asyncapi inMemoryBroker as host and port for async runOptions`(@TempDir tempDir: File) {
         val specFile = tempDir.resolve("contract.yaml").apply { writeText("asyncapi: 3.0.0") }
         val source = SourceV3.create(filesystem = SourceV3.FileSystem(directory = tempDir.canonicalPath))
 
@@ -121,7 +121,9 @@ class MockServiceConfigTest {
         val sourceEntries = mockServiceConfig.getSpecificationSources(resolver).values.flatten()
 
         assertThat(sourceEntries).hasSize(1)
-        assertThat(sourceEntries.single().baseUrl).isEqualTo("localhost:8081")
+        assertThat(sourceEntries.single().host).isEqualTo("localhost")
+        assertThat(sourceEntries.single().port).isEqualTo(8081)
+        assertThat(sourceEntries.single().baseUrl).isNull()
     }
 
     @Test
@@ -293,7 +295,7 @@ class MockServiceConfigTest {
     }
 
     @Test
-    fun `getSpecificationSources should use protobuf per-spec baseUrl when spec id matches`(@TempDir tempDir: File) {
+    fun `getSpecificationSources should use protobuf per-spec host and port when spec id matches`(@TempDir tempDir: File) {
         val specFile = tempDir.resolve("service.proto").apply { writeText("syntax = \"proto3\";") }
         val source = SourceV3.create(filesystem = SourceV3.FileSystem(directory = tempDir.canonicalPath))
         val protobufConfig = ProtobufMockConfig(
@@ -324,11 +326,13 @@ class MockServiceConfigTest {
         )
 
         val entries = MockServiceConfig(services = listOf(MockServiceConfig.Value(service = RefOrValue.Value(serviceConfig))), settings = null).getSpecificationSources(resolver).values.flatten()
-        assertThat(entries.single().baseUrl).isEqualTo("proto-spec:9201")
+        assertThat(entries.single().host).isEqualTo("proto-spec")
+        assertThat(entries.single().port).isEqualTo(9201)
+        assertThat(entries.single().baseUrl).isNull()
     }
 
     @Test
-    fun `getSpecificationSources should fallback to protobuf runOption baseUrl when spec id has no match`(@TempDir tempDir: File) {
+    fun `getSpecificationSources should fallback to protobuf runOption host and port when spec id has no match`(@TempDir tempDir: File) {
         val specFile = tempDir.resolve("service.proto").apply { writeText("syntax = \"proto3\";") }
         val source = SourceV3.create(filesystem = SourceV3.FileSystem(directory = tempDir.canonicalPath))
         val protobufConfig = ProtobufMockConfig(
@@ -359,11 +363,13 @@ class MockServiceConfigTest {
         )
 
         val entries = MockServiceConfig(services = listOf(MockServiceConfig.Value(service = RefOrValue.Value(serviceConfig))), settings = null).getSpecificationSources(resolver).values.flatten()
-        assertThat(entries.single().baseUrl).isEqualTo("proto-default:9200")
+        assertThat(entries.single().host).isEqualTo("proto-default")
+        assertThat(entries.single().port).isEqualTo(9200)
+        assertThat(entries.single().baseUrl).isNull()
     }
 
     @Test
-    fun `getSpecificationSources should use graphql per-spec baseUrl when spec id matches`(@TempDir tempDir: File) {
+    fun `getSpecificationSources should use graphql per-spec host and port when spec id matches`(@TempDir tempDir: File) {
         val specFile = tempDir.resolve("service.graphql").apply { writeText("type Query { ping: String }") }
         val source = SourceV3.create(filesystem = SourceV3.FileSystem(directory = tempDir.canonicalPath))
         val graphConfig = GraphQLSdlMockConfig(
@@ -394,11 +400,13 @@ class MockServiceConfigTest {
         )
 
         val entries = MockServiceConfig(services = listOf(MockServiceConfig.Value(service = RefOrValue.Value(serviceConfig))), settings = null).getSpecificationSources(resolver).values.flatten()
-        assertThat(entries.single().baseUrl).isEqualTo("graphql-spec:9301")
+        assertThat(entries.single().host).isEqualTo("graphql-spec")
+        assertThat(entries.single().port).isEqualTo(9301)
+        assertThat(entries.single().baseUrl).isNull()
     }
 
     @Test
-    fun `getSpecificationSources should fallback to graphql runOption baseUrl when spec id has no match`(@TempDir tempDir: File) {
+    fun `getSpecificationSources should fallback to graphql runOption host and port when spec id has no match`(@TempDir tempDir: File) {
         val specFile = tempDir.resolve("service.graphql").apply { writeText("type Query { ping: String }") }
         val source = SourceV3.create(filesystem = SourceV3.FileSystem(directory = tempDir.canonicalPath))
         val graphConfig = GraphQLSdlMockConfig(
@@ -429,11 +437,13 @@ class MockServiceConfigTest {
         )
 
         val entries = MockServiceConfig(services = listOf(MockServiceConfig.Value(service = RefOrValue.Value(serviceConfig))), settings = null).getSpecificationSources(resolver).values.flatten()
-        assertThat(entries.single().baseUrl).isEqualTo("graphql-default:9300")
+        assertThat(entries.single().host).isEqualTo("graphql-default")
+        assertThat(entries.single().port).isEqualTo(9300)
+        assertThat(entries.single().baseUrl).isNull()
     }
 
     @Test
-    fun `getSpecificationSources should resolve openapi and asyncapi yaml specs in same service`(@TempDir tempDir: File) {
+    fun `getSpecificationSources should resolve openapi and asyncapi yaml specs with async host and port in same service`(@TempDir tempDir: File) {
         val openApiSpecFile = tempDir.resolve("openapi-contract.yaml").apply { writeText("openapi: 3.0.0") }
         val asyncApiSpecFile = tempDir.resolve("asyncapi-contract.yaml").apply { writeText("asyncapi: 2.6.0") }
         val source = SourceV3.create(filesystem = SourceV3.FileSystem(directory = tempDir.canonicalPath))
@@ -468,7 +478,9 @@ class MockServiceConfigTest {
             .associateBy { it.specPathInConfig }
 
         assertThat(entriesByPath[openApiSpecFile.name]?.baseUrl).isEqualTo("http://openapi-host:9401")
-        assertThat(entriesByPath[asyncApiSpecFile.name]?.baseUrl).isEqualTo("async-host:9400")
+        assertThat(entriesByPath[asyncApiSpecFile.name]?.host).isEqualTo("async-host")
+        assertThat(entriesByPath[asyncApiSpecFile.name]?.port).isEqualTo(9400)
+        assertThat(entriesByPath[asyncApiSpecFile.name]?.baseUrl).isNull()
     }
 
 }

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/components/services/SpecificationDefinitionTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/components/services/SpecificationDefinitionTest.kt
@@ -1,6 +1,8 @@
 package io.specmatic.core.config.v3.components.services
 
+import io.specmatic.core.config.v3.ServerOrigin
 import io.specmatic.core.config.v3.components.sources.SourceV3
+import io.specmatic.core.utilities.Flags
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -15,5 +17,38 @@ class SpecificationDefinitionTest {
         val relativeInputPath = File("contracts/orders.yaml")
 
         assertThat(definition.matchesFile(source, relativeInputPath)).isTrue()
+    }
+
+    @Test
+    fun `getServerOriginWithBasePath should append urlPathPrefix to server origin`() {
+        val definition = SpecificationDefinition.ObjectValue(
+            SpecificationDefinition.Specification(
+                id = "orders",
+                urlPathPrefix = "/v1/",
+                path = "contracts/orders.yaml",
+            )
+        )
+
+        val serverOrigin = ServerOrigin.NetworkAddress(host = "localhost", port = 8080)
+        assertThat(definition.getServerOriginWithBasePath(serverOrigin)).isEqualTo(
+            ServerOrigin.from("http://localhost:8080/v1")
+        )
+    }
+
+    @Test
+    fun `getServerOriginWithBasePath should use SPECMATIC_BASE_URL when server origin is missing`() {
+        val definition = SpecificationDefinition.ObjectValue(
+            SpecificationDefinition.Specification(
+                id = "orders",
+                urlPathPrefix = "v1",
+                path = "contracts/orders.yaml",
+            )
+        )
+
+        Flags.using(Flags.SPECMATIC_BASE_URL to "http://default.example:9090") {
+            assertThat(definition.getServerOriginWithBasePath(null)).isEqualTo(
+                ServerOrigin.from("http://default.example:9090/v1")
+           )
+        }
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/components/services/TestServiceConfigTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/components/services/TestServiceConfigTest.kt
@@ -26,7 +26,7 @@ class TestServiceConfigTest {
     }
 
     @Test
-    fun `getSpecificationSources should use asyncapi inMemoryBroker for async runOptions`(@TempDir tempDir: File) {
+    fun `getSpecificationSources should use asyncapi inMemoryBroker as host and port for async runOptions`(@TempDir tempDir: File) {
         val specFile = tempDir.resolve("contract.yaml").apply { writeText("asyncapi: 3.0.0") }
         val source = SourceV3.create(filesystem = SourceV3.FileSystem(directory = tempDir.canonicalPath))
         val asyncApiTestConfig = AsyncApiTestConfig().apply {
@@ -48,7 +48,9 @@ class TestServiceConfigTest {
         val sourceEntries = testServiceConfig.getSpecificationSources(resolver, testSettings = null).values.flatten()
 
         assertThat(sourceEntries).hasSize(1)
-        assertThat(sourceEntries.single().baseUrl).isEqualTo("localhost:8082")
+        assertThat(sourceEntries.single().host).isEqualTo("localhost")
+        assertThat(sourceEntries.single().port).isEqualTo(8082)
+        assertThat(sourceEntries.single().baseUrl).isNull()
     }
 
     @Test
@@ -276,7 +278,7 @@ class TestServiceConfigTest {
     }
 
     @Test
-    fun `getSpecificationSources should use protobuf per-spec baseUrl when spec id matches`(@TempDir tempDir: File) {
+    fun `getSpecificationSources should use protobuf per-spec host and port when spec id matches`(@TempDir tempDir: File) {
         val specFile = tempDir.resolve("service.proto").apply { writeText("syntax = \"proto3\";") }
         val source = SourceV3.create(filesystem = SourceV3.FileSystem(directory = tempDir.canonicalPath))
         val protobufConfig = ProtobufTestConfig(
@@ -307,11 +309,13 @@ class TestServiceConfigTest {
         )
 
         val entries = TestServiceConfig(service = RefOrValue.Value(serviceConfig)).getSpecificationSources(resolver, null).values.flatten()
-        assertThat(entries.single().baseUrl).isEqualTo("proto-spec:9201")
+        assertThat(entries.single().host).isEqualTo("proto-spec")
+        assertThat(entries.single().port).isEqualTo(9201)
+        assertThat(entries.single().baseUrl).isNull()
     }
 
     @Test
-    fun `getSpecificationSources should fallback to protobuf runOption baseUrl when spec id has no match`(@TempDir tempDir: File) {
+    fun `getSpecificationSources should fallback to protobuf runOption host and port when spec id has no match`(@TempDir tempDir: File) {
         val specFile = tempDir.resolve("service.proto").apply { writeText("syntax = \"proto3\";") }
         val source = SourceV3.create(filesystem = SourceV3.FileSystem(directory = tempDir.canonicalPath))
         val protobufConfig = ProtobufTestConfig(
@@ -342,11 +346,13 @@ class TestServiceConfigTest {
         )
 
         val entries = TestServiceConfig(service = RefOrValue.Value(serviceConfig)).getSpecificationSources(resolver, null).values.flatten()
-        assertThat(entries.single().baseUrl).isEqualTo("proto-default:9200")
+        assertThat(entries.single().host).isEqualTo("proto-default")
+        assertThat(entries.single().port).isEqualTo(9200)
+        assertThat(entries.single().baseUrl).isNull()
     }
 
     @Test
-    fun `getSpecificationSources should use graphql per-spec baseUrl when spec id matches`(@TempDir tempDir: File) {
+    fun `getSpecificationSources should use graphql per-spec host and port when spec id matches`(@TempDir tempDir: File) {
         val specFile = tempDir.resolve("service.graphql").apply { writeText("type Query { ping: String }") }
         val source = SourceV3.create(filesystem = SourceV3.FileSystem(directory = tempDir.canonicalPath))
         val graphConfig = GraphQLSdlTestConfig(
@@ -377,11 +383,13 @@ class TestServiceConfigTest {
         )
 
         val entries = TestServiceConfig(service = RefOrValue.Value(serviceConfig)).getSpecificationSources(resolver, null).values.flatten()
-        assertThat(entries.single().baseUrl).isEqualTo("graphql-spec:9301")
+        assertThat(entries.single().host).isEqualTo("graphql-spec")
+        assertThat(entries.single().port).isEqualTo(9301)
+        assertThat(entries.single().baseUrl).isNull()
     }
 
     @Test
-    fun `getSpecificationSources should fallback to graphql runOption baseUrl when spec id has no match`(@TempDir tempDir: File) {
+    fun `getSpecificationSources should fallback to graphql runOption host and port when spec id has no match`(@TempDir tempDir: File) {
         val specFile = tempDir.resolve("service.graphql").apply { writeText("type Query { ping: String }") }
         val source = SourceV3.create(filesystem = SourceV3.FileSystem(directory = tempDir.canonicalPath))
         val graphConfig = GraphQLSdlTestConfig(
@@ -412,11 +420,13 @@ class TestServiceConfigTest {
         )
 
         val entries = TestServiceConfig(service = RefOrValue.Value(serviceConfig)).getSpecificationSources(resolver, null).values.flatten()
-        assertThat(entries.single().baseUrl).isEqualTo("graphql-default:9300")
+        assertThat(entries.single().host).isEqualTo("graphql-default")
+        assertThat(entries.single().port).isEqualTo(9300)
+        assertThat(entries.single().baseUrl).isNull()
     }
 
     @Test
-    fun `getSpecificationSources should resolve openapi and asyncapi yaml specs in same service`(@TempDir tempDir: File) {
+    fun `getSpecificationSources should resolve openapi and asyncapi yaml specs with async host and port in same service`(@TempDir tempDir: File) {
         val openApiSpecFile = tempDir.resolve("openapi-contract.yaml").apply { writeText("openapi: 3.0.0") }
         val asyncApiSpecFile = tempDir.resolve("asyncapi-contract.yaml").apply { writeText("asyncapi: 2.6.0") }
         val source = SourceV3.create(filesystem = SourceV3.FileSystem(directory = tempDir.canonicalPath))
@@ -451,7 +461,9 @@ class TestServiceConfigTest {
             .associateBy { it.specPathInConfig }
 
         assertThat(entriesByPath[openApiSpecFile.name]?.baseUrl).isEqualTo("http://openapi-host:9401")
-        assertThat(entriesByPath[asyncApiSpecFile.name]?.baseUrl).isEqualTo("async-host:9400")
+        assertThat(entriesByPath[asyncApiSpecFile.name]?.host).isEqualTo("async-host")
+        assertThat(entriesByPath[asyncApiSpecFile.name]?.port).isEqualTo(9400)
+        assertThat(entriesByPath[asyncApiSpecFile.name]?.baseUrl).isNull()
     }
 
 }


### PR DESCRIPTION
**What:** Fix `stubBaseUrls` in Config V3 when it produces unparseable URLs.

**How:** Avoid normalizing everything into a base URL, as it may not be practical for other modules like async, gRPC, and so on

**Checklist**:

- [x] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
