### PR TITLE
Fix regression in handling of 4xx status codes beyond 400

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -1052,8 +1052,7 @@ data class Feature(
         val matchingScenarios = scenariosMatchingPathAndMethod(scenario, scenariosToLookInto)
 
         val badRequestResponses = matchingScenarios.filter {
-            it.httpResponsePattern.status in 400..499 &&
-                    !it.httpRequestPattern.hasUndeclaredRequestVariant()
+            it.httpResponsePattern.status in 400..499
         }
         val defaultResponses = matchingScenarios.filter { it.httpResponsePattern.status == DEFAULT_RESPONSE_CODE }
 
@@ -1153,10 +1152,10 @@ data class Feature(
         return scenarios.mapNotNull { scenarioDecision ->
             val scenario = if (scenarioDecision is Decision.Execute) scenarioDecision.value else scenarioDecision.context
             val badRequestOrDefault = getBadRequestsOrDefault(scenario)
-            if (badRequestOrDefaultWasFilteredOut(badRequestOrDefault, scenario, originalScenarios)) {
+            if (hasOnlyUndeclaredRequestVariant4xxResponses(scenario)) {
                 return@mapNotNull null
             }
-            if (badRequestOrDefault == null && hasOnlyUndeclaredRequestVariant4xxResponses(scenario)) {
+            if (badRequestOrDefaultWasFilteredOut(badRequestOrDefault, scenario, originalScenarios)) {
                 return@mapNotNull null
             }
 

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -770,6 +770,12 @@ data class Scenario(
         testBaseURLs: Map<String, String> = emptyMap(),
         fn: (Scenario, Row) -> Scenario = { s, _ -> s }
     ): Sequence<ReturnValue<Scenario>> {
+        if (httpRequestPattern.hasUndeclaredRequestVariant() && !hasExamples()) return emptySequence()
+
+        val generationFlagsBased =
+            if (httpRequestPattern.hasUndeclaredRequestVariant()) flagsBased.withoutGenerativeTests()
+            else flagsBased
+
         val referencesWithBaseURLs = references.mapValues { (_, reference) ->
             reference.copy(variables = variables, baseURLs = testBaseURLs)
         }
@@ -784,7 +790,7 @@ data class Scenario(
                 }
             }.flatMap { row ->
                 val updatedScenario = newBasedOnAttributeSelectionFields(row.requestExample?.queryParams)
-                updatedScenario.newBasedOn(row, flagsBased).map { scenarioR ->
+                updatedScenario.newBasedOn(row, generationFlagsBased).map { scenarioR ->
                     scenarioR.ifValue { scenario ->
                         fn(scenario, row)
                     }

--- a/core/src/test/kotlin/integration_tests/UnsupportedMediaTypeExamplesTest.kt
+++ b/core/src/test/kotlin/integration_tests/UnsupportedMediaTypeExamplesTest.kt
@@ -129,6 +129,45 @@ class UnsupportedMediaTypeExamplesTest {
     }
 
     @Test
+    fun `generated negative test accepts declared external 415 response`() {
+        val specFile = writeSpec(ordersSpecWith400And415())
+        val exampleFile = writeExample(
+            name = "post-text-plain",
+            requestMethod = "POST",
+            requestPath = "/orders",
+            requestBody = """"body": "request sent here"""",
+            responseStatus = 415,
+            responseBody = """"body": { "error": "occurred" }""",
+            requestContentType = "text/plain"
+        )
+        val (feature, unusedExamples) = loadFeatureWithExamples(specFile, exampleFile)
+        val featureWithNegativeGeneration = feature.copy(specmaticConfig = specmaticConfigWith(ResiliencyTestSuite.all))
+
+        assertThat(unusedExamples).isEmpty()
+
+        var sawGeneratedNegativeRequest = false
+        val results = featureWithNegativeGeneration.executeTests(object : TestExecutor {
+            override fun execute(request: HttpRequest): HttpResponse {
+                return when (request.expectedResponseCode()) {
+                    200 -> HttpResponse.ok("")
+                    400 -> {
+                        sawGeneratedNegativeRequest = true
+                        unsupportedMediaTypeResponse()
+                    }
+                    415 -> unsupportedMediaTypeResponse()
+                    else -> throw ContractException("Unexpected response code hint ${request.expectedResponseCode()}")
+                }
+            }
+
+            override fun setServerState(serverState: Map<String, Value>) {
+            }
+        })
+
+        assertThat(sawGeneratedNegativeRequest).isTrue()
+        assertThat(results.failureCount).isEqualTo(0)
+    }
+
+    @Test
     fun `generated 415 request uses a content type not supported by the operation`() {
         val feature = OpenApiSpecification.fromFile(writeSpec(ordersSpecWithParameterizedTextPlainRequestContentType()).canonicalPath).toFeature()
         val unsupportedMediaTypeScenario = feature.scenarios.single { it.status == 415 }
@@ -697,6 +736,13 @@ class UnsupportedMediaTypeExamplesTest {
             ResiliencyTestSuite.all -> SpecmaticConfig().enableResiliencyTests(onlyPositive = false)
         }
 
+    private fun unsupportedMediaTypeResponse(): HttpResponse =
+        HttpResponse(
+            status = 415,
+            headers = mapOf("Content-Type" to "application/json"),
+            body = parsedJSONObject("""{"error":"occurred"}""")
+        )
+
     private fun HttpRequest.hasHeader(name: String, value: String): Boolean =
         headers.any { (headerName, headerValue) -> headerName.equals(name, ignoreCase = true) && headerValue == value }
 
@@ -739,6 +785,52 @@ class UnsupportedMediaTypeExamplesTest {
               responses:
                 "200":
                   description: ok
+                "415":
+                  description: unsupported media type
+                  content:
+                    application/json:
+                      schema:
+                        type: object
+                        required:
+                          - error
+                        properties:
+                          error:
+                            type: string
+    """
+
+    private fun ordersSpecWith400And415() = """
+        openapi: 3.0.4
+        info:
+          title: Orders
+          version: 1.0.0
+        paths:
+          /orders:
+            post:
+              requestBody:
+                required: true
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      required:
+                        - data
+                      properties:
+                        data:
+                          type: string
+              responses:
+                "200":
+                  description: ok
+                "400":
+                  description: bad request
+                  content:
+                    application/json:
+                      schema:
+                        type: object
+                        required:
+                          - error
+                        properties:
+                          error:
+                            type: string
                 "415":
                   description: unsupported media type
                   content:

--- a/core/src/test/kotlin/io/specmatic/core/FeatureKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FeatureKtTest.kt
@@ -1230,6 +1230,75 @@ paths:
     }
 
     @Test
+    fun `should not generate negative scenarios when only 4xx definitions are undeclared request variants`() {
+        val path = "/orders/(id:string)"
+        val orderPostOk = Scenario(ScenarioInfo(
+            httpRequestPattern = HttpRequestPattern(httpPathPattern = HttpPathPattern.from(path), method = "POST", body = DeferredPattern("(RequestBody)")),
+            httpResponsePattern = HttpResponsePattern(status = 201),
+            patterns = mapOf("(RequestBody)" to toJSONObjectPattern("""{"digit": "(number)"}""", "(RequestBody")),
+            protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI
+        ))
+
+        val orderPostUnsupportedMediaType = Scenario(ScenarioInfo(
+            httpRequestPattern = HttpRequestPattern(
+                httpPathPattern = HttpPathPattern.from(path),
+                method = "POST",
+                undeclaredRequestVariantMetadata = UndeclaredRequestVariantMetadata(responseStatus = 415)
+            ),
+            httpResponsePattern = HttpResponsePattern(status = 415),
+            protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI
+        ))
+
+        val featureComplete = Feature(name = "Orders Complete", scenarios = listOf(orderPostOk, orderPostUnsupportedMediaType), protocol = SpecmaticProtocol.HTTP)
+
+        val results = featureComplete.negativeTestScenarios(originalScenarios = featureComplete.scenarios).toList()
+
+        assertThat(results).isEmpty()
+    }
+
+    @Test
+    fun `should retain undeclared request variant 4xx responses for generated negative response validation`() {
+        val path = "/orders/(id:string)"
+        val orderPostOk = Scenario(ScenarioInfo(
+            httpRequestPattern = HttpRequestPattern(httpPathPattern = HttpPathPattern.from(path), method = "POST", body = DeferredPattern("(RequestBody)")),
+            httpResponsePattern = HttpResponsePattern(status = 201),
+            patterns = mapOf("(RequestBody)" to toJSONObjectPattern("""{"digit": "(number)"}""", "(RequestBody")),
+            protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI
+        ))
+
+        val orderPostBadRequest = Scenario(ScenarioInfo(
+            httpRequestPattern = HttpRequestPattern(httpPathPattern = HttpPathPattern.from(path), method = "POST"),
+            httpResponsePattern = HttpResponsePattern(status = 400),
+            protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI
+        ))
+
+        val orderPostUnsupportedMediaType = Scenario(ScenarioInfo(
+            httpRequestPattern = HttpRequestPattern(
+                httpPathPattern = HttpPathPattern.from(path),
+                method = "POST",
+                undeclaredRequestVariantMetadata = UndeclaredRequestVariantMetadata(responseStatus = 415)
+            ),
+            httpResponsePattern = HttpResponsePattern(status = 415),
+            protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI
+        ))
+
+        val featureComplete = Feature(
+            name = "Orders Complete",
+            scenarios = listOf(orderPostOk, orderPostBadRequest, orderPostUnsupportedMediaType),
+            protocol = SpecmaticProtocol.HTTP
+        )
+
+        val results = featureComplete.negativeTestScenarios(originalScenarios = featureComplete.scenarios).toList()
+        assertThat(results).hasSize(4)
+
+        results.forEach { (_, generatedScenario) ->
+            val scenario = generatedScenario.value
+            assertThat(scenario.badRequestOrDefault?.badRequestResponses?.keys).contains(400, 415)
+            assertThat(scenario.matches(HttpResponse(status = 415)).isSuccess()).isTrue()
+        }
+    }
+
+    @Test
     fun `should NOT filter out scenario when 4xx definitions are missing from the Feature as well as originalScenarios`() {
         val path = "/orders/(id:string)"
         val orderPostOk = Scenario(ScenarioInfo(

--- a/core/src/test/kotlin/io/specmatic/core/ScenarioTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ScenarioTest.kt
@@ -657,6 +657,76 @@ class ScenarioTest {
     }
 
     @Nested
+    inner class GenerateTestScenariosTests {
+        @Test
+        fun `generateTestScenarios should skip undeclared request variants without example rows`() {
+            val scenario = unsupportedMediaTypeScenario()
+
+            val generatedScenarios = scenario.generateTestScenarios(generativeFlagsBased()).toList()
+
+            assertThat(generatedScenarios).isEmpty()
+        }
+
+        @Test
+        fun `generateTestScenarios should not generate positive mutations for undeclared request variant examples`() {
+            val requestExample = HttpRequest(
+                method = "POST",
+                path = "/orders",
+                headers = mapOf(CONTENT_TYPE to "text/plain"),
+                body = StringValue("request sent here")
+            )
+            val scenario = unsupportedMediaTypeScenario(
+                examples = listOf(
+                    Examples(
+                        emptyList(),
+                        listOf(
+                            Row(
+                                name = "post-text-plain",
+                                requestExample = requestExample,
+                                responseExample = HttpResponse(status = 415)
+                            )
+                        )
+                    )
+                )
+            )
+
+            val generatedScenarios = scenario.generateTestScenarios(generativeFlagsBased()).toList()
+
+            assertThat(generatedScenarios).hasSize(1)
+            val generatedScenario = generatedScenarios.single().value
+            assertThat(generatedScenario.generatedFrom).isEqualTo(GeneratedScenarioOrigin.EXAMPLE_ROW)
+            assertThat(generatedScenario.generateHttpRequest().contentType()).isEqualTo("text/plain")
+        }
+
+        private fun unsupportedMediaTypeScenario(examples: List<Examples> = emptyList()): Scenario {
+            return Scenario(
+                name = "unsupported-media-type",
+                httpRequestPattern = HttpRequestPattern(
+                    httpPathPattern = buildHttpPathPattern("/orders"),
+                    method = "POST",
+                    headersPattern = HttpHeadersPattern(contentType = "application/json"),
+                    body = JSONObjectPattern(mapOf("id" to NumberPattern())),
+                    undeclaredRequestVariantMetadata = UndeclaredRequestVariantMetadata(
+                        responseStatus = 415,
+                        requestContentTypesForOperation = setOf("application/json")
+                    )
+                ),
+                httpResponsePattern = HttpResponsePattern(status = 415),
+                examples = examples,
+                protocol = SpecmaticProtocol.HTTP,
+                specType = SpecType.OPENAPI
+            )
+        }
+
+        private fun generativeFlagsBased(): FlagsBased =
+            DefaultStrategies.copy(
+                generation = GenerativeTestsEnabled(positiveOnly = false),
+                positivePrefix = POSITIVE_TEST_DESCRIPTION_PREFIX,
+                negativePrefix = NEGATIVE_TEST_DESCRIPTION_PREFIX
+            )
+    }
+
+    @Nested
     inner class AttributeSelectionTest {
         @Test
         fun `should validate unexpected keys when the request is attribute based`() {


### PR DESCRIPTION
## Summary
- Prevent negative test generation from being filtered out when undeclared request variant 4xx responses are present alongside declared bad-request responses.
- Skip generative test mutation for undeclared request variants that have no examples, while still allowing example-backed generation.
- Add coverage for 415 responses declared via examples and for scenario generation behavior around undeclared request variants.

Fixes a regression caused by #2583 