### PR TITLE
Ensure basedOn methods can work with substitution tokens

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/HttpPathPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpPathPattern.kt
@@ -197,6 +197,11 @@ data class HttpPathPattern(
                         }
                     }
 
+                    isSubstitution(rowValue) -> {
+                        val exactValuePattern = ExactValuePattern(StringValue(rowValue))
+                        urlPathParamPattern.copy(pattern = exactValuePattern)
+                    }
+
                     else -> attempt("Format error in example of path parameter \"$key\"") {
                         val value = urlPathParamPattern.parse(rowValue, resolver)
 
@@ -324,6 +329,11 @@ data class HttpPathPattern(
                         is Success -> sequenceOf(urlPathPattern.copy(pattern = rowPattern))
                         is Failure -> throw ContractException(result.toFailureReport())
                     }
+                }
+
+                isSubstitution(rowValue) -> {
+                    val exactValuePattern = ExactValuePattern(StringValue(rowValue))
+                    sequenceOf(urlPathPattern.copy(pattern = exactValuePattern))
                 }
 
                 else -> attempt("Format error in example of path parameter \"$key\"") {

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
@@ -26,6 +26,7 @@ import io.specmatic.core.pattern.breadCrumb
 import io.specmatic.core.pattern.isDollarMethodOrLookup
 import io.specmatic.core.pattern.isOptional
 import io.specmatic.core.pattern.isPatternToken
+import io.specmatic.core.pattern.isSubstitution
 import io.specmatic.core.pattern.newBasedOn
 import io.specmatic.core.pattern.newMapBasedOn
 import io.specmatic.core.pattern.parsedPattern
@@ -325,7 +326,7 @@ data class HttpRequestPattern(
             val bodyValue =
                 if (httpRequest.body is JSONObjectValue || httpRequest.body is JSONArrayValue || httpRequest.body is XMLNode) {
                     httpRequest.body
-                } else if (isPatternToken(httpRequest.bodyString)) {
+                } else if (isPatternToken(httpRequest.bodyString) || isSubstitution(httpRequest.bodyString)) {
                     StringValue(httpRequest.bodyString)
                 } else {
                     body.parse(httpRequest.bodyString, resolver)
@@ -859,16 +860,17 @@ data class HttpRequestPattern(
 
             val newBodies: Sequence<ReturnValue<Pattern>> = returnValue(breadCrumb = "BODY") BODY@ {
                 val rawRequestBody = row.getFieldOrNull(REQUEST_BODY_FIELD) ?: return@BODY resolver.generateHttpRequestBodies(this.body, row)
-                val parsedValue = runCatching { body.parse(rawRequestBody, resolver) }.getOrElse { e ->
+                val parsedValue = runCatching {
+                    if (isSubstitution(rawRequestBody)) return@runCatching StringValue(rawRequestBody)
+                    val parsedValue = body.parse(rawRequestBody, resolver)
+                    if (!isInvalidRequestResponse(status)) resolver.matchesPattern(null, body, parsedValue).throwOnFailure()
+                    parsedValue
+                }.getOrElse { e ->
                     if (isInvalidRequestResponse(status)) StringValue(rawRequestBody)
                     else throw e
                 }
+
                 val requestBodyAsIs = ExactValuePattern(parsedValue)
-
-                if (!isInvalidRequestResponse(status)) {
-                    resolver.matchesPattern(null, body, parsedValue).throwOnFailure()
-                }
-
                 if (status in 200..299)
                     resolver.generateHttpRequestBodies(this.body, row, requestBodyAsIs)
                 else
@@ -1025,6 +1027,7 @@ data class HttpRequestPattern(
 
             val newBodies: Sequence<ReturnValue<out Pattern>> = (returnValue(breadCrumb = "BODY") returnNewBodies@ {
                 val rawRequestBody = row.getFieldOrNull(REQUEST_BODY_FIELD) ?: return@returnNewBodies body.negativeBasedOn(row, resolver)
+                if (isSubstitution(rawRequestBody)) return@returnNewBodies body.negativeBasedOn(row, resolver)
                 val parsedValue = body.parse(rawRequestBody, resolver)
                 body.matches(parsedValue, resolver).throwOnFailure()
                 this.body.negativeBasedOn(row.noteRequestBody(), resolver)

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
@@ -1043,17 +1043,12 @@ data class HttpRequestPattern(
             val newFormFieldsPatterns = newMapBasedOn(formFieldsPattern, row, resolver).map { it.value }
             val newFormDataPartLists = newMultiPartBasedOn(multiPartFormDataPattern, row, resolver)
 
+            val securitySchemeInRow = securitySchemes.find { scheme -> scheme.isInRow(row) }
             sequence {
                 try {
                     // If security schemes are present, for now we'll just take the first scheme and assign it to each negative request pattern.
                     // Ideally we should generate negative patterns from the security schemes and use them.
-                    val positivePattern: HttpRequestPattern =
-                        newBasedOn(
-                            row,
-                            resolver,
-                            400
-                        ).first().value.copy(securitySchemes = listOf(securitySchemes.first()))
-
+                    val positivePattern: HttpRequestPattern = newBasedOn(row, resolver, 400).first().value
                     newHttpPathPatterns.forEach { pathParamPatternR ->
                         if (pathParamPatternR != null) {
                             yield(pathParamPatternR.ifValue { pathParamPattern ->
@@ -1093,6 +1088,14 @@ data class HttpRequestPattern(
                 } catch (t: Throwable) {
                     yield(HasException(t))
                 }
+            }.withSecuritySchemeElseFirst(row, securitySchemeInRow)
+        }
+    }
+
+    private fun Sequence<ReturnValue<HttpRequestPattern>>.withSecuritySchemeElseFirst(row: Row, scheme: OpenAPISecurityScheme?): Sequence<ReturnValue<HttpRequestPattern>> {
+        return this.map {
+            it.ifValue { requestPattern ->
+                scheme?.addTo(requestPattern, row) ?: requestPattern.copy(securitySchemes = listOf(securitySchemes.first()))
             }
         }
     }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/Grammar.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/Grammar.kt
@@ -3,6 +3,7 @@ package io.specmatic.core.pattern
 import io.specmatic.core.DefaultMismatchMessages
 import io.specmatic.core.MismatchMessages
 import io.specmatic.core.log.logger
+import io.specmatic.core.substitution.InterpolatedSubstitution
 import io.specmatic.core.utilities.jsonStringToValueArray
 import io.specmatic.core.utilities.jsonStringToValueMap
 import io.specmatic.core.utilities.yamlStringToValue
@@ -115,6 +116,12 @@ fun isPatternToken(patternValue: Any?) =
 fun isDollarMethodOrLookup(patternValue: Any?) = when (patternValue) {
     is String -> DOLLAR_METHOD_OR_LOOKUP_PATTERN.matchEntire(patternValue) != null
     is StringValue -> DOLLAR_METHOD_OR_LOOKUP_PATTERN.matchEntire(patternValue.string) != null
+    else -> false
+}
+
+fun isSubstitution(patternValue: Any?) = when (patternValue) {
+    is String -> InterpolatedSubstitution.isLookup(patternValue)
+    is StringValue -> InterpolatedSubstitution.isLookup(patternValue.string)
     else -> false
 }
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/TabularPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/TabularPattern.kt
@@ -193,7 +193,12 @@ fun newPatternsBasedOn(row: Row, key: String, pattern: Pattern, resolver: Resolv
         row.containsField(keyWithoutOptionality) -> {
             val rowValue = row.getField(keyWithoutOptionality)
 
-            if (isPatternToken(rowValue)) {
+            if (isSubstitution(rowValue)) {
+                val exactValuePattern = ExactValuePattern(StringValue(rowValue))
+                val generativePatterns: Sequence<ReturnValue<Pattern>> = resolver.generatedPatternsForGenerativeTests(pattern, key)
+                val sequence: Sequence<ReturnValue<Pattern>> = sequenceOf(HasValue(exactValuePattern))
+                sequence + generativePatterns
+            } else if (isPatternToken(rowValue)) {
                 val rowPattern = resolver.getPattern(rowValue)
 
                 attempt(breadCrumb = keyWithoutOptionality) {

--- a/core/src/main/kotlin/io/specmatic/core/substitution/InterpolatedSubstitution.kt
+++ b/core/src/main/kotlin/io/specmatic/core/substitution/InterpolatedSubstitution.kt
@@ -11,6 +11,10 @@ internal object InterpolatedSubstitution {
     private val captureRegex = Regex("\\(([^()]+:[^()]+)\\)")
     private val dollarFunctionBeforeParenRegex = Regex("""\$\w+\s*$""")
 
+    fun isLookup(value: String): Boolean {
+        return useRegex.matches(value)
+    }
+
     fun containsLookup(value: String): Boolean {
         return useRegex.containsMatchIn(value)
     }

--- a/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
+++ b/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
@@ -11,6 +11,7 @@ import io.specmatic.core.examples.source.DirectoryExampleSource
 import io.specmatic.core.examples.source.PreLoadedExampleObjects
 import io.specmatic.core.examples.module.ExampleValidationModule
 import io.specmatic.core.log.*
+import io.specmatic.core.pattern.HasValue
 import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.pattern.parsedJSONArray
 import io.specmatic.core.pattern.parsedJSONObject
@@ -21,11 +22,18 @@ import io.specmatic.core.utilities.Flags.Companion.IGNORE_INLINE_EXAMPLES
 import io.specmatic.core.value.*
 import io.specmatic.mock.ScenarioStub
 import io.specmatic.test.TestExecutor
+import io.specmatic.test.FixtureExecutionDetails
+import io.specmatic.test.fixtures.FixtureExecutionMetadata
+import io.specmatic.test.fixtures.OpenAPIFixtureExecutor
+import io.specmatic.test.interceptor.ContractTestInterceptor
+import io.specmatic.test.interceptor.InterceptResult
 import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
 import java.math.BigDecimal
+import java.net.URLClassLoader
+import java.nio.file.Files
 
 private val doubleMax = BigDecimal(Double.MAX_VALUE)
 private val doubleMin = BigDecimal(-Double.MAX_VALUE)
@@ -188,6 +196,77 @@ class LoadTestsFromExternalisedFiles {
         assertThat(loadedFeature.scenarios).hasSize(1)
         assertThat(loadedFeature.scenarios.single().examples.single().rows).hasSize(2)
         assertThat(unusedExamples).isEmpty()
+    }
+
+    @Test
+    fun `should resolve lookup expressions in row values for positive and negative generated tests`() {
+        val specFile = File("src/test/resources/openapi/row_value_lookup/api.yaml")
+        val examplesDir = specFile.resolveSibling("api_examples")
+
+        Flags.using(EXAMPLE_DIRECTORIES to examplesDir.canonicalPath) {
+            val feature = OpenApiSpecification.fromFile(specFile.canonicalPath).toFeature().copy(strictMode = true).loadExternalisedExamples()
+            feature.validateExamplesOrException()
+
+            val observedRequests = mutableListOf<String>()
+            val positiveRequests = mutableListOf<HttpRequest>()
+            val negativeMutationEvidences = mutableSetOf<String>()
+            val expectedPositiveRequestBody = parsedJSONObject("""{"name": "Sherlock"}""")
+            val positiveHeaderPattern = Regex("A+")
+
+            val results = withServiceLoaderEntries(
+                mapOf(
+                    OpenAPIFixtureExecutor::class.java to RowValueLookupFixtureExecutor::class.java.name,
+                    ContractTestInterceptor::class.java to RowValueLookupContractTestInterceptor::class.java.name
+                )
+            ) {
+                feature.enableGenerativeTesting().executeTests(object : TestExecutor {
+                    override fun execute(request: HttpRequest): HttpResponse {
+                        println(request.toLogString())
+                        observedRequests.add(request.toLogString())
+                        assertThat(request.path).doesNotContain("\$(")
+                        assertThat(request.queryParams.toString()).doesNotContain("\$(")
+                        assertThat(request.headers.values.joinToString(" ")).doesNotContain("\$(")
+                        assertThat(request.body.toStringLiteral()).doesNotContain("\$(")
+
+                        val randomHeader = request.headers["Random-String"]
+                        val hasValidRandomHeader = randomHeader == null || positiveHeaderPattern.matches(randomHeader)
+                        val isPositiveRequest =
+                            request.path == "/orders/order-123" &&
+                                request.queryParams.asMap()["page"] == "page-7" &&
+                                request.headers["X-Tenant"] == "north" &&
+                                request.body == expectedPositiveRequestBody &&
+                                hasValidRandomHeader
+
+                        if (isPositiveRequest) {
+                            positiveRequests.add(request)
+                            return HttpResponse.ok(parsedJSONObject("""{"result": "accepted"}"""))
+                        }
+
+                        when {
+                            request.path != "/orders/order-123" -> negativeMutationEvidences.add("path")
+                            request.queryParams.asMap()["page"] != "page-7" -> negativeMutationEvidences.add("query")
+                            request.headers["X-Tenant"] != "north" -> negativeMutationEvidences.add("header")
+                            request.body != expectedPositiveRequestBody -> negativeMutationEvidences.add("body")
+                        }
+
+                        return HttpResponse(
+                            status = 400,
+                            body = parsedJSONObject("""{"message": "bad request"}"""),
+                            headers = mapOf("Content-Type" to "application/json")
+                        )
+                    }
+                })
+            }
+
+            assertThat(results.success())
+                .withFailMessage("Observed requests:\n%s\n\n%s", observedRequests.joinToString("\n\n"), results.report())
+                .isTrue()
+
+            assertThat(negativeMutationEvidences).contains("query", "header", "body")
+            assertThat(positiveRequests)
+                .withFailMessage("Observed requests:\n%s\n\n%s", observedRequests.joinToString("\n\n"), results.report())
+                .isNotEmpty()
+        }
     }
 
     @Test
@@ -1508,5 +1587,77 @@ class LoadTestsFromExternalisedFiles {
                 }
             }
         }
+    }
+}
+
+private fun <T> withServiceLoaderEntries(entries: Map<Class<*>, String>, block: () -> T): T {
+    val previousContextClassLoader = Thread.currentThread().contextClassLoader
+    val tempDir = Files.createTempDirectory("specmatic-service-loader-test")
+    val servicesDir = tempDir.resolve("META-INF/services")
+    Files.createDirectories(servicesDir)
+    entries.forEach { (service, implementationClassName) ->
+        Files.writeString(servicesDir.resolve(service.name), "$implementationClassName\n")
+    }
+
+    val classLoader = URLClassLoader(arrayOf(tempDir.toUri().toURL()), previousContextClassLoader)
+    Thread.currentThread().contextClassLoader = classLoader
+
+    return try {
+        block()
+    } finally {
+        Thread.currentThread().contextClassLoader = previousContextClassLoader
+        classLoader.close()
+        tempDir.toFile().deleteRecursively()
+    }
+}
+
+class RowValueLookupFixtureExecutor : OpenAPIFixtureExecutor {
+    override fun execute(
+        id: String,
+        fixtures: List<Value>,
+        fixtureDiscriminatorKey: String,
+        executionMetadata: FixtureExecutionMetadata,
+        substitution: Substitution
+    ): FixtureExecutionDetails {
+        val updatedSubstitution = substitution
+            .upsertStoreUsing(StringValue("(ORDER_ID:string)"), StringValue("order-123"))
+            .upsertStoreUsing(StringValue("(PAGE:string)"), StringValue("page-7"))
+            .upsertStoreUsing(StringValue("(TENANT:string)"), StringValue("north"))
+            .upsertStoreUsing(StringValue("(NAME:string)"), StringValue("Sherlock"))
+
+        return FixtureExecutionDetails(
+            combinedResult = Result.Success(),
+            updatedSubstitution = updatedSubstitution
+        )
+    }
+}
+
+class RowValueLookupContractTestInterceptor : ContractTestInterceptor {
+    override fun updateRequest(
+        testScenario: Scenario,
+        originalScenario: Scenario,
+        httpRequest: HttpRequest,
+        substitution: Substitution,
+    ): InterceptResult<HttpRequest> {
+        return InterceptResult.Processed(
+            value = originalScenario.resolveRequestSubstitutions(httpRequest, substitution)
+        )
+    }
+
+    override fun updateSubstitution(
+        testScenario: Scenario,
+        originalScenario: Scenario,
+        httpResponse: HttpResponse,
+        substitution: Substitution,
+    ): InterceptResult<Substitution> {
+        val example = testScenario.exampleRow?.scenarioStub ?: return InterceptResult.PassThrough
+        return InterceptResult.Processed(
+            value = HasValue(
+                substitution.upsertStoreUsing(
+                    runningValue = httpResponse.toJSON(),
+                    originalValue = example.response().toJSON(),
+                )
+            )
+        )
     }
 }

--- a/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
+++ b/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
@@ -198,14 +198,12 @@ class LoadTestsFromExternalisedFiles {
         assertThat(unusedExamples).isEmpty()
     }
 
-    @Test
-    fun `should resolve lookup expressions in row values for positive and negative generated tests`() {
-        val specFile = File("src/test/resources/openapi/row_value_lookup/api.yaml")
-        val examplesDir = specFile.resolveSibling("api_examples")
-
-        Flags.using(EXAMPLE_DIRECTORIES to examplesDir.canonicalPath) {
-            val feature = OpenApiSpecification.fromFile(specFile.canonicalPath).toFeature().copy(strictMode = true).loadExternalisedExamples()
-            feature.validateExamplesOrException()
+    @Nested
+    inner class RowValueLookupGenerationTest {
+        @Test
+        fun `should resolve lookup expressions in row values for positive and negative generated tests`() {
+            val specFile = File("src/test/resources/openapi/row_value_lookup/api.yaml")
+            val feature = loadRowValueLookupFeature(specFile)
 
             val observedRequests = mutableListOf<String>()
             val positiveRequests = mutableListOf<HttpRequest>()
@@ -213,49 +211,37 @@ class LoadTestsFromExternalisedFiles {
             val expectedPositiveRequestBody = parsedJSONObject("""{"name": "Sherlock"}""")
             val positiveHeaderPattern = Regex("A+")
 
-            val results = withServiceLoaderEntries(
-                mapOf(
-                    OpenAPIFixtureExecutor::class.java to RowValueLookupFixtureExecutor::class.java.name,
-                    ContractTestInterceptor::class.java to RowValueLookupContractTestInterceptor::class.java.name
-                )
-            ) {
-                feature.enableGenerativeTesting().executeTests(object : TestExecutor {
-                    override fun execute(request: HttpRequest): HttpResponse {
-                        println(request.toLogString())
-                        observedRequests.add(request.toLogString())
-                        assertThat(request.path).doesNotContain("\$(")
-                        assertThat(request.queryParams.toString()).doesNotContain("\$(")
-                        assertThat(request.headers.values.joinToString(" ")).doesNotContain("\$(")
-                        assertThat(request.body.toStringLiteral()).doesNotContain("\$(")
+            val results = executeRowValueLookupGenerativeTests(feature) { request ->
+                println(request.toLogString())
+                observedRequests.add(request.toLogString())
+                assertRequestHasNoUnresolvedLookupExpressions(request)
 
-                        val randomHeader = request.headers["Random-String"]
-                        val hasValidRandomHeader = randomHeader == null || positiveHeaderPattern.matches(randomHeader)
-                        val isPositiveRequest =
-                            request.path == "/orders/order-123" &&
-                                request.queryParams.asMap()["page"] == "page-7" &&
-                                request.headers["X-Tenant"] == "north" &&
-                                request.body == expectedPositiveRequestBody &&
-                                hasValidRandomHeader
+                val randomHeader = request.headers["Random-String"]
+                val hasValidRandomHeader = randomHeader == null || positiveHeaderPattern.matches(randomHeader)
+                val isPositiveRequest =
+                    request.path == "/orders/order-123" &&
+                        request.queryParams.asMap()["page"] == "page-7" &&
+                        request.headers["X-Tenant"] == "north" &&
+                        request.body == expectedPositiveRequestBody &&
+                        hasValidRandomHeader
 
-                        if (isPositiveRequest) {
-                            positiveRequests.add(request)
-                            return HttpResponse.ok(parsedJSONObject("""{"result": "accepted"}"""))
-                        }
-
-                        when {
-                            request.path != "/orders/order-123" -> negativeMutationEvidences.add("path")
-                            request.queryParams.asMap()["page"] != "page-7" -> negativeMutationEvidences.add("query")
-                            request.headers["X-Tenant"] != "north" -> negativeMutationEvidences.add("header")
-                            request.body != expectedPositiveRequestBody -> negativeMutationEvidences.add("body")
-                        }
-
-                        return HttpResponse(
-                            status = 400,
-                            body = parsedJSONObject("""{"message": "bad request"}"""),
-                            headers = mapOf("Content-Type" to "application/json")
-                        )
+                if (isPositiveRequest) {
+                    positiveRequests.add(request)
+                    HttpResponse.ok(parsedJSONObject("""{"result": "accepted"}"""))
+                } else {
+                    when {
+                        request.path != "/orders/order-123" -> negativeMutationEvidences.add("path")
+                        request.queryParams.asMap()["page"] != "page-7" -> negativeMutationEvidences.add("query")
+                        request.headers["X-Tenant"] != "north" -> negativeMutationEvidences.add("header")
+                        request.body != expectedPositiveRequestBody -> negativeMutationEvidences.add("body")
                     }
-                })
+
+                    HttpResponse(
+                        status = 400,
+                        body = parsedJSONObject("""{"message": "bad request"}"""),
+                        headers = mapOf("Content-Type" to "application/json")
+                    )
+                }
             }
 
             assertThat(results.success())
@@ -266,6 +252,72 @@ class LoadTestsFromExternalisedFiles {
             assertThat(positiveRequests)
                 .withFailMessage("Observed requests:\n%s\n\n%s", observedRequests.joinToString("\n\n"), results.report())
                 .isNotEmpty()
+        }
+
+        @Test
+        fun `should resolve lookup expressions when the top level body is substituted with a number`() {
+            val specFile = File("src/test/resources/openapi/row_value_lookup/top_level_number_body_api.yaml")
+            val feature = loadRowValueLookupFeature(specFile)
+
+            val observedRequests = mutableListOf<String>()
+            val positiveRequests = mutableListOf<HttpRequest>()
+            val negativeBodies = mutableListOf<Value>()
+
+            val results = executeRowValueLookupGenerativeTests(feature) { request ->
+                println(request.toLogString())
+                observedRequests.add(request.toLogString())
+                assertRequestHasNoUnresolvedLookupExpressions(request)
+
+                if (request.path == "/counts" && request.body.toUnformattedString().toIntOrNull() in setOf(42, 43)) {
+                    positiveRequests.add(request)
+                    HttpResponse.ok(parsedJSONObject("""{"result": "accepted"}"""))
+                } else {
+                    negativeBodies.add(request.body)
+                    HttpResponse(
+                        status = 400,
+                        body = parsedJSONObject("""{"message": "bad request"}"""),
+                        headers = mapOf("Content-Type" to "application/json")
+                    )
+                }
+            }
+
+            assertThat(results.success())
+                .withFailMessage("Observed requests:\n%s\n\n%s", observedRequests.joinToString("\n\n"), results.report())
+                .isTrue()
+
+            assertThat(negativeBodies).isNotEmpty
+            assertThat(positiveRequests)
+                .withFailMessage("Observed requests:\n%s\n\n%s", observedRequests.joinToString("\n\n"), results.report())
+                .isNotEmpty()
+        }
+
+        private fun loadRowValueLookupFeature(specFile: File): Feature {
+            val examplesDir = specFile.resolveSibling(specFile.nameWithoutExtension + "_examples")
+            return Flags.using(EXAMPLE_DIRECTORIES to examplesDir.canonicalPath) {
+                OpenApiSpecification.fromFile(specFile.canonicalPath).toFeature().copy(strictMode = true).loadExternalisedExamples().also {
+                    it.validateExamplesOrException()
+                }
+            }
+        }
+
+        private fun executeRowValueLookupGenerativeTests(feature: Feature, handler: (HttpRequest) -> HttpResponse): Results {
+            return withServiceLoaderEntries(
+                mapOf(
+                    OpenAPIFixtureExecutor::class.java to RowValueLookupFixtureExecutor::class.java.name,
+                    ContractTestInterceptor::class.java to RowValueLookupContractTestInterceptor::class.java.name
+                )
+            ) {
+                feature.enableGenerativeTesting().executeTests(object : TestExecutor {
+                    override fun execute(request: HttpRequest): HttpResponse = handler(request)
+                })
+            }
+        }
+
+        private fun assertRequestHasNoUnresolvedLookupExpressions(request: HttpRequest) {
+            assertThat(request.path).doesNotContain("$(")
+            assertThat(request.queryParams.toString()).doesNotContain("$(")
+            assertThat(request.headers.values.joinToString(" ")).doesNotContain("$(")
+            assertThat(request.body.toStringLiteral()).doesNotContain("$(")
         }
     }
 
@@ -1624,6 +1676,7 @@ class RowValueLookupFixtureExecutor : OpenAPIFixtureExecutor {
             .upsertStoreUsing(StringValue("(PAGE:string)"), StringValue("page-7"))
             .upsertStoreUsing(StringValue("(TENANT:string)"), StringValue("north"))
             .upsertStoreUsing(StringValue("(NAME:string)"), StringValue("Sherlock"))
+            .upsertStoreUsing(StringValue("(COUNT:number)"), NumberValue(42))
 
         return FixtureExecutionDetails(
             combinedResult = Result.Success(),

--- a/core/src/test/kotlin/integration_tests/TestSubstitutionIntegrationTest.kt
+++ b/core/src/test/kotlin/integration_tests/TestSubstitutionIntegrationTest.kt
@@ -4,7 +4,6 @@ import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.core.Dictionary
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpResponse
-import io.specmatic.core.NoBodyValue
 import io.specmatic.core.Result
 import io.specmatic.core.Results
 import io.specmatic.core.Scenario
@@ -55,19 +54,19 @@ class TestSubstitutionIntegrationTest {
             )
         ) {
             val updatedFeature = feature.copy(scenarios = feature.scenarios.map { it.copy(dictionary = valueDictionary) })
-            updatedFeature.enableGenerativeTesting().executeTests(SubstitutionTestExecutor())
+            updatedFeature.executeTests(SubstitutionTestExecutor())
         }
 
-        assertThat(results.successCount).withFailMessage { results.report() }.isEqualTo(16)
+        assertThat(results.successCount).withFailMessage { results.report() }.isEqualTo(1)
         assertThat(results.failureCount).withFailMessage { results.report() }.isEqualTo(0)
 
-        assertThat(SubstitutionFixtureExecutor.calls).hasSize(32)
-        assertThat(SubstitutionFixtureExecutor.calls.count { it == "before" }).isEqualTo(16)
-        assertThat(SubstitutionFixtureExecutor.calls.count { it == "after" }).isEqualTo(16)
+        assertThat(SubstitutionFixtureExecutor.calls).hasSize(2)
+        assertThat(SubstitutionFixtureExecutor.calls.count { it == "before" }).isEqualTo(1)
+        assertThat(SubstitutionFixtureExecutor.calls.count { it == "after" }).isEqualTo(1)
 
-        assertThat(SubstitutionFixtureExecutor.receivedContexts).hasSize(32)
-        assertThat(SubstitutionFixtureExecutor.beforeFixtureRequests).hasSize(32)
-        assertThat(SubstitutionFixtureExecutor.afterFixtureRequests).hasSize(32)
+        assertThat(SubstitutionFixtureExecutor.receivedContexts).hasSize(2)
+        assertThat(SubstitutionFixtureExecutor.beforeFixtureRequests).hasSize(2)
+        assertThat(SubstitutionFixtureExecutor.afterFixtureRequests).hasSize(2)
 
         assertThat(
             SubstitutionFixtureExecutor.positiveAfterUpdatedSubstitution.substitute(
@@ -75,12 +74,6 @@ class TestSubstitutionIntegrationTest {
                 StringPattern(),
             )
         ).isEqualTo(HasValue(StringValue("beforePositive")))
-        assertThat(
-            SubstitutionFixtureExecutor.negativeAfterUpdatedSubstitution.substitute(
-                StringValue("$(BEFORE_NEGATIVE)"),
-                StringPattern(),
-            )
-        ).isEqualTo(HasValue(StringValue("beforeNegative")))
 
         assertThat(
             SubstitutionFixtureExecutor.positiveAfterUpdatedSubstitution.substitute(
@@ -88,44 +81,14 @@ class TestSubstitutionIntegrationTest {
                 StringPattern(),
             )
         ).isEqualTo(HasValue(StringValue("afterPositive")))
-        assertThat(
-            SubstitutionFixtureExecutor.negativeAfterUpdatedSubstitution.substitute(
-                StringValue("$(AFTER_NEGATIVE)"),
-                StringPattern(),
-            )
-        ).isEqualTo(HasValue(StringValue("afterNegative")))
 
-        assertThat(SubstitutionTestExecutor.requestsSeen).hasSize(16).allSatisfy { request ->
+        assertThat(SubstitutionTestExecutor.requestsSeen).hasSize(1).allSatisfy { request ->
             assertThat(request.path).isEqualTo("/test")
             assertThat(request.method).isEqualTo("POST")
         }
 
         assertThat(SubstitutionTestExecutor.requestsSeen.map { it.body }).containsExactlyElementsOf(
             listOf(
-                // 1. The happy path payload and Positive scenarios for 'Random-String'
-                parsedJSONObject("""{ "before1": "before1", "before2": "before2" }"""),
-                parsedJSONObject("""{ "before1": "before1", "before2": "before2" }"""),
-                parsedJSONObject("""{ "before1": "before1", "before2": "before2" }"""),
-                parsedJSONObject("""{ "before1": "before1", "before2": "before2" }"""),
-
-                // 2. The empty body test case
-                NoBodyValue,
-
-                // 3. Negative scenarios for 'before1'
-                parsedJSONObject("""{ "before1": null, "before2": "before2" }"""),
-                parsedJSONObject("""{ "before1": 123, "before2": "before2" }"""),
-                parsedJSONObject("""{ "before1": false, "before2": "before2" }"""),
-
-                // 4. Negative scenarios for 'before2'
-                parsedJSONObject("""{ "before1": "before1", "before2": null }"""),
-                parsedJSONObject("""{ "before1": "before1", "before2": 123 }"""),
-                parsedJSONObject("""{ "before1": "before1", "before2": false }"""),
-
-                // 5. Negative scenarios for 'Random-String'
-                parsedJSONObject("""{ "before1": "before1", "before2": "before2" }"""),
-                parsedJSONObject("""{ "before1": "before1", "before2": "before2" }"""),
-                parsedJSONObject("""{ "before1": "before1", "before2": "before2" }"""),
-                parsedJSONObject("""{ "before1": "before1", "before2": "before2" }"""),
                 parsedJSONObject("""{ "before1": "before1", "before2": "before2" }"""),
             )
         )

--- a/core/src/test/kotlin/io/specmatic/core/HttpRequestPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpRequestPatternTest.kt
@@ -1031,6 +1031,53 @@ internal class HttpRequestPatternTest {
         assertThat(newRequestPattern.headersPattern.contentType).isEqualTo("application/json")
     }
 
+    @Test
+    fun `negativeBasedOn should use security scheme from row when available`() {
+        val requestPattern = HttpRequestPattern(
+            method = "GET",
+            httpPathPattern = buildHttpPathPattern("/pets/(id:number)"),
+            securitySchemes = listOf(
+                APIKeyInHeaderSecurityScheme("X-Api-Key", null),
+                APIKeyInQueryParamSecurityScheme("api_key", null)
+            )
+        )
+
+        val negativePatterns = requestPattern.negativeBasedOn(
+            row = Row(mapOf("id" to "10", "api_key" to "row-token")),
+            resolver = Resolver()
+        ).map { it.value }.toList()
+
+        assertThat(negativePatterns).isNotEmpty
+        assertThat(negativePatterns).allSatisfy { negativePattern ->
+            assertThat(negativePattern.httpQueryParamPattern.queryPatterns).containsKey("api_key")
+            assertThat(negativePattern.headersPattern.pattern).doesNotContainKey("X-Api-Key")
+        }
+    }
+
+    @Test
+    fun `negativeBasedOn should fallback to first security scheme when row has none`() {
+        val requestPattern = HttpRequestPattern(
+            method = "GET",
+            httpPathPattern = buildHttpPathPattern("/pets/(id:number)"),
+            securitySchemes = listOf(
+                APIKeyInHeaderSecurityScheme("X-Api-Key", null),
+                APIKeyInQueryParamSecurityScheme("api_key", null)
+            )
+        )
+
+        val negativePatterns = requestPattern.negativeBasedOn(
+            row = Row(mapOf("id" to "10")),
+            resolver = Resolver()
+        ).map { it.value }.toList()
+
+        assertThat(negativePatterns).isNotEmpty
+        assertThat(negativePatterns).allSatisfy { negativePattern ->
+            assertThat(negativePattern.headersPattern.pattern).doesNotContainKey("X-Api-Key")
+            assertThat(negativePattern.httpQueryParamPattern.queryPatterns).doesNotContainKey("api_key")
+            assertThat(negativePattern.securitySchemes).contains(APIKeyInHeaderSecurityScheme("X-Api-Key", null))
+        }
+    }
+
     @Nested
     inner class GenerateV2Tests {
         @Test

--- a/core/src/test/resources/openapi/row_value_lookup/api.yaml
+++ b/core/src/test/resources/openapi/row_value_lookup/api.yaml
@@ -1,0 +1,72 @@
+openapi: 3.0.3
+info:
+  title: Row Value Lookup API
+  version: 1.0.0
+paths:
+  /orders/{orderId}:
+    post:
+      parameters:
+        - name: orderId
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: order-123
+        - name: page
+          in: query
+          required: true
+          schema:
+            type: string
+            pattern: page-7
+        - name: X-Tenant
+          in: header
+          required: true
+          schema:
+            type: string
+            pattern: north
+        - name: Random-String
+          in: header
+          required: false
+          schema:
+            type: string
+            pattern: A+
+            minLength: 1
+            maxLength: 3
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+                  pattern: Sherlock
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                required:
+                  - result
+                properties:
+                  result:
+                    type: string
+        '400':
+          description: bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                required:
+                  - message
+                properties:
+                  message:
+                    type: string

--- a/core/src/test/resources/openapi/row_value_lookup/api_examples/lookup_example.json
+++ b/core/src/test/resources/openapi/row_value_lookup/api_examples/lookup_example.json
@@ -1,0 +1,50 @@
+{
+  "before": [
+    {
+      "type": "http",
+      "http-request": {
+        "baseUrl": "http://localhost:8000",
+        "path": "/seed",
+        "method": "POST",
+        "body": {}
+      },
+      "http-response": {
+        "status": 200,
+        "body": {
+          "orderId": "(ORDER_ID:string)",
+          "page": "(PAGE:string)",
+          "tenant": "(TENANT:string)",
+          "name": "(NAME:string)"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      }
+    }
+  ],
+  "partial": {
+    "http-request": {
+      "path": "/orders/$(ORDER_ID)",
+      "method": "POST",
+      "query": {
+        "page": "$(PAGE)"
+      },
+      "headers": {
+        "Content-Type": "application/json",
+        "X-Tenant": "$(TENANT)"
+      },
+      "body": {
+        "name": "$(NAME)"
+      }
+    },
+    "http-response": {
+      "status": 200,
+      "body": {
+        "result": "accepted"
+      },
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  }
+}

--- a/core/src/test/resources/openapi/row_value_lookup/top_level_number_body_api.yaml
+++ b/core/src/test/resources/openapi/row_value_lookup/top_level_number_body_api.yaml
@@ -1,0 +1,40 @@
+openapi: 3.0.3
+info:
+  title: Row Value Lookup Top Level Number Body API
+  version: 1.0.0
+paths:
+  /counts:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: integer
+              minimum: 42
+              maximum: 43
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                required:
+                  - result
+                properties:
+                  result:
+                    type: string
+        '400':
+          description: bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                required:
+                  - message
+                properties:
+                  message:
+                    type: string

--- a/core/src/test/resources/openapi/row_value_lookup/top_level_number_body_api_examples/lookup_example.json
+++ b/core/src/test/resources/openapi/row_value_lookup/top_level_number_body_api_examples/lookup_example.json
@@ -1,0 +1,41 @@
+{
+  "before": [
+    {
+      "type": "http",
+      "http-request": {
+        "baseUrl": "http://localhost:8000",
+        "path": "/seed",
+        "method": "POST",
+        "body": {}
+      },
+      "http-response": {
+        "status": 200,
+        "body": {
+          "count": "(COUNT:number)"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      }
+    }
+  ],
+  "partial": {
+    "http-request": {
+      "path": "/counts",
+      "method": "POST",
+      "headers": {
+        "Content-Type": "application/json"
+      },
+      "body": "$(COUNT)"
+    },
+    "http-response": {
+      "status": 200,
+      "body": {
+        "result": "accepted"
+      },
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  }
+}


### PR DESCRIPTION
**What**: 
Ensure `basedOn` flows support substitution tokens during both positive and negative test generation

**Why**:
Externalized examples and row values can contain substitution tokens such as `$(VARIABLE_NAME)`. Positive and negative generation paths were not handling these properly, which caused generation-time failures

**How**:
Updated generation logic so substitution-backed row values are accepted and propagated through `basedOn` processing for both positive and negative request generation via escape hatches similar to pattern tokens.

**Checklist**:
- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate N/A
- [ ] Security scans don't report any vulnerabilities N/A
- [ ] Documentation added/updated (share link) N/A
- [ ] Sample Project added/updated (share link) N/A
- [ ] Demo video (share link) N/A
- [ ] Article on Website (share link) N/A
- [ ] Roadmpap updated (share link) N/A
- [ ] Conference Talk (share link) N/A