### PR TITLE
Ensure data is passed to substitution in ScenarioAsTest

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/substitution/SubstitutionImpl.kt
+++ b/core/src/main/kotlin/io/specmatic/core/substitution/SubstitutionImpl.kt
@@ -149,8 +149,8 @@ class SubstitutionImpl private constructor(
     companion object {
         const val DROP_DIRECTIVE = "$(drop)"
 
-        fun empty(strictMode: Boolean = false): SubstitutionImpl {
-            return SubstitutionImpl(strictMode = strictMode)
+        fun empty(data: JSONObjectValue = JSONObjectValue(), strictMode: Boolean = false): SubstitutionImpl {
+            return SubstitutionImpl(strictMode = strictMode, data = data)
         }
 
         fun from(

--- a/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
@@ -21,6 +21,7 @@ import io.specmatic.core.pattern.HasValue
 import io.specmatic.core.pattern.ReturnFailure
 import io.specmatic.core.pattern.ReturnValue
 import io.specmatic.core.substitution.SubstitutionImpl
+import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.test.ContractTest.Companion.updateBasedOnResponseIfNegativeGeneration
 import io.specmatic.test.fixtures.FixtureExecutionMetadata
 import io.specmatic.test.interceptor.ContractTestInterceptor
@@ -54,7 +55,10 @@ data class ScenarioAsTest(
     private val responseHandlerRegistry: ResponseHandlerRegistry = ResponseHandlerRegistry(feature, originalScenario),
     private val requestValidator: RequestValidator = DefaultRequestValidator,
     val reasoning: Reasoning = Reasoning(),
-    private val substitution: Substitution = SubstitutionImpl.empty(strictMode = feature.specmaticConfig.getTestStrictMode() ?: feature.strictMode),
+    private val substitution: Substitution = SubstitutionImpl.empty(
+        data = scenario.exampleRow?.scenarioStub?.data ?: JSONObjectValue(),
+        strictMode = feature.specmaticConfig.getTestStrictMode() ?: feature.strictMode
+    ),
 ) : ContractTest {
     companion object {
         private var id: Value? = null

--- a/core/src/test/kotlin/io/specmatic/test/ScenarioAsTestTest.kt
+++ b/core/src/test/kotlin/io/specmatic/test/ScenarioAsTestTest.kt
@@ -390,6 +390,43 @@ class ScenarioAsTestTest {
     }
 
     @Test
+    fun `runTest should seed substitution data from example when available`() {
+        ServiceLoaderTestFixtureExecutor.reset()
+        val testScenario = scenario(
+            exampleRow = Row(
+                scenarioStub = ScenarioStub(
+                    beforeFixtures = listOf(StringValue("before")),
+                    data = parsedJSONObject(
+                        """{"lookupData":{"dictionary":{"*":{"message":"from-example-data"}}}}"""
+                    )
+                )
+            )
+        )
+
+        val executionResult = withServiceLoaderEntries(
+            mapOf(
+                OpenAPIFixtureExecutor::class.java to ServiceLoaderTestFixtureExecutor::class.java.name,
+                ContractTestInterceptor::class.java to ServiceLoaderTestInterceptor::class.java.name
+            )
+        ) {
+            val feature = Feature(name = "feature", scenarios = listOf(testScenario), protocol = SpecmaticProtocol.HTTP)
+            ScenarioAsTest(
+                feature = feature,
+                scenario = testScenario,
+                specType = SpecType.OPENAPI,
+                flagsBased = feature.flagsBased,
+                originalScenario = testScenario,
+                protocol = SpecmaticProtocol.HTTP,
+            ).runTest(fixedResponseExecutor(body = "ok"))
+        }
+
+        assertThat(
+            ServiceLoaderTestFixtureExecutor.receivedSubstitution?.substitute(StringValue("$(lookupData.dictionary[ID].message)"))
+        ).isEqualTo(HasValue(StringValue("from-example-data")))
+        assertThat(executionResult.result).isInstanceOf(Result.Success::class.java)
+    }
+
+    @Test
     fun `runTest should choose default response with matching content type when same-status content type does not match`() {
         val negativeScenario = negativeScenario(
             expectedResponses = mapOf(400 to listOf(expectationScenario(status = 400, contentType = "text/plain"))),


### PR DESCRIPTION
**What**: Ensure data is passed to substitution in Contract tests

**Why**: Allows contract test to substitute from dataLookups similar to mock

<!-- Have you done all of these things?  -->

**Checklist**:
- [x] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
