### PR TITLE
validate snapshots before we do any heavy lifting

### DIFF
--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -31,7 +31,7 @@ jobs:
         uses: specmatic/specmatic-github-workflows/action-build-gradle@main
         with:
           # compile/assemble in parallel to speed things up, but we will run the tests in a separate step (in sequence)
-          pre-gradle-command: ./gradlew compileTestKotlin assemble --parallel -Preposilite.user=${{ vars.SPECMATIC_REPOSILITE_USERNAME }} -Preposilite.token=${{ secrets.SPECMATIC_REPOSILITE_TOKEN }}
+          pre-gradle-command: ./gradlew validateSnapshotDependencies compileTestKotlin assemble --parallel -Preposilite.user=${{ vars.SPECMATIC_REPOSILITE_USERNAME }} -Preposilite.token=${{ secrets.SPECMATIC_REPOSILITE_TOKEN }}
           gradle-extra-args: -Preposilite.user=${{ vars.SPECMATIC_REPOSILITE_USERNAME }} -Preposilite.token=${{ secrets.SPECMATIC_REPOSILITE_TOKEN }}
 
       - name: 'Release'


### PR DESCRIPTION
ensure that we validate snapshot deps and fail the build in case of snapshot reps early on in the build
