### PR TITLE
feat: add spec-level coverage metrics to CTRF reports

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/report/CoverageReportOperationExtensions.kt
+++ b/core/src/main/kotlin/io/specmatic/core/report/CoverageReportOperationExtensions.kt
@@ -5,28 +5,40 @@ import io.specmatic.reporter.internal.dto.coverage.CoverageStatus
 import io.specmatic.reporter.internal.dto.coverage.OmittedStatus
 import kotlin.math.roundToInt
 
+fun List<BaseCoverageReportOperation>.coveredOperationsCount(): Int {
+    return this.count { operation ->
+        operation.eligibleForCoverage && operation.coverageStatus == CoverageStatus.COVERED
+    }
+}
+
+fun List<BaseCoverageReportOperation>.totalOperationForCoverageIncludingFilters(): List<BaseCoverageReportOperation> {
+    return this.filter { it.eligibleForCoverage }
+}
+
+fun List<BaseCoverageReportOperation>.totalOperationsForCoverage(): List<BaseCoverageReportOperation> {
+    return this.filter { operation ->
+        operation.eligibleForCoverage || operation.omittedStatus == OmittedStatus.EXCLUDED
+    }
+}
+
 fun List<BaseCoverageReportOperation>.calculateCoverage(): Int {
-    val coverageReportOperations = this.filter { it.eligibleForCoverage }
+    val coverageReportOperations = this.totalOperationForCoverageIncludingFilters()
     if (coverageReportOperations.isEmpty()) {
         return 0
     }
 
-    val coveredOperationCount = coverageReportOperations.count { it.coverageStatus == CoverageStatus.COVERED }
+    val coveredOperationCount = coverageReportOperations.coveredOperationsCount()
     return ((coveredOperationCount.toDouble() / coverageReportOperations.size) * 100).roundToInt()
 }
 
 fun List<BaseCoverageReportOperation>.calculateAbsoluteCoverage(): Int {
-    val denominatorOperations = this.filter { operation ->
-        operation.eligibleForCoverage || operation.omittedStatus == OmittedStatus.EXCLUDED
-    }
+    val denominatorOperations = this.totalOperationsForCoverage()
 
     if (denominatorOperations.isEmpty()) {
         return 0
     }
 
-    val coveredOperationCount = denominatorOperations.count { operation ->
-        operation.eligibleForCoverage && operation.coverageStatus == CoverageStatus.COVERED
-    }
+    val coveredOperationCount = denominatorOperations.coveredOperationsCount()
 
     return ((coveredOperationCount.toDouble() / denominatorOperations.size) * 100).roundToInt()
 }

--- a/core/src/main/kotlin/io/specmatic/core/report/CtrfSpecExecutionDetailExtensions.kt
+++ b/core/src/main/kotlin/io/specmatic/core/report/CtrfSpecExecutionDetailExtensions.kt
@@ -3,14 +3,13 @@ package io.specmatic.core.report
 import io.specmatic.reporter.ctrf.CoverageReportSpecification
 import io.specmatic.reporter.ctrf.model.BaseCoverageReportOperation
 import io.specmatic.reporter.ctrf.model.CoverageMetrics
-import io.specmatic.reporter.ctrf.model.CtrfSpecConfig
-import io.specmatic.reporter.ctrf.model.matches
 
 fun List<BaseCoverageReportOperation>.toCoverageReportSpecifications(
-    specConfigs: List<CtrfSpecConfig>,
 ): List<CoverageReportSpecification> {
+    val specConfigs = map { it.specConfig }.distinct()
+
     return specConfigs.distinct().map { specConfig ->
-        val specCoverageOperations = filter { it.specConfig.matches(specConfig) }
+        val specCoverageOperations = filter { it.specConfig == specConfig }
 
         CoverageReportSpecification(
             specConfig = specConfig,

--- a/core/src/main/kotlin/io/specmatic/core/report/CtrfSpecExecutionDetailExtensions.kt
+++ b/core/src/main/kotlin/io/specmatic/core/report/CtrfSpecExecutionDetailExtensions.kt
@@ -1,0 +1,30 @@
+package io.specmatic.core.report
+
+import io.specmatic.reporter.ctrf.CoverageReportSpecification
+import io.specmatic.reporter.ctrf.model.BaseCoverageReportOperation
+import io.specmatic.reporter.ctrf.model.CoverageMetrics
+import io.specmatic.reporter.ctrf.model.CtrfSpecConfig
+import io.specmatic.reporter.ctrf.model.matches
+
+fun List<BaseCoverageReportOperation>.toCoverageReportSpecifications(
+    specConfigs: List<CtrfSpecConfig>,
+): List<CoverageReportSpecification> {
+    return specConfigs.distinct().map { specConfig ->
+        val specCoverageOperations = filter { it.specConfig.matches(specConfig) }
+
+        CoverageReportSpecification(
+            specConfig = specConfig,
+            coverageReportOperations = specCoverageOperations,
+            coverageMetrics = specCoverageOperations.toCoverageMetrics()
+        )
+    }
+}
+
+fun List<BaseCoverageReportOperation>.toCoverageMetrics(): CoverageMetrics? {
+    if (isEmpty()) return null
+
+    return CoverageMetrics(
+        apiCoverage = calculateCoverage(),
+        absoluteCoverage = calculateAbsoluteCoverage(),
+    )
+}

--- a/core/src/main/kotlin/io/specmatic/core/report/CtrfSpecExecutionDetailExtensions.kt
+++ b/core/src/main/kotlin/io/specmatic/core/report/CtrfSpecExecutionDetailExtensions.kt
@@ -23,8 +23,15 @@ fun List<BaseCoverageReportOperation>.toCoverageReportSpecifications(
 fun List<BaseCoverageReportOperation>.toCoverageMetrics(): CoverageMetrics? {
     if (isEmpty()) return null
 
+    val coveredOperations = coveredOperationsCount()
+    val totalOperationsWithFilters = totalOperationForCoverageIncludingFilters().size
+    val totalOperations = totalOperationsForCoverage().size
+
     return CoverageMetrics(
         apiCoverage = calculateCoverage(),
         absoluteCoverage = calculateAbsoluteCoverage(),
+        coveredOperations = coveredOperations,
+        totalOperationsWithFilters = totalOperationsWithFilters,
+        totalOperations = totalOperations,
     )
 }

--- a/core/src/main/kotlin/io/specmatic/core/report/ReportGenerator.kt
+++ b/core/src/main/kotlin/io/specmatic/core/report/ReportGenerator.kt
@@ -23,13 +23,7 @@ object ReportGenerator {
         reportDir: File,
         toolName: String = "Specmatic ${VersionInfo.describe()}",
     ) {
-        val specConfigs = coverageReportSpecifications.map { it.specConfig }
-        if(isCtrfSpecConfigsValid(specConfigs).not()) return
-
-        val coverageReportOperations = coverageReportSpecifications.flatMap { it.coverageReportOperations }
-        val testResultRecords = coverageReportOperations
-            .flatMap { it.tests }
-            .distinctBy { it.id }
+        if (isCoverageReportSpecificationsValid(coverageReportSpecifications).not()) return
 
         val extra = buildMap<String, Any> {
             coverage?.let { put("apiCoverage", "$coverage%") }
@@ -38,11 +32,7 @@ object ReportGenerator {
             put("specmaticConfigPath", getConfigFilePath())
         }
 
-        consoleLog(
-            "Generating report for ${testResultRecords.size} tests and ${coverageReportOperations.size} coverage operations..."
-        )
-
-        consoleLog("Using report generation method that accepts coverage report specifications.")
+        logCoverageReportGeneration(coverageReportSpecifications)
         val report = CtrfReportGenerator.generate(
             coverageReportSpecifications = coverageReportSpecifications,
             startTime = startTime,
@@ -93,6 +83,17 @@ object ReportGenerator {
         }
     }
 
+    private fun isCoverageReportSpecificationsValid(
+        coverageReportSpecifications: List<CoverageReportSpecification>,
+    ): Boolean {
+        if (coverageReportSpecifications.isEmpty()) {
+            consoleLog("Skipping the CTRF report generation as coverage report specifications list is empty.")
+            return false
+        }
+
+        return isCtrfSpecConfigsValid(coverageReportSpecifications.map { it.specConfig })
+    }
+
     private fun isCtrfSpecConfigsValid(specConfigs: List<CtrfSpecConfig>): Boolean {
         if (specConfigs.isEmpty()) {
             consoleLog("Skipping the CTRF report generation as ctrf spec configs list is empty.")
@@ -104,4 +105,25 @@ object ReportGenerator {
         }
         return true
     }
+
+    private fun logCoverageReportGeneration(coverageReportSpecifications: List<CoverageReportSpecification>) {
+        val (totalTests, totalOperations) = coverageReportCounts(coverageReportSpecifications)
+        consoleLog(
+            "Generating report for $totalTests tests and $totalOperations coverage operations..."
+        )
+        consoleLog("Using report generation method that accepts coverage report specifications.")
+    }
+
+    private fun coverageReportCounts(
+        coverageReportSpecifications: List<CoverageReportSpecification>,
+    ): Pair<Int, Int> {
+        val coverageReportOperations = coverageReportSpecifications.flatMap { it.coverageReportOperations }
+        val totalTests = coverageReportOperations
+            .flatMap { it.tests }
+            .distinctBy { it.id }
+            .size
+
+        return totalTests to coverageReportOperations.size
+    }
+
 }

--- a/core/src/main/kotlin/io/specmatic/core/report/ReportGenerator.kt
+++ b/core/src/main/kotlin/io/specmatic/core/report/ReportGenerator.kt
@@ -3,9 +3,9 @@ package io.specmatic.core.report
 import io.specmatic.core.config.toResolvedSpecmaticConfigMap
 import io.specmatic.core.getConfigFilePath
 import io.specmatic.core.log.consoleLog
+import io.specmatic.reporter.ctrf.CoverageReportSpecification
 import io.specmatic.reporter.ctrf.CtrfReportGenerator
 import io.specmatic.reporter.ctrf.model.BaseBccReportOperation
-import io.specmatic.reporter.ctrf.model.BaseCoverageReportOperation
 import io.specmatic.reporter.ctrf.model.CtrfReport
 import io.specmatic.reporter.ctrf.model.CtrfSpecConfig
 import io.specmatic.reporter.reporting.ReportProvider
@@ -14,18 +14,19 @@ import java.io.File
 
 object ReportGenerator {
     fun generateReport(
-        coverageReportOperations: List<BaseCoverageReportOperation>,
+        coverageReportSpecifications: List<CoverageReportSpecification>,
         startTime: Long,
         endTime: Long,
-        specConfigs: List<CtrfSpecConfig>,
         coverage: Int? = null,
         actuatorEnabled: Boolean? = null,
         absoluteCoverage: Int? = null,
         reportDir: File,
         toolName: String = "Specmatic ${VersionInfo.describe()}",
     ) {
+        val specConfigs = coverageReportSpecifications.map { it.specConfig }
         if(isCtrfSpecConfigsValid(specConfigs).not()) return
 
+        val coverageReportOperations = coverageReportSpecifications.flatMap { it.coverageReportOperations }
         val testResultRecords = coverageReportOperations
             .flatMap { it.tests }
             .distinctBy { it.id }
@@ -41,13 +42,12 @@ object ReportGenerator {
             "Generating report for ${testResultRecords.size} tests and ${coverageReportOperations.size} coverage operations..."
         )
 
-        consoleLog("Using new report generation method that accepts coverage report operations.")
+        consoleLog("Using report generation method that accepts coverage report specifications.")
         val report = CtrfReportGenerator.generate(
-            coverageReportOperations = coverageReportOperations,
+            coverageReportSpecifications = coverageReportSpecifications,
             startTime = startTime,
             endTime = endTime,
             extra = extra,
-            specConfig = specConfigs,
             toolName = toolName
         )
 

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -1163,16 +1163,15 @@ class HttpStub(
 
     private fun generateReports() {
         synchronized(ctrfTestResultRecords) {
-            val mockUsage = OpenApiMockUsage()
+            val mockUsage = OpenApiMockUsage(specmaticConfigInstance)
             mockUsage.addEndpoints(_allEndpoints)
             ctrfTestResultRecords.forEach(mockUsage::addTestResultRecord)
             val mockUsageReport = mockUsage.generate()
 
             ReportGenerator.generateReport(
-                coverageReportOperations = mockUsageReport.coverageReportOperations,
+                coverageReportSpecifications = mockUsage.coverageReportSpecifications(mockUsageReport.coverageReportOperations),
                 startTime = startTime.toEpochMilli(),
                 endTime = Instant.now().toEpochMilli(),
-                specConfigs = mockUsageReport.getSpecConfigs(),
                 coverage = mockUsageReport.coverage,
                 absoluteCoverage = mockUsageReport.absoluteCoverage,
                 reportDir = File("${specmaticConfigInstance.getReportDirPath()}/stub")

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -1163,7 +1163,7 @@ class HttpStub(
 
     private fun generateReports() {
         synchronized(ctrfTestResultRecords) {
-            val mockUsage = OpenApiMockUsage(specmaticConfigInstance)
+            val mockUsage = OpenApiMockUsage()
             mockUsage.addEndpoints(_allEndpoints)
             ctrfTestResultRecords.forEach(mockUsage::addTestResultRecord)
             val mockUsageReport = mockUsage.generate()

--- a/core/src/main/kotlin/io/specmatic/stub/report/OpenApiMockUsage.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/report/OpenApiMockUsage.kt
@@ -2,6 +2,9 @@ package io.specmatic.stub.report
 
 import io.specmatic.core.report.calculateAbsoluteCoverage
 import io.specmatic.core.report.calculateCoverage
+import io.specmatic.core.report.toCoverageReportSpecifications
+import io.specmatic.reporter.ctrf.CoverageReportSpecification
+import io.specmatic.reporter.ctrf.model.BaseCoverageReportOperation
 import io.specmatic.test.TestResultRecord
 
 class OpenApiMockUsage(
@@ -34,5 +37,9 @@ class OpenApiMockUsage(
             coverage = coverageReportOperations.calculateCoverage(),
             absoluteCoverage = coverageReportOperations.calculateAbsoluteCoverage(),
         )
+    }
+
+    fun coverageReportSpecifications(coverageReportOperations: List<BaseCoverageReportOperation>): List<CoverageReportSpecification> {
+        return coverageReportOperations.toCoverageReportSpecifications()
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/report/CtrfSpecExecutionDetailExtensionsTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/report/CtrfSpecExecutionDetailExtensionsTest.kt
@@ -72,6 +72,9 @@ class CtrfSpecExecutionDetailExtensionsTest {
 
         assertThat(coverageReportSpecifications.single().coverageMetrics?.apiCoverage).isEqualTo(100)
         assertThat(coverageReportSpecifications.single().coverageMetrics?.absoluteCoverage).isEqualTo(50)
+        assertThat(coverageReportSpecifications.single().coverageMetrics?.coveredOperations).isEqualTo(1)
+        assertThat(coverageReportSpecifications.single().coverageMetrics?.totalOperationsWithFilters).isEqualTo(1)
+        assertThat(coverageReportSpecifications.single().coverageMetrics?.totalOperations).isEqualTo(2)
     }
 
     @Test
@@ -107,6 +110,9 @@ class CtrfSpecExecutionDetailExtensionsTest {
 
         assertThat(coverageReportSpecifications.single().coverageMetrics?.apiCoverage).isEqualTo(50)
         assertThat(coverageReportSpecifications.single().coverageMetrics?.absoluteCoverage).isEqualTo(50)
+        assertThat(coverageReportSpecifications.single().coverageMetrics?.coveredOperations).isEqualTo(1)
+        assertThat(coverageReportSpecifications.single().coverageMetrics?.totalOperationsWithFilters).isEqualTo(2)
+        assertThat(coverageReportSpecifications.single().coverageMetrics?.totalOperations).isEqualTo(2)
     }
 
     @Test
@@ -174,11 +180,17 @@ class CtrfSpecExecutionDetailExtensionsTest {
         assertThat(ordersMetrics.coverageReportOperations.map { it.specConfig.specification }).containsOnly("specs/orders.yaml")
         assertThat(ordersMetrics.coverageMetrics?.apiCoverage).isEqualTo(50)
         assertThat(ordersMetrics.coverageMetrics?.absoluteCoverage).isEqualTo(50)
+        assertThat(ordersMetrics.coverageMetrics?.coveredOperations).isEqualTo(1)
+        assertThat(ordersMetrics.coverageMetrics?.totalOperationsWithFilters).isEqualTo(2)
+        assertThat(ordersMetrics.coverageMetrics?.totalOperations).isEqualTo(2)
 
         assertThat(paymentsMetrics.coverageReportOperations).hasSize(2)
         assertThat(paymentsMetrics.coverageReportOperations.map { it.specConfig.specification }).containsOnly("specs/payments.yaml")
         assertThat(paymentsMetrics.coverageMetrics?.apiCoverage).isEqualTo(100)
         assertThat(paymentsMetrics.coverageMetrics?.absoluteCoverage).isEqualTo(50)
+        assertThat(paymentsMetrics.coverageMetrics?.coveredOperations).isEqualTo(1)
+        assertThat(paymentsMetrics.coverageMetrics?.totalOperationsWithFilters).isEqualTo(1)
+        assertThat(paymentsMetrics.coverageMetrics?.totalOperations).isEqualTo(2)
     }
 
     @Test
@@ -217,6 +229,9 @@ class CtrfSpecExecutionDetailExtensionsTest {
         assertThat(ordersMetrics.coverageReportOperations).hasSize(1)
         assertThat(ordersMetrics.coverageMetrics?.apiCoverage).isEqualTo(100)
         assertThat(ordersMetrics.coverageMetrics?.absoluteCoverage).isEqualTo(100)
+        assertThat(ordersMetrics.coverageMetrics?.coveredOperations).isEqualTo(1)
+        assertThat(ordersMetrics.coverageMetrics?.totalOperationsWithFilters).isEqualTo(1)
+        assertThat(ordersMetrics.coverageMetrics?.totalOperations).isEqualTo(1)
 
         assertThat(paymentsMetrics.coverageReportOperations).isEmpty()
         assertThat(paymentsMetrics.coverageMetrics).isNull()

--- a/core/src/test/kotlin/io/specmatic/core/report/CtrfSpecExecutionDetailExtensionsTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/report/CtrfSpecExecutionDetailExtensionsTest.kt
@@ -1,0 +1,235 @@
+package io.specmatic.core.report
+
+import io.specmatic.license.core.SpecmaticProtocol
+import io.specmatic.reporter.ctrf.model.BaseCoverageReportOperation
+import io.specmatic.reporter.ctrf.model.CoverageReportOperation
+import io.specmatic.reporter.ctrf.model.CtrfSpecConfig
+import io.specmatic.reporter.ctrf.model.CtrfTestMetadata
+import io.specmatic.reporter.ctrf.model.CtrfTestResultRecord
+import io.specmatic.reporter.internal.dto.coverage.CoverageStatus
+import io.specmatic.reporter.internal.dto.coverage.OmittedStatus
+import io.specmatic.reporter.internal.dto.operation.APIOperation
+import io.specmatic.reporter.model.OpenAPIOperation
+import io.specmatic.reporter.model.SpecType
+import io.specmatic.reporter.model.TestResult
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+private class TestCtrfTestResultRecord(
+    override val id: UUID = UUID.randomUUID(),
+    override val duration: Long = 100,
+    override val specification: String? = "spec1.yaml",
+    override val rawStatus: String? = "PASSED",
+    override val testType: String = "unit",
+    override val result: TestResult = TestResult.Success,
+    override val isWip: Boolean = false,
+    override val repository: String? = "https://github.com/example/repo.git",
+    override val branch: String? = "main",
+    override val operations: Set<APIOperation>,
+    override val specType: SpecType = SpecType.OPENAPI,
+) : CtrfTestResultRecord {
+    override fun testName() = "test"
+
+    override fun testMessage() = ""
+
+    override fun tags() = emptyList<String>()
+
+    override fun extraFields() = CtrfTestMetadata(input = "", inputTime = 0L)
+}
+
+class CtrfSpecExecutionDetailExtensionsTest {
+    @Test
+    fun `should calculate contract metrics per spec`() {
+        val specConfig = CtrfSpecConfig(
+            protocol = SpecmaticProtocol.HTTP.key,
+            specType = SpecType.OPENAPI.value,
+            specification = "specs/order.yaml",
+        )
+        val coveredOperation = openApiOperation(path = "/orders", method = "GET")
+        val excludedOperation = openApiOperation(path = "/internal/orders", method = "GET")
+        val testRecord = TestCtrfTestResultRecord(
+            specification = "specs/order.yaml",
+            operations = setOf(coveredOperation),
+        )
+
+        val coverageReportSpecifications = listOf<BaseCoverageReportOperation>(
+            CoverageReportOperation(
+                operation = coveredOperation,
+                specConfig = specConfig,
+                tests = listOf(testRecord),
+                coverageStatus = CoverageStatus.COVERED,
+                eligibleForCoverage = true,
+            ),
+            CoverageReportOperation(
+                operation = excludedOperation,
+                specConfig = specConfig,
+                coverageStatus = CoverageStatus.NOT_COVERED,
+                eligibleForCoverage = false,
+                omittedStatus = OmittedStatus.EXCLUDED,
+            )
+        ).toCoverageReportSpecifications(listOf(specConfig))
+
+        assertThat(coverageReportSpecifications.single().coverageMetrics?.apiCoverage).isEqualTo(100)
+        assertThat(coverageReportSpecifications.single().coverageMetrics?.absoluteCoverage).isEqualTo(50)
+    }
+
+    @Test
+    fun `should calculate coverage metrics per spec for stub reports`() {
+        val specConfig = CtrfSpecConfig(
+            protocol = SpecmaticProtocol.HTTP.key,
+            specType = SpecType.OPENAPI.value,
+            specification = "specs/order.yaml",
+        )
+        val coveredOperation = openApiOperation(path = "/orders", method = "POST", responseCode = 201)
+        val uncoveredOperation = openApiOperation(path = "/orders", method = "GET")
+        val stubTestRecord = TestCtrfTestResultRecord(
+            specification = "specs/order.yaml",
+            testType = "Stub",
+            operations = setOf(coveredOperation),
+        )
+
+        val coverageReportSpecifications = listOf<BaseCoverageReportOperation>(
+            CoverageReportOperation(
+                operation = coveredOperation,
+                specConfig = specConfig,
+                tests = listOf(stubTestRecord),
+                coverageStatus = CoverageStatus.COVERED,
+                eligibleForCoverage = true,
+            ),
+            CoverageReportOperation(
+                operation = uncoveredOperation,
+                specConfig = specConfig,
+                coverageStatus = CoverageStatus.NOT_COVERED,
+                eligibleForCoverage = true,
+            )
+        ).toCoverageReportSpecifications(listOf(specConfig))
+
+        assertThat(coverageReportSpecifications.single().coverageMetrics?.apiCoverage).isEqualTo(50)
+        assertThat(coverageReportSpecifications.single().coverageMetrics?.absoluteCoverage).isEqualTo(50)
+    }
+
+    @Test
+    fun `should group operations by spec and calculate metrics independently`() {
+        val ordersSpecConfig = CtrfSpecConfig(
+            protocol = SpecmaticProtocol.HTTP.key,
+            specType = SpecType.OPENAPI.value,
+            specification = "specs/orders.yaml",
+        )
+        val paymentsSpecConfig = CtrfSpecConfig(
+            protocol = SpecmaticProtocol.HTTP.key,
+            specType = SpecType.OPENAPI.value,
+            specification = "specs/payments.yaml",
+        )
+
+        val ordersCoveredOperation = openApiOperation(path = "/orders", method = "GET")
+        val ordersUncoveredOperation = openApiOperation(path = "/orders/{id}", method = "GET")
+        val paymentsCoveredOperation = openApiOperation(path = "/payments", method = "POST", responseCode = 201)
+        val paymentsExcludedOperation = openApiOperation(path = "/internal/payments", method = "GET")
+
+        val ordersTestRecord = TestCtrfTestResultRecord(
+            specification = "specs/orders.yaml",
+            operations = setOf(ordersCoveredOperation),
+        )
+        val paymentsTestRecord = TestCtrfTestResultRecord(
+            specification = "specs/payments.yaml",
+            operations = setOf(paymentsCoveredOperation),
+        )
+
+        val coverageReportSpecifications = listOf<BaseCoverageReportOperation>(
+            CoverageReportOperation(
+                operation = ordersCoveredOperation,
+                specConfig = ordersSpecConfig,
+                tests = listOf(ordersTestRecord),
+                coverageStatus = CoverageStatus.COVERED,
+                eligibleForCoverage = true,
+            ),
+            CoverageReportOperation(
+                operation = ordersUncoveredOperation,
+                specConfig = ordersSpecConfig,
+                coverageStatus = CoverageStatus.NOT_COVERED,
+                eligibleForCoverage = true,
+            ),
+            CoverageReportOperation(
+                operation = paymentsCoveredOperation,
+                specConfig = paymentsSpecConfig,
+                tests = listOf(paymentsTestRecord),
+                coverageStatus = CoverageStatus.COVERED,
+                eligibleForCoverage = true,
+            ),
+            CoverageReportOperation(
+                operation = paymentsExcludedOperation,
+                specConfig = paymentsSpecConfig,
+                coverageStatus = CoverageStatus.NOT_COVERED,
+                eligibleForCoverage = false,
+                omittedStatus = OmittedStatus.EXCLUDED,
+            ),
+        ).toCoverageReportSpecifications(listOf(ordersSpecConfig, paymentsSpecConfig))
+
+        val groupedBySpec = coverageReportSpecifications.associateBy { it.specConfig.specification }
+        val ordersMetrics = groupedBySpec.getValue("specs/orders.yaml")
+        val paymentsMetrics = groupedBySpec.getValue("specs/payments.yaml")
+
+        assertThat(ordersMetrics.coverageReportOperations).hasSize(2)
+        assertThat(ordersMetrics.coverageReportOperations.map { it.specConfig.specification }).containsOnly("specs/orders.yaml")
+        assertThat(ordersMetrics.coverageMetrics?.apiCoverage).isEqualTo(50)
+        assertThat(ordersMetrics.coverageMetrics?.absoluteCoverage).isEqualTo(50)
+
+        assertThat(paymentsMetrics.coverageReportOperations).hasSize(2)
+        assertThat(paymentsMetrics.coverageReportOperations.map { it.specConfig.specification }).containsOnly("specs/payments.yaml")
+        assertThat(paymentsMetrics.coverageMetrics?.apiCoverage).isEqualTo(100)
+        assertThat(paymentsMetrics.coverageMetrics?.absoluteCoverage).isEqualTo(50)
+    }
+
+    @Test
+    fun `should leave coverage metrics null when a spec has no matching operations`() {
+        val ordersSpecConfig = CtrfSpecConfig(
+            protocol = SpecmaticProtocol.HTTP.key,
+            specType = SpecType.OPENAPI.value,
+            specification = "specs/orders.yaml",
+        )
+        val paymentsSpecConfig = CtrfSpecConfig(
+            protocol = SpecmaticProtocol.HTTP.key,
+            specType = SpecType.OPENAPI.value,
+            specification = "specs/payments.yaml",
+        )
+
+        val ordersCoveredOperation = openApiOperation(path = "/orders", method = "GET")
+        val ordersTestRecord = TestCtrfTestResultRecord(
+            specification = "specs/orders.yaml",
+            operations = setOf(ordersCoveredOperation),
+        )
+
+        val coverageReportSpecifications = listOf<BaseCoverageReportOperation>(
+            CoverageReportOperation(
+                operation = ordersCoveredOperation,
+                specConfig = ordersSpecConfig,
+                tests = listOf(ordersTestRecord),
+                coverageStatus = CoverageStatus.COVERED,
+                eligibleForCoverage = true,
+            )
+        ).toCoverageReportSpecifications(listOf(ordersSpecConfig, paymentsSpecConfig))
+
+        val groupedBySpec = coverageReportSpecifications.associateBy { it.specConfig.specification }
+        val ordersMetrics = groupedBySpec.getValue("specs/orders.yaml")
+        val paymentsMetrics = groupedBySpec.getValue("specs/payments.yaml")
+
+        assertThat(ordersMetrics.coverageReportOperations).hasSize(1)
+        assertThat(ordersMetrics.coverageMetrics?.apiCoverage).isEqualTo(100)
+        assertThat(ordersMetrics.coverageMetrics?.absoluteCoverage).isEqualTo(100)
+
+        assertThat(paymentsMetrics.coverageReportOperations).isEmpty()
+        assertThat(paymentsMetrics.coverageMetrics).isNull()
+    }
+
+    private fun openApiOperation(
+        path: String,
+        method: String,
+        responseCode: Int = 200,
+    ) = OpenAPIOperation(
+        path = path,
+        method = method,
+        responseCode = responseCode,
+        protocol = SpecmaticProtocol.HTTP,
+    )
+}

--- a/core/src/test/kotlin/io/specmatic/core/report/CtrfSpecExecutionDetailExtensionsTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/report/CtrfSpecExecutionDetailExtensionsTest.kt
@@ -68,7 +68,7 @@ class CtrfSpecExecutionDetailExtensionsTest {
                 eligibleForCoverage = false,
                 omittedStatus = OmittedStatus.EXCLUDED,
             )
-        ).toCoverageReportSpecifications(listOf(specConfig))
+        ).toCoverageReportSpecifications()
 
         assertThat(coverageReportSpecifications.single().coverageMetrics?.apiCoverage).isEqualTo(100)
         assertThat(coverageReportSpecifications.single().coverageMetrics?.absoluteCoverage).isEqualTo(50)
@@ -106,7 +106,7 @@ class CtrfSpecExecutionDetailExtensionsTest {
                 coverageStatus = CoverageStatus.NOT_COVERED,
                 eligibleForCoverage = true,
             )
-        ).toCoverageReportSpecifications(listOf(specConfig))
+        ).toCoverageReportSpecifications()
 
         assertThat(coverageReportSpecifications.single().coverageMetrics?.apiCoverage).isEqualTo(50)
         assertThat(coverageReportSpecifications.single().coverageMetrics?.absoluteCoverage).isEqualTo(50)
@@ -170,7 +170,7 @@ class CtrfSpecExecutionDetailExtensionsTest {
                 eligibleForCoverage = false,
                 omittedStatus = OmittedStatus.EXCLUDED,
             ),
-        ).toCoverageReportSpecifications(listOf(ordersSpecConfig, paymentsSpecConfig))
+        ).toCoverageReportSpecifications()
 
         val groupedBySpec = coverageReportSpecifications.associateBy { it.specConfig.specification }
         val ordersMetrics = groupedBySpec.getValue("specs/orders.yaml")
@@ -194,7 +194,7 @@ class CtrfSpecExecutionDetailExtensionsTest {
     }
 
     @Test
-    fun `should leave coverage metrics null when a spec has no matching operations`() {
+    fun `should only return specifications present in coverage operations`() {
         val ordersSpecConfig = CtrfSpecConfig(
             protocol = SpecmaticProtocol.HTTP.key,
             specType = SpecType.OPENAPI.value,
@@ -220,21 +220,18 @@ class CtrfSpecExecutionDetailExtensionsTest {
                 coverageStatus = CoverageStatus.COVERED,
                 eligibleForCoverage = true,
             )
-        ).toCoverageReportSpecifications(listOf(ordersSpecConfig, paymentsSpecConfig))
+        ).toCoverageReportSpecifications()
 
-        val groupedBySpec = coverageReportSpecifications.associateBy { it.specConfig.specification }
-        val ordersMetrics = groupedBySpec.getValue("specs/orders.yaml")
-        val paymentsMetrics = groupedBySpec.getValue("specs/payments.yaml")
+        val ordersMetrics = coverageReportSpecifications.single()
 
+        assertThat(coverageReportSpecifications).hasSize(1)
+        assertThat(ordersMetrics.specConfig.specification).isEqualTo("specs/orders.yaml")
         assertThat(ordersMetrics.coverageReportOperations).hasSize(1)
         assertThat(ordersMetrics.coverageMetrics?.apiCoverage).isEqualTo(100)
         assertThat(ordersMetrics.coverageMetrics?.absoluteCoverage).isEqualTo(100)
         assertThat(ordersMetrics.coverageMetrics?.coveredOperations).isEqualTo(1)
         assertThat(ordersMetrics.coverageMetrics?.totalOperationsWithFilters).isEqualTo(1)
         assertThat(ordersMetrics.coverageMetrics?.totalOperations).isEqualTo(1)
-
-        assertThat(paymentsMetrics.coverageReportOperations).isEmpty()
-        assertThat(paymentsMetrics.coverageMetrics).isNull()
     }
 
     private fun openApiOperation(

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 group=io.specmatic
 version=2.48.1-SNAPSHOT
 specmaticGradlePluginVersion=0.15.13
-specmaticReporterVersion=0.3.35-SNAPSHOT
+specmaticReporterVersion=0.3.35
 swaggerParserVersion=2.1.35
 kotlin.daemon.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=384m
 org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=384m

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -207,16 +207,15 @@ open class SpecmaticJUnitSupport {
         val end = startTime?.let { Instant.now().toEpochMilli() } ?: 0L
         val coverageReport = openApiCoverage.generateWithoutHooks()
 
-        consoleLog("Generating CTRF report using  coverageReportOperations...")
+        consoleLog("Generating CTRF report using coverage report specifications...")
         ReportGenerator.generateReport(
             endTime = end,
             startTime = start,
             reportDir = File("$reportDirPath/test"),
-            coverageReportOperations = coverageReport.coverageOperations,
+            coverageReportSpecifications = coverageReport.coverageReportSpecifications(),
             coverage = coverageReport.totalCoveragePercentage,
             actuatorEnabled = coverageReport.actuatorEnabled,
             absoluteCoverage = coverageReport.absoluteCoveragePercentage,
-            specConfigs = coverageReport.getSpecConfigs(),
         )
     }
 

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReport.kt
@@ -3,7 +3,8 @@ package io.specmatic.test.reports.coverage
 import io.specmatic.core.Result
 import io.specmatic.core.report.calculateAbsoluteCoverage
 import io.specmatic.core.report.calculateCoverage
-import io.specmatic.reporter.ctrf.model.CtrfSpecConfig
+import io.specmatic.core.report.toCoverageMetrics
+import io.specmatic.reporter.ctrf.CoverageReportSpecification
 import io.specmatic.reporter.internal.dto.coverage.CoverageStatus
 import io.specmatic.test.API
 import io.specmatic.test.HttpInteractionsLog
@@ -33,8 +34,14 @@ data class OpenApiCoverageReport(
     val totalCoveragePercentage: Int = coverageOperations.calculateCoverage()
     val absoluteCoveragePercentage: Int = coverageOperations.calculateAbsoluteCoverage()
 
-    fun getSpecConfigs(): List<CtrfSpecConfig> {
-        return coverageOperations.map { it.specConfig }.distinct()
+    fun coverageReportSpecifications(): List<CoverageReportSpecification> {
+        return coverageOperations.groupBy { it.specConfig }.map { (specConfig, operations) ->
+            CoverageReportSpecification(
+                specConfig = specConfig,
+                coverageReportOperations = operations,
+                coverageMetrics = operations.toCoverageMetrics(),
+            )
+        }
     }
 
     fun onProcessingComplete() {

--- a/junit5-support/src/test/kotlin/io/specmatic/test/CtrfApiCoverageReportIntegrationTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/CtrfApiCoverageReportIntegrationTest.kt
@@ -240,11 +240,17 @@ class CtrfApiCoverageReportIntegrationTest {
 
         assertThat(petsExecutionDetail["coverageMetrics"]["apiCoverage"].asInt()).isEqualTo(50)
         assertThat(petsExecutionDetail["coverageMetrics"]["absoluteCoverage"].asInt()).isEqualTo(50)
+        assertThat(petsExecutionDetail["coverageMetrics"]["coveredOperations"].asInt()).isEqualTo(1)
+        assertThat(petsExecutionDetail["coverageMetrics"]["totalOperationsWithFilters"].asInt()).isEqualTo(2)
+        assertThat(petsExecutionDetail["coverageMetrics"]["totalOperations"].asInt()).isEqualTo(2)
         assertThat(petsExecutionDetail["operations"].map { it["path"].asText() })
             .containsExactlyInAnyOrder("/pets/find", "/pets/search")
 
         assertThat(ownersExecutionDetail["coverageMetrics"]["apiCoverage"].asInt()).isEqualTo(100)
         assertThat(ownersExecutionDetail["coverageMetrics"]["absoluteCoverage"].asInt()).isEqualTo(50)
+        assertThat(ownersExecutionDetail["coverageMetrics"]["coveredOperations"].asInt()).isEqualTo(1)
+        assertThat(ownersExecutionDetail["coverageMetrics"]["totalOperationsWithFilters"].asInt()).isEqualTo(1)
+        assertThat(ownersExecutionDetail["coverageMetrics"]["totalOperations"].asInt()).isEqualTo(2)
         assertThat(ownersExecutionDetail["operations"].map { it["path"].asText() })
             .containsExactlyInAnyOrder("/owners/{ownerId}", "/owners")
     }

--- a/junit5-support/src/test/kotlin/io/specmatic/test/CtrfApiCoverageReportIntegrationTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/CtrfApiCoverageReportIntegrationTest.kt
@@ -55,8 +55,8 @@ class CtrfApiCoverageReportIntegrationTest {
 
         val reportNode = ctrfReportNode(report)
 
-        assertThat(findTextValue(reportNode, "apiCoverage")).isEqualTo("100%")
-        assertThat(findTextValue(reportNode, "absoluteCoverage")).isEqualTo("50%")
+        assertThat(reportNode["results"]["extra"]["apiCoverage"].asText()).isEqualTo("100%")
+        assertThat(reportNode["results"]["extra"]["absoluteCoverage"].asText()).isEqualTo("50%")
         assertThat(reportNode["results"]["extra"]["actuatorEnabled"].asBoolean()).isTrue()
     }
 
@@ -275,7 +275,7 @@ class CtrfApiCoverageReportIntegrationTest {
         val report = coverage.generate()
         val reportNode = ctrfReportNode(report)
         assertThat(report.totalCoveragePercentage).isEqualTo(0)
-        assertThat(findTextValue(reportNode, "apiCoverage")).isEqualTo("0%")
+        assertThat(reportNode["results"]["extra"]["apiCoverage"].asText()).isEqualTo("0%")
         assertThat(reportNode["results"]["tests"].map { it["name"].asText() }).anyMatch { it.contains("/pets/search") }
     }
 
@@ -301,7 +301,7 @@ class CtrfApiCoverageReportIntegrationTest {
         val tests = reportNode["results"]["tests"].toList()
 
         assertThat(report.totalCoveragePercentage).isEqualTo(100)
-        assertThat(findTextValue(reportNode, "apiCoverage")).isEqualTo("100%")
+        assertThat(reportNode["results"]["extra"]["apiCoverage"].asText()).isEqualTo("100%")
         assertThat(tests.single()["extra"]["wip"].asBoolean()).isTrue()
         assertThat(executionOperations.single()["coverageStatus"].asText()).isEqualTo("covered")
         assertThat(executionOperations.single()["qualifiers"].get(0).asText()).isEqualTo("wip")

--- a/junit5-support/src/test/kotlin/io/specmatic/test/CtrfApiCoverageReportIntegrationTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/CtrfApiCoverageReportIntegrationTest.kt
@@ -193,6 +193,63 @@ class CtrfApiCoverageReportIntegrationTest {
     }
 
     @Test
+    fun `ctrf report should include build level and per spec coverage metrics for multi spec coverage`() {
+        val petsSpec = File("src/test/resources/openapi/api_coverage/openapi.yaml").canonicalFile
+        val ownersSpec = File("src/test/resources/openapi/api_coverage/owners.yaml").canonicalFile
+
+        val coverage = buildCoverage {
+            configFilePath(petsSpec.canonicalPath)
+
+            specEndpoint(method = "GET", path = "/pets/find", responseCode = 200, specification = petsSpec.canonicalPath)
+            specEndpoint(method = "GET", path = "/pets/search", responseCode = 200, specification = petsSpec.canonicalPath)
+            specEndpoint(method = "GET", path = "/owners/{ownerId}", responseCode = 200, specification = ownersSpec.canonicalPath)
+            specEndpoint(method = "POST", path = "/owners", responseCode = 201, specification = ownersSpec.canonicalPath)
+
+            decisionSkip(
+                path = "/owners",
+                method = "POST",
+                responseCode = 201,
+                reasoning = Reasoning(mainReason = TestSkipReason.EXCLUDED),
+            )
+
+            testResult(
+                path = "/pets/find",
+                method = "GET",
+                responseCode = 200,
+                result = TestResult.Success,
+                specification = petsSpec.canonicalPath,
+            )
+            testResult(
+                path = "/owners/{ownerId}",
+                method = "GET",
+                responseCode = 200,
+                result = TestResult.Success,
+                specification = ownersSpec.canonicalPath,
+            )
+        }
+
+        val report = coverage.generate()
+        val reportNode = ctrfReportNode(report)
+        val executionDetails = reportNode["results"]["summary"]["extra"]["executionDetails"].toList()
+
+        val petsExecutionDetail = executionDetails.single { it["specification"].asText() == petsSpec.canonicalPath }
+        val ownersExecutionDetail = executionDetails.single { it["specification"].asText() == ownersSpec.canonicalPath }
+
+        assertThat(reportNode["results"]["extra"]["apiCoverage"].asText()).isEqualTo("67%")
+        assertThat(reportNode["results"]["extra"]["absoluteCoverage"].asText()).isEqualTo("50%")
+
+        assertThat(petsExecutionDetail["coverageMetrics"]["apiCoverage"].asInt()).isEqualTo(50)
+        assertThat(petsExecutionDetail["coverageMetrics"]["absoluteCoverage"].asInt()).isEqualTo(50)
+        assertThat(petsExecutionDetail["operations"].map { it["path"].asText() })
+            .containsExactlyInAnyOrder("/pets/find", "/pets/search")
+
+        assertThat(ownersExecutionDetail["coverageMetrics"]["apiCoverage"].asInt()).isEqualTo(100)
+        assertThat(ownersExecutionDetail["coverageMetrics"]["absoluteCoverage"].asInt()).isEqualTo(50)
+        assertThat(ownersExecutionDetail["operations"].map { it["path"].asText() })
+            .containsExactlyInAnyOrder("/owners/{ownerId}", "/owners")
+    }
+
+    @Test
     fun `ctrf report summary coverage should match console coverage for not implemented endpoints`() {
         val specFile = File("src/test/resources/openapi/api_coverage/openapi.yaml").canonicalFile
         val coverage = buildCoverage {
@@ -448,8 +505,7 @@ class CtrfApiCoverageReportIntegrationTest {
                     endTime = 0L,
                     startTime = 0L,
                     toolName = "Specmatic test",
-                    specConfig = report.getSpecConfigs(),
-                    coverageReportOperations = report.coverageOperations,
+                    coverageReportSpecifications = report.coverageReportSpecifications(),
                     extra = buildMap {
                         put("apiCoverage", "${report.totalCoveragePercentage}%")
                         put("actuatorEnabled", report.actuatorEnabled)

--- a/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageIntegrationTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageIntegrationTest.kt
@@ -250,8 +250,8 @@ class OpenApiCoverageIntegrationTest {
         val expectedSpecificationPath = "specs/orders.yaml"
 
         report.verify {
-            assertThat(report.getSpecConfigs()).hasSize(1)
-            assertThat(report.getSpecConfigs().single().specification).isEqualTo(expectedSpecificationPath)
+            assertThat(report.coverageReportSpecifications()).hasSize(1)
+            assertThat(report.coverageReportSpecifications().single().specConfig.specification).isEqualTo(expectedSpecificationPath)
         }
     }
 

--- a/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInputTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInputTest.kt
@@ -46,7 +46,7 @@ class OpenApiCoverageReportInputTest {
         }
 
         val report = input.generate()
-        val specPaths = report.getSpecConfigs().map { it.specification }
+        val specPaths = report.coverageReportSpecifications().map { it.specConfig.specification }
 
         assertThat(specPaths).hasSize(1)
         assertThat(specPaths).containsExactly("specs/openapi.yaml")


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Add spec-level coverage metrics to CTRF execution details so each spec in a build can carry its own apiCoverage and absoluteCoverage values, while keeping the existing build-level coverage values unchanged.

<!-- Why are these changes necessary? -->

**Why**: Insights needs spec-scoped coverage data from the CTRF report instead of relying only on build-level percentages or recomputing coverage later. Since the build history view is scoped by spec, using only overall build coverage would be misleading. The CTRF output therefore needs to include coverage calculated per spec.

<!-- How were these changes implemented? -->

**How**: Implemented spec-level grouping of coverage operations in specmatic-core, calculated apiCoverage and absoluteCoverage for each grouped spec using the existing coverage calculation logic, and wrapped each spec’s CtrfSpecConfig, operations, and coverage metrics into CoverageReportSpecification. Updated CTRF report generation to pass these wrapper objects through to specmatic-reporter, and added unit and integration coverage around multi-spec execution details and final CTRF JSON output.



