### PR TITLE
fix: matchers should not be run in case of negative scenarios

### DIFF
--- a/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
@@ -233,7 +233,7 @@ data class ScenarioAsTest(
 
             val responseBodyFromExample = testScenario.responseBodyFromExample()
 
-            if(responseBodyFromExample != null) {
+            if(testScenario.isNegative.not() && responseBodyFromExample != null) {
                 matcherEngine?.let {
                     val matchesResult = it.matchResponseValue(
                         responseBodyFromExample,

--- a/core/src/test/kotlin/integration_tests/ResiliencyTests.kt
+++ b/core/src/test/kotlin/integration_tests/ResiliencyTests.kt
@@ -15,7 +15,11 @@ import io.specmatic.core.Results
 import io.specmatic.core.Scenario
 import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.SpecmaticConfigV1V2Common
+import io.specmatic.core.matchers.MatcherEngine
 import io.specmatic.core.pattern.ContractException
+import io.specmatic.core.pattern.parsedJSONObject
+import io.specmatic.core.utilities.Flags
+import io.specmatic.core.utilities.Flags.Companion.EXAMPLE_DIRECTORIES
 import io.specmatic.core.utilities.Flags.Companion.ONLY_POSITIVE
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.NullValue
@@ -28,6 +32,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
 
 internal val Results.testCount: Int
     get() {
@@ -2467,6 +2473,130 @@ class GenerativeTests {
             "-ve  Scenario: POST /items -> 4xx with the request from the example 'sampleItems' where REQUEST.BODY.[] contains all the keys AND the key quantity is set to a value greater than maximum value '5000'",
             "-ve  Scenario: POST /items -> 4xx with the request from the example 'sampleItems' where REQUEST.BODY.[] contains all the keys AND the key quantity is set to a value lesser than minimum value '1'"
         )
+    }
+
+    @Test
+    fun `negative tests generated from an external 200 example should not run the 200 example response matcher`(@TempDir tempDir: File) {
+        val matcherEngine = mockk<MatcherEngine>()
+        var negativeMatcherCallCount = 0
+        var currentScenarioIsNegative = false
+        mockkObject(MatcherEngine.Companion)
+        every { MatcherEngine.load() } returns matcherEngine
+        every { matcherEngine.matchResponseValue(any(), any(), any()) } answers {
+            if (currentScenarioIsNegative) negativeMatcherCallCount++
+            Result.Success()
+        }
+
+        val specFile = tempDir.resolve("orders.yaml").apply {
+            writeText(
+                """
+                openapi: "3.0.1"
+                info:
+                  title: Orders API
+                  version: "1"
+                paths:
+                  /orders:
+                    post:
+                      requestBody:
+                        required: true
+                        content:
+                          application/json:
+                            schema:
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                name:
+                                  type: string
+                      responses:
+                        200:
+                          description: Created
+                          content:
+                            application/json:
+                              schema:
+                                type: object
+                                required:
+                                  - id
+                                properties:
+                                  id:
+                                    type: integer
+                        400:
+                          description: Bad request
+                          content:
+                            application/json:
+                              schema:
+                                type: object
+                                required:
+                                  - error
+                                properties:
+                                  error:
+                                    type: string
+                """.trimIndent()
+            )
+        }
+        tempDir.resolve("order-created.json").writeText(
+            """
+            {
+              "http-request": {
+                "path": "/orders",
+                "method": "POST",
+                "headers": {
+                  "Content-Type": "application/json"
+                },
+                "body": {
+                  "name": "widget"
+                }
+              },
+              "http-response": {
+                "status": 200,
+                "headers": {
+                  "Content-Type": "application/json"
+                },
+                "body": {
+                  "id": 10
+                }
+              }
+            }
+            """.trimIndent()
+        )
+
+        val feature = Flags.using(EXAMPLE_DIRECTORIES to tempDir.canonicalPath) {
+            OpenApiSpecification.fromFile(specFile.canonicalPath).toFeature().loadExternalisedExamples().enableGenerativeTesting()
+        }
+
+        val testDescriptions = mutableListOf<String>()
+
+        val results = feature.executeTests(object : TestExecutor {
+            override fun execute(request: HttpRequest): HttpResponse {
+                return when (request.expectedResponseCode()) {
+                    200 -> HttpResponse(
+                        status = 200,
+                        headers = mapOf("Content-Type" to "application/json"),
+                        body = parsedJSONObject("""{"id":10}""")
+                    )
+
+                    400 -> HttpResponse(
+                        status = 400,
+                        headers = mapOf("Content-Type" to "application/json"),
+                        body = parsedJSONObject("""{"error":"bad request"}""")
+                    )
+
+                    else -> throw ContractException("Unexpected response code hint ${request.expectedResponseCode()}")
+                }
+            }
+
+            override fun preExecuteScenario(scenario: Scenario, request: HttpRequest) {
+                currentScenarioIsNegative = scenario.isNegative
+                testDescriptions.add(scenario.testDescription())
+            }
+        })
+
+        assertThat(testDescriptions).anySatisfy {
+            assertThat(it).startsWith("-ve")
+            assertThat(it).contains("order-created")
+        }
+        assertThat(negativeMatcherCallCount).isEqualTo(0)
+        assertThat(results.success()).withFailMessage(results.report()).isTrue()
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/test/ScenarioAsTestTest.kt
+++ b/core/src/test/kotlin/io/specmatic/test/ScenarioAsTestTest.kt
@@ -1,5 +1,9 @@
 package io.specmatic.test
 
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.verify
 import io.specmatic.core.Feature
 import io.specmatic.core.utilities.Decision
 import io.specmatic.core.utilities.Reasoning
@@ -14,6 +18,7 @@ import io.specmatic.core.Scenario
 import io.specmatic.core.ScenarioInfo
 import io.specmatic.core.Substitution
 import io.specmatic.core.HttpQueryParamPattern
+import io.specmatic.core.matchers.MatcherEngine
 import io.specmatic.core.pattern.ExactValuePattern
 import io.specmatic.core.pattern.HasValue
 import io.specmatic.core.pattern.Row
@@ -442,6 +447,90 @@ class ScenarioAsTestTest {
         assertThat(updatedScenario.statusInDescription).isEqualTo("1000")
         assertThat(scenarioInRecord.statusInDescription).isEqualTo("1000")
         assertThat(updatedScenario.httpResponsePattern.headersPattern.contentType).isEqualTo("application/xml")
+    }
+
+    @Test
+    fun `runTest should call matcher when positive scenario has response body example`() {
+        val matcherEngine = mockk<MatcherEngine>()
+        mockkObject(MatcherEngine.Companion)
+        every { MatcherEngine.load() } returns matcherEngine
+        every { matcherEngine.matchResponseValue(any(), any(), any()) } returns Result.Success()
+
+        val responseBody = parsedJSONObject("""{"id": 10}""")
+        val scenario = Scenario(
+            ScenarioInfo(
+                specType = SpecType.OPENAPI,
+                protocol = SpecmaticProtocol.HTTP,
+                httpRequestPattern = HttpRequestPattern(httpPathPattern = buildHttpPathPattern("/resource"), method = "GET"),
+                httpResponsePattern = HttpResponsePattern(
+                    status = 200,
+                    body = JSONObjectPattern(mapOf("id" to NumberPattern())),
+                    headersPattern = HttpHeadersPattern(contentType = "application/json")
+                ),
+            )
+        ).copy(
+            exampleRow = Row(
+                scenarioStub = ScenarioStub(
+                    response = HttpResponse(
+                        status = 200,
+                        headers = mapOf("Content-Type" to "application/json"),
+                        body = responseBody
+                    )
+                )
+            )
+        )
+
+        scenarioAsTest(scenario).runTest(
+            fixedResponseExecutor(
+                status = 200,
+                body = """{"id": 10}""",
+                headers = mapOf("Content-Type" to "application/json")
+            )
+        )
+
+        verify(exactly = 1) { matcherEngine.matchResponseValue(responseBody, responseBody, any()) }
+    }
+
+    @Test
+    fun `runTest should not call matcher when negative scenario has response body example`() {
+        val matcherEngine = mockk<MatcherEngine>()
+        mockkObject(MatcherEngine.Companion)
+        every { MatcherEngine.load() } returns matcherEngine
+        every { matcherEngine.matchResponseValue(any(), any(), any()) } returns Result.Success()
+
+        val scenario = Scenario(
+            ScenarioInfo(
+                specType = SpecType.OPENAPI,
+                protocol = SpecmaticProtocol.HTTP,
+                httpRequestPattern = HttpRequestPattern(httpPathPattern = buildHttpPathPattern("/resource"), method = "GET"),
+                httpResponsePattern = HttpResponsePattern(
+                    status = 400,
+                    body = JSONObjectPattern(mapOf("error" to StringPattern())),
+                    headersPattern = HttpHeadersPattern(contentType = "application/json")
+                ),
+            )
+        ).copy(
+            isNegative = true,
+            exampleRow = Row(
+                scenarioStub = ScenarioStub(
+                    response = HttpResponse(
+                        status = 200,
+                        headers = mapOf("Content-Type" to "application/json"),
+                        body = parsedJSONObject("""{"id": 10}""")
+                    )
+                )
+            )
+        )
+
+        scenarioAsTest(scenario).runTest(
+            fixedResponseExecutor(
+                status = 400,
+                body = """{"error": "bad request"}""",
+                headers = mapOf("Content-Type" to "application/json")
+            )
+        )
+
+        verify(exactly = 0) { matcherEngine.matchResponseValue(any(), any(), any()) }
     }
 
     @Test


### PR DESCRIPTION
Bug Report:

What -
MatcherEngine used to kick in for negative scenarios which are generated based off the examples associated to  positive scenarios. 

Why -
It should not kick in because the matchers rely on the response body schema for assertions but in case of negative scenarios, the test should not rely on the response body schema from the examples associated to positive scenarios because the schema would be different for negative scenarios.

How -
The bug is fixed by skipping MatcherEngine based assertions for negative scenarios.