### PR TITLE
Fix flaky test in SpecmaticMcpServerTest

### DIFF
--- a/application/src/test/kotlin/application/mcp/server/SpecmaticMcpServerTest.kt
+++ b/application/src/test/kotlin/application/mcp/server/SpecmaticMcpServerTest.kt
@@ -8,8 +8,9 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
-import java.io.PipedInputStream
-import java.io.PipedOutputStream
+import java.io.InputStream
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
 class SpecmaticMcpServerTest {
@@ -49,8 +50,7 @@ class SpecmaticMcpServerTest {
 
     @Test
     fun `run should keep server process alive while stdio input is open`() {
-        val inputStream = PipedInputStream()
-        val inputWriter = PipedOutputStream(inputStream)
+        val inputStream = BlockingInputStream()
         val localServer = SpecmaticMcpServer(inputStream = inputStream, outputStream = ByteArrayOutputStream())
         val runReturned = AtomicBoolean(false)
         val runThread = Thread {
@@ -63,12 +63,11 @@ class SpecmaticMcpServerTest {
         runThread.start()
 
         try {
-            Thread.sleep(250)
-
+            assertThat(inputStream.readStarted.await(5, TimeUnit.SECONDS)).isTrue()
             assertThat(runReturned.get()).isFalse()
             assertThat(runThread.isAlive).isTrue()
         } finally {
-            inputWriter.close()
+            inputStream.close()
             runThread.join(5_000)
         }
     }
@@ -130,5 +129,20 @@ class SpecmaticMcpServerTest {
         val field = SpecmaticMcpServer::class.java.getDeclaredField("server")
         field.isAccessible = true
         return field.get(server) as McpSyncServer
+    }
+
+    private class BlockingInputStream : InputStream() {
+        val readStarted = CountDownLatch(1)
+        private val closeLatch = CountDownLatch(1)
+
+        override fun read(): Int {
+            readStarted.countDown()
+            closeLatch.await()
+            return -1
+        }
+
+        override fun close() {
+            closeLatch.countDown()
+        }
     }
 }


### PR DESCRIPTION
**What**: Fix flaky test in SpecmaticMcpServerTest

**Why**:
The test was relying on a fixed sleep to assume the server had started reading from stdio. On slower or busier environments, that timing assumption could make the test flaky.

**How**:
Replaced the pipe-based input and fixed delay with a custom blocking `InputStream`. The test now waits until `read()` has actually started, verifies that `run()` is still blocked while input remains open, and then closes the stream to let the server exit cleanly.

**Checklist**:
- [ ] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
