### PR TITLE
Fix handling of single schema allOf wrappers

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -2604,7 +2604,22 @@ class OpenApiSpecification(
         return AnyOfPattern(pattern = patterns, typeAlias = "($patternName)", example = example)
     }
 
+    private fun Schema<*>.isPureSingleSchemaAllOf(): Boolean {
+        return this.xml == null &&
+        this.items == null &&
+        this.allOf?.size == 1 &&
+        this.discriminator == null &&
+        this.required.isNullOrEmpty() &&
+        this.properties.isNullOrEmpty() &&
+        this.additionalProperties == null
+    }
+
     private fun handleAllOf(schema: Schema<*>, typeStack: List<String>, patternName: String, collectorContext: CollectorContext): Pattern {
+        if (schema.isPureSingleSchemaAllOf()) {
+            val schemaContext = collectorContext.at("allOf").at(0)
+            return toSpecmaticPattern(schema.allOf.single(), typeStack, patternName = patternName, collectorContext = schemaContext)
+        }
+
         val (deepListOfAllOfs, allDiscriminators) = resolveDeepAllOfs(schema, DiscriminatorDetails(), emptySet(), topLevel = true, collectorContext = collectorContext)
         val explodedDiscriminators = allDiscriminators.explode()
         val topLevelRequired = schema.required.orEmpty()

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -2617,7 +2617,8 @@ class OpenApiSpecification(
     private fun handleAllOf(schema: Schema<*>, typeStack: List<String>, patternName: String, collectorContext: CollectorContext): Pattern {
         if (schema.isPureSingleSchemaAllOf()) {
             val schemaContext = collectorContext.at("allOf").at(0)
-            return toSpecmaticPattern(schema.allOf.single(), typeStack, patternName = patternName, collectorContext = schemaContext)
+            val pattern = toSpecmaticPattern(schema.allOf.single(), typeStack, patternName = patternName, collectorContext = schemaContext)
+            return cacheComponentPattern(patternName, annotateAllOfPattern(pattern, schema, patternName))
         }
 
         val (deepListOfAllOfs, allDiscriminators) = resolveDeepAllOfs(schema, DiscriminatorDetails(), emptySet(), topLevel = true, collectorContext = collectorContext)

--- a/core/src/test/kotlin/integration_tests/YamlToPatternTests.kt
+++ b/core/src/test/kotlin/integration_tests/YamlToPatternTests.kt
@@ -16,6 +16,7 @@ import io.specmatic.core.pattern.BinaryPattern
 import io.specmatic.core.pattern.BooleanPattern
 import io.specmatic.core.pattern.DatePattern
 import io.specmatic.core.pattern.DateTimePattern
+import io.specmatic.core.pattern.EnumPattern
 import io.specmatic.core.pattern.DeferredPattern
 import io.specmatic.core.pattern.EmailPattern
 import io.specmatic.core.pattern.ExactValuePattern
@@ -26,6 +27,7 @@ import io.specmatic.core.pattern.Pattern
 import io.specmatic.core.pattern.StringPattern
 import io.specmatic.core.pattern.UUIDPattern
 import io.specmatic.core.pattern.parsedValue
+import io.specmatic.core.pattern.resolvedHop
 import io.specmatic.core.pattern.withoutPatternDelimiters
 import io.specmatic.core.utilities.toValue
 import io.specmatic.core.utilities.yamlMapper
@@ -247,6 +249,17 @@ class YamlToPatternTests {
     @ParameterizedTest(name = "{index}: [{0}] {1}")
     @MethodSource("xmlSchemaScenarios")
     fun xml_schema_tests(openApiVersion: OpenApiVersion, case: PatternTestCase, info: TestInfo) = runCase(openApiVersion, case, info)
+
+    @ParameterizedTest(name = "{index}: [{0}] {1}")
+    @MethodSource("casesInvolvingComponents")
+    fun special_components_tests(openApiVersion: OpenApiVersion, composite: CompositePatternTestCase, info: TestInfo) {
+        val (patterns, resolver) = parseAndExtractCompositePatterns(openApiVersion, composite)
+        composite.schemas.forEach { (name, case) ->
+            val schemaPattern = patterns.getValue(name)
+            case.validate(schemaPattern)
+        }
+        composite.validate(patterns, resolver)
+    }
 
     companion object {
         @JvmStatic
@@ -1518,6 +1531,126 @@ class YamlToPatternTests {
                     validate { pattern ->
                         assertSuccess(pattern.matchParseValue("<Order><Product><id>123</id><name>Widget</name></Product><quantity>10</quantity></Order>"))
                         assertFailure(pattern.matchParseValue("<Order><Product><id>123</id></Product><quantity>10</quantity></Order>"))
+                    }
+                },
+            ).flatten().stream()
+        }
+
+        @JvmStatic
+        fun casesInvolvingComponents(): Stream<Arguments>  {
+            return listOf(
+                multiVersionCompositeCase(name = "single element allOf behaves like the target", OpenApiVersion.OAS30, OpenApiVersion.OAS31) {
+                    schema("Status") {
+                        schema {
+                            put("type", "string")
+                            put("enum", listOf("Active", "Inactive"))
+                        }
+                    }
+                    schema("Wrapper") {
+                        schema {
+                            put("type", "object")
+                            put("required", listOf("status"))
+                            put("properties", mapOf("status" to mapOf("allOf" to listOf(mapOf($$"$ref" to "#/components/schemas/Status")))))
+                        }
+                    }
+                    validate { patterns, resolver ->
+                        val wrapperPattern = patterns.getValue("Wrapper")
+                        assertFailure(wrapperPattern.match(mapOf("status" to null), resolver))
+                        assertSuccess(wrapperPattern.match(mapOf("status" to "Active"), resolver))
+                        assertSuccess(wrapperPattern.match(mapOf("status" to "Inactive"), resolver))
+                        assertFailure(wrapperPattern.match(mapOf("status" to "SomethingElse"), resolver))
+                    }
+                },
+                singleVersionCompositeCase(name = "single element allOf nullability is retained within the target 3.0", OpenApiVersion.OAS30) {
+                    schema("Status") {
+                        schema {
+                            put("type", "string")
+                            put("enum", listOf("Active", "Inactive"))
+                        }
+                    }
+                    schema("NullableWrapper") {
+                        schema {
+                            put("type", "object")
+                            put("properties", mapOf(
+                                "allOfStatus" to mapOf(
+                                    "nullable" to true,
+                                    "allOf" to listOf(mapOf($$"$ref" to "#/components/schemas/Status"))
+                                ),
+                                "anyOfStatus" to mapOf(
+                                    "nullable" to true,
+                                    "anyOf" to listOf(mapOf($$"$ref" to "#/components/schemas/Status"))
+                                ),
+                                "oneOfStatus" to mapOf(
+                                    "nullable" to true,
+                                    "oneOf" to listOf(mapOf($$"$ref" to "#/components/schemas/Status"))
+                                ),
+                                "allOfAnyOfStatus" to mapOf(
+                                    "nullable" to true,
+                                    "anyOf" to listOf(mapOf("allOf" to listOf(mapOf($$"$ref" to "#/components/schemas/Status"))))
+                                ),
+                                "allOfOneOfStatus" to mapOf(
+                                    "nullable" to true,
+                                    "oneOf" to listOf(mapOf("allOf" to listOf(mapOf($$"$ref" to "#/components/schemas/Status"))))
+                                ),
+                            ))
+                        }
+                    }
+                    validate { patterns, resolver ->
+                        val wrapperPattern = patterns.getValue("NullableWrapper")
+                        listOf("allOfStatus", "anyOfStatus", "oneOfStatus", "allOfAnyOfStatus", "allOfOneOfStatus").forEach { property ->
+                            assertSuccess(wrapperPattern.match(mapOf(property to null), resolver))
+                            assertSuccess(wrapperPattern.match(mapOf(property to "Active"), resolver))
+                            assertSuccess(wrapperPattern.match(mapOf(property to "Inactive"), resolver))
+                            assertFailure(wrapperPattern.match(mapOf(property to "SomethingElse"), resolver))
+                        }
+                    }
+                },
+                singleVersionCompositeCase(name = "single element allOf nullability is retained within the target 3.1", OpenApiVersion.OAS30) {
+                    schema("Status") {
+                        schema {
+                            put("type", "string")
+                            put("enum", listOf("Active", "Inactive"))
+                        }
+                    }
+                    schema("NullableWrapper") {
+                        schema {
+                            put("type", "object")
+                            put("properties", mapOf(
+                                "anyOfStatus" to mapOf(
+                                    "anyOf" to listOf(
+                                        mapOf("type" to "null"),
+                                        mapOf($$"$ref" to "#/components/schemas/Status"),
+                                    )
+                                ),
+                                "oneOfStatus" to mapOf(
+                                    "oneOf" to listOf(
+                                        mapOf("type" to "null"),
+                                        mapOf($$"$ref" to "#/components/schemas/Status"),
+                                    ),
+                                ),
+                                "allOfAnyOfStatus" to mapOf(
+                                    "anyOf" to listOf(
+                                        mapOf("type" to "null"),
+                                        mapOf("allOf" to listOf(mapOf($$"$ref" to "#/components/schemas/Status")))
+                                    )
+                                ),
+                                "allOfOneOfStatus" to mapOf(
+                                    "oneOf" to listOf(
+                                        mapOf("type" to "null"),
+                                        mapOf("allOf" to listOf(mapOf($$"$ref" to "#/components/schemas/Status")))
+                                    )
+                                ),
+                            ))
+                        }
+                    }
+                    validate { patterns, resolver ->
+                        val wrapperPattern = patterns.getValue("NullableWrapper")
+                        listOf("anyOfStatus", "oneOfStatus", "allOfAnyOfStatus", "allOfOneOfStatus",).forEach { property ->
+                            assertSuccess(wrapperPattern.match(mapOf(property to null), resolver))
+                            assertSuccess(wrapperPattern.match(mapOf(property to "Active"), resolver))
+                            assertSuccess(wrapperPattern.match(mapOf(property to "Inactive"), resolver))
+                            assertFailure(wrapperPattern.match(mapOf(property to "SomethingElse"), resolver))
+                        }
                     }
                 },
             ).flatten().stream()

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiIntegrationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiIntegrationTest.kt
@@ -6,6 +6,8 @@ import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.pattern.parsedJSONObject
 import io.specmatic.core.utilities.exceptionCauseMessage
 import io.specmatic.core.value.Value
+import io.specmatic.core.value.JSONObjectValue
+import io.specmatic.core.value.NullValue
 import io.specmatic.mock.ScenarioStub
 import io.specmatic.stub.HttpStub
 import io.specmatic.stub.createStubFromContracts
@@ -16,6 +18,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.ValueSource
 import java.io.File
 
 class OpenApiIntegrationTest {
@@ -1172,5 +1175,39 @@ Feature: Authenticated
             "pass" -> assertThat(result).isInstanceOf(Result.Success::class.java)
             "fail" -> assertThat(result).isInstanceOf(Result.Failure::class.java)
         }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["30", "31"])
+    fun `single wrapper allOf should run successfully against a mock by contract test`(openApiVersion: String) {
+        val specFile = File("src/test/resources/openapi/has_single_wrapper_allof/openapi_$openApiVersion.yaml")
+        val feature = OpenApiSpecification.fromFile(specFile.canonicalPath).toFeature()
+        val assertValidStatusValue: (Value?) -> Unit = { value ->
+            assertThat(value?.toUnformattedString()).isIn("Active", "Inactive")
+        }
+
+        val assertValidNullableStatusValue: (Value?) -> Unit = { value ->
+            assertThat(value).satisfiesAnyOf(
+                { assertThat(it).isEqualTo(NullValue) },
+                { assertThat(it?.toUnformattedString()).isIn("Active", "Inactive") }
+            )
+        }
+
+        val results = HttpStub(feature).use { stub ->
+            feature.executeTests(object : TestExecutor {
+                override fun execute(request: HttpRequest): HttpResponse {
+                    val response = stub.client.execute(request)
+                    when (request.path) {
+                        "/status" -> assertValidStatusValue(response.body)
+                        "/wrappedStatus" -> assertValidStatusValue((response.body as JSONObjectValue).findFirstChildByPath("status"))
+                        "/wrappedOptionalStatus" -> assertValidNullableStatusValue((response.body as JSONObjectValue).findFirstChildByPath("status"))
+                        else -> error("Unexpected path ${request.path}")
+                    }
+                    return response
+                }
+            })
+        }
+
+        assertThat(results.success()).withFailMessage { results.report() }.isTrue
     }
 }

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationParseTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationParseTest.kt
@@ -14,10 +14,16 @@ import io.specmatic.core.QueryPropertyStyle
 import io.specmatic.core.Resolver
 import io.specmatic.core.Result
 import io.specmatic.core.pattern.AnythingPattern
+import io.specmatic.core.pattern.AnyPattern
+import io.specmatic.core.pattern.AnyOfPattern
 import io.specmatic.core.pattern.BooleanPattern
 import io.specmatic.core.pattern.ContractException
+import io.specmatic.core.pattern.EnumPattern
 import io.specmatic.core.pattern.DeferredPattern
+import io.specmatic.core.pattern.JSONObjectPattern
 import io.specmatic.core.pattern.NumberPattern
+import io.specmatic.core.pattern.NullPattern
+import io.specmatic.core.pattern.Pattern
 import io.specmatic.core.pattern.QueryParameterScalarPattern
 import io.specmatic.core.pattern.StringPattern
 import io.specmatic.core.pattern.XMLPattern
@@ -27,6 +33,7 @@ import io.specmatic.core.utilities.yamlMapper
 import io.specmatic.mock.NoMatchingScenario
 import io.specmatic.stub.captureStandardOutput
 import io.specmatic.toViolationReportString
+import io.specmatic.core.value.StringValue
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -72,6 +79,60 @@ class OpenApiSpecificationParseTest {
 
         assertThat(pathPattern?.matches("/orders/123,abc/data", Resolver())).isInstanceOf(Result.Success::class.java)
         assertThat(pathPattern?.matches("/orders/abc,123/data", Resolver())).isInstanceOf(Result.Failure::class.java)
+    }
+
+    @Test
+    fun `single wrapper allOf should preserve wrapped scalar enum and nullability 3_0`() {
+        val specFile = File("src/test/resources/openapi/has_single_wrapper_allof/openapi_30.yaml").canonicalFile
+        val feature = OpenApiSpecification.fromFile(specFile.canonicalPath).toFeature()
+
+        val statusScenario = feature.scenarios.single { it.httpRequestPattern.httpPathPattern?.toInternalPath() == "/status" }
+        val wrappedStatusScenario = feature.scenarios.single { it.httpRequestPattern.httpPathPattern?.toInternalPath() == "/wrappedStatus" }
+        val wrappedOptionalStatusScenario = feature.scenarios.single { it.httpRequestPattern.httpPathPattern?.toInternalPath() == "/wrappedOptionalStatus" }
+
+        val statusPattern = resolvedHop(statusScenario.httpResponsePattern.body, statusScenario.resolver)
+        assertThat(statusPattern).isInstanceOf(EnumPattern::class.java)
+        assertThat(statusPattern).isNotInstanceOf(JSONObjectPattern::class.java)
+
+        val wrappedStatusPattern = resolvedHop(wrappedStatusScenario.httpResponsePattern.body, wrappedStatusScenario.resolver) as JSONObjectPattern
+        val wrappedStatusValuePattern = resolvedHop(wrappedStatusPattern.pattern.getValue("status"), wrappedStatusScenario.resolver)
+        assertThat(wrappedStatusValuePattern).isInstanceOf(EnumPattern::class.java)
+        assertThat(wrappedStatusValuePattern).isNotInstanceOf(JSONObjectPattern::class.java)
+
+        val wrappedOptionalStatusPattern = resolvedHop(wrappedOptionalStatusScenario.httpResponsePattern.body, wrappedOptionalStatusScenario.resolver) as JSONObjectPattern
+        val wrappedOptionalStatusValuePattern = resolvedHop(wrappedOptionalStatusPattern.pattern.getValue("status"), wrappedOptionalStatusScenario.resolver)
+        assertThat(wrappedOptionalStatusValuePattern).isInstanceOf(AnyPattern::class.java)
+
+        val wrappedOptionalStatusMembers = (wrappedOptionalStatusValuePattern as AnyPattern).pattern
+        assertThat(wrappedOptionalStatusMembers).anyMatch { it is NullPattern }
+        assertThat(wrappedOptionalStatusMembers).anyMatch { it is DeferredPattern }
+    }
+
+    @Test
+    fun `single wrapper allOf should preserve wrapped scalar enum and nullability 3_1`() {
+        val specFile = File("src/test/resources/openapi/has_single_wrapper_allof/openapi_31.yaml").canonicalFile
+        val feature = OpenApiSpecification.fromFile(specFile.canonicalPath).toFeature()
+
+        val statusScenario = feature.scenarios.single { it.httpRequestPattern.httpPathPattern?.toInternalPath() == "/status" }
+        val wrappedStatusScenario = feature.scenarios.single { it.httpRequestPattern.httpPathPattern?.toInternalPath() == "/wrappedStatus" }
+        val wrappedOptionalStatusScenario = feature.scenarios.single { it.httpRequestPattern.httpPathPattern?.toInternalPath() == "/wrappedOptionalStatus" }
+
+        val statusPattern = resolvedHop(statusScenario.httpResponsePattern.body, statusScenario.resolver)
+        assertThat(statusPattern).isInstanceOf(EnumPattern::class.java)
+        assertThat(statusPattern).isNotInstanceOf(JSONObjectPattern::class.java)
+
+        val wrappedStatusPattern = resolvedHop(wrappedStatusScenario.httpResponsePattern.body, wrappedStatusScenario.resolver) as JSONObjectPattern
+        val wrappedStatusValuePattern = resolvedHop(wrappedStatusPattern.pattern.getValue("status"), wrappedStatusScenario.resolver)
+        assertThat(wrappedStatusValuePattern).isInstanceOf(EnumPattern::class.java)
+        assertThat(wrappedStatusValuePattern).isNotInstanceOf(JSONObjectPattern::class.java)
+
+        val wrappedOptionalStatusPattern = resolvedHop(wrappedOptionalStatusScenario.httpResponsePattern.body, wrappedOptionalStatusScenario.resolver) as JSONObjectPattern
+        val wrappedOptionalStatusValuePattern = resolvedHop(wrappedOptionalStatusPattern.pattern.getValue("status"), wrappedOptionalStatusScenario.resolver)
+        assertThat(wrappedOptionalStatusValuePattern).isInstanceOf(AnyOfPattern::class.java)
+
+        val wrappedOptionalStatusMembers = (wrappedOptionalStatusValuePattern as AnyOfPattern).pattern
+        assertThat(wrappedOptionalStatusMembers).anyMatch { it is NullPattern }
+        assertThat(wrappedOptionalStatusMembers).anyMatch { it is DeferredPattern }
     }
 
     @ParameterizedTest

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationParseTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationParseTest.kt
@@ -1786,6 +1786,57 @@ class OpenApiSpecificationParseTest {
         }
     }
 
+    @Test
+    fun `pure single schema allOf preserves wrapper component pointer and inner schema annotations`() {
+        val spec = $$"""
+        openapi: 3.0.1
+        info:
+          title: Wrapper allOf
+          version: 1.0.0
+        components:
+          schemas:
+            Status:
+              type: string
+            WrappedInlineObject:
+              allOf:
+                - type: object
+                  properties:
+                    status:
+                      type: string
+            WrappedObjectWithRefProperty:
+              allOf:
+                - type: object
+                  properties:
+                    status:
+                      $ref: "#/components/schemas/Status"
+            WrappedOptionalStatus:
+              type: object
+              required:
+                - status
+              properties:
+                status:
+                  nullable: true
+                  allOf:
+                    - $ref: "#/components/schemas/Status"
+        """.trimIndent()
+
+        val specification = OpenApiSpecification.fromYAML(yamlContent = spec, openApiFilePath = "")
+        val patterns = specification.parseUnreferencedSchemas()
+        val resolver = Resolver(newPatterns = specification.patterns)
+
+        val inlineObjectPattern = patterns.getValue("(WrappedInlineObject)") as JSONObjectPattern
+        assertThat(inlineObjectPattern.schemaPointer).isEqualTo("/components/schemas/WrappedInlineObject")
+        assertThat(inlineObjectPattern.propertyPointers["status"]).isEqualTo("/components/schemas/WrappedInlineObject/allOf/0/properties/status")
+
+        val objectWithRefPropertyPattern = resolvedHop(patterns.getValue("(WrappedObjectWithRefProperty)"), resolver) as JSONObjectPattern
+        assertThat(objectWithRefPropertyPattern.schemaPointer).isEqualTo("/components/schemas/WrappedObjectWithRefProperty")
+        assertThat(objectWithRefPropertyPattern.propertyPointers["status"]).isEqualTo("/components/schemas/WrappedObjectWithRefProperty/allOf/0/properties/status")
+
+        val optionalStatusPattern = resolvedHop(patterns.getValue("(WrappedOptionalStatus)"), resolver) as JSONObjectPattern
+        assertThat(optionalStatusPattern.schemaPointer).isEqualTo("/components/schemas/WrappedOptionalStatus")
+        assertThat(optionalStatusPattern.propertyPointers["status"]).isEqualTo("/components/schemas/WrappedOptionalStatus/properties/status")
+    }
+
     private fun queryParamPatternWithObjectAdditionalProperties(
         personAdditionalProperties: Any?,
         departmentAdditionalProperties: Any? = null

--- a/core/src/test/resources/openapi/has_single_wrapper_allof/openapi_30.yaml
+++ b/core/src/test/resources/openapi/has_single_wrapper_allof/openapi_30.yaml
@@ -1,0 +1,72 @@
+openapi: 3.0.1
+info:
+  title: allof-enum-repro
+  version: "1.0"
+paths:
+  /status:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Status"
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Status"
+  /wrappedStatus:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WrappedStatus"
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WrappedStatus"
+  /wrappedOptionalStatus:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WrappedOptionalStatus"
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WrappedOptionalStatus"
+components:
+  schemas:
+    Status:
+      type: string
+      enum: [Active, Inactive]
+    WrappedStatus:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          allOf:
+            - $ref: "#/components/schemas/Status"
+    WrappedOptionalStatus:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          nullable: true
+          allOf:
+            - $ref: "#/components/schemas/Status"

--- a/core/src/test/resources/openapi/has_single_wrapper_allof/openapi_31.yaml
+++ b/core/src/test/resources/openapi/has_single_wrapper_allof/openapi_31.yaml
@@ -1,0 +1,73 @@
+openapi: 3.1.0
+info:
+  title: allof-enum-repro
+  version: "1.0"
+paths:
+  /status:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Status"
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Status"
+  /wrappedStatus:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WrappedStatus"
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WrappedStatus"
+  /wrappedOptionalStatus:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WrappedOptionalStatus"
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WrappedOptionalStatus"
+components:
+  schemas:
+    Status:
+      type: string
+      enum: [Active, Inactive]
+    WrappedStatus:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          allOf:
+            - $ref: "#/components/schemas/Status"
+    WrappedOptionalStatus:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          anyOf:
+            - type: "null"
+            - allOf:
+                - $ref: "#/components/schemas/Status"


### PR DESCRIPTION
**What**:

Fix OpenAPI parsing so a single-item `allOf` wrapper with no additional effective schema constraints is treated as the wrapped schema itself.

For example:

```yaml
allOf:
  - $ref: "#/components/schemas/Status"
```

should behave the same as:

```yaml
$ref: "#/components/schemas/Status"
```

**Why**:

Schemas like this are common in generated OpenAPI documents. They are often emitted when generators need to extend a `$ref` at the usage site, for example to attach nullability or other metadata without changing the shared component schema

Without this fix, Specmatic can misclassify the wrapper and treat scalar enum references as object-like patterns. That breaks:
* mock generation, where the wrapped enum can be generated as `{}` instead of a valid enum value
* externalised example loading, where valid enum strings can be rejected with `R1001`
* contract validation, where the effective schema shape is interpreted incorrectly

**Scope note**:

This PR is intentionally surgical. It does **not** fix the broader underlying `allOf` implementation limitation where Specmatic does not yet fully compose non-object `allOf` schemas or mixed schema intersections.

The goal here is only to correctly handle the pure wrapper case where `allOf` has a single schema and does not add any additional effective constraints. Multi-schema `allOf` behavior is left unchanged.

Related Swashbuckle discussions around nullable reference modeling i.e [`domaindrivendev/Swashbuckle.AspNetCore/issues/3649`](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/3649) for OpenAPI 3.1, whichever fix lands for this, Specmatic should be able to handle the wrapped schema correctly

**Checklist**:

* [x] Unit Tests
* [x] Build passing locally
* [ ] Sonar Quality Gate
* [ ] Security scans don't report any vulnerabilities
* [ ] Documentation added/updated (share link)
* [ ] Sample Project added/updated (share link)
* [ ] Demo video (share link)
* [ ] Article on Website (share link)
* [ ] Roadmap updated (share link)
* [ ] Conference Talk (share link)

**Issue ID**:
Closes #2582