### PR TITLE
Remove SPECMATIC_BCC_REPORT feature flag

### DIFF
--- a/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
+++ b/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
@@ -20,7 +20,6 @@ import io.specmatic.license.core.SpecmaticProtocol
 import io.specmatic.reporter.backwardcompat.dto.OperationUsageResponse
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.entry
-import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -50,14 +49,6 @@ class BackwardCompatibilityCheckCommandV2Test {
                 feature = SpecmaticFeature.BACKWARD_COMPATIBILITY_CHECK,
                 protocol = listOf(SpecmaticProtocol.HTTP)
             )
-
-            System.setProperty("SPECMATIC_BCC_REPORT", "true")
-        }
-
-        @AfterAll
-        @JvmStatic
-        fun teardown() {
-            System.clearProperty("SPECMATIC_BCC_REPORT")
         }
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityCheckRecord.kt
+++ b/core/src/main/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityCheckRecord.kt
@@ -1,7 +1,6 @@
 package io.specmatic.core
 
 import io.specmatic.conversions.convertPathParameterStyle
-import io.specmatic.core.utilities.Flags
 import io.specmatic.reporter.ctrf.model.CtrfBackwardCompatibilityRecord
 import io.specmatic.reporter.ctrf.model.CtrfBreakingChange
 import io.specmatic.reporter.ctrf.model.CtrfOperationQualifiers
@@ -31,7 +30,7 @@ data class OpenApiBackwardCompatibilityCheckRecord(
 
     // TODO: Need actual positive variation from generatedScenario
     override val name: String = scenario.fullApiDescription
-    override val message: String = compatResult.reportString(addSourceLocation = Flags.getBooleanValue(SPECMATIC_BCC_REPORT_FLAG))
+    override val message: String = compatResult.reportString(addSourceLocation = true)
     override val breakingChanges: List<CtrfBreakingChange> = compatResult.toIssues().flatMap { issue ->
         val sourceLocations = issue.sourceLocations.map { CtrfSourceLocation(it.filePath, it.line, it.column) }
         val rules: List<CtrfRuleSnapshot?> = issue.ruleViolations.map {

--- a/core/src/main/kotlin/io/specmatic/core/TestBackwardCompatibility.kt
+++ b/core/src/main/kotlin/io/specmatic/core/TestBackwardCompatibility.kt
@@ -2,7 +2,6 @@ package io.specmatic.core
 
 import io.specmatic.core.report.BccReportGenerator
 import io.specmatic.core.report.ReportGenerator
-import io.specmatic.core.utilities.Flags
 import io.specmatic.core.utilities.capitalizeFirstChar
 import io.specmatic.core.value.NullValue
 import io.specmatic.core.value.Value
@@ -10,7 +9,6 @@ import io.specmatic.reporter.ctrf.model.CtrfBackwardCompatibilityRecord
 import io.specmatic.reporter.ctrf.model.CtrfReport
 
 private const val BCC_REPORT_DIR_SUFFIX = "backward_compatibility"
-internal const val SPECMATIC_BCC_REPORT_FLAG = "SPECMATIC_BCC_REPORT"
 
 fun testBackwardCompatibility(older: Feature, newer: Feature): Results {
     return testBackwardCompatibilityWithReport(older, newer).first
@@ -21,14 +19,14 @@ internal fun testBackwardCompatibilityWithReport(older: Feature, newer: Feature)
     val records = OpenApiBackwardCompatibilityChecker(older, newer).run()
     val endTime = System.currentTimeMillis()
 
-    val result = records.toBackwardCompatibilityStatuses().copy(addSourceLocation = Flags.getBooleanValue(SPECMATIC_BCC_REPORT_FLAG))
+    val result = records.toBackwardCompatibilityStatuses().copy(addSourceLocation = true)
     val report = generateBackwardCompatibilityReport(records, startTime, endTime)
     return Pair(result, report)
 }
 
 fun backwardCompatibilityRecords(older: Feature, newer: Feature, repoDir: String? = null): Pair<Results, List<CtrfBackwardCompatibilityRecord>> {
     val records = OpenApiBackwardCompatibilityChecker(older, newer, repoDir).run()
-    return records.toBackwardCompatibilityStatuses().copy(addSourceLocation = Flags.getBooleanValue(SPECMATIC_BCC_REPORT_FLAG)) to records
+    return records.toBackwardCompatibilityStatuses().copy(addSourceLocation = true) to records
 }
 
 fun List<CtrfBackwardCompatibilityRecord>.toBackwardCompatibilityStatuses(): Results {
@@ -41,7 +39,6 @@ fun List<CtrfBackwardCompatibilityRecord>.toBackwardCompatibilityStatuses(): Res
 
 fun generateBackwardCompatibilityReport(records: List<CtrfBackwardCompatibilityRecord>, startTime: Long, endTime: Long): CtrfReport? {
     if (records.isEmpty()) return null
-    if (!Flags.getBooleanValue(SPECMATIC_BCC_REPORT_FLAG)) return null
     val reportOperations = BccReportGenerator().generateReportOperations(records)
     val reportDir = loadSpecmaticConfigOrDefault(getConfigFileName()).getReportDirPath(BCC_REPORT_DIR_SUFFIX).toFile()
     return ReportGenerator.generateReportBcc(

--- a/core/src/test/kotlin/integration_tests/InterpolatedPathsE2ETest.kt
+++ b/core/src/test/kotlin/integration_tests/InterpolatedPathsE2ETest.kt
@@ -18,8 +18,6 @@ import io.specmatic.stub.listener.MockEvent
 import io.specmatic.stub.listener.MockEventListener
 import io.specmatic.test.TestExecutor
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import java.io.File
@@ -55,20 +53,6 @@ class InterpolatedPathsE2ETest {
 
         testBlock(listener)
         return events
-    }
-
-    companion object {
-        @BeforeAll
-        @JvmStatic
-        fun setup() {
-            System.setProperty("SPECMATIC_BCC_REPORT", "true")
-        }
-
-        @AfterAll
-        @JvmStatic
-        fun teardown() {
-            System.clearProperty("SPECMATIC_BCC_REPORT")
-        }
     }
 
     @ParameterizedTest

--- a/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
@@ -16,8 +16,6 @@ import io.specmatic.stub.captureStandardOutput
 import io.specmatic.toViolationReportString
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -36,20 +34,6 @@ internal class TestBackwardCompatibilityKtTest {
         }
         assertThat(stripTrailingWhitespacePerLine(results.report()))
             .isEqualToNormalizingNewlines(stripTrailingWhitespacePerLine(expectedReport.trimIndent()))
-    }
-
-    companion object {
-        @BeforeAll
-        @JvmStatic
-        fun setup() {
-            System.setProperty("SPECMATIC_BCC_REPORT", "true")
-        }
-
-        @AfterAll
-        @JvmStatic
-        fun teardown() {
-            System.clearProperty("SPECMATIC_BCC_REPORT")
-        }
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityPerfTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityPerfTest.kt
@@ -2,8 +2,6 @@ package io.specmatic.core
 
 import io.specmatic.conversions.OpenApiSpecification
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertTimeoutPreemptively
 import java.io.File
@@ -11,20 +9,6 @@ import java.time.Duration.ofSeconds
 import kotlin.system.measureTimeMillis
 
 class TestBackwardCompatibilityPerfTest {
-    companion object {
-        @BeforeAll
-        @JvmStatic
-        fun setup() {
-            System.setProperty("SPECMATIC_BCC_REPORT", "true")
-        }
-
-        @AfterAll
-        @JvmStatic
-        fun teardown() {
-            System.clearProperty("SPECMATIC_BCC_REPORT")
-        }
-    }
-
     @Test
     fun `backward compatibility check performance should not regress`() {
         val specFile = File(javaClass.getResource("/openapi/multi_res_perf.yaml")!!.toURI())


### PR DESCRIPTION
Source locations are now always added and the BCC report is always
generated, removing the now-unconditional feature toggle.
