### PR TITLE
Fix status precedence for nested query parameters

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/NestedObjectRootPropertyEntries.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/NestedObjectRootPropertyEntries.kt
@@ -1,0 +1,48 @@
+package io.specmatic.conversions
+
+import io.specmatic.conversions.lenient.CollectorContext
+import io.specmatic.core.NestedObjectQueryParam
+import io.specmatic.core.ObjectQueryRoot
+import io.specmatic.core.QueryParameterCollisionOwnerKind
+import io.swagger.v3.oas.models.media.Schema
+import io.swagger.v3.oas.models.parameters.QueryParameter
+
+internal fun OpenApiSpecification.nestedObjectRootPropertyEntries(
+    parameter: QueryParameter,
+    resolvedSchema: Schema<*>,
+    schemaContext: CollectorContext,
+    nestedObjectQueryParam: NestedObjectQueryParam,
+    schemaPointer: String?
+): List<QueryParameterPatternEntry> {
+    if (nestedObjectQueryParam.syntax.root != ObjectQueryRoot.Unwrapped) return emptyList()
+
+    val requiredProperties = resolvedSchema.required.orEmpty().toSet()
+
+    return resolvedSchema.properties.orEmpty().map { (propertyName, propertySchema) ->
+        val propertyContext = schemaContext.at("properties").at(propertyName)
+        val (resolvedPropertySchema, resolvedPropertyContext) = resolveSchemaIfRefElseAtSchema(
+            schema = propertySchema,
+            collectorContext = propertyContext
+        )
+        val optional = parameter.required != true || propertyName !in requiredProperties
+
+        QueryParameterPatternEntry(
+            key = toSpecmaticParamName(optional, propertyName),
+            wireKey = propertyName,
+            pattern = toQueryParameterPattern(
+                parameterName = propertyName,
+                schema = propertySchema,
+                resolvedSchema = resolvedPropertySchema,
+                resolvedSchemaContext = resolvedPropertyContext,
+                schemaContext = propertyContext
+            ),
+            source = QueryParameterPatternSource(
+                parameterName = parameter.name,
+                propertyName = propertyName,
+                kind = QueryParameterCollisionOwnerKind.NestedObjectProperty
+            ),
+            collectorContext = propertyContext,
+            pointer = schemaPointer?.let { "$it/properties/${escapeJsonPointer(propertyName)}" }
+        )
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiConversionHelpers.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiConversionHelpers.kt
@@ -1,0 +1,9 @@
+package io.specmatic.conversions
+
+internal fun toSpecmaticParamName(optional: Boolean, name: String) = when (optional) {
+    true -> "${name}?"
+    false -> name
+}
+
+internal fun escapeJsonPointer(token: String): String =
+    token.replace("~", "~0").replace("/", "~1")

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiLintViolations.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiLintViolations.kt
@@ -57,7 +57,8 @@ enum class OpenApiLintViolations(
     REQUIRED_QUERY_OBJECT_CONFLICT(
         id = "OAS0012",
         title = "Required query object conflict",
-        summary = "A required form-exploded object query parameter must have at least one required schema property to make a concrete query parameter mandatory"
+        summary = "A required form-exploded object query parameter must have at least one required schema property to make a concrete query parameter mandatory",
+        severity = IssueSeverity.WARNING
     ),
 
     QUERY_PARAMETER_TYPE_COLLISION(

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -2003,9 +2003,6 @@ class OpenApiSpecification(
         }
     }
 
-    private fun escapeJsonPointer(token: String): String =
-        token.replace("~", "~0").replace("/", "~1")
-
     private fun sourceMapFor(file: String): Map<String, YamlNodeLocation> =
         sourceMapCache.getOrPut(file) {
             readExternalFileContent(file)?.let { JsonPointerSourceMap(it).build() }.orEmpty()
@@ -2703,7 +2700,7 @@ class OpenApiSpecification(
         return resolveSchema(schemaToProcess, collectorContext)
     }
 
-    private fun resolveSchemaIfRefElseAtSchema(schema: Schema<*>, collectorContext: CollectorContext): Pair<Schema<*>, CollectorContext> {
+    internal fun resolveSchemaIfRefElseAtSchema(schema: Schema<*>, collectorContext: CollectorContext): Pair<Schema<*>, CollectorContext> {
         val schemaToProcess = collectorContext.requirePojo(
             message = { "No schema defined, defaulting to empty schema" },
             extract = { schema },
@@ -3282,11 +3279,6 @@ class OpenApiSpecification(
         }
     }
 
-    private fun toSpecmaticParamName(optional: Boolean, name: String) = when (optional) {
-        true -> "${name}?"
-        false -> name
-    }
-
     private fun resolveReferenceToSchema(component: String, collectorContext: CollectorContext): Pair<String, Schema<*>> {
         val componentName = extractComponentName(component, collectorContext)
         val components = parsedOpenApi.components ?: Components()
@@ -3342,9 +3334,13 @@ class OpenApiSpecification(
         val queryParameters = parameters.safeFilter<QueryParameter>(collectorContext)
         val parsedQueryParameters = queryParameters.map { toQueryParameterParseResult(it, parameterPointers) }
         val queryPatternEntries = parsedQueryParameters.flatMap(QueryParameterParseResult::entries)
+        val nestedObjectQueryParams = parsedQueryParameters.mapNotNull(QueryParameterParseResult::nestedObjectQueryParam)
+        val collisionEntries = parsedQueryParameters.flatMap { it.entries + it.nestedObjectPropertyEntries }
         val collisionResolution = resolveQueryParameterCollisions(
             entries = queryPatternEntries,
+            collisionEntries = collisionEntries,
             formExplodedObjectQueryParams = parsedQueryParameters.mapNotNull(QueryParameterParseResult::formExplodedObjectQueryParam),
+            nestedObjectQueryParams = nestedObjectQueryParams,
             patterns = patterns
         )
 
@@ -3359,7 +3355,7 @@ class OpenApiSpecification(
             additionalProperties,
             extensibleQueryParams = extensibleQueryParams,
             formExplodedObjectQueryParams = collisionResolution.formExplodedObjectQueryParams,
-            nestedObjectQueryParams = parsedQueryParameters.mapNotNull(QueryParameterParseResult::nestedObjectQueryParam),
+            nestedObjectQueryParams = collisionResolution.nestedObjectQueryParams,
             parameterPointers = queryParameterPointers,
             collisionGroupsByWireKey = collisionResolution.collisionGroupsByWireKey
         )
@@ -3369,6 +3365,7 @@ class OpenApiSpecification(
         val entries: List<QueryParameterPatternEntry>,
         val formExplodedObjectQueryParam: FormExplodedObjectQueryParam? = null,
         val nestedObjectQueryParam: NestedObjectQueryParam? = null,
+        val nestedObjectPropertyEntries: List<QueryParameterPatternEntry> = emptyList(),
         val additionalProperties: Pattern? = null
     )
 
@@ -3455,6 +3452,13 @@ class OpenApiSpecification(
                     )
                 ),
                 nestedObjectQueryParam = nestedObjectQueryParam,
+                nestedObjectPropertyEntries = nestedObjectRootPropertyEntries(
+                    parameter = parameter,
+                    resolvedSchema = resolvedSchema,
+                    schemaContext = schemaContext,
+                    nestedObjectQueryParam = nestedObjectQueryParam,
+                    schemaPointer = schemaPointer
+                ),
                 additionalProperties = additionalPropertiesInQueryParam(resolvedSchema, schemaContext)
             )
         }
@@ -3506,7 +3510,7 @@ class OpenApiSpecification(
         return (style == null || style == Parameter.StyleEnum.FORM) && explode != false
     }
 
-    private fun toQueryParameterPattern(
+    internal fun toQueryParameterPattern(
         parameterName: String,
         schema: Schema<*>,
         resolvedSchema: Schema<*>,

--- a/core/src/main/kotlin/io/specmatic/conversions/QueryParameterCollisionResolver.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/QueryParameterCollisionResolver.kt
@@ -2,17 +2,28 @@ package io.specmatic.conversions
 
 import io.specmatic.conversions.lenient.CollectorContext
 import io.specmatic.core.FormExplodedObjectQueryParam
+import io.specmatic.core.NestedObjectQueryParam
 import io.specmatic.core.QueryParameterCollisionGroup
 import io.specmatic.core.QueryParameterCollisionOwner
 import io.specmatic.core.QueryParameterCollisionOwnerKind
 import io.specmatic.core.Resolver
+import io.specmatic.core.pattern.JSONObjectPattern
 import io.specmatic.core.pattern.Pattern
+import io.specmatic.core.pattern.PossibleJsonObjectPatternContainer
 import io.specmatic.core.pattern.QueryParameterArrayPattern
 import io.specmatic.core.pattern.QueryParameterScalarPattern
 import io.specmatic.core.pattern.resolvedHop
+import io.specmatic.core.pattern.withoutOptionality
 
-internal data class QueryParameterPatternSource(val parameterName: String, val propertyName: String? = null) {
-    val isFormExplodedObjectProperty: Boolean = propertyName != null
+internal data class QueryParameterPatternSource(
+    val parameterName: String,
+    val propertyName: String? = null,
+    val kind: QueryParameterCollisionOwnerKind = if (propertyName == null) {
+        QueryParameterCollisionOwnerKind.ScalarParameter
+    } else {
+        QueryParameterCollisionOwnerKind.FormExplodedObjectProperty
+    }
+) {
     val displayName: String = propertyName?.let { "$parameterName.$it" } ?: parameterName
 }
 
@@ -28,15 +39,18 @@ internal data class QueryParameterPatternEntry(
 internal data class QueryParameterCollisionResolution(
     val effectiveEntries: List<QueryParameterPatternEntry>,
     val formExplodedObjectQueryParams: List<FormExplodedObjectQueryParam>,
+    val nestedObjectQueryParams: List<NestedObjectQueryParam>,
     val collisionGroupsByWireKey: Map<String, QueryParameterCollisionGroup>
 )
 
 internal fun resolveQueryParameterCollisions(
     entries: List<QueryParameterPatternEntry>,
+    collisionEntries: List<QueryParameterPatternEntry> = entries,
     formExplodedObjectQueryParams: List<FormExplodedObjectQueryParam>,
+    nestedObjectQueryParams: List<NestedObjectQueryParam>,
     patterns: Map<String, Pattern>
 ): QueryParameterCollisionResolution {
-    val collisionEntriesByWireKey = entries.groupBy(QueryParameterPatternEntry::wireKey).filterValues { it.size > 1 }
+    val collisionEntriesByWireKey = collisionEntries.groupBy(QueryParameterPatternEntry::wireKey).filterValues { it.size > 1 }
     val collisionGroupsByWireKey = collisionEntriesByWireKey.mapValues { (wireKey, collidingEntries) ->
         toQueryParameterCollisionGroup(wireKey, collidingEntries)
     }
@@ -45,23 +59,43 @@ internal fun resolveQueryParameterCollisions(
         recordQueryParameterTypeCollisionIfNeeded(collidingEntries, patterns)
     }
 
-    val nonAuthoritativeObjectPropertiesByParameter = nonAuthoritativeFormExplodedObjectPropertiesByParameter(collisionEntriesByWireKey)
+    val authoritativeEntriesByWireKey = collisionEntriesByWireKey.mapValues { (_, entries) -> entries.last() }
+    val nonAuthoritativeFormExplodedObjectPropertiesByParameter = nonAuthoritativeObjectPropertiesByParameter(
+        collisionEntriesByWireKey,
+        QueryParameterCollisionOwnerKind.FormExplodedObjectProperty
+    )
+    val nonAuthoritativeNestedObjectPropertiesByParameter = nonAuthoritativeObjectPropertiesByParameter(
+        collisionEntriesByWireKey,
+        QueryParameterCollisionOwnerKind.NestedObjectProperty
+    )
     val effectiveEntries = entries.filter { entry ->
-        entry.wireKey !in collisionEntriesByWireKey || collisionEntriesByWireKey.getValue(entry.wireKey).first() == entry
+        authoritativeEntriesByWireKey[entry.wireKey]?.let { it == entry } ?: true
+    }.map { entry ->
+        entry.withoutNestedObjectProperties(
+            nonAuthoritativeNestedObjectPropertiesByParameter[entry.source.parameterName].orEmpty(),
+            patterns
+        )
     }
 
     return QueryParameterCollisionResolution(
         effectiveEntries = effectiveEntries,
         formExplodedObjectQueryParams = formExplodedObjectQueryParams.map {
-            it.withoutProperties(nonAuthoritativeObjectPropertiesByParameter[it.parameterName].orEmpty())
+            it.withoutProperties(nonAuthoritativeFormExplodedObjectPropertiesByParameter[it.parameterName].orEmpty())
+        },
+        nestedObjectQueryParams = nestedObjectQueryParams.map {
+            it.withoutRootProperties(nonAuthoritativeNestedObjectPropertiesByParameter[it.parameterName].orEmpty())
         },
         collisionGroupsByWireKey = collisionGroupsByWireKey
     )
 }
 
-private fun nonAuthoritativeFormExplodedObjectPropertiesByParameter(collisionEntriesByWireKey: Map<String, List<QueryParameterPatternEntry>>): Map<String, Set<String>> {
+private fun nonAuthoritativeObjectPropertiesByParameter(
+    collisionEntriesByWireKey: Map<String, List<QueryParameterPatternEntry>>,
+    ownerKind: QueryParameterCollisionOwnerKind
+): Map<String, Set<String>> {
     return collisionEntriesByWireKey.values
-        .flatMap { entries -> entries.drop(1) }
+        .flatMap { entries -> entries.dropLast(1) }
+        .filter { entry -> entry.source.kind == ownerKind }
         .mapNotNull { entry ->
             entry.source.propertyName?.let { propertyName ->
                 entry.source.parameterName to propertyName
@@ -80,12 +114,34 @@ private fun FormExplodedObjectQueryParam.withoutProperties(propertyNames: Set<St
     )
 }
 
+private fun QueryParameterPatternEntry.withoutNestedObjectProperties(propertyNames: Set<String>, patterns: Map<String, Pattern>): QueryParameterPatternEntry {
+    if (propertyNames.isEmpty()) return this
+
+    return copy(pattern = pattern.withoutRootProperties(propertyNames, patterns))
+}
+
+private fun Pattern.withoutRootProperties(propertyNames: Set<String>, patterns: Map<String, Pattern>): Pattern {
+    if (propertyNames.isEmpty()) return this
+
+    val resolver = Resolver(newPatterns = patterns)
+    return when (this) {
+        is QueryParameterScalarPattern -> QueryParameterScalarPattern(pattern.withoutRootProperties(propertyNames, patterns))
+        is JSONObjectPattern -> withoutRootProperties(propertyNames)
+        is PossibleJsonObjectPatternContainer -> jsonObjectPattern(resolver)?.withoutRootProperties(propertyNames) ?: this
+        else -> this
+    }
+}
+
+private fun JSONObjectPattern.withoutRootProperties(propertyNames: Set<String>): JSONObjectPattern {
+    return copy(pattern = pattern.filterKeys { key -> withoutOptionality(key) !in propertyNames })
+}
+
 private fun toQueryParameterCollisionGroup(wireKey: String, entries: List<QueryParameterPatternEntry>): QueryParameterCollisionGroup {
     val owners = entries.map(::toQueryParameterCollisionOwner)
     return QueryParameterCollisionGroup(
         wireKey = wireKey,
         owners = owners,
-        authoritativeOwner = owners.first()
+        authoritativeOwner = owners.last()
     )
 }
 
@@ -93,11 +149,7 @@ private fun toQueryParameterCollisionOwner(entry: QueryParameterPatternEntry): Q
     return QueryParameterCollisionOwner(
         wireKey = entry.wireKey,
         sourceName = entry.source.displayName,
-        kind = if (entry.source.isFormExplodedObjectProperty) {
-            QueryParameterCollisionOwnerKind.FormExplodedObjectProperty
-        } else {
-            QueryParameterCollisionOwnerKind.ScalarParameter
-        },
+        kind = entry.source.kind,
         pattern = entry.pattern,
         required = !entry.key.endsWith("?"),
         parameterName = entry.source.parameterName,
@@ -110,10 +162,10 @@ private fun recordQueryParameterTypeCollisionIfNeeded(entries: List<QueryParamet
     val resolvedPatterns = entries.map { normalizedQueryParameterPattern(it.pattern, patterns) }
     if (resolvedPatterns.distinct().size == 1) return
 
-    val authoritativeEntry = entries.first()
+    val authoritativeEntry = entries.last()
     val ownerDetails = entries.joinToString(separator = "\n") { "- ${it.diagnosticDisplayName()}" }
     authoritativeEntry.collectorContext.record(
-        message = "Query parameter wire key ${authoritativeEntry.wireKey} has conflicting schemas:\n$ownerDetails\nSpecmatic will use the first declared query parameter ${authoritativeEntry.source.displayName} as authoritative.",
+        message = "Query parameter wire key ${authoritativeEntry.wireKey} has conflicting schemas:\n$ownerDetails\nSpecmatic will use the last declared query parameter ${authoritativeEntry.source.displayName} as authoritative.",
         isWarning = true,
         ruleViolation = OpenApiLintViolations.QUERY_PARAMETER_TYPE_COLLISION
     )

--- a/core/src/main/kotlin/io/specmatic/core/HttpQueryParamPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpQueryParamPattern.kt
@@ -19,7 +19,8 @@ data class FormExplodedObjectQueryParam(
 
 enum class QueryParameterCollisionOwnerKind {
     ScalarParameter,
-    FormExplodedObjectProperty
+    FormExplodedObjectProperty,
+    NestedObjectProperty
 }
 
 data class QueryParameterCollisionOwner(
@@ -538,7 +539,12 @@ data class HttpQueryParamPattern(
 
     private fun activeFormExplodedObjectQueryParams(): List<FormExplodedObjectQueryParam> {
         val nonAuthoritativeObjectPropertiesByParameter = collisionGroupsByWireKey.values
-            .flatMap { collisionGroup -> collisionGroup.owners.drop(1).filter { it.kind == QueryParameterCollisionOwnerKind.FormExplodedObjectProperty } }
+            .flatMap { collisionGroup ->
+                collisionGroup.owners.filter {
+                    it.kind == QueryParameterCollisionOwnerKind.FormExplodedObjectProperty &&
+                        it != collisionGroup.authoritativeOwner
+                }
+            }
             .mapNotNull { owner -> owner.propertyName?.let { propertyName -> owner.parameterName to propertyName } }
             .groupBy({ it.first }, { it.second })
             .mapValues { (_, propertyNames) -> propertyNames.toSet() }

--- a/core/src/main/kotlin/io/specmatic/core/NestedObjectQueryParam.kt
+++ b/core/src/main/kotlin/io/specmatic/core/NestedObjectQueryParam.kt
@@ -33,6 +33,12 @@ data class NestedObjectQueryParam(
         return path.serialize(parameterName, syntax)
     }
 
+    internal fun withoutRootProperties(propertyNames: Set<String>): NestedObjectQueryParam {
+        if (propertyNames.isEmpty()) return this
+
+        return copy(schema = schema.copy(properties = schema.properties - propertyNames))
+    }
+
     internal fun reconstructObjectValueFromQueryParamPairs(
         pairs: List<Pair<String, String>>,
         effectivePatterns: Map<String, Pattern> = emptyMap(),

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationParseTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationParseTest.kt
@@ -755,6 +755,11 @@ class OpenApiSpecificationParseTest {
     }
 
     @Test
+    fun `required query object conflict lint violation should be classified as a warning`() {
+        assertThat(OpenApiLintViolations.REQUIRED_QUERY_OBJECT_CONFLICT.severity).isEqualTo(IssueSeverity.WARNING)
+    }
+
+    @Test
     fun `query parameter type collision lint violation should be classified as a warning`() {
         assertThat(OpenApiLintViolations.QUERY_PARAMETER_TYPE_COLLISION.severity).isEqualTo(IssueSeverity.WARNING)
     }

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationParseTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationParseTest.kt
@@ -2,6 +2,7 @@ package io.specmatic.conversions
 
 import integration_tests.OpenApiVersion
 import io.specmatic.core.HttpRequest
+import io.specmatic.core.HttpResponse
 import io.specmatic.core.IssueSeverity
 import io.specmatic.core.NestedQuerySchema
 import io.specmatic.core.ObjectQueryRoot
@@ -23,6 +24,7 @@ import io.specmatic.core.pattern.XMLPattern
 import io.specmatic.core.pattern.XMLTypeData
 import io.specmatic.core.pattern.resolvedHop
 import io.specmatic.core.utilities.yamlMapper
+import io.specmatic.mock.NoMatchingScenario
 import io.specmatic.stub.captureStandardOutput
 import io.specmatic.toViolationReportString
 import org.assertj.core.api.Assertions.assertThat
@@ -698,13 +700,13 @@ class OpenApiSpecificationParseTest {
         val feature = OpenApiSpecification.fromYAML(spec, "").toFeature()
         val queryParamPattern = feature.scenarios.single().httpRequestPattern.httpQueryParamPattern
         val queryPatterns = queryParamPattern.queryPatterns
-        val typePattern = queryPatterns["type"]
+        val typePattern = queryPatterns["type?"]
         val collisionGroup = queryParamPattern.collisionGroupsByWireKey.getValue("type")
 
         assertThat(collisionGroup.owners.map { it.sourceName }).containsExactly("info.type", "type")
-        assertThat(collisionGroup.authoritativeOwner.sourceName).isEqualTo("info.type")
-        assertThat(collisionGroup.authoritativeOwner.kind).isEqualTo(QueryParameterCollisionOwnerKind.FormExplodedObjectProperty)
-        assertThat(queryPatterns.keys).containsExactly("type")
+        assertThat(collisionGroup.authoritativeOwner.sourceName).isEqualTo("type")
+        assertThat(collisionGroup.authoritativeOwner.kind).isEqualTo(QueryParameterCollisionOwnerKind.ScalarParameter)
+        assertThat(queryPatterns.keys).containsExactly("type?")
         assertThat(typePattern).isInstanceOf(QueryParameterScalarPattern::class.java)
         assertThat((typePattern as QueryParameterScalarPattern).pattern).isInstanceOf(NumberPattern::class.java)
     }
@@ -749,7 +751,7 @@ class OpenApiSpecificationParseTest {
         val collisionGroup = queryParamPattern.collisionGroupsByWireKey.getValue("age")
 
         assertThat(collisionGroup.owners.map { it.sourceName }).containsExactly("info.age", "age")
-        assertThat(collisionGroup.authoritativeOwner.sourceName).isEqualTo("info.age")
+        assertThat(collisionGroup.authoritativeOwner.sourceName).isEqualTo("age")
     }
 
     @Test
@@ -797,9 +799,9 @@ class OpenApiSpecificationParseTest {
         assertThat(stdout).doesNotContain(OpenApiLintViolations.INVALID_PARAMETER_DEFINITION.id)
         assertThat(stdout).contains("type")
         assertThat(stdout).contains("info.type")
-        assertThat(stdout).contains("first declared query parameter info.type")
+        assertThat(stdout).contains("last declared query parameter type")
         assertThat(stdout).doesNotContain("if parsing continues")
-        assertThat(queryParamPattern.collisionGroupsByWireKey.getValue("type").authoritativeOwner.sourceName).isEqualTo("info.type")
+        assertThat(queryParamPattern.collisionGroupsByWireKey.getValue("type").authoritativeOwner.sourceName).isEqualTo("type")
     }
 
     @Test
@@ -855,13 +857,13 @@ class OpenApiSpecificationParseTest {
         assertThat(stdout).contains("- filter.type at paths./orders.get.parameters[1].schema.properties.type")
         assertThat(stdout).contains("- type at paths./orders.get.parameters[2].name")
         assertThat(stdout).doesNotContain("/paths/~1orders/get/parameters")
-        assertThat(stdout).contains("first declared query parameter info.type as authoritative")
+        assertThat(stdout).contains("last declared query parameter type as authoritative")
         assertThat(stdout).doesNotContain("if parsing continues")
         assertThat(queryParamPattern.collisionGroupsByWireKey.getValue("type").owners.map { it.sourceName }).containsExactly("info.type", "filter.type", "type")
     }
 
     @Test
-    fun `different type collision should select object property as authoritative when declared first in lenient parsing`() {
+    fun `different type collision should select standalone scalar as authoritative when declared last in lenient parsing`() {
         val spec = """
             openapi: 3.0.0
             info:
@@ -886,54 +888,6 @@ class OpenApiSpecificationParseTest {
                       required: false
                       schema:
                         type: string
-                  responses:
-                    '200':
-                      description: OK
-        """.trimIndent()
-
-        val (feature, result) = OpenApiSpecification.fromYAML(spec, "").toFeatureLenient()
-        val queryParamPattern = feature.scenarios.single().httpRequestPattern.httpQueryParamPattern
-        val typePattern = queryParamPattern.queryPatterns["type"]
-        val collisionGroup = queryParamPattern.collisionGroupsByWireKey.getValue("type")
-
-        assertThat(result).isInstanceOf(Result.Failure::class.java)
-        assertThat(result.toIssues().single().severity).isEqualTo(IssueSeverity.WARNING)
-        assertThat(result.reportString()).contains(OpenApiLintViolations.QUERY_PARAMETER_TYPE_COLLISION.id)
-        assertThat(result.reportString()).doesNotContain(OpenApiLintViolations.INVALID_PARAMETER_DEFINITION.id)
-        assertThat(result.reportString()).contains("type")
-        assertThat(result.reportString()).contains("info.type")
-        assertThat(collisionGroup.authoritativeOwner.sourceName).isEqualTo("info.type")
-        assertThat(collisionGroup.authoritativeOwner.kind).isEqualTo(QueryParameterCollisionOwnerKind.FormExplodedObjectProperty)
-        assertThat(typePattern).isInstanceOf(QueryParameterScalarPattern::class.java)
-        assertThat((typePattern as QueryParameterScalarPattern).pattern).isInstanceOf(NumberPattern::class.java)
-    }
-
-    @Test
-    fun `different type collision should select standalone scalar as authoritative when declared first in lenient parsing`() {
-        val spec = """
-            openapi: 3.0.0
-            info:
-              title: Colliding Form Exploded Object Query Param
-              version: 1.0.0
-            paths:
-              /orders:
-                get:
-                  parameters:
-                    - in: query
-                      name: type
-                      required: false
-                      schema:
-                        type: string
-                    - in: query
-                      name: info
-                      required: true
-                      schema:
-                        type: object
-                        required:
-                          - type
-                        properties:
-                          type:
-                            type: integer
                   responses:
                     '200':
                       description: OK
@@ -945,17 +899,198 @@ class OpenApiSpecificationParseTest {
         val collisionGroup = queryParamPattern.collisionGroupsByWireKey.getValue("type")
 
         assertThat(result).isInstanceOf(Result.Failure::class.java)
+        assertThat(result.toIssues().single().severity).isEqualTo(IssueSeverity.WARNING)
         assertThat(result.reportString()).contains(OpenApiLintViolations.QUERY_PARAMETER_TYPE_COLLISION.id)
         assertThat(result.reportString()).doesNotContain(OpenApiLintViolations.INVALID_PARAMETER_DEFINITION.id)
-        assertThat(result.reportString()).contains("- type at paths./orders.get.parameters[0].name")
-        assertThat(result.reportString()).contains("- info.type at paths./orders.get.parameters[1].schema.properties.type")
-        assertThat(result.reportString()).contains("first declared query parameter type as authoritative")
-        assertThat(collisionGroup.owners.map { it.sourceName }).containsExactly("type", "info.type")
+        assertThat(result.reportString()).contains("type")
+        assertThat(result.reportString()).contains("info.type")
         assertThat(collisionGroup.authoritativeOwner.sourceName).isEqualTo("type")
         assertThat(collisionGroup.authoritativeOwner.kind).isEqualTo(QueryParameterCollisionOwnerKind.ScalarParameter)
         assertThat(typePattern).isInstanceOf(QueryParameterScalarPattern::class.java)
         assertThat((typePattern as QueryParameterScalarPattern).pattern).isInstanceOf(StringPattern::class.java)
-        assertThat(queryParamPattern.matches(HttpRequest("GET", "/orders"), Resolver())).isInstanceOf(Result.Success::class.java)
+    }
+
+    @Test
+    fun `last declared scalar collision owner should not require object query property`() {
+        val spec = """
+            openapi: 3.0.0
+            info:
+              title: Colliding Required Object Property Query Param
+              version: 1.0.0
+            paths:
+              /orders:
+                get:
+                  parameters:
+                    - in: query
+                      name: info
+                      required: true
+                      schema:
+                        type: object
+                        required:
+                          - status
+                        properties:
+                          status:
+                            type: integer
+                    - in: query
+                      name: status
+                      required: false
+                      schema:
+                        type: boolean
+                  responses:
+                    '200':
+                      description: OK
+        """.trimIndent()
+
+        val feature = OpenApiSpecification.fromYAML(spec, "").toFeature()
+        val queryParamPattern = feature.scenarios.single().httpRequestPattern.httpQueryParamPattern
+        val result = queryParamPattern.matches(
+            HttpRequest("GET", "/orders", queryParams = QueryParameters(listOf("status" to "866"))),
+            Resolver()
+        )
+
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
+        assertThat((result as Result.Failure).reportString()).contains("Expected type boolean")
+        assertThat(result.reportString()).doesNotContain("mandatory property \"status\"")
+    }
+
+    @Test
+    fun `last declared scalar collision owner should not require object query property when matching stub examples`() {
+        val spec = """
+            openapi: 3.0.0
+            info:
+              title: Colliding Required Object Property Query Param
+              version: 1.0.0
+            paths:
+              /orders:
+                get:
+                  parameters:
+                    - in: query
+                      name: info
+                      required: true
+                      schema:
+                        type: object
+                        required:
+                          - status
+                        properties:
+                          status:
+                            type: integer
+                    - in: query
+                      name: status
+                      required: false
+                      schema:
+                        type: boolean
+                  responses:
+                    '200':
+                      description: OK
+        """.trimIndent()
+
+        val feature = OpenApiSpecification.fromYAML(spec, "").toFeature()
+        val exception = assertThrows<NoMatchingScenario> {
+            feature.matchingStub(
+                HttpRequest("GET", "/orders", queryParams = QueryParameters(listOf("status" to "866"))),
+                HttpResponse.OK
+            )
+        }
+
+        assertThat(exception.message).contains("Expected type boolean")
+        assertThat(exception.message).doesNotContain("mandatory property \"status\"")
+    }
+
+    @Test
+    fun `last declared scalar collision owner should not require unwrapped nested object query property`() {
+        val spec = nestedStatusCollisionSpec(scalarDeclaredLast = true)
+
+        val feature = OpenApiSpecification.fromYAML(spec, "").toFeature()
+        val queryParamPattern = feature.scenarios.single().httpRequestPattern.httpQueryParamPattern
+        val collisionGroup = queryParamPattern.collisionGroupsByWireKey.getValue("status")
+        val result = queryParamPattern.matches(
+            HttpRequest(
+                "GET",
+                "/orders",
+                queryParams = QueryParameters(listOf("name" to "Jack", "address.street" to "Baker", "status" to "866"))
+            ),
+            Resolver()
+        )
+
+        assertThat(collisionGroup.owners.map { it.sourceName }).containsExactly("details.status", "status")
+        assertThat(collisionGroup.authoritativeOwner.sourceName).isEqualTo("status")
+        assertThat(collisionGroup.authoritativeOwner.kind).isEqualTo(QueryParameterCollisionOwnerKind.ScalarParameter)
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
+        assertThat((result as Result.Failure).reportString()).contains("Expected type boolean")
+        assertThat(result.reportString()).doesNotContain("mandatory property \"status\"")
+    }
+
+    @Test
+    fun `last declared unwrapped nested object query property should take precedence over scalar query parameter`() {
+        val spec = nestedStatusCollisionSpec(scalarDeclaredLast = false)
+
+        val feature = OpenApiSpecification.fromYAML(spec, "").toFeature()
+        val queryParamPattern = feature.scenarios.single().httpRequestPattern.httpQueryParamPattern
+        val collisionGroup = queryParamPattern.collisionGroupsByWireKey.getValue("status")
+
+        assertThat(collisionGroup.owners.map { it.sourceName }).containsExactly("status", "details.status")
+        assertThat(collisionGroup.authoritativeOwner.sourceName).isEqualTo("details.status")
+        assertThat(collisionGroup.authoritativeOwner.kind).isEqualTo(QueryParameterCollisionOwnerKind.NestedObjectProperty)
+        assertThat(
+            queryParamPattern.matches(
+                HttpRequest(
+                    "GET",
+                    "/orders",
+                    queryParams = QueryParameters(listOf("name" to "Jack", "address.street" to "Baker", "status" to "866"))
+                ),
+                Resolver()
+            )
+        ).isInstanceOf(Result.Success::class.java)
+    }
+
+    @Test
+    fun `different type collision should select object property as authoritative when declared last in lenient parsing`() {
+        val spec = """
+            openapi: 3.0.0
+            info:
+              title: Colliding Form Exploded Object Query Param
+              version: 1.0.0
+            paths:
+              /orders:
+                get:
+                  parameters:
+                    - in: query
+                      name: type
+                      required: false
+                      schema:
+                        type: string
+                    - in: query
+                      name: info
+                      required: true
+                      schema:
+                        type: object
+                        required:
+                          - type
+                        properties:
+                          type:
+                            type: integer
+                  responses:
+                    '200':
+                      description: OK
+        """.trimIndent()
+
+        val (feature, result) = OpenApiSpecification.fromYAML(spec, "").toFeatureLenient()
+        val queryParamPattern = feature.scenarios.single().httpRequestPattern.httpQueryParamPattern
+        val typePattern = queryParamPattern.queryPatterns["type"]
+        val collisionGroup = queryParamPattern.collisionGroupsByWireKey.getValue("type")
+
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
+        assertThat(result.reportString()).contains(OpenApiLintViolations.QUERY_PARAMETER_TYPE_COLLISION.id)
+        assertThat(result.reportString()).doesNotContain(OpenApiLintViolations.INVALID_PARAMETER_DEFINITION.id)
+        assertThat(result.reportString()).contains("- type at paths./orders.get.parameters[0].name")
+        assertThat(result.reportString()).contains("- info.type at paths./orders.get.parameters[1].schema.properties.type")
+        assertThat(result.reportString()).contains("last declared query parameter info.type as authoritative")
+        assertThat(collisionGroup.owners.map { it.sourceName }).containsExactly("type", "info.type")
+        assertThat(collisionGroup.authoritativeOwner.sourceName).isEqualTo("info.type")
+        assertThat(collisionGroup.authoritativeOwner.kind).isEqualTo(QueryParameterCollisionOwnerKind.FormExplodedObjectProperty)
+        assertThat(typePattern).isInstanceOf(QueryParameterScalarPattern::class.java)
+        assertThat((typePattern as QueryParameterScalarPattern).pattern).isInstanceOf(NumberPattern::class.java)
+        assertThat(queryParamPattern.matches(HttpRequest("GET", "/orders", queryParams = QueryParameters(listOf("type" to "10"))), Resolver())).isInstanceOf(Result.Success::class.java)
     }
 
     @Test
@@ -1007,7 +1142,69 @@ class OpenApiSpecificationParseTest {
         val collisionGroup = queryParamPattern.collisionGroupsByWireKey.getValue("age")
 
         assertThat(collisionGroup.owners.map { it.sourceName }).containsExactly("info.age", "filters.age")
-        assertThat(collisionGroup.authoritativeOwner.sourceName).isEqualTo("info.age")
+        assertThat(collisionGroup.authoritativeOwner.sourceName).isEqualTo("filters.age")
+    }
+
+    @Test
+    fun `different type collision across two form exploded object query params should select last object property at parse time`() {
+        val spec = """
+            openapi: 3.0.0
+            info:
+              title: Colliding Form Exploded Object Query Params
+              version: 1.0.0
+            paths:
+              /orders:
+                get:
+                  parameters:
+                    - in: query
+                      name: info
+                      required: true
+                      schema:
+                        ${"$"}ref: '#/components/schemas/InfoParams'
+                    - in: query
+                      name: filters
+                      required: true
+                      schema:
+                        ${"$"}ref: '#/components/schemas/FilterParams'
+                  responses:
+                    '200':
+                      description: OK
+            components:
+              schemas:
+                InfoParams:
+                  type: object
+                  required:
+                    - age
+                  properties:
+                    age:
+                      type: integer
+                FilterParams:
+                  type: object
+                  required:
+                    - age
+                  properties:
+                    age:
+                      type: boolean
+        """.trimIndent()
+
+        val (stdout, feature) = captureStandardOutput {
+            OpenApiSpecification.fromYAML(spec, "").toFeature()
+        }
+        val scenario = feature.scenarios.single()
+        val queryParamPattern = scenario.httpRequestPattern.httpQueryParamPattern
+        val agePattern = queryParamPattern.queryPatterns["age"]
+        val collisionGroup = queryParamPattern.collisionGroupsByWireKey.getValue("age")
+
+        assertThat(stdout).contains(OpenApiLintViolations.QUERY_PARAMETER_TYPE_COLLISION.id)
+        assertThat(stdout).contains("- info.age at components.schemas.InfoParams.properties.age")
+        assertThat(stdout).contains("- filters.age at components.schemas.FilterParams.properties.age")
+        assertThat(stdout).contains("last declared query parameter filters.age as authoritative")
+        assertThat(collisionGroup.owners.map { it.sourceName }).containsExactly("info.age", "filters.age")
+        assertThat(collisionGroup.authoritativeOwner.sourceName).isEqualTo("filters.age")
+        assertThat(collisionGroup.authoritativeOwner.kind).isEqualTo(QueryParameterCollisionOwnerKind.FormExplodedObjectProperty)
+        assertThat(agePattern).isInstanceOf(QueryParameterScalarPattern::class.java)
+        assertThat(resolvedHop((agePattern as QueryParameterScalarPattern).pattern, scenario.resolver)).isInstanceOf(BooleanPattern::class.java)
+        assertThat(queryParamPattern.matches(HttpRequest("GET", "/orders", queryParams = QueryParameters(listOf("age" to "true"))), Resolver())).isInstanceOf(Result.Success::class.java)
     }
 
     @Test
@@ -1062,7 +1259,7 @@ class OpenApiSpecificationParseTest {
         val (feature, result) = OpenApiSpecification.fromYAML(spec, "").toFeatureLenient()
         val scenario = feature.scenarios.single()
         val queryParamPattern = scenario.httpRequestPattern.httpQueryParamPattern
-        val agePattern = queryParamPattern.queryPatterns["age"]
+        val agePattern = queryParamPattern.queryPatterns["age?"]
         val collisionGroup = queryParamPattern.collisionGroupsByWireKey.getValue("age")
 
         assertThat(result).isInstanceOf(Result.Failure::class.java)
@@ -1073,9 +1270,9 @@ class OpenApiSpecificationParseTest {
         assertThat(result.reportString()).contains("- age at paths./orders.get.parameters[2].name")
         assertThat(result.reportString()).doesNotContain("/paths/~1orders/get/parameters")
         assertThat(collisionGroup.owners.map { it.sourceName }).containsExactly("info.age", "filters.age", "age")
-        assertThat(collisionGroup.authoritativeOwner.sourceName).isEqualTo("info.age")
+        assertThat(collisionGroup.authoritativeOwner.sourceName).isEqualTo("age")
         assertThat(agePattern).isInstanceOf(QueryParameterScalarPattern::class.java)
-        assertThat(resolvedHop((agePattern as QueryParameterScalarPattern).pattern, scenario.resolver)).isInstanceOf(NumberPattern::class.java)
+        assertThat(resolvedHop((agePattern as QueryParameterScalarPattern).pattern, scenario.resolver)).isInstanceOf(BooleanPattern::class.java)
     }
 
     @ParameterizedTest(name = "openapi {0}")
@@ -1511,6 +1708,56 @@ class OpenApiSpecificationParseTest {
         ),
         "test-api.yaml"
     ).toFeature().scenarios.single().httpRequestPattern.httpQueryParamPattern
+
+    private fun nestedStatusCollisionSpec(scalarDeclaredLast: Boolean): String {
+        val scalarStatusParam = """
+                    - in: query
+                      name: status
+                      required: false
+                      schema:
+                        type: boolean
+        """.trimIndent()
+        val nestedDetailsParam = """
+                    - in: query
+                      name: details
+                      required: true
+                      schema:
+                        type: object
+                        required:
+                          - status
+                        properties:
+                          status:
+                            type: integer
+                          name:
+                            type: string
+                          address:
+                            type: object
+                            properties:
+                              street:
+                                type: string
+                      example: status=10&name=Jack&address.street=Baker
+        """.trimIndent()
+        val parameters = if (scalarDeclaredLast) {
+            listOf(nestedDetailsParam, scalarStatusParam)
+        } else {
+            listOf(scalarStatusParam, nestedDetailsParam)
+        }.joinToString("\n") { it.prependIndent("                    ") }
+
+        return """
+            openapi: 3.0.0
+            info:
+              title: Colliding Nested Object Query Param
+              version: 1.0.0
+            paths:
+              /orders:
+                get:
+                  parameters:
+$parameters
+                  responses:
+                    '200':
+                      description: OK
+        """.trimIndent()
+    }
 
     private fun nestedObjectQueryParamSpec(
         schema: Map<String, Any?>,

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationParseTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationParseTest.kt
@@ -227,6 +227,49 @@ class OpenApiSpecificationParseTest {
         assertThat(headerPattern).isInstanceOf(NumberPattern::class.java)
     }
 
+    @Test
+    fun `scalar only query parameters with unique wire keys should not create collision groups`() {
+        val spec = """
+            openapi: 3.0.0
+            info:
+              title: Scalar Query Params
+              version: 1.0.0
+            paths:
+              /orders:
+                get:
+                  parameters:
+                    - in: query
+                      name: page
+                      required: true
+                      schema:
+                        type: integer
+                    - in: query
+                      name: status
+                      required: false
+                      schema:
+                        type: string
+                  responses:
+                    '200':
+                      description: OK
+        """.trimIndent()
+
+        val queryParamPattern = OpenApiSpecification.fromYAML(spec, "").toFeature().scenarios.single().httpRequestPattern.httpQueryParamPattern
+        val queryPatterns = queryParamPattern.queryPatterns
+
+        assertThat(queryPatterns.keys).containsExactlyInAnyOrder("page", "status?")
+        assertThat(queryPatterns["page"]).isInstanceOf(QueryParameterScalarPattern::class.java)
+        assertThat((queryPatterns["page"] as QueryParameterScalarPattern).pattern).isInstanceOf(NumberPattern::class.java)
+        assertThat(queryPatterns["status?"]).isInstanceOf(QueryParameterScalarPattern::class.java)
+        assertThat((queryPatterns["status?"] as QueryParameterScalarPattern).pattern).isInstanceOf(StringPattern::class.java)
+        assertThat(queryParamPattern.collisionGroupsByWireKey).isEmpty()
+        assertThat(
+            queryParamPattern.matches(
+                HttpRequest("GET", "/orders", queryParams = QueryParameters(listOf("page" to "1", "status" to "open"))),
+                Resolver()
+            )
+        ).isInstanceOf(Result.Success::class.java)
+    }
+
     @ParameterizedTest
     @ValueSource(booleans = [false, true])
     fun `should parse form exploded object query parameter properties as query params`(explicitSerialization: Boolean) {

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -12789,21 +12789,16 @@ paths:
     }
 
     @Test
-    fun `inline examples validate execute and mock through scalar-first authoritative collision owner in lenient mode`() {
+    fun `inline examples validate execute and mock through scalar declared last collision owner in lenient mode`() {
         val spec = """
             openapi: 3.0.0
             info:
-              title: Scalar First Query Param Collision Inline Example
+              title: Scalar Last Query Param Collision Inline Example
               version: 1.0.0
             paths:
               /data:
                 get:
                   parameters:
-                    - in: query
-                      name: age
-                      required: false
-                      schema:
-                        type: string
                     - in: query
                       name: info
                       required: false
@@ -12818,6 +12813,11 @@ paths:
                         SUCCESS:
                           value:
                             age: abc
+                    - in: query
+                      name: age
+                      required: false
+                      schema:
+                        type: string
                   responses:
                     '200':
                       description: OK
@@ -12865,16 +12865,21 @@ paths:
     }
 
     @Test
-    fun `inline examples fail validation through object-first authoritative collision owner in lenient mode`() {
+    fun `inline examples fail validation through object property declared last collision owner in lenient mode`() {
         val spec = """
             openapi: 3.0.0
             info:
-              title: Object First Query Param Collision Invalid Inline Example
+              title: Object Last Query Param Collision Invalid Inline Example
               version: 1.0.0
             paths:
               /data:
                 get:
                   parameters:
+                    - in: query
+                      name: age
+                      required: false
+                      schema:
+                        type: string
                     - in: query
                       name: info
                       required: false
@@ -12894,11 +12899,6 @@ paths:
                           value:
                             age: abc
                             name: Jane
-                    - in: query
-                      name: age
-                      required: false
-                      schema:
-                        type: string
                   responses:
                     '200':
                       description: OK

--- a/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
@@ -3374,7 +3374,7 @@ paths:
     }
 
     @Test
-    fun `externalized query example validates through object-first authoritative collision owner in lenient mode`() {
+    fun `externalized query example validates through scalar declared last collision owner in lenient mode`() {
         val feature = OpenApiSpecification.fromFile(QUERY_PARAM_COLLISION_EXTERNAL_EXAMPLE_SPEC, lenientMode = true)
             .toFeature()
             .loadExternalisedExamples()
@@ -3383,7 +3383,7 @@ paths:
     }
 
     @Test
-    fun `contract tests use externalized colliding query example with object-first authoritative owner`() {
+    fun `contract tests use externalized colliding query example with scalar declared last collision owner`() {
         val feature = OpenApiSpecification.fromFile(QUERY_PARAM_COLLISION_EXTERNAL_EXAMPLE_SPEC, lenientMode = true)
             .toFeature()
             .loadExternalisedExamples()
@@ -3404,7 +3404,7 @@ paths:
     }
 
     @Test
-    fun `mock matches externalized colliding query example with object-first authoritative owner`() {
+    fun `mock matches externalized colliding query example with scalar declared last collision owner`() {
         val feature = OpenApiSpecification.fromFile(QUERY_PARAM_COLLISION_EXTERNAL_EXAMPLE_SPEC, lenientMode = true)
             .toFeature()
             .loadExternalisedExamples()
@@ -3413,17 +3413,17 @@ paths:
             val matchingResponse = stub.client.execute(
                 HttpRequest("GET", "/data", queryParams = QueryParameters(mapOf("age" to "45", "name" to "Jane")))
             )
-            val mismatchingResponse = stub.client.execute(
+            val scalarStringResponse = stub.client.execute(
                 HttpRequest("GET", "/data", queryParams = QueryParameters(mapOf("age" to "abc", "name" to "Jane")))
             )
 
             assertThat(matchingResponse.status).isEqualTo(200)
-            assertThat(mismatchingResponse.status).isEqualTo(400)
+            assertThat(scalarStringResponse.status).isEqualTo(200)
         }
     }
 
     @Test
-    fun `contract tests without examples use generated colliding query params from object-first authoritative owner`() {
+    fun `contract tests without examples use generated colliding query params from object property declared last collision owner`() {
         val feature = OpenApiSpecification.fromYAML(NO_EXAMPLES_QUERY_PARAM_COLLISION_SPEC, "", lenientMode = true).toFeature()
         val seenQueryParams = mutableListOf<Map<String, String>>()
 
@@ -3448,7 +3448,7 @@ paths:
     }
 
     @Test
-    fun `mock without examples matches generated request through object-first authoritative collision owner`() {
+    fun `mock without examples matches generated request through object property declared last collision owner`() {
         val feature = OpenApiSpecification.fromYAML(NO_EXAMPLES_QUERY_PARAM_COLLISION_SPEC, "", lenientMode = true).toFeature()
 
         HttpStub(feature, port = ServerSocket(0).use { it.localPort }).use { stub ->
@@ -4144,6 +4144,10 @@ paths:
                 get:
                   parameters:
                     - in: query
+                      name: age
+                      schema:
+                        type: string
+                    - in: query
                       name: info
                       style: form
                       explode: true
@@ -4157,10 +4161,6 @@ paths:
                             type: integer
                           name:
                             type: string
-                    - in: query
-                      name: age
-                      schema:
-                        type: string
                   responses:
                     '200':
                       description: OK

--- a/core/src/test/kotlin/io/specmatic/core/HttpQueryParamPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpQueryParamPatternTest.kt
@@ -1211,17 +1211,17 @@ class HttpQueryParamPatternTest {
                     owners = listOf(
                         queryCollisionOwner(
                             wireKey = "ids",
-                            sourceName = "ids",
-                            kind = QueryParameterCollisionOwnerKind.ScalarParameter,
-                            pattern = QueryParameterArrayPattern(listOf(NumberPattern()), "ids")
-                        ),
-                        queryCollisionOwner(
-                            wireKey = "ids",
                             sourceName = "filter.ids",
                             kind = QueryParameterCollisionOwnerKind.FormExplodedObjectProperty,
                             pattern = QueryParameterScalarPattern(StringPattern()),
                             parameterName = "filter",
                             propertyName = "ids"
+                        ),
+                        queryCollisionOwner(
+                            wireKey = "ids",
+                            sourceName = "ids",
+                            kind = QueryParameterCollisionOwnerKind.ScalarParameter,
+                            pattern = QueryParameterArrayPattern(listOf(NumberPattern()), "ids")
                         )
                     ),
                     authoritativeOwner = queryCollisionOwner(
@@ -1253,18 +1253,18 @@ class HttpQueryParamPatternTest {
                     owners = listOf(
                         queryCollisionOwner(
                             wireKey = "age",
-                            sourceName = "age",
-                            kind = QueryParameterCollisionOwnerKind.ScalarParameter,
-                            pattern = QueryParameterScalarPattern(NumberPattern()),
-                            required = true
-                        ),
-                        queryCollisionOwner(
-                            wireKey = "age",
                             sourceName = "info.age",
                             kind = QueryParameterCollisionOwnerKind.FormExplodedObjectProperty,
                             pattern = QueryParameterScalarPattern(StringPattern()),
                             parameterName = "info",
                             propertyName = "age"
+                        ),
+                        queryCollisionOwner(
+                            wireKey = "age",
+                            sourceName = "age",
+                            kind = QueryParameterCollisionOwnerKind.ScalarParameter,
+                            pattern = QueryParameterScalarPattern(NumberPattern()),
+                            required = true
                         )
                     ),
                     authoritativeOwner = queryCollisionOwner(
@@ -1292,18 +1292,18 @@ class HttpQueryParamPatternTest {
                     owners = listOf(
                         queryCollisionOwner(
                             wireKey = "age",
+                            sourceName = "age",
+                            kind = QueryParameterCollisionOwnerKind.ScalarParameter,
+                            pattern = QueryParameterScalarPattern(StringPattern())
+                        ),
+                        queryCollisionOwner(
+                            wireKey = "age",
                             sourceName = "info.age",
                             kind = QueryParameterCollisionOwnerKind.FormExplodedObjectProperty,
                             pattern = QueryParameterScalarPattern(NumberPattern()),
                             required = true,
                             parameterName = "info",
                             propertyName = "age"
-                        ),
-                        queryCollisionOwner(
-                            wireKey = "age",
-                            sourceName = "age",
-                            kind = QueryParameterCollisionOwnerKind.ScalarParameter,
-                            pattern = QueryParameterScalarPattern(StringPattern())
                         )
                     ),
                     authoritativeOwner = queryCollisionOwner(
@@ -1333,18 +1333,18 @@ class HttpQueryParamPatternTest {
                     owners = listOf(
                         queryCollisionOwner(
                             wireKey = "age",
-                            sourceName = "age",
-                            kind = QueryParameterCollisionOwnerKind.ScalarParameter,
-                            pattern = QueryParameterScalarPattern(NumberPattern()),
-                            required = true
-                        ),
-                        queryCollisionOwner(
-                            wireKey = "age",
                             sourceName = "info.age",
                             kind = QueryParameterCollisionOwnerKind.FormExplodedObjectProperty,
                             pattern = QueryParameterScalarPattern(StringPattern()),
                             parameterName = "info",
                             propertyName = "age"
+                        ),
+                        queryCollisionOwner(
+                            wireKey = "age",
+                            sourceName = "age",
+                            kind = QueryParameterCollisionOwnerKind.ScalarParameter,
+                            pattern = QueryParameterScalarPattern(NumberPattern()),
+                            required = true
                         )
                     ),
                     authoritativeOwner = queryCollisionOwner(
@@ -1376,18 +1376,18 @@ class HttpQueryParamPatternTest {
                     owners = listOf(
                         queryCollisionOwner(
                             wireKey = "age",
-                            sourceName = "age",
-                            kind = QueryParameterCollisionOwnerKind.ScalarParameter,
-                            pattern = QueryParameterScalarPattern(NumberPattern()),
-                            required = true
-                        ),
-                        queryCollisionOwner(
-                            wireKey = "age",
                             sourceName = "info.age",
                             kind = QueryParameterCollisionOwnerKind.FormExplodedObjectProperty,
                             pattern = QueryParameterScalarPattern(StringPattern()),
                             parameterName = "info",
                             propertyName = "age"
+                        ),
+                        queryCollisionOwner(
+                            wireKey = "age",
+                            sourceName = "age",
+                            kind = QueryParameterCollisionOwnerKind.ScalarParameter,
+                            pattern = QueryParameterScalarPattern(NumberPattern()),
+                            required = true
                         )
                     ),
                     authoritativeOwner = queryCollisionOwner(
@@ -1417,18 +1417,18 @@ class HttpQueryParamPatternTest {
                     owners = listOf(
                         queryCollisionOwner(
                             wireKey = "age",
-                            sourceName = "age",
-                            kind = QueryParameterCollisionOwnerKind.ScalarParameter,
-                            pattern = QueryParameterScalarPattern(NumberPattern()),
-                            required = true
-                        ),
-                        queryCollisionOwner(
-                            wireKey = "age",
                             sourceName = "info.age",
                             kind = QueryParameterCollisionOwnerKind.FormExplodedObjectProperty,
                             pattern = QueryParameterScalarPattern(StringPattern()),
                             parameterName = "info",
                             propertyName = "age"
+                        ),
+                        queryCollisionOwner(
+                            wireKey = "age",
+                            sourceName = "age",
+                            kind = QueryParameterCollisionOwnerKind.ScalarParameter,
+                            pattern = QueryParameterScalarPattern(NumberPattern()),
+                            required = true
                         )
                     ),
                     authoritativeOwner = queryCollisionOwner(
@@ -1469,17 +1469,17 @@ class HttpQueryParamPatternTest {
                     owners = listOf(
                         queryCollisionOwner(
                             wireKey = "age",
+                            sourceName = "age",
+                            kind = QueryParameterCollisionOwnerKind.ScalarParameter,
+                            pattern = QueryParameterScalarPattern(StringPattern())
+                        ),
+                        queryCollisionOwner(
+                            wireKey = "age",
                             sourceName = "info.age",
                             kind = QueryParameterCollisionOwnerKind.FormExplodedObjectProperty,
                             pattern = QueryParameterScalarPattern(NumberPattern()),
                             parameterName = "info",
                             propertyName = "age"
-                        ),
-                        queryCollisionOwner(
-                            wireKey = "age",
-                            sourceName = "age",
-                            kind = QueryParameterCollisionOwnerKind.ScalarParameter,
-                            pattern = QueryParameterScalarPattern(StringPattern())
                         )
                     ),
                     authoritativeOwner = queryCollisionOwner(
@@ -1513,18 +1513,18 @@ class HttpQueryParamPatternTest {
                         owners = listOf(
                             queryCollisionOwner(
                                 wireKey = "age",
-                                sourceName = "age",
-                                kind = QueryParameterCollisionOwnerKind.ScalarParameter,
-                                pattern = QueryParameterScalarPattern(NumberPattern()),
-                                required = true
-                            ),
-                            queryCollisionOwner(
-                                wireKey = "age",
                                 sourceName = "info.age",
                                 kind = QueryParameterCollisionOwnerKind.FormExplodedObjectProperty,
                                 pattern = QueryParameterScalarPattern(StringPattern()),
                                 parameterName = "info",
                                 propertyName = "age"
+                            ),
+                            queryCollisionOwner(
+                                wireKey = "age",
+                                sourceName = "age",
+                                kind = QueryParameterCollisionOwnerKind.ScalarParameter,
+                                pattern = QueryParameterScalarPattern(NumberPattern()),
+                                required = true
                             )
                         ),
                         authoritativeOwner = queryCollisionOwner(
@@ -1546,7 +1546,7 @@ class HttpQueryParamPatternTest {
     }
 
     @Test
-    fun `generation from row should preserve exact scalar-first authoritative collision value`() {
+    fun `generation from row should preserve exact scalar declared last collision value`() {
         val queryPattern = HttpQueryParamPattern(
             mapOf("age?" to QueryParameterScalarPattern(StringPattern())),
             collisionGroupsByWireKey = mapOf(
@@ -1555,18 +1555,18 @@ class HttpQueryParamPatternTest {
                     owners = listOf(
                         queryCollisionOwner(
                             wireKey = "age",
-                            sourceName = "age",
-                            kind = QueryParameterCollisionOwnerKind.ScalarParameter,
-                            pattern = QueryParameterScalarPattern(NumberPattern()),
-                            required = true
-                        ),
-                        queryCollisionOwner(
-                            wireKey = "age",
                             sourceName = "info.age",
                             kind = QueryParameterCollisionOwnerKind.FormExplodedObjectProperty,
                             pattern = QueryParameterScalarPattern(StringPattern()),
                             parameterName = "info",
                             propertyName = "age"
+                        ),
+                        queryCollisionOwner(
+                            wireKey = "age",
+                            sourceName = "age",
+                            kind = QueryParameterCollisionOwnerKind.ScalarParameter,
+                            pattern = QueryParameterScalarPattern(NumberPattern()),
+                            required = true
                         )
                     ),
                     authoritativeOwner = queryCollisionOwner(
@@ -1586,7 +1586,7 @@ class HttpQueryParamPatternTest {
     }
 
     @Test
-    fun `generation from row should preserve exact object-first authoritative collision value`() {
+    fun `generation from row should preserve exact object property declared last collision value`() {
         val queryPattern = HttpQueryParamPattern(
             mapOf(
                 "age?" to QueryParameterScalarPattern(StringPattern()),
@@ -1606,17 +1606,17 @@ class HttpQueryParamPatternTest {
                     owners = listOf(
                         queryCollisionOwner(
                             wireKey = "age",
+                            sourceName = "age",
+                            kind = QueryParameterCollisionOwnerKind.ScalarParameter,
+                            pattern = QueryParameterScalarPattern(StringPattern())
+                        ),
+                        queryCollisionOwner(
+                            wireKey = "age",
                             sourceName = "info.age",
                             kind = QueryParameterCollisionOwnerKind.FormExplodedObjectProperty,
                             pattern = QueryParameterScalarPattern(NumberPattern()),
                             parameterName = "info",
                             propertyName = "age"
-                        ),
-                        queryCollisionOwner(
-                            wireKey = "age",
-                            sourceName = "age",
-                            kind = QueryParameterCollisionOwnerKind.ScalarParameter,
-                            pattern = QueryParameterScalarPattern(StringPattern())
                         )
                     ),
                     authoritativeOwner = queryCollisionOwner(
@@ -1637,7 +1637,7 @@ class HttpQueryParamPatternTest {
     }
 
     @Test
-    fun `generation should not reintroduce omitted optional scalar-first authoritative collision key`() {
+    fun `generation should not reintroduce omitted optional scalar declared last collision key`() {
         val queryPattern = HttpQueryParamPattern(
             mapOf(
                 "age?" to QueryParameterScalarPattern(StringPattern()),
@@ -1649,17 +1649,17 @@ class HttpQueryParamPatternTest {
                     owners = listOf(
                         queryCollisionOwner(
                             wireKey = "age",
-                            sourceName = "age",
-                            kind = QueryParameterCollisionOwnerKind.ScalarParameter,
-                            pattern = QueryParameterScalarPattern(NumberPattern())
-                        ),
-                        queryCollisionOwner(
-                            wireKey = "age",
                             sourceName = "info.age",
                             kind = QueryParameterCollisionOwnerKind.FormExplodedObjectProperty,
                             pattern = QueryParameterScalarPattern(StringPattern()),
                             parameterName = "info",
                             propertyName = "age"
+                        ),
+                        queryCollisionOwner(
+                            wireKey = "age",
+                            sourceName = "age",
+                            kind = QueryParameterCollisionOwnerKind.ScalarParameter,
+                            pattern = QueryParameterScalarPattern(NumberPattern())
                         )
                     ),
                     authoritativeOwner = queryCollisionOwner(
@@ -1678,7 +1678,7 @@ class HttpQueryParamPatternTest {
     }
 
     @Test
-    fun `generation should not reintroduce omitted optional object-first authoritative collision key`() {
+    fun `generation should not reintroduce omitted optional object property declared last collision key`() {
         val queryPattern = HttpQueryParamPattern(
             mapOf(
                 "age?" to QueryParameterScalarPattern(StringPattern()),
@@ -1698,17 +1698,17 @@ class HttpQueryParamPatternTest {
                     owners = listOf(
                         queryCollisionOwner(
                             wireKey = "age",
+                            sourceName = "age",
+                            kind = QueryParameterCollisionOwnerKind.ScalarParameter,
+                            pattern = QueryParameterScalarPattern(StringPattern())
+                        ),
+                        queryCollisionOwner(
+                            wireKey = "age",
                             sourceName = "info.age",
                             kind = QueryParameterCollisionOwnerKind.FormExplodedObjectProperty,
                             pattern = QueryParameterScalarPattern(NumberPattern()),
                             parameterName = "info",
                             propertyName = "age"
-                        ),
-                        queryCollisionOwner(
-                            wireKey = "age",
-                            sourceName = "age",
-                            kind = QueryParameterCollisionOwnerKind.ScalarParameter,
-                            pattern = QueryParameterScalarPattern(StringPattern())
                         )
                     ),
                     authoritativeOwner = queryCollisionOwner(
@@ -1738,18 +1738,18 @@ class HttpQueryParamPatternTest {
                     owners = listOf(
                         queryCollisionOwner(
                             wireKey = "age",
-                            sourceName = "age",
-                            kind = QueryParameterCollisionOwnerKind.ScalarParameter,
-                            pattern = QueryParameterScalarPattern(NumberPattern()),
-                            required = true
-                        ),
-                        queryCollisionOwner(
-                            wireKey = "age",
                             sourceName = "info.age",
                             kind = QueryParameterCollisionOwnerKind.FormExplodedObjectProperty,
                             pattern = QueryParameterScalarPattern(StringPattern()),
                             parameterName = "info",
                             propertyName = "age"
+                        ),
+                        queryCollisionOwner(
+                            wireKey = "age",
+                            sourceName = "age",
+                            kind = QueryParameterCollisionOwnerKind.ScalarParameter,
+                            pattern = QueryParameterScalarPattern(NumberPattern()),
+                            required = true
                         )
                     ),
                     authoritativeOwner = queryCollisionOwner(
@@ -1776,18 +1776,18 @@ class HttpQueryParamPatternTest {
                     owners = listOf(
                         queryCollisionOwner(
                             wireKey = "ids",
-                            sourceName = "ids",
-                            kind = QueryParameterCollisionOwnerKind.ScalarParameter,
-                            pattern = QueryParameterArrayPattern(listOf(NumberPattern()), "ids"),
-                            required = true
-                        ),
-                        queryCollisionOwner(
-                            wireKey = "ids",
                             sourceName = "filter.ids",
                             kind = QueryParameterCollisionOwnerKind.FormExplodedObjectProperty,
                             pattern = QueryParameterScalarPattern(StringPattern()),
                             parameterName = "filter",
                             propertyName = "ids"
+                        ),
+                        queryCollisionOwner(
+                            wireKey = "ids",
+                            sourceName = "ids",
+                            kind = QueryParameterCollisionOwnerKind.ScalarParameter,
+                            pattern = QueryParameterArrayPattern(listOf(NumberPattern()), "ids"),
+                            required = true
                         )
                     ),
                     authoritativeOwner = queryCollisionOwner(
@@ -1809,7 +1809,7 @@ class HttpQueryParamPatternTest {
     }
 
     @Test
-    fun `fill in the blanks should complete required sibling for object-first authoritative collision owner`() {
+    fun `fill in the blanks should complete required sibling for object property declared last collision owner`() {
         val queryPattern = HttpQueryParamPattern(
             mapOf(
                 "age?" to QueryParameterScalarPattern(StringPattern()),
@@ -1829,17 +1829,17 @@ class HttpQueryParamPatternTest {
                     owners = listOf(
                         queryCollisionOwner(
                             wireKey = "age",
+                            sourceName = "age",
+                            kind = QueryParameterCollisionOwnerKind.ScalarParameter,
+                            pattern = QueryParameterScalarPattern(StringPattern())
+                        ),
+                        queryCollisionOwner(
+                            wireKey = "age",
                             sourceName = "info.age",
                             kind = QueryParameterCollisionOwnerKind.FormExplodedObjectProperty,
                             pattern = QueryParameterScalarPattern(NumberPattern()),
                             parameterName = "info",
                             propertyName = "age"
-                        ),
-                        queryCollisionOwner(
-                            wireKey = "age",
-                            sourceName = "age",
-                            kind = QueryParameterCollisionOwnerKind.ScalarParameter,
-                            pattern = QueryParameterScalarPattern(StringPattern())
                         )
                     ),
                     authoritativeOwner = queryCollisionOwner(
@@ -1861,7 +1861,7 @@ class HttpQueryParamPatternTest {
     }
 
     @Test
-    fun `fix value should repair object-first authoritative collision owner and keep required sibling`() {
+    fun `fix value should repair object property declared last collision owner and keep required sibling`() {
         val queryPattern = HttpQueryParamPattern(
             mapOf(
                 "age?" to QueryParameterScalarPattern(StringPattern()),
@@ -1881,17 +1881,17 @@ class HttpQueryParamPatternTest {
                     owners = listOf(
                         queryCollisionOwner(
                             wireKey = "age",
+                            sourceName = "age",
+                            kind = QueryParameterCollisionOwnerKind.ScalarParameter,
+                            pattern = QueryParameterScalarPattern(StringPattern())
+                        ),
+                        queryCollisionOwner(
+                            wireKey = "age",
                             sourceName = "info.age",
                             kind = QueryParameterCollisionOwnerKind.FormExplodedObjectProperty,
                             pattern = QueryParameterScalarPattern(NumberPattern()),
                             parameterName = "info",
                             propertyName = "age"
-                        ),
-                        queryCollisionOwner(
-                            wireKey = "age",
-                            sourceName = "age",
-                            kind = QueryParameterCollisionOwnerKind.ScalarParameter,
-                            pattern = QueryParameterScalarPattern(StringPattern())
                         )
                     ),
                     authoritativeOwner = queryCollisionOwner(
@@ -1922,18 +1922,18 @@ class HttpQueryParamPatternTest {
                     owners = listOf(
                         queryCollisionOwner(
                             wireKey = "age",
-                            sourceName = "age",
-                            kind = QueryParameterCollisionOwnerKind.ScalarParameter,
-                            pattern = QueryParameterScalarPattern(NumberPattern()),
-                            required = true
-                        ),
-                        queryCollisionOwner(
-                            wireKey = "age",
                             sourceName = "info.age",
                             kind = QueryParameterCollisionOwnerKind.FormExplodedObjectProperty,
                             pattern = QueryParameterScalarPattern(StringPattern()),
                             parameterName = "info",
                             propertyName = "age"
+                        ),
+                        queryCollisionOwner(
+                            wireKey = "age",
+                            sourceName = "age",
+                            kind = QueryParameterCollisionOwnerKind.ScalarParameter,
+                            pattern = QueryParameterScalarPattern(NumberPattern()),
+                            required = true
                         )
                     ),
                     authoritativeOwner = queryCollisionOwner(
@@ -1954,7 +1954,7 @@ class HttpQueryParamPatternTest {
     }
 
     @Test
-    fun `generation without row should preserve object-first authoritative collision owner combinations`() {
+    fun `generation without row should preserve object property declared last collision owner combinations`() {
         val queryPattern = HttpQueryParamPattern(
             mapOf(
                 "age?" to QueryParameterScalarPattern(StringPattern()),
@@ -1974,17 +1974,17 @@ class HttpQueryParamPatternTest {
                     owners = listOf(
                         queryCollisionOwner(
                             wireKey = "age",
+                            sourceName = "age",
+                            kind = QueryParameterCollisionOwnerKind.ScalarParameter,
+                            pattern = QueryParameterScalarPattern(StringPattern())
+                        ),
+                        queryCollisionOwner(
+                            wireKey = "age",
                             sourceName = "info.age",
                             kind = QueryParameterCollisionOwnerKind.FormExplodedObjectProperty,
                             pattern = QueryParameterScalarPattern(NumberPattern()),
                             parameterName = "info",
                             propertyName = "age"
-                        ),
-                        queryCollisionOwner(
-                            wireKey = "age",
-                            sourceName = "age",
-                            kind = QueryParameterCollisionOwnerKind.ScalarParameter,
-                            pattern = QueryParameterScalarPattern(StringPattern())
                         )
                     ),
                     authoritativeOwner = queryCollisionOwner(
@@ -2021,18 +2021,18 @@ class HttpQueryParamPatternTest {
                     owners = listOf(
                         queryCollisionOwner(
                             wireKey = "age",
-                            sourceName = "age",
-                            kind = QueryParameterCollisionOwnerKind.ScalarParameter,
-                            pattern = QueryParameterScalarPattern(NumberPattern()),
-                            required = true
-                        ),
-                        queryCollisionOwner(
-                            wireKey = "age",
                             sourceName = "info.age",
                             kind = QueryParameterCollisionOwnerKind.FormExplodedObjectProperty,
                             pattern = QueryParameterScalarPattern(StringPattern()),
                             parameterName = "info",
                             propertyName = "age"
+                        ),
+                        queryCollisionOwner(
+                            wireKey = "age",
+                            sourceName = "age",
+                            kind = QueryParameterCollisionOwnerKind.ScalarParameter,
+                            pattern = QueryParameterScalarPattern(NumberPattern()),
+                            required = true
                         )
                     ),
                     authoritativeOwner = queryCollisionOwner(
@@ -2048,18 +2048,18 @@ class HttpQueryParamPatternTest {
                     owners = listOf(
                         queryCollisionOwner(
                             wireKey = "active",
+                            sourceName = "active",
+                            kind = QueryParameterCollisionOwnerKind.ScalarParameter,
+                            pattern = QueryParameterScalarPattern(StringPattern())
+                        ),
+                        queryCollisionOwner(
+                            wireKey = "active",
                             sourceName = "filter.active",
                             kind = QueryParameterCollisionOwnerKind.FormExplodedObjectProperty,
                             pattern = QueryParameterScalarPattern(BooleanPattern()),
                             required = true,
                             parameterName = "filter",
                             propertyName = "active"
-                        ),
-                        queryCollisionOwner(
-                            wireKey = "active",
-                            sourceName = "active",
-                            kind = QueryParameterCollisionOwnerKind.ScalarParameter,
-                            pattern = QueryParameterScalarPattern(StringPattern())
                         )
                     ),
                     authoritativeOwner = queryCollisionOwner(

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=io.specmatic
-version=2.46.6-SNAPSHOT
+version=2.47.0-SNAPSHOT
 specmaticGradlePluginVersion=0.15.12
 specmaticReporterVersion=0.3.34
 swaggerParserVersion=2.1.35


### PR DESCRIPTION
**What**:

Fix query parameter collision resolution so the last declared parameter owner wins when form-exploded or nested object properties share the same wire key with scalar query parameters.

**Why**:

Specs can declare an object query parameter and a scalar query parameter that serialize to the same wire key, such as `msResponse.status` and `status`. Specmatic already warns about the conflict, but parsing and example handling need to consistently honor declaration order so the last declaration is authoritative.

**How**:

- Resolve colliding query parameter owners at parse time using last-declared ownership for scalar, form-exploded object, and nested object property collisions.
- Preserve collision metadata on query parameter patterns so matching, example validation, generation, fill-in-the-blanks, and fix-value flows use the same authoritative owner.
- Move unwrapped nested object root-property expansion out of `OpenApiSpecification` into a focused helper.
- Mark `OAS0013` / `REQUIRED_QUERY_OBJECT_CONFLICT` as a warning in lint metadata to match current parser behavior.
- Add focused parser and core regression coverage for scalar-before-object, scalar-after-object, object-vs-object collisions, and scalar-only query parameters with unique wire keys.

**Checklist**:

- [x] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
