### PR TITLE
Lenient substitutions and internal changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Each release section should stand on its own and describe the behavior shipped i
 - Improved config-driven target resolution so Specmatic preserves scheme, host, port, path-prefix, and certificate details separately instead of flattening them into a base URL, which keeps more run and mock configurations intact.
 - Improved bundled CTRF reporting so coverage execution details now include spec-level coverage metrics and match operations back to the correct spec more reliably across absolute, relative, and normalized paths.
 - Improved bundled backward-compatibility HTML reporting so breakages in shared specs are attributed to the shared spec that actually changed, instead of being misreported against a referring spec when only one consumer is affected.
+- Substitutions to be lenient by default, i.e. missing variables now use auto-generated values, while enabling `strictMode` restores the previous behavior of failing instead of generating.
 
 ## 2.48.0 (2026-06-18)
 

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
@@ -1106,10 +1106,12 @@ data class HttpRequestPattern(
         originalRequest: HttpRequest,
         data: JSONObjectValue,
         resolver: Resolver,
+        strictMode: Boolean,
     ): Substitution {
         return SubstitutionImpl.from(
             data = data,
             resolver = resolver,
+            strictMode = strictMode,
             runningRequest = runningRequest,
             originalRequest = originalRequest,
         )

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -1148,10 +1148,11 @@ data class Scenario(
         request: HttpRequest,
         originalRequest: HttpRequest,
         response: HttpResponse,
-        data: JSONObjectValue
+        data: JSONObjectValue,
+        strictMode: Boolean
     ): HttpResponse {
         val substitutionResolver = resolver.copy(mockMode = true)
-        val substitution = httpRequestPattern.getSubstitution(request, originalRequest, data, substitutionResolver)
+        val substitution = httpRequestPattern.getSubstitution(request, originalRequest, data, substitutionResolver, strictMode)
         return httpResponsePattern.resolveSubstitutions(substitution, response, substitutionResolver).value
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/Substitution.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Substitution.kt
@@ -6,7 +6,9 @@ import io.specmatic.core.value.Value
 
 interface Substitution {
     fun isDropDirective(value: Value): Boolean
+    fun resolveIfLookup(value: Value): Value
+    fun substitute(value: Value): ReturnValue<Value>
     fun resolveIfLookup(value: Value, pattern: Pattern): Value
     fun substitute(value: Value, pattern: Pattern, key: String?): ReturnValue<Value>
-    fun upsertStoreUsing(originalValue: Value, runningValue: Value): Substitution = this
+    fun upsertStoreUsing(originalValue: Value, runningValue: Value): Substitution
 }

--- a/core/src/main/kotlin/io/specmatic/core/substitution/InterpolatedSubstitution.kt
+++ b/core/src/main/kotlin/io/specmatic/core/substitution/InterpolatedSubstitution.kt
@@ -1,7 +1,10 @@
 package io.specmatic.core.substitution
 
+import io.specmatic.core.Resolver
 import io.specmatic.core.pattern.isPatternToken
 import io.specmatic.core.pattern.ContractException
+import io.specmatic.core.value.StringValue
+import io.specmatic.core.value.Value
 
 internal object InterpolatedSubstitution {
     private val useRegex = Regex("\\$\\(([^()]+)\\)")
@@ -12,18 +15,25 @@ internal object InterpolatedSubstitution {
         return useRegex.containsMatchIn(value)
     }
 
-    fun resolve(value: String, resolveToken: (String) -> String): String {
-        return useRegex.replace(value) { resolveToken(it.value) }
+    fun resolve(value: String, resolveToken: (String) -> Value): Value {
+        val entireMatch = useRegex.matchEntire(value)
+        if (entireMatch != null) {
+            return resolveToken(entireMatch.value)
+        }
+
+        return StringValue(useRegex.replace(value) {
+            resolveToken(it.value).toUnformattedString()
+        })
     }
 
-    fun extractVariables(original: String, running: String): Map<String, String> {
-        return when (val result = extractVariablesResult(original, running)) {
+    fun extractVariables(original: String, running: String, resolver: Resolver = Resolver()): Map<String, Value> {
+        return when (val result = extractVariablesResult(original, running, resolver)) {
             is ExtractionResult.Success -> result.variables
             is ExtractionResult.Failure -> throw ContractException(result.message)
         }
     }
 
-    private fun extractVariablesResult(original: String, running: String): ExtractionResult {
+    private fun extractVariablesResult(original: String, running: String, resolver: Resolver): ExtractionResult {
         val placeholders = captureRegex
             .findAll(original)
             .filterNot { isDollarFunctionCall(original, it.range.first) }
@@ -41,24 +51,25 @@ internal object InterpolatedSubstitution {
             message = "Could not extract substitution variables from \"$running\" using template \"$original\""
         )
 
-        val variables = linkedMapOf<String, String>()
+        val variables = linkedMapOf<String, Value>()
         placeholders.forEachIndexed { index, placeholder ->
-            val name = placeholderTokenName(placeholder.value) ?: return ExtractionResult.Failure(
+            val parts = placeholderParts(placeholder.value) ?: return ExtractionResult.Failure(
                 message = "Invalid placeholder token \"${placeholder.value}\" in \"$original\""
             )
 
+            val (name, typeName) = parts
             val value = match.groups[index + 1]?.value ?: return ExtractionResult.Failure(
                 message = "Could not extract placeholder \"$name\" from \"$running\" using template \"$original\""
             )
 
             val existingValue = variables[name]
-            if (existingValue != null && existingValue != value) {
+            if (existingValue != null && existingValue.toStringLiteral() != value) {
                 return ExtractionResult.Failure(
-                    message = "Conflicting extracted values for \"$name\" in \"$original\": \"$existingValue\" and \"$value\""
+                    message = "Conflicting extracted values for \"$name\" in \"$original\": \"${existingValue.toStringLiteral()}\" and \"$value\""
                 )
             }
 
-            variables[name] = value
+            variables[name] = parseExtractedValue(typeName, value, resolver)
         }
 
         return ExtractionResult.Success(variables)
@@ -80,13 +91,22 @@ internal object InterpolatedSubstitution {
         return regex.toString()
     }
 
-    private fun placeholderTokenName(token: String): String? {
+    private fun parseExtractedValue(typeName: String, value: String, resolver: Resolver): Value {
+        return runCatching {
+            resolver.getPattern("($typeName)").parse(value, resolver)
+        }.getOrDefault(StringValue(value))
+    }
+
+    private fun placeholderParts(token: String): Pair<String, String>? {
         if (!isPatternToken(token)) return null
-        return token
-            .removeSurrounding("(", ")")
-            .split(":", limit = 2)
-            .firstOrNull()
-            ?.takeIf(String::isNotBlank)
+        val pieces = token.removeSurrounding("(", ")").split(":", limit = 2)
+        if (pieces.size != 2) return null
+
+        val name = pieces[0].trim()
+        val type = pieces[1].trim()
+        if (name.isBlank() || type.isBlank()) return null
+
+        return name to type
     }
 
     private fun hasAdjacentPlaceholders(placeholders: List<MatchResult>): Boolean {
@@ -100,7 +120,7 @@ internal object InterpolatedSubstitution {
     }
 
     private sealed interface ExtractionResult {
-        data class Success(val variables: Map<String, String>) : ExtractionResult
+        data class Success(val variables: Map<String, Value>) : ExtractionResult
         data class Failure(val message: String) : ExtractionResult
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/substitution/SubstitutionImpl.kt
+++ b/core/src/main/kotlin/io/specmatic/core/substitution/SubstitutionImpl.kt
@@ -16,16 +16,16 @@ import io.specmatic.core.value.Value
 class SubstitutionImpl private constructor(
     private val resolver: Resolver,
     private val strictMode: Boolean = false,
-    private val variableValues: Map<String, String> = emptyMap(),
+    private val variableValues: Map<String, Value> = emptyMap(),
     private val data: JSONObjectValue = JSONObjectValue(emptyMap()),
 ) : Substitution {
-    private fun substituteSimpleVariableLookup(string: String): String {
+    private fun substituteSimpleVariableLookup(string: String): Value {
         val name = string.trim().removeSurrounding("$(", ")")
         return variableValues[name]
             ?: throw ContractException("Could not resolve expression $string as no variable by the name $name was found")
     }
 
-    private fun substituteDataLookupExpression(value: String): String {
+    private fun substituteDataLookupExpression(value: String): Value {
         val pieces = value.removeSurrounding("$(", ")").split('.')
 
         val lookupSyntaxErrorMessage =
@@ -52,7 +52,7 @@ class SubstitutionImpl private constructor(
         val dictionary: JSONObjectValue = dictionaryValue as? JSONObjectValue
             ?: throw ContractException("Dictionary $lookupStoreName.$dictionaryName should be an object")
 
-        val dictionaryLookupValue = variableValues[dictionaryLookupVariableName] ?: "*"
+        val dictionaryLookupValue = variableValues[dictionaryLookupVariableName]?.toStringLiteral() ?: "*"
 
         val finalObject = dictionary.findFirstChildByPath(dictionaryLookupValue) ?: dictionary.findFirstChildByPath("*")
             ?: throw MissingDataException("Could not resolve lookup expression $value because variable $lookupStoreName.$dictionaryName[$dictionaryLookupVariableName] does not exist")
@@ -63,7 +63,7 @@ class SubstitutionImpl private constructor(
         val valueToReturn = finalObjectDictionary.findFirstChildByPath(keyName)
             ?: throw ContractException("Could not resolve lookup expression $value because value $keyName in $lookupStoreName.$dictionaryName[$dictionaryLookupVariableName] does not exist")
 
-        return valueToReturn.toStringLiteral()
+        return valueToReturn
     }
 
     private fun isDataLookup(value: String): Boolean {
@@ -76,12 +76,12 @@ class SubstitutionImpl private constructor(
     private fun isLookup(value: String) =
         value.startsWith("$(") && value.endsWith(")")
 
-    private fun resolveValue(value: StringValue): String {
+    private fun resolveValue(value: StringValue): Value {
         return InterpolatedSubstitution.resolve(value.string) { token ->
             when {
                 isDataLookup(token) -> substituteDataLookupExpression(token)
                 isSimpleVariableLookup(token) -> substituteSimpleVariableLookup(token)
-                else -> token
+                else -> StringValue(token)
             }
         }
     }
@@ -100,7 +100,7 @@ class SubstitutionImpl private constructor(
             return unresolvedSubstitutionFallback(value, pattern, e)
         }
 
-        return runCatching { HasValue(pattern.parse(updatedString, resolver)) }.getOrElse { e ->
+        return runCatching { HasValue(pattern.parse(updatedString.toUnformattedString(), resolver)) }.getOrElse { e ->
             return unresolvedSubstitutionFallback(value, pattern, e)
         }
     }
@@ -112,7 +112,7 @@ class SubstitutionImpl private constructor(
         val resolvedValue = runCatching { substituteDataLookupExpression(strValue) }.getOrElse { e ->
             logger.debug(e, "Error resolving data lookup expression ${value.string}, using original value")
             return value
-        }
+        }.toUnformattedString()
 
         return runCatching { pattern.parse(resolvedValue, resolver) }.getOrDefault(StringValue(resolvedValue))
     }
@@ -120,12 +120,12 @@ class SubstitutionImpl private constructor(
     override fun isDropDirective(value: Value): Boolean {
         val strValue = (value as? StringValue)?.nativeValue ?: return false
 
-        val resolved =
+        val resolved: String =
             if (!isDataLookup(strValue)) {
                 strValue
             } else {
                 try {
-                    substituteDataLookupExpression(strValue)
+                    substituteDataLookupExpression(strValue).toUnformattedString()
                 } catch (e: Throwable) {
                     logger.debug(e, "Failed to check for drop directive")
                     strValue
@@ -138,7 +138,8 @@ class SubstitutionImpl private constructor(
     override fun upsertStoreUsing(originalValue: Value, runningValue: Value): SubstitutionImpl {
         val extractedVariables = SubstitutionVariableExtractor.fromValues(
             originalValue = originalValue,
-            runningValue = runningValue
+            runningValue = runningValue,
+            resolver = resolver
         )
 
         return SubstitutionImpl(
@@ -164,23 +165,27 @@ class SubstitutionImpl private constructor(
             strictMode: Boolean = false,
         ): SubstitutionImpl {
             val variableValuesFromHeaders = SubstitutionVariableExtractor.fromMap(
+                resolver = resolver,
+                runningMap = runningRequest.headers,
                 originalMap = originalRequest.headers,
-                runningMap = runningRequest.headers
             )
 
             val variableValuesFromRequestBody = SubstitutionVariableExtractor.fromValues(
+                resolver = resolver,
+                runningValue = runningRequest.body,
                 originalValue = originalRequest.body,
-                runningValue = runningRequest.body
             )
 
             val variableValuesFromQueryParams = SubstitutionVariableExtractor.fromMap(
+                resolver = resolver,
+                runningMap = runningRequest.queryParams.asMap(),
                 originalMap = originalRequest.queryParams.asMap(),
-                runningMap = runningRequest.queryParams.asMap()
             )
 
             val variableValuesFromPath = SubstitutionVariableExtractor.fromPath(
+                resolver = resolver,
+                runningPath = runningRequest.path,
                 originalPath = originalRequest.path,
-                runningPath = runningRequest.path
             )
 
             val variableValues = variableValuesFromHeaders + variableValuesFromRequestBody + variableValuesFromQueryParams + variableValuesFromPath

--- a/core/src/main/kotlin/io/specmatic/core/substitution/SubstitutionImpl.kt
+++ b/core/src/main/kotlin/io/specmatic/core/substitution/SubstitutionImpl.kt
@@ -92,16 +92,35 @@ class SubstitutionImpl private constructor(
         return runCatching { resolver.generate(pattern) }.map(::HasValue).getOrElse(::HasException)
     }
 
+    override fun substitute(value: Value): ReturnValue<Value> {
+        if (value !is StringValue) return HasValue(value)
+        if (!InterpolatedSubstitution.containsLookup(value.string)) return HasValue(value)
+        return runCatching { HasValue(resolveValue(value)) }.getOrElse(::HasException)
+    }
+
     override fun substitute(value: Value, pattern: Pattern, key: String?): ReturnValue<Value> {
         if (value !is StringValue) return HasValue(value)
         if (!InterpolatedSubstitution.containsLookup(value.string)) return HasValue(value)
 
-        val updatedString = runCatching { resolveValue(value) }.getOrElse { e ->
+        val resolvedValue = runCatching { resolveValue(value) }.getOrElse { e ->
             return unresolvedSubstitutionFallback(value, pattern, e)
         }
 
-        return runCatching { HasValue(pattern.parse(updatedString.toUnformattedString(), resolver)) }.getOrElse { e ->
+        return runCatching { HasValue(pattern.parse(resolvedValue.toUnformattedString(), resolver)) }.getOrElse { e ->
             return unresolvedSubstitutionFallback(value, pattern, e)
+        }
+    }
+
+    override fun resolveIfLookup(value: Value): Value {
+        if (value !is StringValue) return value
+        val text = value.nativeValue
+
+        if (!isDataLookup(text)) return value
+        return runCatching {
+            substituteDataLookupExpression(text)
+        }.getOrElse { e ->
+            logger.debug(e, "Error resolving data lookup expression ${value.string}, using original value")
+            value
         }
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/substitution/SubstitutionImpl.kt
+++ b/core/src/main/kotlin/io/specmatic/core/substitution/SubstitutionImpl.kt
@@ -15,6 +15,7 @@ import io.specmatic.core.value.Value
 
 class SubstitutionImpl private constructor(
     private val resolver: Resolver,
+    private val strictMode: Boolean = false,
     private val variableValues: Map<String, String> = emptyMap(),
     private val data: JSONObjectValue = JSONObjectValue(emptyMap()),
 ) : Substitution {
@@ -85,14 +86,22 @@ class SubstitutionImpl private constructor(
         }
     }
 
+    private fun unresolvedSubstitutionFallback(value: StringValue, pattern: Pattern, e: Throwable): ReturnValue<Value> {
+        if (strictMode) return HasException(e)
+        logger.log(e, "Could not resolve substitution expression ${value.string}, using generated value instead")
+        return runCatching { resolver.generate(pattern) }.map(::HasValue).getOrElse(::HasException)
+    }
+
     override fun substitute(value: Value, pattern: Pattern, key: String?): ReturnValue<Value> {
-        return try {
-            if (value !is StringValue) return HasValue(value)
-            if (!InterpolatedSubstitution.containsLookup(value.string)) return HasValue(value)
-            val updatedString = resolveValue(value)
-            HasValue(pattern.parse(updatedString, resolver))
-        } catch (e: Throwable) {
-            HasException(e)
+        if (value !is StringValue) return HasValue(value)
+        if (!InterpolatedSubstitution.containsLookup(value.string)) return HasValue(value)
+
+        val updatedString = runCatching { resolveValue(value) }.getOrElse { e ->
+            return unresolvedSubstitutionFallback(value, pattern, e)
+        }
+
+        return runCatching { HasValue(pattern.parse(updatedString, resolver)) }.getOrElse { e ->
+            return unresolvedSubstitutionFallback(value, pattern, e)
         }
     }
 
@@ -126,7 +135,7 @@ class SubstitutionImpl private constructor(
         return resolved == DROP_DIRECTIVE
     }
 
-    override fun upsertStoreUsing(originalValue: Value, runningValue: Value): Substitution {
+    override fun upsertStoreUsing(originalValue: Value, runningValue: Value): SubstitutionImpl {
         val extractedVariables = SubstitutionVariableExtractor.fromValues(
             originalValue = originalValue,
             runningValue = runningValue
@@ -135,6 +144,7 @@ class SubstitutionImpl private constructor(
         return SubstitutionImpl(
             data = data,
             resolver = resolver,
+            strictMode = strictMode,
             variableValues = variableValues + extractedVariables,
         )
     }
@@ -142,11 +152,17 @@ class SubstitutionImpl private constructor(
     companion object {
         const val DROP_DIRECTIVE = "$(drop)"
 
-        fun empty(resolver: Resolver): SubstitutionImpl {
-            return SubstitutionImpl(resolver = resolver)
+        fun empty(resolver: Resolver, strictMode: Boolean = false): SubstitutionImpl {
+            return SubstitutionImpl(resolver = resolver, strictMode = strictMode)
         }
 
-        fun from(runningRequest: HttpRequest, originalRequest: HttpRequest, data: JSONObjectValue, resolver: Resolver): SubstitutionImpl {
+        fun from(
+            runningRequest: HttpRequest,
+            originalRequest: HttpRequest,
+            data: JSONObjectValue,
+            resolver: Resolver,
+            strictMode: Boolean = false,
+        ): SubstitutionImpl {
             val variableValuesFromHeaders = SubstitutionVariableExtractor.fromMap(
                 originalMap = originalRequest.headers,
                 runningMap = runningRequest.headers
@@ -168,7 +184,7 @@ class SubstitutionImpl private constructor(
             )
 
             val variableValues = variableValuesFromHeaders + variableValuesFromRequestBody + variableValuesFromQueryParams + variableValuesFromPath
-            return SubstitutionImpl(variableValues = variableValues, resolver = resolver, data = data)
+            return SubstitutionImpl(variableValues = variableValues, resolver = resolver, data = data, strictMode = strictMode)
         }
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/substitution/SubstitutionVariableExtractor.kt
+++ b/core/src/main/kotlin/io/specmatic/core/substitution/SubstitutionVariableExtractor.kt
@@ -1,52 +1,57 @@
 package io.specmatic.core.substitution
 
+import io.specmatic.core.Resolver
 import io.specmatic.core.value.JSONArrayValue
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.StringValue
 import io.specmatic.core.value.Value
 
 internal object SubstitutionVariableExtractor {
-    fun fromValues(originalValue: Value, runningValue: Value): Map<String, String> {
-        return variablesFromValue(originalValue, runningValue)
-    }
-
-    fun fromMap(originalMap: Map<String, String>, runningMap: Map<String, String>): Map<String, String> {
+    fun fromMap(originalMap: Map<String, String>, runningMap: Map<String, String>, resolver: Resolver = Resolver()): Map<String, Value> {
         return originalMap.entries.fold(emptyMap()) { acc, (key, originalValue) ->
             val runningValue = runningMap[key] ?: return@fold acc
-            acc + InterpolatedSubstitution.extractVariables(originalValue, runningValue)
+            acc + InterpolatedSubstitution.extractVariables(originalValue, runningValue, resolver)
         }
     }
 
-    fun fromPath(originalPath: String?, runningPath: String?): Map<String, String> {
+    fun fromPath(originalPath: String?, runningPath: String?, resolver: Resolver = Resolver()): Map<String, Value> {
         if (originalPath == null || runningPath == null) return emptyMap()
         val originalPathPieces = originalPath.split('/').filterNot(String::isBlank)
         val runningPathPieces = runningPath.split('/').filterNot(String::isBlank)
         return originalPathPieces.zip(runningPathPieces).fold(emptyMap()) { acc, (originalPiece, runningPiece) ->
-            acc + InterpolatedSubstitution.extractVariables(originalPiece, runningPiece)
+            acc + InterpolatedSubstitution.extractVariables(originalPiece, runningPiece, resolver)
         }
     }
 
-    private fun variablesFromValue(originalValue: Value, runningValue: Value): Map<String, String> {
+    fun fromValues(originalValue: Value, runningValue: Value, resolver: Resolver = Resolver()): Map<String, Value> {
         return when (originalValue) {
-            is StringValue -> InterpolatedSubstitution.extractVariables(originalValue.string, runningValue.toStringLiteral())
-            is JSONObjectValue -> variablesFromObject(originalValue, runningValue)
-            is JSONArrayValue -> variablesFromArray(originalValue, runningValue)
+            is StringValue -> variablesFromString(originalValue, runningValue, resolver)
+            is JSONObjectValue -> variablesFromObject(originalValue, runningValue, resolver)
+            is JSONArrayValue -> variablesFromArray(originalValue, runningValue, resolver)
             else -> emptyMap()
         }
     }
 
-    private fun variablesFromObject(originalValue: JSONObjectValue, runningValue: Value): Map<String, String> {
+    private fun variablesFromString(originalValue: StringValue, runningValue: Value, resolver: Resolver): Map<String, Value> {
+        return InterpolatedSubstitution.extractVariables(
+            resolver = resolver,
+            original = originalValue.string,
+            running = runningValue.toStringLiteral(),
+        )
+    }
+
+    private fun variablesFromObject(originalValue: JSONObjectValue, runningValue: Value, resolver: Resolver): Map<String, Value> {
         val runningObject = runningValue as? JSONObjectValue ?: return emptyMap()
         return originalValue.jsonObject.entries.fold(emptyMap()) { acc, (key, originalChild) ->
             val runningChild = runningObject.jsonObject[key] ?: return@fold acc
-            acc + variablesFromValue(originalChild, runningChild)
+            acc + fromValues(originalChild, runningChild, resolver)
         }
     }
 
-    private fun variablesFromArray(originalValue: JSONArrayValue, runningValue: Value): Map<String, String> {
+    private fun variablesFromArray(originalValue: JSONArrayValue, runningValue: Value, resolver: Resolver): Map<String, Value> {
         val runningArray = runningValue as? JSONArrayValue ?: return emptyMap()
         return originalValue.list.zip(runningArray.list).fold(emptyMap()) { acc, (originalItem, runningItem) ->
-            acc + variablesFromValue(originalItem, runningItem)
+            acc + fromValues(originalItem, runningItem, resolver)
         }
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/value/CDATAValue.kt
+++ b/core/src/main/kotlin/io/specmatic/core/value/CDATAValue.kt
@@ -2,6 +2,8 @@
 
 package io.specmatic.core.value
 
+import io.specmatic.core.value.fold.TextValueCase
+import io.specmatic.core.value.fold.ValueVisitor
 import org.w3c.dom.Document
 import org.w3c.dom.Node
 
@@ -10,6 +12,17 @@ data class CDATAValue(
 ) : ScalarValue,
     XMLValue by stringValue {
     constructor(string: String) : this(StringValue(string))
+
+    override fun <C, R> accept(visitor: ValueVisitor<C, R>, context: C): R {
+        return visitor.text(
+            case = TextValueCase(
+                value = this,
+                context = context,
+                text = stringValue.string,
+                replaceText = { newText -> copy(stringValue = StringValue(newText)) }
+            )
+        )
+    }
 
     override fun build(document: Document): Node = document.createCDATASection(stringValue.string)
 

--- a/core/src/main/kotlin/io/specmatic/core/value/JSONArrayValue.kt
+++ b/core/src/main/kotlin/io/specmatic/core/value/JSONArrayValue.kt
@@ -6,10 +6,28 @@ import io.specmatic.core.Result
 import io.specmatic.core.pattern.*
 import io.specmatic.core.utilities.valueArrayToJsonString
 import io.specmatic.core.utilities.valueArrayToUnformattedJsonString
+import io.specmatic.core.value.fold.IndexedListValueCase
+import io.specmatic.core.value.fold.Item
+import io.specmatic.core.value.fold.ValueVisitor
 
 typealias TypeDeclarationsCallType = (Value, String, Map<String, Pattern>, ExampleDeclarations) -> Pair<TypeDeclaration, ExampleDeclarations>
 
 data class JSONArrayValue(override val list: List<Value> = emptyList()) : Value, ListValue, JSONComposite {
+    override fun <C, R> accept(visitor: ValueVisitor<C, R>, context: C): R {
+        return visitor.indexedList(
+            case = IndexedListValueCase(
+                value = this,
+                context = context,
+                items = {
+                    list.mapIndexed { index, child -> Item(index = index, value = child) }
+                },
+                rebuild = { items ->
+                    copy(list = items.map { item -> item.value })
+                }
+            )
+        )
+    }
+
     override val httpContentType: String = "application/json"
 
     override fun displayableValue(): String = toStringLiteral()

--- a/core/src/main/kotlin/io/specmatic/core/value/JSONObjectValue.kt
+++ b/core/src/main/kotlin/io/specmatic/core/value/JSONObjectValue.kt
@@ -5,8 +5,26 @@ import io.specmatic.core.Resolver
 import io.specmatic.core.Result
 import io.specmatic.core.pattern.*
 import io.specmatic.core.utilities.*
+import io.specmatic.core.value.fold.Field
+import io.specmatic.core.value.fold.FieldObjectValueCase
+import io.specmatic.core.value.fold.ValueVisitor
 
 data class JSONObjectValue(val jsonObject: Map<String, Value> = emptyMap()) : Value, JSONComposite {
+    override fun <C, R> accept(visitor: ValueVisitor<C, R>, context: C): R {
+        return visitor.fieldObject(
+            case = FieldObjectValueCase(
+                value = this,
+                context = context,
+                fields = {
+                    jsonObject.map { (name, child) -> Field(name = name, value = child) }
+                },
+                rebuild = { fields ->
+                    copy(jsonObject = fields.associate { field -> field.name to field.value })
+                }
+            )
+        )
+    }
+
     override val httpContentType = "application/json"
 
     override fun valueErrorSnippet(): String {

--- a/core/src/main/kotlin/io/specmatic/core/value/ScalarValue.kt
+++ b/core/src/main/kotlin/io/specmatic/core/value/ScalarValue.kt
@@ -1,9 +1,16 @@
 package io.specmatic.core.value
 
+import io.specmatic.core.value.fold.ScalarValueCase
+import io.specmatic.core.value.fold.ValueVisitor
+
 interface ScalarValue: Value {
     val nativeValue: Any?
 
     override fun toNativeValue(): Any? = nativeValue
+
+    override fun <C, R> accept(visitor: ValueVisitor<C, R>, context: C): R {
+        return visitor.scalar(ScalarValueCase(value = this, context = context, nativeValue = nativeValue))
+    }
 
     fun alterValue(): ScalarValue
 }

--- a/core/src/main/kotlin/io/specmatic/core/value/StringValue.kt
+++ b/core/src/main/kotlin/io/specmatic/core/value/StringValue.kt
@@ -3,6 +3,8 @@ package io.specmatic.core.value
 import io.specmatic.core.ExampleDeclarations
 import io.specmatic.core.Result
 import io.specmatic.core.pattern.*
+import io.specmatic.core.value.fold.TextValueCase
+import io.specmatic.core.value.fold.ValueVisitor
 import io.ktor.http.*
 import org.apache.commons.lang3.StringEscapeUtils
 import org.w3c.dom.Document
@@ -10,6 +12,17 @@ import org.w3c.dom.Node
 
 data class StringValue(val string: String = "", private val xml: Boolean) : Value, ScalarValue, XMLValue {
     constructor(string: String = "") : this(string, false)
+
+    override fun <C, R> accept(visitor: ValueVisitor<C, R>, context: C): R {
+        return visitor.text(
+            case = TextValueCase(
+                value = this,
+                text = string,
+                context = context,
+                replaceText = { newText -> copy(string = newText) }
+            )
+        )
+    }
 
     override val httpContentType = "text/plain"
 

--- a/core/src/main/kotlin/io/specmatic/core/value/Value.kt
+++ b/core/src/main/kotlin/io/specmatic/core/value/Value.kt
@@ -2,8 +2,17 @@ package io.specmatic.core.value
 
 import io.specmatic.core.ExampleDeclarations
 import io.specmatic.core.pattern.Pattern
+import io.specmatic.core.value.fold.OpaqueValueCase
+import io.specmatic.core.value.fold.ValueVisitor
 
 interface Value {
+    fun <C, R> accept(
+        visitor: ValueVisitor<C, R>,
+        context: C = visitor.rootContext
+    ): R {
+        return visitor.opaque(OpaqueValueCase(value = this, context = context))
+    }
+
     fun valueErrorSnippet(): String = "${this.displayableValue()} (${this.displayableType()})"
 
     val httpContentType: String

--- a/core/src/main/kotlin/io/specmatic/core/value/XMLNode.kt
+++ b/core/src/main/kotlin/io/specmatic/core/value/XMLNode.kt
@@ -10,6 +10,10 @@ import io.specmatic.core.pattern.Pattern
 import io.specmatic.core.pattern.XMLPattern
 import io.specmatic.core.utilities.capitalizeFirstChar
 import io.specmatic.core.utilities.parseXML
+import io.specmatic.core.value.fold.ValueVisitor
+import io.specmatic.core.value.fold.XmlElementValueCase
+import io.specmatic.core.value.fold.XmlAttribute
+import io.specmatic.core.value.fold.XmlValueChild
 import io.specmatic.core.wsdl.parser.WSDL
 
 private const val DEFAULT_NAMESPACE_PREFIX = ""
@@ -86,6 +90,40 @@ data class XMLNode(val name: String, val realName: String, val attributes: Map<S
     constructor(realName: String, attributes: Map<String, StringValue>, childNodes: List<XMLValue>, parentNamespaces: Map<String, String> = emptyMap()) : this(realName.localName(), realName, attributes, childNodes, realName.namespacePrefix(), parentNamespaces.plus(getNamespaces(attributes)))
 
     val oneLineDescription: String = "<$realName ${attributeString()}>"
+
+    override fun <C, R> accept(visitor: ValueVisitor<C, R>, context: C): R {
+        return visitor.xmlElement(
+            case = XmlElementValueCase(
+                value = this,
+                context = context,
+                children = {
+                    childNodes.mapIndexed { index, child -> XmlValueChild(index = index, value = child) }
+                },
+                attributes = {
+                    attributes.map { (name, attributeValue) ->
+                        XmlAttribute(name = name, value = attributeValue)
+                    }
+                },
+                rebuild = { rewrittenAttributes, rewrittenChildren ->
+                    val updatedAttributes = rewrittenAttributes.associate { attribute ->
+                        attribute.name to attribute.value
+                    }
+
+                    copy(
+                        attributes = updatedAttributes,
+                        namespaces = rebuildNamespaces(updatedAttributes),
+                        childNodes = rewrittenChildren.map { child -> child.value }
+                    )
+                }
+            )
+        )
+    }
+
+    private fun rebuildNamespaces(updatedAttributes: Map<String, StringValue>): Map<String, String> {
+        val declaredNamespaces = getNamespaces(attributes)
+        val parentNamespaces = namespaces.filterKeys { key -> key !in declaredNamespaces.keys }
+        return parentNamespaces.plus(getNamespaces(updatedAttributes))
+    }
 
     private fun attributeString(): String {
         return attributes.entries.joinToString(" ") { (name, value) ->

--- a/core/src/main/kotlin/io/specmatic/core/value/fold/ValueCase.kt
+++ b/core/src/main/kotlin/io/specmatic/core/value/fold/ValueCase.kt
@@ -1,0 +1,92 @@
+package io.specmatic.core.value.fold
+
+import io.specmatic.core.value.StringValue
+import io.specmatic.core.value.Value
+import io.specmatic.core.value.XMLValue
+
+sealed interface ValueCase<out V : Value, out C> {
+    val value: V
+    val context: C
+}
+
+data class ScalarValueCase<V : Value, C>(
+    val nativeValue: Any?,
+    override val value: V,
+    override val context: C,
+) : ValueCase<V, C>
+
+data class TextValueCase<V : Value, C>(
+    val text: String,
+    override val value: V,
+    override val context: C,
+    val replaceText: (String) -> V,
+) : ValueCase<V, C>
+
+
+data class FieldObjectValueCase<V : Value, C>(
+    override val value: V,
+    override val context: C,
+    val fields: () -> List<Field<Value>>,
+    val rebuild: (List<Field<Value>>) -> V,
+) : ValueCase<V, C> {
+    fun <R> projectFields(visitor: ValueVisitor<C, R>): List<Field<R>> {
+        return fields().map { field ->
+            Field(
+                name = field.name,
+                value = field.value.accept(visitor = visitor, context = visitor.contextForField(context, field.name))
+            )
+        }
+    }
+}
+
+data class IndexedListValueCase<V : Value, C>(
+    override val value: V,
+    override val context: C,
+    val items: () -> List<Item<Value>>,
+    val rebuild: (List<Item<Value>>) -> V,
+) : ValueCase<V, C> {
+    fun <R> projectItems(visitor: ValueVisitor<C, R>): List<Item<R>> {
+        return items().map { item ->
+            Item(
+                index = item.index,
+                value = item.value.accept(visitor = visitor, context = visitor.contextForIndex(context, item.index))
+            )
+        }
+    }
+}
+
+data class XmlElementValueCase<V : XMLValue, C>(
+    override val value: V,
+    override val context: C,
+    val children: () -> List<XmlValueChild<XMLValue>>,
+    val attributes: () -> List<XmlAttribute<StringValue>>,
+    val rebuild: (List<XmlAttribute<StringValue>>, List<XmlValueChild<XMLValue>>) -> V
+) : ValueCase<V, C> {
+    fun <R> projectAttributes(visitor: ValueVisitor<C, R>): List<XmlAttribute<R>> {
+        return attributes().map { attribute ->
+            XmlAttribute(
+                name = attribute.name,
+                value = attribute.value.accept(
+                    visitor = visitor,
+                    context = visitor.contextForXmlAttribute(context, attribute.name)
+                )
+            )
+        }
+    }
+
+    fun <R> projectChildren(visitor: ValueVisitor<C, R>): List<XmlProjectedChild<R>> {
+        return children().map { child ->
+            XmlProjectedChild(
+                index = child.index,
+                value = child.value.accept(visitor = visitor, context = visitor.contextForXmlChild(context, child.index))
+            )
+        }
+    }
+}
+
+data class OpaqueValueCase<V : Value, C>(
+    override val value: V,
+    override val context: C,
+) : ValueCase<V, C> {
+    val kind: String = value::class.simpleName ?: "Value"
+}

--- a/core/src/main/kotlin/io/specmatic/core/value/fold/ValueProjection.kt
+++ b/core/src/main/kotlin/io/specmatic/core/value/fold/ValueProjection.kt
@@ -1,0 +1,28 @@
+package io.specmatic.core.value.fold
+
+import io.specmatic.core.value.XMLValue
+
+data class Field<out T>(
+    val name: String,
+    val value: T
+)
+
+data class Item<out T>(
+    val index: Int,
+    val value: T
+)
+
+data class XmlProjectedChild<out T>(
+    val index: Int,
+    val value: T
+)
+
+data class XmlAttribute<out T>(
+    val name: String,
+    val value: T
+)
+
+data class XmlValueChild<out T : XMLValue>(
+    val index: Int,
+    val value: T
+)

--- a/core/src/main/kotlin/io/specmatic/core/value/fold/ValueVisitor.kt
+++ b/core/src/main/kotlin/io/specmatic/core/value/fold/ValueVisitor.kt
@@ -1,0 +1,40 @@
+package io.specmatic.core.value.fold
+
+import io.specmatic.core.value.Value
+import io.specmatic.core.value.XMLValue
+
+interface ValueVisitor<C, R> {
+    val rootContext: C
+
+    fun opaque(case: OpaqueValueCase<out Value, C>): R
+
+    fun scalar(case: ScalarValueCase<out Value, C>): R {
+        return opaque(OpaqueValueCase(value = case.value, context = case.context))
+    }
+
+    fun text(case: TextValueCase<out Value, C>): R {
+        return opaque(OpaqueValueCase(value = case.value, context = case.context))
+    }
+
+    fun fieldObject(case: FieldObjectValueCase<out Value, C>): R {
+        return opaque(OpaqueValueCase(value = case.value, context = case.context))
+    }
+
+    fun indexedList(case: IndexedListValueCase<out Value, C>): R {
+        return opaque(OpaqueValueCase(value = case.value, context = case.context))
+    }
+
+    fun xmlElement(case: XmlElementValueCase<out XMLValue, C>): R {
+        return opaque(OpaqueValueCase(value = case.value, context = case.context))
+    }
+
+    fun contextForOpaque(currentContext: C, name: String): C = currentContext
+
+    fun contextForField(currentContext: C, name: String): C = currentContext
+
+    fun contextForIndex(currentContext: C, index: Int): C = currentContext
+
+    fun contextForXmlChild(currentContext: C, index: Int): C = currentContext
+
+    fun contextForXmlAttribute(currentContext: C, name: String): C = currentContext
+}

--- a/core/src/main/kotlin/io/specmatic/stub/HttpExpectations.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpExpectations.kt
@@ -2,6 +2,7 @@ package io.specmatic.stub
 
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.Result
+import io.specmatic.core.SpecmaticConfig
 import io.specmatic.mock.ScenarioStub
 
 class HttpExpectations private constructor (
@@ -12,11 +13,13 @@ class HttpExpectations private constructor (
     constructor(
         static: MutableList<HttpStubData>,
         transient: MutableList<HttpStubData> = mutableListOf(),
-        specToBaseUrlMap: Map<String, String> = emptyMap()
+        specToBaseUrlMap: Map<String, String> = emptyMap(),
+        strictMode: Boolean = false,
+        specmaticConfig: SpecmaticConfig = SpecmaticConfig(),
     ) : this(
-        static = ThreadSafeListOfStubs(static, specToBaseUrlMap),
-        transient = ThreadSafeListOfStubs(transient, specToBaseUrlMap),
-        dynamic = ThreadSafeListOfStubs(mutableListOf(), specToBaseUrlMap)
+        static = ThreadSafeListOfStubs(static, specToBaseUrlMap, strictMode, specmaticConfig),
+        transient = ThreadSafeListOfStubs(transient, specToBaseUrlMap, strictMode, specmaticConfig),
+        dynamic = ThreadSafeListOfStubs(mutableListOf(), specToBaseUrlMap, strictMode, specmaticConfig)
     )
 
     val stubCount: Int get() { return static.size }

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -173,6 +173,7 @@ class HttpStub(
             feature.path to endPointFromHostAndPort(host, port, null)
         ),
         listeners: List<MockEventListener> = emptyList(),
+        strictMode: Boolean = false,
     ) : this(
         listOf(feature),
         contractInfoToHttpExpectations(listOf(Pair(feature, scenarioStubs))),
@@ -181,6 +182,7 @@ class HttpStub(
         log,
         specToStubBaseUrlMap = specToStubBaseUrlMap,
         listeners = listeners,
+        strictMode = strictMode
     )
 
     constructor(
@@ -231,10 +233,13 @@ class HttpStub(
     )
 
     private val httpExpectations: HttpExpectations = HttpExpectations(
+        strictMode = strictMode,
+        specmaticConfig = specmaticConfigInstance,
         static = staticHttpStubData(rawHttpStubs),
         transient = rawHttpStubs.filter { it.stubToken != null }.reversed().toMutableList(),
         specToBaseUrlMap = specToBaseUrlMap
     )
+
     private val firstMockedOpenApiSpec: MockedOpenApiSpec? by lazy {
         features.asSequence()
             .filter { it.path.isNotBlank() }

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStubResponse.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStubResponse.kt
@@ -12,7 +12,8 @@ data class HttpStubResponse(
     val feature: Feature? = null,
     val scenario: Scenario? = null,
     val mock: HttpStubData? = null,
-    val isInternalStubPath: Boolean = false
+    val isInternalStubPath: Boolean = false,
+    val strictMode: Boolean = false
 ) {
     val responseBody = response.body
 
@@ -24,7 +25,13 @@ data class HttpStubResponse(
         if(scenario == null)
             return this
 
-        val updatedResponse = scenario.resolveSubstitutions(request, originalRequest, response, data)
+        val updatedResponse = scenario.resolveSubstitutions(
+            data = data,
+            request = request,
+            response = response,
+            originalRequest = originalRequest,
+            strictMode = strictMode,
+        )
 
         return this.copy(response = updatedResponse)
     }

--- a/core/src/main/kotlin/io/specmatic/stub/ThreadSafeListOfStubs.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/ThreadSafeListOfStubs.kt
@@ -1,19 +1,21 @@
 package io.specmatic.stub
 
 import io.specmatic.core.HttpRequest
-import io.specmatic.core.RequestScore
 import io.specmatic.core.RequestScore.Companion.orEmpty
 import io.specmatic.core.Result
+import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.invalidRequestStatuses
 import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.pattern.IgnoreUnexpectedKeys
-import io.specmatic.core.utilities.SegmentCounts
 import io.specmatic.mock.ScenarioStub
+import java.io.File
 import java.net.URI
 
 class ThreadSafeListOfStubs(
     private val httpStubs: MutableList<HttpStubData>,
-    private val specToBaseUrlMap: Map<String, String>
+    private val specToBaseUrlMap: Map<String, String>,
+    private val strictMode: Boolean = false,
+    private val specmaticConfig: SpecmaticConfig = SpecmaticConfig(),
 ) {
     val size: Int
         get() {
@@ -148,19 +150,21 @@ class ThreadSafeListOfStubs(
             return httpStubs.groupBy {
                 specToBaseUrlMap[it.contractPath] ?: defaultBaseUrl
             }.mapValues { (_, stubs) ->
-                ThreadSafeListOfStubs(stubs as MutableList<HttpStubData>, specToBaseUrlMap)
+                ThreadSafeListOfStubs(stubs as MutableList<HttpStubData>, specToBaseUrlMap, strictMode, specmaticConfig)
             }
         }
     }
 
     private fun substituteThenFillIn(httpRequest: HttpRequest, stubData: HttpStubData): Pair<Result, HttpStubData> {
         val originalRequest = stubData.resolveOriginalRequest()
+        val strictMode = stubData.feature?.path?.let(::File)?.let(specmaticConfig::getStubStrictMode) ?: strictMode
         val stubResponse = HttpStubResponse(
             stubData.partial?.response ?: stubData.response,
             stubData.delayInMilliseconds,
             stubData.contractPath,
             feature = stubData.feature,
-            scenario = stubData.scenario
+            scenario = stubData.scenario,
+            strictMode = strictMode
         )
 
         return runCatching {
@@ -197,7 +201,7 @@ class ThreadSafeListOfStubs(
     }
 
     private fun emptyStubs(): ThreadSafeListOfStubs {
-        return ThreadSafeListOfStubs(mutableListOf(), specToBaseUrlMap)
+        return ThreadSafeListOfStubs(mutableListOf(), specToBaseUrlMap, strictMode, specmaticConfig)
     }
 
     companion object {

--- a/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
@@ -54,7 +54,10 @@ data class ScenarioAsTest(
     private val responseHandlerRegistry: ResponseHandlerRegistry = ResponseHandlerRegistry(feature, originalScenario),
     private val requestValidator: RequestValidator = DefaultRequestValidator,
     val reasoning: Reasoning = Reasoning(),
-    private val substitution: Substitution = SubstitutionImpl.empty(scenario.resolver),
+    private val substitution: Substitution = SubstitutionImpl.empty(
+        resolver = scenario.resolver,
+        strictMode = feature.specmaticConfig.getTestStrictMode() ?: feature.strictMode
+    ),
 ) : ContractTest {
     companion object {
         private var id: Value? = null

--- a/core/src/main/kotlin/io/specmatic/test/interceptor/ContractTestInterceptor.kt
+++ b/core/src/main/kotlin/io/specmatic/test/interceptor/ContractTestInterceptor.kt
@@ -29,8 +29,20 @@ interface ContractTestInterceptor {
     ): InterceptResult<Substitution>
 
     companion object {
-        fun load(): ContractTestInterceptor?  {
-            return ServiceLoader.load(ContractTestInterceptor::class.java).firstNotNullOfOrNull { it }
+        private val loaderOverride = ThreadLocal<(() -> ContractTestInterceptor?)?>()
+
+        fun load(): ContractTestInterceptor? {
+            return loaderOverride.get()?.invoke()
+                ?: ServiceLoader.load(ContractTestInterceptor::class.java).firstNotNullOfOrNull { it }
+        }
+
+        internal fun <T> withLoaderForTest(loader: () -> ContractTestInterceptor?, block: () -> T): T {
+            loaderOverride.set(loader)
+            return try {
+                block()
+            } finally {
+                loaderOverride.remove()
+            }
         }
     }
 }

--- a/core/src/test/kotlin/integration_tests/StubSubstitutionTest.kt
+++ b/core/src/test/kotlin/integration_tests/StubSubstitutionTest.kt
@@ -1,33 +1,45 @@
 package integration_tests
 
+import io.mockk.every
+import io.mockk.mockk
 import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.core.DefaultMismatchMessages
+import io.specmatic.core.Feature
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpResponse
+import io.specmatic.core.SPECMATIC_RESULT_HEADER
 import io.specmatic.core.SPECMATIC_STUB_DICTIONARY
 import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.SpecmaticConfigV1V2Common
 import io.specmatic.core.StubConfiguration
 import io.specmatic.core.StandardRuleViolation
 import io.specmatic.core.pattern.ContractException
+import io.specmatic.core.pattern.parsedJSON
 import io.specmatic.core.pattern.parsedJSONObject
 import io.specmatic.core.value.JSONArrayValue
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.NumberValue
 import io.specmatic.core.value.StringValue
+import io.specmatic.license.core.SpecmaticProtocol
 import io.specmatic.mock.ScenarioStub
 import io.specmatic.osAgnosticPath
 import io.specmatic.stub.HttpStub
+import io.specmatic.stub.HttpStubData
 import io.specmatic.stub.HttpStubResponse
+import io.specmatic.stub.SpecmaticConfigSource
 import io.specmatic.stub.captureStandardOutput
+import io.specmatic.stub.contractInfoToHttpExpectations
 import io.specmatic.stub.createStubFromContracts
 import io.specmatic.toViolationReportString
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
+import java.io.File
 
 class StubSubstitutionTest {
     @Test
@@ -340,7 +352,7 @@ class StubSubstitutionTest {
         val exampleRequest = HttpRequest("POST", "/data", body = parsedJSONObject("""{"id": "(ID:string)"}"""))
         val exampleResponse = HttpResponse(200, headers = mapOf("Content-Type" to "application/json"), body = parsedJSONObject("""{"id": "$(ID)"}"""))
 
-        HttpStub(feature, listOf(ScenarioStub(exampleRequest, exampleResponse))).use { stub ->
+        HttpStub(feature, listOf(ScenarioStub(exampleRequest, exampleResponse)), strictMode = true).use { stub ->
             val response = stub.client.execute(exampleRequest)
 
             assertThat(response.status).isEqualTo(400)
@@ -388,7 +400,7 @@ class StubSubstitutionTest {
         val exampleRequest = HttpRequest("POST", "/data", body = parsedJSONObject("""{"id": "(ID:string)"}"""))
         val exampleResponse = HttpResponse(200, headers = mapOf("Content-Type" to "text/plain", "X-Id" to "$(ID)"), body = StringValue("success"))
 
-        HttpStub(feature, listOf(ScenarioStub(exampleRequest, exampleResponse))).use { stub ->
+        HttpStub(feature, listOf(ScenarioStub(exampleRequest, exampleResponse)), strictMode = true).use { stub ->
             val response = stub.client.execute(exampleRequest)
 
             assertThat(response.status).isEqualTo(400)
@@ -939,7 +951,7 @@ class StubSubstitutionTest {
         """.trimIndent())
         val scenarioStub = ScenarioStub(request = exampleRequest, response = exampleResponse, data = dataLookup)
 
-        HttpStub(feature, listOf(scenarioStub)).use { stub ->
+        HttpStub(feature, listOf(scenarioStub), strictMode = true).use { stub ->
             val request = HttpRequest("GET", "/data/123")
             val response = stub.client.execute(request)
             val responseBody = response.body as JSONObjectValue
@@ -1501,6 +1513,66 @@ class StubSubstitutionTest {
             assertThat(responseBody.findFirstChildByPath("id")).isEqualTo(StringValue("123"))
             assertThat(responseBody.findFirstChildByPath("names.[0]")).isEqualTo(StringValue("John"))
             assertThat(responseBody.findFirstChildByPath("names.[1]")).isEqualTo(StringValue("Jane"))
+        }
+    }
+
+    @Nested
+    inner class StrictMode {
+        @Test
+        fun `http stub fails unresolved substitution when strict mode is enabled`() {
+            val specFilePath = "src/test/resources/openapi/spec_with_dictionary/spec.yaml"
+            val feature = OpenApiSpecification.fromFile(specFilePath).toFeature()
+            val example = ScenarioStub(
+                request = HttpRequest("POST", "/data", body = parsedJSON("""{"name": "John"}""")),
+                response = HttpResponse(200, body = parsedJSON("""{"data": "$(MISSING)"}"""))
+            )
+
+            HttpStub(
+                feature = feature,
+                strictMode = true,
+                scenarioStubs = listOf(example),
+            ).use { stub ->
+                val response = stub.client.execute(example.requestElsePartialRequest())
+                assertThat(response.status).isEqualTo(400)
+                assertThat(response.headers.getValue(SPECMATIC_RESULT_HEADER)).isEqualTo("failure")
+                assertThat(response.body.toUnformattedString()).contains("""
+                Could not resolve expression $(MISSING) as no variable by the name MISSING was found
+                """.trimIndent())
+            }
+        }
+    }
+
+    @Nested
+    inner class LenientMode {
+        @Test
+        fun `http stub falls back to generated value when strict mode is disabled`() {
+            val specFilePath = "src/test/resources/openapi/spec_with_dictionary/spec.yaml"
+            val feature = OpenApiSpecification.fromFile(specFilePath).toFeature()
+            val example = ScenarioStub(
+                request = HttpRequest("POST", "/data", body = parsedJSON("""{"name": "John"}""")),
+                response = HttpResponse(200, body = parsedJSON("""{"data": "$(MISSING)"}"""))
+            )
+
+            val specmaticConfig = mockk<SpecmaticConfig>(relaxed = true)
+            every { specmaticConfig.getStubStrictMode(File(specFilePath)) } returns false
+
+            HttpStub(
+                strictMode = true,
+                rawHttpStubs = listOf(example).toStubData(feature),
+                // Stops HttpStub from generating CTRF/HTML Report on close
+                features = listOf(feature.copy(protocol = SpecmaticProtocol.WEB_SOCKET)),
+                specmaticConfigSource = SpecmaticConfigSource.fromConfigObject(specmaticConfig)
+            ).use { stub ->
+                val response = stub.client.execute(example.requestElsePartialRequest())
+                assertThat(response.status).isEqualTo(200)
+                assertThat(response.headers).doesNotContainKey("X-Specmatic-Random")
+                assertThat(response.headers.getValue(SPECMATIC_RESULT_HEADER)).isEqualTo("success")
+                assertDoesNotThrow { (response.body as JSONObjectValue).getString("data") }
+            }
+        }
+
+        private fun List<ScenarioStub>.toStubData(feature: Feature): List<HttpStubData> {
+            return contractInfoToHttpExpectations(listOf(Pair(feature, this)))
         }
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
@@ -9,6 +9,7 @@ import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.core.discriminator.DiscriminatorBasedItem
 import io.specmatic.core.discriminator.DiscriminatorMetadata
 import io.specmatic.core.examples.module.ExampleValidationModule
+import io.specmatic.core.examples.source.PreLoadedExampleObjects
 import io.specmatic.core.filters.ScenarioMetadataFilter
 import io.specmatic.core.pattern.*
 import io.specmatic.core.utilities.Flags
@@ -26,6 +27,8 @@ import io.specmatic.stub.createStubFromContracts
 import io.specmatic.test.ScenarioTestGenerationException
 import io.specmatic.test.ScenarioTestGenerationFailure
 import io.specmatic.test.TestExecutor
+import io.specmatic.test.interceptor.ContractTestInterceptor
+import io.specmatic.test.interceptor.InterceptResult
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.json.JSONObject
@@ -4831,5 +4834,132 @@ paths:
 
         assertThat(matchedScenario?.method).isEqualTo("POST")
         assertThat(matchedScenario?.status).isEqualTo(415)
+    }
+
+    @Nested
+    inner class StrictSubstitutionConfigWiring {
+        @Test
+        fun `contract test fails unresolved substitution with strict mode`() {
+            val specFilePath = "src/test/resources/openapi/spec_with_dictionary/spec.yaml"
+            val specmaticConfig = mockk<SpecmaticConfig>(relaxed = true)
+            every { specmaticConfig.getTestStrictMode() } returns true
+            every { specmaticConfig.getWorkflowDetails() } returns null
+
+            val examples = PreLoadedExampleObjects.transform(
+                specmaticConfig = specmaticConfig,
+                examples = listOf(
+                    ScenarioStub(
+                        request = HttpRequest("POST", "/data", body = parsedJSON("""{"name": "$(MISSING)"}""")),
+                        response = HttpResponse(200, body = parsedJSON("""{"data": "123"}"""))
+                    )
+                )
+            )
+
+            val feature = OpenApiSpecification.fromFile(specFilePath, specmaticConfig).toFeature()
+            val (updatedFeature) = feature.loadExternalisedExamplesAndListUnloadableExamples(
+                exampleSource = PreLoadedExampleObjects(examples = examples)
+            )
+
+            val results = ContractTestInterceptor.withLoaderForTest (
+                loader = {
+                    object : ContractTestInterceptor {
+                        override fun updateRequest(
+                            testScenario: Scenario,
+                            originalScenario: Scenario,
+                            httpRequest: HttpRequest,
+                            substitution: Substitution
+                        ): InterceptResult<HttpRequest> {
+                            return InterceptResult.Processed(
+                                value = originalScenario.resolveRequestSubstitutions(httpRequest, substitution)
+                            )
+                        }
+
+                        override fun updateSubstitution(
+                            testScenario: Scenario,
+                            originalScenario: Scenario,
+                            httpResponse: HttpResponse,
+                            substitution: Substitution
+                        ): InterceptResult<Substitution> {
+                            return InterceptResult.PassThrough
+                        }
+                    }
+                },
+                block = {
+                    updatedFeature.executeTests(object : TestExecutor {
+                        override fun execute(request: HttpRequest): HttpResponse {
+                            throw IllegalStateException("Should not be called")
+                        }
+                    })
+                }
+            )
+
+            assertThat(results.success()).withFailMessage { results.report() }.isFalse
+            assertThat(results.failureCount).withFailMessage { results.report() }.isEqualTo(1)
+            assertThat(results.report()).contains("""
+            Could not resolve expression $(MISSING) as no variable by the name MISSING was found
+            """.trimIndent())
+        }
+    }
+
+    @Nested
+    inner class LenientSubstitutionConfigWiring {
+        @Test
+        fun `contract test falls back to generated when strict mode is disabled`() {
+            val specFilePath = "src/test/resources/openapi/spec_with_dictionary/spec.yaml"
+            val examples = PreLoadedExampleObjects.transform(
+                specmaticConfig = SpecmaticConfig(),
+                examples = listOf(
+                    ScenarioStub(
+                        request = HttpRequest("POST", "/data", body = parsedJSON("""{"name": "$(MISSING)"}""")),
+                        response = HttpResponse(200, body = parsedJSON("""{"data": "123"}"""))
+                    )
+                )
+            )
+
+            val feature = OpenApiSpecification.fromFile(specFilePath).toFeature()
+            val (updatedFeature) = feature.loadExternalisedExamplesAndListUnloadableExamples(
+                exampleSource = PreLoadedExampleObjects(examples = examples)
+            )
+
+            val results = ContractTestInterceptor.withLoaderForTest (
+                loader = {
+                    object : ContractTestInterceptor {
+                        override fun updateRequest(
+                            testScenario: Scenario,
+                            originalScenario: Scenario,
+                            httpRequest: HttpRequest,
+                            substitution: Substitution
+                        ): InterceptResult<HttpRequest> {
+                            return InterceptResult.Processed(
+                                value = originalScenario.resolveRequestSubstitutions(httpRequest, substitution)
+                            )
+                        }
+
+                        override fun updateSubstitution(
+                            testScenario: Scenario,
+                            originalScenario: Scenario,
+                            httpResponse: HttpResponse,
+                            substitution: Substitution
+                        ): InterceptResult<Substitution> {
+                            return InterceptResult.PassThrough
+                        }
+                    }
+                },
+                block = {
+                    updatedFeature.executeTests(object : TestExecutor {
+                        override fun execute(request: HttpRequest): HttpResponse {
+                            assertThat(request.body.toStringLiteral()).doesNotContain("$(MISSING_ID)")
+                            return HttpResponse(200, body = parsedJSON("""{"data": "123"}"""))
+                        }
+                    })
+                }
+            )
+
+            assertThat(results.success()).withFailMessage { results.report() }.isTrue
+            assertThat(results.successCount).withFailMessage { results.report() }.isEqualTo(1)
+            assertThat(results.report()).doesNotContain("""
+            Could not resolve expression $(MISSING) as no variable by the name MISSING was found
+            """.trimIndent())
+        }
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/HttpHeadersPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpHeadersPatternTest.kt
@@ -1075,6 +1075,9 @@ internal class HttpHeadersPatternTest {
         private fun substitutionOf(vararg mappings: Pair<String, String>): Substitution {
             return object : Substitution {
                 override fun isDropDirective(value: Value): Boolean = false
+                override fun resolveIfLookup(value: Value): Value = value
+                override fun substitute(value: Value): ReturnValue<Value> = HasValue(value)
+                override fun upsertStoreUsing(originalValue: Value, runningValue: Value): Substitution = this
                 override fun resolveIfLookup(value: Value, pattern: Pattern): Value = value
                 override fun substitute(value: Value, pattern: Pattern, key: String?): ReturnValue<Value> {
                     val expression = (value as? StringValue)?.string ?: return HasValue(value)

--- a/core/src/test/kotlin/io/specmatic/core/HttpPathPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpPathPatternTest.kt
@@ -1065,6 +1065,9 @@ internal class HttpPathPatternTest {
         private fun substitutionOf(vararg mappings: Pair<String, String>): Substitution {
             return object : Substitution {
                 override fun isDropDirective(value: Value): Boolean = false
+                override fun resolveIfLookup(value: Value): Value = value
+                override fun substitute(value: Value): ReturnValue<Value> = HasValue(value)
+                override fun upsertStoreUsing(originalValue: Value, runningValue: Value): Substitution = this
                 override fun resolveIfLookup(value: Value, pattern: Pattern): Value = value
                 override fun substitute(value: Value, pattern: Pattern, key: String?): ReturnValue<Value> {
                     val expression = (value as? StringValue)?.string ?: return HasValue(value)

--- a/core/src/test/kotlin/io/specmatic/core/HttpQueryParamPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpQueryParamPatternTest.kt
@@ -2951,6 +2951,9 @@ class HttpQueryParamPatternTest {
         private fun substitutionOf(vararg mappings: Pair<String, String>): Substitution {
             return object : Substitution {
                 override fun isDropDirective(value: Value): Boolean = false
+                override fun resolveIfLookup(value: Value): Value = value
+                override fun substitute(value: Value): ReturnValue<Value> = HasValue(value)
+                override fun upsertStoreUsing(originalValue: Value, runningValue: Value): Substitution = this
                 override fun resolveIfLookup(value: Value, pattern: Pattern): Value = value
                 override fun substitute(value: Value, pattern: Pattern, key: String?): ReturnValue<Value> {
                     val expression = (value as? StringValue)?.string ?: return HasValue(value)

--- a/core/src/test/kotlin/io/specmatic/core/HttpRequestPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpRequestPatternTest.kt
@@ -1195,6 +1195,9 @@ internal class HttpRequestPatternTest {
         private fun substitutionOf(vararg mappings: Pair<String, String>): Substitution {
             return object : Substitution {
                 override fun isDropDirective(value: Value): Boolean = false
+                override fun resolveIfLookup(value: Value): Value = value
+                override fun substitute(value: Value): ReturnValue<Value> = HasValue(value)
+                override fun upsertStoreUsing(originalValue: Value, runningValue: Value): Substitution = this
                 override fun resolveIfLookup(value: Value, pattern: Pattern): Value = value
                 override fun substitute(value: Value, pattern: Pattern, key: String?): ReturnValue<Value> {
                     val expression = (value as? StringValue)?.string ?: return HasValue(value)

--- a/core/src/test/kotlin/io/specmatic/core/substitution/InterpolatedSubstitutionTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/substitution/InterpolatedSubstitutionTest.kt
@@ -1,8 +1,14 @@
 package io.specmatic.core.substitution
 
+import io.specmatic.core.Resolver
 import io.specmatic.core.pattern.ContractException
+import io.specmatic.core.pattern.NumberPattern
+import io.specmatic.core.value.BooleanValue
+import io.specmatic.core.value.NumberValue
+import io.specmatic.core.value.StringValue
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class InterpolatedSubstitutionTest {
@@ -13,7 +19,7 @@ class InterpolatedSubstitutionTest {
             running = "order-123"
         )
 
-        assertThat(result).isEqualTo(mapOf("ORDER_ID" to "123"))
+        assertThat(result).isEqualTo(mapOf("ORDER_ID" to NumberValue(123)))
     }
 
     @Test
@@ -23,7 +29,7 @@ class InterpolatedSubstitutionTest {
             running = "order-123-item-456"
         )
 
-        assertThat(result).isEqualTo(mapOf("ORDER_ID" to "123", "ITEM_ID" to "456"))
+        assertThat(result).isEqualTo(mapOf("ORDER_ID" to NumberValue(123), "ITEM_ID" to NumberValue(456)))
     }
 
     @Test
@@ -54,7 +60,7 @@ class InterpolatedSubstitutionTest {
             running = "hello (world) id-123"
         )
 
-        assertThat(result).isEqualTo(mapOf("ID" to "123"))
+        assertThat(result).isEqualTo(mapOf("ID" to NumberValue(123)))
     }
 
     @Test
@@ -102,24 +108,83 @@ class InterpolatedSubstitutionTest {
             running = "10-again-10"
         )
 
-        assertThat(result).isEqualTo(mapOf("ID" to "10"))
+        assertThat(result).isEqualTo(mapOf("ID" to NumberValue(10)))
     }
 
     @Test
     fun `resolves interpolated lookups`() {
         val result = InterpolatedSubstitution.resolve("prefix-$(ID)-suffix") { token ->
             when (token) {
-                "$(ID)" -> "123"
-                else -> token
+                "$(ID)" -> StringValue("123")
+                else -> StringValue(token)
             }
         }
 
-        assertThat(result).isEqualTo("prefix-123-suffix")
+        assertThat(result).isEqualTo(StringValue("prefix-123-suffix"))
+    }
+
+    @Test
+    fun `returns resolved value unchanged for exact lookup token`() {
+        val result = InterpolatedSubstitution.resolve("$(ID)") { token ->
+            when (token) {
+                "$(ID)" -> NumberValue(123)
+                else -> StringValue(token)
+            }
+        }
+
+        assertThat(result).isEqualTo(NumberValue(123))
+    }
+
+    @Test
+    fun `uses unformatted string for embedded non string lookup value`() {
+        val result = InterpolatedSubstitution.resolve("prefix-$(ID)-suffix") { token ->
+            when (token) {
+                "$(ID)" -> NumberValue(123)
+                else -> StringValue(token)
+            }
+        }
+
+        assertThat(result).isEqualTo(StringValue("prefix-123-suffix"))
     }
 
     @Test
     fun `detects lookup tokens`() {
         assertThat(InterpolatedSubstitution.containsLookup("order-$(ID)")).isTrue()
         assertThat(InterpolatedSubstitution.containsLookup("prefix-abc")).isFalse()
+    }
+
+    @Nested
+    inner class TypedExtraction {
+        @Test
+        fun `parses built in boolean type`() {
+            val result = InterpolatedSubstitution.extractVariables(
+                original = "flag-(FLAG:boolean)",
+                running = "flag-true"
+            )
+
+            assertThat(result).isEqualTo(mapOf("FLAG" to BooleanValue(true)))
+        }
+
+        @Test
+        fun `falls back to string value when built in type parse fails`() {
+            val result = InterpolatedSubstitution.extractVariables(
+                original = "id-(ID:number)",
+                running = "id-abc"
+            )
+
+            assertThat(result).isEqualTo(mapOf("ID" to StringValue("abc")))
+        }
+
+        @Test
+        fun `parses custom resolver type not in built ins`() {
+            val resolver = Resolver(newPatterns = mapOf("(special)" to NumberPattern()))
+            val result = InterpolatedSubstitution.extractVariables(
+                original = "custom-(CUSTOM:special)",
+                running = "custom-42",
+                resolver = resolver
+            )
+
+            assertThat(result).isEqualTo(mapOf("CUSTOM" to NumberValue(42)))
+        }
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/substitution/SubstitutionImplTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/substitution/SubstitutionImplTest.kt
@@ -8,9 +8,12 @@ import io.specmatic.core.Substitution
 import io.specmatic.core.pattern.HasException
 import io.specmatic.core.pattern.HasValue
 import io.specmatic.core.pattern.ExactValuePattern
+import io.specmatic.core.pattern.JSONArrayPattern
 import io.specmatic.core.pattern.NumberPattern
+import io.specmatic.core.pattern.JSONObjectPattern
 import io.specmatic.core.pattern.StringPattern
 import io.specmatic.core.pattern.parsedValue
+import io.specmatic.core.value.JSONArrayValue
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.NumberValue
 import io.specmatic.core.value.StringValue
@@ -280,6 +283,117 @@ class SubstitutionImplTest {
     }
 
     @Nested
+    inner class ValueOnlySubstitution {
+        @Test
+        fun `whole simple variable returns stored scalar value as is`() {
+            val substitution = SubstitutionImpl.empty(Resolver()).upsertStoreUsing(
+                originalValue = StringValue("(id:number)"),
+                runningValue = NumberValue(10)
+            )
+
+            assertThat(substitution.substitute(StringValue("$(id)"))).isEqualTo(HasValue(NumberValue(10)))
+        }
+
+        @Test
+        fun `whole simple variable returns stored object value as is`() {
+            val resolver = Resolver(
+                newPatterns = mapOf(
+                    "(User)" to JSONObjectPattern(
+                        pattern = mapOf(
+                            "id" to NumberPattern(),
+                            "name" to StringPattern()
+                        ),
+                        typeAlias = "(User)"
+                    )
+                )
+            )
+
+            val user = JSONObjectValue(
+                mapOf(
+                    "id" to NumberValue(10),
+                    "name" to StringValue("John")
+                )
+            )
+
+            val substitution = SubstitutionImpl.empty(resolver).upsertStoreUsing(
+                originalValue = StringValue("(user:User)"),
+                runningValue = StringValue(user.toUnformattedString())
+            )
+
+            assertThat(substitution.substitute(StringValue("$(user)"))).isEqualTo(HasValue(user))
+        }
+
+        @Test
+        fun `interpolated simple variable returns string value`() {
+            val substitution = SubstitutionImpl.empty(Resolver()).upsertStoreUsing(
+                originalValue = StringValue("(name:string)"),
+                runningValue = StringValue("John")
+            )
+
+            assertThat(substitution.substitute(StringValue("hello $(name)"))).isEqualTo(HasValue(StringValue("hello John")))
+        }
+
+        @Test
+        fun `value only path does not parse whole token values`() {
+            val resolver = Resolver(
+                newPatterns = mapOf(
+                    "(Orders)" to JSONArrayPattern(
+                        pattern = listOf(NumberPattern(), NumberPattern()),
+                        typeAlias = "(Orders)"
+                    )
+                )
+            )
+
+            val orders = JSONArrayValue(listOf(NumberValue(10), NumberValue(20)))
+            val substitution = SubstitutionImpl.empty(resolver).upsertStoreUsing(
+                originalValue = StringValue("(orders:Orders)"),
+                runningValue = StringValue(orders.toUnformattedString())
+            )
+
+            val result = substitution.substitute(StringValue("$(orders)"))
+            assertThat(result).isEqualTo(HasValue(orders))
+        }
+
+        @Test
+        fun `missing variable returns exception`() {
+            val result = SubstitutionImpl.empty(Resolver()).substitute(StringValue("$(missing)"))
+            assertThat(result).isInstanceOf(HasException::class.java)
+        }
+
+        @Test
+        fun `whole data lookup returns looked up value as is`() {
+            val substitution = lookupSubstitution(strictMode = true)
+            assertThat(substitution.substitute(StringValue("$(lookupData.dictionary[ID].payload)")))
+                .isEqualTo(HasValue(JSONObjectValue(mapOf("id" to NumberValue(10)))))
+        }
+
+        @Test
+        fun `interpolated data lookup returns string value`() {
+            val substitution = lookupSubstitution(strictMode = true)
+            assertThat(substitution.substitute(StringValue("hello $(lookupData.dictionary[ID].message)")))
+                .isEqualTo(HasValue(StringValue("hello resolved")))
+        }
+
+        @Test
+        fun `value only resolveIfLookup returns looked up value as is`() {
+            val substitution = lookupSubstitution(strictMode = true)
+            assertThat(substitution.resolveIfLookup(StringValue("$(lookupData.dictionary[ID].payload)")))
+                .isEqualTo(JSONObjectValue(mapOf("id" to NumberValue(10))))
+        }
+
+        @Test
+        fun `pattern aware substitution still parses through pattern`() {
+            val substitution = SubstitutionImpl.empty(Resolver()).upsertStoreUsing(
+                originalValue = StringValue("(id:number)"),
+                runningValue = NumberValue(10)
+            )
+
+            assertThat(substitution.substitute(StringValue("$(id)"), StringPattern(), null))
+                .isEqualTo(HasValue(StringValue("10")))
+        }
+    }
+
+    @Nested
     inner class LenientMode {
         @Test
         fun `simple variable missing uses pattern generate`() {
@@ -424,8 +538,11 @@ class SubstitutionImplTest {
                     mapOf(
                         "dictionary" to JSONObjectValue(
                             mapOf(
-                                "present" to JSONObjectValue(
-                                    mapOf("message" to StringValue("resolved"))
+                                "1" to JSONObjectValue(
+                                    mapOf(
+                                        "message" to StringValue("resolved"),
+                                        "payload" to JSONObjectValue(mapOf("id" to NumberValue(10)))
+                                    )
                                 )
                             )
                         )

--- a/core/src/test/kotlin/io/specmatic/core/substitution/SubstitutionImplTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/substitution/SubstitutionImplTest.kt
@@ -1,10 +1,13 @@
 package io.specmatic.core.substitution
 
+import io.specmatic.core.Dictionary
 import io.specmatic.core.HttpRequest
+import io.specmatic.core.KeyWithPattern
 import io.specmatic.core.Resolver
 import io.specmatic.core.Substitution
 import io.specmatic.core.pattern.HasException
 import io.specmatic.core.pattern.HasValue
+import io.specmatic.core.pattern.ExactValuePattern
 import io.specmatic.core.pattern.NumberPattern
 import io.specmatic.core.pattern.StringPattern
 import io.specmatic.core.pattern.parsedValue
@@ -12,6 +15,7 @@ import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.NumberValue
 import io.specmatic.core.value.StringValue
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class SubstitutionImplTest {
@@ -79,7 +83,7 @@ class SubstitutionImplTest {
     @Test
     fun `upsertStoreUsing returns new substitution and keeps original unchanged`() {
         val resolver = Resolver()
-        val original = SubstitutionImpl.empty(resolver)
+        val original = SubstitutionImpl.empty(resolver, strictMode = true)
 
         val updated = original.upsertStoreUsing(
             originalValue = StringValue("(ID:number)"),
@@ -275,15 +279,121 @@ class SubstitutionImplTest {
         assertThat((result as HasValue<*>).value).isEqualTo(StringValue("one-two"))
     }
 
-    @Test
-    fun `interpolated lookup returns exception when missing`() {
-        val result = SubstitutionImpl.empty(Resolver()).substitute(
-            value = StringValue("order-$(MISSING)"),
-            pattern = StringPattern(),
-            key = null
-        )
+    @Nested
+    inner class LenientMode {
+        @Test
+        fun `simple variable missing uses pattern generate`() {
+            val result = substitution(strictMode = false).substitute(
+                value = StringValue("$(MISSING_VAR)"),
+                pattern = ExactValuePattern(StringValue("generated")),
+                key = null
+            )
 
-        assertThat(result).isInstanceOf(HasException::class.java)
+            assertThat(result).isInstanceOf(HasValue::class.java)
+            assertThat((result as HasValue<*>).value).isEqualTo(StringValue("generated"))
+        }
+
+        @Test
+        fun `parse failure falls back to pattern generate`() {
+            val result = substitutionWithResolvedVariable(strictMode = false).substitute(
+                value = StringValue("$(ID)"),
+                pattern = NumberPattern(),
+                key = null
+            )
+
+            assertThat(result).isInstanceOf(HasValue::class.java)
+            assertThat((result as HasValue<*>).value).isInstanceOf(NumberValue::class.java)
+        }
+
+        @Test
+        fun `data lookup missing uses pattern generate`() {
+            val result = lookupSubstitution(strictMode = false).substitute(
+                value = StringValue("$(lookupData.dictionary[MISSING_VAR].message)"),
+                pattern = ExactValuePattern(StringValue("generated")),
+                key = null
+            )
+
+            assertThat(result).isInstanceOf(HasValue::class.java)
+            assertThat((result as HasValue<*>).value).isEqualTo(StringValue("generated"))
+        }
+
+        @Test
+        fun `pattern generation should use dictionary if present`() {
+            val resolver = Resolver(dictionary = Dictionary.fromYaml("""{Object: {Key: 123456}}"""))
+            val updatedResolver = resolver.updateLookupPath("(Object)", KeyWithPattern("Key", NumberPattern()))
+            val result = substitution(strictMode = false, resolver = updatedResolver).substitute(
+                key = null,
+                pattern = NumberPattern(),
+                value = StringValue("$(MISSING_VAR)"),
+            )
+
+            assertThat(result).isInstanceOf(HasValue::class.java)
+            assertThat((result as HasValue<*>).value).isEqualTo(NumberValue(123456))
+        }
+    }
+
+    @Nested
+    inner class StrictMode {
+        @Test
+        fun `missing simple variable returns exception`() {
+            val result = substitution(strictMode = true).substitute(
+                value = StringValue("order-$(MISSING)"),
+                pattern = StringPattern(),
+                key = null
+            )
+
+            assertThat(result).isInstanceOf(HasException::class.java)
+        }
+
+        @Test
+        fun `missing simple variable in exact pattern returns exception`() {
+            val result = substitution(strictMode = true).substitute(
+                value = StringValue("$(MISSING_VAR)"),
+                pattern = ExactValuePattern(StringValue("generated")),
+                key = null
+            )
+
+            assertThat(result).isInstanceOf(HasException::class.java)
+            assertThat((result as HasException).t.message).contains("no variable by the name MISSING_VAR")
+        }
+
+        @Test
+        fun `parse failure returns exception`() {
+            val result = substitutionWithResolvedVariable(strictMode = true).substitute(
+                value = StringValue("$(ID)"),
+                pattern = NumberPattern(),
+                key = null
+            )
+
+            assertThat(result).isInstanceOf(HasException::class.java)
+        }
+
+        @Test
+        fun `data lookup missing returns exception`() {
+            val result = lookupSubstitution(strictMode = true).substitute(
+                value = StringValue("$(lookupData.dictionary[MISSING_VAR].message)"),
+                pattern = ExactValuePattern(StringValue("generated")),
+                key = null
+            )
+
+            assertThat(result).isInstanceOf(HasException::class.java)
+        }
+
+        @Test
+        fun `upsertStoreUsing preserves strict mode`() {
+            val substitution = SubstitutionImpl.empty(Resolver(), strictMode = true).upsertStoreUsing(
+                originalValue = StringValue("(ID:number)"),
+                runningValue = NumberValue(10)
+            )
+
+            val result = substitution.substitute(
+                value = StringValue("$(MISSING_VAR)"),
+                pattern = ExactValuePattern(StringValue("generated")),
+                key = null
+            )
+
+            assertThat(result).isInstanceOf(HasException::class.java)
+        }
     }
 
     private fun assertResolvedValue(substitution: Substitution, lookup: String, expectedValue: NumberValue) {
@@ -291,4 +401,37 @@ class SubstitutionImplTest {
         assertThat(result).isInstanceOf(HasValue::class.java)
         assertThat((result as HasValue<*>).value).isEqualTo(expectedValue)
     }
+
+    private fun substitution(strictMode: Boolean, resolver: Resolver = Resolver()): SubstitutionImpl {
+        return SubstitutionImpl.empty(resolver, strictMode = strictMode)
+    }
+
+    private fun substitutionWithResolvedVariable(strictMode: Boolean): SubstitutionImpl {
+        return SubstitutionImpl.empty(Resolver(), strictMode = strictMode).upsertStoreUsing(
+            originalValue = StringValue("(ID:string)"),
+            runningValue = StringValue("not-a-number")
+        )
+    }
+
+    private fun lookupSubstitution(strictMode: Boolean): SubstitutionImpl = SubstitutionImpl.from(
+        resolver = Resolver(),
+        strictMode = strictMode,
+        runningRequest = HttpRequest(method = "POST", path = "/orders/1"),
+        originalRequest = HttpRequest(method = "POST", path = "/orders/(ID:string)"),
+        data = JSONObjectValue(
+            mapOf(
+                "lookupData" to JSONObjectValue(
+                    mapOf(
+                        "dictionary" to JSONObjectValue(
+                            mapOf(
+                                "present" to JSONObjectValue(
+                                    mapOf("message" to StringValue("resolved"))
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        ),
+    )
 }

--- a/core/src/test/kotlin/io/specmatic/core/substitution/SubstitutionVariableExtractorTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/substitution/SubstitutionVariableExtractorTest.kt
@@ -1,6 +1,9 @@
 package io.specmatic.core.substitution
 
+import io.specmatic.core.Resolver
+import io.specmatic.core.pattern.NumberPattern
 import io.specmatic.core.value.JSONArrayValue
+import io.specmatic.core.value.BooleanValue
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.NumberValue
 import io.specmatic.core.value.StringValue
@@ -23,7 +26,7 @@ class SubstitutionVariableExtractorTest {
                     runningValue = StringValue("10")
                 )
 
-                assertThat(result).isEqualTo(mapOf("ID" to "10"))
+                assertThat(result).isEqualTo(mapOf("ID" to NumberValue(10)))
             }
 
             @Test
@@ -33,7 +36,7 @@ class SubstitutionVariableExtractorTest {
                     runningValue = NumberValue(10)
                 )
 
-                assertThat(result).isEqualTo(mapOf("ID" to "10"))
+                assertThat(result).isEqualTo(mapOf("ID" to NumberValue(10)))
             }
 
             @Test
@@ -68,7 +71,7 @@ class SubstitutionVariableExtractorTest {
                     )
                 )
 
-                assertThat(result).isEqualTo(mapOf("ID" to "10"))
+                assertThat(result).isEqualTo(mapOf("ID" to NumberValue(10)))
             }
 
             @Test
@@ -86,7 +89,7 @@ class SubstitutionVariableExtractorTest {
                     )
                 )
 
-                assertThat(result).isEqualTo(mapOf("ORDER_ID" to "123"))
+                assertThat(result).isEqualTo(mapOf("ORDER_ID" to NumberValue(123)))
             }
 
             @Test
@@ -141,7 +144,7 @@ class SubstitutionVariableExtractorTest {
                     runningValue = JSONArrayValue(listOf(NumberValue(10)))
                 )
 
-                assertThat(result).isEqualTo(mapOf("ID" to "10"))
+                assertThat(result).isEqualTo(mapOf("ID" to NumberValue(10)))
             }
 
             @Test
@@ -151,7 +154,7 @@ class SubstitutionVariableExtractorTest {
                     runningValue = JSONArrayValue(listOf(StringValue("order-123")))
                 )
 
-                assertThat(result).isEqualTo(mapOf("ORDER_ID" to "123"))
+                assertThat(result).isEqualTo(mapOf("ORDER_ID" to NumberValue(123)))
             }
 
             @Test
@@ -195,7 +198,7 @@ class SubstitutionVariableExtractorTest {
                     runningValue = JSONArrayValue(listOf(NumberValue(10)))
                 )
 
-                assertThat(result).isEqualTo(mapOf("FIRST" to "10"))
+                assertThat(result).isEqualTo(mapOf("FIRST" to NumberValue(10)))
             }
         }
 
@@ -208,7 +211,7 @@ class SubstitutionVariableExtractorTest {
                     runningValue = StringValue("order-123")
                 )
 
-                assertThat(result).isEqualTo(mapOf("ORDER_ID" to "123"))
+                assertThat(result).isEqualTo(mapOf("ORDER_ID" to NumberValue(123)))
             }
 
             @Test
@@ -218,7 +221,7 @@ class SubstitutionVariableExtractorTest {
                     runningValue = StringValue("order-123-item-456")
                 )
 
-                assertThat(result).isEqualTo(mapOf("ORDER_ID" to "123", "ITEM_ID" to "456"))
+                assertThat(result).isEqualTo(mapOf("ORDER_ID" to NumberValue(123), "ITEM_ID" to NumberValue(456)))
             }
 
             @Test
@@ -263,6 +266,54 @@ class SubstitutionVariableExtractorTest {
                 }.isInstanceOf(ContractException::class.java)
                     .hasMessageContaining("Conflicting extracted values")
             }
+
+            @Test
+            fun `falls back to string value when typed parse fails`() {
+                val result = SubstitutionVariableExtractor.fromValues(
+                    originalValue = StringValue("(ID:number)"),
+                    runningValue = StringValue("abc")
+                )
+
+                assertThat(result).isEqualTo(mapOf("ID" to StringValue("abc")))
+            }
+        }
+
+        @Nested
+        inner class ResolverAware {
+            @Test
+            fun `parses built in boolean through resolver backed extraction`() {
+                val result = SubstitutionVariableExtractor.fromValues(
+                    originalValue = JSONObjectValue(mapOf("active" to StringValue("(ACTIVE:boolean)"))),
+                    runningValue = JSONObjectValue(mapOf("active" to StringValue("true"))),
+                    resolver = Resolver()
+                )
+
+                assertThat(result).isEqualTo(mapOf("ACTIVE" to BooleanValue(true)))
+            }
+
+            @Test
+            fun `parses custom resolver type not in built ins`() {
+                val resolver = Resolver(newPatterns = mapOf("(special)" to NumberPattern()))
+                val result = SubstitutionVariableExtractor.fromValues(
+                    originalValue = JSONArrayValue(listOf(StringValue("(ID:special)"))),
+                    runningValue = JSONArrayValue(listOf(NumberValue(10))),
+                    resolver = resolver
+                )
+
+                assertThat(result).isEqualTo(mapOf("ID" to NumberValue(10)))
+            }
+
+            @Test
+            fun `falls back to string when custom resolver type parse fails`() {
+                val resolver = Resolver(newPatterns = mapOf("(special)" to NumberPattern()))
+                val result = SubstitutionVariableExtractor.fromValues(
+                    originalValue = StringValue("(ID:special)"),
+                    runningValue = StringValue("abc"),
+                    resolver = resolver
+                )
+
+                assertThat(result).isEqualTo(mapOf("ID" to StringValue("abc")))
+            }
         }
 
         @Test
@@ -282,7 +333,7 @@ class SubstitutionVariableExtractorTest {
                 )
             )
 
-            assertThat(result).isEqualTo(mapOf("ID" to "20"))
+            assertThat(result).isEqualTo(mapOf("ID" to NumberValue(20)))
         }
     }
 
@@ -295,7 +346,7 @@ class SubstitutionVariableExtractorTest {
                 runningMap = mapOf("X-ID" to "10")
             )
 
-            assertThat(result).isEqualTo(mapOf("ID" to "10"))
+            assertThat(result).isEqualTo(mapOf("ID" to NumberValue(10)))
         }
 
         @Test
@@ -305,7 +356,7 @@ class SubstitutionVariableExtractorTest {
                 runningMap = mapOf("X-ID" to "order-10")
             )
 
-            assertThat(result).isEqualTo(mapOf("ID" to "10"))
+            assertThat(result).isEqualTo(mapOf("ID" to NumberValue(10)))
         }
 
         @Test
@@ -329,7 +380,7 @@ class SubstitutionVariableExtractorTest {
                 runningPath = "/orders/123"
             )
 
-            assertThat(result).isEqualTo(mapOf("ORDER_ID" to "123"))
+            assertThat(result).isEqualTo(mapOf("ORDER_ID" to NumberValue(123)))
         }
 
         @Test
@@ -339,7 +390,7 @@ class SubstitutionVariableExtractorTest {
                 runningPath = "/orders/order-123"
             )
 
-            assertThat(result).isEqualTo(mapOf("ORDER_ID" to "123"))
+            assertThat(result).isEqualTo(mapOf("ORDER_ID" to NumberValue(123)))
         }
 
         @Test

--- a/core/src/test/kotlin/io/specmatic/core/value/fold/ValueVisitorContextTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/value/fold/ValueVisitorContextTest.kt
@@ -1,0 +1,156 @@
+package io.specmatic.core.value.fold
+
+import io.specmatic.core.value.StringValue
+import io.specmatic.core.value.Value
+import io.specmatic.core.value.XMLNode
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+internal class ValueVisitorContextTest {
+    @Nested
+    inner class UnitContext {
+        @Test
+        fun `value can be visited with unit context`() {
+            val result = UnknownValue().accept(object : ValueVisitor<Unit, String> {
+                override val rootContext: Unit = Unit
+
+                override fun opaque(case: OpaqueValueCase<out Value, Unit>): String {
+                    return "opaque:${case.kind}"
+                }
+            })
+
+            assertThat(result).isEqualTo("opaque:UnknownValue")
+        }
+    }
+
+    @Nested
+    inner class PathAwareContext {
+        @Test
+        fun `projection helpers derive child path context through visitor hooks`() {
+            val value = FakeObjectValue(
+                rawFields = listOf(
+                    Field("id", LeafValue("10")),
+                    Field(
+                        "items",
+                        FakeListValue(
+                            rawItems = listOf(
+                                Item(0, LeafValue("a")),
+                                Item(1, LeafValue("b"))
+                            )
+                        )
+                    )
+                )
+            )
+
+            val result = value.accept(PathTraceVisitor())
+
+            assertThat(result).containsExactly(
+                "object:[]",
+                "field:id",
+                "leaf:10:[Field(name=id)]",
+                "field:items",
+                "list:[Field(name=items)]",
+                "item:0",
+                "leaf:a:[Field(name=items), Index(index=0)]",
+                "item:1",
+                "leaf:b:[Field(name=items), Index(index=1)]"
+            )
+        }
+
+        @Test
+        fun `xml attribute and child projection use dedicated xml hooks`() {
+            val value = XMLNode(
+                realName = "root",
+                attributes = mapOf("lang" to StringValue("en")),
+                childNodes = listOf(StringValue("hello"))
+            )
+
+            val result = value.accept(PathTraceVisitor())
+
+            assertThat(result).containsExactly(
+                "xml:[]",
+                "attr:lang",
+                "leaf:en:[XmlAttribute(name=lang)]",
+                "xmlChild:0",
+                "leaf:hello:[XmlChild(index=0)]"
+            )
+        }
+    }
+
+    @Nested
+    inner class CustomContext {
+        @Test
+        fun `projection helpers can update non path context`() {
+            val value = FakeObjectValue(
+                rawFields = listOf(
+                    Field(
+                        "nested",
+                        FakeListValue(
+                            rawItems = listOf(Item(0, LeafValue("a")))
+                        )
+                    )
+                )
+            )
+
+            val result = value.accept(object : ValueVisitor<DepthContext, List<String>> {
+                override val rootContext: DepthContext = DepthContext(level = 0, trail = "root")
+
+                override fun opaque(case: OpaqueValueCase<out Value, DepthContext>): List<String> {
+                    return listOf("${case.value.toStringLiteral()}@${case.context.level}:${case.context.trail}")
+                }
+
+                override fun fieldObject(case: FieldObjectValueCase<out Value, DepthContext>): List<String> {
+                    return listOf("object@${case.context.level}") + case.projectFields(this).flatMap(Field<List<String>>::value)
+                }
+
+                override fun indexedList(case: IndexedListValueCase<out Value, DepthContext>): List<String> {
+                    return listOf("list@${case.context.level}") + case.projectItems(this).flatMap(Item<List<String>>::value)
+                }
+
+                override fun contextForField(currentContext: DepthContext, name: String): DepthContext {
+                    return currentContext.child("field:$name")
+                }
+
+                override fun contextForIndex(currentContext: DepthContext, index: Int): DepthContext {
+                    return currentContext.child("index:$index")
+                }
+            })
+
+            assertThat(result).containsExactly(
+                "object@0",
+                "list@1",
+                "a@2:index:0"
+            )
+        }
+
+        @Test
+        fun `manual traversal can use contextForOpaque`() {
+            val value = FakeObjectValue(
+                rawFields = listOf(
+                    Field("leaf", UnknownValue())
+                )
+            )
+
+            val result = value.accept(object : ValueVisitor<DepthContext, List<String>> {
+                override val rootContext: DepthContext = DepthContext(level = 0, trail = "root")
+
+                override fun opaque(case: OpaqueValueCase<out Value, DepthContext>): List<String> {
+                    return listOf("${case.kind}@${case.context.level}:${case.context.trail}")
+                }
+
+                override fun fieldObject(case: FieldObjectValueCase<out Value, DepthContext>): List<String> {
+                    return case.fields().flatMap { field ->
+                        field.value.accept(this, contextForOpaque(case.context, field.name))
+                    }
+                }
+
+                override fun contextForOpaque(currentContext: DepthContext, name: String): DepthContext {
+                    return currentContext.child("opaque:$name")
+                }
+            })
+
+            assertThat(result).containsExactly("UnknownValue@1:opaque:leaf")
+        }
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/value/fold/ValueVisitorProjectionTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/value/fold/ValueVisitorProjectionTest.kt
@@ -1,0 +1,139 @@
+package io.specmatic.core.value.fold
+
+import io.specmatic.core.value.Value
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+internal class ValueVisitorProjectionTest {
+    @Nested
+    inner class GenericCases {
+        @Test
+        fun `scalar value carries visitor owned context`() {
+            val result = TestScalarValue(10).accept(
+                visitor = object : ValueVisitor<DepthContext, String> {
+                    override val rootContext: DepthContext = DepthContext(level = 0, trail = "root")
+
+                    override fun opaque(case: OpaqueValueCase<out Value, DepthContext>): String = "opaque"
+
+                    override fun scalar(case: ScalarValueCase<out Value, DepthContext>): String {
+                        return "${case.nativeValue}@${case.context.trail}"
+                    }
+                }
+            )
+
+            assertThat(result).isEqualTo("10@root")
+        }
+
+        @Test
+        fun `text case keeps replacement behavior`() {
+            val replaced = io.specmatic.core.value.StringValue("hello").accept(
+                visitor = object : ValueVisitor<Unit, Value> {
+                    override val rootContext: Unit = Unit
+
+                    override fun opaque(case: OpaqueValueCase<out Value, Unit>): Value = case.value
+
+                    override fun text(case: TextValueCase<out Value, Unit>): Value {
+                        return case.replaceText(case.text.uppercase())
+                    }
+                }
+            )
+
+            assertThat(replaced).isEqualTo(io.specmatic.core.value.StringValue("HELLO"))
+        }
+    }
+
+    @Nested
+    inner class RawChildAccess {
+        @Test
+        fun `field object exposes raw children without recursion`() {
+            var childVisits = 0
+            val value = FakeObjectValue(
+                rawFields = listOf(
+                    Field("id", CountingValue { childVisits++ }),
+                    Field("name", CountingValue { childVisits++ })
+                )
+            )
+
+            val result = value.accept(object : ValueVisitor<Unit, List<String>> {
+                override val rootContext: Unit = Unit
+
+                override fun opaque(case: OpaqueValueCase<out Value, Unit>): List<String> = emptyList()
+
+                override fun fieldObject(case: FieldObjectValueCase<out Value, Unit>): List<String> {
+                    return case.fields().map(Field<Value>::name)
+                }
+            })
+
+            assertThat(result).containsExactly("id", "name")
+            assertThat(childVisits).isZero()
+        }
+
+        @Test
+        fun `indexed list exposes raw children without recursion`() {
+            var childVisits = 0
+            val value = FakeListValue(
+                rawItems = listOf(
+                    Item(0, CountingValue { childVisits++ }),
+                    Item(1, CountingValue { childVisits++ })
+                )
+            )
+
+            val result = value.accept(object : ValueVisitor<Unit, List<Int>> {
+                override val rootContext: Unit = Unit
+
+                override fun opaque(case: OpaqueValueCase<out Value, Unit>): List<Int> = emptyList()
+
+                override fun indexedList(case: IndexedListValueCase<out Value, Unit>): List<Int> {
+                    return case.items().map(Item<Value>::index)
+                }
+            })
+
+            assertThat(result).containsExactly(0, 1)
+            assertThat(childVisits).isZero()
+        }
+    }
+
+    @Nested
+    inner class ProjectionHelpers {
+        @Test
+        fun `projection helpers keep recursive conversion ergonomic`() {
+            val value = FakeObjectValue(
+                rawFields = listOf(
+                    Field("name", LeafValue("Jane")),
+                    Field(
+                        "items",
+                        FakeListValue(
+                            rawItems = listOf(
+                                Item(0, LeafValue("a")),
+                                Item(1, LeafValue("b"))
+                            )
+                        )
+                    )
+                )
+            )
+
+            val result = value.accept(object : ValueVisitor<Unit, String> {
+                override val rootContext: Unit = Unit
+
+                override fun opaque(case: OpaqueValueCase<out Value, Unit>): String {
+                    return case.value.toStringLiteral()
+                }
+
+                override fun fieldObject(case: FieldObjectValueCase<out Value, Unit>): String {
+                    return case.projectFields(this).joinToString(prefix = "{", postfix = "}") {
+                        "${it.name}=${it.value}"
+                    }
+                }
+
+                override fun indexedList(case: IndexedListValueCase<out Value, Unit>): String {
+                    return case.projectItems(this).joinToString(prefix = "[", postfix = "]") {
+                        "${it.index}:${it.value}"
+                    }
+                }
+            })
+
+            assertThat(result).isEqualTo("{name=Jane, items=[0:a, 1:b]}")
+        }
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/value/fold/ValueVisitorTestSupport.kt
+++ b/core/src/test/kotlin/io/specmatic/core/value/fold/ValueVisitorTestSupport.kt
@@ -1,0 +1,148 @@
+package io.specmatic.core.value.fold
+
+import io.specmatic.core.ExampleDeclarations
+import io.specmatic.core.NoBodyValue
+import io.specmatic.core.pattern.Pattern
+import io.specmatic.core.pattern.StringPattern
+import io.specmatic.core.value.ScalarValue
+import io.specmatic.core.value.TypeDeclaration
+import io.specmatic.core.value.Value
+import io.specmatic.core.value.XMLValue
+
+sealed interface ValuePathSegment {
+    data class Field(val name: String) : ValuePathSegment
+    data class Index(val index: Int) : ValuePathSegment
+    data class XmlChild(val index: Int) : ValuePathSegment
+    data class XmlAttribute(val name: String) : ValuePathSegment
+}
+
+internal data class BreadcrumbContext(val path: List<ValuePathSegment> = emptyList()) {
+    fun append(segment: ValuePathSegment): BreadcrumbContext = copy(path = path + segment)
+}
+
+internal data class DepthContext(val level: Int, val trail: String) {
+    fun child(trail: String): DepthContext = copy(level = level + 1, trail = trail)
+}
+
+internal class PathTraceVisitor : ValueVisitor<BreadcrumbContext, List<String>> {
+    override val rootContext: BreadcrumbContext = BreadcrumbContext()
+
+    override fun opaque(case: OpaqueValueCase<out Value, BreadcrumbContext>): List<String> {
+        return listOf("leaf:${case.value.toStringLiteral()}:${case.context.path}")
+    }
+
+    override fun fieldObject(case: FieldObjectValueCase<out Value, BreadcrumbContext>): List<String> {
+        return listOf("object:${case.context.path}") + case.projectFields(this).flatMap { field ->
+            listOf("field:${field.name}") + field.value
+        }
+    }
+
+    override fun indexedList(case: IndexedListValueCase<out Value, BreadcrumbContext>): List<String> {
+        return listOf("list:${case.context.path}") + case.projectItems(this).flatMap { item ->
+            listOf("item:${item.index}") + item.value
+        }
+    }
+
+    override fun xmlElement(case: XmlElementValueCase<out XMLValue, BreadcrumbContext>): List<String> {
+        return listOf("xml:${case.context.path}") +
+            case.projectAttributes(this).flatMap { attribute ->
+                listOf("attr:${attribute.name}") + attribute.value
+            } +
+            case.projectChildren(this).flatMap { child ->
+                listOf("xmlChild:${child.index}") + child.value
+            }
+    }
+
+    override fun contextForField(currentContext: BreadcrumbContext, name: String): BreadcrumbContext {
+        return currentContext.append(ValuePathSegment.Field(name))
+    }
+
+    override fun contextForIndex(currentContext: BreadcrumbContext, index: Int): BreadcrumbContext {
+        return currentContext.append(ValuePathSegment.Index(index))
+    }
+
+    override fun contextForXmlChild(currentContext: BreadcrumbContext, index: Int): BreadcrumbContext {
+        return currentContext.append(ValuePathSegment.XmlChild(index))
+    }
+
+    override fun contextForXmlAttribute(currentContext: BreadcrumbContext, name: String): BreadcrumbContext {
+        return currentContext.append(ValuePathSegment.XmlAttribute(name))
+    }
+}
+
+internal class UnknownValue : BaseTestValue("unknown")
+
+internal class LeafValue(rendered: String) : BaseTestValue(rendered)
+
+internal class CountingValue(private val onVisit: () -> Unit) : BaseTestValue("counting") {
+    override fun <C, R> accept(visitor: ValueVisitor<C, R>, context: C): R {
+        onVisit()
+        return visitor.opaque(OpaqueValueCase(this, context))
+    }
+}
+
+internal class TestScalarValue(private val number: Int) : BaseTestValue(number.toString()), ScalarValue {
+    override val nativeValue: Any = number
+
+    override fun alterValue(): ScalarValue = TestScalarValue(number + 1)
+}
+
+internal class FakeObjectValue(private val rawFields: List<Field<Value>>) : BaseTestValue("object") {
+    override fun <C, R> accept(visitor: ValueVisitor<C, R>, context: C): R {
+        return visitor.fieldObject(
+            FieldObjectValueCase(
+                value = this,
+                context = context,
+                fields = { rawFields },
+                rebuild = { fields -> FakeObjectValue(fields) }
+            )
+        )
+    }
+}
+
+internal class FakeListValue(private val rawItems: List<Item<Value>>) : BaseTestValue("list") {
+    override fun <C, R> accept(visitor: ValueVisitor<C, R>, context: C): R {
+        return visitor.indexedList(
+            IndexedListValueCase(
+                value = this,
+                context = context,
+                items = { rawItems },
+                rebuild = { items -> FakeListValue(items) }
+            )
+        )
+    }
+}
+
+internal open class BaseTestValue(private val rendered: String) : Value {
+    override val httpContentType: String = "text/plain"
+
+    override fun displayableValue(): String = rendered
+
+    override fun toStringLiteral(): String = rendered
+
+    override fun displayableType(): String = rendered
+
+    override fun exactMatchElseType(): Pattern = StringPattern()
+
+    override fun type(): Pattern = StringPattern()
+
+    override fun typeDeclarationWithoutKey(
+        exampleKey: String,
+        types: Map<String, Pattern>,
+        exampleDeclarations: ExampleDeclarations
+    ): Pair<TypeDeclaration, ExampleDeclarations> {
+        return TypeDeclaration(rendered, types) to exampleDeclarations
+    }
+
+    override fun typeDeclarationWithKey(
+        key: String,
+        types: Map<String, Pattern>,
+        exampleDeclarations: ExampleDeclarations
+    ): Pair<TypeDeclaration, ExampleDeclarations> {
+        return TypeDeclaration(rendered, types) to exampleDeclarations
+    }
+
+    override fun listOf(valueList: List<Value>): Value = NoBodyValue
+
+    override fun specificity(): Int = 1
+}

--- a/core/src/test/kotlin/io/specmatic/core/value/fold/ValueVisitorTraversalControlTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/value/fold/ValueVisitorTraversalControlTest.kt
@@ -1,0 +1,33 @@
+package io.specmatic.core.value.fold
+
+import io.specmatic.core.value.Value
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class ValueVisitorTraversalControlTest {
+    @Test
+    fun `visitor can choose which children to traverse`() {
+        val value = FakeObjectValue(
+            rawFields = listOf(
+                Field("keep", LeafValue("yes")),
+                Field("skip", CountingValue { throw IllegalStateException("must not visit skipped child") })
+            )
+        )
+
+        val result = value.accept(object : ValueVisitor<Unit, List<String>> {
+            override val rootContext: Unit = Unit
+
+            override fun opaque(case: OpaqueValueCase<out Value, Unit>): List<String> {
+                return listOf(case.value.toStringLiteral())
+            }
+
+            override fun fieldObject(case: FieldObjectValueCase<out Value, Unit>): List<String> {
+                return case.fields().filter { it.name == "keep" }.flatMap { field ->
+                    field.value.accept(this).map { valueText -> "${field.name}=$valueText" }
+                }
+            }
+        })
+
+        assertThat(result).containsExactly("keep=yes")
+    }
+}


### PR DESCRIPTION
**What**: 
Updates substitutions to be lenient by default. When a substitution variable is missing, Specmatic now falls back to generating a value instead of failing immediately.


**Why**:
Substitution should be usable even when every variable is not explicitly provided. Falling back to generated values keeps substitution-based flows easier to use, while still allowing stricter validation when needed.
> The previous strict behavior is still available through `strictMode`

**Checklist**:

* [x] Unit Tests
* [ ] Build passing locally
* [ ] Sonar Quality Gate
* [ ] Security scans don't report any vulnerabilities
* [ ] Documentation added/updated (share link) N/A
* [ ] Sample Project added/updated (share link) N/A
* [ ] Demo video (share link) N/A
* [ ] Article on Website (share link) N/A
* [ ] Roadmap updated (share link) N/A
* [ ] Conference Talk (share link) N/A