### PR TITLE
Composite substitutions and dictionary fallback generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Each release section should stand on its own and describe the behavior shipped i
 - Improved bundled CTRF reporting so coverage execution details now include spec-level coverage metrics and match operations back to the correct spec more reliably across absolute, relative, and normalized paths.
 - Improved bundled backward-compatibility HTML reporting so breakages in shared specs are attributed to the shared spec that actually changed, instead of being misreported against a referring spec when only one consumer is affected.
 - Substitutions to be lenient by default, i.e. missing variables now use auto-generated values, while enabling `strictMode` restores the previous behavior of failing instead of generating.
+- Substitutions stored values and data lookups can reuse composite JSON objects and arrays, and unresolved substitutions now fall back to dictionary-backed generation when available.
 
 ## 2.48.0 (2026-06-18)
 

--- a/core/src/main/kotlin/io/specmatic/core/HttpResponsePattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpResponsePattern.kt
@@ -188,8 +188,9 @@ data class HttpResponsePattern(
     }
 
     fun resolveSubstitutions(substitution: Substitution, response: HttpResponse, resolver: Resolver): ReturnValue<HttpResponse> {
+        val headersResolver = resolver.updateLookupPath(BreadCrumb.RESPONSE.value)
         val substitutedHeaders = this.headersPattern.resolveSubstitutions(
-            resolver = resolver,
+            resolver = headersResolver,
             headers = response.headers,
             substitution = substitution,
         ).breadCrumb(BreadCrumb.HEADER.value)

--- a/core/src/main/kotlin/io/specmatic/core/Substitution.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Substitution.kt
@@ -6,9 +6,7 @@ import io.specmatic.core.value.Value
 
 interface Substitution {
     fun isDropDirective(value: Value): Boolean
-    fun resolveIfLookup(value: Value): Value
     fun substitute(value: Value): ReturnValue<Value>
-    fun resolveIfLookup(value: Value, pattern: Pattern): Value
-    fun substitute(value: Value, pattern: Pattern, key: String?): ReturnValue<Value>
-    fun upsertStoreUsing(originalValue: Value, runningValue: Value): Substitution
+    fun substitute(value: Value, pattern: Pattern, resolver: Resolver = Resolver(), key: String? = null): ReturnValue<Value>
+    fun upsertStoreUsing(originalValue: Value, runningValue: Value, resolver: Resolver = Resolver()): Substitution
 }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/AnyNonNullJSONValue.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/AnyNonNullJSONValue.kt
@@ -20,7 +20,7 @@ data class AnyNonNullJSONValue(override val pattern: Pattern = AnythingPattern):
         resolver: Resolver,
         key: String?
     ): ReturnValue<Value> {
-        return scalarResolveSubstitutions(substitution, value, key, this)
+        return scalarResolveSubstitutions(substitution, value, key, this, resolver)
     }
 
     override fun encompasses(

--- a/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
@@ -8,6 +8,7 @@ import io.specmatic.core.discriminator.DiscriminatorMetadata
 import io.specmatic.core.pattern.config.NegativePatternConfiguration
 import io.specmatic.core.utilities.EarlyResult
 import io.specmatic.core.utilities.firstSuccessOrFailures
+import io.specmatic.core.utilities.getOrElse
 import io.specmatic.core.value.*
 
 fun List<Pattern>.extractCombinedExtensions(): Map<String, Any> {
@@ -146,51 +147,41 @@ data class AnyPattern(
             is ReturnFailure -> return resolvedPattern.cast()
             else -> resolvedPattern.value
         }
+
         if (isPatternToken(value) && patternToConsider == this) return HasValue(resolver.generate(this))
-
-        val updatedPatterns = getUpdatedPattern(resolver)
-        val newPatterns = updatedPatterns.filter { it.typeAlias != null && it !is DeferredPattern }.associateBy { it.typeAlias.orEmpty() }
-        val updatedResolver = resolver.copy(newPatterns = resolver.newPatterns.plus(newPatterns) ).updateLookupPath(this.typeAlias)
-
-        val results = updatedPatterns.asSequence().map { it.fillInTheBlanks(value, updatedResolver, removeExtraKeys) }
-        val successfulGeneration = results.firstOrNull { it is HasValue }
-        if(successfulGeneration != null) return successfulGeneration
-
-        val resultList = results.toList()
-        val failures = resultList.filterIsInstance<ReturnFailure>().map { it.toFailure() }
-        return HasFailure(Failure.fromFailures(failures))
+        return evaluateWithUpdatedResolver(resolver) { pattern, updatedResolver ->
+            pattern.fillInTheBlanks(value, updatedResolver, removeExtraKeys)
+        }
     }
 
-    override fun resolveSubstitutions(
-        substitution: Substitution,
-        value: Value,
+    override fun resolveSubstitutions(substitution: Substitution, value: Value, resolver: Resolver, key: String?): ReturnValue<Value> {
+        return evaluateWithUpdatedResolver(resolver) { pattern, updatedResolver ->
+            pattern.resolveSubstitutions(substitution, value, updatedResolver, key)
+        }
+    }
+
+    private inline fun evaluateWithUpdatedResolver(
         resolver: Resolver,
-        key: String?
+        crossinline evaluate: (Pattern, Resolver) -> ReturnValue<Value>
     ): ReturnValue<Value> {
-        val options = pattern.map {
-            try {
-                it.resolveSubstitutions(substitution, value, resolver, key)
-            } catch(e: Throwable) {
-                HasException(e)
-            }
+        val updatedPatterns = getUpdatedPattern(resolver)
+        val newPatterns = updatedPatterns
+            .filter { it.typeAlias != null && it !is DeferredPattern }
+            .associateBy { it.typeAlias.orEmpty() }
+
+        val updatedResolver = resolver
+            .copy(newPatterns = resolver.newPatterns.plus(newPatterns))
+            .updateLookupPath(this.typeAlias)
+
+        val result = updatedPatterns.firstSuccessOrFailures(
+            evaluate = { evaluate(it, updatedResolver) },
+            isSuccess = { it is HasValue },
+            toFailure = { it as ReturnFailure }
+        )
+
+        return result.getOrElse { failures ->
+            HasFailure(Failure.fromFailures(failures.map { it.toFailure() }))
         }
-
-        val hasValue = options.find { it is HasValue }
-
-        if(hasValue != null)
-            return hasValue
-
-        val failures = options.map {
-            it.realise(
-                hasValue = { _, _ ->
-                    throw NotImplementedError()
-                },
-                orFailure = { failure -> failure.failure },
-                orException = { exception -> exception.toHasFailure().failure }
-            )
-        }
-
-        return HasFailure(Failure.fromFailures(failures))
     }
 
     override fun getTemplateTypes(key: String, value: Value, resolver: Resolver): ReturnValue<Map<String, Pattern>> {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/DictionaryPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/DictionaryPattern.kt
@@ -29,7 +29,7 @@ data class DictionaryPattern(val keyPattern: Pattern, val valuePattern: Pattern,
         resolver: Resolver,
         key: String?
     ): ReturnValue<Value> {
-        val resolved = runCatching { substitution.resolveIfLookup(value, this) }.getOrElse { e -> return HasException(e) }
+        val resolved = substitution.substitute(value, this, resolver).unwrapOrReturn { return it.cast() }
         val resolvedValue = resolved as? JSONObjectValue ?: return HasValue(resolved)
 
         val updatedMap = resolvedValue.jsonObject.mapValues { (key, value) ->

--- a/core/src/main/kotlin/io/specmatic/core/pattern/EmailPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/EmailPattern.kt
@@ -28,7 +28,7 @@ class EmailPattern (private val stringPatternDelegate: StringPattern, val exampl
         resolver: Resolver,
         key: String?
     ): ReturnValue<Value> {
-        return scalarResolveSubstitutions(substitution, value, key, this)
+        return scalarResolveSubstitutions(substitution, value, key, this, resolver)
     }
 
     override fun matches(sampleData: Value?, resolver: Resolver): Result {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/EnumPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/EnumPattern.kt
@@ -56,7 +56,7 @@ data class EnumPattern(override val pattern: AnyPattern, val nullable: Boolean) 
         resolver: Resolver,
         key: String?
     ): ReturnValue<Value> {
-        return scalarResolveSubstitutions(substitution, value, key, this)
+        return scalarResolveSubstitutions(substitution, value, key, this, resolver)
     }
 
     override fun matches(sampleData: Value?, resolver: Resolver): Result {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/JSONObjectPattern.kt
@@ -3,6 +3,7 @@ package io.specmatic.core.pattern
 import io.ktor.http.*
 import io.specmatic.core.*
 import io.specmatic.core.pattern.config.NegativePatternConfiguration
+import io.specmatic.core.substitution.ValueSubstitutionVisitor
 import io.specmatic.core.utilities.mapZip
 import io.specmatic.core.utilities.stringToPatternMap
 import io.specmatic.core.utilities.withNullPattern
@@ -200,13 +201,14 @@ data class JSONObjectPattern(
         resolver: Resolver,
         key: String?
     ): ReturnValue<Value> {
-        val resolved = runCatching { substitution.resolveIfLookup(value, this) }.getOrElse { e -> return HasException(e) }
+        val resolved = substitution.substitute(value, this, resolver).unwrapOrReturn { return it.cast() }
         val resolvedValue = resolved as? JSONObjectValue ?: return HasValue(resolved)
         val adjustedPattern = additionalProperties.updatePatternMap(patternMap = pattern, valueMap = resolvedValue.jsonObject)
 
         if (adjustedPattern.isEmpty()) return HasValue(value)
         return resolveSubstitutions(
             resolver = resolver,
+            typeAlias = typeAlias,
             substitution = substitution,
             jsonPatternMap = adjustedPattern,
             jsonValueMap = resolvedValue.jsonObject,
@@ -859,6 +861,7 @@ fun fill(jsonPatternMap: Map<String, Pattern>, jsonValueMap: Map<String, Value>,
 
 fun resolveSubstitutions(
     resolver: Resolver,
+    typeAlias: String? = null,
     substitution: Substitution,
     jsonValueMap: Map<String, Value>,
     jsonPatternMap: Map<String, Pattern>,
@@ -866,6 +869,8 @@ fun resolveSubstitutions(
 ): ReturnValue<Map<String, Value>> {
     val resolvedValuesMap = jsonValueMap.mapNotNull { (key, value) ->
         val patternKey = findPatternKey(jsonPatternMap, key)
+        val pattern = jsonPatternMap[patternKey]
+
         if (substitution.isDropDirective(value)) {
             if (patternKey != null && !isOptional(patternKey)) {
                 return HasFailure(Result.Failure(breadCrumb = key, message = "Cannot drop mandatory key ${key.quote()}"))
@@ -874,8 +879,13 @@ fun resolveSubstitutions(
             return@mapNotNull null
         }
 
-        val pattern = jsonPatternMap.getOrDefault(patternKey, AnyValuePattern)
-        key to pattern.resolveSubstitutions(substitution, value, resolver, key).breadCrumb(key)
+        if (pattern == null) {
+            val resolvedExtraValue = ValueSubstitutionVisitor.resolve(value, substitution)
+            return@mapNotNull key to resolvedExtraValue
+        }
+
+        val updatedResolver = resolver.updateLookupPath(typeAlias, KeyWithPattern(key, pattern))
+        key to pattern.resolveSubstitutions(substitution, value, updatedResolver, key).breadCrumb(key)
     }.toMap()
 
     return resolvedValuesMap.mapFoldException()

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
@@ -77,12 +77,13 @@ data class ListPattern(
         resolver: Resolver,
         key: String?
     ): ReturnValue<Value> {
-        val resolved = runCatching { substitution.resolveIfLookup(value, this) }.getOrElse { e -> return HasException(e) }
+        val resolved = substitution.substitute(value, this, resolver).unwrapOrReturn { return it.cast() }
         val resolvedValue = resolved as? JSONArrayValue ?: return HasValue(resolved)
+        val updatedResolver = resolver.updateLookupPath(this, this.pattern)
 
         val updatedList = resolvedValue.list.withIndex().mapNotNull { item ->
             if (substitution.isDropDirective(item.value)) return@mapNotNull null
-            pattern.resolveSubstitutions(substitution, item.value, resolver).breadCrumb("[${item.index}]")
+            pattern.resolveSubstitutions(substitution, item.value, updatedResolver).breadCrumb("[${item.index}]")
         }.listFoldException()
 
         return updatedList.ifValue(resolvedValue::copy)

--- a/core/src/main/kotlin/io/specmatic/core/pattern/Pattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/Pattern.kt
@@ -72,7 +72,7 @@ interface Pattern {
     }
 
     fun resolveSubstitutions(substitution: Substitution, value: Value, resolver: Resolver, key: String? = null): ReturnValue<Value> {
-        return scalarResolveSubstitutions(substitution, value, key, this)
+        return scalarResolveSubstitutions(substitution, value, key, this, resolver)
     }
 
     fun getTemplateTypes(key: String, value: Value, resolver: Resolver): ReturnValue<Map<String, Pattern>> {
@@ -177,7 +177,6 @@ fun fixValue(value: Value, pattern: Pattern, resolver: Resolver): Value {
     } ?: resolver.generate(pattern)
 }
 
-fun scalarResolveSubstitutions(substitution: Substitution, value: Value, key: String?, pattern: Pattern): ReturnValue<Value> {
-    val resolvedValue = runCatching { substitution.resolveIfLookup(value, pattern) }.getOrElse { e -> return HasException(e) }
-    return substitution.substitute(resolvedValue, pattern, key)
+fun scalarResolveSubstitutions(substitution: Substitution, value: Value, key: String?, pattern: Pattern, resolver: Resolver): ReturnValue<Value> {
+    return substitution.substitute(value, pattern, resolver, key)
 }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/QueryParameterScalarPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/QueryParameterScalarPattern.kt
@@ -14,7 +14,7 @@ data class QueryParameterScalarPattern(override val pattern: Pattern): Pattern b
         resolver: Resolver,
         key: String?
     ): ReturnValue<Value> {
-        return scalarResolveSubstitutions(substitution, value, key, this)
+        return scalarResolveSubstitutions(substitution, value, key, this, resolver)
     }
 
     override fun matches(sampleData: Value?, resolver: Resolver): Result {

--- a/core/src/main/kotlin/io/specmatic/core/substitution/SubstitutionImpl.kt
+++ b/core/src/main/kotlin/io/specmatic/core/substitution/SubstitutionImpl.kt
@@ -9,12 +9,12 @@ import io.specmatic.core.pattern.HasException
 import io.specmatic.core.pattern.HasValue
 import io.specmatic.core.pattern.Pattern
 import io.specmatic.core.pattern.ReturnValue
+import io.specmatic.core.pattern.breadCrumb
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.StringValue
 import io.specmatic.core.value.Value
 
 class SubstitutionImpl private constructor(
-    private val resolver: Resolver,
     private val strictMode: Boolean = false,
     private val variableValues: Map<String, Value> = emptyMap(),
     private val data: JSONObjectValue = JSONObjectValue(emptyMap()),
@@ -86,10 +86,13 @@ class SubstitutionImpl private constructor(
         }
     }
 
-    private fun unresolvedSubstitutionFallback(value: StringValue, pattern: Pattern, e: Throwable): ReturnValue<Value> {
+    private fun unresolvedSubstitutionFallback(value: StringValue, pattern: Pattern, key: String?, resolver: Resolver, e: Throwable): ReturnValue<Value> {
         if (strictMode) return HasException(e)
         logger.log(e, "Could not resolve substitution expression ${value.string}, using generated value instead")
-        return runCatching { resolver.generate(pattern) }.map(::HasValue).getOrElse(::HasException)
+        return runCatching {
+            if (key == null) return@runCatching resolver.generate(pattern)
+            resolver.generate(pattern.typeAlias, key, pattern)
+        }.map(::HasValue).getOrElse(::HasException).breadCrumb(key)
     }
 
     override fun substitute(value: Value): ReturnValue<Value> {
@@ -98,42 +101,17 @@ class SubstitutionImpl private constructor(
         return runCatching { HasValue(resolveValue(value)) }.getOrElse(::HasException)
     }
 
-    override fun substitute(value: Value, pattern: Pattern, key: String?): ReturnValue<Value> {
+    override fun substitute(value: Value, pattern: Pattern, resolver: Resolver, key: String?): ReturnValue<Value> {
         if (value !is StringValue) return HasValue(value)
         if (!InterpolatedSubstitution.containsLookup(value.string)) return HasValue(value)
 
         val resolvedValue = runCatching { resolveValue(value) }.getOrElse { e ->
-            return unresolvedSubstitutionFallback(value, pattern, e)
+            return unresolvedSubstitutionFallback(value, pattern, key, resolver, e)
         }
 
         return runCatching { HasValue(pattern.parse(resolvedValue.toUnformattedString(), resolver)) }.getOrElse { e ->
-            return unresolvedSubstitutionFallback(value, pattern, e)
+            return unresolvedSubstitutionFallback(value, pattern, key, resolver, e)
         }
-    }
-
-    override fun resolveIfLookup(value: Value): Value {
-        if (value !is StringValue) return value
-        val text = value.nativeValue
-
-        if (!isDataLookup(text)) return value
-        return runCatching {
-            substituteDataLookupExpression(text)
-        }.getOrElse { e ->
-            logger.debug(e, "Error resolving data lookup expression ${value.string}, using original value")
-            value
-        }
-    }
-
-    override fun resolveIfLookup(value: Value, pattern: Pattern): Value {
-        val strValue = (value as? StringValue)?.nativeValue ?: return value
-        if (!isDataLookup(strValue)) return value
-
-        val resolvedValue = runCatching { substituteDataLookupExpression(strValue) }.getOrElse { e ->
-            logger.debug(e, "Error resolving data lookup expression ${value.string}, using original value")
-            return value
-        }.toUnformattedString()
-
-        return runCatching { pattern.parse(resolvedValue, resolver) }.getOrDefault(StringValue(resolvedValue))
     }
 
     override fun isDropDirective(value: Value): Boolean {
@@ -154,16 +132,15 @@ class SubstitutionImpl private constructor(
         return resolved == DROP_DIRECTIVE
     }
 
-    override fun upsertStoreUsing(originalValue: Value, runningValue: Value): SubstitutionImpl {
+    override fun upsertStoreUsing(originalValue: Value, runningValue: Value, resolver: Resolver): SubstitutionImpl {
         val extractedVariables = SubstitutionVariableExtractor.fromValues(
-            originalValue = originalValue,
+            resolver = resolver,
             runningValue = runningValue,
-            resolver = resolver
+            originalValue = originalValue,
         )
 
         return SubstitutionImpl(
             data = data,
-            resolver = resolver,
             strictMode = strictMode,
             variableValues = variableValues + extractedVariables,
         )
@@ -172,8 +149,8 @@ class SubstitutionImpl private constructor(
     companion object {
         const val DROP_DIRECTIVE = "$(drop)"
 
-        fun empty(resolver: Resolver, strictMode: Boolean = false): SubstitutionImpl {
-            return SubstitutionImpl(resolver = resolver, strictMode = strictMode)
+        fun empty(strictMode: Boolean = false): SubstitutionImpl {
+            return SubstitutionImpl(strictMode = strictMode)
         }
 
         fun from(
@@ -208,7 +185,7 @@ class SubstitutionImpl private constructor(
             )
 
             val variableValues = variableValuesFromHeaders + variableValuesFromRequestBody + variableValuesFromQueryParams + variableValuesFromPath
-            return SubstitutionImpl(variableValues = variableValues, resolver = resolver, data = data, strictMode = strictMode)
+            return SubstitutionImpl(variableValues = variableValues, data = data, strictMode = strictMode)
         }
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/substitution/ValueSubstitutionVisitor.kt
+++ b/core/src/main/kotlin/io/specmatic/core/substitution/ValueSubstitutionVisitor.kt
@@ -1,0 +1,58 @@
+package io.specmatic.core.substitution
+
+import io.specmatic.core.Substitution
+import io.specmatic.core.pattern.HasValue
+import io.specmatic.core.pattern.ReturnValue
+import io.specmatic.core.pattern.breadCrumb
+import io.specmatic.core.pattern.listFold
+import io.specmatic.core.pattern.unwrapOrReturn
+import io.specmatic.core.value.Value
+import io.specmatic.core.value.fold.Field
+import io.specmatic.core.value.fold.FieldObjectValueCase
+import io.specmatic.core.value.fold.IndexedListValueCase
+import io.specmatic.core.value.fold.Item
+import io.specmatic.core.value.fold.OpaqueValueCase
+import io.specmatic.core.value.fold.TextValueCase
+import io.specmatic.core.value.fold.ValueVisitor
+
+class ValueSubstitutionVisitor(private val substitution: Substitution) : ValueVisitor<Unit, ReturnValue<Value>> {
+    override val rootContext: Unit = Unit
+
+    override fun opaque(case: OpaqueValueCase<out Value, Unit>): ReturnValue<Value> {
+        return HasValue(case.value)
+    }
+
+    override fun text(case: TextValueCase<out Value, Unit>): ReturnValue<Value> {
+        return substitution.substitute(case.value)
+    }
+
+    override fun fieldObject(case: FieldObjectValueCase<out Value, Unit>): ReturnValue<Value> {
+        val resolved = case.fields().map { (name, value) ->
+            val resolvedValue = resolve(value).breadCrumb(name)
+            resolvedValue.ifValue { Field(name, it) }
+        }.listFold()
+
+        return resolved.ifValue { fields -> case.rebuild(fields) }
+    }
+
+    override fun indexedList(case: IndexedListValueCase<out Value, Unit>): ReturnValue<Value> {
+        val resolved = case.items().map { (index, value) ->
+            val resolvedValue = resolve(value).breadCrumb(index.toString())
+            resolvedValue.ifValue { Item(index, it) }
+        }.listFold()
+
+        return resolved.ifValue { items -> case.rebuild(items) }
+    }
+
+    private fun resolve(value: Value): ReturnValue<Value> {
+        val resolved = substitution.substitute(value).unwrapOrReturn { return it.cast()}
+        return resolved.accept(this)
+    }
+
+    companion object {
+        fun resolve(value: Value, substitution: Substitution): ReturnValue<Value> {
+            val resolver = ValueSubstitutionVisitor(substitution = substitution)
+            return resolver.resolve(value)
+        }
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
@@ -54,10 +54,7 @@ data class ScenarioAsTest(
     private val responseHandlerRegistry: ResponseHandlerRegistry = ResponseHandlerRegistry(feature, originalScenario),
     private val requestValidator: RequestValidator = DefaultRequestValidator,
     val reasoning: Reasoning = Reasoning(),
-    private val substitution: Substitution = SubstitutionImpl.empty(
-        resolver = scenario.resolver,
-        strictMode = feature.specmaticConfig.getTestStrictMode() ?: feature.strictMode
-    ),
+    private val substitution: Substitution = SubstitutionImpl.empty(strictMode = feature.specmaticConfig.getTestStrictMode() ?: feature.strictMode),
 ) : ContractTest {
     companion object {
         private var id: Value? = null

--- a/core/src/test/kotlin/integration_tests/TestSubstitutionIntegrationTest.kt
+++ b/core/src/test/kotlin/integration_tests/TestSubstitutionIntegrationTest.kt
@@ -7,7 +7,6 @@ import io.specmatic.core.HttpResponse
 import io.specmatic.core.NoBodyValue
 import io.specmatic.core.Result
 import io.specmatic.core.Results
-import io.specmatic.core.Resolver
 import io.specmatic.core.Scenario
 import io.specmatic.core.Substitution
 import io.specmatic.core.pattern.HasValue
@@ -74,14 +73,12 @@ class TestSubstitutionIntegrationTest {
             SubstitutionFixtureExecutor.positiveAfterUpdatedSubstitution.substitute(
                 StringValue("$(BEFORE_POSITIVE)"),
                 StringPattern(),
-                null
             )
         ).isEqualTo(HasValue(StringValue("beforePositive")))
         assertThat(
             SubstitutionFixtureExecutor.negativeAfterUpdatedSubstitution.substitute(
                 StringValue("$(BEFORE_NEGATIVE)"),
                 StringPattern(),
-                null
             )
         ).isEqualTo(HasValue(StringValue("beforeNegative")))
 
@@ -89,14 +86,12 @@ class TestSubstitutionIntegrationTest {
             SubstitutionFixtureExecutor.positiveAfterUpdatedSubstitution.substitute(
                 StringValue("$(AFTER_POSITIVE)"),
                 StringPattern(),
-                null
             )
         ).isEqualTo(HasValue(StringValue("afterPositive")))
         assertThat(
             SubstitutionFixtureExecutor.negativeAfterUpdatedSubstitution.substitute(
                 StringValue("$(AFTER_NEGATIVE)"),
                 StringPattern(),
-                null
             )
         ).isEqualTo(HasValue(StringValue("afterNegative")))
 
@@ -451,24 +446,24 @@ class SubstitutionFixtureExecutor : OpenAPIFixtureExecutor {
 
         val beforeFixtureRequests = mutableListOf<Value>()
         val afterFixtureRequests = mutableListOf<Value>()
-        var updatedSubstitution: Substitution = SubstitutionImpl.empty(Resolver())
-        var positiveAfterUpdatedSubstitution: Substitution = SubstitutionImpl.empty(Resolver())
-        var negativeAfterUpdatedSubstitution: Substitution = SubstitutionImpl.empty(Resolver())
+        var updatedSubstitution: Substitution = SubstitutionImpl.empty()
+        var positiveAfterUpdatedSubstitution: Substitution = SubstitutionImpl.empty()
+        var negativeAfterUpdatedSubstitution: Substitution = SubstitutionImpl.empty()
 
         fun reset() {
             calls.clear()
             receivedContexts.clear()
             beforeFixtureRequests.clear()
             afterFixtureRequests.clear()
-            updatedSubstitution = SubstitutionImpl.empty(Resolver())
-            positiveAfterUpdatedSubstitution = SubstitutionImpl.empty(Resolver())
-            negativeAfterUpdatedSubstitution = SubstitutionImpl.empty(Resolver())
+            updatedSubstitution = SubstitutionImpl.empty()
+            positiveAfterUpdatedSubstitution = SubstitutionImpl.empty()
+            negativeAfterUpdatedSubstitution = SubstitutionImpl.empty()
         }
     }
 
     private fun assertSubstitutes(substitution: Substitution, lookupKey: String, expectedValue: String) {
         assertThat(
-            substitution.substitute(StringValue($$"$($$lookupKey)"), StringPattern(), null).value
+            substitution.substitute(StringValue($$"$($$lookupKey)"), StringPattern()).value
         ).isEqualTo(StringValue(expectedValue))
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/HttpHeadersPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpHeadersPatternTest.kt
@@ -6,10 +6,10 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import io.ktor.util.reflect.*
 import io.specmatic.conversions.OpenApiSpecification
+import io.specmatic.core.substitution.SubstitutionImpl
 import io.specmatic.core.value.*
 import io.specmatic.test.TestExecutor
 import io.specmatic.toViolationReportString
-import org.assertj.core.api.Assertions.assertThatCode
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Nested
@@ -1058,7 +1058,7 @@ internal class HttpHeadersPatternTest {
         fun `should resolve values in headers and extra keys`() {
             val httpHeaders = HttpHeadersPattern(mapOf("number" to NumberPattern()))
             val headers = mapOf("number" to "$(number)", "extraKey" to "$(extraKey)")
-            val substitution = substitutionOf("$(number)" to "999", "$(extraKey)" to "extraValue")
+            val substitution = substitutionOf("number" to NumberValue(999), "extraKey" to StringValue("extraValue"))
             val resolved = httpHeaders.resolveSubstitutions(headers, substitution, Resolver()).value
             assertThat(resolved).isEqualTo(mapOf("number" to "999", "extraKey" to "extraValue"))
         }
@@ -1066,24 +1066,15 @@ internal class HttpHeadersPatternTest {
         @Test
         fun `should be case insensitive for header keys`() {
             val httpHeaders = HttpHeadersPattern(mapOf("x-trace" to StringPattern()))
-            val substitution = substitutionOf("$(trace)" to "abc")
+            val substitution = substitutionOf("trace" to StringValue("abc"))
             val headers = mapOf("X-TRACE" to "$(trace)")
             val resolved = httpHeaders.resolveSubstitutions(headers, substitution, Resolver()).value
             assertThat(resolved).containsEntry("X-TRACE", "abc")
         }
 
-        private fun substitutionOf(vararg mappings: Pair<String, String>): Substitution {
-            return object : Substitution {
-                override fun isDropDirective(value: Value): Boolean = false
-                override fun resolveIfLookup(value: Value): Value = value
-                override fun substitute(value: Value): ReturnValue<Value> = HasValue(value)
-                override fun upsertStoreUsing(originalValue: Value, runningValue: Value): Substitution = this
-                override fun resolveIfLookup(value: Value, pattern: Pattern): Value = value
-                override fun substitute(value: Value, pattern: Pattern, key: String?): ReturnValue<Value> {
-                    val expression = (value as? StringValue)?.string ?: return HasValue(value)
-                    val resolved = mappings.toMap()[expression] ?: return HasValue(value)
-                    return HasValue(runCatching { pattern.parse(resolved, Resolver()) }.getOrDefault(StringValue(resolved)))
-                }
+        private fun substitutionOf(vararg mappings: Pair<String, Value>): Substitution {
+            return mappings.fold(SubstitutionImpl.empty()) { acc, (key, value) ->
+                acc.upsertStoreUsing(StringValue("($key:${value.type().typeName})"), value)
             }
         }
     }

--- a/core/src/test/kotlin/io/specmatic/core/HttpPathPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpPathPatternTest.kt
@@ -8,6 +8,7 @@ import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import io.specmatic.core.pattern.*
+import io.specmatic.core.substitution.SubstitutionImpl
 import io.specmatic.core.utilities.toStringMap
 import io.specmatic.core.value.Value
 import io.specmatic.toViolationReportString
@@ -1049,7 +1050,7 @@ internal class HttpPathPatternTest {
         @Test
         fun `should resolve values in path segments`() {
             val pathPattern = buildHttpPathPattern("/pets/(id:string)")
-            val substitution = substitutionOf("$(id)" to "123")
+            val substitution = substitutionOf("id" to NumberValue(123))
             val resolvedPath = pathPattern.resolveSubstitutions(substitution, "/pets/$(id)", Resolver()).value
             assertThat(resolvedPath).isEqualTo("/pets/123")
         }
@@ -1057,23 +1058,14 @@ internal class HttpPathPatternTest {
         @Test
         fun `should resolve interpolated values in path segments`() {
             val pathPattern = buildHttpPathPattern("/pets/item-(id:string)")
-            val substitution = substitutionOf("$(id)" to "123")
+            val substitution = substitutionOf("id" to NumberValue(123))
             val resolvedPath = pathPattern.resolveSubstitutions(substitution, "/pets/item-$(id)", Resolver()).value
             assertThat(resolvedPath).isEqualTo("/pets/item-123")
         }
 
-        private fun substitutionOf(vararg mappings: Pair<String, String>): Substitution {
-            return object : Substitution {
-                override fun isDropDirective(value: Value): Boolean = false
-                override fun resolveIfLookup(value: Value): Value = value
-                override fun substitute(value: Value): ReturnValue<Value> = HasValue(value)
-                override fun upsertStoreUsing(originalValue: Value, runningValue: Value): Substitution = this
-                override fun resolveIfLookup(value: Value, pattern: Pattern): Value = value
-                override fun substitute(value: Value, pattern: Pattern, key: String?): ReturnValue<Value> {
-                    val expression = (value as? StringValue)?.string ?: return HasValue(value)
-                    val resolved = mappings.toMap()[expression] ?: return HasValue(value)
-                    return HasValue(runCatching { pattern.parse(resolved, Resolver()) }.getOrDefault(StringValue(resolved)))
-                }
+        private fun substitutionOf(vararg mappings: Pair<String, Value>): Substitution {
+            return mappings.fold(SubstitutionImpl.empty()) { acc, (key, value) ->
+                acc.upsertStoreUsing(StringValue("($key:${value.type().typeName})"), value)
             }
         }
     }

--- a/core/src/test/kotlin/io/specmatic/core/HttpQueryParamPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpQueryParamPatternTest.kt
@@ -6,6 +6,7 @@ import io.specmatic.GENERATION
 import io.specmatic.core.Result.Failure
 import io.specmatic.core.Result.Success
 import io.specmatic.core.pattern.*
+import io.specmatic.core.substitution.SubstitutionImpl
 import io.specmatic.core.value.JSONArrayValue
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.NumberValue
@@ -2936,7 +2937,7 @@ class HttpQueryParamPatternTest {
     inner class ResolveSubstitutionsTests {
         @Test
         fun `should resolve values in query params and extra keys`() {
-            val substitution = substitutionOf("$(id)" to "123", "$(extra)" to "456")
+            val substitution = substitutionOf("id" to NumberValue(123), "extra" to StringValue("456"))
             val queryPattern = HttpQueryParamPattern(mapOf("id" to QueryParameterScalarPattern(StringPattern())))
             val resolved = queryPattern.resolveSubstitutions(
                 queryParams = QueryParameters(mapOf("id" to "$(id)", "extra" to "$(extra)")),
@@ -2948,18 +2949,9 @@ class HttpQueryParamPatternTest {
             assertThat(resolved.asMap()).containsEntry("extra", "456")
         }
 
-        private fun substitutionOf(vararg mappings: Pair<String, String>): Substitution {
-            return object : Substitution {
-                override fun isDropDirective(value: Value): Boolean = false
-                override fun resolveIfLookup(value: Value): Value = value
-                override fun substitute(value: Value): ReturnValue<Value> = HasValue(value)
-                override fun upsertStoreUsing(originalValue: Value, runningValue: Value): Substitution = this
-                override fun resolveIfLookup(value: Value, pattern: Pattern): Value = value
-                override fun substitute(value: Value, pattern: Pattern, key: String?): ReturnValue<Value> {
-                    val expression = (value as? StringValue)?.string ?: return HasValue(value)
-                    val resolved = mappings.toMap()[expression] ?: return HasValue(value)
-                    return HasValue(runCatching { pattern.parse(resolved, Resolver()) }.getOrDefault(StringValue(resolved)))
-                }
+        private fun substitutionOf(vararg mappings: Pair<String, Value>): Substitution {
+            return mappings.fold(SubstitutionImpl.empty()) { acc, (key, value) ->
+                acc.upsertStoreUsing(StringValue("($key:${value.type().typeName})"), value)
             }
         }
     }

--- a/core/src/test/kotlin/io/specmatic/core/HttpRequestPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpRequestPatternTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test
 import io.specmatic.core.Result.Failure
 import io.specmatic.core.Result.Success
 import io.specmatic.core.pattern.*
+import io.specmatic.core.substitution.SubstitutionImpl
 import io.specmatic.core.value.JSONArrayValue
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.NumberValue
@@ -1144,10 +1145,10 @@ internal class HttpRequestPatternTest {
             )
 
             val substitution = substitutionOf(
-                "$(id)" to "123",
-                "$(page)" to "2",
-                "$(name)" to "John",
-                "$(trace)" to "abc",
+                "id" to NumberValue(123),
+                "page" to NumberValue(2),
+                "name" to StringValue("John"),
+                "trace" to StringValue("abc"),
             )
 
             val resolved = requestPattern.resolveSubstitutions(substitution, request, Resolver()).value
@@ -1177,11 +1178,11 @@ internal class HttpRequestPatternTest {
             )
 
             val substitution = substitutionOf(
-                "$(id)" to "123",
-                "$(page)" to "2",
-                "$(trace)" to "abc",
-                "$(api_key)" to "secret",
-                "$(header_key)" to "header-secret"
+                "id" to NumberValue(123),
+                "page" to NumberValue(2),
+                "trace" to StringValue("abc"),
+                "api_key" to StringValue("secret"),
+                "header_key" to StringValue("header-secret")
             )
 
             val resolved = requestPattern.resolveSubstitutions(substitution, request, Resolver()).value
@@ -1192,18 +1193,62 @@ internal class HttpRequestPatternTest {
             assertThat(resolved.headers).containsEntry("X-Api-Key", "header-secret")
         }
 
-        private fun substitutionOf(vararg mappings: Pair<String, String>): Substitution {
-            return object : Substitution {
-                override fun isDropDirective(value: Value): Boolean = false
-                override fun resolveIfLookup(value: Value): Value = value
-                override fun substitute(value: Value): ReturnValue<Value> = HasValue(value)
-                override fun upsertStoreUsing(originalValue: Value, runningValue: Value): Substitution = this
-                override fun resolveIfLookup(value: Value, pattern: Pattern): Value = value
-                override fun substitute(value: Value, pattern: Pattern, key: String?): ReturnValue<Value> {
-                    val expression = (value as? StringValue)?.string ?: return HasValue(value)
-                    val resolved = mappings.toMap()[expression] ?: return HasValue(value)
-                    return HasValue(runCatching { pattern.parse(resolved, Resolver()) }.getOrDefault(StringValue(resolved)))
-                }
+        @Test
+        fun `should use dictionary backed generation when substitutions are unresolved across request`() {
+            val addressPattern = JSONObjectPattern(
+                typeAlias = "(Address)",
+                pattern = mapOf("street" to StringPattern()),
+            )
+
+            val bodyPattern = JSONObjectPattern(
+                typeAlias = "(Pet)",
+                pattern = mapOf("name" to StringPattern(), "address" to addressPattern),
+            )
+
+            val requestPattern = HttpRequestPattern(
+                body = bodyPattern,
+                httpPathPattern = buildHttpPathPattern("/pets/(id:number)"),
+                headersPattern = HttpHeadersPattern(mapOf("X-Trace" to StringPattern())),
+                httpQueryParamPattern = HttpQueryParamPattern(mapOf("page" to QueryParameterScalarPattern(NumberPattern()))),
+            )
+
+            val request = HttpRequest(
+                method = "GET",
+                path = "/pets/$(missing-id)",
+                headers = mapOf("X-Trace" to "$(missing-trace)"),
+                queryParams = QueryParameters(mapOf("page" to "$(missing-page)")),
+                body = parsedJSONObject("""{"name": "$(missing-name)", "address": {"street": "$(missing-street)"}}"""),
+            )
+
+            val resolver = Resolver(
+                newPatterns = mapOf("(Pet)" to bodyPattern, "(Address)" to addressPattern),
+                dictionary = Dictionary.fromYaml("""
+                PARAMETERS:
+                  PATH:
+                    id: 123
+                  QUERY:
+                    page: 7
+                  HEADER:
+                    X-Trace: trace-from-dictionary
+                Pet:
+                  name: Fido
+                Address:
+                  street: Baker Street
+                """.trimIndent())
+            )
+
+            val resolved = requestPattern.resolveSubstitutions(SubstitutionImpl.empty(), request, resolver).value
+            assertThat(resolved.path).isEqualTo("/pets/123")
+            assertThat(resolved.queryParams.asMap()).containsEntry("page", "7")
+            assertThat(resolved.headers).containsEntry("X-Trace", "trace-from-dictionary")
+            assertThat(resolved.body).isEqualTo(
+                parsedJSONObject("""{"name": "Fido", "address": {"street": "Baker Street"}}""")
+            )
+        }
+
+        private fun substitutionOf(vararg mappings: Pair<String, Value>): Substitution {
+            return mappings.fold(SubstitutionImpl.empty()) { acc, (key, value) ->
+                acc.upsertStoreUsing(StringValue("($key:${value.type().typeName})"), value)
             }
         }
     }

--- a/core/src/test/kotlin/io/specmatic/core/HttpRequestPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpRequestPatternTest.kt
@@ -1128,6 +1128,98 @@ internal class HttpRequestPatternTest {
     @Nested
     inner class ResolveSubstitutionsTests {
         @Test
+        fun `should resolve stored composite object and array values in request body`() {
+            val profilePattern = JSONObjectPattern(
+                typeAlias = "(Profile)",
+                pattern = mapOf("name" to StringPattern()),
+            )
+
+            val petPattern = JSONObjectPattern(
+                typeAlias = "(Pet)",
+                pattern = mapOf("name" to StringPattern()),
+            )
+
+            val petsPattern = ListPattern(petPattern, typeAlias = "(Pets)")
+            val bodyPattern = JSONObjectPattern(pattern = mapOf("profile" to profilePattern, "pets" to petsPattern))
+            val resolver = Resolver(newPatterns = mapOf("(Profile)" to profilePattern, "(Pet)" to petPattern, "(Pets)" to petsPattern))
+
+            val profile = parsedJSONObject("""{"name": "Sherlock"}""")
+            val pets = parsedJSONArray("""[{"name": "Dog"},{"name": "Cat"}]""")
+            val substitution = SubstitutionImpl.empty()
+                .upsertStoreUsing(StringValue("(profile:Profile)"), StringValue(profile.toUnformattedString()), resolver)
+                .upsertStoreUsing(StringValue("(pets:Pets)"), StringValue(pets.toUnformattedString()), resolver)
+
+            val requestPattern = HttpRequestPattern(
+                httpPathPattern = buildHttpPathPattern("/pets"),
+                body = bodyPattern,
+            )
+            val request = HttpRequest(
+                method = "POST",
+                path = "/pets",
+                body = parsedJSONObject("""{"profile": "$(profile)", "pets": "$(pets)"}"""),
+            )
+
+            val resolved = requestPattern.resolveSubstitutions(substitution, request, resolver).value
+            assertThat(resolved.body).isEqualTo(
+                parsedJSONObject("""{"profile": {"name": "Sherlock"}, "pets": [{"name": "Dog"}, {"name": "Cat"}]}""")
+            )
+        }
+
+        @Test
+        fun `should resolve composite object and array values from data lookup in request body`() {
+            val profilePattern = JSONObjectPattern(
+                typeAlias = "(Profile)",
+                pattern = mapOf("name" to StringPattern()),
+            )
+
+            val petPattern = JSONObjectPattern(
+                typeAlias = "(Pet)",
+                pattern = mapOf("name" to StringPattern()),
+            )
+
+            val petsPattern = ListPattern(petPattern, typeAlias = "(Pets)")
+            val bodyPattern = JSONObjectPattern(pattern = mapOf("profile" to profilePattern, "pets" to petsPattern))
+            val resolver = Resolver(newPatterns = mapOf("(Profile)" to profilePattern, "(Pet)" to petPattern, "(Pets)" to petsPattern))
+
+            val substitution = SubstitutionImpl.from(
+                resolver = resolver,
+                runningRequest = HttpRequest(method = "POST", path = "/profiles/10"),
+                originalRequest = HttpRequest(method = "POST", path = "/profiles/(ID:number)"),
+                data = parsedJSONObject("""
+                {
+                  "lookupData": {
+                    "dictionary": {
+                      "10": {
+                        "profile": {"name": "Sherlock"},
+                        "pets": [{"name": "Dog"}, {"name": "Cat"}]
+                      }
+                    }
+                  }
+                }
+                """.trimIndent())
+            )
+
+            val requestPattern = HttpRequestPattern(
+                method = "POST",
+                httpPathPattern = buildHttpPathPattern("/profiles/(ID:number)"),
+                body = bodyPattern,
+            )
+
+            val request = HttpRequest(
+                method = "POST",
+                path = "/profiles/10",
+                body = parsedJSONObject(
+                    """{"profile": "$(lookupData.dictionary[ID].profile)", "pets": "$(lookupData.dictionary[ID].pets)"}"""
+                ),
+            )
+
+            val resolved = requestPattern.resolveSubstitutions(substitution, request, resolver).value
+            assertThat(resolved.body).isEqualTo(
+                parsedJSONObject("""{"profile": {"name": "Sherlock"}, "pets": [{"name": "Dog"}, {"name": "Cat"}]}""")
+            )
+        }
+
+        @Test
         fun `should resolve path query and header and body values`() {
             val requestPattern = HttpRequestPattern(
                 httpPathPattern = buildHttpPathPattern("/pets/(id:string)"),

--- a/core/src/test/kotlin/io/specmatic/core/HttpResponsePatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpResponsePatternTest.kt
@@ -272,6 +272,88 @@ internal class HttpResponsePatternTest {
     @Nested
     inner class ResolveSubstitutionsTests {
         @Test
+        fun `should resolve stored composite object and array values in response body`() {
+            val profilePattern = JSONObjectPattern(
+                typeAlias = "(Profile)",
+                pattern = mapOf("name" to StringPattern()),
+            )
+
+            val petPattern = JSONObjectPattern(
+                typeAlias = "(Pet)",
+                pattern = mapOf("name" to StringPattern()),
+            )
+
+            val petsPattern = ListPattern(petPattern, typeAlias = "(Pets)")
+            val bodyPattern = JSONObjectPattern(pattern = mapOf("profile" to profilePattern, "pets" to petsPattern))
+            val resolver = Resolver(newPatterns = mapOf("(Profile)" to profilePattern, "(Pet)" to petPattern, "(Pets)" to petsPattern))
+
+            val profile = parsedJSONObject("""{"name": "Sherlock"}""")
+            val pets = parsedJSONArray("""[{"name": "Dog"},{"name": "Cat"}]""")
+            val substitution = SubstitutionImpl.empty()
+                .upsertStoreUsing(StringValue("(profile:Profile)"), StringValue(profile.toUnformattedString()), resolver)
+                .upsertStoreUsing(StringValue("(pets:Pets)"), StringValue(pets.toUnformattedString()), resolver)
+
+            val responsePattern = HttpResponsePattern(status = 200, body = bodyPattern)
+            val response = HttpResponse(
+                status = 200,
+                body = parsedJSONObject("""{"profile": "$(profile)", "pets": "$(pets)"}""")
+            )
+
+            val resolved = responsePattern.resolveSubstitutions(substitution, response, resolver).value
+            assertThat(resolved.body).isEqualTo(
+                parsedJSONObject("""{"profile": {"name": "Sherlock"}, "pets": [{"name": "Dog"}, {"name": "Cat"}]}""")
+            )
+        }
+
+        @Test
+        fun `should resolve composite object and array values from data lookup in response body`() {
+            val profilePattern = JSONObjectPattern(
+                typeAlias = "(Profile)",
+                pattern = mapOf("name" to StringPattern()),
+            )
+
+            val petPattern = JSONObjectPattern(
+                typeAlias = "(Pet)",
+                pattern = mapOf("name" to StringPattern()),
+            )
+
+            val petsPattern = ListPattern(petPattern, typeAlias = "(Pets)")
+            val bodyPattern = JSONObjectPattern(pattern = mapOf("profile" to profilePattern, "pets" to petsPattern))
+            val resolver = Resolver(newPatterns = mapOf("(Profile)" to profilePattern, "(Pet)" to petPattern, "(Pets)" to petsPattern))
+
+            val substitution = SubstitutionImpl.from(
+                resolver = resolver,
+                runningRequest = HttpRequest(method = "GET", path = "/profiles/10"),
+                originalRequest = HttpRequest(method = "GET", path = "/profiles/(ID:number)"),
+                data = parsedJSONObject("""
+                {
+                  "lookupData": {
+                    "dictionary": {
+                      "10": {
+                        "profile": {"name": "Sherlock"},
+                        "pets": [{"name": "Dog"}, {"name": "Cat"}]
+                      }
+                    }
+                  }
+                }
+                """.trimIndent())
+            )
+
+            val responsePattern = HttpResponsePattern(status = 200, body = bodyPattern)
+            val response = HttpResponse(
+                status = 200,
+                body = parsedJSONObject(
+                    """{"profile": "$(lookupData.dictionary[ID].profile)", "pets": "$(lookupData.dictionary[ID].pets)"}"""
+                )
+            )
+
+            val resolved = responsePattern.resolveSubstitutions(substitution, response, resolver).value
+            assertThat(resolved.body).isEqualTo(
+                parsedJSONObject("""{"profile": {"name": "Sherlock"}, "pets": [{"name": "Dog"}, {"name": "Cat"}]}""")
+            )
+        }
+
+        @Test
         fun `should use dictionary backed generation when substitutions are unresolved across response`() {
             val addressPattern = JSONObjectPattern(
                 typeAlias = "(Address)",
@@ -312,7 +394,7 @@ internal class HttpResponsePatternTest {
             )
 
             val resolved = responsePattern.resolveSubstitutions(SubstitutionImpl.empty(), response, resolver).value
-            assertThat(resolved.headers).containsKey("X-Trace")
+            assertThat(resolved.headers["X-Trace"]).isEqualTo("trace-from-dictionary")
             assertThat(resolved.body).isEqualTo(
                 parsedJSONObject("""{"message": "done", "addresses": [{"street": "Baker Street"}]}""")
             )

--- a/core/src/test/kotlin/io/specmatic/core/HttpResponsePatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpResponsePatternTest.kt
@@ -3,6 +3,7 @@ package io.specmatic.core
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import io.specmatic.core.pattern.*
+import io.specmatic.core.substitution.SubstitutionImpl
 import io.specmatic.core.value.JSONArrayValue
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.StringValue
@@ -265,6 +266,56 @@ internal class HttpResponsePatternTest {
             val currentAccountRequestBody = (responses.first { it.discriminatorValue ==  "current"}.value.body as JSONObjectValue)
             assertThat(savingsAccountRequestBody.jsonObject["@type"]?.toStringLiteral()).isEqualTo("savings")
             assertThat(currentAccountRequestBody.jsonObject["@type"]?.toStringLiteral()).isEqualTo("current")
+        }
+    }
+
+    @Nested
+    inner class ResolveSubstitutionsTests {
+        @Test
+        fun `should use dictionary backed generation when substitutions are unresolved across response`() {
+            val addressPattern = JSONObjectPattern(
+                typeAlias = "(Address)",
+                pattern = mapOf("street" to StringPattern()),
+            )
+
+            val bodyPattern = JSONObjectPattern(
+                typeAlias = "(PetResponse)",
+                pattern = mapOf(
+                    "message" to StringPattern(),
+                    "addresses" to ListPattern(addressPattern)
+                ),
+            )
+
+            val responsePattern = HttpResponsePattern(
+                status = 200,
+                body = bodyPattern,
+                headersPattern = HttpHeadersPattern(mapOf("X-Trace" to StringPattern())),
+            )
+
+            val response = HttpResponse(
+                status = 200,
+                headers = mapOf("X-Trace" to "$(missing-trace)"),
+                body = parsedJSONObject("""{"message": "$(missing-message)", "addresses": [{"street": "$(missing-street)"}]}""")
+            )
+
+            val resolver = Resolver(
+                newPatterns = mapOf("(PetResponse)" to bodyPattern, "(Address)" to addressPattern),
+                dictionary = Dictionary.fromYaml("""
+                RESPONSE:
+                  HEADER:
+                    X-Trace: trace-from-dictionary
+                PetResponse:
+                  message: done
+                Address:
+                  street: Baker Street
+                """.trimIndent())
+            )
+
+            val resolved = responsePattern.resolveSubstitutions(SubstitutionImpl.empty(), response, resolver).value
+            assertThat(resolved.headers).containsKey("X-Trace")
+            assertThat(resolved.body).isEqualTo(
+                parsedJSONObject("""{"message": "done", "addresses": [{"street": "Baker Street"}]}""")
+            )
         }
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/pattern/AnyPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/AnyPatternTest.kt
@@ -2,6 +2,7 @@ package io.specmatic.core.pattern
 
 import io.specmatic.*
 import io.specmatic.core.*
+import io.specmatic.core.substitution.SubstitutionImpl
 import io.specmatic.core.utilities.withNullPattern
 import io.specmatic.core.value.*
 import org.assertj.core.api.Assertions.assertThat
@@ -1193,6 +1194,53 @@ internal class AnyPatternTest {
             val filledInValue = pattern.fillInTheBlanks(partialValue, resolver).value
 
             assertThat(filledInValue).isInstanceOf(BooleanValue::class.java)
+        }
+    }
+
+    @Nested
+    inner class ResolveSubstitutionsTests {
+        @Test
+        fun `should use dictionary backed generation with discriminator`() {
+            val pattern = AnyPattern(
+                pattern = listOf(
+                    JSONObjectPattern(mapOf("type" to "sub1".toDiscriminator(), "text" to StringPattern()), typeAlias = "(Sub1)"),
+                    JSONObjectPattern(mapOf("type" to "sub2".toDiscriminator(), "amount" to NumberPattern()), typeAlias = "(Sub2)")
+                ),
+                typeAlias = "(Base)",
+                discriminator = Discriminator(
+                    property = "type",
+                    values = setOf("sub1", "sub2"),
+                    mapping = mapOf("sub1" to "#/components/schemas/Sub1", "sub2" to "#/components/schemas/Sub2")
+                )
+            )
+
+            val resolver = Resolver(dictionary = Dictionary.fromYaml("Sub2: { amount: 999 }"))
+            val valueToBeResolved = JSONObjectValue(mapOf("type" to StringValue("sub2"), "amount" to StringValue("$(missing-amount)")))
+
+            val resolvedValue = pattern.resolveSubstitutions(SubstitutionImpl.empty(), valueToBeResolved, resolver).value
+            assertThat(resolvedValue).isEqualTo(
+                JSONObjectValue(
+                    mapOf(
+                        "type" to StringValue("sub2"),
+                        "amount" to NumberValue(999)
+                    )
+                )
+            )
+        }
+
+        @Test
+        fun `should use dictionary backed generation without discriminator`() {
+            val numberObjectPattern = JSONObjectPattern(mapOf("prop" to NumberPattern()))
+            val textObjectPattern = JSONObjectPattern(mapOf("prop" to StringPattern()))
+            val pattern = AnyPattern(
+                extensions = emptyMap(),
+                pattern = listOf(numberObjectPattern, textObjectPattern),
+            )
+
+            val resolver = Resolver(dictionary = Dictionary.fromYaml("'*': { prop: 999 }"))
+            val valueToBeResolved = JSONObjectValue(mapOf("prop" to StringValue("$(missing-prop)")))
+            val resolvedValue = pattern.resolveSubstitutions(SubstitutionImpl.empty(), valueToBeResolved, resolver).value
+            assertThat(resolvedValue).isEqualTo(JSONObjectValue(mapOf("prop" to NumberValue(999))))
         }
     }
 

--- a/core/src/test/kotlin/io/specmatic/core/pattern/JSONObjectPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/JSONObjectPatternTest.kt
@@ -2637,6 +2637,95 @@ components:
     }
 
     @Nested
+    inner class ResolveSubstitutionsTests {
+        @Test
+        fun `should use dictionary value for unresolved top level field`() {
+            val pattern = JSONObjectPattern(pattern = mapOf("id" to NumberPattern()), typeAlias = "(Person)")
+            val resolver = Resolver(
+                newPatterns = mapOf("(Person)" to pattern),
+                dictionary = Dictionary.fromYaml("Person: { id: 123 }")
+            )
+
+            val valueToBeResolved = JSONObjectValue(mapOf("id" to StringValue("$(missing-id)")))
+            val resolvedValue = pattern.resolveSubstitutions(SubstitutionImpl.empty(), valueToBeResolved, resolver).value
+            assertThat(resolvedValue).isEqualTo(JSONObjectValue(mapOf("id" to NumberValue(123))))
+        }
+
+        @Test
+        fun `should use dictionary value from star entry for unresolved top level field when pattern has no typeAlias`() {
+            val pattern = JSONObjectPattern(pattern = mapOf("id" to NumberPattern()))
+            val resolver = Resolver(dictionary = Dictionary.fromYaml("'*': { id: 321 }"))
+
+            val valueToBeResolved = JSONObjectValue(mapOf("id" to StringValue("$(missing-id)")))
+            val resolvedValue = pattern.resolveSubstitutions(SubstitutionImpl.empty(), valueToBeResolved, resolver).value
+            assertThat(resolvedValue).isEqualTo(JSONObjectValue(mapOf("id" to NumberValue(321))))
+        }
+
+        @Test
+        fun `should use dictionary values for unresolved nested fields and sibling keys`() {
+            val pattern = JSONObjectPattern(
+                typeAlias = "(Person)",
+                pattern = mapOf(
+                    "status" to StringPattern(),
+                    "name" to JSONObjectPattern(mapOf("first_name" to StringPattern(), "last_name" to StringPattern()))
+                ),
+            )
+
+            val resolver = Resolver(
+                newPatterns = mapOf("(Person)" to pattern),
+                dictionary = Dictionary.fromYaml("""
+                Person:
+                  name:
+                    first_name: Jane
+                    last_name: Doe
+                  status: active
+                """.trimIndent())
+            )
+
+            val valueToBeResolved = parsedJSONObject("""
+            {
+              "name": {
+                "first_name": "$(missing-first-name)",
+                "last_name": "$(missing-last-name)"
+              },
+              "status": "$(missing-status)"
+            }
+            """.trimIndent())
+
+            val resolvedValue = pattern.resolveSubstitutions(SubstitutionImpl.empty(), valueToBeResolved, resolver).value
+
+            assertThat(resolvedValue).isEqualTo(
+                parsedJSONObject("""
+                {
+                  "name": {
+                    "first_name": "Jane",
+                    "last_name": "Doe"
+                  },
+                  "status": "active"
+                }
+                """.trimIndent())
+            )
+        }
+
+        @Test
+        fun `should use dictionary values for unresolved lookup`() {
+            val addressPattern = JSONObjectPattern(
+                pattern = mapOf("street" to StringPattern()),
+                typeAlias = "(Address)"
+            )
+
+            val resolver = Resolver(
+                newPatterns = mapOf("(Address)" to addressPattern),
+                dictionary = Dictionary.fromYaml("Address: { street: Baker Street }")
+            )
+
+            val valueToBeResolved = StringValue(""""$(missing-street)"""")
+            val resolvedValue = addressPattern.resolveSubstitutions(SubstitutionImpl.empty(), valueToBeResolved, resolver).value
+            assertThat(resolvedValue).isEqualTo(parsedJSONObject("""{"street": "Baker Street"}"""))
+        }
+    }
+
+    @Nested
     inner class FillInTheBlanksTests {
 
         @Test

--- a/core/src/test/kotlin/io/specmatic/core/pattern/ListPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/ListPatternTest.kt
@@ -3,6 +3,7 @@ package io.specmatic.core.pattern
 import io.specmatic.GENERATION
 import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.core.*
+import io.specmatic.core.substitution.SubstitutionImpl
 import io.specmatic.core.value.*
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.*
@@ -856,6 +857,27 @@ Feature: Recursive test
                 assertThat(result).isInstanceOf(HasValue::class.java); result as HasValue
                 println(result.value)
             }
+        }
+    }
+
+    @Nested
+    inner class ResolveSubstitutionsTests {
+        @Test
+        fun `should use dictionary values for unresolved array items`() {
+            val addressPattern = JSONObjectPattern(
+                pattern = mapOf("street" to StringPattern()),
+                typeAlias = "(Address)"
+            )
+
+            val listPattern = ListPattern(addressPattern)
+            val resolver = Resolver(
+                newPatterns = mapOf("(Address)" to addressPattern),
+                dictionary = Dictionary.fromYaml("Address: { street: Baker Street }")
+            )
+
+            val valueToBeResolved = parsedJSONArray("""["$(missing-street)"]""")
+            val resolvedValue = listPattern.resolveSubstitutions(SubstitutionImpl.empty(), valueToBeResolved, resolver).value
+            assertThat(resolvedValue).isEqualTo(parsedJSONArray("""[{"street": "Baker Street"}]"""))
         }
     }
 

--- a/core/src/test/kotlin/io/specmatic/core/substitution/SubstitutionImplTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/substitution/SubstitutionImplTest.kt
@@ -10,6 +10,7 @@ import io.specmatic.core.pattern.HasValue
 import io.specmatic.core.pattern.ExactValuePattern
 import io.specmatic.core.pattern.JSONArrayPattern
 import io.specmatic.core.pattern.JSONObjectPattern
+import io.specmatic.core.pattern.ListPattern
 import io.specmatic.core.pattern.NumberPattern
 import io.specmatic.core.pattern.StringPattern
 import io.specmatic.core.pattern.parsedValue
@@ -314,6 +315,39 @@ class SubstitutionImplTest {
         }
 
         @Test
+        fun `whole simple variables return stored composite object and array values as is`() {
+            val profilePattern = JSONObjectPattern(
+                pattern = mapOf("name" to StringPattern()),
+                typeAlias = "(Profile)"
+            )
+
+            val petPattern = JSONObjectPattern(
+                pattern = mapOf("name" to StringPattern()),
+                typeAlias = "(Pet)"
+            )
+
+            val petsPattern = ListPattern(petPattern, typeAlias = "(Pets)")
+            val resolver = Resolver(newPatterns = mapOf("(Profile)" to profilePattern, "(Pet)" to petPattern, "(Pets)" to petsPattern))
+
+            val profile = parsedValue("""{"name":"Sherlock"}""")
+            val pets = parsedValue("""[{"name":"Dog"},{"name":"Cat"}]""")
+            val substitution = SubstitutionImpl.empty()
+                .upsertStoreUsing(
+                    resolver = resolver,
+                    originalValue = StringValue("(profile:Profile)"),
+                    runningValue = StringValue(profile.toUnformattedString())
+                )
+                .upsertStoreUsing(
+                    resolver = resolver,
+                    originalValue = StringValue("(pets:Pets)"),
+                    runningValue = StringValue(pets.toUnformattedString())
+                )
+
+            assertThat(substitution.substitute(StringValue("$(profile)"))).isEqualTo(HasValue(profile))
+            assertThat(substitution.substitute(StringValue("$(pets)"))).isEqualTo(HasValue(pets))
+        }
+
+        @Test
         fun `interpolated simple variable returns string value`() {
             val substitution = SubstitutionImpl.empty().upsertStoreUsing(
                 originalValue = StringValue("(name:string)"),
@@ -356,6 +390,15 @@ class SubstitutionImplTest {
             val substitution = lookupSubstitution(strictMode = true)
             assertThat(substitution.substitute(StringValue("$(lookupData.dictionary[ID].payload)")))
                 .isEqualTo(HasValue(JSONObjectValue(mapOf("id" to NumberValue(10)))))
+        }
+
+        @Test
+        fun `whole data lookup returns looked up composite object and array values as is`() {
+            val substitution = lookupSubstitution(strictMode = true)
+            assertThat(substitution.substitute(StringValue("$(lookupData.dictionary[ID].payload)")))
+                .isEqualTo(HasValue(JSONObjectValue(mapOf("id" to NumberValue(10)))))
+            assertThat(substitution.substitute(StringValue("$(lookupData.dictionary[ID].items)")))
+                .isEqualTo(HasValue(JSONArrayValue(listOf(NumberValue(10), NumberValue(20)))))
         }
 
         @Test
@@ -575,7 +618,8 @@ class SubstitutionImplTest {
                                 "1" to JSONObjectValue(
                                     mapOf(
                                         "message" to StringValue("resolved"),
-                                        "payload" to JSONObjectValue(mapOf("id" to NumberValue(10)))
+                                        "payload" to JSONObjectValue(mapOf("id" to NumberValue(10))),
+                                        "items" to JSONArrayValue(listOf(NumberValue(10), NumberValue(20)))
                                     )
                                 )
                             )

--- a/core/src/test/kotlin/io/specmatic/core/substitution/SubstitutionImplTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/substitution/SubstitutionImplTest.kt
@@ -9,8 +9,8 @@ import io.specmatic.core.pattern.HasException
 import io.specmatic.core.pattern.HasValue
 import io.specmatic.core.pattern.ExactValuePattern
 import io.specmatic.core.pattern.JSONArrayPattern
-import io.specmatic.core.pattern.NumberPattern
 import io.specmatic.core.pattern.JSONObjectPattern
+import io.specmatic.core.pattern.NumberPattern
 import io.specmatic.core.pattern.StringPattern
 import io.specmatic.core.pattern.parsedValue
 import io.specmatic.core.value.JSONArrayValue
@@ -71,40 +71,37 @@ class SubstitutionImplTest {
 
         assertThat(substitution.isDropDirective(StringValue("no-drop"))).isFalse()
         assertThat(substitution.isDropDirective(StringValue("$(lookupData.dictionary[traceId].dropMessage)"))).isTrue()
-        assertThat(substitution.substitute(StringValue("$(age)"), StringPattern(), null).value).isEqualTo(StringValue("33"))
-        assertThat(substitution.substitute(StringValue("$(code)"), StringPattern(), null).value).isEqualTo(StringValue("X1"))
-        assertThat(substitution.substitute(StringValue("$(name)"), StringPattern(), null).value).isEqualTo(StringValue("Ada"))
-        assertThat(substitution.substitute(StringValue("$(userId)"), StringPattern(), null).value).isEqualTo(StringValue("123"))
-        assertThat(substitution.substitute(StringValue("$(orderId)"), StringPattern(), null).value).isEqualTo(StringValue("456"))
-        assertThat(substitution.substitute(StringValue("$(pageNumber)"), StringPattern(), null).value).isEqualTo(StringValue("2"))
-        assertThat(substitution.substitute(StringValue("$(traceId)"), StringPattern(), null).value).isEqualTo(StringValue("trace-1"))
+        assertThat(substitution.substitute(StringValue("$(age)"), StringPattern()).value).isEqualTo(StringValue("33"))
+        assertThat(substitution.substitute(StringValue("$(code)"), StringPattern()).value).isEqualTo(StringValue("X1"))
+        assertThat(substitution.substitute(StringValue("$(name)"), StringPattern()).value).isEqualTo(StringValue("Ada"))
+        assertThat(substitution.substitute(StringValue("$(userId)"), StringPattern()).value).isEqualTo(StringValue("123"))
+        assertThat(substitution.substitute(StringValue("$(orderId)"), StringPattern()).value).isEqualTo(StringValue("456"))
+        assertThat(substitution.substitute(StringValue("$(pageNumber)"), StringPattern()).value).isEqualTo(StringValue("2"))
+        assertThat(substitution.substitute(StringValue("$(traceId)"), StringPattern()).value).isEqualTo(StringValue("trace-1"))
         assertThat(
-            substitution.resolveIfLookup(StringValue("$(lookupData.dictionary[traceId].message)"), StringPattern())
+            substitution.substitute(StringValue("$(lookupData.dictionary[traceId].message)"), StringPattern()).value
         ).isEqualTo(StringValue("resolved-from-data"))
     }
 
     @Test
     fun `upsertStoreUsing returns new substitution and keeps original unchanged`() {
-        val resolver = Resolver()
-        val original = SubstitutionImpl.empty(resolver, strictMode = true)
-
+        val original = SubstitutionImpl.empty(strictMode = true)
         val updated = original.upsertStoreUsing(
             originalValue = StringValue("(ID:number)"),
             runningValue = NumberValue(10)
         )
 
         assertThat(updated).isNotSameAs(original)
-        assertThat(original.substitute(StringValue("$(ID)"), NumberPattern(), null)).isInstanceOf(HasException::class.java)
+        assertThat(original.substitute(StringValue("$(ID)"), NumberPattern())).isInstanceOf(HasException::class.java)
 
-        val updatedResult = updated.substitute(StringValue("$(ID)"), NumberPattern(), null)
+        val updatedResult = updated.substitute(StringValue("$(ID)"), NumberPattern())
         assertThat(updatedResult).isInstanceOf(HasValue::class.java)
         assertThat((updatedResult as HasValue<*>).value).isEqualTo(NumberValue(10))
     }
 
     @Test
     fun `upsertStoreUsing preserves existing variables and adds new ones`() {
-        val resolver = Resolver()
-        val original = SubstitutionImpl.empty(resolver).upsertStoreUsing(
+        val original = SubstitutionImpl.empty().upsertStoreUsing(
             originalValue = StringValue("(FIRST:number)"),
             runningValue = NumberValue(1)
         )
@@ -121,8 +118,7 @@ class SubstitutionImplTest {
 
     @Test
     fun `upsertStoreUsing overrides existing variables`() {
-        val resolver = Resolver()
-        val first = SubstitutionImpl.empty(resolver).upsertStoreUsing(
+        val first = SubstitutionImpl.empty().upsertStoreUsing(
             originalValue = StringValue("(ID:number)"),
             runningValue = NumberValue(10)
         )
@@ -168,14 +164,13 @@ class SubstitutionImplTest {
         )
 
         assertThat(
-            substitution.resolveIfLookup(StringValue("$(lookupData.dictionary[ID].message)"), StringPattern())
+            substitution.substitute(StringValue("$(lookupData.dictionary[ID].message)"), StringPattern()).value
         ).isEqualTo(StringValue("resolved-from-data"))
     }
 
     @Test
     fun `upsertStoreUsing supports interpolated extraction and substitution end to end`() {
-        val resolver = Resolver()
-        val substitution = SubstitutionImpl.empty(resolver)
+        val substitution = SubstitutionImpl.empty()
 
         val updated = substitution.upsertStoreUsing(
             originalValue = StringValue("order-(ORDER_ID:number)"),
@@ -185,7 +180,6 @@ class SubstitutionImplTest {
         val result = updated.substitute(
             value = StringValue("resolved-$(ORDER_ID)"),
             pattern = StringPattern(),
-            key = null
         )
 
         assertThat(result).isInstanceOf(HasValue::class.java)
@@ -224,7 +218,6 @@ class SubstitutionImplTest {
         val result = substitution.substitute(
             value = StringValue("status-$(lookupData.statusByType[TYPE].status)"),
             pattern = StringPattern(),
-            key = null
         )
 
         assertThat(result).isInstanceOf(HasValue::class.java)
@@ -233,8 +226,7 @@ class SubstitutionImplTest {
 
     @Test
     fun `interpolated simple lookup resolves whole string as number`() {
-        val resolver = Resolver()
-        val substitution = SubstitutionImpl.empty(resolver).upsertStoreUsing(
+        val substitution = SubstitutionImpl.empty().upsertStoreUsing(
             originalValue = StringValue("(ID:number)"),
             runningValue = NumberValue(123)
         )
@@ -242,7 +234,6 @@ class SubstitutionImplTest {
         val result = substitution.substitute(
             value = StringValue("$(ID)"),
             pattern = NumberPattern(),
-            key = null
         )
 
         assertThat(result).isInstanceOf(HasValue::class.java)
@@ -251,7 +242,7 @@ class SubstitutionImplTest {
 
     @Test
     fun `interpolated simple lookup resolves embedded text`() {
-        val substitution = SubstitutionImpl.empty(Resolver()).upsertStoreUsing(
+        val substitution = SubstitutionImpl.empty().upsertStoreUsing(
             originalValue = StringValue("(ID:number)"),
             runningValue = NumberValue(123)
         )
@@ -259,7 +250,6 @@ class SubstitutionImplTest {
         val result = substitution.substitute(
             value = StringValue("order-$(ID)"),
             pattern = StringPattern(),
-            key = null
         )
 
         assertThat(result).isInstanceOf(HasValue::class.java)
@@ -268,14 +258,13 @@ class SubstitutionImplTest {
 
     @Test
     fun `multiple interpolated simple lookups resolve embedded text`() {
-        val substitution = SubstitutionImpl.empty(Resolver())
+        val substitution = SubstitutionImpl.empty()
             .upsertStoreUsing(StringValue("(A:string)"), StringValue("one"))
             .upsertStoreUsing(StringValue("(B:string)"), StringValue("two"))
 
         val result = substitution.substitute(
             value = StringValue("$(A)-$(B)"),
             pattern = StringPattern(),
-            key = null
         )
 
         assertThat(result).isInstanceOf(HasValue::class.java)
@@ -286,7 +275,7 @@ class SubstitutionImplTest {
     inner class ValueOnlySubstitution {
         @Test
         fun `whole simple variable returns stored scalar value as is`() {
-            val substitution = SubstitutionImpl.empty(Resolver()).upsertStoreUsing(
+            val substitution = SubstitutionImpl.empty().upsertStoreUsing(
                 originalValue = StringValue("(id:number)"),
                 runningValue = NumberValue(10)
             )
@@ -315,7 +304,8 @@ class SubstitutionImplTest {
                 )
             )
 
-            val substitution = SubstitutionImpl.empty(resolver).upsertStoreUsing(
+            val substitution = SubstitutionImpl.empty().upsertStoreUsing(
+                resolver = resolver,
                 originalValue = StringValue("(user:User)"),
                 runningValue = StringValue(user.toUnformattedString())
             )
@@ -325,7 +315,7 @@ class SubstitutionImplTest {
 
         @Test
         fun `interpolated simple variable returns string value`() {
-            val substitution = SubstitutionImpl.empty(Resolver()).upsertStoreUsing(
+            val substitution = SubstitutionImpl.empty().upsertStoreUsing(
                 originalValue = StringValue("(name:string)"),
                 runningValue = StringValue("John")
             )
@@ -345,7 +335,8 @@ class SubstitutionImplTest {
             )
 
             val orders = JSONArrayValue(listOf(NumberValue(10), NumberValue(20)))
-            val substitution = SubstitutionImpl.empty(resolver).upsertStoreUsing(
+            val substitution = SubstitutionImpl.empty().upsertStoreUsing(
+                resolver = resolver,
                 originalValue = StringValue("(orders:Orders)"),
                 runningValue = StringValue(orders.toUnformattedString())
             )
@@ -356,7 +347,7 @@ class SubstitutionImplTest {
 
         @Test
         fun `missing variable returns exception`() {
-            val result = SubstitutionImpl.empty(Resolver()).substitute(StringValue("$(missing)"))
+            val result = SubstitutionImpl.empty().substitute(StringValue("$(missing)"))
             assertThat(result).isInstanceOf(HasException::class.java)
         }
 
@@ -377,18 +368,18 @@ class SubstitutionImplTest {
         @Test
         fun `value only resolveIfLookup returns looked up value as is`() {
             val substitution = lookupSubstitution(strictMode = true)
-            assertThat(substitution.resolveIfLookup(StringValue("$(lookupData.dictionary[ID].payload)")))
+            assertThat(substitution.substitute(StringValue("$(lookupData.dictionary[ID].payload)")).value)
                 .isEqualTo(JSONObjectValue(mapOf("id" to NumberValue(10))))
         }
 
         @Test
         fun `pattern aware substitution still parses through pattern`() {
-            val substitution = SubstitutionImpl.empty(Resolver()).upsertStoreUsing(
+            val substitution = SubstitutionImpl.empty().upsertStoreUsing(
                 originalValue = StringValue("(id:number)"),
                 runningValue = NumberValue(10)
             )
 
-            assertThat(substitution.substitute(StringValue("$(id)"), StringPattern(), null))
+            assertThat(substitution.substitute(StringValue("$(id)"), StringPattern()))
                 .isEqualTo(HasValue(StringValue("10")))
         }
     }
@@ -400,7 +391,6 @@ class SubstitutionImplTest {
             val result = substitution(strictMode = false).substitute(
                 value = StringValue("$(MISSING_VAR)"),
                 pattern = ExactValuePattern(StringValue("generated")),
-                key = null
             )
 
             assertThat(result).isInstanceOf(HasValue::class.java)
@@ -408,11 +398,32 @@ class SubstitutionImplTest {
         }
 
         @Test
+        fun `simple variable missing uses dictionary backed generation`() {
+            val pattern = JSONObjectPattern(
+                typeAlias = "(Object)",
+                pattern = mapOf("id" to NumberPattern()),
+            )
+
+            val resolver = Resolver(
+                newPatterns = mapOf("(Object)" to pattern),
+                dictionary = Dictionary.fromYaml("Object: { id: 123456 }")
+            )
+
+            val result = substitution(strictMode = false).substitute(
+                pattern = pattern,
+                resolver = resolver,
+                value = StringValue("$(MISSING_VAR)"),
+            )
+
+            assertThat(result).isInstanceOf(HasValue::class.java)
+            assertThat((result as HasValue<*>).value).isEqualTo(JSONObjectValue(mapOf("id" to NumberValue(123456))))
+        }
+
+        @Test
         fun `parse failure falls back to pattern generate`() {
             val result = substitutionWithResolvedVariable(strictMode = false).substitute(
                 value = StringValue("$(ID)"),
                 pattern = NumberPattern(),
-                key = null
             )
 
             assertThat(result).isInstanceOf(HasValue::class.java)
@@ -420,11 +431,25 @@ class SubstitutionImplTest {
         }
 
         @Test
+        fun `parse failure falls back to dictionary backed generation`() {
+            val resolver = Resolver(dictionary = Dictionary.fromYaml("""{Object: {Key: 123456}}"""))
+            val updatedResolver = resolver.updateLookupPath("(Object)", KeyWithPattern("Key", NumberPattern()))
+
+            val result = substitutionWithResolvedVariable(strictMode = false).substitute(
+                value = StringValue("$(ID)"),
+                pattern = NumberPattern(),
+                resolver = updatedResolver,
+            )
+
+            assertThat(result).isInstanceOf(HasValue::class.java)
+            assertThat((result as HasValue<*>).value).isEqualTo(NumberValue(123456))
+        }
+
+        @Test
         fun `data lookup missing uses pattern generate`() {
             val result = lookupSubstitution(strictMode = false).substitute(
                 value = StringValue("$(lookupData.dictionary[MISSING_VAR].message)"),
                 pattern = ExactValuePattern(StringValue("generated")),
-                key = null
             )
 
             assertThat(result).isInstanceOf(HasValue::class.java)
@@ -435,10 +460,24 @@ class SubstitutionImplTest {
         fun `pattern generation should use dictionary if present`() {
             val resolver = Resolver(dictionary = Dictionary.fromYaml("""{Object: {Key: 123456}}"""))
             val updatedResolver = resolver.updateLookupPath("(Object)", KeyWithPattern("Key", NumberPattern()))
-            val result = substitution(strictMode = false, resolver = updatedResolver).substitute(
-                key = null,
+            val result = substitution(strictMode = false).substitute(
+                pattern = NumberPattern(),
+                resolver = updatedResolver,
+                value = StringValue("$(MISSING_VAR)"),
+            )
+
+            assertThat(result).isInstanceOf(HasValue::class.java)
+            assertThat((result as HasValue<*>).value).isEqualTo(NumberValue(123456))
+        }
+
+        @Test
+        fun `missing variable with key uses resolver dictionary fallback`() {
+            val resolver = Resolver(dictionary = Dictionary.fromYaml("""{Object: {Key: 123456}}"""))
+            val result = substitution(strictMode = false).substitute(
+                key = "Key",
                 pattern = NumberPattern(),
                 value = StringValue("$(MISSING_VAR)"),
+                resolver = resolver.updateLookupPath("(Object)"),
             )
 
             assertThat(result).isInstanceOf(HasValue::class.java)
@@ -453,7 +492,6 @@ class SubstitutionImplTest {
             val result = substitution(strictMode = true).substitute(
                 value = StringValue("order-$(MISSING)"),
                 pattern = StringPattern(),
-                key = null
             )
 
             assertThat(result).isInstanceOf(HasException::class.java)
@@ -464,7 +502,6 @@ class SubstitutionImplTest {
             val result = substitution(strictMode = true).substitute(
                 value = StringValue("$(MISSING_VAR)"),
                 pattern = ExactValuePattern(StringValue("generated")),
-                key = null
             )
 
             assertThat(result).isInstanceOf(HasException::class.java)
@@ -476,7 +513,6 @@ class SubstitutionImplTest {
             val result = substitutionWithResolvedVariable(strictMode = true).substitute(
                 value = StringValue("$(ID)"),
                 pattern = NumberPattern(),
-                key = null
             )
 
             assertThat(result).isInstanceOf(HasException::class.java)
@@ -487,7 +523,6 @@ class SubstitutionImplTest {
             val result = lookupSubstitution(strictMode = true).substitute(
                 value = StringValue("$(lookupData.dictionary[MISSING_VAR].message)"),
                 pattern = ExactValuePattern(StringValue("generated")),
-                key = null
             )
 
             assertThat(result).isInstanceOf(HasException::class.java)
@@ -495,7 +530,7 @@ class SubstitutionImplTest {
 
         @Test
         fun `upsertStoreUsing preserves strict mode`() {
-            val substitution = SubstitutionImpl.empty(Resolver(), strictMode = true).upsertStoreUsing(
+            val substitution = SubstitutionImpl.empty(strictMode = true).upsertStoreUsing(
                 originalValue = StringValue("(ID:number)"),
                 runningValue = NumberValue(10)
             )
@@ -503,7 +538,6 @@ class SubstitutionImplTest {
             val result = substitution.substitute(
                 value = StringValue("$(MISSING_VAR)"),
                 pattern = ExactValuePattern(StringValue("generated")),
-                key = null
             )
 
             assertThat(result).isInstanceOf(HasException::class.java)
@@ -511,17 +545,17 @@ class SubstitutionImplTest {
     }
 
     private fun assertResolvedValue(substitution: Substitution, lookup: String, expectedValue: NumberValue) {
-        val result = substitution.substitute(StringValue(lookup), NumberPattern(), null)
+        val result = substitution.substitute(StringValue(lookup), NumberPattern())
         assertThat(result).isInstanceOf(HasValue::class.java)
         assertThat((result as HasValue<*>).value).isEqualTo(expectedValue)
     }
 
-    private fun substitution(strictMode: Boolean, resolver: Resolver = Resolver()): SubstitutionImpl {
-        return SubstitutionImpl.empty(resolver, strictMode = strictMode)
+    private fun substitution(strictMode: Boolean): SubstitutionImpl {
+        return SubstitutionImpl.empty(strictMode = strictMode)
     }
 
     private fun substitutionWithResolvedVariable(strictMode: Boolean): SubstitutionImpl {
-        return SubstitutionImpl.empty(Resolver(), strictMode = strictMode).upsertStoreUsing(
+        return SubstitutionImpl.empty(strictMode = strictMode).upsertStoreUsing(
             originalValue = StringValue("(ID:string)"),
             runningValue = StringValue("not-a-number")
         )

--- a/core/src/test/kotlin/io/specmatic/test/ScenarioAsTestTest.kt
+++ b/core/src/test/kotlin/io/specmatic/test/ScenarioAsTestTest.kt
@@ -12,7 +12,6 @@ import io.specmatic.core.HttpResponsePattern
 import io.specmatic.core.Result
 import io.specmatic.core.Scenario
 import io.specmatic.core.ScenarioInfo
-import io.specmatic.core.Resolver
 import io.specmatic.core.Substitution
 import io.specmatic.core.HttpQueryParamPattern
 import io.specmatic.core.pattern.ExactValuePattern
@@ -89,7 +88,7 @@ class ScenarioAsTestTest {
 
         @Test
         fun `request generation should be able to use before fixture substitution store`() {
-            val substitution = SubstitutionImpl.empty(Resolver())
+            val substitution = SubstitutionImpl.empty()
             val originalScenario = Scenario(
                 ScenarioInfo(
                     specType = SpecType.OPENAPI,
@@ -140,7 +139,8 @@ class ScenarioAsTestTest {
             assertThat(headers["Authorization"]).isEqualTo("token-123")
             assertThat(ServiceLoaderTestFixtureExecutor.receivedSubstitution).isNotNull
             assertThat(ServiceLoaderTestFixtureExecutor.receivedSubstitution?.substitute(
-                StringValue("$(SECRET)"), StringPattern(), null)?.value
+                StringValue("$(SECRET)"), StringPattern(),
+            )?.value
             ).isEqualTo(StringValue("token-123"))
         }
 
@@ -148,7 +148,7 @@ class ScenarioAsTestTest {
         fun `after fixture should be able to use before and response substitution store`() {
             ServiceLoaderTestFixtureExecutor.reset()
 
-            val substitution = SubstitutionImpl.empty(Resolver())
+            val substitution = SubstitutionImpl.empty()
             val scenario = scenario(
                 exampleRow = Row(
                     scenarioStub = ScenarioStub(
@@ -200,9 +200,9 @@ class ScenarioAsTestTest {
             assertThat(result.result).isInstanceOf(Result.Success::class.java)
             assertThat(ServiceLoaderTestFixtureExecutor.calls).containsExactly("before", "after")
             assertThat(ServiceLoaderTestFixtureExecutor.receivedSubstitution).isNotNull
-            assertThat(ServiceLoaderTestFixtureExecutor.receivedSubstitution?.substitute(StringValue("$(SECRET)"), StringPattern(), null)?.value)
+            assertThat(ServiceLoaderTestFixtureExecutor.receivedSubstitution?.substitute(StringValue("$(SECRET)"), StringPattern())?.value)
                 .isEqualTo(StringValue("token-123"))
-            assertThat(ServiceLoaderTestFixtureExecutor.receivedSubstitution?.substitute(StringValue("$(QUERY_ID)"), StringPattern(), null)?.value)
+            assertThat(ServiceLoaderTestFixtureExecutor.receivedSubstitution?.substitute(StringValue("$(QUERY_ID)"), StringPattern())?.value)
                 .isEqualTo(StringValue("query-456"))
         }
 
@@ -497,7 +497,7 @@ class ScenarioAsTestTest {
         scenario: Scenario,
         scenarios: List<Scenario> = listOf(scenario),
         originalScenario: Scenario = scenario,
-        substitution: Substitution = SubstitutionImpl.empty(Resolver())
+        substitution: Substitution = SubstitutionImpl.empty()
     ): ScenarioAsTest {
         val feature = Feature(name = "feature", scenarios = scenarios, protocol = SpecmaticProtocol.HTTP)
         return ScenarioAsTest(


### PR DESCRIPTION
**What**:
- Support for substitutions that store and reuse composite JSON values such as objects and arrays.
- Ensure unresolved substitutions fall back to generated values using the active resolver, including dictionary-backed generation when matching dictionary entries exist

**Why**:
- Substitutions should work consistently for real-world payloads, not just scalar values.
- When a substitution variable cannot be resolved, fallback generation must still honor the resolver and dictionary so generated values remain deterministic and contract-aware where dictionary data is available

> **Note:** Please merge after dependency https://github.com/specmatic/specmatic/pull/2606

**Checklist**:
- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link) N/A
- [ ] Demo video (share link) N/A
- [ ] Article on Website (share link) N/A
- [ ] Roadmpap updated (share link) N/A
- [ ] Conference Talk (share link) N/A