### PR TITLE
Replace java.net.URL with okhttp HttpUrl

### DIFF
--- a/application/build.gradle.kts
+++ b/application/build.gradle.kts
@@ -55,6 +55,7 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.14.4")
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.14.4")
     testImplementation("io.kotest:kotest-assertions-core-jvm:6.1.11")
+    testImplementation("com.squareup.okhttp3:okhttp:4.12.0")
 }
 
 tasks.test {

--- a/application/src/test/kotlin/io/specmatic/test/SpecmaticMockIncomingMtlsTest.kt
+++ b/application/src/test/kotlin/io/specmatic/test/SpecmaticMockIncomingMtlsTest.kt
@@ -10,6 +10,7 @@ import io.specmatic.core.parseGherkinStringToFeature
 import io.specmatic.stub.HttpStub
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
@@ -184,7 +185,7 @@ class SpecmaticMockIncomingMtlsTest {
 
     private fun openConnection(url: String, keyData: KeyData?): java.net.URLConnection {
         if (!url.startsWith("https://")) {
-            return java.net.URL(url).openConnection()
+            return url.toHttpUrl().toUrl().openConnection()
         }
 
         val keyManagers: Array<KeyManager>? = keyData?.let {
@@ -203,7 +204,7 @@ class SpecmaticMockIncomingMtlsTest {
             init(keyManagers, trustManagers, null)
         }
 
-        return (java.net.URL(url).openConnection() as HttpsURLConnection).apply {
+        return (url.toHttpUrl().toUrl().openConnection() as HttpsURLConnection).apply {
             sslSocketFactory = sslContext.socketFactory
             hostnameVerifier = javax.net.ssl.HostnameVerifier { _, _ -> true }
         }

--- a/core/src/main/kotlin/io/specmatic/conversions/Postman.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/Postman.kt
@@ -12,8 +12,9 @@ import io.specmatic.license.core.LicenseResolver
 import io.specmatic.license.core.LicensedProduct
 import io.specmatic.license.core.SpecmaticFeature
 import io.specmatic.test.LegacyHttpClient
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import java.net.URI
-import java.net.URL
 
 fun hostAndPort(uriString: String): BaseURLInfo {
     val uri = URI.create(uriString)
@@ -171,8 +172,8 @@ fun postmanItemRequest(request: JSONObjectValue): Pair<String, HttpRequest> {
     val method = request.getString("method")
     val url = urlFromPostmanValue(request.jsonObject.getValue("url"))
 
-    val baseURL = "${url.protocol}://${url.authority}"
-    val query: Map<String, String> = url.query?.split("&")?.map { it.split("=").let { parts -> Pair(parts[0], parts[1]) } }?.fold(emptyMap()) { acc, entry -> acc.plus(entry) }
+    val baseURL = "${url.scheme}://${url.toUri().authority}"
+    val query: Map<String, String> = url.encodedQuery?.split("&")?.map { it.split("=").let { parts -> Pair(parts[0], parts[1]) } }?.fold(emptyMap()) { acc, entry -> acc.plus(entry) }
             ?: emptyMap()
     val headers: Map<String, String> = request.getJSONArray("header").map { it as JSONObjectValue }.fold(emptyMap()) { headers, header ->
         headers.plus(Pair(header.getString("key"), header.getString("value")))
@@ -213,11 +214,11 @@ fun postmanItemRequest(request: JSONObjectValue): Pair<String, HttpRequest> {
         else -> Triple(EmptyString, emptyMap(), emptyList())
     }
 
-    val httpRequest = HttpRequest(method, url.path, headers, body, query, formFields, formData)
+    val httpRequest = HttpRequest(method, url.encodedPath, headers, body, query, formFields, formData)
     return Pair(baseURL, httpRequest)
 }
 
-internal fun urlFromPostmanValue(urlValue: Value): URL {
+internal fun urlFromPostmanValue(urlValue: Value): HttpUrl {
     return when(urlValue) {
         is JSONObjectValue -> urlValue.jsonObject.getValue("raw")
         else -> urlValue
@@ -226,9 +227,7 @@ internal fun urlFromPostmanValue(urlValue: Value): URL {
             it
         else
             "http://$it"
-    }.let {
-        URI.create(it).toURL()
-    }
+    }.toHttpUrl()
 }
 
 fun guessType(value: Value): Value = when(value) {

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfigV1V2Common.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfigV1V2Common.kt
@@ -48,9 +48,8 @@ import io.specmatic.reporter.model.SpecType
 import io.specmatic.stub.isSameBaseIgnoringHost
 import io.specmatic.test.TestResultRecord.Companion.CONTRACT_TEST_TEST_TYPE
 import java.io.File
-import java.net.MalformedURLException
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import java.net.URI
-import java.net.URL
 import java.nio.file.Path
 import kotlin.collections.filterIsInstance
 import kotlin.collections.orEmpty
@@ -1659,12 +1658,9 @@ data class Source(
                 )
             }
 
-            cachedWebSpec ?: try {
-                val url = URL(specPath)
-                sourceBaseDir.resolve("web").resolve(url.host).resolve(url.path.removePrefix("/")).canonicalFile
-            } catch (_: MalformedURLException) {
-                sourceBaseDir.resolve(specPath).canonicalFile
-            }
+            cachedWebSpec ?: specPath.toHttpUrlOrNull()?.let { url ->
+                sourceBaseDir.resolve("web").resolve(url.host).resolve(url.encodedPath.removePrefix("/")).canonicalFile
+            } ?: sourceBaseDir.resolve(specPath).canonicalFile
         }
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/utilities/ResolvedWebSource.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/ResolvedWebSource.kt
@@ -4,10 +4,10 @@ import io.specmatic.core.DEFAULT_WORKING_DIRECTORY
 import io.specmatic.core.git.SystemGit
 import io.specmatic.core.log.logger
 import io.specmatic.core.pattern.ContractException
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import java.io.File
-import java.net.MalformedURLException
 import java.net.URI
-import java.net.URL
 
 data class ResolvedWebSource(
     val baseUrl: String,
@@ -36,7 +36,7 @@ data class ResolvedWebSource(
         val resolvedPath = downloadRoot(File(workingDirectory), configFilePath)
 
         return selector.select(this).map { entry ->
-            val resolvedUrl = URL(resolveSpecUrl(entry.path))
+            val resolvedUrl = resolveSpecUrl(entry.path).toHttpUrl()
             val initialDownloadPath = localPathFor(resolvedPath, baseUrl, entry.path).canonicalFile
             initialDownloadPath.parentFile.mkdirs()
 
@@ -65,16 +65,7 @@ data class ResolvedWebSource(
 
     companion object {
         fun validateRelativeSpecPath(specPath: String) {
-            try {
-                val url = URL(specPath)
-                if (url.protocol.isNotBlank()) {
-                    throw ContractException("Web source specifications must be relative paths, but got \"$specPath\"")
-                }
-            } catch (_: MalformedURLException) {
-                // Relative paths are not valid URLs and are allowed here.
-            }
-
-            val parsed = runCatching { URI(specPath) }.getOrNull()
+            val parsed = runCatching { URI(specPath.replace('\\', '/')) }.getOrNull()
             if (parsed?.isAbsolute == true) {
                 throw ContractException("Web source specifications must be relative paths, but got \"$specPath\"")
             }
@@ -103,8 +94,8 @@ data class ResolvedWebSource(
             return root.resolve("web")
         }
 
-        private fun download(url: URL, specificationFile: File): File {
-            val connection = url.openConnection()
+        private fun download(url: HttpUrl, specificationFile: File): File {
+            val connection = url.toUrl().openConnection()
             connection.setRequestProperty("User-Agent", "Mozilla/5.0")
             connection.connect()
 

--- a/core/src/main/kotlin/io/specmatic/core/utilities/Utilities.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/Utilities.kt
@@ -29,10 +29,8 @@ import org.xml.sax.InputSource
 import java.io.File
 import java.io.StringReader
 import java.io.StringWriter
-import java.net.MalformedURLException
 import java.net.URI
 import java.net.URISyntaxException
-import java.net.URL
 import java.util.concurrent.*
 import javax.xml.parsers.DocumentBuilder
 import javax.xml.parsers.DocumentBuilderFactory
@@ -567,11 +565,8 @@ enum class URIValidationResult(
 fun validateTestOrStubUri(uri: String): URIValidationResult {
     val parsedURI =
         try {
-            URL(uri).toURI()
+            URI(uri).parseServerAuthority()
         } catch (e: URISyntaxException) {
-            consoleDebug(e)
-            return URIValidationResult.URIParsingError
-        } catch (e: MalformedURLException) {
             consoleDebug(e)
             return URIValidationResult.URIParsingError
         }
@@ -580,6 +575,7 @@ fun validateTestOrStubUri(uri: String): URIValidationResult {
     val validPorts = 1..65535
 
     return when {
+        parsedURI.scheme.isNullOrBlank() -> URIValidationResult.URIParsingError
         !validProtocols.contains(parsedURI.scheme) -> URIValidationResult.InvalidURLSchemeError
         parsedURI.host.isNullOrBlank() -> URIValidationResult.MissingHostError
         parsedURI.port != -1 && !validPorts.contains(parsedURI.port) -> URIValidationResult.InvalidPortError

--- a/core/src/main/kotlin/io/specmatic/core/utilities/WebSource.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/WebSource.kt
@@ -4,9 +4,10 @@ import io.specmatic.core.CONTRACT_EXTENSIONS
 import io.specmatic.core.git.SystemGit
 import io.specmatic.core.log.logger
 import io.specmatic.core.pattern.ContractException
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import java.io.File
 import java.net.ServerSocket
-import java.net.URL
 
 class WebSource(override val testContracts: List<ContractSourceEntry>, override val stubContracts: List<ContractSourceEntry>) : ContractSource {
     override val type: String = "web"
@@ -35,12 +36,12 @@ class WebSource(override val testContracts: List<ContractSourceEntry>, override 
     ): List<ContractPathData> {
         val resolvedPath = File(workingDirectory).resolve("web")
         return selector.select(this).map { (url, baseUrl, generative, examples) ->
-            val path = toSpecificationPath(URL(url))
+            val path = toSpecificationPath(url.toHttpUrl())
 
             val initialDownloadPath = resolvedPath.resolve(path).canonicalFile
             initialDownloadPath.parentFile.mkdirs()
 
-            val actualDownloadPath = download(URL(url), initialDownloadPath)
+            val actualDownloadPath = download(url.toHttpUrl(), initialDownloadPath)
 
             ContractPathData(
                 resolvedPath.path,
@@ -58,13 +59,13 @@ class WebSource(override val testContracts: List<ContractSourceEntry>, override 
         return emptyList()
     }
 
-    private fun toSpecificationPath(url: URL): String {
-        val path = url.host + "/" + url.path.removePrefix("/")
+    private fun toSpecificationPath(url: HttpUrl): String {
+        val path = url.host + "/" + url.encodedPath.removePrefix("/")
         return path
     }
 
-    private fun download(url: URL, specificationFile: File): File {
-        val connection = url.openConnection()
+    private fun download(url: HttpUrl, specificationFile: File): File {
+        val connection = url.toUrl().openConnection()
         connection.setRequestProperty("User-Agent", "Mozilla/5.0")
         connection.connect()
 

--- a/core/src/main/kotlin/io/specmatic/proxy/Proxy.kt
+++ b/core/src/main/kotlin/io/specmatic/proxy/Proxy.kt
@@ -29,10 +29,10 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import java.io.Closeable
 import java.io.File
 import java.net.URI
-import java.net.URL
 import java.util.*
 
 fun interface RequestObserver {
@@ -379,13 +379,7 @@ class Proxy(
         }
 
     private fun isFullURL(path: String?): Boolean =
-        path != null &&
-            try {
-                URL(URLParts(path).withEncodedPathSegments())
-                true
-            } catch (e: Throwable) {
-                false
-            }
+        path != null && URLParts(path).withEncodedPathSegments().toHttpUrlOrNull() != null
 
     init {
         val initializers = ServiceLoader.load(ProxyInitializer::class.java)

--- a/core/src/main/kotlin/io/specmatic/test/HttpClient.kt
+++ b/core/src/main/kotlin/io/specmatic/test/HttpClient.kt
@@ -24,7 +24,7 @@ import io.specmatic.core.value.StringValue
 import io.specmatic.core.value.Value
 import io.specmatic.stub.toParams
 import kotlinx.coroutines.runBlocking
-import java.net.URL
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import java.util.*
 import java.util.concurrent.atomic.AtomicReference
 import java.util.zip.GZIPInputStream
@@ -56,7 +56,7 @@ data class HttpClient(
 ) : TestExecutor, AutoCloseable {
 
     override fun execute(request: HttpRequest): HttpResponse {
-        val url = URL(request.getURL(baseURL))
+        val url = request.getURL(baseURL).toHttpUrl().toUrl()
 
         val requestWithFileContent = request.loadFileContentIntoParts()
         httpLogMessage.logStartRequestTime()
@@ -92,7 +92,7 @@ data class HttpClient(
     override fun setServerState(serverState: Map<String, Value>) {
         if (serverState.isEmpty()) return
 
-        val url = URL(baseURL + SERVER_STATE_URL)
+        val url = (baseURL + SERVER_STATE_URL).toHttpUrl().toUrl()
 
         val startTime = Date()
 

--- a/core/src/test/kotlin/io/specmatic/core/PostmanKtTests.kt
+++ b/core/src/test/kotlin/io/specmatic/core/PostmanKtTests.kt
@@ -251,7 +251,7 @@ class PostmanKtTests {
         val request = stub.second.stub
         assertThat(request.request.method).isEqualTo("POST")
         assertThat(request.request.headers).isEqualTo(mapOf("X-Header" to "10"))
-        assertThat(request.request.path).isEqualTo("")
+        assertThat(request.request.path).isEqualTo("/")
 
         val response = stub.second.stub.response
         assertThat(response.status).isEqualTo(200)

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubKtTest.kt
@@ -2314,7 +2314,7 @@ paths:
         assertThat(result).isInstanceOf(Result.Failure::class.java)
         assertThat(result.reportString()).isEqualToIgnoringWhitespace("""
         >> Invalid baseURL "httd://localhost:8080/api" for spec1.yaml
-        Please specify a valid URL in 'scheme://host[:port][path]' format
+        Please specify a valid scheme / protocol (http or https)
         >> Invalid baseURL "ftp://localhost:8080/api" for spec2.yaml
         Please specify a valid scheme / protocol (http or https)
         >> Invalid baseURL "http://localhost:99999/api" for spec3.yaml

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
@@ -3782,7 +3782,7 @@ Then status 200
             assertThat(exception.code).isEqualTo(1)
             assertThat(exception.message).isEqualToNormalizingWhitespace("""
             >> Invalid baseURL "localhost:9001/api" for ${File(".").resolve("hello.yaml").path}
-            Please specify a valid URL in 'scheme://host[:port][path]' format
+            Please specify a valid scheme / protocol (http or https)
             """.trimIndent())
         }
 

--- a/junit5-support/build.gradle.kts
+++ b/junit5-support/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
 
     implementation("net.minidev:json-smart:2.6.0")
     implementation("com.ezylang:EvalEx:3.6.1")
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
     implementation(project(":specmatic-core"))
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.11.0")
     implementation("org.assertj:assertj-core:3.27.7")

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -30,6 +30,7 @@ import io.specmatic.test.reports.OpenApiCoverageReportProcessor
 import io.specmatic.test.reports.coverage.Endpoint
 import io.specmatic.test.reports.coverage.OpenApiCoverage
 import kotlinx.serialization.Serializable
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.DynamicTest
 import org.junit.jupiter.api.TestFactory
@@ -40,7 +41,6 @@ import org.opentest4j.TestAbortedException
 import java.io.File
 import java.net.HttpURLConnection
 import java.net.URI
-import java.net.URL
 import java.time.Instant
 import java.util.*
 import java.util.concurrent.ConcurrentLinkedDeque
@@ -896,7 +896,7 @@ fun <T, U> selectTestsToRunWithDecision(
 fun isBaseURLReachable(baseUrl: String, timeOutMs: Int = 3000, keyData: KeyData? = null): Boolean {
     return try {
         val url = if (baseUrl.endsWith("/")) baseUrl else "$baseUrl/"
-        val connection = URL(url).openConnection() as HttpURLConnection
+        val connection = url.toHttpUrl().toUrl().openConnection() as HttpURLConnection
 
         if (connection is HttpsURLConnection) {
             val trustAllCerts = arrayOf<TrustManager>(


### PR DESCRIPTION
## Why

Java's `java.net.URL` is fundamentally broken: its `equals()`/`hashCode()` perform **blocking DNS resolution**, making URL comparison slow, unreliable, and network-dependent. JDK 20 deprecated its `URL(String)` constructors for this reason.

This removes `java.net.URL` from Specmatic's own code, replacing every dereferenced-URL usage with **`okhttp3.HttpUrl`** (already a `:core` dependency — its `equals()`/`hashCode()` are purely syntactic). Where an external API still demands a `java.net.URL`, we unwrap at that boundary with `HttpUrl.toUrl()`.

## What changed

**Dereferenced URLs → `okhttp3.HttpUrl`:**
- `WebSource` / `ResolvedWebSource` — parse + download (`httpUrl.toUrl().openConnection()`)
- `HttpClient` — request target as `HttpUrl`, `.toUrl()` passed to Ktor
- `SpecmaticConfigV1V2Common` — `toHttpUrlOrNull()` replaces the `URL` + `MalformedURLException` try/catch
- `Postman.urlFromPostmanValue` — returns `HttpUrl`; consumer uses `scheme`/`encodedPath`/`encodedQuery`
- `Proxy.isFullURL` — collapses to `toHttpUrlOrNull() != null`
- `SpecmaticJUnitSupport.isBaseURLReachable`

**Identifier validation → `java.net.URI`:** `validateTestOrStubUri` is pure syntactic validation returning granular error codes, so it uses `URI(uri).parseServerAuthority()` (plus a null-scheme guard) rather than `HttpUrl` — `URI` is not the broken type, and `HttpUrl.parse()` would collapse the granular codes.

**Kept `java.net.URL`:** only `GitOperations`, where JGit's `HttpConnectionFactory.create(url: URL?)` interface fixes the signature and the body delegates to JGit's own URL-typed factory.

**Dependencies:** okhttp added to `:junit5-support` (`implementation`) and `:application` (`testImplementation`); `:core` already had it.

## Behavior changes (test expectations updated)

1. **Pathless URLs** (e.g. `https://localhost`): request path is now `/` instead of `""` — the HTTP-correct root, consistent with the rest of Specmatic.
2. **Unknown/missing scheme** (`httd://…`, `localhost:9001/api`): now reports `InvalidURLSchemeError` ("specify http or https") uniformly. The old behavior was JVM-protocol-handler-dependent (`ftp://` → scheme error but `httd://` → parse error); the test author had even grouped `httd://` and `ftp://` under `// invalid scheme`.
3. **`Proxy.isFullURL`** no longer treats `ftp://`/`file://` as full URLs (fine for an HTTP proxy).

## Verification

- All modules compile (main + test); grep confirms only `GitOperations.kt` retains `java.net.URL`.
- Full `:core` suite green (6507 tests), plus targeted `UtilitiesTest`, `PostmanKtTests`, `WebSourceTest`, `ResolvedWebSourceTest`, `ProxyTest`/`ProxyOperationTest`, `HttpStubKtTest`/`HttpStubTest`, and the `:application` mTLS test.