### PR TITLE
Stop linting inline 405 and 415 examples as undeclared request variants

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -810,7 +810,6 @@ class OpenApiSpecification(
                         )
                     }
                     httpResponsePatterns.forEach {
-                        recordInlineUndeclaredRequestVariantExamplesIgnored(methodContext, httpMethod, openApiPath, it)
                         recordMethodNotAllowedResponseWithoutDisallowedMethod(methodContext, httpMethod, openApiPath, methodsForPath, it)
                     }
 
@@ -1157,28 +1156,6 @@ class OpenApiSpecification(
             message = "Accept header values ${knownAcceptValues.joinToString(", ")} do not allow response Content-Type \"$responseContentType\"",
             isWarning = true,
             ruleViolation = OpenApiLintViolations.MEDIA_TYPE_OVERRIDDEN
-        )
-    }
-
-    private fun recordInlineUndeclaredRequestVariantExamplesIgnored(
-        collectorContext: CollectorContext,
-        httpMethod: String,
-        openApiPath: String,
-        responsePatternData: ResponsePatternData
-    ) {
-        if (responsePatternData.examples.isEmpty()) return
-
-        val responsePattern = responsePatternData.responsePattern
-        val unsupportedInlineExampleReason = when (responsePattern.status) {
-            HttpStatusCode.MethodNotAllowed.value -> "inline OpenAPI examples cannot specify a disallowed request method"
-            HttpStatusCode.UnsupportedMediaType.value -> "inline OpenAPI examples cannot specify an unsupported request media type"
-            else -> return
-        }
-
-        collectorContext.at("responses").at(responsePattern.status.toString()).record(
-            message = "Inline OpenAPI ${responsePattern.status} examples for $httpMethod $openApiPath are not used to generate tests or inline mock data. External ${responsePattern.status} examples are still loaded and used. This is required because $unsupportedInlineExampleReason.",
-            isWarning = true,
-            ruleViolation = OpenApiLintViolations.UNDECLARED_REQUEST_VARIANT_RESPONSE_REQUIRES_EXTERNAL_EXAMPLE
         )
     }
 

--- a/core/src/test/kotlin/integration_tests/MethodNotAllowedExamplesTest.kt
+++ b/core/src/test/kotlin/integration_tests/MethodNotAllowedExamplesTest.kt
@@ -4,6 +4,7 @@ import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.conversions.ExampleFromFile
 import io.specmatic.conversions.OpenApiLintViolations
 import io.specmatic.conversions.lenient.CollectorContext
+import io.specmatic.conversions.missingRequestExampleErrorMessageForTest
 import io.specmatic.core.FailureReason
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpResponse
@@ -166,9 +167,9 @@ class MethodNotAllowedExamplesTest {
         specification.toScenarioInfos(collectorContext)
 
         val warningReport = collectorContext.toCollector().toResult().reportString()
-        assertThat(warningReport).contains(OpenApiLintViolations.UNDECLARED_REQUEST_VARIANT_RESPONSE_REQUIRES_EXTERNAL_EXAMPLE.id)
-        assertThat(warningReport).contains("paths./orders.post.responses.405")
-        assertThat(warningReport).contains("External 405 examples are still loaded and used")
+        assertThat(warningReport).doesNotContain(OpenApiLintViolations.UNDECLARED_REQUEST_VARIANT_RESPONSE_REQUIRES_EXTERNAL_EXAMPLE.id)
+        assertThat(warningReport).doesNotContain("paths./orders.post.responses.405")
+        assertThat(warningReport).doesNotContain(missingRequestExampleErrorMessageForTest("method-not-allowed"))
 
         val feature = specification.toFeature()
 
@@ -722,10 +723,6 @@ class MethodNotAllowedExamplesTest {
                       properties:
                         data:
                           type: string
-                    examples:
-                      method-not-allowed:
-                        value:
-                          data: found
               responses:
                 "405":
                   description: method not allowed

--- a/core/src/test/kotlin/integration_tests/UnsupportedMediaTypeExamplesTest.kt
+++ b/core/src/test/kotlin/integration_tests/UnsupportedMediaTypeExamplesTest.kt
@@ -4,6 +4,7 @@ import io.specmatic.conversions.ExampleFromFile
 import io.specmatic.conversions.OpenApiLintViolations
 import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.conversions.lenient.CollectorContext
+import io.specmatic.conversions.missingRequestExampleErrorMessageForTest
 import io.specmatic.core.DefaultMismatchMessages
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpResponse
@@ -336,9 +337,9 @@ class UnsupportedMediaTypeExamplesTest {
         specification.toScenarioInfos(collectorContext)
 
         val warningReport = collectorContext.toCollector().toResult().reportString()
-        assertThat(warningReport).contains(OpenApiLintViolations.UNDECLARED_REQUEST_VARIANT_RESPONSE_REQUIRES_EXTERNAL_EXAMPLE.id)
-        assertThat(warningReport).contains("paths./orders.post.responses.415")
-        assertThat(warningReport).contains("External 415 examples are still loaded and used")
+        assertThat(warningReport).doesNotContain(OpenApiLintViolations.UNDECLARED_REQUEST_VARIANT_RESPONSE_REQUIRES_EXTERNAL_EXAMPLE.id)
+        assertThat(warningReport).doesNotContain("paths./orders.post.responses.415")
+        assertThat(warningReport).doesNotContain(missingRequestExampleErrorMessageForTest("unsupported-media-type"))
 
         val feature = specification.toFeature()
 
@@ -1104,10 +1105,6 @@ ${requestContentTypes(contentTypes)}
                       properties:
                         data:
                           type: string
-                    examples:
-                      unsupported-media-type:
-                        value:
-                          data: found
               responses:
                 "415":
                   description: unsupported media type


### PR DESCRIPTION
**What**:

Ignore inline OpenAPI response examples declared on `405 Method Not Allowed` and `415 Unsupported Media Type` responses without emitting the undeclared-request-variant warning.

**Why**:

These responses require external examples to describe the actual invalid request variant. Inline OpenAPI response examples cannot describe the disallowed method or unsupported request media type, so they should be silently ignored instead of producing warnings that suggest users must manually remove them.

**How**:

Removed the parse-time warning hook for inline `405` and `415` response examples while keeping the existing filters that prevent those examples from becoming scenario rows or inline mock data. Updated the focused 405 and 415 integration tests to cover response-only inline examples and assert that no warning, missing-request message, inline stub, or generated test is produced.

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
