### PR TITLE
Optimize WSDL choice-group parsing for XML patterns

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLChoiceGroupPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLChoiceGroupPattern.kt
@@ -277,41 +277,96 @@ data class XMLChoiceGroupPattern(
         otherResolver: Resolver,
         typeStack: TypeStack
     ): Result {
-        val mySequences = limitedConcretePatternSequences(thisResolver)
-        if (mySequences.isEmpty()) {
-            return Failure("Choice group had no valid expansions")
-        }
+        val otherResolvedPattern = resolvedHop(otherPattern, otherResolver)
 
-        val otherSequences = concretePatternSequencesFrom(otherPattern, otherResolver)
-
-        val results = otherSequences.map { otherSequence ->
-            mySequences.allows(otherSequence, otherPattern, thisResolver, otherResolver, typeStack)
-        }
-
-        return Result.fromResults(results)
+        return concreteSequence?.encompassesResolved(otherResolvedPattern, otherPattern, thisResolver, otherResolver, typeStack)
+            ?: encompassesResolved(otherResolvedPattern, otherPattern, thisResolver, otherResolver, typeStack)
     }
 
-    private fun limitedConcretePatternSequences(resolver: Resolver): List<List<Pattern>> {
-        return concretePatternSequences(resolver)
-            .take(resolver.maxTestRequestCombinations)
-            .toList()
-    }
+    private fun encompassesResolved(
+        otherResolvedPattern: Pattern,
+        otherPattern: Pattern,
+        thisResolver: Resolver,
+        otherResolver: Resolver,
+        typeStack: TypeStack
+    ): Result {
+        return when (otherResolvedPattern) {
+            is XMLChoiceGroupPattern -> when (val otherConcreteSequence = otherResolvedPattern.concreteSequence) {
+                null -> Result.fromResults(
+                    listOf(occurrenceRange.encompassesRange(otherResolvedPattern.occurrenceRange)) +
+                        choices.allowAll(otherResolvedPattern.choices, otherPattern, thisResolver, otherResolver, typeStack)
+                )
 
-    private fun concretePatternSequencesFrom(pattern: Pattern, resolver: Resolver): List<List<Pattern>> {
-        return when (val resolvedPattern = resolvedHop(pattern, resolver)) {
-            is XMLChoiceGroupPattern -> resolvedPattern.limitedConcretePatternSequences(resolver)
-            else -> listOf(listOf(resolvedPattern))
+                else -> Result.fromResults(
+                    listOf(occurrenceRange.encompassesRange(exactOccurrenceRange(otherConcreteSequence.size))) +
+                        otherConcreteSequence.map { otherSequence ->
+                            choices.allows(otherSequence, otherPattern, thisResolver, otherResolver, typeStack)
+                        }
+                )
+            }
+
+            else -> Result.fromResults(
+                listOf(occurrenceRange.encompassesRange(exactOccurrenceRange(1))) +
+                    listOf(choices.allows(listOf(otherResolvedPattern), otherPattern, thisResolver, otherResolver, typeStack))
+            )
         }
     }
 
-    private fun concretePatternSequences(resolver: Resolver): Sequence<List<Pattern>> {
-        if (concreteSequence != null) {
-            return sequenceOf(concreteSequence.flatten())
-        }
+    private fun List<List<Pattern>>.encompassesResolved(
+        otherResolvedPattern: Pattern,
+        otherPattern: Pattern,
+        thisResolver: Resolver,
+        otherResolver: Resolver,
+        typeStack: TypeStack
+    ): Result {
+        return when (otherResolvedPattern) {
+            is XMLChoiceGroupPattern -> when (val otherConcreteSequence = otherResolvedPattern.concreteSequence) {
+                null -> Result.fromResults(
+                    listOf(exactOccurrenceRange(size).encompassesExactly(otherResolvedPattern.occurrenceRange)) +
+                        map { mySequence ->
+                            mySequence.allowsAll(otherResolvedPattern.choices, otherPattern, thisResolver, otherResolver, typeStack)
+                        }
+                )
 
-        return newBasedOn(resolver)
-            .filterIsInstance<XMLChoiceGroupPattern>()
-            .mapNotNull { it.concreteSequence?.flatten() }
+                else -> allowsConcreteSequence(otherConcreteSequence, thisResolver, otherResolver, typeStack)
+            }
+
+            else -> when {
+                size != 1 -> Failure("Choice branch length $size does not encompass 1")
+                else -> single().allowsSequence(listOf(otherResolvedPattern), thisResolver, otherResolver, typeStack)
+            }
+        }
+    }
+
+    private val occurrenceRange: XMLOccurrenceRange
+        get() = XMLOccurrenceRange(minOccurs, maxOccurs)
+
+    private fun exactOccurrenceRange(count: Int): XMLOccurrenceRange = XMLOccurrenceRange(count, count)
+
+    private fun XMLOccurrenceRange.encompassesRange(other: XMLOccurrenceRange): Result {
+        return when {
+            encompasses(other) -> Success()
+            else -> Failure("Choice occurrence range $this does not encompass $other")
+        }
+    }
+
+    private fun XMLOccurrenceRange.encompassesExactly(other: XMLOccurrenceRange): Result {
+        return when {
+            this == other -> Success()
+            else -> Failure("Concrete choice occurrence range $this does not encompass $other")
+        }
+    }
+
+    private fun List<List<Pattern>>.allowAll(
+        otherChoices: List<List<Pattern>>,
+        otherPattern: Pattern,
+        thisResolver: Resolver,
+        otherResolver: Resolver,
+        typeStack: TypeStack
+    ): List<Result> {
+        return otherChoices.map { otherChoice ->
+            allows(otherChoice, otherPattern, thisResolver, otherResolver, typeStack)
+        }
     }
 
     private fun List<List<Pattern>>.allows(
@@ -323,27 +378,69 @@ data class XMLChoiceGroupPattern(
     ): Result {
         val successfulResult = asSequence()
             .map { mySequence ->
-                sequenceAllows(mySequence, otherSequence, thisResolver, otherResolver, typeStack)
+                mySequence.allowsSequence(otherSequence, thisResolver, otherResolver, typeStack)
             }.find { it is Success }
 
         return successfulResult ?: Failure("Choice group does not encompass ${otherPattern.typeName}")
     }
 
-    private fun sequenceAllows(
-        mySequence: List<Pattern>,
+    private fun List<List<Pattern>>.allowsConcreteSequence(
+        otherSequence: List<List<Pattern>>,
+        thisResolver: Resolver,
+        otherResolver: Resolver,
+        typeStack: TypeStack
+    ): Result {
+        if (size != otherSequence.size) {
+            return Failure("Choice branch length $size does not encompass ${otherSequence.size}")
+        }
+
+        val results = mapIndexed { index, mySequence ->
+            mySequence.allowsSequence(otherSequence[index], thisResolver, otherResolver, typeStack)
+        }
+
+        return Result.fromResults(results)
+    }
+
+    private fun List<Pattern>.allowsAll(
+        otherChoices: List<List<Pattern>>,
+        otherPattern: Pattern,
+        thisResolver: Resolver,
+        otherResolver: Resolver,
+        typeStack: TypeStack
+    ): Result {
+        val results = otherChoices.map { otherChoice ->
+            allowsSequence(otherChoice, thisResolver, otherResolver, typeStack)
+        }
+
+        return when (Result.fromResults(results)) {
+            is Success -> Success()
+            is Failure -> Failure("Choice group does not encompass ${otherPattern.typeName}")
+        }
+    }
+
+    private fun List<Pattern>.allowsSequence(
         otherSequence: List<Pattern>,
         thisResolver: Resolver,
         otherResolver: Resolver,
         typeStack: TypeStack
     ): Result {
-        if (mySequence.size != otherSequence.size) {
-            return Failure("Choice branch length ${mySequence.size} does not encompass ${otherSequence.size}")
+        val result = fold(ConsumeResult<Pattern, Pattern>(Success(), otherSequence)) { consumeResult, myPattern ->
+            when (consumeResult.result) {
+                is Failure -> consumeResult
+                is Success -> myPattern.encompasses(
+                    consumeResult.remainder,
+                    thisResolver,
+                    otherResolver,
+                    "Choice branch length $size does not encompass ${otherSequence.size}",
+                    typeStack
+                )
+            }
         }
 
-        val results = mySequence.mapIndexed { index, myPattern ->
-            myPattern.encompasses(otherSequence[index], thisResolver, otherResolver, typeStack)
+        return when {
+            result.result is Failure -> result.result
+            result.remainder.isNotEmpty() -> Failure("Choice branch length $size does not encompass ${otherSequence.size}")
+            else -> Success()
         }
-
-        return Result.fromResults(results)
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLChoiceGroupPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLChoiceGroupPattern.kt
@@ -277,13 +277,55 @@ data class XMLChoiceGroupPattern(
         otherResolver: Resolver,
         typeStack: TypeStack
     ): Result {
-        val patterns = newBasedOn(thisResolver).take(thisResolver.maxTestRequestCombinations).toList()
-        if (patterns.isEmpty()) {
+        val theseSequences = concretePatternSequences(thisResolver)
+            .take(thisResolver.maxTestRequestCombinations)
+            .toList()
+        if (theseSequences.isEmpty()) {
             return Failure("Choice group had no valid expansions")
         }
 
-        return patterns.asSequence().map { pattern ->
-            pattern.encompasses(otherPattern, thisResolver, otherResolver, typeStack)
-        }.find { it is Success } ?: Failure("Choice group does not encompass ${otherPattern.typeName}")
+        val otherSequences =
+            when (val otherResolvedPattern = resolvedHop(otherPattern, otherResolver)) {
+                is XMLChoiceGroupPattern -> otherResolvedPattern.concretePatternSequences(otherResolver)
+                    .take(otherResolver.maxTestRequestCombinations)
+                    .toList()
+
+                else -> listOf(listOf(otherResolvedPattern))
+            }
+
+        val results = otherSequences.map { otherSequence ->
+            theseSequences.asSequence().map { thisSequence ->
+                thisSequence.encompasses(otherSequence, thisResolver, otherResolver, typeStack)
+            }.find { it is Success } ?: Failure("Choice group does not encompass ${otherPattern.typeName}")
+        }
+
+        return Result.fromResults(results)
+    }
+
+    private fun concretePatternSequences(resolver: Resolver): Sequence<List<Pattern>> {
+        if (concreteSequence != null) {
+            return sequenceOf(concreteSequence.flatten())
+        }
+
+        return newBasedOn(resolver)
+            .filterIsInstance<XMLChoiceGroupPattern>()
+            .mapNotNull { it.concreteSequence?.flatten() }
+    }
+
+    private fun List<Pattern>.encompasses(
+        otherSequence: List<Pattern>,
+        thisResolver: Resolver,
+        otherResolver: Resolver,
+        typeStack: TypeStack
+    ): Result {
+        if (size != otherSequence.size) {
+            return Failure("Choice branch length $size does not encompass ${otherSequence.size}")
+        }
+
+        val results = mapIndexed { index, thisPattern ->
+            thisPattern.encompasses(otherSequence[index], thisResolver, otherResolver, typeStack)
+        }
+
+        return Result.fromResults(results)
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLChoiceGroupPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLChoiceGroupPattern.kt
@@ -277,29 +277,31 @@ data class XMLChoiceGroupPattern(
         otherResolver: Resolver,
         typeStack: TypeStack
     ): Result {
-        val theseSequences = concretePatternSequences(thisResolver)
-            .take(thisResolver.maxTestRequestCombinations)
-            .toList()
-        if (theseSequences.isEmpty()) {
+        val mySequences = limitedConcretePatternSequences(thisResolver)
+        if (mySequences.isEmpty()) {
             return Failure("Choice group had no valid expansions")
         }
 
-        val otherSequences =
-            when (val otherResolvedPattern = resolvedHop(otherPattern, otherResolver)) {
-                is XMLChoiceGroupPattern -> otherResolvedPattern.concretePatternSequences(otherResolver)
-                    .take(otherResolver.maxTestRequestCombinations)
-                    .toList()
-
-                else -> listOf(listOf(otherResolvedPattern))
-            }
+        val otherSequences = concretePatternSequencesFrom(otherPattern, otherResolver)
 
         val results = otherSequences.map { otherSequence ->
-            theseSequences.asSequence().map { thisSequence ->
-                thisSequence.encompasses(otherSequence, thisResolver, otherResolver, typeStack)
-            }.find { it is Success } ?: Failure("Choice group does not encompass ${otherPattern.typeName}")
+            mySequences.allows(otherSequence, otherPattern, thisResolver, otherResolver, typeStack)
         }
 
         return Result.fromResults(results)
+    }
+
+    private fun limitedConcretePatternSequences(resolver: Resolver): List<List<Pattern>> {
+        return concretePatternSequences(resolver)
+            .take(resolver.maxTestRequestCombinations)
+            .toList()
+    }
+
+    private fun concretePatternSequencesFrom(pattern: Pattern, resolver: Resolver): List<List<Pattern>> {
+        return when (val resolvedPattern = resolvedHop(pattern, resolver)) {
+            is XMLChoiceGroupPattern -> resolvedPattern.limitedConcretePatternSequences(resolver)
+            else -> listOf(listOf(resolvedPattern))
+        }
     }
 
     private fun concretePatternSequences(resolver: Resolver): Sequence<List<Pattern>> {
@@ -312,18 +314,34 @@ data class XMLChoiceGroupPattern(
             .mapNotNull { it.concreteSequence?.flatten() }
     }
 
-    private fun List<Pattern>.encompasses(
+    private fun List<List<Pattern>>.allows(
+        otherSequence: List<Pattern>,
+        otherPattern: Pattern,
+        thisResolver: Resolver,
+        otherResolver: Resolver,
+        typeStack: TypeStack
+    ): Result {
+        val successfulResult = asSequence()
+            .map { mySequence ->
+                sequenceAllows(mySequence, otherSequence, thisResolver, otherResolver, typeStack)
+            }.find { it is Success }
+
+        return successfulResult ?: Failure("Choice group does not encompass ${otherPattern.typeName}")
+    }
+
+    private fun sequenceAllows(
+        mySequence: List<Pattern>,
         otherSequence: List<Pattern>,
         thisResolver: Resolver,
         otherResolver: Resolver,
         typeStack: TypeStack
     ): Result {
-        if (size != otherSequence.size) {
-            return Failure("Choice branch length $size does not encompass ${otherSequence.size}")
+        if (mySequence.size != otherSequence.size) {
+            return Failure("Choice branch length ${mySequence.size} does not encompass ${otherSequence.size}")
         }
 
-        val results = mapIndexed { index, thisPattern ->
-            thisPattern.encompasses(otherSequence[index], thisResolver, otherResolver, typeStack)
+        val results = mySequence.mapIndexed { index, myPattern ->
+            myPattern.encompasses(otherSequence[index], thisResolver, otherResolver, typeStack)
         }
 
         return Result.fromResults(results)

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLChoiceGroupPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLChoiceGroupPattern.kt
@@ -92,11 +92,16 @@ data class XMLChoiceGroupPattern(
         remaining: List<XMLValue>,
         resolver: Resolver
     ): ConsumeResult<Value, Value> {
-        return alternative.fold(ConsumeResult<Value, Value>(Success(), remaining)) { consumeResult, pattern ->
+        val matched = alternative.fold(ConsumeResult<Value, Value>(Success(), remaining)) { consumeResult, pattern ->
             when (consumeResult.result) {
                 is Failure -> consumeResult
                 else -> pattern.matches(consumeResult.remainder, resolver)
             }
+        }
+
+        return when (matched.result) {
+            is Failure -> matched.copy(remainder = remaining)
+            else -> matched
         }
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLChoiceGroupPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLChoiceGroupPattern.kt
@@ -15,16 +15,18 @@ data class XMLChoiceGroupPattern(
     val choices: List<List<Pattern>>,
     val minOccurs: Int = 1,
     val maxOccurs: Int? = 1,
-    val concreteSequence: List<List<Pattern>>? = null,
     override val typeAlias: String? = null
 ) : Pattern, SequenceType {
     override val pattern: Any
-        get() = concreteSequence ?: choices
+        get() = choices
 
     override val typeName: String = "xml-choice-group"
 
     override val memberList: MemberList
-        get() = MemberList(concreteSequence?.flatten() ?: choices.firstOrNull() ?: emptyList(), null)
+        get() = MemberList(
+            choices.firstOrNull() ?: emptyList(),
+            null
+        )
 
     override fun matches(sampleData: Value?, resolver: Resolver): Result {
         return when (sampleData) {
@@ -55,14 +57,12 @@ data class XMLChoiceGroupPattern(
             results += ConsumeResult(Success(), remaining)
         }
 
-        val maxReached = concreteSequence?.let { matchedCount >= it.size } ?: maxOccurs?.let { matchedCount >= it } ?: false
+        val maxReached = maxOccurs?.let { matchedCount >= it } ?: false
         if (maxReached) {
             return results
         }
 
-        val alternatives = concreteSequence?.let { listOf(it[matchedCount]) } ?: choices
-
-        alternatives.forEach { alternative ->
+        choices.forEach { alternative ->
             val matchedAlternative = matchAlternative(alternative, remaining, resolver)
             when (matchedAlternative.result) {
                 is Success -> {
@@ -106,8 +106,7 @@ data class XMLChoiceGroupPattern(
     }
 
     override fun generate(resolver: Resolver): Value {
-        val occurrences = concreteSequence ?: generateOccurrenceSequence(resolver)
-        val generatedNodes = occurrences.flatMap { alternative ->
+        val generatedNodes = generateOccurrenceSequence(resolver).flatMap { alternative ->
             alternative.flatMap { pattern ->
                 if (pattern.hasXMLChoiceReferenceCycle(resolver)) {
                     return@flatMap emptyList()
@@ -161,17 +160,13 @@ data class XMLChoiceGroupPattern(
     private fun XMLPattern.hasTypeReference(): Boolean = referredType != null
 
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
-        if (concreteSequence != null) {
-            return sequenceOf(HasValue(this))
-        }
-
-        return concreteSequences { alternative ->
+        return materializedSequences { alternative ->
             listCombinations(
                 alternative.map { pattern ->
                     HasValue(pattern.newBasedOnXMLChoice(row, resolver))
                 }
             ).map { it.value }
-        }.map { HasValue(copy(concreteSequence = it)) }
+        }.map { HasValue(materialized(it)) }
     }
 
     override fun negativeBasedOn(
@@ -181,17 +176,13 @@ data class XMLChoiceGroupPattern(
     ): Sequence<ReturnValue<Pattern>> = emptySequence()
 
     override fun newBasedOn(resolver: Resolver): Sequence<Pattern> {
-        if (concreteSequence != null) {
-            return sequenceOf(this)
-        }
-
-        return concreteSequences { alternative ->
+        return materializedSequences { alternative ->
             listCombinations(
                 alternative.map { pattern ->
                     HasValue(pattern.newBasedOnXMLChoice(resolver))
                 }
             ).map { it.value }
-        }.map { copy(concreteSequence = it) }
+        }.map(::materialized)
     }
 
     private fun Pattern.newBasedOnXMLChoice(row: Row, resolver: Resolver): Sequence<Pattern?> {
@@ -220,21 +211,26 @@ data class XMLChoiceGroupPattern(
         } ?: sequenceOf(null)
     }
 
-    private fun concreteSequences(
+    private fun materialized(selectedChoices: List<List<Pattern>>): Pattern =
+        XMLSequencePattern(selectedChoices.flatten())
+
+    private fun materializedSequences(
         expandAlternative: (List<Pattern>) -> Sequence<List<Pattern>>
     ): Sequence<List<List<Pattern>>> {
-        val counts = occurrenceCounts()
-
-        return counts.asSequence().flatMap { count ->
+        return occurrenceCountsForMaterialization().asSequence().flatMap { count ->
             branchSelections(count).asSequence().flatMap { selection ->
                 expandSelections(selection, expandAlternative)
             }
         }
     }
 
-    private fun occurrenceCounts(): List<Int> {
+    private fun occurrenceCountsForMaterialization(): List<Int> {
         val upperBound = maxOccurs ?: max(minOccurs, 2)
-        return (minOccurs..upperBound).toList()
+        return listOfNotNull(
+            0.takeIf { minOccurs == 0 },
+            minOccurs.takeIf { minOccurs > 0 },
+            upperBound.takeIf { upperBound > minOccurs }
+        ).distinct()
     }
 
     private fun branchSelections(count: Int): List<List<List<Pattern>>> {
@@ -242,8 +238,28 @@ data class XMLChoiceGroupPattern(
             return listOf(emptyList())
         }
 
-        return branchSelections(count - 1).flatMap { partial ->
-            choices.map { choice -> partial + listOf(choice) }
+        if (choices.isEmpty()) {
+            return emptyList()
+        }
+
+        return when {
+            count <= choices.size -> combinations(choices, count)
+            else -> listOf(0.until(count).map { index -> choices[index % choices.size] })
+        }
+    }
+
+    private fun combinations(
+        remainingChoices: List<List<Pattern>>,
+        count: Int
+    ): List<List<List<Pattern>>> {
+        if (count == 0) {
+            return listOf(emptyList())
+        }
+
+        return remainingChoices.flatMapIndexed { index, choice ->
+            combinations(remainingChoices.drop(index + 1), count - 1).map { rest ->
+                listOf(choice) + rest
+            }
         }
     }
 
@@ -277,10 +293,13 @@ data class XMLChoiceGroupPattern(
         otherResolver: Resolver,
         typeStack: TypeStack
     ): Result {
-        val otherResolvedPattern = resolvedHop(otherPattern, otherResolver)
-
-        return concreteSequence?.encompassesResolved(otherResolvedPattern, otherPattern, thisResolver, otherResolver, typeStack)
-            ?: encompassesResolved(otherResolvedPattern, otherPattern, thisResolver, otherResolver, typeStack)
+        return encompassesResolved(
+            resolvedHop(otherPattern, otherResolver),
+            otherPattern,
+            thisResolver,
+            otherResolver,
+            typeStack
+        )
     }
 
     private fun encompassesResolved(
@@ -291,50 +310,17 @@ data class XMLChoiceGroupPattern(
         typeStack: TypeStack
     ): Result {
         return when (otherResolvedPattern) {
-            is XMLChoiceGroupPattern -> when (val otherConcreteSequence = otherResolvedPattern.concreteSequence) {
-                null -> Result.fromResults(
-                    listOf(occurrenceRange.encompassesRange(otherResolvedPattern.occurrenceRange)) +
-                        choices.allowAll(otherResolvedPattern.choices, otherPattern, thisResolver, otherResolver, typeStack)
-                )
+            is XMLChoiceGroupPattern -> Result.fromResults(
+                listOf(occurrenceRange.encompassesRange(otherResolvedPattern.occurrenceRange)) +
+                    choices.allowAll(otherResolvedPattern.choices, otherPattern, thisResolver, otherResolver, typeStack)
+            )
 
-                else -> Result.fromResults(
-                    listOf(occurrenceRange.encompassesRange(exactOccurrenceRange(otherConcreteSequence.size))) +
-                        otherConcreteSequence.map { otherSequence ->
-                            choices.allows(otherSequence, otherPattern, thisResolver, otherResolver, typeStack)
-                        }
-                )
-            }
+            is XMLSequencePattern -> encompassesSequence(otherResolvedPattern.members, thisResolver, otherResolver, typeStack)
 
             else -> Result.fromResults(
                 listOf(occurrenceRange.encompassesRange(exactOccurrenceRange(1))) +
                     listOf(choices.allows(listOf(otherResolvedPattern), otherPattern, thisResolver, otherResolver, typeStack))
             )
-        }
-    }
-
-    private fun List<List<Pattern>>.encompassesResolved(
-        otherResolvedPattern: Pattern,
-        otherPattern: Pattern,
-        thisResolver: Resolver,
-        otherResolver: Resolver,
-        typeStack: TypeStack
-    ): Result {
-        return when (otherResolvedPattern) {
-            is XMLChoiceGroupPattern -> when (val otherConcreteSequence = otherResolvedPattern.concreteSequence) {
-                null -> Result.fromResults(
-                    listOf(exactOccurrenceRange(size).encompassesExactly(otherResolvedPattern.occurrenceRange)) +
-                        map { mySequence ->
-                            mySequence.allowsAll(otherResolvedPattern.choices, otherPattern, thisResolver, otherResolver, typeStack)
-                        }
-                )
-
-                else -> allowsConcreteSequence(otherConcreteSequence, thisResolver, otherResolver, typeStack)
-            }
-
-            else -> when {
-                size != 1 -> Failure("Choice branch length $size does not encompass 1")
-                else -> single().allowsSequence(listOf(otherResolvedPattern), thisResolver, otherResolver, typeStack)
-            }
         }
     }
 
@@ -347,13 +333,6 @@ data class XMLChoiceGroupPattern(
         return when {
             encompasses(other) -> Success()
             else -> Failure("Choice occurrence range $this does not encompass $other")
-        }
-    }
-
-    private fun XMLOccurrenceRange.encompassesExactly(other: XMLOccurrenceRange): Result {
-        return when {
-            this == other -> Success()
-            else -> Failure("Concrete choice occurrence range $this does not encompass $other")
         }
     }
 
@@ -384,38 +363,45 @@ data class XMLChoiceGroupPattern(
         return successfulResult ?: Failure("Choice group does not encompass ${otherPattern.typeName}")
     }
 
-    private fun List<List<Pattern>>.allowsConcreteSequence(
-        otherSequence: List<List<Pattern>>,
+    private fun encompassesSequence(
+        otherSequence: List<Pattern>,
         thisResolver: Resolver,
         otherResolver: Resolver,
         typeStack: TypeStack
     ): Result {
-        if (size != otherSequence.size) {
-            return Failure("Choice branch length $size does not encompass ${otherSequence.size}")
-        }
-
-        val results = mapIndexed { index, mySequence ->
-            mySequence.allowsSequence(otherSequence[index], thisResolver, otherResolver, typeStack)
-        }
-
-        return Result.fromResults(results)
+        return choices.consumeSequence(otherSequence, 0, thisResolver, otherResolver, typeStack)
+            ?: Failure("Choice group does not encompass xml-sequence")
     }
 
-    private fun List<Pattern>.allowsAll(
-        otherChoices: List<List<Pattern>>,
-        otherPattern: Pattern,
+    private fun List<List<Pattern>>.consumeSequence(
+        remaining: List<Pattern>,
+        matchedCount: Int,
         thisResolver: Resolver,
         otherResolver: Resolver,
         typeStack: TypeStack
-    ): Result {
-        val results = otherChoices.map { otherChoice ->
-            allowsSequence(otherChoice, thisResolver, otherResolver, typeStack)
+    ): Result? {
+        if (remaining.isEmpty()) {
+            return occurrenceRange.encompassesRange(exactOccurrenceRange(matchedCount))
         }
 
-        return when (Result.fromResults(results)) {
-            is Success -> Success()
-            is Failure -> Failure("Choice group does not encompass ${otherPattern.typeName}")
+        val maxReached = maxOccurs?.let { matchedCount >= it } ?: false
+        if (maxReached) {
+            return null
         }
+
+        val results = mapNotNull { choice ->
+            val consumedChoice = choice.consumeAllowedPrefix(remaining, thisResolver, otherResolver, typeStack)
+            val consumed = remaining.size - consumedChoice.remainder.size
+
+            when {
+                consumedChoice.result is Success && consumed > 0 ->
+                    consumeSequence(consumedChoice.remainder, matchedCount + 1, thisResolver, otherResolver, typeStack)
+
+                else -> null
+            }
+        }
+
+        return results.find { it is Success } ?: results.firstOrNull()
     }
 
     private fun List<Pattern>.allowsSequence(
@@ -424,7 +410,22 @@ data class XMLChoiceGroupPattern(
         otherResolver: Resolver,
         typeStack: TypeStack
     ): Result {
-        val result = fold(ConsumeResult<Pattern, Pattern>(Success(), otherSequence)) { consumeResult, myPattern ->
+        val result = consumeAllowedPrefix(otherSequence, thisResolver, otherResolver, typeStack)
+
+        return when {
+            result.result is Failure -> result.result
+            result.remainder.isNotEmpty() -> Failure("Choice branch length $size does not encompass ${otherSequence.size}")
+            else -> Success()
+        }
+    }
+
+    private fun List<Pattern>.consumeAllowedPrefix(
+        otherSequence: List<Pattern>,
+        thisResolver: Resolver,
+        otherResolver: Resolver,
+        typeStack: TypeStack
+    ): ConsumeResult<Pattern, Pattern> {
+        return fold(ConsumeResult<Pattern, Pattern>(Success(), otherSequence)) { consumeResult, myPattern ->
             when (consumeResult.result) {
                 is Failure -> consumeResult
                 is Success -> myPattern.encompasses(
@@ -436,10 +437,107 @@ data class XMLChoiceGroupPattern(
                 )
             }
         }
+    }
+}
+
+data class XMLSequencePattern(
+    val members: List<Pattern>,
+    override val typeAlias: String? = null
+) : Pattern, SequenceType {
+    override val pattern: Any
+        get() = members
+
+    override val typeName: String = "xml-sequence"
+
+    override val memberList: MemberList
+        get() = MemberList(members, null)
+
+    override fun matches(sampleData: Value?, resolver: Resolver): Result {
+        return when (sampleData) {
+            is XMLNode -> matches(sampleData.childNodes, resolver).result
+            null -> matches(emptyList(), resolver).result
+            else -> Failure("Expected XML but got ${sampleData.displayableType()}")
+        }
+    }
+
+    override fun matches(sampleData: List<Value>, resolver: Resolver): ConsumeResult<Value, Value> {
+        return members.fold(ConsumeResult<Value, Value>(Success(), sampleData)) { consumeResult, pattern ->
+            when (consumeResult.result) {
+                is Failure -> consumeResult
+                is Success -> pattern.matches(consumeResult.remainder, resolver)
+            }
+        }
+    }
+
+    override fun generate(resolver: Resolver): Value {
+        val generatedNodes = members.flatMap { pattern ->
+            pattern.generateXMLSequenceNodes(resolver)
+        }
+
+        return XMLNode("", "", emptyMap(), generatedNodes, "", emptyMap())
+    }
+
+    private fun Pattern.generateXMLSequenceNodes(resolver: Resolver): List<XMLValue> {
+        val generated = generate(resolver)
+
+        return when {
+            this is XMLSequencePattern -> (generated as XMLNode).childNodes
+            this is XMLChoiceGroupPattern -> (generated as XMLNode).childNodes
+            this is XMLWildcardPattern -> (generated as XMLNode).childNodes
+            this is ListPattern -> (generated as XMLNode).childNodes
+            generated is XMLNode -> listOf(generated)
+            generated is XMLValue -> listOf(generated)
+            else -> listOf(StringValue(generated.toStringLiteral()))
+        }
+    }
+
+    override fun newBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> =
+        sequenceOf(HasValue(this))
+
+    override fun negativeBasedOn(
+        row: Row,
+        resolver: Resolver,
+        config: NegativePatternConfiguration
+    ): Sequence<ReturnValue<Pattern>> = emptySequence()
+
+    override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
+
+    override fun parse(value: String, resolver: Resolver): Value {
+        return XMLPattern("<sequence>$value</sequence>").parse(value, resolver)
+    }
+
+    override fun listOf(valueList: List<Value>, resolver: Resolver): Value {
+        return XMLNode("", "", emptyMap(), valueList.map { it as XMLValue }, "", emptyMap())
+    }
+
+    override fun encompasses(
+        otherPattern: Pattern,
+        thisResolver: Resolver,
+        otherResolver: Resolver,
+        typeStack: TypeStack
+    ): Result {
+        val otherSequence = when (val otherResolvedPattern = resolvedHop(otherPattern, otherResolver)) {
+            is XMLSequencePattern -> otherResolvedPattern.members
+            is SequenceType -> otherResolvedPattern.memberList.patternList()
+            else -> listOf(otherResolvedPattern)
+        }
+
+        val result = members.fold(ConsumeResult<Pattern, Pattern>(Success(), otherSequence)) { consumeResult, myPattern ->
+            when (consumeResult.result) {
+                is Failure -> consumeResult
+                is Success -> myPattern.encompasses(
+                    consumeResult.remainder,
+                    thisResolver,
+                    otherResolver,
+                    "XML sequence length ${members.size} does not encompass ${otherSequence.size}",
+                    typeStack
+                )
+            }
+        }
 
         return when {
             result.result is Failure -> result.result
-            result.remainder.isNotEmpty() -> Failure("Choice branch length $size does not encompass ${otherSequence.size}")
+            result.remainder.isNotEmpty() -> Failure("XML sequence length ${members.size} does not encompass ${otherSequence.size}")
             else -> Success()
         }
     }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLChoiceGroupPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLChoiceGroupPattern.kt
@@ -160,13 +160,13 @@ data class XMLChoiceGroupPattern(
     private fun XMLPattern.hasTypeReference(): Boolean = referredType != null
 
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
-        return materializedSequences { alternative ->
+        return representativeMaterializedSequences { choiceBranch ->
             listCombinations(
-                alternative.map { pattern ->
+                choiceBranch.map { pattern ->
                     HasValue(pattern.newBasedOnXMLChoice(row, resolver))
                 }
             ).map { it.value }
-        }.map { HasValue(materialized(it)) }
+        }.map { HasValue(materializedSequencePattern(it)) }
     }
 
     override fun negativeBasedOn(
@@ -176,13 +176,13 @@ data class XMLChoiceGroupPattern(
     ): Sequence<ReturnValue<Pattern>> = emptySequence()
 
     override fun newBasedOn(resolver: Resolver): Sequence<Pattern> {
-        return materializedSequences { alternative ->
+        return representativeMaterializedSequences { choiceBranch ->
             listCombinations(
-                alternative.map { pattern ->
+                choiceBranch.map { pattern ->
                     HasValue(pattern.newBasedOnXMLChoice(resolver))
                 }
             ).map { it.value }
-        }.map(::materialized)
+        }.map(::materializedSequencePattern)
     }
 
     private fun Pattern.newBasedOnXMLChoice(row: Row, resolver: Resolver): Sequence<Pattern?> {
@@ -211,20 +211,20 @@ data class XMLChoiceGroupPattern(
         } ?: sequenceOf(null)
     }
 
-    private fun materialized(selectedChoices: List<List<Pattern>>): Pattern =
-        XMLSequencePattern(selectedChoices.flatten())
+    private fun materializedSequencePattern(selectedBranches: List<List<Pattern>>): Pattern =
+        XMLSequencePattern(selectedBranches.flatten())
 
-    private fun materializedSequences(
-        expandAlternative: (List<Pattern>) -> Sequence<List<Pattern>>
+    private fun representativeMaterializedSequences(
+        examplesForChoiceBranch: (List<Pattern>) -> Sequence<List<Pattern>>
     ): Sequence<List<List<Pattern>>> {
-        return occurrenceCountsForMaterialization().asSequence().flatMap { count ->
-            branchSelections(count).asSequence().flatMap { selection ->
-                expandSelections(selection, expandAlternative)
+        return representativeOccurrenceCounts().asSequence().flatMap { occurrenceCount ->
+            representativeChoiceSelections(occurrenceCount).asSequence().flatMap { selectedBranches ->
+                materializedVariantsFor(selectedBranches, examplesForChoiceBranch)
             }
         }
     }
 
-    private fun occurrenceCountsForMaterialization(): List<Int> {
+    private fun representativeOccurrenceCounts(): List<Int> {
         val upperBound = maxOccurs ?: max(minOccurs, 2)
         return listOfNotNull(
             0.takeIf { minOccurs == 0 },
@@ -233,8 +233,8 @@ data class XMLChoiceGroupPattern(
         ).distinct()
     }
 
-    private fun branchSelections(count: Int): List<List<List<Pattern>>> {
-        if (count == 0) {
+    private fun representativeChoiceSelections(occurrenceCount: Int): List<List<List<Pattern>>> {
+        if (occurrenceCount == 0) {
             return listOf(emptyList())
         }
 
@@ -243,12 +243,12 @@ data class XMLChoiceGroupPattern(
         }
 
         return when {
-            count <= choices.size -> combinations(choices, count)
-            else -> listOf(0.until(count).map { index -> choices[index % choices.size] })
+            occurrenceCount <= choices.size -> combinationsOfChoiceBranches(choices, occurrenceCount)
+            else -> listOf(0.until(occurrenceCount).map { index -> choices[index % choices.size] })
         }
     }
 
-    private fun combinations(
+    private fun combinationsOfChoiceBranches(
         remainingChoices: List<List<Pattern>>,
         count: Int
     ): List<List<List<Pattern>>> {
@@ -257,25 +257,27 @@ data class XMLChoiceGroupPattern(
         }
 
         return remainingChoices.flatMapIndexed { index, choice ->
-            combinations(remainingChoices.drop(index + 1), count - 1).map { rest ->
+            combinationsOfChoiceBranches(remainingChoices.drop(index + 1), count - 1).map { rest ->
                 listOf(choice) + rest
             }
         }
     }
 
-    private fun expandSelections(
-        selection: List<List<Pattern>>,
-        expandAlternative: (List<Pattern>) -> Sequence<List<Pattern>>
+    private fun materializedVariantsFor(
+        selectedBranches: List<List<Pattern>>,
+        examplesForChoiceBranch: (List<Pattern>) -> Sequence<List<Pattern>>
     ): Sequence<List<List<Pattern>>> {
-        if (selection.isEmpty()) {
+        if (selectedBranches.isEmpty()) {
             return sequenceOf(emptyList())
         }
 
-        val head = expandAlternative(selection.first())
-        val tail = expandSelections(selection.drop(1), expandAlternative)
+        val firstBranchExamples = examplesForChoiceBranch(selectedBranches.first())
+        val remainingBranchExamples = materializedVariantsFor(selectedBranches.drop(1), examplesForChoiceBranch)
 
-        return head.flatMap { headPatterns ->
-            tail.map { tailPatterns -> listOf(headPatterns) + tailPatterns }
+        return firstBranchExamples.flatMap { firstBranchPatterns ->
+            remainingBranchExamples.map { remainingBranchPatterns ->
+                listOf(firstBranchPatterns) + remainingBranchPatterns
+            }
         }
     }
 
@@ -312,14 +314,33 @@ data class XMLChoiceGroupPattern(
         return when (otherResolvedPattern) {
             is XMLChoiceGroupPattern -> Result.fromResults(
                 listOf(occurrenceRange.encompassesRange(otherResolvedPattern.occurrenceRange)) +
-                    choices.allowAll(otherResolvedPattern.choices, otherPattern, thisResolver, otherResolver, typeStack)
+                    choices.encompassesEveryChoiceBranchFrom(
+                        otherResolvedPattern.choices,
+                        otherPattern,
+                        thisResolver,
+                        otherResolver,
+                        typeStack
+                    )
             )
 
-            is XMLSequencePattern -> encompassesSequence(otherResolvedPattern.members, thisResolver, otherResolver, typeStack)
+            is XMLSequencePattern -> encompassesMaterializedSequence(
+                otherResolvedPattern.members,
+                thisResolver,
+                otherResolver,
+                typeStack
+            )
 
             else -> Result.fromResults(
                 listOf(occurrenceRange.encompassesRange(exactOccurrenceRange(1))) +
-                    listOf(choices.allows(listOf(otherResolvedPattern), otherPattern, thisResolver, otherResolver, typeStack))
+                    listOf(
+                        choices.hasBranchThatEncompasses(
+                            listOf(otherResolvedPattern),
+                            otherPattern,
+                            thisResolver,
+                            otherResolver,
+                            typeStack
+                        )
+                    )
             )
         }
     }
@@ -336,7 +357,7 @@ data class XMLChoiceGroupPattern(
         }
     }
 
-    private fun List<List<Pattern>>.allowAll(
+    private fun List<List<Pattern>>.encompassesEveryChoiceBranchFrom(
         otherChoices: List<List<Pattern>>,
         otherPattern: Pattern,
         thisResolver: Resolver,
@@ -344,11 +365,11 @@ data class XMLChoiceGroupPattern(
         typeStack: TypeStack
     ): List<Result> {
         return otherChoices.map { otherChoice ->
-            allows(otherChoice, otherPattern, thisResolver, otherResolver, typeStack)
+            hasBranchThatEncompasses(otherChoice, otherPattern, thisResolver, otherResolver, typeStack)
         }
     }
 
-    private fun List<List<Pattern>>.allows(
+    private fun List<List<Pattern>>.hasBranchThatEncompasses(
         otherSequence: List<Pattern>,
         otherPattern: Pattern,
         thisResolver: Resolver,
@@ -356,24 +377,24 @@ data class XMLChoiceGroupPattern(
         typeStack: TypeStack
     ): Result {
         val successfulResult = asSequence()
-            .map { mySequence ->
-                mySequence.allowsSequence(otherSequence, thisResolver, otherResolver, typeStack)
+            .map { candidateBranch ->
+                candidateBranch.encompassesWholeSequence(otherSequence, thisResolver, otherResolver, typeStack)
             }.find { it is Success }
 
         return successfulResult ?: Failure("Choice group does not encompass ${otherPattern.typeName}")
     }
 
-    private fun encompassesSequence(
+    private fun encompassesMaterializedSequence(
         otherSequence: List<Pattern>,
         thisResolver: Resolver,
         otherResolver: Resolver,
         typeStack: TypeStack
     ): Result {
-        return choices.consumeSequence(otherSequence, 0, thisResolver, otherResolver, typeStack)
+        return choices.consumeMaterializedSequence(otherSequence, 0, thisResolver, otherResolver, typeStack)
             ?: Failure("Choice group does not encompass xml-sequence")
     }
 
-    private fun List<List<Pattern>>.consumeSequence(
+    private fun List<List<Pattern>>.consumeMaterializedSequence(
         remaining: List<Pattern>,
         matchedCount: Int,
         thisResolver: Resolver,
@@ -390,12 +411,23 @@ data class XMLChoiceGroupPattern(
         }
 
         val results = mapNotNull { choice ->
-            val consumedChoice = choice.consumeAllowedPrefix(remaining, thisResolver, otherResolver, typeStack)
+            val consumedChoice = choice.consumeEncompassedPrefix(
+                remaining,
+                thisResolver,
+                otherResolver,
+                typeStack
+            )
             val consumed = remaining.size - consumedChoice.remainder.size
 
             when {
                 consumedChoice.result is Success && consumed > 0 ->
-                    consumeSequence(consumedChoice.remainder, matchedCount + 1, thisResolver, otherResolver, typeStack)
+                    consumeMaterializedSequence(
+                        consumedChoice.remainder,
+                        matchedCount + 1,
+                        thisResolver,
+                        otherResolver,
+                        typeStack
+                    )
 
                 else -> null
             }
@@ -404,13 +436,13 @@ data class XMLChoiceGroupPattern(
         return results.find { it is Success } ?: results.firstOrNull()
     }
 
-    private fun List<Pattern>.allowsSequence(
+    private fun List<Pattern>.encompassesWholeSequence(
         otherSequence: List<Pattern>,
         thisResolver: Resolver,
         otherResolver: Resolver,
         typeStack: TypeStack
     ): Result {
-        val result = consumeAllowedPrefix(otherSequence, thisResolver, otherResolver, typeStack)
+        val result = consumeEncompassedPrefix(otherSequence, thisResolver, otherResolver, typeStack)
 
         return when {
             result.result is Failure -> result.result
@@ -419,7 +451,7 @@ data class XMLChoiceGroupPattern(
         }
     }
 
-    private fun List<Pattern>.consumeAllowedPrefix(
+    private fun List<Pattern>.consumeEncompassedPrefix(
         otherSequence: List<Pattern>,
         thisResolver: Resolver,
         otherResolver: Resolver,
@@ -522,10 +554,10 @@ data class XMLSequencePattern(
             else -> listOf(otherResolvedPattern)
         }
 
-        val result = members.fold(ConsumeResult<Pattern, Pattern>(Success(), otherSequence)) { consumeResult, myPattern ->
+        val consumedSequence = members.fold(ConsumeResult<Pattern, Pattern>(Success(), otherSequence)) { consumeResult, member ->
             when (consumeResult.result) {
                 is Failure -> consumeResult
-                is Success -> myPattern.encompasses(
+                is Success -> member.encompasses(
                     consumeResult.remainder,
                     thisResolver,
                     otherResolver,
@@ -536,8 +568,10 @@ data class XMLSequencePattern(
         }
 
         return when {
-            result.result is Failure -> result.result
-            result.remainder.isNotEmpty() -> Failure("XML sequence length ${members.size} does not encompass ${otherSequence.size}")
+            consumedSequence.result is Failure -> consumedSequence.result
+            consumedSequence.remainder.isNotEmpty() ->
+                Failure("XML sequence length ${members.size} does not encompass ${otherSequence.size}")
+
             else -> Success()
         }
     }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLPattern.kt
@@ -824,6 +824,7 @@ data class XMLPattern(
         return when {
             this is ListPattern -> (generate(resolver) as XMLNode).childNodes
             this is XMLChoiceGroupPattern -> (generate(resolver) as XMLNode).childNodes
+            this is XMLSequencePattern -> (generate(resolver) as XMLNode).childNodes
             this is XMLWildcardPattern -> (generate(resolver) as XMLNode).childNodes
             this is XMLPattern && occurMultipleTimes() ->
                 0.until(randomNumber(XML_RANDOM_NUMBER_CEILING)).map { generate(resolver) }

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/WSDL.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/WSDL.kt
@@ -161,7 +161,29 @@ fun addSchemasToNodes(schemas: Map<String, XMLNode>): Map<String, XMLNode> {
     }
 }
 
+private data class SchemaLookupKey(val namespace: String, val schemaNamespace: String?)
+
+private data class NamedSchemaLookupKey(
+    val namespace: String,
+    val schemaNamespace: String?,
+    val localName: String
+)
+
+private data class DefinitionLookupKey(
+    val tagName: String,
+    val namespace: String,
+    val localName: String
+)
+
 data class WSDL(private val rootDefinition: XMLNode, val definitions: Map<String, XMLNode>, val schemas: Map<String, XMLNode>, private val typesNode: XMLNode, val namespaceToPrefix: Map<String, String>, val prefixToNamespace: Map<String, String>, val rootPrefixesToNamespace: Map<String, String>) {
+    private val schemaLookupCache = mutableMapOf<SchemaLookupKey, XMLNode>()
+    private val complexTypeLookupCache = mutableMapOf<NamedSchemaLookupKey, XMLNode?>()
+    private val simpleTypeLookupCache = mutableMapOf<NamedSchemaLookupKey, XMLNode?>()
+    private val elementLookupCache = mutableMapOf<NamedSchemaLookupKey, XMLNode>()
+    private val attributeLookupCache = mutableMapOf<NamedSchemaLookupKey, XMLNode>()
+    private val attributeGroupLookupCache = mutableMapOf<NamedSchemaLookupKey, XMLNode>()
+    private val definitionLookupCache = mutableMapOf<DefinitionLookupKey, XMLNode>()
+
     fun allNamespaces(): Map<String, String> {
         return prefixToNamespace.plus(rootPrefixesToNamespace)
     }
@@ -190,10 +212,28 @@ data class WSDL(private val rootDefinition: XMLNode, val definitions: Map<String
     ): XMLNode {
         val namespace = node.resolveNamespace(qname)
         val localName = qname.localName()
+        return findInDefinition(
+            tagName,
+            namespace,
+            localName,
+            "Tried to lookup $tagName named $qname, resolved namespace prefix to $namespace, but could not find a definition with that namespace"
+        )
+    }
 
-        val definition = definitions[namespace]
-            ?: throw ContractException("Tried to lookup $tagName named $qname, resolved namespace prefix to $namespace, but could not find a definition with that namespace")
-        return definition.findByNodeNameAndAttribute(tagName, "name", localName)
+    private fun findInDefinition(
+        tagName: String,
+        namespace: String,
+        localName: String,
+        definitionMissingMessage: String,
+        missingMessage: String? = null
+    ): XMLNode {
+        val key = DefinitionLookupKey(tagName, namespace, localName)
+        return definitionLookupCache.getOrPut(key) {
+            val definition = definitions[namespace]
+                ?: throw ContractException(definitionMissingMessage)
+
+            definition.findByNodeNameAndAttribute(tagName, "name", localName, missingMessage)
+        }
     }
 
     private fun getServicePort() = rootDefinition.getXMLNodeByPath("service.port")
@@ -264,8 +304,12 @@ data class WSDL(private val rootDefinition: XMLNode, val definitions: Map<String
         attributeName: String
     ): XMLNode? {
         val fullTypeName = element.attributes.getValue(attributeName).toStringLiteral()
-        val schema = findSchema(namespace(fullTypeName, element), element.schema)
-        return schema.findByNodeNameAndAttributeOrNull("complexType", "name", fullTypeName.localName())
+        val key = namedSchemaLookupKey(fullTypeName, element)
+
+        return complexTypeLookupCache.getOrPutNullable(key) {
+            val schema = findSchema(key.namespace, element.schema)
+            schema.findByNodeNameAndAttributeOrNull("complexType", "name", key.localName)
+        }
     }
 
     fun findSimpleType(
@@ -273,8 +317,12 @@ data class WSDL(private val rootDefinition: XMLNode, val definitions: Map<String
         attributeName: String
     ): XMLNode? {
         val fullTypeName = (element.attributes[attributeName] ?: throw ContractException("Node ${element.realName} does not have an attribute named $attributeName")).toStringLiteral()
-        val schema = findSchema(namespace(fullTypeName, element), element.schema)
-        return schema.findByNodeNameAndAttributeOrNull("simpleType", "name", fullTypeName.localName())
+        val key = namedSchemaLookupKey(fullTypeName, element)
+
+        return simpleTypeLookupCache.getOrPutNullable(key) {
+            val schema = findSchema(key.namespace, element.schema)
+            schema.findByNodeNameAndAttributeOrNull("simpleType", "name", key.localName)
+        }
     }
 
     fun findTypeFromAttribute(
@@ -282,7 +330,7 @@ data class WSDL(private val rootDefinition: XMLNode, val definitions: Map<String
         attributeName: String
     ): XMLNode {
         val fullTypeName = element.attributes.getValue(attributeName).toStringLiteral()
-        return findElement(fullTypeName.localName(), namespace(fullTypeName, element), element)
+        return findElement(fullTypeName.localName(), namespace(fullTypeName, element), element.schema)
     }
 
     private fun namespace(fullTypeName: String, element: XMLNode): String {
@@ -294,16 +342,24 @@ data class WSDL(private val rootDefinition: XMLNode, val definitions: Map<String
                 ?: throw ContractException("Could not find namespace with prefix $namespacePrefix in xml node $element")
     }
 
-    private fun findElement(typeName: String, namespace: String, element: XMLNode? = null): XMLNode {
-        val schema = findSchema(namespace, element?.schema)
+    private fun namedSchemaLookupKey(fullTypeName: String, element: XMLNode?): NamedSchemaLookupKey {
+        val namespace = element?.let { namespace(fullTypeName, it) } ?: ""
+        return NamedSchemaLookupKey(namespace, element.attachedSchemaNamespace(), fullTypeName.localName())
+    }
 
-        return schema.getXMLNodeByAttributeValue("name", typeName)
+    private fun findElement(typeName: String, namespace: String, localSchema: XMLNode? = null): XMLNode {
+        val key = NamedSchemaLookupKey(namespace, localSchema.schemaFallbackNamespace(), typeName)
+
+        return elementLookupCache.getOrPut(key) {
+            val schema = findSchema(namespace, localSchema)
+            schema.getXMLNodeByAttributeValue("name", typeName)
+        }
     }
 
     fun getSOAPElement(fullyQualifiedName: FullyQualifiedName, localSchema: XMLNode? = null, otherRefAttributes: Map<String, StringValue> = emptyMap()): WSDLElement {
         val schema = findSchema(fullyQualifiedName.namespace, localSchema)
 
-        val node = schema.getXMLNodeByAttributeValue("name", fullyQualifiedName.localName).addSchema(schema).let {
+        val node = findElement(fullyQualifiedName.localName, fullyQualifiedName.namespace, localSchema).addSchema(schema).let {
             it.copy(attributes = it.attributes.plus(otherRefAttributes))
         }
 
@@ -315,22 +371,34 @@ data class WSDL(private val rootDefinition: XMLNode, val definitions: Map<String
     }
 
     fun findAttributeGroup(fullyQualifiedName: FullyQualifiedName, localSchema: XMLNode? = null): XMLNode {
-        val schema = findSchema(fullyQualifiedName.namespace, localSchema)
-        return schema.findByNodeNameAndAttribute("attributeGroup", "name", fullyQualifiedName.localName)
+        val key = NamedSchemaLookupKey(fullyQualifiedName.namespace, localSchema.schemaFallbackNamespace(), fullyQualifiedName.localName)
+
+        return attributeGroupLookupCache.getOrPut(key) {
+            val schema = findSchema(fullyQualifiedName.namespace, localSchema)
+            schema.findByNodeNameAndAttribute("attributeGroup", "name", fullyQualifiedName.localName)
+        }
     }
 
     fun findAttribute(fullyQualifiedName: FullyQualifiedName, localSchema: XMLNode? = null): XMLNode {
-        val schema = findSchema(fullyQualifiedName.namespace, localSchema)
-        return schema.findByNodeNameAndAttribute("attribute", "name", fullyQualifiedName.localName)
+        val key = NamedSchemaLookupKey(fullyQualifiedName.namespace, localSchema.schemaFallbackNamespace(), fullyQualifiedName.localName)
+
+        return attributeLookupCache.getOrPut(key) {
+            val schema = findSchema(fullyQualifiedName.namespace, localSchema)
+            schema.findByNodeNameAndAttribute("attribute", "name", fullyQualifiedName.localName)
+        }
     }
 
     private fun findSchema(namespace: String, schema: XMLNode?): XMLNode {
-        val resolvedNamespace: String? = namespaceOrSchemaNamespace(namespace, schema)
-        if(resolvedNamespace.isNullOrBlank())
-            throw ContractException("Cannot look for an empty schema namespace. Please report this to the Specmatic Builders at $SPECMATIC_GITHUB_ISSUES")
+        val key = SchemaLookupKey(namespace, schema.schemaFallbackNamespace())
 
-        return schemas[resolvedNamespace]
-            ?: throw ContractException("Couldn't find schema with targetNamespace $resolvedNamespace")
+        return schemaLookupCache.getOrPut(key) {
+            val resolvedNamespace: String? = namespaceOrSchemaNamespace(namespace, schema)
+            if(resolvedNamespace.isNullOrBlank())
+                throw ContractException("Cannot look for an empty schema namespace. Please report this to the Specmatic Builders at $SPECMATIC_GITHUB_ISSUES")
+
+            schemas[resolvedNamespace]
+                ?: throw ContractException("Couldn't find schema with targetNamespace $resolvedNamespace")
+        }
     }
 
     fun getComplexTypeNode(element: XMLNode): ComplexType {
@@ -354,13 +422,11 @@ data class WSDL(private val rootDefinition: XMLNode, val definitions: Map<String
     }
 
     fun findMessageNode(fullyQualifiedName: FullyQualifiedName): XMLNode {
-        val definition = definitions[fullyQualifiedName.namespace]
-            ?: throw ContractException("Could not find message named ${fullyQualifiedName.qName}. ${fullyQualifiedName.prefix} mapped to ${fullyQualifiedName.namespace}, but could not find a definition with this targetNamespace.")
-
-        return definition.findByNodeNameAndAttribute(
+        return findInDefinition(
             "message",
-            "name",
+            fullyQualifiedName.namespace,
             fullyQualifiedName.localName,
+            "Could not find message named ${fullyQualifiedName.qName}. ${fullyQualifiedName.prefix} mapped to ${fullyQualifiedName.namespace}, but could not find a definition with this targetNamespace.",
             "Message node ${fullyQualifiedName.qName} not found"
         )
     }
@@ -418,3 +484,19 @@ data class WSDL(private val rootDefinition: XMLNode, val definitions: Map<String
 
 fun namespaceOrSchemaNamespace(namespace: String, schema: XMLNode?) =
     namespace.ifBlank { schema?.attributes?.get("xmlns")?.toStringLiteral() }
+
+private fun XMLNode?.schemaFallbackNamespace(): String? =
+    this?.attributes?.get("xmlns")?.toStringLiteral()
+
+private fun XMLNode?.attachedSchemaNamespace(): String? =
+    this?.schema?.attributes?.get("xmlns")?.toStringLiteral()
+
+private fun <K, V> MutableMap<K, V?>.getOrPutNullable(key: K, defaultValue: () -> V?): V? {
+    if (containsKey(key)) {
+        return this[key]
+    }
+
+    val value = defaultValue()
+    this[key] = value
+    return value
+}

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/WSDL.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/WSDL.kt
@@ -161,28 +161,35 @@ fun addSchemasToNodes(schemas: Map<String, XMLNode>): Map<String, XMLNode> {
     }
 }
 
-private data class SchemaLookupKey(val namespace: String, val schemaNamespace: String?)
-
-private data class NamedSchemaLookupKey(
-    val namespace: String,
-    val schemaNamespace: String?,
-    val localName: String
-)
-
 private data class DefinitionLookupKey(
     val tagName: String,
     val namespace: String,
     val localName: String
 )
 
+private data class SchemaLookupKey(
+    val tagName: String,
+    val namespace: String,
+    val localName: String
+)
+
+private data class WsdlIndexes(
+    val definitions: Map<DefinitionLookupKey, XMLNode>,
+    val schemas: Map<SchemaLookupKey, XMLNode>,
+    val namedSchemas: Map<NamedSchemaLookupKey, XMLNode>
+)
+
+private data class NamedSchemaLookupKey(
+    val namespace: String,
+    val localName: String
+)
+
 data class WSDL(private val rootDefinition: XMLNode, val definitions: Map<String, XMLNode>, val schemas: Map<String, XMLNode>, private val typesNode: XMLNode, val namespaceToPrefix: Map<String, String>, val prefixToNamespace: Map<String, String>, val rootPrefixesToNamespace: Map<String, String>) {
-    private val schemaLookupCache = mutableMapOf<SchemaLookupKey, XMLNode>()
-    private val complexTypeLookupCache = mutableMapOf<NamedSchemaLookupKey, XMLNode?>()
-    private val simpleTypeLookupCache = mutableMapOf<NamedSchemaLookupKey, XMLNode?>()
-    private val elementLookupCache = mutableMapOf<NamedSchemaLookupKey, XMLNode>()
-    private val attributeLookupCache = mutableMapOf<NamedSchemaLookupKey, XMLNode>()
-    private val attributeGroupLookupCache = mutableMapOf<NamedSchemaLookupKey, XMLNode>()
-    private val definitionLookupCache = mutableMapOf<DefinitionLookupKey, XMLNode>()
+    private val indexes = WsdlIndexes(
+        definitions = indexDefinitions(definitions),
+        schemas = indexSchemas(schemas),
+        namedSchemas = indexNamedSchemas(schemas)
+    )
 
     fun allNamespaces(): Map<String, String> {
         return prefixToNamespace.plus(rootPrefixesToNamespace)
@@ -228,12 +235,9 @@ data class WSDL(private val rootDefinition: XMLNode, val definitions: Map<String
         missingMessage: String? = null
     ): XMLNode {
         val key = DefinitionLookupKey(tagName, namespace, localName)
-        return definitionLookupCache.getOrPut(key) {
-            val definition = definitions[namespace]
-                ?: throw ContractException(definitionMissingMessage)
-
-            definition.findByNodeNameAndAttribute(tagName, "name", localName, missingMessage)
-        }
+        definitions[namespace] ?: throw ContractException(definitionMissingMessage)
+        return indexes.definitions[key]
+            ?: throw ContractException(missingMessage ?: "Couldn't find a node named $tagName with attribute name=\"$localName\"")
     }
 
     private fun getServicePort() = rootDefinition.getXMLNodeByPath("service.port")
@@ -304,12 +308,7 @@ data class WSDL(private val rootDefinition: XMLNode, val definitions: Map<String
         attributeName: String
     ): XMLNode? {
         val fullTypeName = element.attributes.getValue(attributeName).toStringLiteral()
-        val key = namedSchemaLookupKey(fullTypeName, element)
-
-        return complexTypeLookupCache.getOrPutNullable(key) {
-            val schema = findSchema(key.namespace, element.schema)
-            schema.findByNodeNameAndAttributeOrNull("complexType", "name", key.localName)
-        }
+        return findSchemaNodeOrNull("complexType", namespace(fullTypeName, element), fullTypeName.localName(), element.schema)
     }
 
     fun findSimpleType(
@@ -317,12 +316,7 @@ data class WSDL(private val rootDefinition: XMLNode, val definitions: Map<String
         attributeName: String
     ): XMLNode? {
         val fullTypeName = (element.attributes[attributeName] ?: throw ContractException("Node ${element.realName} does not have an attribute named $attributeName")).toStringLiteral()
-        val key = namedSchemaLookupKey(fullTypeName, element)
-
-        return simpleTypeLookupCache.getOrPutNullable(key) {
-            val schema = findSchema(key.namespace, element.schema)
-            schema.findByNodeNameAndAttributeOrNull("simpleType", "name", key.localName)
-        }
+        return findSchemaNodeOrNull("simpleType", namespace(fullTypeName, element), fullTypeName.localName(), element.schema)
     }
 
     fun findTypeFromAttribute(
@@ -342,18 +336,8 @@ data class WSDL(private val rootDefinition: XMLNode, val definitions: Map<String
                 ?: throw ContractException("Could not find namespace with prefix $namespacePrefix in xml node $element")
     }
 
-    private fun namedSchemaLookupKey(fullTypeName: String, element: XMLNode?): NamedSchemaLookupKey {
-        val namespace = element?.let { namespace(fullTypeName, it) } ?: ""
-        return NamedSchemaLookupKey(namespace, element.attachedSchemaNamespace(), fullTypeName.localName())
-    }
-
     private fun findElement(typeName: String, namespace: String, localSchema: XMLNode? = null): XMLNode {
-        val key = NamedSchemaLookupKey(namespace, localSchema.schemaFallbackNamespace(), typeName)
-
-        return elementLookupCache.getOrPut(key) {
-            val schema = findSchema(namespace, localSchema)
-            schema.getXMLNodeByAttributeValue("name", typeName)
-        }
+        return findNamedSchemaNode(namespace, typeName, localSchema)
     }
 
     fun getSOAPElement(fullyQualifiedName: FullyQualifiedName, localSchema: XMLNode? = null, otherRefAttributes: Map<String, StringValue> = emptyMap()): WSDLElement {
@@ -371,34 +355,50 @@ data class WSDL(private val rootDefinition: XMLNode, val definitions: Map<String
     }
 
     fun findAttributeGroup(fullyQualifiedName: FullyQualifiedName, localSchema: XMLNode? = null): XMLNode {
-        val key = NamedSchemaLookupKey(fullyQualifiedName.namespace, localSchema.schemaFallbackNamespace(), fullyQualifiedName.localName)
-
-        return attributeGroupLookupCache.getOrPut(key) {
-            val schema = findSchema(fullyQualifiedName.namespace, localSchema)
-            schema.findByNodeNameAndAttribute("attributeGroup", "name", fullyQualifiedName.localName)
-        }
+        return findSchemaNode("attributeGroup", fullyQualifiedName.namespace, fullyQualifiedName.localName, localSchema)
     }
 
     fun findAttribute(fullyQualifiedName: FullyQualifiedName, localSchema: XMLNode? = null): XMLNode {
-        val key = NamedSchemaLookupKey(fullyQualifiedName.namespace, localSchema.schemaFallbackNamespace(), fullyQualifiedName.localName)
-
-        return attributeLookupCache.getOrPut(key) {
-            val schema = findSchema(fullyQualifiedName.namespace, localSchema)
-            schema.findByNodeNameAndAttribute("attribute", "name", fullyQualifiedName.localName)
-        }
+        return findSchemaNode("attribute", fullyQualifiedName.namespace, fullyQualifiedName.localName, localSchema)
     }
 
     private fun findSchema(namespace: String, schema: XMLNode?): XMLNode {
-        val key = SchemaLookupKey(namespace, schema.schemaFallbackNamespace())
+        val resolvedNamespace = resolvedSchemaNamespace(namespace, schema)
+        return schemas[resolvedNamespace]
+            ?: throw ContractException("Couldn't find schema with targetNamespace $resolvedNamespace")
+    }
 
-        return schemaLookupCache.getOrPut(key) {
-            val resolvedNamespace: String? = namespaceOrSchemaNamespace(namespace, schema)
-            if(resolvedNamespace.isNullOrBlank())
-                throw ContractException("Cannot look for an empty schema namespace. Please report this to the Specmatic Builders at $SPECMATIC_GITHUB_ISSUES")
+    private fun findSchemaNode(
+        tagName: String,
+        namespace: String,
+        localName: String,
+        schema: XMLNode?,
+        missingMessage: String? = null
+    ): XMLNode {
+        findSchema(namespace, schema)
+        return findSchemaNodeOrNull(tagName, namespace, localName, schema)
+            ?: throw ContractException(missingMessage ?: "Couldn't find a node named $tagName with attribute name=\"$localName\"")
+    }
 
-            schemas[resolvedNamespace]
-                ?: throw ContractException("Couldn't find schema with targetNamespace $resolvedNamespace")
-        }
+    private fun findSchemaNodeOrNull(tagName: String, namespace: String, localName: String, schema: XMLNode?): XMLNode? {
+        val resolvedNamespace = resolvedSchemaNamespace(namespace, schema)
+        val key = SchemaLookupKey(tagName, resolvedNamespace, localName)
+        return indexes.schemas[key]
+    }
+
+    private fun findNamedSchemaNode(namespace: String, localName: String, schema: XMLNode?): XMLNode {
+        findSchema(namespace, schema)
+        val resolvedNamespace = resolvedSchemaNamespace(namespace, schema)
+        return indexes.namedSchemas[NamedSchemaLookupKey(resolvedNamespace, localName)]
+            ?: throw ContractException("Couldn't find a node with attribute name=$localName")
+    }
+
+    private fun resolvedSchemaNamespace(namespace: String, schema: XMLNode?): String {
+        val resolvedNamespace = namespaceOrSchemaNamespace(namespace, schema)
+        if (resolvedNamespace.isNullOrBlank())
+            throw ContractException("Cannot look for an empty schema namespace. Please report this to the Specmatic Builders at $SPECMATIC_GITHUB_ISSUES")
+
+        return resolvedNamespace
     }
 
     fun getComplexTypeNode(element: XMLNode): ComplexType {
@@ -485,18 +485,46 @@ data class WSDL(private val rootDefinition: XMLNode, val definitions: Map<String
 fun namespaceOrSchemaNamespace(namespace: String, schema: XMLNode?) =
     namespace.ifBlank { schema?.attributes?.get("xmlns")?.toStringLiteral() }
 
-private fun XMLNode?.schemaFallbackNamespace(): String? =
-    this?.attributes?.get("xmlns")?.toStringLiteral()
-
-private fun XMLNode?.attachedSchemaNamespace(): String? =
-    this?.schema?.attributes?.get("xmlns")?.toStringLiteral()
-
-private fun <K, V> MutableMap<K, V?>.getOrPutNullable(key: K, defaultValue: () -> V?): V? {
-    if (containsKey(key)) {
-        return this[key]
-    }
-
-    val value = defaultValue()
-    this[key] = value
-    return value
+private fun indexDefinitions(definitions: Map<String, XMLNode>): Map<DefinitionLookupKey, XMLNode> {
+    val definitionTags = setOf("message", "binding", "portType")
+    return definitions.flatMap { (namespace, definition) ->
+        definition.childNodes.filterIsInstance<XMLNode>()
+            .filter { it.name in definitionTags }
+            .mapNotNull { node ->
+                node.attributes["name"]?.toStringLiteral()?.let { localName ->
+                    DefinitionLookupKey(node.name, namespace, localName) to node
+                }
+            }
+    }.firstByKey()
 }
+
+private fun indexSchemas(schemas: Map<String, XMLNode>): Map<SchemaLookupKey, XMLNode> {
+    val schemaTags = setOf("element", "complexType", "simpleType", "attribute", "attributeGroup")
+    return schemas.flatMap { (namespace, schema) ->
+        schema.childNodes.filterIsInstance<XMLNode>()
+            .filter { it.name in schemaTags }
+            .mapNotNull { node ->
+                node.attributes["name"]?.toStringLiteral()?.let { localName ->
+                    SchemaLookupKey(node.name, namespace, localName) to node
+                }
+            }
+    }.firstByKey()
+}
+
+private fun indexNamedSchemas(schemas: Map<String, XMLNode>): Map<NamedSchemaLookupKey, XMLNode> {
+    return schemas.flatMap { (namespace, schema) ->
+        schema.childNodes.filterIsInstance<XMLNode>()
+            .mapNotNull { node ->
+                node.attributes["name"]?.toStringLiteral()?.let { localName ->
+                    NamedSchemaLookupKey(namespace, localName) to node
+                }
+            }
+    }.firstByKey()
+}
+
+private fun <K, V> List<Pair<K, V>>.firstByKey(): Map<K, V> =
+    LinkedHashMap<K, V>().also { indexedValues ->
+        forEach { entry ->
+            indexedValues.putIfAbsent(entry.first, entry.second)
+        }
+    }

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/message/ChoiceOfChildrenInComplexType.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/message/ChoiceOfChildrenInComplexType.kt
@@ -25,25 +25,18 @@ internal class ChoiceOfChildrenInComplexType(
         val minOccurs = child.attributes["minOccurs"]?.toStringLiteral()?.toIntOrNull() ?: 1
         val maxOccursLiteral = child.attributes["maxOccurs"]?.toStringLiteral() ?: "1"
 
-        return when {
-            maxOccursLiteral == "1" && minOccurs <= 1 ->
-                if (minOccurs == 0) choiceVariants.plus(WSDLTypeInfo()) else choiceVariants
-
-            else -> {
-                listOf(
-                    WSDLTypeInfo(
-                        members = listOf(
-                            XMLChoiceGroupPattern(
-                                choices = choiceVariants.map { it.effectiveMembers },
-                                minOccurs = minOccurs,
-                                maxOccurs = maxOccursLiteral.takeUnless { it == "unbounded" }?.toInt()
-                            )
-                        ),
-                        types = choiceVariants.fold(existingTypes) { accumulated, variant -> accumulated + variant.types },
-                        namespacePrefixes = choiceVariants.flatMap { it.namespacePrefixes }.toSet()
+        return listOf(
+            WSDLTypeInfo(
+                members = listOf(
+                    XMLChoiceGroupPattern(
+                        choices = choiceVariants.map { it.effectiveMembers },
+                        minOccurs = minOccurs,
+                        maxOccurs = maxOccursLiteral.takeUnless { it == "unbounded" }?.toInt()
                     )
-                )
-            }
-        }
+                ),
+                types = choiceVariants.fold(existingTypes) { accumulated, variant -> accumulated + variant.types },
+                namespacePrefixes = choiceVariants.flatMap { it.namespacePrefixes }.toSet()
+            )
+        )
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/pattern/XMLChoiceGroupPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/XMLChoiceGroupPatternTest.kt
@@ -88,21 +88,242 @@ class XMLChoiceGroupPatternTest {
     }
 
     @Test
-    fun `encompasses treats a new choice branch as incompatible and a removed branch as compatible`() {
-        val oldChoice = choiceGroup("CustomerNumber", "LoginId")
-        val choiceWithAddedBranch = choiceGroup("CustomerNumber", "LoginId", "Email")
-        val choiceWithRemovedBranch = choiceGroup("CustomerNumber")
+    fun `encompasses succeeds when my choice and other choice have the same branches`() {
+        val myChoice = choiceGroup("CustomerNumber", "LoginId")
+        val otherChoice = choiceGroup("CustomerNumber", "LoginId")
 
-        assertThat(oldChoice.encompasses(oldChoice, resolver, resolver)).isInstanceOf(Result.Success::class.java)
-        assertThat(oldChoice.encompasses(choiceWithAddedBranch, resolver, resolver)).isInstanceOf(Result.Failure::class.java)
-        assertThat(oldChoice.encompasses(choiceWithRemovedBranch, resolver, resolver)).isInstanceOf(Result.Success::class.java)
+        assertSuccess(myChoice.encompasses(otherChoice, resolver, resolver))
     }
 
-    private fun choiceGroup(vararg branchNames: String): XMLChoiceGroupPattern {
+    @Test
+    fun `encompasses fails when a branch is added to the other choice`() {
+        val myChoice = choiceGroup("CustomerNumber", "LoginId")
+        val otherChoice = choiceGroup("CustomerNumber", "LoginId", "Email")
+
+        assertFailure(myChoice.encompasses(otherChoice, resolver, resolver))
+    }
+
+    @Test
+    fun `encompasses succeeds when a branch is added to my choice`() {
+        val myChoice = choiceGroup("CustomerNumber", "LoginId", "Email")
+        val otherChoice = choiceGroup("CustomerNumber", "LoginId")
+
+        assertSuccess(myChoice.encompasses(otherChoice, resolver, resolver))
+    }
+
+    @Test
+    fun `encompasses succeeds when a branch is removed from the other choice`() {
+        val myChoice = choiceGroup("CustomerNumber", "LoginId")
+        val otherChoice = choiceGroup("CustomerNumber")
+
+        assertSuccess(myChoice.encompasses(otherChoice, resolver, resolver))
+    }
+
+    @Test
+    fun `encompasses fails when a branch is removed from my choice`() {
+        val myChoice = choiceGroup("CustomerNumber")
+        val otherChoice = choiceGroup("CustomerNumber", "LoginId")
+
+        assertFailure(myChoice.encompasses(otherChoice, resolver, resolver))
+    }
+
+    @Test
+    fun `encompasses fails for an other branch beyond max test request combinations`() {
+        val boundedResolver = resolver.copy(maxTestRequestCombinations = 1)
+        val myChoice = choiceGroup("A")
+        val otherChoice = choiceGroup("A", "B")
+
+        assertFailure(myChoice.encompasses(otherChoice, boundedResolver, boundedResolver))
+    }
+
+    @Test
+    fun `optional my choice encompasses required other choice`() {
+        val myChoice = choiceGroup("A", minOccurs = 0, maxOccurs = 1)
+        val otherChoice = choiceGroup("A", minOccurs = 1, maxOccurs = 1)
+
+        assertSuccess(myChoice.encompasses(otherChoice, resolver, resolver))
+    }
+
+    @Test
+    fun `required my choice does not encompass optional other choice`() {
+        val myChoice = choiceGroup("A", minOccurs = 1, maxOccurs = 1)
+        val otherChoice = choiceGroup("A", minOccurs = 0, maxOccurs = 1)
+
+        assertFailure(myChoice.encompasses(otherChoice, resolver, resolver))
+    }
+
+    @Test
+    fun `my choice with wider max encompasses other choice with narrower max`() {
+        val myChoice = choiceGroup("A", minOccurs = 1, maxOccurs = 2)
+        val otherChoice = choiceGroup("A", minOccurs = 1, maxOccurs = 1)
+
+        assertSuccess(myChoice.encompasses(otherChoice, resolver, resolver))
+    }
+
+    @Test
+    fun `my choice with narrower max does not encompass other choice with wider max`() {
+        val myChoice = choiceGroup("A", minOccurs = 1, maxOccurs = 1)
+        val otherChoice = choiceGroup("A", minOccurs = 1, maxOccurs = 2)
+
+        assertFailure(myChoice.encompasses(otherChoice, resolver, resolver))
+    }
+
+    @Test
+    fun `unbounded my choice encompasses bounded other choice`() {
+        val myChoice = choiceGroup("A", minOccurs = 1, maxOccurs = null)
+        val otherChoice = choiceGroup("A", minOccurs = 1, maxOccurs = 5)
+
+        assertSuccess(myChoice.encompasses(otherChoice, resolver, resolver))
+    }
+
+    @Test
+    fun `bounded my choice does not encompass unbounded other choice`() {
+        val myChoice = choiceGroup("A", minOccurs = 1, maxOccurs = 5)
+        val otherChoice = choiceGroup("A", minOccurs = 1, maxOccurs = null)
+
+        assertFailure(myChoice.encompasses(otherChoice, resolver, resolver))
+    }
+
+    @Test
+    fun `encompasses succeeds for a matching multi node branch`() {
+        val myChoice = choiceGroupOfBranches(
+            listOf("Common", "BranchB"),
+            listOf("Common", "BranchC")
+        )
+        val otherChoice = choiceGroupOfBranches(listOf("Common", "BranchC"))
+
+        assertSuccess(myChoice.encompasses(otherChoice, resolver, resolver))
+    }
+
+    @Test
+    fun `encompasses fails for an unknown multi node branch`() {
+        val myChoice = choiceGroupOfBranches(
+            listOf("Common", "BranchB"),
+            listOf("Common", "BranchC")
+        )
+        val otherChoice = choiceGroupOfBranches(listOf("Common", "BranchD"))
+
+        assertFailure(myChoice.encompasses(otherChoice, resolver, resolver))
+    }
+
+    @Test
+    fun `encompasses succeeds for a nested choice subset`() {
+        val myChoice = XMLChoiceGroupPattern(
+            choices = listOf(
+                listOf(xmlElement("DirectId")),
+                listOf(choiceGroup("NestedA", "NestedB"))
+            )
+        )
+        val otherChoice = XMLChoiceGroupPattern(
+            choices = listOf(listOf(choiceGroup("NestedA")))
+        )
+
+        assertSuccess(myChoice.encompasses(otherChoice, resolver, resolver))
+    }
+
+    @Test
+    fun `encompasses fails for a nested branch added to the other choice`() {
+        val myChoice = XMLChoiceGroupPattern(
+            choices = listOf(
+                listOf(xmlElement("DirectId")),
+                listOf(choiceGroup("NestedA", "NestedB"))
+            )
+        )
+        val otherChoice = XMLChoiceGroupPattern(
+            choices = listOf(listOf(choiceGroup("NestedA", "NestedC")))
+        )
+
+        assertFailure(myChoice.encompasses(otherChoice, resolver, resolver))
+    }
+
+    @Test
+    fun `normal choice encompasses a concrete sequence within range`() {
+        val myChoice = choiceGroup("A", "B", minOccurs = 2, maxOccurs = 2)
+        val otherChoice = concreteChoiceSequence("A", "B")
+
+        assertSuccess(myChoice.encompasses(otherChoice, resolver, resolver))
+    }
+
+    @Test
+    fun `concrete sequence encompasses identical concrete sequence`() {
+        val myChoice = concreteChoiceSequence("A", "B")
+        val otherChoice = concreteChoiceSequence("A", "B")
+
+        assertSuccess(myChoice.encompasses(otherChoice, resolver, resolver))
+    }
+
+    @Test
+    fun `concrete sequence rejects different order`() {
+        val myChoice = concreteChoiceSequence("A", "B")
+        val otherChoice = concreteChoiceSequence("B", "A")
+
+        assertFailure(myChoice.encompasses(otherChoice, resolver, resolver))
+    }
+
+    @Test
+    fun `concrete sequence does not encompass normal choice permutations`() {
+        val myChoice = concreteChoiceSequence("A", "B")
+        val otherChoice = choiceGroup("A", "B", minOccurs = 2, maxOccurs = 2)
+
+        assertFailure(myChoice.encompasses(otherChoice, resolver, resolver))
+    }
+
+    @Test
+    fun `choice encompasses a matching single XML pattern`() {
+        val myChoice = choiceGroup("A", "B")
+        val otherPattern = xmlElement("A")
+
+        assertSuccess(myChoice.encompasses(otherPattern, resolver, resolver))
+    }
+
+    @Test
+    fun `choice rejects an unknown single XML pattern`() {
+        val myChoice = choiceGroup("A", "B")
+        val otherPattern = xmlElement("C")
+
+        assertFailure(myChoice.encompasses(otherPattern, resolver, resolver))
+    }
+
+    private fun choiceGroup(
+        vararg branchNames: String,
+        minOccurs: Int = 1,
+        maxOccurs: Int? = 1
+    ): XMLChoiceGroupPattern {
         return XMLChoiceGroupPattern(
             choices = branchNames.map { branchName ->
-                listOf(XMLPattern("<$branchName>(string)</$branchName>"))
+                listOf(xmlElement(branchName))
+            },
+            minOccurs = minOccurs,
+            maxOccurs = maxOccurs
+        )
+    }
+
+    private fun choiceGroupOfBranches(vararg branches: List<String>): XMLChoiceGroupPattern {
+        return XMLChoiceGroupPattern(
+            choices = branches.map { branch ->
+                branch.map(::xmlElement)
             }
         )
+    }
+
+    private fun concreteChoiceSequence(vararg branchNames: String): XMLChoiceGroupPattern {
+        val branchPatterns = branchNames.map(::xmlElement)
+
+        return XMLChoiceGroupPattern(
+            choices = branchNames.distinct().map { branchName ->
+                listOf(xmlElement(branchName))
+            },
+            concreteSequence = branchPatterns.map { listOf(it) }
+        )
+    }
+
+    private fun xmlElement(name: String): XMLPattern = XMLPattern("<$name>(string)</$name>")
+
+    private fun assertSuccess(result: Result) {
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+    }
+
+    private fun assertFailure(result: Result) {
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/pattern/XMLChoiceGroupPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/XMLChoiceGroupPatternTest.kt
@@ -59,7 +59,7 @@ class XMLChoiceGroupPatternTest {
     }
 
     @Test
-    fun `new based on only emits valid repeated occurrence sequences`() {
+    fun `new based on materializes bounded repeated occurrence sequences`() {
         val pattern = XMLChoiceGroupPattern(
             choices = listOf(
                 listOf(XMLPattern("<A>(string)</A>")),
@@ -69,22 +69,148 @@ class XMLChoiceGroupPatternTest {
             maxOccurs = 2
         )
 
-        val generated = pattern.newBasedOn(resolver).map { it as XMLChoiceGroupPattern }.toList()
-        val sequences = generated.map { variant ->
-            variant.concreteSequence.orEmpty().map { occurrence ->
-                ((occurrence.single() as XMLPattern).pattern.name).substringAfter(":")
-            }
-        }
+        val generated = pattern.newBasedOn(resolver).map { it as XMLSequencePattern }.toList()
 
-        assertThat(generated).hasSize(6)
-        assertThat(sequences).containsExactlyInAnyOrder(
+        assertThat(generated.map(::choiceNames)).containsExactlyInAnyOrder(
             listOf("A"),
             listOf("B"),
-            listOf("A", "A"),
             listOf("A", "B"),
-            listOf("B", "A"),
-            listOf("B", "B"),
         )
+        assertThat(generated).allSatisfy { variant ->
+            assertThat(variant.members).isNotEmpty()
+        }
+    }
+
+    @Test
+    fun `new based on materializes one single occurrence variant per branch`() {
+        val generated = choiceGroup("A", "B", "C").newBasedOn(resolver).map { it as XMLSequencePattern }.toList()
+
+        assertThat(generated.map(::choiceNames)).containsExactlyInAnyOrder(
+            listOf("A"),
+            listOf("B"),
+            listOf("C")
+        )
+    }
+
+    @Test
+    fun `new based on materializes optional absence and single branch variants`() {
+        val generated = choiceGroup("A", "B", minOccurs = 0, maxOccurs = 1)
+            .newBasedOn(resolver)
+            .map { it as XMLSequencePattern }
+            .toList()
+
+        assertThat(generated.map(::choiceNames)).containsExactlyInAnyOrder(
+            emptyList(),
+            listOf("A"),
+            listOf("B")
+        )
+    }
+
+    @Test
+    fun `new based on cycles declaration order when max exceeds branch count`() {
+        val generated = choiceGroup("A", "B", minOccurs = 0, maxOccurs = 3)
+            .newBasedOn(resolver)
+            .map { it as XMLSequencePattern }
+            .toList()
+
+        assertThat(generated.map(::choiceNames)).containsExactlyInAnyOrder(
+            emptyList(),
+            listOf("A", "B", "A")
+        )
+    }
+
+    @Test
+    fun `new based on includes exact min and max representatives`() {
+        val generated = choiceGroup("A", "B", minOccurs = 2, maxOccurs = 4)
+            .newBasedOn(resolver)
+            .map { it as XMLSequencePattern }
+            .toList()
+
+        assertThat(generated.map(::choiceNames)).containsExactlyInAnyOrder(
+            listOf("A", "B"),
+            listOf("A", "B", "A", "B")
+        )
+    }
+
+    @Test
+    fun `new based on generates combinations when count does not exceed branch count`() {
+        val generated = choiceGroup("A", "B", "C", minOccurs = 1, maxOccurs = 2)
+            .newBasedOn(resolver)
+            .map { it as XMLSequencePattern }
+            .toList()
+
+        assertThat(generated.map(::choiceNames)).containsExactlyInAnyOrder(
+            listOf("A"),
+            listOf("B"),
+            listOf("C"),
+            listOf("A", "B"),
+            listOf("A", "C"),
+            listOf("B", "C")
+        )
+    }
+
+    @Test
+    fun `new based on preserves multi node branch as one choice occurrence`() {
+        val generated = choiceGroupOfBranches(listOf("Common", "BranchB"), listOf("Common", "BranchC"))
+            .newBasedOn(resolver)
+            .map { it as XMLSequencePattern }
+            .toList()
+
+        assertThat(generated.map(::choiceNames)).containsExactlyInAnyOrder(
+            listOf("Common", "BranchB"),
+            listOf("Common", "BranchC")
+        )
+    }
+
+    @Test
+    fun `new based on preserves repeated multi node branch grouping`() {
+        val generated = choiceGroupOfBranches(
+            listOf("Common", "BranchB"),
+            listOf("Common", "BranchC"),
+            minOccurs = 2,
+            maxOccurs = 2
+        ).newBasedOn(resolver).map { it as XMLSequencePattern }.toList()
+
+        assertThat(generated.map(::choiceNames)).containsExactlyInAnyOrder(
+            listOf("Common", "BranchB", "Common", "BranchC")
+        )
+    }
+
+    @Test
+    fun `materialized choice generates each selected occurrence exactly once`() {
+        val materialized = choiceGroup("A", "B", minOccurs = 2, maxOccurs = 2)
+            .newBasedOn(resolver)
+            .map { it as XMLSequencePattern }
+            .single()
+
+        assertThat(generatedNodeNames(materialized)).containsExactly("A", "B")
+    }
+
+    @Test
+    fun `new based on materializes nested choice branches recursively`() {
+        val generated = XMLChoiceGroupPattern(
+            choices = listOf(
+                listOf(xmlElement("DirectId")),
+                listOf(choiceGroup("NestedA", "NestedB"))
+            )
+        ).newBasedOn(resolver).map { it as XMLSequencePattern }.toList()
+
+        assertThat(generated.map(::expandedChoiceNames)).containsExactlyInAnyOrder(
+            listOf("DirectId"),
+            listOf("NestedA"),
+            listOf("NestedB")
+        )
+    }
+
+    @Test
+    fun `row based new based on preserves example values in materialized choices`() {
+        val materialized = choiceGroup("A", "B")
+            .newBasedOn(Row(listOf("A"), listOf("example value")), resolver)
+            .map { it.value as XMLSequencePattern }
+            .first { choiceNames(it) == listOf("A") }
+
+        assertThat(generatedNodeNames(materialized)).containsExactly("A")
+        assertThat(materialized.generate(resolver).toStringLiteral()).contains("<A>example value</A>")
     }
 
     @Test
@@ -237,32 +363,24 @@ class XMLChoiceGroupPatternTest {
     }
 
     @Test
-    fun `normal choice encompasses a concrete sequence within range`() {
+    fun `normal choice encompasses a materialized choice within range`() {
         val myChoice = choiceGroup("A", "B", minOccurs = 2, maxOccurs = 2)
-        val otherChoice = concreteChoiceSequence("A", "B")
+        val otherChoice = materializedChoice("A", "B")
 
         assertSuccess(myChoice.encompasses(otherChoice, resolver, resolver))
     }
 
     @Test
-    fun `concrete sequence encompasses identical concrete sequence`() {
-        val myChoice = concreteChoiceSequence("A", "B")
-        val otherChoice = concreteChoiceSequence("A", "B")
+    fun `materialized choice encompasses identical materialized choice`() {
+        val myChoice = materializedChoice("A", "B")
+        val otherChoice = materializedChoice("A", "B")
 
         assertSuccess(myChoice.encompasses(otherChoice, resolver, resolver))
     }
 
     @Test
-    fun `concrete sequence rejects different order`() {
-        val myChoice = concreteChoiceSequence("A", "B")
-        val otherChoice = concreteChoiceSequence("B", "A")
-
-        assertFailure(myChoice.encompasses(otherChoice, resolver, resolver))
-    }
-
-    @Test
-    fun `concrete sequence does not encompass normal choice permutations`() {
-        val myChoice = concreteChoiceSequence("A", "B")
+    fun `materialized sequence does not encompass repeated choice schema`() {
+        val myChoice = materializedChoice("A", "B")
         val otherChoice = choiceGroup("A", "B", minOccurs = 2, maxOccurs = 2)
 
         assertFailure(myChoice.encompasses(otherChoice, resolver, resolver))
@@ -298,23 +416,49 @@ class XMLChoiceGroupPatternTest {
         )
     }
 
-    private fun choiceGroupOfBranches(vararg branches: List<String>): XMLChoiceGroupPattern {
+    private fun choiceGroupOfBranches(
+        vararg branches: List<String>,
+        minOccurs: Int = 1,
+        maxOccurs: Int? = 1
+    ): XMLChoiceGroupPattern {
         return XMLChoiceGroupPattern(
-            choices = branches.map { branch ->
-                branch.map(::xmlElement)
-            }
+            choices = branches.map { branch -> branch.map(::xmlElement) },
+            minOccurs = minOccurs,
+            maxOccurs = maxOccurs
         )
     }
 
-    private fun concreteChoiceSequence(vararg branchNames: String): XMLChoiceGroupPattern {
-        val branchPatterns = branchNames.map(::xmlElement)
+    private fun materializedChoice(vararg branchNames: String): XMLSequencePattern {
+        return XMLSequencePattern(branchNames.map(::xmlElement))
+    }
 
-        return XMLChoiceGroupPattern(
-            choices = branchNames.distinct().map { branchName ->
-                listOf(xmlElement(branchName))
-            },
-            concreteSequence = branchPatterns.map { listOf(it) }
-        )
+    private fun choiceNames(choiceGroup: XMLSequencePattern): List<String> {
+        return choiceGroup.members.map { pattern ->
+            ((pattern as XMLPattern).pattern.name).substringAfter(":")
+        }
+    }
+
+    private fun expandedChoiceNames(choiceGroup: XMLSequencePattern): List<String> {
+        return choiceGroup.members.flatMap { pattern ->
+            patternNames(pattern)
+        }
+    }
+
+    private fun patternNames(pattern: Pattern): List<String> {
+        return when (pattern) {
+            is XMLPattern -> listOf(pattern.pattern.name.substringAfter(":"))
+            is XMLChoiceGroupPattern -> pattern.choices.flatten().flatMap(::patternNames)
+            is XMLSequencePattern -> pattern.members.flatMap(::patternNames)
+            else -> emptyList()
+        }
+    }
+
+    private fun generatedNodeNames(choiceGroup: XMLSequencePattern): List<String> {
+        val generated = choiceGroup.generate(resolver) as io.specmatic.core.value.XMLNode
+
+        return generated.childNodes.filterIsInstance<io.specmatic.core.value.XMLNode>().map { childNode ->
+            childNode.name.substringAfter(":")
+        }
     }
 
     private fun xmlElement(name: String): XMLPattern = XMLPattern("<$name>(string)</$name>")

--- a/core/src/test/kotlin/io/specmatic/core/pattern/XMLChoiceGroupPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/XMLChoiceGroupPatternTest.kt
@@ -43,6 +43,21 @@ class XMLChoiceGroupPatternTest {
     }
 
     @Test
+    fun `matches accepts a later branch when the first branch fails`() {
+        val pattern = XMLChoiceGroupPattern(
+            choices = listOf(
+                listOf(XMLPattern("<A>(string)</A>")),
+                listOf(XMLPattern("<B>(string)</B>"))
+            )
+        )
+
+        val result = pattern.matches(listOf(toXMLNode("<B>two</B>")), resolver)
+
+        assertThat(result.result).isInstanceOf(io.specmatic.core.Result.Success::class.java)
+        assertThat(result.remainder).isEmpty()
+    }
+
+    @Test
     fun `new based on only emits valid repeated occurrence sequences`() {
         val pattern = XMLChoiceGroupPattern(
             choices = listOf(

--- a/core/src/test/kotlin/io/specmatic/core/pattern/XMLChoiceGroupPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/XMLChoiceGroupPatternTest.kt
@@ -1,6 +1,7 @@
 package io.specmatic.core.pattern
 
 import io.specmatic.core.Resolver
+import io.specmatic.core.Result
 import io.specmatic.core.value.toXMLNode
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -83,6 +84,25 @@ class XMLChoiceGroupPatternTest {
             listOf("A", "B"),
             listOf("B", "A"),
             listOf("B", "B"),
+        )
+    }
+
+    @Test
+    fun `encompasses treats a new choice branch as incompatible and a removed branch as compatible`() {
+        val oldChoice = choiceGroup("CustomerNumber", "LoginId")
+        val choiceWithAddedBranch = choiceGroup("CustomerNumber", "LoginId", "Email")
+        val choiceWithRemovedBranch = choiceGroup("CustomerNumber")
+
+        assertThat(oldChoice.encompasses(oldChoice, resolver, resolver)).isInstanceOf(Result.Success::class.java)
+        assertThat(oldChoice.encompasses(choiceWithAddedBranch, resolver, resolver)).isInstanceOf(Result.Failure::class.java)
+        assertThat(oldChoice.encompasses(choiceWithRemovedBranch, resolver, resolver)).isInstanceOf(Result.Success::class.java)
+    }
+
+    private fun choiceGroup(vararg branchNames: String): XMLChoiceGroupPattern {
+        return XMLChoiceGroupPattern(
+            choices = branchNames.map { branchName ->
+                listOf(XMLPattern("<$branchName>(string)</$branchName>"))
+            }
         )
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/pattern/XMLPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/XMLPatternTest.kt
@@ -215,10 +215,10 @@ internal class XMLPatternTest {
             val resolver = Resolver(newPatterns = mapOf(withPatternDelimiters("Node") to XMLPattern("<Node/>")))
 
             val expandedChoice = resolver.withCyclePrevention(DeferredPattern(withPatternDelimiters("Node"))) { cycleResolver ->
-                choiceGroup.newBasedOn(cycleResolver).first() as XMLChoiceGroupPattern
+                choiceGroup.newBasedOn(cycleResolver).first() as XMLSequencePattern
             }
 
-            assertThat(expandedChoice.concreteSequence).containsExactly(emptyList<Pattern>())
+            assertThat(expandedChoice.members).isEmpty()
         }
 
         @Test
@@ -229,10 +229,10 @@ internal class XMLPatternTest {
             val resolver = Resolver(newPatterns = mapOf(withPatternDelimiters("Node") to XMLPattern("<Node/>")))
 
             val expandedChoice = resolver.withCyclePrevention(DeferredPattern(withPatternDelimiters("Node"))) { cycleResolver ->
-                choiceGroup.newBasedOn(Row(), cycleResolver).first().value as XMLChoiceGroupPattern
+                choiceGroup.newBasedOn(Row(), cycleResolver).first().value as XMLSequencePattern
             }
 
-            assertThat(expandedChoice.concreteSequence).containsExactly(emptyList<Pattern>())
+            assertThat(expandedChoice.members).isEmpty()
         }
 
         @Test

--- a/core/src/test/kotlin/io/specmatic/core/wsdl/WSDLParserBlackBoxSupport.kt
+++ b/core/src/test/kotlin/io/specmatic/core/wsdl/WSDLParserBlackBoxSupport.kt
@@ -1,8 +1,12 @@
 package io.specmatic.core.wsdl
 
+import io.ktor.http.ContentType
+import io.specmatic.conversions.wsdlContentToFeature
+import io.specmatic.core.CONTENT_TYPE
 import io.specmatic.core.Feature
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.parseContractFileToFeature
+import io.specmatic.core.value.StringValue
 import io.specmatic.mock.ScenarioStub
 import org.assertj.core.api.Assertions.assertThat
 import java.io.File
@@ -29,4 +33,110 @@ internal fun assertHttpRequestMatches(actual: HttpRequest, expected: HttpRequest
     assertThat(actual.path).isEqualTo(expected.path)
     assertThat(actual.headers["SOAPAction"]).isEqualTo(expected.headers["SOAPAction"])
     assertThat(actual.body).isEqualTo(expected.body)
+}
+
+internal fun choiceWsdlFeature(
+    requestName: String,
+    requestBodySchema: String,
+    path: String,
+    operation: String,
+    namespace: String = "http://choice-edge",
+): Feature {
+    val wsdlContent = """
+        <wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                          xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                          xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                          xmlns:tns="$namespace"
+                          targetNamespace="$namespace">
+            <wsdl:types>
+                <xsd:schema targetNamespace="$namespace" elementFormDefault="qualified">
+                    <xsd:element name="$requestName">
+                        <xsd:complexType>
+                            <xsd:sequence>
+                                $requestBodySchema
+                            </xsd:sequence>
+                        </xsd:complexType>
+                    </xsd:element>
+                    <xsd:element name="ChoiceResponse">
+                        <xsd:complexType>
+                            <xsd:sequence>
+                                <xsd:element name="status" type="xsd:string"/>
+                            </xsd:sequence>
+                        </xsd:complexType>
+                    </xsd:element>
+                </xsd:schema>
+            </wsdl:types>
+
+            <wsdl:message name="ChoiceRequestMessage">
+                <wsdl:part name="parameters" element="tns:$requestName"/>
+            </wsdl:message>
+            <wsdl:message name="ChoiceResponseMessage">
+                <wsdl:part name="parameters" element="tns:ChoiceResponse"/>
+            </wsdl:message>
+
+            <wsdl:portType name="ChoicePortType">
+                <wsdl:operation name="$operation">
+                    <wsdl:input message="tns:ChoiceRequestMessage"/>
+                    <wsdl:output message="tns:ChoiceResponseMessage"/>
+                </wsdl:operation>
+            </wsdl:portType>
+
+            <wsdl:binding name="ChoiceBinding" type="tns:ChoicePortType">
+                <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+                <wsdl:operation name="$operation">
+                    <soap:operation soapAction="$path/$operation"/>
+                    <wsdl:input>
+                        <soap:body use="literal"/>
+                    </wsdl:input>
+                    <wsdl:output>
+                        <soap:body use="literal"/>
+                    </wsdl:output>
+                </wsdl:operation>
+            </wsdl:binding>
+
+            <wsdl:service name="ChoiceService">
+                <wsdl:port name="ChoicePort" binding="tns:ChoiceBinding">
+                    <soap:address location="http://localhost:9000$path"/>
+                </wsdl:port>
+            </wsdl:service>
+        </wsdl:definitions>
+    """.trimIndent()
+
+    return wsdlContentToFeature(wsdlContent, "$requestName.wsdl")
+}
+
+internal fun choiceSoapRequest(
+    requestName: String,
+    requestBody: String,
+    path: String,
+    operation: String,
+    namespace: String = "http://choice-edge",
+): HttpRequest {
+    return HttpRequest(
+        method = "POST",
+        path = path,
+        headers = mapOf("SOAPAction" to "\"$path/$operation\"", CONTENT_TYPE to ContentType.Text.Xml.toString()),
+        body = StringValue(
+            """
+            <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:t="$namespace">
+                <soapenv:Body>
+                    <t:$requestName>
+                        $requestBody
+                    </t:$requestName>
+                </soapenv:Body>
+            </soapenv:Envelope>
+            """.trimIndent()
+        ),
+    )
+}
+
+internal fun generatedRequestBodies(feature: Feature): List<String> {
+    return feature.scenarios.single()
+        .generateTestScenarios(feature.flagsBased)
+        .map { it.value.generateHttpRequest(feature.flagsBased).body.toStringLiteral() }
+        .toList()
+}
+
+internal fun countOccurrences(text: String, token: String): Int {
+    return text.windowed(token.length, 1).count { it == token }
 }

--- a/core/src/test/kotlin/io/specmatic/core/wsdl/WSDLParserContractBlackBoxTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/wsdl/WSDLParserContractBlackBoxTest.kt
@@ -7,6 +7,7 @@ import io.specmatic.core.HttpResponse
 import io.specmatic.core.SPECMATIC_RESULT_HEADER
 import io.specmatic.core.parseContractFileToFeature
 import io.specmatic.core.pattern.parsedValue
+import io.specmatic.core.testBackwardCompatibility
 import io.specmatic.core.value.toXMLNode
 import io.specmatic.core.wsdl.parser.WSDL
 import io.specmatic.core.wsdl.payload.emptySoapMessage
@@ -109,6 +110,158 @@ class WSDLParserContractBlackBoxTest {
             val loginCount = countOccurrences(body, "<Choice-scalar-repeating:LoginId>")
             assertThat(customerCount + loginCount).isBetween(1, 2)
         }
+    }
+
+    @Test
+    fun `scenario generation for sequential choices emits every valid branch combination`() {
+        val feature = choiceWsdlFeature(
+            requestName = "SequentialChoiceRequest",
+            requestBodySchema = """
+                <xsd:choice>
+                    <xsd:element name="FirstA" type="xsd:string"/>
+                    <xsd:element name="FirstB" type="xsd:string"/>
+                </xsd:choice>
+                <xsd:choice>
+                    <xsd:element name="SecondA" type="xsd:string"/>
+                    <xsd:element name="SecondB" type="xsd:string"/>
+                </xsd:choice>
+            """.trimIndent(),
+            path = "/choice-edge-sequential",
+            operation = "sequentialChoice",
+        )
+
+        val generatedBodies = generatedRequestBodies(feature)
+        val generatedBranchPairs = generatedBodies.map { body ->
+            assertThat(body.contains("FirstA")).isNotEqualTo(body.contains("FirstB"))
+            assertThat(body.contains("SecondA")).isNotEqualTo(body.contains("SecondB"))
+
+            "${selectedBranch(body, listOf("FirstA", "FirstB"))}/${selectedBranch(body, listOf("SecondA", "SecondB"))}"
+        }
+
+        assertThat(generatedBodies).hasSize(4)
+        assertThat(generatedBranchPairs).containsExactlyInAnyOrder(
+            "FirstA/SecondA",
+            "FirstA/SecondB",
+            "FirstB/SecondA",
+            "FirstB/SecondB",
+        )
+    }
+
+    @Test
+    fun `scenario generation for shared-prefix choice emits valid multi-node branches`() {
+        val feature = choiceWsdlFeature(
+            requestName = "SharedPrefixChoiceRequest",
+            requestBodySchema = """
+                <xsd:choice>
+                    <xsd:sequence>
+                        <xsd:element name="Common" type="xsd:string"/>
+                        <xsd:element name="BranchB" type="xsd:string"/>
+                    </xsd:sequence>
+                    <xsd:sequence>
+                        <xsd:element name="Common" type="xsd:string"/>
+                        <xsd:element name="BranchC" type="xsd:string"/>
+                    </xsd:sequence>
+                </xsd:choice>
+            """.trimIndent(),
+            path = "/choice-edge-shared-prefix",
+            operation = "sharedPrefixChoice",
+        )
+
+        val generatedBodies = generatedRequestBodies(feature)
+        val generatedBranches = generatedBodies.map { body ->
+            assertThat(body).contains("Common")
+            assertThat(body.contains("BranchB")).isNotEqualTo(body.contains("BranchC"))
+
+            selectedBranch(body, listOf("BranchB", "BranchC"))
+        }
+
+        assertThat(generatedBodies).hasSize(2)
+        assertThat(generatedBranches).containsExactlyInAnyOrder("BranchB", "BranchC")
+    }
+
+    @Test
+    fun `scenario generation for optional middle choice emits omitted and branch-present requests`() {
+        val feature = choiceWsdlFeature(
+            requestName = "OptionalMiddleChoiceRequest",
+            requestBodySchema = """
+                <xsd:element name="Before" type="xsd:string"/>
+                <xsd:choice minOccurs="0">
+                    <xsd:element name="OptionalA" type="xsd:string"/>
+                    <xsd:element name="OptionalB" type="xsd:string"/>
+                </xsd:choice>
+                <xsd:element name="After" type="xsd:string"/>
+            """.trimIndent(),
+            path = "/choice-edge-optional-middle",
+            operation = "optionalMiddleChoice",
+        )
+
+        val generatedBodies = generatedRequestBodies(feature)
+        val generatedBranches = generatedBodies.map { body ->
+            assertThat(body).contains("Before", "After")
+            assertThat(body.indexOf("Before")).isLessThan(body.indexOf("After"))
+            assertThat(body.contains("OptionalA") && body.contains("OptionalB")).isFalse()
+
+            selectedOptionalBranch(body, listOf("OptionalA", "OptionalB"))
+        }
+
+        assertThat(generatedBodies).hasSize(3)
+        assertThat(generatedBranches).containsExactlyInAnyOrder("omitted", "OptionalA", "OptionalB")
+    }
+
+    @Test
+    fun `scenario generation for nested choice emits direct and nested branches without mixing them`() {
+        val feature = choiceWsdlFeature(
+            requestName = "NestedChoiceRequest",
+            requestBodySchema = """
+                <xsd:choice>
+                    <xsd:element name="DirectId" type="xsd:string"/>
+                    <xsd:choice>
+                        <xsd:element name="NestedA" type="xsd:string"/>
+                        <xsd:element name="NestedB" type="xsd:string"/>
+                    </xsd:choice>
+                </xsd:choice>
+            """.trimIndent(),
+            path = "/choice-edge-nested",
+            operation = "nestedChoice",
+        )
+
+        val generatedBodies = generatedRequestBodies(feature)
+        val generatedBranches = generatedBodies.map { body ->
+            assertThat(body.contains("DirectId") && body.contains("NestedA")).isFalse()
+            assertThat(body.contains("DirectId") && body.contains("NestedB")).isFalse()
+            assertThat(body.contains("NestedA") && body.contains("NestedB")).isFalse()
+
+            selectedBranch(body, listOf("DirectId", "NestedA", "NestedB"))
+        }
+
+        assertThat(generatedBodies).hasSize(3)
+        assertThat(generatedBranches).containsExactlyInAnyOrder("DirectId", "NestedA", "NestedB")
+    }
+
+    @Test
+    fun `backward compatibility for wsdl request choice tracks branch additions and removals`() {
+        val oldFeature = choiceWsdlFeature(
+            requestName = "ChoiceRequest",
+            requestBodySchema = customerChoiceSchema("CustomerNumber", "LoginId"),
+            path = "/choice-edge-bcc-request",
+            operation = "requestChoiceBcc",
+        )
+        val featureWithAddedBranch = choiceWsdlFeature(
+            requestName = "ChoiceRequest",
+            requestBodySchema = customerChoiceSchema("CustomerNumber", "LoginId", "Email"),
+            path = "/choice-edge-bcc-request",
+            operation = "requestChoiceBcc",
+        )
+        val featureWithRemovedBranch = choiceWsdlFeature(
+            requestName = "ChoiceRequest",
+            requestBodySchema = customerChoiceSchema("CustomerNumber"),
+            path = "/choice-edge-bcc-request",
+            operation = "requestChoiceBcc",
+        )
+
+        assertThat(testBackwardCompatibility(oldFeature, oldFeature).success()).isTrue()
+        assertThat(testBackwardCompatibility(oldFeature, featureWithAddedBranch).success()).isTrue()
+        assertThat(testBackwardCompatibility(oldFeature, featureWithRemovedBranch).success()).isFalse()
     }
 
     @Test
@@ -469,7 +622,22 @@ class WSDLParserContractBlackBoxTest {
         }
     }
 
-    private fun countOccurrences(text: String, token: String): Int {
-        return text.windowed(token.length, 1).count { it == token }
+    private fun selectedBranch(body: String, branches: List<String>): String {
+        return branches.singleOrNull { it in body }
+            ?: error("Expected exactly one of $branches in request body: $body")
+    }
+
+    private fun selectedOptionalBranch(body: String, branches: List<String>): String {
+        return branches.singleOrNull { it in body } ?: "omitted"
+    }
+
+    private fun customerChoiceSchema(vararg branchNames: String): String {
+        return branchNames.joinToString(
+            separator = "\n",
+            prefix = "<xsd:choice>\n",
+            postfix = "\n</xsd:choice>",
+        ) { branchName ->
+            """<xsd:element name="$branchName" type="xsd:string"/>"""
+        }
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/wsdl/WSDLParserMockBlackBoxTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/wsdl/WSDLParserMockBlackBoxTest.kt
@@ -329,6 +329,256 @@ class WSDLParserMockBlackBoxTest {
     }
 
     @Test
+    fun `mock for sequential choices accepts valid branch combination and rejects extra branch`() {
+        val path = "/choice-edge-sequential"
+        val operation = "sequentialChoice"
+        val feature = choiceWsdlFeature(
+            requestName = "SequentialChoiceRequest",
+            requestBodySchema = """
+                <xsd:choice>
+                    <xsd:element name="FirstA" type="xsd:string"/>
+                    <xsd:element name="FirstB" type="xsd:string"/>
+                </xsd:choice>
+                <xsd:choice>
+                    <xsd:element name="SecondA" type="xsd:string"/>
+                    <xsd:element name="SecondB" type="xsd:string"/>
+                </xsd:choice>
+            """.trimIndent(),
+            path = path,
+            operation = operation,
+        )
+
+        HttpStub(feature).use { stub ->
+            val validResponse = stub.client.execute(
+                choiceSoapRequest(
+                    requestName = "SequentialChoiceRequest",
+                    requestBody = """
+                        <t:FirstB>first-b</t:FirstB>
+                        <t:SecondA>second-a</t:SecondA>
+                    """.trimIndent(),
+                    path = path,
+                    operation = operation,
+                )
+            )
+            val invalidResponse = stub.client.execute(
+                choiceSoapRequest(
+                    requestName = "SequentialChoiceRequest",
+                    requestBody = """
+                        <t:FirstA>first-a</t:FirstA>
+                        <t:FirstB>first-b</t:FirstB>
+                        <t:SecondA>second-a</t:SecondA>
+                    """.trimIndent(),
+                    path = path,
+                    operation = operation,
+                )
+            )
+
+            assertThat(validResponse.status).isEqualTo(200)
+            assertThat(invalidResponse.status).isEqualTo(400)
+        }
+    }
+
+    @Test
+    fun `mock for shared-prefix choice accepts later branch after partial branch failure`() {
+        val path = "/choice-edge-shared-prefix"
+        val operation = "sharedPrefixChoice"
+        val feature = choiceWsdlFeature(
+            requestName = "SharedPrefixChoiceRequest",
+            requestBodySchema = """
+                <xsd:choice>
+                    <xsd:sequence>
+                        <xsd:element name="Common" type="xsd:string"/>
+                        <xsd:element name="BranchB" type="xsd:string"/>
+                    </xsd:sequence>
+                    <xsd:sequence>
+                        <xsd:element name="Common" type="xsd:string"/>
+                        <xsd:element name="BranchC" type="xsd:string"/>
+                    </xsd:sequence>
+                </xsd:choice>
+            """.trimIndent(),
+            path = path,
+            operation = operation,
+        )
+
+        HttpStub(feature).use { stub ->
+            val validResponse = stub.client.execute(
+                choiceSoapRequest(
+                    requestName = "SharedPrefixChoiceRequest",
+                    requestBody = """
+                        <t:Common>same-prefix</t:Common>
+                        <t:BranchC>second-branch</t:BranchC>
+                    """.trimIndent(),
+                    path = path,
+                    operation = operation,
+                )
+            )
+            val invalidResponse = stub.client.execute(
+                choiceSoapRequest(
+                    requestName = "SharedPrefixChoiceRequest",
+                    requestBody = """
+                        <t:Common>same-prefix</t:Common>
+                        <t:BranchB>first-branch</t:BranchB>
+                        <t:BranchC>second-branch</t:BranchC>
+                    """.trimIndent(),
+                    path = path,
+                    operation = operation,
+                )
+            )
+
+            assertThat(validResponse.status).isEqualTo(200)
+            assertThat(invalidResponse.status).isEqualTo(400)
+        }
+    }
+
+    @Test
+    fun `mock for optional choice in middle accepts omitted and present choice`() {
+        val path = "/choice-edge-optional-middle"
+        val operation = "optionalMiddleChoice"
+        val feature = choiceWsdlFeature(
+            requestName = "OptionalMiddleChoiceRequest",
+            requestBodySchema = """
+                <xsd:element name="Before" type="xsd:string"/>
+                <xsd:choice minOccurs="0">
+                    <xsd:element name="OptionalA" type="xsd:string"/>
+                    <xsd:element name="OptionalB" type="xsd:string"/>
+                </xsd:choice>
+                <xsd:element name="After" type="xsd:string"/>
+            """.trimIndent(),
+            path = path,
+            operation = operation,
+        )
+
+        HttpStub(feature).use { stub ->
+            val omittedResponse = stub.client.execute(
+                choiceSoapRequest(
+                    requestName = "OptionalMiddleChoiceRequest",
+                    requestBody = """
+                        <t:Before>before</t:Before>
+                        <t:After>after</t:After>
+                    """.trimIndent(),
+                    path = path,
+                    operation = operation,
+                )
+            )
+            val presentResponse = stub.client.execute(
+                choiceSoapRequest(
+                    requestName = "OptionalMiddleChoiceRequest",
+                    requestBody = """
+                        <t:Before>before</t:Before>
+                        <t:OptionalB>optional-b</t:OptionalB>
+                        <t:After>after</t:After>
+                    """.trimIndent(),
+                    path = path,
+                    operation = operation,
+                )
+            )
+
+            assertThat(omittedResponse.status).isEqualTo(200)
+            assertThat(presentResponse.status).isEqualTo(200)
+        }
+    }
+
+    @Test
+    fun `mock for bounded choice rejects too few and too many occurrences`() {
+        val path = "/choice-edge-bounded"
+        val operation = "boundedChoice"
+        val feature = choiceWsdlFeature(
+            requestName = "BoundedChoiceRequest",
+            requestBodySchema = """
+                <xsd:choice minOccurs="2" maxOccurs="2">
+                    <xsd:element name="CustomerNumber" type="xsd:string"/>
+                    <xsd:element name="LoginId" type="xsd:string"/>
+                </xsd:choice>
+            """.trimIndent(),
+            path = path,
+            operation = operation,
+        )
+
+        HttpStub(feature).use { stub ->
+            val validResponse = stub.client.execute(
+                choiceSoapRequest(
+                    requestName = "BoundedChoiceRequest",
+                    requestBody = """
+                        <t:CustomerNumber>C-123</t:CustomerNumber>
+                        <t:LoginId>login-123</t:LoginId>
+                    """.trimIndent(),
+                    path = path,
+                    operation = operation,
+                )
+            )
+            val tooFewResponse = stub.client.execute(
+                choiceSoapRequest(
+                    requestName = "BoundedChoiceRequest",
+                    requestBody = "<t:CustomerNumber>C-123</t:CustomerNumber>",
+                    path = path,
+                    operation = operation,
+                )
+            )
+            val tooManyResponse = stub.client.execute(
+                choiceSoapRequest(
+                    requestName = "BoundedChoiceRequest",
+                    requestBody = """
+                        <t:CustomerNumber>C-123</t:CustomerNumber>
+                        <t:LoginId>login-123</t:LoginId>
+                        <t:CustomerNumber>C-456</t:CustomerNumber>
+                    """.trimIndent(),
+                    path = path,
+                    operation = operation,
+                )
+            )
+
+            assertThat(validResponse.status).isEqualTo(200)
+            assertThat(tooFewResponse.status).isEqualTo(400)
+            assertThat(tooManyResponse.status).isEqualTo(400)
+        }
+    }
+
+    @Test
+    fun `mock for nested choice accepts nested branch and rejects mixed outer branches`() {
+        val path = "/choice-edge-nested"
+        val operation = "nestedChoice"
+        val feature = choiceWsdlFeature(
+            requestName = "NestedChoiceRequest",
+            requestBodySchema = """
+                <xsd:choice>
+                    <xsd:element name="DirectId" type="xsd:string"/>
+                    <xsd:choice>
+                        <xsd:element name="NestedA" type="xsd:string"/>
+                        <xsd:element name="NestedB" type="xsd:string"/>
+                    </xsd:choice>
+                </xsd:choice>
+            """.trimIndent(),
+            path = path,
+            operation = operation,
+        )
+
+        HttpStub(feature).use { stub ->
+            val validResponse = stub.client.execute(
+                choiceSoapRequest(
+                    requestName = "NestedChoiceRequest",
+                    requestBody = "<t:NestedB>nested-b</t:NestedB>",
+                    path = path,
+                    operation = operation,
+                )
+            )
+            val invalidResponse = stub.client.execute(
+                choiceSoapRequest(
+                    requestName = "NestedChoiceRequest",
+                    requestBody = """
+                        <t:DirectId>D-123</t:DirectId>
+                        <t:NestedB>nested-b</t:NestedB>
+                    """.trimIndent(),
+                    path = path,
+                    operation = operation,
+                )
+            )
+
+            assertThat(validResponse.status).isEqualTo(200)
+            assertThat(invalidResponse.status).isEqualTo(400)
+        }
+    }
+
+    @Test
     fun `mock for element ref wsdl returns the example soap response`() {
         val fixture = loadWsdlExampleFixture(
             "src/test/resources/wsdl/state_machine/element_ref.wsdl",

--- a/core/src/test/kotlin/io/specmatic/core/wsdl/parser/WSDLWiringCharacterizationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/wsdl/parser/WSDLWiringCharacterizationTest.kt
@@ -6,6 +6,7 @@ import io.specmatic.core.pattern.DeferredPattern
 import io.specmatic.core.pattern.XMLChoiceGroupPattern
 import io.specmatic.core.pattern.TYPE_ATTRIBUTE_NAME
 import io.specmatic.core.pattern.XMLPattern
+import io.specmatic.core.pattern.XMLSequencePattern
 import io.specmatic.core.pattern.XMLWildcardPattern
 import io.specmatic.core.pattern.withPatternDelimiters
 import io.specmatic.core.value.StringValue
@@ -51,8 +52,8 @@ class WSDLWiringCharacterizationTest {
             }
         }
         assertThat(choiceNames(choiceGroup)).containsExactlyInAnyOrder(
-            listOf("Choice-ref:CustId"),
-            listOf("Choice-ref:CustLoginId")
+            listOf("CustId"),
+            listOf("CustLoginId")
         )
     }
 
@@ -72,8 +73,8 @@ class WSDLWiringCharacterizationTest {
         assertThat(choiceGroup.maxOccurs).isEqualTo(1)
         assertThat(choiceGroup.choices).hasSize(2)
         assertThat(choiceNames(choiceGroup)).containsExactlyInAnyOrder(
-            listOf("Choice-scalar:CustomerNumber"),
-            listOf("Choice-scalar:LoginId")
+            listOf("CustomerNumber"),
+            listOf("LoginId")
         )
     }
 
@@ -93,7 +94,7 @@ class WSDLWiringCharacterizationTest {
         assertThat(choiceGroup.maxOccurs).isEqualTo(1)
         assertThat(choiceGroup.choices).hasSize(1)
         assertThat(choiceGroup.matches(emptyList(), Resolver()).result).isInstanceOf(Result.Success::class.java)
-        assertThat(choiceNames(choiceGroup)).containsExactly(listOf("Choice-optional:CustLoginId"))
+        assertThat(choiceNames(choiceGroup)).containsExactly(listOf("CustLoginId"))
     }
 
     @Test
@@ -124,10 +125,10 @@ class WSDLWiringCharacterizationTest {
         val resolver = Resolver(newPatterns = typeInfo.types.mapKeys { (typeName, _) -> withPatternDelimiters(typeName) })
         val rootPattern = typeInfo.types.getValue("RepeatingScalarChoiceRequestType") as XMLPattern
         val choiceGroup = rootPattern.pattern.nodes.filterIsInstance<XMLChoiceGroupPattern>().single()
-        val variants = choiceGroup.newBasedOn(resolver).map { it as XMLChoiceGroupPattern }.toList()
+        val variants = choiceGroup.newBasedOn(resolver).map { it as XMLSequencePattern }.toList()
         val generatedBodies = variants.map { XMLPattern(rootPattern.pattern.copy(nodes = listOf(rootPattern.pattern.nodes.first(), it))).generate(resolver).toStringLiteral() }
 
-        assertThat(variants).hasSize(6)
+        assertThat(variants).hasSize(3)
         assertThat(generatedBodies).anySatisfy {
             assertThat(it).contains("PrimaryName>") 
             assertThat(countOccurrences(it, "<Choice-scalar-repeating:CustomerNumber>")).isEqualTo(1)
@@ -138,18 +139,7 @@ class WSDLWiringCharacterizationTest {
             assertThat(it).doesNotContain("CustomerNumber>")
         }
         assertThat(generatedBodies).anySatisfy {
-            assertThat(countOccurrences(it, "<Choice-scalar-repeating:CustomerNumber>")).isEqualTo(2)
-            assertThat(it).doesNotContain("LoginId>")
-        }
-        assertThat(generatedBodies).anySatisfy {
             assertThat(it).contains("CustomerNumber>").contains("LoginId>")
-        }
-        assertThat(generatedBodies).anySatisfy {
-            assertThat(it).contains("LoginId>").contains("CustomerNumber>")
-        }
-        assertThat(generatedBodies).anySatisfy {
-            assertThat(countOccurrences(it, "<Choice-scalar-repeating:LoginId>")).isEqualTo(2)
-            assertThat(it).doesNotContain("CustomerNumber>")
         }
     }
 
@@ -181,20 +171,15 @@ class WSDLWiringCharacterizationTest {
         val resolver = Resolver(newPatterns = typeInfo.types)
         val rootPattern = typeInfo.types.getValue("RepeatingComplexChoiceRequestType") as XMLPattern
         val choiceGroup = rootPattern.pattern.nodes.filterIsInstance<XMLChoiceGroupPattern>().single()
-        val variants = choiceGroup.newBasedOn(resolver).map { it as XMLChoiceGroupPattern }.toList()
-        val sequences = variants.map { variant ->
-            variant.concreteSequence.orEmpty().map { occurrence ->
-                ((occurrence.single() as XMLPattern).pattern.name).substringAfter(":")
-            }
-        }
+        val variants = choiceGroup.newBasedOn(resolver).map { it as XMLSequencePattern }.toList()
+        val sequences = variants.map(::choiceNames)
 
-        assertThat(variants).hasSize(6)
-        assertThat(sequences).contains(listOf("CustomerByPermId"))
-        assertThat(sequences).contains(listOf("CustomerByLogin"))
-        assertThat(sequences).contains(listOf("CustomerByPermId", "CustomerByPermId"))
-        assertThat(sequences).contains(listOf("CustomerByPermId", "CustomerByLogin"))
-        assertThat(sequences).contains(listOf("CustomerByLogin", "CustomerByPermId"))
-        assertThat(sequences).contains(listOf("CustomerByLogin", "CustomerByLogin"))
+        assertThat(variants).hasSize(3)
+        assertThat(sequences).containsExactlyInAnyOrder(
+            listOf("CustomerByPermId"),
+            listOf("CustomerByLogin"),
+            listOf("CustomerByPermId", "CustomerByLogin")
+        )
     }
 
     @Test
@@ -209,20 +194,13 @@ class WSDLWiringCharacterizationTest {
         val resolver = Resolver(newPatterns = typeInfo.types)
         val rootPattern = typeInfo.types.getValue("RepeatingScalarChoiceMinTwoRequestType") as XMLPattern
         val choiceGroup = rootPattern.pattern.nodes.filterIsInstance<XMLChoiceGroupPattern>().single()
-        val variants = choiceGroup.newBasedOn(resolver).map { it as XMLChoiceGroupPattern }.toList()
-        val sequences = variants.map { variant ->
-            variant.concreteSequence.orEmpty().map { occurrence ->
-                ((occurrence.single() as XMLPattern).pattern.name).substringAfter(":")
-            }
-        }
+        val variants = choiceGroup.newBasedOn(resolver).map { it as XMLSequencePattern }.toList()
+        val sequences = variants.map(::choiceNames)
 
-        assertThat(variants).hasSize(4)
+        assertThat(variants).hasSize(1)
         assertThat(sequences).allSatisfy { assertThat(it).hasSize(2) }
         assertThat(sequences).containsExactlyInAnyOrder(
-            listOf("CustomerNumber", "CustomerNumber"),
             listOf("CustomerNumber", "LoginId"),
-            listOf("LoginId", "CustomerNumber"),
-            listOf("LoginId", "LoginId"),
         )
     }
 
@@ -230,9 +208,12 @@ class WSDLWiringCharacterizationTest {
         return text.windowed(token.length, 1).count { it == token }
     }
 
+    private fun choiceNames(sequence: XMLSequencePattern): List<String> =
+        sequence.members.map { pattern -> (pattern as XMLPattern).pattern.realName.substringAfter(":") }
+
     private fun choiceNames(choiceGroup: XMLChoiceGroupPattern): List<List<String>> =
         choiceGroup.choices.map { choice ->
-            choice.map { pattern -> (pattern as XMLPattern).pattern.realName }
+            choice.map { pattern -> (pattern as XMLPattern).pattern.realName.substringAfter(":") }
         }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/core/wsdl/parser/WSDLWiringCharacterizationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/wsdl/parser/WSDLWiringCharacterizationTest.kt
@@ -2,7 +2,6 @@ package io.specmatic.core.wsdl.parser
 
 import io.specmatic.core.Resolver
 import io.specmatic.core.Result
-import io.specmatic.core.pattern.AnyPattern
 import io.specmatic.core.pattern.DeferredPattern
 import io.specmatic.core.pattern.XMLChoiceGroupPattern
 import io.specmatic.core.pattern.TYPE_ATTRIBUTE_NAME
@@ -40,24 +39,21 @@ class WSDLWiringCharacterizationTest {
 
         assertThat(rootNode.name).isEqualTo("SignonCustId")
         assertThat(rootNode.attributes[TYPE_ATTRIBUTE_NAME]?.toStringLiteral()).isEqualTo("SignonCustIdType")
-        assertThat(rootPattern).isInstanceOf(AnyPattern::class.java)
-        rootPattern as AnyPattern
-        assertThat(rootPattern.pattern).hasSize(2)
-        assertThat(rootPattern.pattern).allSatisfy { pattern ->
-            assertThat(pattern).isInstanceOf(XMLPattern::class.java)
+        assertThat(rootPattern).isInstanceOf(XMLPattern::class.java)
+        rootPattern as XMLPattern
+        assertThat(rootPattern.pattern.nodes.filterIsInstance<XMLPattern>().map { it.pattern.realName })
+            .contains("Choice-ref:SPName")
+        val choiceGroup = rootPattern.pattern.nodes.filterIsInstance<XMLChoiceGroupPattern>().single()
+        assertThat(choiceGroup.choices).hasSize(2)
+        assertThat(choiceGroup.choices).allSatisfy { choice ->
+            assertThat(choice).allSatisfy { pattern ->
+                assertThat(pattern).isInstanceOf(XMLPattern::class.java)
+            }
         }
-        assertThat(rootPattern.pattern.map { (it as XMLPattern).toPrettyString() }).anySatisfy {
-            assertThat(it)
-                .contains("<Choice-ref:SPName>(string)</Choice-ref:SPName>")
-                .contains("<Choice-ref:CustId")
-            assertThat(it).doesNotContain("<Choice-ref:CustLoginId>(string)</Choice-ref:CustLoginId>")
-        }
-        assertThat(rootPattern.pattern.map { (it as XMLPattern).toPrettyString() }).anySatisfy {
-            assertThat(it)
-                .contains("<Choice-ref:SPName>(string)</Choice-ref:SPName>")
-                .contains("<Choice-ref:CustLoginId>(string)</Choice-ref:CustLoginId>")
-            assertThat(it).doesNotContain("<Choice-ref:CustPermId>")
-        }
+        assertThat(choiceNames(choiceGroup)).containsExactlyInAnyOrder(
+            listOf("Choice-ref:CustId"),
+            listOf("Choice-ref:CustLoginId")
+        )
     }
 
     @Test
@@ -69,14 +65,16 @@ class WSDLWiringCharacterizationTest {
         )
 
         val typeInfo = soapElement.deriveSpecmaticTypes("ScalarChoiceRequestType", emptyMap(), emptySet())
-        val rootPattern = typeInfo.types.getValue("ScalarChoiceRequestType") as AnyPattern
+        val rootPattern = typeInfo.types.getValue("ScalarChoiceRequestType") as XMLPattern
+        val choiceGroup = rootPattern.pattern.nodes.filterIsInstance<XMLChoiceGroupPattern>().single()
 
-        assertThat(rootPattern.pattern).hasSize(2)
-        assertThat(rootPattern.pattern.map { (it as XMLPattern).toPrettyString() }).allSatisfy {
-            assertThat(it).contains("<Choice-scalar:PrimaryName>(string)</Choice-scalar:PrimaryName>")
-            assertThat(it.contains("<Choice-scalar:CustomerNumber>(string)</Choice-scalar:CustomerNumber>"))
-                .isNotEqualTo(it.contains("<Choice-scalar:LoginId>(string)</Choice-scalar:LoginId>"))
-        }
+        assertThat(choiceGroup.minOccurs).isEqualTo(1)
+        assertThat(choiceGroup.maxOccurs).isEqualTo(1)
+        assertThat(choiceGroup.choices).hasSize(2)
+        assertThat(choiceNames(choiceGroup)).containsExactlyInAnyOrder(
+            listOf("Choice-scalar:CustomerNumber"),
+            listOf("Choice-scalar:LoginId")
+        )
     }
 
     @Test
@@ -88,19 +86,30 @@ class WSDLWiringCharacterizationTest {
         )
 
         val typeInfo = soapElement.deriveSpecmaticTypes("OptionalChoiceRequestType", emptyMap(), emptySet())
-        val rootPattern = typeInfo.types.getValue("OptionalChoiceRequestType") as AnyPattern
+        val rootPattern = typeInfo.types.getValue("OptionalChoiceRequestType") as XMLPattern
+        val choiceGroup = rootPattern.pattern.nodes.filterIsInstance<XMLChoiceGroupPattern>().single()
 
-        assertThat(rootPattern.pattern).hasSize(2)
-        assertThat(rootPattern.pattern.map { (it as XMLPattern).toPrettyString() }).anySatisfy {
-            assertThat(it)
-                .contains("<Choice-optional:SPName>(string)</Choice-optional:SPName>")
-                .doesNotContain("CustLoginId")
-        }
-        assertThat(rootPattern.pattern.map { (it as XMLPattern).toPrettyString() }).anySatisfy {
-            assertThat(it)
-                .contains("<Choice-optional:SPName>(string)</Choice-optional:SPName>")
-                .contains("<Choice-optional:CustLoginId>(string)</Choice-optional:CustLoginId>")
-        }
+        assertThat(choiceGroup.minOccurs).isEqualTo(0)
+        assertThat(choiceGroup.maxOccurs).isEqualTo(1)
+        assertThat(choiceGroup.choices).hasSize(1)
+        assertThat(choiceGroup.matches(emptyList(), Resolver()).result).isInstanceOf(Result.Success::class.java)
+        assertThat(choiceNames(choiceGroup)).containsExactly(listOf("Choice-optional:CustLoginId"))
+    }
+
+    @Test
+    fun `sequential choices remain compact instead of expanding into Cartesian variants`() {
+        val wsdl = WSDL(toXMLNode(sequentialChoiceWsdl()), "/path/to/sequential-choice.wsdl")
+
+        val soapElement = wsdl.getSOAPElement(
+            FullyQualifiedName("tns", "http://sequential-choice", "SequentialChoiceRequest")
+        )
+
+        val typeInfo = soapElement.deriveSpecmaticTypes("SequentialChoiceRequestType", emptyMap(), emptySet())
+        val rootPattern = typeInfo.types.getValue("SequentialChoiceRequestType")
+
+        assertThat(rootPattern).isInstanceOf(XMLPattern::class.java)
+        rootPattern as XMLPattern
+        assertThat(rootPattern.pattern.nodes.filterIsInstance<XMLChoiceGroupPattern>()).hasSize(2)
     }
 
     @Test
@@ -220,6 +229,11 @@ class WSDLWiringCharacterizationTest {
     private fun countOccurrences(text: String, token: String): Int {
         return text.windowed(token.length, 1).count { it == token }
     }
+
+    private fun choiceNames(choiceGroup: XMLChoiceGroupPattern): List<List<String>> =
+        choiceGroup.choices.map { choice ->
+            choice.map { pattern -> (pattern as XMLPattern).pattern.realName }
+        }
 
     @Test
     fun `getSOAPElement keeps simple primitive request payload wiring intact`() {
@@ -1359,6 +1373,66 @@ class WSDLWiringCharacterizationTest {
         val wsdlFile = File(path)
         return WSDL(toXMLNode(wsdlFile.readText()), wsdlFile.canonicalPath)
     }
+
+    private fun sequentialChoiceWsdl(): String =
+        """
+        <definitions name="SequentialChoiceService"
+                     targetNamespace="http://sequential-choice"
+                     xmlns:tns="http://sequential-choice"
+                     xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns="http://schemas.xmlsoap.org/wsdl/">
+            <types>
+                <xsd:schema targetNamespace="http://sequential-choice" elementFormDefault="qualified">
+                    <xsd:element name="FirstA" type="xsd:string"/>
+                    <xsd:element name="FirstB" type="xsd:string"/>
+                    <xsd:element name="SecondA" type="xsd:string"/>
+                    <xsd:element name="SecondB" type="xsd:string"/>
+                    <xsd:element name="SequentialChoiceRequest">
+                        <xsd:complexType>
+                            <xsd:sequence>
+                                <xsd:choice>
+                                    <xsd:element ref="tns:FirstA"/>
+                                    <xsd:element ref="tns:FirstB"/>
+                                </xsd:choice>
+                                <xsd:choice>
+                                    <xsd:element ref="tns:SecondA"/>
+                                    <xsd:element ref="tns:SecondB"/>
+                                </xsd:choice>
+                            </xsd:sequence>
+                        </xsd:complexType>
+                    </xsd:element>
+                </xsd:schema>
+            </types>
+            <message name="SequentialChoiceRequestMessage">
+                <part name="parameters" element="tns:SequentialChoiceRequest"/>
+            </message>
+            <message name="SequentialChoiceResponseMessage"/>
+            <portType name="SequentialChoicePortType">
+                <operation name="sequentialChoice">
+                    <input message="tns:SequentialChoiceRequestMessage"/>
+                    <output message="tns:SequentialChoiceResponseMessage"/>
+                </operation>
+            </portType>
+            <binding name="SequentialChoiceBinding" type="tns:SequentialChoicePortType">
+                <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+                <operation name="sequentialChoice">
+                    <soap:operation soapAction="/sequential-choice"/>
+                    <input>
+                        <soap:body use="literal"/>
+                    </input>
+                    <output>
+                        <soap:body use="literal"/>
+                    </output>
+                </operation>
+            </binding>
+            <service name="SequentialChoiceService">
+                <port name="SequentialChoicePort" binding="tns:SequentialChoiceBinding">
+                    <soap:address location="http://localhost:9000/sequential-choice"/>
+                </port>
+            </service>
+        </definitions>
+        """.trimIndent()
 
     private fun concreteRoot(pattern: XMLPattern, name: String, realName: String, namespace: String): XMLPattern =
         pattern.copy(pattern = pattern.pattern.copy(name = name, realName = realName, namespaceUri = namespace))


### PR DESCRIPTION
**What**:

Optimizes WSDL parsing for complex schemas that use choice-of-children structures. The change avoids eager Cartesian expansion of XML choice variants, preserves choice groups in XML patterns, and adds top-level WSDL/schema lookup indexes for faster repeated parsing lookups.

**Why**:

Some large WSDLs may take several minutes to start as a mock because parsing expanded choice variants eagerly and repeatedly searched WSDL definitions, schema types, messages, and elements. The updated parser keeps the same observable mock/contract behavior while reducing startup time for the repro case from about 30 seconds to about 2 seconds.

**How**:

The WSDL parser now builds immutable top-level lookup indexes during initialization and uses them for definitions, schema nodes, and named schema nodes. Choice handling now carries grouped XML choice patterns instead of expanding every possible child combination up front. Focused XML pattern tests, WSDL wiring characterization tests, and WSDL mock/contract blackbox tests cover the changed behavior.

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link) N/A
- [ ] Sample Project added/updated (share link) N/A
- [ ] Demo video (share link) N/A
- [ ] Article on Website (share link) N/A
- [ ] Roadmpap updated (share link) N/A
- [ ] Conference Talk (share link) N/A
