### PR TITLE
Implement example preprocessor support

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/ExampleFromFile.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/ExampleFromFile.kt
@@ -5,6 +5,7 @@ import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpResponse
 import io.specmatic.core.Result
 import io.specmatic.core.SpecmaticConfig
+import io.specmatic.core.examples.preprocessor.PreProcessorAttributes
 import io.specmatic.core.examples.server.SchemaExample
 import io.specmatic.core.log.LogStrategy
 import io.specmatic.core.pattern.*
@@ -30,7 +31,7 @@ class ExampleFromFile(private val scenarioStub: ScenarioStub, val file: File) {
     }
 
     constructor(file: File, strictMode: Boolean = true): this(scenarioStub = ScenarioStub.readFromFile(file, strictMode), file = file)
-    constructor(json: JSONObjectValue, file: File, strictMode: Boolean = true): this(scenarioStub = ScenarioStub.parse(json, strictMode), file = file)
+    constructor(json: JSONObjectValue, file: File, strictMode: Boolean = true): this(scenarioStub = ScenarioStub.parse(json, strictMode, file.path), file = file)
     constructor(scenarioStub: ScenarioStub) : this(scenarioStub, File(scenarioStub.filePath.orEmpty()))
 
     fun toRow(specmaticConfig: SpecmaticConfig = SpecmaticConfig(), logger: LogStrategy = io.specmatic.core.log.logger): Row {
@@ -70,6 +71,8 @@ class ExampleFromFile(private val scenarioStub: ScenarioStub, val file: File) {
     val expectationFilePath: String = file.canonicalPath
     @Suppress("MemberVisibilityCanBePrivate") // Used in openapi-module
     val testName: String = scenarioStub.name ?: file.nameWithoutExtension
+    @Suppress("MemberVisibilityCanBePrivate", "unused") // Used in openapi-module
+    val preProcessorAttributes: PreProcessorAttributes = scenarioStub.preProcessorAttributes
 
     val request: HttpRequest = scenarioStub.requestElsePartialRequest()
     val requestPath: String? = request.path?.let(::URI)?.path

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -2472,8 +2472,7 @@ data class Feature(
                 if(strictMode.not()) logger.log("  $externalizedExamplePath")
 
                 try {
-                    val example = ScenarioStub.parse(File(externalizedExamplePath).readText())
-
+                    val example = ScenarioStub.parse(File(externalizedExamplePath).readText(), filePath = externalizedExamplePath)
                     val method = example.requestMethod()
                     val path = example.requestPath()
                     val responseCode = example.responseStatus()

--- a/core/src/main/kotlin/io/specmatic/core/Result.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Result.kt
@@ -459,6 +459,9 @@ data class MatchFailureDetails(
     val sourceLocation: SourceLocation? = null
 )
 
+@Serializable
+data class Offset(val start: Int, val end: Int)
+
 // `via` holds the ordered $ref use-site hops that lead to this location, head-first (the use-site in
 // the spec under check), excluding this location itself which is the tail (the actual source of the
 // breakage). Empty for locations that live directly in the entry spec.
@@ -468,6 +471,7 @@ data class SourceLocation(
     val line: Int,
     val column: Int,
     val pointer: String,
+    val valueOffset: Offset? = null,
     val via: List<SourceLocation> = emptyList()
 ) {
     fun mapFilePath(transform: (String) -> String): SourceLocation =

--- a/core/src/main/kotlin/io/specmatic/core/examples/module/ExampleValidationModule.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/module/ExampleValidationModule.kt
@@ -90,6 +90,14 @@ class ExampleValidationModule(private val lenientMode: Boolean = false, private 
         )
     }
 
+    fun validateExample(contractFile: File, exampleFile: ExampleFromFile): ValidationResult {
+        val feature = parseContractFileToFeature(contractFile, specmaticConfig = specmaticConfig, lenientMode = lenientMode)
+        return ValidationResult(
+            exampleValidationResult = validateExample(feature, exampleFile),
+            hookValidationResult = callLifecycleHook(feature, listOf(exampleFile))
+        )
+    }
+
     fun validateExample(feature: Feature, scenarioStub: ScenarioStub): Results {
         return feature.matchResultFlagBased(scenarioStub, ExampleMismatchMessages)
     }

--- a/core/src/main/kotlin/io/specmatic/core/examples/preprocessor/ExamplePreProcessor.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/preprocessor/ExamplePreProcessor.kt
@@ -1,0 +1,46 @@
+package io.specmatic.core.examples.preprocessor
+
+import io.specmatic.core.Result
+import io.specmatic.core.value.Value
+import java.util.ServiceLoader
+import java.util.concurrent.CopyOnWriteArrayList
+
+data class ExamplePreProcessResult(
+    val result: Result,
+    val outcome: Map<String, Value>,
+    val attributes: PreProcessorAttributes = PreProcessorAttributes.Empty
+)
+
+interface ExamplePreProcessor {
+    fun process(rawData: Map<String, Value>, filePath: String?): ExamplePreProcessResult
+
+    companion object {
+        private val registry = CopyOnWriteArrayList<ExamplePreProcessor>()
+
+        init {
+            val preProcessors = ServiceLoader.load(ExamplePreProcessor::class.java)
+            registry.addAll(preProcessors.filterNotNull())
+        }
+
+        fun <T> withPreProcessor(processor: ExamplePreProcessor, block: () -> T): T {
+            registry.add(processor)
+            try {
+                return block()
+            } finally {
+                registry.remove(processor)
+            }
+        }
+
+        fun process(rawData: Map<String, Value>, filePath: String? = null): ExamplePreProcessResult {
+            val initial = ExamplePreProcessResult(Result.Success(), rawData)
+            return registry.fold(initial) { acc, processor ->
+                val processed = processor.process(acc.outcome, filePath)
+                ExamplePreProcessResult(
+                    outcome = processed.outcome,
+                    attributes = acc.attributes.merge(processed.attributes),
+                    result = Result.fromResults(listOf(acc.result, processed.result)),
+                )
+            }
+        }
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/core/examples/preprocessor/PreProcessorAttributes.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/preprocessor/PreProcessorAttributes.kt
@@ -1,0 +1,22 @@
+package io.specmatic.core.examples.preprocessor
+
+class PreProcessorAttributes private constructor(private val values: Map<Key<*>, Any>) {
+    interface Key<T : Any>
+
+    @Suppress("UNCHECKED_CAST")
+    operator fun <T : Any> get(key: Key<T>): T? {
+        return values[key] as? T
+    }
+
+    fun <T : Any> put(key: Key<T>, value: T): PreProcessorAttributes {
+        return PreProcessorAttributes(values + (key to value))
+    }
+
+    fun merge(other: PreProcessorAttributes): PreProcessorAttributes {
+        return PreProcessorAttributes(values + other.values)
+    }
+
+    companion object {
+        val Empty = PreProcessorAttributes(emptyMap())
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/core/utilities/JSONSerialisation.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/JSONSerialisation.kt
@@ -45,6 +45,11 @@ fun stringToPatternMap(stringContent: String): Map<String, Pattern>  {
     }
 }
 
+fun jsonStringToValue(stringContent: String): Value {
+    val jsonElement = lenientJson.parseToJsonElement(stringContent.removePrefix(UTF_BYTE_ORDER_MARK))
+    return toValue(jsonElement)
+}
+
 fun jsonStringToValueMap(stringContent: String): Map<String, Value>  {
     val data = lenientJson.parseToJsonElement(stringContent.removePrefix(UTF_BYTE_ORDER_MARK)).jsonObject.toMap()
     return convertToMapValue(data)

--- a/core/src/main/kotlin/io/specmatic/mock/ScenarioStub.kt
+++ b/core/src/main/kotlin/io/specmatic/mock/ScenarioStub.kt
@@ -2,6 +2,9 @@ package io.specmatic.mock
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.specmatic.core.*
+import io.specmatic.core.examples.preprocessor.ExamplePreProcessResult
+import io.specmatic.core.examples.preprocessor.PreProcessorAttributes
+import io.specmatic.core.examples.preprocessor.ExamplePreProcessor
 import io.specmatic.core.log.logger
 import io.specmatic.core.pattern.*
 import io.specmatic.core.utilities.exceptionCauseMessage
@@ -38,7 +41,8 @@ data class ScenarioStub(
     val id: String? = null,
     val beforeFixtures: List<Value> = emptyList(),
     val afterFixtures: List<Value> = emptyList(),
-    val exampleType: ExampleType = ExampleType.EXTERNAL
+    val exampleType: ExampleType = ExampleType.EXTERNAL,
+    val preProcessorAttributes: PreProcessorAttributes = PreProcessorAttributes.Empty,
 ) {
     init {
         if (strictMode && !validationErrors.isSuccess()) validationErrors.throwOnFailure()
@@ -368,16 +372,20 @@ data class ScenarioStub(
 
     companion object {
         fun readFromFile(file: File, strictMode: Boolean = true): ScenarioStub {
-            return parse(file.readText(Charsets.UTF_8), strictMode).copy(filePath = file.path)
+            return parse(file.readText(Charsets.UTF_8), strictMode, file.path)
         }
 
         fun parse(text: String, strictMode: Boolean = true): ScenarioStub {
-            return parse(StringValue(text), strictMode)
+            return parse(StringValue(text), strictMode, null)
         }
 
-        fun parse(json: Value, strictMode: Boolean = true): ScenarioStub {
+        fun parse(text: String, strictMode: Boolean = true, filePath: String? = null): ScenarioStub {
+            return parse(StringValue(text), strictMode, filePath)
+        }
+
+        fun parse(json: Value, strictMode: Boolean = true, filePath: String? = null): ScenarioStub {
             val parsedJson = jsonStringToValueMap(json.toStringLiteral())
-            return mockFromJSON(parsedJson, strictMode)
+            return mockFromJSON(parsedJson, strictMode, filePath)
         }
     }
 }
@@ -396,28 +404,65 @@ const val BEFORE_FIXTURES = "before"
 const val AFTER_FIXTURES = "after"
 private val nonMetadataDataKeys = listOf(MOCK_HTTP_REQUEST, MOCK_HTTP_RESPONSE, PARTIAL)
 
-fun mockFromJSON(mockSpec: Map<String, Value>, strictMode: Boolean = true): ScenarioStub {
-    val validationResult = FuzzyExampleJsonValidator.matches(mockSpec)
-    val data = mockSpec.filterKeys { it !in nonMetadataDataKeys }
-    return if (PARTIAL in mockSpec) {
-        parsePartialExample(mockSpec, data, validationResult, strictMode)
+fun mockFromJSON(mockSpec: Map<String, Value>, strictMode: Boolean = true, filePath: String? = null): ScenarioStub {
+    val result = preProcessAndValidate(mockSpec, filePath)
+    val data = result.outcome.filterKeys { it !in nonMetadataDataKeys }
+    return if (PARTIAL in result.outcome) {
+        parsePartialExample(
+            data = data,
+            filePath = filePath,
+            strictMode = strictMode,
+            mockSpec = result.outcome,
+            validationResult = result.result,
+            preProcessorAttributes = result.attributes,
+        )
     } else {
-        parseStandardExample(mockSpec, data, validationResult, strictMode)
+        parseStandardExample(
+            data = data,
+            filePath = filePath,
+            strictMode = strictMode,
+            mockSpec = result.outcome,
+            validationResult = result.result,
+            preProcessorAttributes = result.attributes,
+        )
     }
 }
 
-private fun parsePartialExample(mockSpec: Map<String, Value>, data: Map<String, Value>, validationResult: Result, strictMode: Boolean): ScenarioStub {
+private fun preProcessAndValidate(mockSpec: Map<String, Value>, filePath: String?): ExamplePreProcessResult {
+    val preProcessResult = ExamplePreProcessor.process(mockSpec, filePath)
+    val fuzzyValidationResult = FuzzyExampleJsonValidator.matches(preProcessResult.outcome)
+    val validationResult = Result.fromResults(listOf(preProcessResult.result, fuzzyValidationResult))
+    return preProcessResult.copy(result = validationResult)
+}
+
+private fun parsePartialExample(
+    strictMode: Boolean,
+    data: Map<String, Value>,
+    validationResult: Result,
+    filePath: String? = null,
+    mockSpec: Map<String, Value>,
+    preProcessorAttributes: PreProcessorAttributes = PreProcessorAttributes.Empty
+): ScenarioStub {
     val template = mockSpec[PARTIAL] as? JSONObjectValue ?: JSONObjectValue()
-    val parsedPartial = mockFromJSON(template.jsonObject.plus(data), strictMode)
+    val parsedPartial = mockFromJSON(template.jsonObject.plus(data), strictMode, filePath)
     return parsedPartial.copy(
         partial = parsedPartial,
         rawJsonData = JSONObjectValue(mockSpec),
         validationErrors = validationResult,
-        strictMode = strictMode
+        strictMode = strictMode,
+        filePath = filePath,
+        preProcessorAttributes = preProcessorAttributes,
     )
 }
 
-private fun parseStandardExample(mockSpec: Map<String, Value>, data: Map<String, Value>, validationResult: Result, strictMode: Boolean): ScenarioStub {
+private fun parseStandardExample(
+    strictMode: Boolean,
+    data: Map<String, Value>,
+    validationResult: Result,
+    filePath: String? = null,
+    mockSpec: Map<String, Value>,
+    preProcessorAttributes: PreProcessorAttributes = PreProcessorAttributes.Empty
+): ScenarioStub {
     val mockRequest: HttpRequest = try {
         val reqMap = getJSONObjectValueOrNull(MOCK_HTTP_REQUEST, mockSpec)
         if (reqMap != null) HttpRequest.fromJSONLenient(reqMap) else HttpRequest("", "")
@@ -456,9 +501,11 @@ private fun parseStandardExample(mockSpec: Map<String, Value>, data: Map<String,
         rawJsonData = JSONObjectValue(mockSpec),
         validationErrors = validationResult,
         strictMode = strictMode,
+        filePath = filePath,
         id = id,
         beforeFixtures = beforeFixtures,
-        afterFixtures = afterFixtures
+        afterFixtures = afterFixtures,
+        preProcessorAttributes = preProcessorAttributes,
     )
 }
 

--- a/core/src/test/kotlin/io/specmatic/core/examples/preprocessor/ExamplePreProcessorTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/examples/preprocessor/ExamplePreProcessorTest.kt
@@ -1,0 +1,46 @@
+package io.specmatic.core.examples.preprocessor
+
+import io.specmatic.core.Result
+import io.specmatic.core.value.StringValue
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class ExamplePreProcessorTest {
+    @Test
+    fun `processors should run in order and merge attributes`() {
+        val firstKey = object : PreProcessorAttributes.Key<String> {}
+        val secondKey = object : PreProcessorAttributes.Key<Int> {}
+
+        val firstProcessor = object : ExamplePreProcessor {
+            override fun process(rawData: Map<String, io.specmatic.core.value.Value>, filePath: String?): ExamplePreProcessResult {
+                return ExamplePreProcessResult(
+                    result = Result.Success(),
+                    outcome = rawData + ("first" to StringValue("one")),
+                    attributes = PreProcessorAttributes.Empty.put(firstKey, "alpha")
+                )
+            }
+        }
+
+        val secondProcessor = object : ExamplePreProcessor {
+            override fun process(rawData: Map<String, io.specmatic.core.value.Value>, filePath: String?): ExamplePreProcessResult {
+                assertThat(rawData["first"]).isEqualTo(StringValue("one"))
+                return ExamplePreProcessResult(
+                    result = Result.Success(),
+                    outcome = rawData + ("second" to StringValue("two")),
+                    attributes = PreProcessorAttributes.Empty.put(secondKey, 2)
+                )
+            }
+        }
+
+        ExamplePreProcessor.withPreProcessor(firstProcessor) {
+            ExamplePreProcessor.withPreProcessor(secondProcessor) {
+                val result = ExamplePreProcessor.process(emptyMap())
+                assertThat(result.outcome["first"]).isEqualTo(StringValue("one"))
+                assertThat(result.outcome["second"]).isEqualTo(StringValue("two"))
+                assertThat(result.attributes[firstKey]).isEqualTo("alpha")
+                assertThat(result.attributes[secondKey]).isEqualTo(2)
+                assertThat(result.result.isSuccess()).isTrue()
+            }
+        }
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/utilities/JSONSerialisationKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/utilities/JSONSerialisationKtTest.kt
@@ -1,6 +1,7 @@
 package io.specmatic.core.utilities
 
 import io.specmatic.core.pattern.parsedJSONObject
+import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.NumberValue
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
@@ -14,6 +15,13 @@ class JSONSerialisationKtTest {
     fun `should parse a JSON string with a UTF-8 BOM`() {
         val jsonContent = "\uFEFF{\"greeting\":\"hello\"}"
         assertDoesNotThrow { parsedJSONObject(jsonContent) }
+    }
+
+    @Test
+    fun `should be able to convert json string to appropriate value`() {
+        val jsonContent = "{\"key\": 123}"
+        val value = jsonStringToValue(jsonContent)
+        assertThat(value).isInstanceOf(JSONObjectValue::class.java)
     }
 
     @ParameterizedTest

--- a/core/src/test/kotlin/io/specmatic/mock/ScenarioStubKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/mock/ScenarioStubKtTest.kt
@@ -12,7 +12,11 @@ import io.specmatic.core.utilities.jsonStringToValueMap
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.StringValue
 import io.specmatic.core.StandardRuleViolation
+import io.specmatic.core.examples.preprocessor.ExamplePreProcessResult
+import io.specmatic.core.examples.preprocessor.ExamplePreProcessor
+import io.specmatic.core.examples.preprocessor.PreProcessorAttributes
 import io.specmatic.core.examples.server.ExampleMismatchMessages
+import io.specmatic.core.value.NumberValue
 import io.specmatic.toViolationReportString
 import io.specmatic.shouldMatch
 import org.junit.jupiter.api.assertThrows
@@ -22,6 +26,7 @@ import org.junit.jupiter.params.provider.MethodSource
 import org.junit.jupiter.params.provider.ValueSource
 import java.util.function.Consumer
 import java.util.stream.Stream
+import kotlin.to
 
 internal class ScenarioStubKtTest {
     @Test
@@ -998,6 +1003,32 @@ paths:
 
         val scenarioStub = mockFromJSON(jsonStringToValueMap(stubText))
         assertThat(scenarioStub.stubToken).isNull()
+    }
+
+    @Test
+    fun `mockFromJSON should apply registered example preprocessor and keep attributes`() {
+        val outputKey = object : PreProcessorAttributes.Key<String> {}
+        val processor = object : ExamplePreProcessor {
+            override fun process(rawData: Map<String, io.specmatic.core.value.Value>, filePath: String?): ExamplePreProcessResult {
+                return ExamplePreProcessResult(
+                    result = Success(),
+                    outcome = rawData + ("processed" to StringValue("yes")),
+                    attributes = PreProcessorAttributes.Empty.put(outputKey, "stored-value")
+                )
+            }
+        }
+
+        val mockSpec = mapOf(
+            "name" to StringValue("original"),
+            MOCK_HTTP_RESPONSE to JSONObjectValue(mapOf("status" to NumberValue(200))),
+            MOCK_HTTP_REQUEST to JSONObjectValue(mapOf("method" to StringValue("GET"), "path" to StringValue("/before"))),
+        )
+
+        ExamplePreProcessor.withPreProcessor(processor) {
+            val scenarioStub = mockFromJSON(mockSpec)
+            assertThat(scenarioStub.data.jsonObject["processed"]).isEqualTo(StringValue("yes"))
+            assertThat(scenarioStub.preProcessorAttributes[outputKey]).isEqualTo("stored-value")
+        }
     }
 
     companion object {


### PR DESCRIPTION
**What**: Implemented example preprocessor support so we can hook into example load time and modify examples externally before they are used

**Why**: This gives external preprocessing a clean entry point during example handling, letting examples be transformed or enriched before validation and downstream use

**How**: On example load, the registered preprocessor is invoked and its processed output becomes the input for validation and later example flow. Any attributes produced during preprocessing are stored with the example so they can be retrieved later by consumers that need them.

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)