### PR TITLE
Add WSDL xsi:type support for XML patterns and SOAP parsing

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -2492,6 +2492,10 @@ data class Feature(
             logger.newLine()
         }
 
+        if (strictMode) {
+            featureWithExternalisedExamples.validateExamplesOrException()
+        }
+
         return featureWithExternalisedExamples to unusedExternalizedExamples
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLPattern.kt
@@ -23,20 +23,6 @@ private sealed class WSDLTypeSelection {
     data class Use(val pattern: Pattern) : WSDLTypeSelection()
     data class Unknown(val assertedType: WSDLTypeName, val declaredType: WSDLTypeName) : WSDLTypeSelection()
     data class Invalid(val assertedType: WSDLTypeName, val declaredType: WSDLTypeName) : WSDLTypeSelection()
-
-    fun match(
-        sampleData: XMLNode,
-        resolver: Resolver,
-        unknownResult: (WSDLTypeName, WSDLTypeName) -> Failure,
-        invalidResult: (WSDLTypeName, WSDLTypeName) -> Failure,
-        matchWith: (Pattern, XMLNode, Resolver) -> Result
-    ): Result {
-        return when (this) {
-            is Unknown -> unknownResult(assertedType, declaredType)
-            is Invalid -> invalidResult(assertedType, declaredType)
-            is Use -> matchWith(pattern, sampleData, resolver)
-        }
-    }
 }
 
 private data class XMLHeaderName(
@@ -224,13 +210,13 @@ data class XMLPattern(
         val sampleDataWithoutEmptyHeader = dropEmptySOAPHeader(sampleData)
 
         selectWSDLType(sampleData, matchingType, resolver)?.let { selectedType ->
-            return selectedType.match(
-                sampleDataWithoutEmptyHeader,
-                resolver,
-                ::unknownXSITypeResult,
-                ::invalidXSITypeResult,
-                ::matchWithType
-            ).breadCrumb(pattern.name, resolver.locate(schemaPointer))
+            val matchResult = when (selectedType) {
+                is WSDLTypeSelection.Unknown -> unknownXSITypeResult(selectedType.assertedType, selectedType.declaredType)
+                is WSDLTypeSelection.Invalid -> invalidXSITypeResult(selectedType.assertedType, selectedType.declaredType)
+                is WSDLTypeSelection.Use -> matchWithType(selectedType.pattern, sampleDataWithoutEmptyHeader, resolver)
+            }
+
+            return matchResult.breadCrumb(pattern.name, resolver.locate(schemaPointer))
         }
 
         return when (matchingType) {
@@ -607,7 +593,7 @@ data class XMLPattern(
 
         val name = pattern.name
 
-        val wsdlVariants = effectiveWSDLVariantPatterns(resolver)
+        val wsdlVariants = wsdlSubtypePatternsForGeneration(resolver)
         if (wsdlVariants.isNotEmpty()) {
             return wsdlVariants.random().generateXML(resolver)
         }
@@ -668,7 +654,7 @@ data class XMLPattern(
             }
         }
 
-        val wsdlVariants = effectiveWSDLVariantPatterns(resolver)
+        val wsdlVariants = wsdlSubtypePatternsForGeneration(resolver)
         if (wsdlVariants.isNotEmpty()) {
             return wsdlVariants.asSequence().flatMap { selectedPattern ->
                 selectedPattern.newBasedOn(row, resolver)
@@ -784,7 +770,7 @@ data class XMLPattern(
     }
 
     override fun newBasedOn(resolver: Resolver): Sequence<XMLPattern> {
-        val wsdlVariants = effectiveWSDLVariantPatterns(resolver)
+        val wsdlVariants = wsdlSubtypePatternsForGeneration(resolver)
         if (wsdlVariants.isNotEmpty()) {
             return wsdlVariants.asSequence().flatMap { selectedPattern ->
                 selectedPattern.newBasedOn(resolver)
@@ -859,7 +845,7 @@ data class XMLPattern(
         }
     }
 
-    private fun effectiveWSDLVariantPatterns(resolver: Resolver): List<XMLPattern> {
+    private fun wsdlSubtypePatternsForGeneration(resolver: Resolver): List<XMLPattern> {
         val declaredPattern = try {
             dereferenceType(resolver)
         } catch (e: ContractException) {
@@ -891,7 +877,7 @@ data class XMLPattern(
             null -> Unit
         }
 
-        val derivedPatterns = declaredPattern.leafDerivedWSDLPatterns(resolver).mapNotNull { derivedPattern ->
+        val derivedPatterns = declaredPattern.concreteSubtypeWSDLPatterns(resolver).mapNotNull { derivedPattern ->
             val derivedType = derivedPattern.pattern.wsdlTypeName() ?: return@mapNotNull null
             val mergedPattern = declaredPattern.mergeReferredPattern(derivedPattern) as? XMLPattern ?: return@mapNotNull null
             mergedPattern.withXSIType(derivedType)
@@ -1304,7 +1290,7 @@ private fun XMLNode.xsiTypeName(): WSDLTypeName? {
 }
 
 private fun Pattern.findPatternForWSDLType(typeName: WSDLTypeName, resolver: Resolver): Pattern? {
-    val typeKey = wsdlMatchableTypeKeys()[typeName] ?: return null
+    val typeKey = wsdlCompatibleTypeKeys()[typeName] ?: return null
     return resolver.patternForWSDLKey(typeKey)
 }
 
@@ -1317,8 +1303,8 @@ private fun Resolver.findPatternForWSDLType(typeName: WSDLTypeName): Pattern? {
 private fun Pattern.knowsWSDLType(typeName: WSDLTypeName): Boolean =
     wsdlKnownTypeKeys().containsKey(typeName)
 
-private fun Pattern.leafDerivedWSDLPatterns(resolver: Resolver): List<XMLPattern> {
-    return wsdlLeafTypeKeys().values.flatMap { typeKey ->
+private fun Pattern.concreteSubtypeWSDLPatterns(resolver: Resolver): List<XMLPattern> {
+    return wsdlConcreteSubtypeKeys().values.flatMap { typeKey ->
         resolver.patternForWSDLKey(typeKey)?.xmlPatternVariants().orEmpty()
     }.filter { pattern ->
         pattern.pattern.wsdlTypeName()?.namespace != XML_SCHEMA_NAMESPACE
@@ -1346,18 +1332,18 @@ private fun Pattern.wsdlKnownTypeKeys(): Map<WSDLTypeName, String> {
     }
 }
 
-private fun Pattern.wsdlMatchableTypeKeys(): Map<WSDLTypeName, String> {
+private fun Pattern.wsdlCompatibleTypeKeys(): Map<WSDLTypeName, String> {
     return when (this) {
-        is XMLPattern -> pattern.wsdlMatchableTypeKeys
-        is AnyPattern -> pattern.flatMap { it.wsdlMatchableTypeKeys().entries }.associate { it.toPair() }
+        is XMLPattern -> pattern.wsdlCompatibleTypeKeys
+        is AnyPattern -> pattern.flatMap { it.wsdlCompatibleTypeKeys().entries }.associate { it.toPair() }
         else -> emptyMap()
     }
 }
 
-private fun Pattern.wsdlLeafTypeKeys(): Map<WSDLTypeName, String> {
+private fun Pattern.wsdlConcreteSubtypeKeys(): Map<WSDLTypeName, String> {
     return when (this) {
-        is XMLPattern -> pattern.wsdlLeafTypeKeys
-        is AnyPattern -> pattern.flatMap { it.wsdlLeafTypeKeys().entries }.associate { it.toPair() }
+        is XMLPattern -> pattern.wsdlConcreteSubtypeKeys
+        is AnyPattern -> pattern.flatMap { it.wsdlConcreteSubtypeKeys().entries }.associate { it.toPair() }
         else -> emptyMap()
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLPattern.kt
@@ -19,6 +19,26 @@ private const val SOAP_ENVELOPE = "Envelope"
 private const val SOAP_HEADER = "Header"
 private const val SOAP_ENVELOPE_NAMESPACE = "http://schemas.xmlsoap.org/soap/envelope/"
 private const val XML_SCHEMA_INSTANCE_NAMESPACE = "http://www.w3.org/2001/XMLSchema-instance"
+private const val XML_SCHEMA_NAMESPACE = "http://www.w3.org/2001/XMLSchema"
+
+private data class WSDLTypeName(val namespace: String, val localName: String)
+
+private sealed class WSDLTypeSelection {
+    data class Use(val pattern: Pattern) : WSDLTypeSelection()
+    data class Invalid(val assertedType: WSDLTypeName, val declaredType: WSDLTypeName) : WSDLTypeSelection()
+
+    fun match(
+        sampleData: XMLNode,
+        resolver: Resolver,
+        invalidResult: (WSDLTypeName, WSDLTypeName) -> Failure,
+        matchWith: (Pattern, XMLNode, Resolver) -> Result
+    ): Result {
+        return when (this) {
+            is Invalid -> invalidResult(assertedType, declaredType)
+            is Use -> matchWith(pattern, sampleData, resolver)
+        }
+    }
+}
 
 private data class XMLHeaderName(
     val namespaceUri: String?,
@@ -202,8 +222,16 @@ data class XMLPattern(
         }
 
         val matchingType = dereferenceType(resolver)
-
         val sampleDataWithoutEmptyHeader = dropEmptySOAPHeader(sampleData)
+
+        selectWSDLType(sampleData, matchingType, resolver)?.let { selectedType ->
+            return selectedType.match(
+                sampleDataWithoutEmptyHeader,
+                resolver,
+                ::invalidXSITypeResult,
+                ::matchWithType
+            ).breadCrumb(pattern.name, resolver.locate(schemaPointer))
+        }
 
         return when (matchingType) {
             is XMLPattern -> {
@@ -227,6 +255,60 @@ data class XMLPattern(
                 matchingType.matches(valueToMatch, resolver)
             }
         }.breadCrumb(pattern.name, resolver.locate(schemaPointer))
+    }
+
+    private fun matchWithType(matchingType: Pattern, sampleData: XMLNode, resolver: Resolver): Result {
+        return when (matchingType) {
+            is XMLPattern -> {
+                matchName(sampleData, resolver).ifSuccess {
+                    matchingType.matchNamespaces(sampleData)
+                }.ifSuccess {
+                    matchingType.matchAttributes(sampleData, resolver)
+                }.ifSuccess {
+                    matchingType.matchNodes(sampleData, resolver)
+                }
+            }
+
+            is AnyPattern -> matchingType.matches(sampleData, resolver)
+            else -> {
+                if (sampleData.childNodes.size != 1) {
+                    return valueMismatchResult("single node", sampleData, resolver.mismatchMessages)
+                }
+
+                val valueToMatch = matchingType.parse(sampleData.firstChild().toStringLiteral(), resolver)
+                matchingType.matches(valueToMatch, resolver)
+            }
+        }
+    }
+
+    private fun invalidXSITypeResult(assertedType: WSDLTypeName, declaredType: WSDLTypeName): Failure {
+        val declaredDescription = "${declaredType.namespace}#${declaredType.localName}"
+        return Failure("Invalid xsi:type ${assertedType.namespace}#${assertedType.localName}; it is known to Specmatic but is not compatible with $declaredDescription.")
+    }
+
+    private fun selectWSDLType(sampleData: XMLNode, declaredType: Pattern, resolver: Resolver): WSDLTypeSelection? {
+        return selectWSDLType(sampleData.xsiTypeName(), declaredType, resolver)
+    }
+
+    private fun selectWSDLType(assertedType: WSDLTypeName?, declaredType: Pattern, resolver: Resolver): WSDLTypeSelection? {
+        assertedType ?: return null
+
+        if (assertedType.namespace == XML_SCHEMA_NAMESPACE) {
+            return null
+        }
+
+        val assertedPattern = resolver.findPatternForWSDLType(assertedType) ?: return null
+        val declaredWSDLType = declaredType.wsdlTypeName() ?: return null
+
+        return when {
+            assertedType == declaredWSDLType ->
+                WSDLTypeSelection.Use(mergeReferredPattern(assertedPattern))
+
+            assertedPattern.isDerivedFrom(declaredWSDLType, resolver) ->
+                WSDLTypeSelection.Use(mergeReferredPattern(assertedPattern))
+
+            else -> WSDLTypeSelection.Invalid(assertedType, declaredWSDLType)
+        }
     }
 
     private fun dropEmptySOAPHeader(sampleData: XMLNode): XMLNode {
@@ -514,6 +596,11 @@ data class XMLPattern(
 
         val name = pattern.name
 
+        val wsdlVariants = effectiveWSDLVariantPatterns(resolver)
+        if (wsdlVariants.isNotEmpty()) {
+            return wsdlVariants.random().generateXML(resolver)
+        }
+
         val resolvedPattern = dereferenceType(resolver) as XMLPattern
 
         val nonSpecmaticAttributes =
@@ -567,6 +654,13 @@ data class XMLPattern(
                 return resolver.withCyclePrevention(dereferenced) { cyclePreventedResolver ->
                     dereferenced.newBasedOn(row, cyclePreventedResolver)
                 }
+            }
+        }
+
+        val wsdlVariants = effectiveWSDLVariantPatterns(resolver)
+        if (wsdlVariants.isNotEmpty()) {
+            return wsdlVariants.asSequence().flatMap { selectedPattern ->
+                selectedPattern.newBasedOn(row, resolver)
             }
         }
 
@@ -679,6 +773,13 @@ data class XMLPattern(
     }
 
     override fun newBasedOn(resolver: Resolver): Sequence<XMLPattern> {
+        val wsdlVariants = effectiveWSDLVariantPatterns(resolver)
+        if (wsdlVariants.isNotEmpty()) {
+            return wsdlVariants.asSequence().flatMap { selectedPattern ->
+                selectedPattern.newBasedOn(resolver)
+            }
+        }
+
         return allOrNothingCombinationIn(
             pattern.attributes,
             Row(),
@@ -745,6 +846,43 @@ data class XMLPattern(
                 XMLPattern(XMLTypeData(pattern.name, pattern.realName, newAttributes, newNodes.toList()))
             }
         }
+    }
+
+    private fun effectiveWSDLVariantPatterns(resolver: Resolver): List<XMLPattern> {
+        val declaredPattern = try {
+            dereferenceType(resolver)
+        } catch (e: ContractException) {
+            return emptyList()
+        }
+
+        if (declaredPattern !is XMLPattern) {
+            return emptyList()
+        }
+
+        val declaredWSDLType = declaredPattern.pattern.wsdlTypeName() ?: return emptyList()
+        when (val selectedType = selectWSDLType(pattern.xsiTypeName(), declaredPattern, resolver)) {
+            is WSDLTypeSelection.Invalid -> throw ContractException(
+                invalidXSITypeResult(selectedType.assertedType, selectedType.declaredType).toFailureReport()
+            )
+
+            is WSDLTypeSelection.Use -> {
+                if (pattern.xsiTypeName() == declaredWSDLType) {
+                    return emptyList()
+                }
+
+                return listOfNotNull(selectedType.pattern as? XMLPattern)
+            }
+
+            null -> Unit
+        }
+
+        val derivedPatterns = resolver.findLeafDerivedPatternsForWSDLType(declaredWSDLType).mapNotNull { derivedPattern ->
+            val derivedType = derivedPattern.pattern.wsdlTypeName() ?: return@mapNotNull null
+            val mergedPattern = declaredPattern.mergeReferredPattern(derivedPattern) as? XMLPattern ?: return@mapNotNull null
+            mergedPattern.withXSIType(derivedType)
+        }
+
+        return derivedPatterns
     }
 
     override fun negativeBasedOn(
@@ -1137,6 +1275,166 @@ data class XMLPattern(
         val typeString = this.toGherkinXMLNode().toPrettyStringValue().trim()
         return "And type $specmaticTypeName\n\"\"\"\n$typeString\n\"\"\""
     }
+}
+
+private fun XMLNode.xsiTypeName(): WSDLTypeName? {
+    val attribute = attributes.keys.firstOrNull { attributeName ->
+        attributeName.substringAfter(":") == "type" &&
+                (runCatching { attributeNamespaceUri(attributeName) }.getOrNull() == XML_SCHEMA_INSTANCE_NAMESPACE ||
+                        attributeName.substringBefore(":", "") == "xsi")
+    } ?: return null
+
+    val value = attributes.getValue(attribute).toStringLiteral()
+    return runCatching {
+        WSDLTypeName(resolveNamespace(value), value.localName())
+    }.getOrNull()
+}
+
+private fun XMLTypeData.xsiTypeName(): WSDLTypeName? {
+    val attribute = attributes.keys.firstOrNull { attributeName ->
+        attributeName.substringAfter(":") == "type" &&
+                (attributeNamespaceUri(attributeName) == XML_SCHEMA_INSTANCE_NAMESPACE ||
+                        attributeName.substringBefore(":", "") == "xsi")
+    } ?: return null
+
+    val value = (attributes.getValue(attribute) as? ExactValuePattern)?.pattern?.toStringLiteral() ?: return null
+    val prefix = value.namespacePrefix()
+    val namespace = when {
+        prefix.isBlank() -> namespaceUri.orEmpty()
+        prefix == "xs" || prefix == "xsd" -> XML_SCHEMA_NAMESPACE
+        else -> attributes["xmlns:$prefix"]?.let { (it as? ExactValuePattern)?.pattern?.toStringLiteral() }.orEmpty()
+    }
+
+    return WSDLTypeName(namespace, value.localName())
+}
+
+private fun Resolver.findPatternForWSDLType(typeName: WSDLTypeName): Pattern? {
+    return newPatterns.values.firstNotNullOfOrNull { pattern ->
+        pattern.findPatternForWSDLType(typeName)
+    }
+}
+
+private fun Resolver.findLeafDerivedPatternsForWSDLType(typeName: WSDLTypeName): List<XMLPattern> {
+    val derivedPatterns = newPatterns.values
+        .flatMap { pattern -> pattern.derivedXMLPatternsFrom(typeName, this) }
+        .distinctBy { pattern -> pattern.pattern.wsdlTypeName() }
+
+    return derivedPatterns.filter { candidate ->
+        val candidateType = candidate.pattern.wsdlTypeName() ?: return@filter false
+        candidateType.namespace != XML_SCHEMA_NAMESPACE &&
+                derivedPatterns.none { other -> other.pattern.isDerivedFrom(candidateType, this) }
+    }
+}
+
+private fun Pattern.findPatternForWSDLType(typeName: WSDLTypeName): Pattern? {
+    return when (this) {
+        is XMLPattern -> takeIf { pattern.wsdlTypeName() == typeName }
+        is AnyPattern -> matchingPatternsForWSDLType(typeName)
+        else -> null
+    }
+}
+
+private fun Pattern.derivedXMLPatternsFrom(typeName: WSDLTypeName, resolver: Resolver): List<XMLPattern> {
+    return when (this) {
+        is XMLPattern -> listOf(this).filter { pattern -> pattern.isDerivedFrom(typeName, resolver) }
+        is AnyPattern -> pattern.flatMap { pattern -> pattern.derivedXMLPatternsFrom(typeName, resolver) }
+        else -> emptyList()
+    }
+}
+
+private fun AnyPattern.matchingPatternsForWSDLType(typeName: WSDLTypeName): Pattern? {
+    val matchingPatterns = pattern.mapNotNull { it.findPatternForWSDLType(typeName) }
+    return when (matchingPatterns.size) {
+        0 -> null
+        1 -> matchingPatterns.single()
+        else -> copy(pattern = matchingPatterns)
+    }
+}
+
+private fun Pattern.wsdlTypeName(): WSDLTypeName? {
+    return when (this) {
+        is XMLPattern -> pattern.wsdlTypeName()
+        is AnyPattern -> pattern.asSequence().mapNotNull { it.wsdlTypeName() }.firstOrNull()
+        else -> null
+    }
+}
+
+private fun XMLTypeData.wsdlTypeName(): WSDLTypeName? {
+    val namespace = wsdlTypeNamespace ?: return null
+    val name = wsdlTypeName ?: return null
+    return WSDLTypeName(namespace, name)
+}
+
+private fun XMLPattern.withXSIType(typeName: WSDLTypeName): XMLPattern {
+    val typePrefix = pattern.prefixForNamespace(typeName.namespace) ?: pattern.prefixForElementNamespace(typeName.namespace) ?: pattern.availableNamespacePrefix()
+    val typeAttributeValue = listOf(typePrefix, typeName.localName).filter(String::isNotBlank).joinToString(":")
+    val namespaceAttributes = pattern.namespaceAttributesForXSIType(typeName.namespace, typePrefix)
+    val xsiTypeAttribute = "xsi:type" to ExactValuePattern(StringValue(typeAttributeValue))
+
+    return copy(
+        pattern = pattern.copy(
+            attributes = pattern.attributes + namespaceAttributes + xsiTypeAttribute,
+            attributeNamespaceUris = pattern.attributeNamespaceUris + mapOf("xsi:type" to XML_SCHEMA_INSTANCE_NAMESPACE)
+        )
+    )
+}
+
+private fun XMLTypeData.namespaceAttributesForXSIType(typeNamespace: String, typePrefix: String): Map<String, Pattern> {
+    val xsiNamespaceAttribute = "xmlns:xsi" to ExactValuePattern(StringValue(XML_SCHEMA_INSTANCE_NAMESPACE))
+    val typeNamespaceAttribute = when {
+        typePrefix.isBlank() -> null
+        prefixForNamespace(typeNamespace) != null -> null
+        else -> "xmlns:$typePrefix" to ExactValuePattern(StringValue(typeNamespace))
+    }
+
+    return listOfNotNull(xsiNamespaceAttribute, typeNamespaceAttribute).toMap()
+}
+
+private fun XMLTypeData.prefixForNamespace(namespace: String): String? {
+    return attributes.entries.firstNotNullOfOrNull { (attributeName, pattern) ->
+        if (!attributeName.startsWith("xmlns:")) return@firstNotNullOfOrNull null
+
+        val attributeValue = (pattern as? ExactValuePattern)?.pattern?.toStringLiteral()
+        attributeName.removePrefix("xmlns:").takeIf { attributeValue == namespace }
+    }
+}
+
+private fun XMLTypeData.prefixForElementNamespace(namespace: String): String? {
+    val prefix = realName.namespacePrefix()
+    return prefix.takeIf { it.isNotBlank() && namespaceUri == namespace }
+}
+
+private fun XMLTypeData.availableNamespacePrefix(): String {
+    val prefixesInUse = attributes.keys
+        .filter { it.startsWith("xmlns:") }
+        .map { it.removePrefix("xmlns:") }
+        .toSet()
+
+    return (listOf("tns") + (1..100).map { index -> "ns$index" })
+        .first { prefix -> prefix !in prefixesInUse }
+}
+
+private fun Pattern.isDerivedFrom(baseType: WSDLTypeName?, resolver: Resolver): Boolean {
+    if (baseType == null) return false
+
+    return when (this) {
+        is XMLPattern -> pattern.isDerivedFrom(baseType, resolver)
+        is AnyPattern -> pattern.any { it.isDerivedFrom(baseType, resolver) }
+        else -> false
+    }
+}
+
+private fun XMLTypeData.isDerivedFrom(baseType: WSDLTypeName, resolver: Resolver): Boolean {
+    val directBase = wsdlBaseTypeName?.let { baseName ->
+        WSDLTypeName(wsdlBaseTypeNamespace.orEmpty(), baseName)
+    } ?: return false
+
+    if (directBase == baseType) {
+        return true
+    }
+
+    val basePattern = resolver.findPatternForWSDLType(directBase) ?: return false
+    return basePattern.isDerivedFrom(baseType, resolver)
 }
 
 private fun <T> PLACEHOLDER_USE_GIT_BLAME_TO_FIND_RELEVANT_COMMIT(value: T, s: String): T {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLPattern.kt
@@ -21,15 +21,18 @@ private const val SOAP_ENVELOPE_NAMESPACE = "http://schemas.xmlsoap.org/soap/env
 
 private sealed class WSDLTypeSelection {
     data class Use(val pattern: Pattern) : WSDLTypeSelection()
+    data class Unknown(val assertedType: WSDLTypeName, val declaredType: WSDLTypeName) : WSDLTypeSelection()
     data class Invalid(val assertedType: WSDLTypeName, val declaredType: WSDLTypeName) : WSDLTypeSelection()
 
     fun match(
         sampleData: XMLNode,
         resolver: Resolver,
+        unknownResult: (WSDLTypeName, WSDLTypeName) -> Failure,
         invalidResult: (WSDLTypeName, WSDLTypeName) -> Failure,
         matchWith: (Pattern, XMLNode, Resolver) -> Result
     ): Result {
         return when (this) {
+            is Unknown -> unknownResult(assertedType, declaredType)
             is Invalid -> invalidResult(assertedType, declaredType)
             is Use -> matchWith(pattern, sampleData, resolver)
         }
@@ -224,6 +227,7 @@ data class XMLPattern(
             return selectedType.match(
                 sampleDataWithoutEmptyHeader,
                 resolver,
+                ::unknownXSITypeResult,
                 ::invalidXSITypeResult,
                 ::matchWithType
             ).breadCrumb(pattern.name, resolver.locate(schemaPointer))
@@ -282,6 +286,11 @@ data class XMLPattern(
         return Failure("Invalid xsi:type ${assertedType.namespace}#${assertedType.localName}; it is known to Specmatic but is not compatible with $declaredDescription.")
     }
 
+    private fun unknownXSITypeResult(assertedType: WSDLTypeName, declaredType: WSDLTypeName): Failure {
+        val declaredDescription = "${declaredType.namespace}#${declaredType.localName}"
+        return Failure("Unknown xsi:type ${assertedType.namespace}#${assertedType.localName}; no matching type was found in the WSDL/schema set for $declaredDescription.")
+    }
+
     private fun selectWSDLType(sampleData: XMLNode, declaredType: Pattern, resolver: Resolver): WSDLTypeSelection? {
         return selectWSDLType(sampleData.xsiTypeName(), declaredType, resolver)
     }
@@ -293,14 +302,21 @@ data class XMLPattern(
             return null
         }
 
-        val assertedPattern = resolver.findPatternForWSDLType(assertedType) ?: return null
         val declaredWSDLType = declaredType.wsdlTypeName() ?: return null
+        val assertedPattern = declaredType.findPatternForWSDLType(assertedType, resolver)
+            ?: resolver.findPatternForWSDLType(assertedType)
+                ?.takeIf { it.wsdlTypeName() == declaredWSDLType || it.isDerivedFrom(declaredWSDLType, resolver) }
+        val assertedTypeIsKnown = declaredType.knowsWSDLType(assertedType) ||
+                resolver.findPatternForWSDLType(assertedType) != null
 
         return when {
-            assertedType == declaredWSDLType ->
-                WSDLTypeSelection.Use(mergeReferredPattern(assertedPattern))
+            assertedPattern == null && !assertedTypeIsKnown ->
+                WSDLTypeSelection.Unknown(assertedType, declaredWSDLType)
 
-            assertedPattern.isDerivedFrom(declaredWSDLType, resolver) ->
+            assertedType == declaredWSDLType ->
+                WSDLTypeSelection.Use(mergeReferredPattern(assertedPattern ?: declaredType))
+
+            assertedPattern != null ->
                 WSDLTypeSelection.Use(mergeReferredPattern(assertedPattern))
 
             else -> WSDLTypeSelection.Invalid(assertedType, declaredWSDLType)
@@ -856,6 +872,10 @@ data class XMLPattern(
 
         val declaredWSDLType = declaredPattern.pattern.wsdlTypeName() ?: return emptyList()
         when (val selectedType = selectWSDLType(pattern.xsiTypeName(), declaredPattern, resolver)) {
+            is WSDLTypeSelection.Unknown -> throw ContractException(
+                unknownXSITypeResult(selectedType.assertedType, selectedType.declaredType).toFailureReport()
+            )
+
             is WSDLTypeSelection.Invalid -> throw ContractException(
                 invalidXSITypeResult(selectedType.assertedType, selectedType.declaredType).toFailureReport()
             )
@@ -871,7 +891,7 @@ data class XMLPattern(
             null -> Unit
         }
 
-        val derivedPatterns = resolver.findLeafDerivedPatternsForWSDLType(declaredWSDLType).mapNotNull { derivedPattern ->
+        val derivedPatterns = declaredPattern.leafDerivedWSDLPatterns(resolver).mapNotNull { derivedPattern ->
             val derivedType = derivedPattern.pattern.wsdlTypeName() ?: return@mapNotNull null
             val mergedPattern = declaredPattern.mergeReferredPattern(derivedPattern) as? XMLPattern ?: return@mapNotNull null
             mergedPattern.withXSIType(derivedType)
@@ -1275,50 +1295,70 @@ data class XMLPattern(
 private fun XMLNode.xsiTypeName(): WSDLTypeName? {
     val value = attributeValueByNamespace(XML_SCHEMA_INSTANCE_NAMESPACE, "type")?.toStringLiteral() ?: return null
     return runCatching {
-        WSDLTypeName(resolveNamespace(value), value.localName())
+        val namespace = when {
+            value.namespacePrefix().isBlank() -> elementNamespaceUriOrNull().orEmpty()
+            else -> resolveNamespace(value)
+        }
+        WSDLTypeName(namespace, value.localName())
     }.getOrNull()
 }
 
+private fun Pattern.findPatternForWSDLType(typeName: WSDLTypeName, resolver: Resolver): Pattern? {
+    val typeKey = wsdlMatchableTypeKeys()[typeName] ?: return null
+    return resolver.patternForWSDLKey(typeKey)
+}
+
 private fun Resolver.findPatternForWSDLType(typeName: WSDLTypeName): Pattern? {
-    return newPatterns.values.firstNotNullOfOrNull { pattern ->
-        pattern.findPatternForWSDLType(typeName)
+    return newPatterns.values.firstOrNull { pattern ->
+        pattern.wsdlTypeName() == typeName
     }
 }
 
-private fun Resolver.findLeafDerivedPatternsForWSDLType(typeName: WSDLTypeName): List<XMLPattern> {
-    val derivedPatterns = newPatterns.values
-        .flatMap { pattern -> pattern.derivedXMLPatternsFrom(typeName, this) }
-        .distinctBy { pattern -> pattern.pattern.wsdlTypeName() }
+private fun Pattern.knowsWSDLType(typeName: WSDLTypeName): Boolean =
+    wsdlKnownTypeKeys().containsKey(typeName)
 
-    return derivedPatterns.filter { candidate ->
-        val candidateType = candidate.pattern.wsdlTypeName() ?: return@filter false
-        candidateType.namespace != XML_SCHEMA_NAMESPACE &&
-                derivedPatterns.none { other -> other.pattern.isDerivedFrom(candidateType, this) }
+private fun Pattern.leafDerivedWSDLPatterns(resolver: Resolver): List<XMLPattern> {
+    return wsdlLeafTypeKeys().values.flatMap { typeKey ->
+        resolver.patternForWSDLKey(typeKey)?.xmlPatternVariants().orEmpty()
+    }.filter { pattern ->
+        pattern.pattern.wsdlTypeName()?.namespace != XML_SCHEMA_NAMESPACE
     }
 }
 
-private fun Pattern.findPatternForWSDLType(typeName: WSDLTypeName): Pattern? {
+private fun Resolver.patternForWSDLKey(typeKey: String): Pattern? {
+    val rawTypeKey = withoutPatternDelimiters(typeKey)
+    return newPatterns[typeKey] ?: newPatterns[withPatternDelimiters(rawTypeKey)] ?: newPatterns[rawTypeKey]
+}
+
+private fun Pattern.xmlPatternVariants(): List<XMLPattern> {
     return when (this) {
-        is XMLPattern -> takeIf { pattern.wsdlTypeName() == typeName }
-        is AnyPattern -> matchingPatternsForWSDLType(typeName)
-        else -> null
-    }
-}
-
-private fun Pattern.derivedXMLPatternsFrom(typeName: WSDLTypeName, resolver: Resolver): List<XMLPattern> {
-    return when (this) {
-        is XMLPattern -> listOf(this).filter { pattern -> pattern.isDerivedFrom(typeName, resolver) }
-        is AnyPattern -> pattern.flatMap { pattern -> pattern.derivedXMLPatternsFrom(typeName, resolver) }
+        is XMLPattern -> listOf(this)
+        is AnyPattern -> pattern.flatMap { it.xmlPatternVariants() }
         else -> emptyList()
     }
 }
 
-private fun AnyPattern.matchingPatternsForWSDLType(typeName: WSDLTypeName): Pattern? {
-    val matchingPatterns = pattern.mapNotNull { it.findPatternForWSDLType(typeName) }
-    return when (matchingPatterns.size) {
-        0 -> null
-        1 -> matchingPatterns.single()
-        else -> copy(pattern = matchingPatterns)
+private fun Pattern.wsdlKnownTypeKeys(): Map<WSDLTypeName, String> {
+    return when (this) {
+        is XMLPattern -> pattern.wsdlKnownTypeKeys
+        is AnyPattern -> pattern.flatMap { it.wsdlKnownTypeKeys().entries }.associate { it.toPair() }
+        else -> emptyMap()
+    }
+}
+
+private fun Pattern.wsdlMatchableTypeKeys(): Map<WSDLTypeName, String> {
+    return when (this) {
+        is XMLPattern -> pattern.wsdlMatchableTypeKeys
+        is AnyPattern -> pattern.flatMap { it.wsdlMatchableTypeKeys().entries }.associate { it.toPair() }
+        else -> emptyMap()
+    }
+}
+
+private fun Pattern.wsdlLeafTypeKeys(): Map<WSDLTypeName, String> {
+    return when (this) {
+        is XMLPattern -> pattern.wsdlLeafTypeKeys
+        is AnyPattern -> pattern.flatMap { it.wsdlLeafTypeKeys().entries }.associate { it.toPair() }
+        else -> emptyMap()
     }
 }
 
@@ -1330,25 +1370,7 @@ private fun Pattern.wsdlTypeName(): WSDLTypeName? {
     }
 }
 
-private fun XMLPattern.withXSIType(typeName: WSDLTypeName): XMLPattern {
-    val typePrefix = pattern.prefixForNamespace(typeName.namespace) ?: pattern.prefixForElementNamespace(typeName.namespace) ?: pattern.availableNamespacePrefix()
-    val typeAttributeValue = listOf(typePrefix, typeName.localName).filter(String::isNotBlank).joinToString(":")
-    val schemaInstancePrefix = pattern.prefixForNamespace(XML_SCHEMA_INSTANCE_NAMESPACE) ?: pattern.availableNamespacePrefix("xsi")
-    val schemaInstanceTypeAttributeName = "$schemaInstancePrefix:type"
-    val namespaceAttributes = pattern.namespaceAttributesForXSIType(typeName.namespace, typePrefix, schemaInstancePrefix)
-    val xsiTypeAttribute = schemaInstanceTypeAttributeName to ExactValuePattern(StringValue(typeAttributeValue))
-
-    return copy(
-        pattern = pattern.copy(
-            attributes = pattern.attributes + namespaceAttributes + xsiTypeAttribute,
-            attributeNamespaceUris = pattern.attributeNamespaceUris + mapOf(schemaInstanceTypeAttributeName to XML_SCHEMA_INSTANCE_NAMESPACE)
-        )
-    )
-}
-
-private fun Pattern.isDerivedFrom(baseType: WSDLTypeName?, resolver: Resolver): Boolean {
-    if (baseType == null) return false
-
+private fun Pattern.isDerivedFrom(baseType: WSDLTypeName, resolver: Resolver): Boolean {
     return when (this) {
         is XMLPattern -> pattern.isDerivedFrom(baseType, resolver)
         is AnyPattern -> pattern.any { it.isDerivedFrom(baseType, resolver) }
@@ -1367,6 +1389,22 @@ private fun XMLTypeData.isDerivedFrom(baseType: WSDLTypeName, resolver: Resolver
 
     val basePattern = resolver.findPatternForWSDLType(directBase) ?: return false
     return basePattern.isDerivedFrom(baseType, resolver)
+}
+
+private fun XMLPattern.withXSIType(typeName: WSDLTypeName): XMLPattern {
+    val typePrefix = pattern.prefixForNamespace(typeName.namespace) ?: pattern.prefixForElementNamespace(typeName.namespace) ?: pattern.availableNamespacePrefix()
+    val typeAttributeValue = listOf(typePrefix, typeName.localName).filter(String::isNotBlank).joinToString(":")
+    val schemaInstancePrefix = pattern.prefixForNamespace(XML_SCHEMA_INSTANCE_NAMESPACE) ?: pattern.availableNamespacePrefix("xsi")
+    val schemaInstanceTypeAttributeName = "$schemaInstancePrefix:type"
+    val namespaceAttributes = pattern.namespaceAttributesForXSIType(typeName.namespace, typePrefix, schemaInstancePrefix)
+    val xsiTypeAttribute = schemaInstanceTypeAttributeName to ExactValuePattern(StringValue(typeAttributeValue))
+
+    return copy(
+        pattern = pattern.copy(
+            attributes = pattern.attributes + namespaceAttributes + xsiTypeAttribute,
+            attributeNamespaceUris = pattern.attributeNamespaceUris + mapOf(schemaInstanceTypeAttributeName to XML_SCHEMA_INSTANCE_NAMESPACE)
+        )
+    )
 }
 
 private fun <T> PLACEHOLDER_USE_GIT_BLAME_TO_FIND_RELEVANT_COMMIT(value: T, s: String): T {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLPattern.kt
@@ -512,11 +512,10 @@ data class XMLPattern(
 
     private fun isSOAP11MetadataAttribute(attributeName: String, namespaceUri: String?): Boolean {
         val name = attributeName.substringAfter(":")
-        val prefix = attributeName.substringBefore(":", "")
 
         return when (name) {
             "encodingStyle" -> namespaceUri == SOAP_ENVELOPE_NAMESPACE
-            "type" -> namespaceUri == XML_SCHEMA_INSTANCE_NAMESPACE || (namespaceUri == null && prefix == "xsi")
+            "type" -> isXMLSchemaInstanceTypeAttribute(attributeName, namespaceUri)
             else -> false
         }
     }
@@ -640,7 +639,7 @@ data class XMLPattern(
             }
         }.toList()
 
-        return XMLNode(pattern.realName, newAttributes, nodes)
+        return XMLNode(pattern.realName, newAttributes, nodes, inheritNamespacesInChildren = true)
     }
 
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
@@ -763,7 +762,7 @@ data class XMLPattern(
             }
 
             newNodesList.map { newNodes ->
-                XMLPattern(XMLTypeData(pattern.name, pattern.realName, newAttributes, newNodes))
+                XMLPattern(pattern.copy(attributes = newAttributes, nodes = newNodes))
             }
         }.map { HasValue(it) }
     }
@@ -839,7 +838,7 @@ data class XMLPattern(
             )
 
             newNodesList.map { newNodes ->
-                XMLPattern(XMLTypeData(pattern.name, pattern.realName, newAttributes, newNodes.toList()))
+                XMLPattern(pattern.copy(attributes = newAttributes, nodes = newNodes.toList()))
             }
         }
     }
@@ -1274,13 +1273,7 @@ data class XMLPattern(
 }
 
 private fun XMLNode.xsiTypeName(): WSDLTypeName? {
-    val attribute = attributes.keys.firstOrNull { attributeName ->
-        attributeName.substringAfter(":") == "type" &&
-                (runCatching { attributeNamespaceUri(attributeName) }.getOrNull() == XML_SCHEMA_INSTANCE_NAMESPACE ||
-                        attributeName.substringBefore(":", "") == "xsi")
-    } ?: return null
-
-    val value = attributes.getValue(attribute).toStringLiteral()
+    val value = attributeValueByNamespace(XML_SCHEMA_INSTANCE_NAMESPACE, "type")?.toStringLiteral() ?: return null
     return runCatching {
         WSDLTypeName(resolveNamespace(value), value.localName())
     }.getOrNull()
@@ -1340,13 +1333,15 @@ private fun Pattern.wsdlTypeName(): WSDLTypeName? {
 private fun XMLPattern.withXSIType(typeName: WSDLTypeName): XMLPattern {
     val typePrefix = pattern.prefixForNamespace(typeName.namespace) ?: pattern.prefixForElementNamespace(typeName.namespace) ?: pattern.availableNamespacePrefix()
     val typeAttributeValue = listOf(typePrefix, typeName.localName).filter(String::isNotBlank).joinToString(":")
-    val namespaceAttributes = pattern.namespaceAttributesForXSIType(typeName.namespace, typePrefix)
-    val xsiTypeAttribute = "xsi:type" to ExactValuePattern(StringValue(typeAttributeValue))
+    val schemaInstancePrefix = pattern.prefixForNamespace(XML_SCHEMA_INSTANCE_NAMESPACE) ?: pattern.availableNamespacePrefix("xsi")
+    val schemaInstanceTypeAttributeName = "$schemaInstancePrefix:type"
+    val namespaceAttributes = pattern.namespaceAttributesForXSIType(typeName.namespace, typePrefix, schemaInstancePrefix)
+    val xsiTypeAttribute = schemaInstanceTypeAttributeName to ExactValuePattern(StringValue(typeAttributeValue))
 
     return copy(
         pattern = pattern.copy(
             attributes = pattern.attributes + namespaceAttributes + xsiTypeAttribute,
-            attributeNamespaceUris = pattern.attributeNamespaceUris + mapOf("xsi:type" to XML_SCHEMA_INSTANCE_NAMESPACE)
+            attributeNamespaceUris = pattern.attributeNamespaceUris + mapOf(schemaInstanceTypeAttributeName to XML_SCHEMA_INSTANCE_NAMESPACE)
         )
     )
 }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLPattern.kt
@@ -18,10 +18,6 @@ private const val XML_RANDOM_NUMBER_CEILING = 3
 private const val SOAP_ENVELOPE = "Envelope"
 private const val SOAP_HEADER = "Header"
 private const val SOAP_ENVELOPE_NAMESPACE = "http://schemas.xmlsoap.org/soap/envelope/"
-private const val XML_SCHEMA_INSTANCE_NAMESPACE = "http://www.w3.org/2001/XMLSchema-instance"
-private const val XML_SCHEMA_NAMESPACE = "http://www.w3.org/2001/XMLSchema"
-
-private data class WSDLTypeName(val namespace: String, val localName: String)
 
 private sealed class WSDLTypeSelection {
     data class Use(val pattern: Pattern) : WSDLTypeSelection()
@@ -1290,24 +1286,6 @@ private fun XMLNode.xsiTypeName(): WSDLTypeName? {
     }.getOrNull()
 }
 
-private fun XMLTypeData.xsiTypeName(): WSDLTypeName? {
-    val attribute = attributes.keys.firstOrNull { attributeName ->
-        attributeName.substringAfter(":") == "type" &&
-                (attributeNamespaceUri(attributeName) == XML_SCHEMA_INSTANCE_NAMESPACE ||
-                        attributeName.substringBefore(":", "") == "xsi")
-    } ?: return null
-
-    val value = (attributes.getValue(attribute) as? ExactValuePattern)?.pattern?.toStringLiteral() ?: return null
-    val prefix = value.namespacePrefix()
-    val namespace = when {
-        prefix.isBlank() -> namespaceUri.orEmpty()
-        prefix == "xs" || prefix == "xsd" -> XML_SCHEMA_NAMESPACE
-        else -> attributes["xmlns:$prefix"]?.let { (it as? ExactValuePattern)?.pattern?.toStringLiteral() }.orEmpty()
-    }
-
-    return WSDLTypeName(namespace, value.localName())
-}
-
 private fun Resolver.findPatternForWSDLType(typeName: WSDLTypeName): Pattern? {
     return newPatterns.values.firstNotNullOfOrNull { pattern ->
         pattern.findPatternForWSDLType(typeName)
@@ -1359,12 +1337,6 @@ private fun Pattern.wsdlTypeName(): WSDLTypeName? {
     }
 }
 
-private fun XMLTypeData.wsdlTypeName(): WSDLTypeName? {
-    val namespace = wsdlTypeNamespace ?: return null
-    val name = wsdlTypeName ?: return null
-    return WSDLTypeName(namespace, name)
-}
-
 private fun XMLPattern.withXSIType(typeName: WSDLTypeName): XMLPattern {
     val typePrefix = pattern.prefixForNamespace(typeName.namespace) ?: pattern.prefixForElementNamespace(typeName.namespace) ?: pattern.availableNamespacePrefix()
     val typeAttributeValue = listOf(typePrefix, typeName.localName).filter(String::isNotBlank).joinToString(":")
@@ -1377,41 +1349,6 @@ private fun XMLPattern.withXSIType(typeName: WSDLTypeName): XMLPattern {
             attributeNamespaceUris = pattern.attributeNamespaceUris + mapOf("xsi:type" to XML_SCHEMA_INSTANCE_NAMESPACE)
         )
     )
-}
-
-private fun XMLTypeData.namespaceAttributesForXSIType(typeNamespace: String, typePrefix: String): Map<String, Pattern> {
-    val xsiNamespaceAttribute = "xmlns:xsi" to ExactValuePattern(StringValue(XML_SCHEMA_INSTANCE_NAMESPACE))
-    val typeNamespaceAttribute = when {
-        typePrefix.isBlank() -> null
-        prefixForNamespace(typeNamespace) != null -> null
-        else -> "xmlns:$typePrefix" to ExactValuePattern(StringValue(typeNamespace))
-    }
-
-    return listOfNotNull(xsiNamespaceAttribute, typeNamespaceAttribute).toMap()
-}
-
-private fun XMLTypeData.prefixForNamespace(namespace: String): String? {
-    return attributes.entries.firstNotNullOfOrNull { (attributeName, pattern) ->
-        if (!attributeName.startsWith("xmlns:")) return@firstNotNullOfOrNull null
-
-        val attributeValue = (pattern as? ExactValuePattern)?.pattern?.toStringLiteral()
-        attributeName.removePrefix("xmlns:").takeIf { attributeValue == namespace }
-    }
-}
-
-private fun XMLTypeData.prefixForElementNamespace(namespace: String): String? {
-    val prefix = realName.namespacePrefix()
-    return prefix.takeIf { it.isNotBlank() && namespaceUri == namespace }
-}
-
-private fun XMLTypeData.availableNamespacePrefix(): String {
-    val prefixesInUse = attributes.keys
-        .filter { it.startsWith("xmlns:") }
-        .map { it.removePrefix("xmlns:") }
-        .toSet()
-
-    return (listOf("tns") + (1..100).map { index -> "ns$index" })
-        .first { prefix -> prefix !in prefixesInUse }
 }
 
 private fun Pattern.isDerivedFrom(baseType: WSDLTypeName?, resolver: Resolver): Boolean {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLTypeData.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLTypeData.kt
@@ -12,6 +12,9 @@ internal const val XML_SCHEMA_NAMESPACE = "http://www.w3.org/2001/XMLSchema"
 
 internal data class WSDLTypeName(val namespace: String, val localName: String)
 
+internal fun isXMLSchemaInstanceTypeAttribute(attributeName: String, namespaceUri: String?): Boolean =
+    attributeName.localName() == "type" && namespaceUri == XML_SCHEMA_INSTANCE_NAMESPACE
+
 data class XMLTypeData(
     val name: String = "",
     val realName: String,
@@ -38,7 +41,17 @@ data class XMLTypeData(
         (attributes[name] as ExactValuePattern?)?.pattern?.toStringLiteral()
 
     fun attributeNamespaceUri(attributeName: String): String? =
-        attributeNamespaceUris[withoutOptionality(attributeName)]
+        attributeNamespaceUris[withoutOptionality(attributeName)] ?: attributeNamespaceUriFromNamespaceDeclarations(attributeName)
+
+    private fun attributeNamespaceUriFromNamespaceDeclarations(attributeName: String): String? {
+        val prefix = attributeName.namespacePrefix()
+
+        return when {
+            prefix.isBlank() -> null
+            prefix == "xml" -> "http://www.w3.org/XML/1998/namespace"
+            else -> attributes["xmlns:$prefix"]?.let { (it as? ExactValuePattern)?.pattern?.toStringLiteral() }
+        }
+    }
 
     fun isEmpty(): Boolean {
         return name.isEmpty() && attributes.isEmpty() && nodes.isEmpty()
@@ -83,7 +96,24 @@ data class XMLTypeData(
             }
         }.filterNotNull()
 
-        return XMLNode(realName, attributes.mapValues { StringValue(it.value.pattern.toString()) }, childXMLNodes)
+        return XMLNode(
+            realName,
+            attributesWithAttributeNamespaceDeclarations().mapValues { StringValue(it.value.pattern.toString()) },
+            childXMLNodes,
+            inheritNamespacesInChildren = true,
+        )
+    }
+
+    private fun attributesWithAttributeNamespaceDeclarations(): Map<String, Pattern> {
+        val namespaceAttributes = attributes.keys.mapNotNull { attributeName ->
+            val prefix = attributeName.namespacePrefix().takeIf(String::isNotBlank) ?: return@mapNotNull null
+            if (attributeName.startsWith("xmlns:") || attributes.containsKey("xmlns:$prefix")) return@mapNotNull null
+
+            val namespaceUri = attributeNamespaceUri(attributeName) ?: return@mapNotNull null
+            "xmlns:$prefix" to ExactValuePattern(StringValue(namespaceUri))
+        }.toMap()
+
+        return namespaceAttributes + attributes
     }
 
     fun isOptionalNode(): Boolean {
@@ -116,9 +146,7 @@ data class XMLTypeData(
 
     internal fun xsiTypeName(): WSDLTypeName? {
         val attribute = attributes.keys.firstOrNull { attributeName ->
-            attributeName.substringAfter(":") == "type" &&
-                    (attributeNamespaceUri(attributeName) == XML_SCHEMA_INSTANCE_NAMESPACE ||
-                            attributeName.substringBefore(":", "") == "xsi")
+            isXMLSchemaInstanceTypeAttribute(attributeName, attributeNamespaceUri(attributeName))
         } ?: return null
 
         val value = (attributes.getValue(attribute) as? ExactValuePattern)?.pattern?.toStringLiteral() ?: return null
@@ -138,8 +166,15 @@ data class XMLTypeData(
         return WSDLTypeName(namespace, name)
     }
 
-    internal fun namespaceAttributesForXSIType(typeNamespace: String, typePrefix: String): Map<String, Pattern> {
-        val xsiNamespaceAttribute = "xmlns:xsi" to ExactValuePattern(StringValue(XML_SCHEMA_INSTANCE_NAMESPACE))
+    internal fun namespaceAttributesForXSIType(
+        typeNamespace: String,
+        typePrefix: String,
+        schemaInstancePrefix: String,
+    ): Map<String, Pattern> {
+        val xsiNamespaceAttribute = when {
+            prefixForNamespace(XML_SCHEMA_INSTANCE_NAMESPACE) != null -> null
+            else -> "xmlns:$schemaInstancePrefix" to ExactValuePattern(StringValue(XML_SCHEMA_INSTANCE_NAMESPACE))
+        }
         val typeNamespaceAttribute = when {
             typePrefix.isBlank() -> null
             prefixForNamespace(typeNamespace) != null -> null
@@ -163,13 +198,16 @@ data class XMLTypeData(
         return prefix.takeIf { it.isNotBlank() && namespaceUri == namespace }
     }
 
-    internal fun availableNamespacePrefix(): String {
+    internal fun availableNamespacePrefix(preferredPrefix: String = "tns"): String {
         val prefixesInUse = attributes.keys
             .filter { it.startsWith("xmlns:") }
             .map { it.removePrefix("xmlns:") }
             .toSet()
 
-        return (listOf("tns") + (1..100).map { index -> "ns$index" })
+        return (sequenceOf(preferredPrefix) + generatedNamespacePrefixes())
             .first { prefix -> prefix !in prefixesInUse }
     }
+
+    private fun generatedNamespacePrefixes(): Sequence<String> =
+        generateSequence(1) { index -> index + 1 }.map { index -> "ns$index" }
 }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLTypeData.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLTypeData.kt
@@ -1,9 +1,16 @@
 package io.specmatic.core.pattern
 
 import io.specmatic.core.Resolver
+import io.specmatic.core.value.localName
+import io.specmatic.core.value.namespacePrefix
 import io.specmatic.core.value.StringValue
 import io.specmatic.core.value.XMLNode
 import io.specmatic.core.wsdl.parser.message.*
+
+internal const val XML_SCHEMA_INSTANCE_NAMESPACE = "http://www.w3.org/2001/XMLSchema-instance"
+internal const val XML_SCHEMA_NAMESPACE = "http://www.w3.org/2001/XMLSchema"
+
+internal data class WSDLTypeName(val namespace: String, val localName: String)
 
 data class XMLTypeData(
     val name: String = "",
@@ -105,5 +112,64 @@ data class XMLTypeData(
         return attributes[NILLABLE_ATTRIBUTE_NAME].let {
             it is ExactValuePattern && it.pattern.toStringLiteral().lowercase() == "true"
         }
+    }
+
+    internal fun xsiTypeName(): WSDLTypeName? {
+        val attribute = attributes.keys.firstOrNull { attributeName ->
+            attributeName.substringAfter(":") == "type" &&
+                    (attributeNamespaceUri(attributeName) == XML_SCHEMA_INSTANCE_NAMESPACE ||
+                            attributeName.substringBefore(":", "") == "xsi")
+        } ?: return null
+
+        val value = (attributes.getValue(attribute) as? ExactValuePattern)?.pattern?.toStringLiteral() ?: return null
+        val prefix = value.namespacePrefix()
+        val namespace = when {
+            prefix.isBlank() -> namespaceUri.orEmpty()
+            prefix == "xs" || prefix == "xsd" -> XML_SCHEMA_NAMESPACE
+            else -> attributes["xmlns:$prefix"]?.let { (it as? ExactValuePattern)?.pattern?.toStringLiteral() }.orEmpty()
+        }
+
+        return WSDLTypeName(namespace, value.localName())
+    }
+
+    internal fun wsdlTypeName(): WSDLTypeName? {
+        val namespace = wsdlTypeNamespace ?: return null
+        val name = wsdlTypeName ?: return null
+        return WSDLTypeName(namespace, name)
+    }
+
+    internal fun namespaceAttributesForXSIType(typeNamespace: String, typePrefix: String): Map<String, Pattern> {
+        val xsiNamespaceAttribute = "xmlns:xsi" to ExactValuePattern(StringValue(XML_SCHEMA_INSTANCE_NAMESPACE))
+        val typeNamespaceAttribute = when {
+            typePrefix.isBlank() -> null
+            prefixForNamespace(typeNamespace) != null -> null
+            else -> "xmlns:$typePrefix" to ExactValuePattern(StringValue(typeNamespace))
+        }
+
+        return listOfNotNull(xsiNamespaceAttribute, typeNamespaceAttribute).toMap()
+    }
+
+    internal fun prefixForNamespace(namespace: String): String? {
+        return attributes.entries.firstNotNullOfOrNull { (attributeName, pattern) ->
+            if (!attributeName.startsWith("xmlns:")) return@firstNotNullOfOrNull null
+
+            val attributeValue = (pattern as? ExactValuePattern)?.pattern?.toStringLiteral()
+            attributeName.removePrefix("xmlns:").takeIf { attributeValue == namespace }
+        }
+    }
+
+    internal fun prefixForElementNamespace(namespace: String): String? {
+        val prefix = realName.namespacePrefix()
+        return prefix.takeIf { it.isNotBlank() && namespaceUri == namespace }
+    }
+
+    internal fun availableNamespacePrefix(): String {
+        val prefixesInUse = attributes.keys
+            .filter { it.startsWith("xmlns:") }
+            .map { it.removePrefix("xmlns:") }
+            .toSet()
+
+        return (listOf("tns") + (1..100).map { index -> "ns$index" })
+            .first { prefix -> prefix !in prefixesInUse }
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLTypeData.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLTypeData.kt
@@ -10,7 +10,7 @@ import io.specmatic.core.wsdl.parser.message.*
 internal const val XML_SCHEMA_INSTANCE_NAMESPACE = "http://www.w3.org/2001/XMLSchema-instance"
 internal const val XML_SCHEMA_NAMESPACE = "http://www.w3.org/2001/XMLSchema"
 
-internal data class WSDLTypeName(val namespace: String, val localName: String)
+data class WSDLTypeName(val namespace: String, val localName: String)
 
 internal fun isXMLSchemaInstanceTypeAttribute(attributeName: String, namespaceUri: String?): Boolean =
     attributeName.localName() == "type" && namespaceUri == XML_SCHEMA_INSTANCE_NAMESPACE
@@ -29,6 +29,11 @@ data class XMLTypeData(
     val wsdlTypeName: String? = null,
     val wsdlBaseTypeNamespace: String? = null,
     val wsdlBaseTypeName: String? = null,
+    val wsdlTypeKey: String? = null,
+    val wsdlBaseTypeKey: String? = null,
+    val wsdlKnownTypeKeys: Map<WSDLTypeName, String> = emptyMap(),
+    val wsdlMatchableTypeKeys: Map<WSDLTypeName, String> = emptyMap(),
+    val wsdlLeafTypeKeys: Map<WSDLTypeName, String> = emptyMap(),
 ) {
     fun hasType(): Boolean = attributes.containsKey(TYPE_ATTRIBUTE_NAME)
     fun hasBeenDereferenced(): Boolean = hasType() && nodes.isNotEmpty()

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLTypeData.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLTypeData.kt
@@ -15,6 +15,10 @@ data class XMLTypeData(
     val attributeWildcards: List<XMLAttributeWildcard> = emptyList(),
     val isSOAPHeader: Boolean = false,
     val attributeNamespaceUris: Map<String, String?> = emptyMap(),
+    val wsdlTypeNamespace: String? = null,
+    val wsdlTypeName: String? = null,
+    val wsdlBaseTypeNamespace: String? = null,
+    val wsdlBaseTypeName: String? = null,
 ) {
     fun hasType(): Boolean = attributes.containsKey(TYPE_ATTRIBUTE_NAME)
     fun hasBeenDereferenced(): Boolean = hasType() && nodes.isNotEmpty()

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLTypeData.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLTypeData.kt
@@ -29,11 +29,9 @@ data class XMLTypeData(
     val wsdlTypeName: String? = null,
     val wsdlBaseTypeNamespace: String? = null,
     val wsdlBaseTypeName: String? = null,
-    val wsdlTypeKey: String? = null,
-    val wsdlBaseTypeKey: String? = null,
     val wsdlKnownTypeKeys: Map<WSDLTypeName, String> = emptyMap(),
-    val wsdlMatchableTypeKeys: Map<WSDLTypeName, String> = emptyMap(),
-    val wsdlLeafTypeKeys: Map<WSDLTypeName, String> = emptyMap(),
+    val wsdlCompatibleTypeKeys: Map<WSDLTypeName, String> = emptyMap(),
+    val wsdlConcreteSubtypeKeys: Map<WSDLTypeName, String> = emptyMap(),
 ) {
     fun hasType(): Boolean = attributes.containsKey(TYPE_ATTRIBUTE_NAME)
     fun hasBeenDereferenced(): Boolean = hasType() && nodes.isNotEmpty()

--- a/core/src/main/kotlin/io/specmatic/core/value/XMLNode.kt
+++ b/core/src/main/kotlin/io/specmatic/core/value/XMLNode.kt
@@ -76,6 +76,25 @@ fun getNamespaces(attributes: Map<String, StringValue>): Map<String, String> =
         }
     }.toMap()
 
+private fun List<XMLValue>.withInheritedNamespaces(parentNamespaces: Map<String, String>, enabled: Boolean): List<XMLValue> {
+    if (!enabled) return this
+
+    return map { child ->
+        when (child) {
+            is XMLNode -> child.withInheritedNamespaces(parentNamespaces)
+            else -> child
+        }
+    }
+}
+
+private fun XMLNode.withInheritedNamespaces(parentNamespaces: Map<String, String>): XMLNode {
+    val updatedNamespaces = parentNamespaces.plus(getNamespaces(attributes))
+    return copy(
+        namespaces = updatedNamespaces,
+        childNodes = childNodes.withInheritedNamespaces(updatedNamespaces, enabled = true)
+    )
+}
+
 data class FullyQualifiedName(val prefix: String, val namespace: String, val localName: String) {
     val qName: String
         get() {
@@ -87,7 +106,25 @@ data class FullyQualifiedName(val prefix: String, val namespace: String, val loc
 }
 
 data class XMLNode(val name: String, val realName: String, val attributes: Map<String, StringValue>, val childNodes: List<XMLValue>, val namespacePrefix: String, val namespaces: Map<String, String>, val schema: XMLNode? = null) : XMLValue, ListValue {
-    constructor(realName: String, attributes: Map<String, StringValue>, childNodes: List<XMLValue>, parentNamespaces: Map<String, String> = emptyMap()) : this(realName.localName(), realName, attributes, childNodes, realName.namespacePrefix(), parentNamespaces.plus(getNamespaces(attributes)))
+    /**
+     * @param inheritNamespacesInChildren set this to true when rebuilding an XML tree from existing child XMLNodes.
+     * Parsed XML already receives inherited namespaces while parsing, but programmatically reconstructed nodes may
+     * need parent namespace mappings pushed into existing descendants so namespaced attributes can be resolved.
+     */
+    constructor(
+        realName: String,
+        attributes: Map<String, StringValue>,
+        childNodes: List<XMLValue>,
+        parentNamespaces: Map<String, String> = emptyMap(),
+        inheritNamespacesInChildren: Boolean = false,
+    ) : this(
+        realName.localName(),
+        realName,
+        attributes,
+        childNodes.withInheritedNamespaces(parentNamespaces.plus(getNamespaces(attributes)), inheritNamespacesInChildren),
+        realName.namespacePrefix(),
+        parentNamespaces.plus(getNamespaces(attributes))
+    )
 
     val oneLineDescription: String = "<$realName ${attributeString()}>"
 
@@ -216,6 +253,13 @@ data class XMLNode(val name: String, val realName: String, val attributes: Map<S
             else -> namespaces[prefix]
                 ?: throw ContractException("Namespace prefix $prefix cannot be resolved")
         }
+    }
+
+    fun attributeValueByNamespace(namespaceUri: String, localName: String): StringValue? {
+        return attributes.entries.firstOrNull { (attributeName, _) ->
+            attributeName.localName() == localName &&
+                    runCatching { attributeNamespaceUri(attributeName) }.getOrNull() == namespaceUri
+        }?.value
     }
 
     override val httpContentType: String = "text/xml"

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/SOAP11Parser.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/SOAP11Parser.kt
@@ -5,6 +5,7 @@ import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.pattern.NodeOccurrence
 import io.specmatic.core.pattern.Pattern
+import io.specmatic.core.pattern.AnyPattern
 import io.specmatic.core.pattern.WSDLTypeName
 import io.specmatic.core.pattern.XMLPattern
 import io.specmatic.core.pattern.withPatternDelimiters
@@ -391,36 +392,6 @@ class SOAP11Parser(private val wsdl: WSDL): SOAPParser {
         )
     }
 
-    private fun WSDLTypeInfo.withoutWSDLTypeMetadata(): WSDLTypeInfo {
-        return copy(
-            members = members.map { it.withoutWSDLTypeMetadata() },
-            types = types.filterValues { it.isReusableWSDLType() }
-                .mapValues { (_, pattern) -> pattern.withoutWSDLTypeMetadata() },
-            wsdlTypeNamespace = null,
-            wsdlTypeName = null,
-            wsdlBaseTypeNamespace = null,
-            wsdlBaseTypeName = null,
-        )
-    }
-
-    private fun Pattern.withoutWSDLTypeMetadata(): Pattern {
-        return when (this) {
-            is XMLPattern -> copy(pattern = pattern.copy(
-                nodes = pattern.nodes.map { it.withoutWSDLTypeMetadata() },
-                wsdlTypeNamespace = null,
-                wsdlTypeName = null,
-                wsdlBaseTypeNamespace = null,
-                wsdlBaseTypeName = null,
-                wsdlTypeKey = null,
-                wsdlBaseTypeKey = null,
-                wsdlKnownTypeKeys = emptyMap(),
-                wsdlMatchableTypeKeys = emptyMap(),
-                wsdlLeafTypeKeys = emptyMap(),
-            ))
-            else -> this
-        }
-    }
-
     private fun List<XMLNode>.wsdlTypeLookupEntries(): List<WSDLTypeLookupEntry> {
         return map { typeNode ->
             val name = typeNode.getAttributeValue("name")
@@ -442,7 +413,7 @@ class SOAP11Parser(private val wsdl: WSDL): SOAPParser {
             return this
         }
 
-        val typeKeys = entries.associate { entry -> entry.typeName to actualTypeKey(entry.typeKey, entry.typeName) }
+        val typeKeys = entries.associate { entry -> entry.typeName to registeredTypeKey(entry.typeKey, entry.typeName) }
         val entriesByType = entries.associateBy { it.typeName }
 
         return mapValues { (typeKey, pattern) ->
@@ -451,12 +422,10 @@ class SOAP11Parser(private val wsdl: WSDL): SOAPParser {
                 ?: return@mapValues pattern
             pattern.withWSDLTypeLookupMetadata(
                 typeName = typeEntry.typeName,
-                typeKey = typeKey,
                 baseTypeName = typeEntry.baseTypeName,
-                baseTypeKey = typeEntry.baseTypeName?.let(typeKeys::get),
                 knownTypeKeys = typeKeys,
-                matchableTypeKeys = matchableTypeKeys(typeEntry.typeName, entries, entriesByType, typeKeys),
-                leafTypeKeys = leafTypeKeys(typeEntry.typeName, entries, entriesByType, typeKeys),
+                compatibleTypeKeys = compatibleTypeKeys(typeEntry.typeName, entries, entriesByType, typeKeys),
+                concreteSubtypeKeys = concreteSubtypeKeys(typeEntry.typeName, entries, entriesByType, typeKeys),
             )
         }
     }
@@ -471,20 +440,17 @@ class SOAP11Parser(private val wsdl: WSDL): SOAPParser {
 
         return map { pattern ->
             val typeEntry = pattern.wsdlTypeNameForLookup()?.let(entriesByType::get) ?: return@map pattern
-            val typeKey = typeKeys[typeEntry.typeName] ?: return@map pattern
             pattern.withWSDLTypeLookupMetadata(
                 typeName = typeEntry.typeName,
-                typeKey = typeKey,
                 baseTypeName = typeEntry.baseTypeName,
-                baseTypeKey = typeEntry.baseTypeName?.let(typeKeys::get),
                 knownTypeKeys = typeKeys,
-                matchableTypeKeys = matchableTypeKeys(typeEntry.typeName, entries, entriesByType, typeKeys),
-                leafTypeKeys = leafTypeKeys(typeEntry.typeName, entries, entriesByType, typeKeys),
+                compatibleTypeKeys = compatibleTypeKeys(typeEntry.typeName, entries, entriesByType, typeKeys),
+                concreteSubtypeKeys = concreteSubtypeKeys(typeEntry.typeName, entries, entriesByType, typeKeys),
             )
         }
     }
 
-    private fun Map<String, Pattern>.actualTypeKey(typeKey: String): String {
+    private fun Map<String, Pattern>.registeredTypeKey(typeKey: String): String {
         val delimitedTypeKey = withPatternDelimiters(typeKey.removeSurrounding("(", ")"))
         return when {
             containsKey(typeKey) -> typeKey
@@ -494,8 +460,8 @@ class SOAP11Parser(private val wsdl: WSDL): SOAPParser {
         }
     }
 
-    private fun Map<String, Pattern>.actualTypeKey(typeKey: String, typeName: WSDLTypeName): String =
-        actualTypeKey(typeKey).takeIf { containsKey(it) }
+    private fun Map<String, Pattern>.registeredTypeKey(typeKey: String, typeName: WSDLTypeName): String =
+        registeredTypeKey(typeKey).takeIf { containsKey(it) }
             ?: entries.firstOrNull { (_, pattern) -> pattern.wsdlTypeNameForLookup() == typeName }?.key
             ?: typeKey
 
@@ -504,19 +470,17 @@ class SOAP11Parser(private val wsdl: WSDL): SOAPParser {
             is XMLPattern -> pattern.wsdlTypeName?.let { typeName ->
                 WSDLTypeName(pattern.wsdlTypeNamespace.orEmpty(), typeName)
             }
-            is io.specmatic.core.pattern.AnyPattern -> pattern.asSequence().mapNotNull { it.wsdlTypeNameForLookup() }.firstOrNull()
+            is AnyPattern -> pattern.asSequence().mapNotNull { it.wsdlTypeNameForLookup() }.firstOrNull()
             else -> null
         }
     }
 
     private fun Pattern.withWSDLTypeLookupMetadata(
         typeName: WSDLTypeName,
-        typeKey: String,
         baseTypeName: WSDLTypeName?,
-        baseTypeKey: String?,
         knownTypeKeys: Map<WSDLTypeName, String>,
-        matchableTypeKeys: Map<WSDLTypeName, String>,
-        leafTypeKeys: Map<WSDLTypeName, String>,
+        compatibleTypeKeys: Map<WSDLTypeName, String>,
+        concreteSubtypeKeys: Map<WSDLTypeName, String>,
     ): Pattern {
         return when (this) {
             is XMLPattern -> copy(
@@ -525,24 +489,20 @@ class SOAP11Parser(private val wsdl: WSDL): SOAPParser {
                     wsdlTypeName = pattern.wsdlTypeName ?: typeName.localName,
                     wsdlBaseTypeNamespace = pattern.wsdlBaseTypeNamespace ?: baseTypeName?.namespace,
                     wsdlBaseTypeName = pattern.wsdlBaseTypeName ?: baseTypeName?.localName,
-                    wsdlTypeKey = typeKey,
-                    wsdlBaseTypeKey = baseTypeKey,
                     wsdlKnownTypeKeys = knownTypeKeys,
-                    wsdlMatchableTypeKeys = matchableTypeKeys,
-                    wsdlLeafTypeKeys = leafTypeKeys,
+                    wsdlCompatibleTypeKeys = compatibleTypeKeys,
+                    wsdlConcreteSubtypeKeys = concreteSubtypeKeys,
                 )
             )
 
-            is io.specmatic.core.pattern.AnyPattern -> copy(
+            is AnyPattern -> copy(
                 pattern = pattern.map {
                     it.withWSDLTypeLookupMetadata(
                         typeName,
-                        typeKey,
                         baseTypeName,
-                        baseTypeKey,
                         knownTypeKeys,
-                        matchableTypeKeys,
-                        leafTypeKeys,
+                        compatibleTypeKeys,
+                        concreteSubtypeKeys,
                     )
                 }
             )
@@ -551,7 +511,7 @@ class SOAP11Parser(private val wsdl: WSDL): SOAPParser {
         }
     }
 
-    private fun matchableTypeKeys(
+    private fun compatibleTypeKeys(
         baseType: WSDLTypeName,
         entries: List<WSDLTypeLookupEntry>,
         entriesByType: Map<WSDLTypeName, WSDLTypeLookupEntry>,
@@ -562,7 +522,7 @@ class SOAP11Parser(private val wsdl: WSDL): SOAPParser {
             .mapNotNull { entry -> typeKeys[entry.typeName]?.let { key -> entry.typeName to key } }
             .toMap()
 
-    private fun leafTypeKeys(
+    private fun concreteSubtypeKeys(
         baseType: WSDLTypeName,
         entries: List<WSDLTypeLookupEntry>,
         entriesByType: Map<WSDLTypeName, WSDLTypeLookupEntry>,
@@ -589,13 +549,6 @@ class SOAP11Parser(private val wsdl: WSDL): SOAPParser {
         }
 
         return entriesByType[directBaseType]?.isDerivedFrom(baseType, entriesByType) == true
-    }
-
-    private fun Pattern.isReusableWSDLType(): Boolean {
-        return when (this) {
-            is XMLPattern -> pattern.name == TYPE_NODE_NAME
-            else -> true
-        }
     }
 
     private fun WSDL.typeNodesNeededForWSDLTypeLookup(namespace: String): List<XMLNode> {

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/SOAP11Parser.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/SOAP11Parser.kt
@@ -5,7 +5,9 @@ import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.pattern.NodeOccurrence
 import io.specmatic.core.pattern.Pattern
+import io.specmatic.core.pattern.WSDLTypeName
 import io.specmatic.core.pattern.XMLPattern
+import io.specmatic.core.pattern.withPatternDelimiters
 import io.specmatic.core.value.FullyQualifiedName
 import io.specmatic.core.value.XMLNode
 import io.specmatic.core.value.xmlNode
@@ -40,6 +42,12 @@ private data class SOAPHeaderAccumulator(
 private data class SOAPHeaderInfo(
     val header: RequestHeaders.Header,
     val types: Map<String, Pattern>,
+)
+
+private data class WSDLTypeLookupEntry(
+    val typeName: WSDLTypeName,
+    val typeKey: String,
+    val baseTypeName: WSDLTypeName?,
 )
 
 class SOAP11Parser(private val wsdl: WSDL): SOAPParser {
@@ -374,8 +382,13 @@ class SOAP11Parser(private val wsdl: WSDL): SOAPParser {
             return withoutWSDLTypeMetadata()
         }
 
+        val lookupEntries = indexableTypes.wsdlTypeLookupEntries(namespace)
         val types = indexableTypes.registerAsWSDLLookupTypes(namespace, this.types)
-        return copy(types = types)
+            .withWSDLTypeLookupMetadata(lookupEntries)
+        return copy(
+            members = members.withWSDLTypeLookupMetadata(lookupEntries),
+            types = types,
+        )
     }
 
     private fun WSDLTypeInfo.withoutWSDLTypeMetadata(): WSDLTypeInfo {
@@ -398,9 +411,183 @@ class SOAP11Parser(private val wsdl: WSDL): SOAPParser {
                 wsdlTypeName = null,
                 wsdlBaseTypeNamespace = null,
                 wsdlBaseTypeName = null,
+                wsdlTypeKey = null,
+                wsdlBaseTypeKey = null,
+                wsdlKnownTypeKeys = emptyMap(),
+                wsdlMatchableTypeKeys = emptyMap(),
+                wsdlLeafTypeKeys = emptyMap(),
             ))
             else -> this
         }
+    }
+
+    private fun List<XMLNode>.wsdlTypeLookupEntries(namespace: String): List<WSDLTypeLookupEntry> {
+        return map { typeNode ->
+            val name = typeNode.getAttributeValue("name")
+            val schemaTypeName = FullyQualifiedName(typeNode.prefixFor(namespace), namespace, name)
+            WSDLTypeLookupEntry(
+                typeName = WSDLTypeName(schemaTypeName.namespace, schemaTypeName.localName),
+                typeKey = "(${specmaticTypeName(schemaTypeName.qName)})",
+                baseTypeName = typeNode.derivationNode()
+                    ?.fullyQualifiedNameFromAttribute("base")
+                    ?.takeUnless { it.namespace == XML_SCHEMA_NAMESPACE }
+                    ?.let { WSDLTypeName(it.namespace, it.localName) },
+            )
+        }
+    }
+
+    private fun Map<String, Pattern>.withWSDLTypeLookupMetadata(entries: List<WSDLTypeLookupEntry>): Map<String, Pattern> {
+        if (entries.isEmpty()) {
+            return this
+        }
+
+        val typeKeys = entries.associate { entry -> entry.typeName to actualTypeKey(entry.typeKey, entry.typeName) }
+        val entriesByType = entries.associateBy { it.typeName }
+
+        return mapValues { (typeKey, pattern) ->
+            val typeEntry = entries.firstOrNull { typeKeys[it.typeName] == typeKey }
+                ?: pattern.wsdlTypeNameForLookup()?.let(entriesByType::get)
+                ?: return@mapValues pattern
+            pattern.withWSDLTypeLookupMetadata(
+                typeName = typeEntry.typeName,
+                typeKey = typeKey,
+                baseTypeName = typeEntry.baseTypeName,
+                baseTypeKey = typeEntry.baseTypeName?.let(typeKeys::get),
+                knownTypeKeys = typeKeys,
+                matchableTypeKeys = matchableTypeKeys(typeEntry.typeName, entries, entriesByType, typeKeys),
+                leafTypeKeys = leafTypeKeys(typeEntry.typeName, entries, entriesByType, typeKeys),
+            )
+        }
+    }
+
+    private fun List<Pattern>.withWSDLTypeLookupMetadata(entries: List<WSDLTypeLookupEntry>): List<Pattern> {
+        if (entries.isEmpty()) {
+            return this
+        }
+
+        val typeKeys = entries.associate { entry -> entry.typeName to withPatternDelimiters(entry.typeKey.removeSurrounding("(", ")")) }
+        val entriesByType = entries.associateBy { it.typeName }
+
+        return map { pattern ->
+            val typeEntry = pattern.wsdlTypeNameForLookup()?.let(entriesByType::get) ?: return@map pattern
+            val typeKey = typeKeys[typeEntry.typeName] ?: return@map pattern
+            pattern.withWSDLTypeLookupMetadata(
+                typeName = typeEntry.typeName,
+                typeKey = typeKey,
+                baseTypeName = typeEntry.baseTypeName,
+                baseTypeKey = typeEntry.baseTypeName?.let(typeKeys::get),
+                knownTypeKeys = typeKeys,
+                matchableTypeKeys = matchableTypeKeys(typeEntry.typeName, entries, entriesByType, typeKeys),
+                leafTypeKeys = leafTypeKeys(typeEntry.typeName, entries, entriesByType, typeKeys),
+            )
+        }
+    }
+
+    private fun Map<String, Pattern>.actualTypeKey(typeKey: String): String {
+        val delimitedTypeKey = withPatternDelimiters(typeKey.removeSurrounding("(", ")"))
+        return when {
+            containsKey(typeKey) -> typeKey
+            containsKey(delimitedTypeKey) -> delimitedTypeKey
+            containsKey(typeKey.removeSurrounding("(", ")")) -> typeKey.removeSurrounding("(", ")")
+            else -> typeKey
+        }
+    }
+
+    private fun Map<String, Pattern>.actualTypeKey(typeKey: String, typeName: WSDLTypeName): String =
+        actualTypeKey(typeKey).takeIf { containsKey(it) }
+            ?: entries.firstOrNull { (_, pattern) -> pattern.wsdlTypeNameForLookup() == typeName }?.key
+            ?: typeKey
+
+    private fun Pattern.wsdlTypeNameForLookup(): WSDLTypeName? {
+        return when (this) {
+            is XMLPattern -> pattern.wsdlTypeName?.let { typeName ->
+                WSDLTypeName(pattern.wsdlTypeNamespace.orEmpty(), typeName)
+            }
+            is io.specmatic.core.pattern.AnyPattern -> pattern.asSequence().mapNotNull { it.wsdlTypeNameForLookup() }.firstOrNull()
+            else -> null
+        }
+    }
+
+    private fun Pattern.withWSDLTypeLookupMetadata(
+        typeName: WSDLTypeName,
+        typeKey: String,
+        baseTypeName: WSDLTypeName?,
+        baseTypeKey: String?,
+        knownTypeKeys: Map<WSDLTypeName, String>,
+        matchableTypeKeys: Map<WSDLTypeName, String>,
+        leafTypeKeys: Map<WSDLTypeName, String>,
+    ): Pattern {
+        return when (this) {
+            is XMLPattern -> copy(
+                pattern = pattern.copy(
+                    wsdlTypeNamespace = pattern.wsdlTypeNamespace ?: typeName.namespace,
+                    wsdlTypeName = pattern.wsdlTypeName ?: typeName.localName,
+                    wsdlBaseTypeNamespace = pattern.wsdlBaseTypeNamespace ?: baseTypeName?.namespace,
+                    wsdlBaseTypeName = pattern.wsdlBaseTypeName ?: baseTypeName?.localName,
+                    wsdlTypeKey = typeKey,
+                    wsdlBaseTypeKey = baseTypeKey,
+                    wsdlKnownTypeKeys = knownTypeKeys,
+                    wsdlMatchableTypeKeys = matchableTypeKeys,
+                    wsdlLeafTypeKeys = leafTypeKeys,
+                )
+            )
+
+            is io.specmatic.core.pattern.AnyPattern -> copy(
+                pattern = pattern.map {
+                    it.withWSDLTypeLookupMetadata(
+                        typeName,
+                        typeKey,
+                        baseTypeName,
+                        baseTypeKey,
+                        knownTypeKeys,
+                        matchableTypeKeys,
+                        leafTypeKeys,
+                    )
+                }
+            )
+
+            else -> this
+        }
+    }
+
+    private fun matchableTypeKeys(
+        baseType: WSDLTypeName,
+        entries: List<WSDLTypeLookupEntry>,
+        entriesByType: Map<WSDLTypeName, WSDLTypeLookupEntry>,
+        typeKeys: Map<WSDLTypeName, String>,
+    ): Map<WSDLTypeName, String> =
+        entries
+            .filter { entry -> entry.typeName == baseType || entry.isDerivedFrom(baseType, entriesByType) }
+            .mapNotNull { entry -> typeKeys[entry.typeName]?.let { key -> entry.typeName to key } }
+            .toMap()
+
+    private fun leafTypeKeys(
+        baseType: WSDLTypeName,
+        entries: List<WSDLTypeLookupEntry>,
+        entriesByType: Map<WSDLTypeName, WSDLTypeLookupEntry>,
+        typeKeys: Map<WSDLTypeName, String>,
+    ): Map<WSDLTypeName, String> {
+        val descendants = entries
+            .filter { entry -> entry.typeName != baseType && entry.isDerivedFrom(baseType, entriesByType) }
+            .map { it.typeName }
+            .toSet()
+
+        return descendants
+            .filter { descendant -> entries.none { entry -> entry.typeName in descendants && entry.isDerivedFrom(descendant, entriesByType) } }
+            .mapNotNull { type -> typeKeys[type]?.let { key -> type to key } }
+            .toMap()
+    }
+
+    private fun WSDLTypeLookupEntry.isDerivedFrom(
+        baseType: WSDLTypeName,
+        entriesByType: Map<WSDLTypeName, WSDLTypeLookupEntry>,
+    ): Boolean {
+        val directBaseType = baseTypeName ?: return false
+        if (directBaseType == baseType) {
+            return true
+        }
+
+        return entriesByType[directBaseType]?.isDerivedFrom(baseType, entriesByType) == true
     }
 
     private fun Pattern.isReusableWSDLType(): Boolean {
@@ -411,7 +598,7 @@ class SOAP11Parser(private val wsdl: WSDL): SOAPParser {
     }
 
     private fun WSDL.typeNodesNeededForWSDLTypeLookup(namespace: String): List<XMLNode> {
-        val namedTypes = namedTypeNodes(namespace)
+        val namedTypes = schemas.keys.plus(namespace).distinct().flatMap(::namedTypeNodes)
         return namedTypes.takeIf { types -> types.any { it.hasActionableDerivation() } }.orEmpty()
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/SOAP11Parser.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/SOAP11Parser.kt
@@ -5,6 +5,7 @@ import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.pattern.NodeOccurrence
 import io.specmatic.core.pattern.Pattern
+import io.specmatic.core.pattern.XMLPattern
 import io.specmatic.core.value.FullyQualifiedName
 import io.specmatic.core.value.XMLNode
 import io.specmatic.core.value.xmlNode
@@ -19,6 +20,7 @@ import io.specmatic.core.wsdl.payload.SoapPayloadType
 import java.net.URI
 
 const val TYPE_NODE_NAME = "SPECMATIC_TYPE"
+private const val XML_SCHEMA_NAMESPACE = "http://www.w3.org/2001/XMLSchema"
 
 private data class QualifiedMessageName(
     val qualification: NamespaceQualification?,
@@ -260,6 +262,7 @@ class SOAP11Parser(private val wsdl: WSDL): SOAPParser {
         val specmaticTypeName =
             "${operationName.replace(":", "_")}_SOAPHeader_${soapMessageType.messageTypeName.capitalizeFirstChar()}_$bindingPartName"
         val typeInfo = topLevelElement.deriveSpecmaticTypes(specmaticTypeName, existingTypes, emptySet())
+            .withWSDLTypeLookupIndex(fullyQualifiedName.namespace)
         val headerNode = RequestHeaders.withOccurrence(typeInfo.nodes.first() as XMLNode, occurrence)
         val namespaces = wsdl.getNamespaces(typeInfo)
 
@@ -321,6 +324,7 @@ class SOAP11Parser(private val wsdl: WSDL): SOAPParser {
         val topLevelElement = wsdl.getSOAPElement(fullyQualifiedName)
         val specmaticTypeName = "${operationName.replace(":", "_")}_SOAPPayload_${soapMessageType.messageTypeName.capitalizeFirstChar()}"
         val typeInfo = topLevelElement.deriveSpecmaticTypes(specmaticTypeName, existingTypes, emptySet())
+            .withWSDLTypeLookupIndex(fullyQualifiedName.namespace)
         val namespaces = wsdl.getNamespaces(typeInfo)
         val nodeNameForSOAPBody = (typeInfo.nodes.first() as XMLNode).realName
         val soapPayload = topLevelElement.getSOAPPayload(soapMessageType, nodeNameForSOAPBody, specmaticTypeName, namespaces, typeInfo)
@@ -356,11 +360,114 @@ class SOAP11Parser(private val wsdl: WSDL): SOAPParser {
 
         val specmaticTypeName = "${operationName.replace(":", "_")}${soapMessageType.messageTypeName.capitalizeFirstChar()} "
         val typeInfo = topLevelElement.deriveSpecmaticTypes(specmaticTypeName, existingTypes, emptySet())
+            .withWSDLTypeLookupIndex(fullyQualifiedTypeName.namespace)
         val namespaces = wsdl.getNamespaces(typeInfo)
         val nodeNameForSOAPBody = (typeInfo.nodes.first() as XMLNode).realName
         val soapPayload = topLevelElement.getSOAPPayload(soapMessageType, nodeNameForSOAPBody, specmaticTypeName, namespaces, typeInfo)
 
         return SoapPayloadType(typeInfo.types, soapPayload)
+    }
+
+    private fun WSDLTypeInfo.withWSDLTypeLookupIndex(namespace: String): WSDLTypeInfo {
+        val indexableTypes = wsdl.typeNodesNeededForWSDLTypeLookup(namespace)
+        if (indexableTypes.isEmpty()) {
+            return withoutWSDLTypeMetadata()
+        }
+
+        val types = indexableTypes.registerAsWSDLLookupTypes(namespace, this.types)
+        return copy(types = types)
+    }
+
+    private fun WSDLTypeInfo.withoutWSDLTypeMetadata(): WSDLTypeInfo {
+        return copy(
+            members = members.map { it.withoutWSDLTypeMetadata() },
+            types = types.filterValues { it.isReusableWSDLType() }
+                .mapValues { (_, pattern) -> pattern.withoutWSDLTypeMetadata() },
+            wsdlTypeNamespace = null,
+            wsdlTypeName = null,
+            wsdlBaseTypeNamespace = null,
+            wsdlBaseTypeName = null,
+        )
+    }
+
+    private fun Pattern.withoutWSDLTypeMetadata(): Pattern {
+        return when (this) {
+            is XMLPattern -> copy(pattern = pattern.copy(
+                nodes = pattern.nodes.map { it.withoutWSDLTypeMetadata() },
+                wsdlTypeNamespace = null,
+                wsdlTypeName = null,
+                wsdlBaseTypeNamespace = null,
+                wsdlBaseTypeName = null,
+            ))
+            else -> this
+        }
+    }
+
+    private fun Pattern.isReusableWSDLType(): Boolean {
+        return when (this) {
+            is XMLPattern -> pattern.name == TYPE_NODE_NAME
+            else -> true
+        }
+    }
+
+    private fun WSDL.typeNodesNeededForWSDLTypeLookup(namespace: String): List<XMLNode> {
+        val namedTypes = namedTypeNodes(namespace)
+        return namedTypes.takeIf { types -> types.any { it.hasActionableDerivation() } }.orEmpty()
+    }
+
+    private fun List<XMLNode>.registerAsWSDLLookupTypes(
+        namespace: String,
+        existingTypes: Map<String, Pattern>
+    ): Map<String, Pattern> {
+        return fold(existingTypes) { accumulatedTypes, typeNode ->
+            val name = typeNode.getAttributeValue("name")
+            val schemaTypeName = FullyQualifiedName(typeNode.prefixFor(namespace), namespace, name)
+            val schemaSpecmaticTypeName = specmaticTypeName(schemaTypeName.qName)
+
+            if (schemaSpecmaticTypeName in accumulatedTypes) {
+                accumulatedTypes
+            } else {
+                val schemaElement = when (typeNode.name) {
+                    "complexType" -> ComplexElement(schemaTypeName.qName, typeNode, wsdl)
+                    "simpleType" -> SimpleElement(schemaTypeName.qName, typeNode, wsdl, simpleTypeNode = typeNode)
+                    else -> throw ContractException("Named schema node ${typeNode.name} cannot be used as an xsi:type target")
+                }
+
+                val schemaTypeInfo = schemaElement.deriveSpecmaticTypes(
+                    schemaSpecmaticTypeName,
+                    accumulatedTypes,
+                    accumulatedTypes.keys
+                )
+
+                accumulatedTypes.plus(schemaTypeInfo.types)
+            }
+        }
+    }
+
+    private fun XMLNode.prefixFor(namespace: String): String {
+        return namespaces.entries.firstOrNull { it.value == namespace }?.key
+            ?: wsdl.getSchemaNamespacePrefix(namespace)
+    }
+
+    private fun XMLNode.hasActionableDerivation(): Boolean {
+        return derivationNode()?.hasBaseOutsideXMLSchemaNamespace() == true
+    }
+
+    private fun XMLNode.derivationNode(): XMLNode? {
+        val directRestriction = findFirstChildByName("restriction")
+        val complexContent = findFirstChildByName("complexContent")
+        val simpleContent = findFirstChildByName("simpleContent")
+
+        return directRestriction
+            ?: complexContent?.findFirstChildByName("extension")
+            ?: complexContent?.findFirstChildByName("restriction")
+            ?: simpleContent?.findFirstChildByName("extension")
+            ?: simpleContent?.findFirstChildByName("restriction")
+    }
+
+    private fun XMLNode.hasBaseOutsideXMLSchemaNamespace(): Boolean {
+        val baseType = attributes["base"]?.toStringLiteral() ?: return false
+        return resolveNamespace(baseType) != XML_SCHEMA_NAMESPACE
     }
 
     private fun qualifyMessageName(fullyQualifiedMessageName: FullyQualifiedName): QualifiedMessageName {

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/SOAP11Parser.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/SOAP11Parser.kt
@@ -379,11 +379,11 @@ class SOAP11Parser(private val wsdl: WSDL): SOAPParser {
     private fun WSDLTypeInfo.withWSDLTypeLookupIndex(namespace: String): WSDLTypeInfo {
         val indexableTypes = wsdl.typeNodesNeededForWSDLTypeLookup(namespace)
         if (indexableTypes.isEmpty()) {
-            return withoutWSDLTypeMetadata()
+            return this
         }
 
-        val lookupEntries = indexableTypes.wsdlTypeLookupEntries(namespace)
-        val types = indexableTypes.registerAsWSDLLookupTypes(namespace, this.types)
+        val lookupEntries = indexableTypes.wsdlTypeLookupEntries()
+        val types = indexableTypes.registerAsWSDLLookupTypes(this.types)
             .withWSDLTypeLookupMetadata(lookupEntries)
         return copy(
             members = members.withWSDLTypeLookupMetadata(lookupEntries),
@@ -421,9 +421,10 @@ class SOAP11Parser(private val wsdl: WSDL): SOAPParser {
         }
     }
 
-    private fun List<XMLNode>.wsdlTypeLookupEntries(namespace: String): List<WSDLTypeLookupEntry> {
+    private fun List<XMLNode>.wsdlTypeLookupEntries(): List<WSDLTypeLookupEntry> {
         return map { typeNode ->
             val name = typeNode.getAttributeValue("name")
+            val namespace = typeNode.schemaTargetNamespace()
             val schemaTypeName = FullyQualifiedName(typeNode.prefixFor(namespace), namespace, name)
             WSDLTypeLookupEntry(
                 typeName = WSDLTypeName(schemaTypeName.namespace, schemaTypeName.localName),
@@ -603,11 +604,11 @@ class SOAP11Parser(private val wsdl: WSDL): SOAPParser {
     }
 
     private fun List<XMLNode>.registerAsWSDLLookupTypes(
-        namespace: String,
         existingTypes: Map<String, Pattern>
     ): Map<String, Pattern> {
         return fold(existingTypes) { accumulatedTypes, typeNode ->
             val name = typeNode.getAttributeValue("name")
+            val namespace = typeNode.schemaTargetNamespace()
             val schemaTypeName = FullyQualifiedName(typeNode.prefixFor(namespace), namespace, name)
             val schemaSpecmaticTypeName = specmaticTypeName(schemaTypeName.qName)
 
@@ -634,6 +635,10 @@ class SOAP11Parser(private val wsdl: WSDL): SOAPParser {
     private fun XMLNode.prefixFor(namespace: String): String {
         return namespaces.entries.firstOrNull { it.value == namespace }?.key
             ?: wsdl.getSchemaNamespacePrefix(namespace)
+    }
+
+    private fun XMLNode.schemaTargetNamespace(): String {
+        return schema?.attributes?.get("targetNamespace")?.toStringLiteral().orEmpty()
     }
 
     private fun XMLNode.hasActionableDerivation(): Boolean {

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/WSDL.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/WSDL.kt
@@ -354,6 +354,18 @@ data class WSDL(private val rootDefinition: XMLNode, val definitions: Map<String
         }
     }
 
+    fun namedTypeNodes(namespace: String, localSchema: XMLNode? = null): List<XMLNode> {
+        val resolvedNamespace = namespaceOrSchemaNamespace(namespace, localSchema) ?: return emptyList()
+        if (resolvedNamespace.isBlank()) {
+            return emptyList()
+        }
+
+        val schema = schemas[resolvedNamespace] ?: return emptyList()
+        return schema.childNodes.filterIsInstance<XMLNode>().filter { typeNode ->
+            typeNode.name == "complexType" || typeNode.name == "simpleType"
+        }
+    }
+
     fun findAttributeGroup(fullyQualifiedName: FullyQualifiedName, localSchema: XMLNode? = null): XMLNode {
         return findSchemaNode("attributeGroup", fullyQualifiedName.namespace, fullyQualifiedName.localName, localSchema)
     }
@@ -482,8 +494,13 @@ data class WSDL(private val rootDefinition: XMLNode, val definitions: Map<String
     }
 }
 
+fun specmaticTypeName(typeName: String): String = typeName.replace(':', '_')
+
 fun namespaceOrSchemaNamespace(namespace: String, schema: XMLNode?) =
-    namespace.ifBlank { schema?.attributes?.get("xmlns")?.toStringLiteral() }
+    namespace.ifBlank {
+        schema?.attributes?.get("targetNamespace")?.toStringLiteral()
+            ?: schema?.attributes?.get("xmlns")?.toStringLiteral()
+    }
 
 private fun indexDefinitions(definitions: Map<String, XMLNode>): Map<DefinitionLookupKey, XMLNode> {
     val definitionTags = setOf("message", "binding", "portType")

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/WSDLTypeInfo.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/WSDLTypeInfo.kt
@@ -14,7 +14,11 @@ data class WSDLTypeInfo(
     val nodes: List<XMLValue> = emptyList(),
     val members: List<Pattern> = emptyList(),
     val types: Map<String, Pattern> = emptyMap(),
-    val namespacePrefixes: Set<String> = emptySet()
+    val namespacePrefixes: Set<String> = emptySet(),
+    val wsdlTypeNamespace: String? = null,
+    val wsdlTypeName: String? = null,
+    val wsdlBaseTypeNamespace: String? = null,
+    val wsdlBaseTypeName: String? = null,
 ) {
     fun getNamespaces(wsdlNamespaces: Map<String, String>): Map<String, String> {
         logger.debug(wsdlNamespaces.toString())
@@ -30,7 +34,11 @@ data class WSDLTypeInfo(
             this.nodes.plus(otherWSDLTypeInfo.nodes),
             this.effectiveMembers.plus(otherWSDLTypeInfo.effectiveMembers),
             this.types.plus(otherWSDLTypeInfo.types),
-            this.namespacePrefixes.plus(otherWSDLTypeInfo.namespacePrefixes)
+            this.namespacePrefixes.plus(otherWSDLTypeInfo.namespacePrefixes),
+            this.wsdlTypeNamespace ?: otherWSDLTypeInfo.wsdlTypeNamespace,
+            this.wsdlTypeName ?: otherWSDLTypeInfo.wsdlTypeName,
+            this.wsdlBaseTypeNamespace ?: otherWSDLTypeInfo.wsdlBaseTypeNamespace,
+            this.wsdlBaseTypeName ?: otherWSDLTypeInfo.wsdlBaseTypeName,
         )
     }
 
@@ -39,7 +47,15 @@ data class WSDLTypeInfo(
 
     val xmlTypeData: XMLTypeData
         get() {
-            return XMLTypeData(TYPE_NODE_NAME, TYPE_NODE_NAME, nodes = effectiveMembers)
+            return XMLTypeData(
+                TYPE_NODE_NAME,
+                TYPE_NODE_NAME,
+                nodes = effectiveMembers,
+                wsdlTypeNamespace = wsdlTypeNamespace,
+                wsdlTypeName = wsdlTypeName,
+                wsdlBaseTypeNamespace = wsdlBaseTypeNamespace,
+                wsdlBaseTypeName = wsdlBaseTypeName,
+            )
         }
 
     private fun toPattern(xmlValue: XMLValue): Pattern {

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/message/ComplexElement.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/message/ComplexElement.kt
@@ -51,9 +51,8 @@ data class ComplexElement(val wsdlTypeReference: String, val element: XMLNode, v
         val childTypes = childTypeInfos.fold(existingTypes) { accumulated, childTypeInfo ->
             accumulated.plus(childTypeInfo.types)
         }
-        val childTypeInfosWithWSDLTypeMetadata = childTypeInfos.withWSDLTypeMetadata(
-            element.typeMetadataName(wsdl, wsdlTypeReference)
-        )
+        val wsdlType = element.typeMetadataName(wsdl, wsdlTypeReference)
+        val childTypeInfosWithWSDLTypeMetadata = childTypeInfos.withWSDLTypeMetadata(wsdlType)
         val resolvedPattern: Pattern = when (childTypeInfos.size) {
             1 -> XMLPattern(childTypeInfosWithWSDLTypeMetadata.single().xmlTypeData.copy(
                 attributes = attributePatterns,
@@ -77,9 +76,11 @@ data class ComplexElement(val wsdlTypeReference: String, val element: XMLNode, v
 
         return WSDLTypeInfo(
             listOf(inPlaceNode),
-            listOf(XMLPattern(inPlaceNode)),
+            listOf(XMLPattern(inPlaceNode).withWSDLTypeMetadata(wsdlType)),
             types,
-            namespaces
+            namespaces,
+            wsdlTypeNamespace = wsdlType?.namespace,
+            wsdlTypeName = wsdlType?.localName,
         )
     }
 
@@ -136,6 +137,14 @@ private fun WSDLTypeInfo.withTypeMetadata(wsdlType: FullyQualifiedName?): WSDLTy
         wsdlTypeName = wsdlType?.localName,
     )
 }
+
+private fun XMLPattern.withWSDLTypeMetadata(wsdlType: FullyQualifiedName?): XMLPattern =
+    copy(
+        pattern = pattern.copy(
+            wsdlTypeNamespace = wsdlType?.namespace,
+            wsdlTypeName = wsdlType?.localName,
+        )
+    )
 
 private fun XMLNode.typeMetadataName(wsdl: WSDL, wsdlTypeReference: String): FullyQualifiedName? {
     return when {

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/message/ComplexElement.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/message/ComplexElement.kt
@@ -168,7 +168,7 @@ private fun XMLNode.fullyQualifiedNameFromQNameOrNull(qName: String): FullyQuali
         null
     }
 
-private fun XMLNode.namedTypeFullyQualifiedName(wsdl: WSDL): FullyQualifiedName {
+internal fun XMLNode.namedTypeFullyQualifiedName(wsdl: WSDL): FullyQualifiedName {
     val namespace = schema?.attributes?.get("targetNamespace")?.toStringLiteral().orEmpty()
     val prefix = namespace.takeIf { it.isNotBlank() }?.let(wsdl::getSchemaNamespacePrefix).orEmpty()
     return FullyQualifiedName(prefix, namespace, getAttributeValue("name"))

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/message/ComplexElement.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/message/ComplexElement.kt
@@ -7,6 +7,7 @@ import io.specmatic.core.pattern.Pattern
 import io.specmatic.core.pattern.TYPE_ATTRIBUTE_NAME
 import io.specmatic.core.pattern.XMLPattern
 import io.specmatic.core.value.XMLNode
+import io.specmatic.core.value.FullyQualifiedName
 import io.specmatic.core.value.namespacePrefix
 import io.specmatic.core.value.toXMLNode
 import io.specmatic.core.wsdl.parser.SOAPMessageType
@@ -50,9 +51,25 @@ data class ComplexElement(val wsdlTypeReference: String, val element: XMLNode, v
         val childTypes = childTypeInfos.fold(existingTypes) { accumulated, childTypeInfo ->
             accumulated.plus(childTypeInfo.types)
         }
+        val childTypeInfosWithWSDLTypeMetadata = childTypeInfos.withWSDLTypeMetadata(
+            element.typeMetadataName(wsdl, wsdlTypeReference)
+        )
         val resolvedPattern: Pattern = when (childTypeInfos.size) {
-            1 -> XMLPattern(childTypeInfos.single().xmlTypeData.copy(attributes = attributePatterns, attributeWildcards = attributeWildcards, attributeNamespaceUris = attributeNamespaceUris))
-            else -> AnyPattern(pattern = childTypeInfos.map { XMLPattern(it.xmlTypeData.copy(attributes = attributePatterns, attributeWildcards = attributeWildcards, attributeNamespaceUris = attributeNamespaceUris)) }, extensions = emptyMap())
+            1 -> XMLPattern(childTypeInfosWithWSDLTypeMetadata.single().xmlTypeData.copy(
+                attributes = attributePatterns,
+                attributeWildcards = attributeWildcards,
+                attributeNamespaceUris = attributeNamespaceUris,
+            ))
+            else -> AnyPattern(
+                pattern = childTypeInfosWithWSDLTypeMetadata.map {
+                    XMLPattern(it.xmlTypeData.copy(
+                        attributes = attributePatterns,
+                        attributeWildcards = attributeWildcards,
+                        attributeNamespaceUris = attributeNamespaceUris,
+                    ))
+                },
+                extensions = emptyMap()
+            )
         }
         val types = childTypes.plus(specmaticTypeName to resolvedPattern)
 
@@ -108,6 +125,44 @@ data class ComplexElement(val wsdlTypeReference: String, val element: XMLNode, v
 
         return ComplexTypedSOAPPayload(soapMessageType, nodeNameForSOAPBody, specmaticTypeName, namespaces, complexType.getAttributes())
     }
+}
+
+private fun List<WSDLTypeInfo>.withWSDLTypeMetadata(wsdlType: FullyQualifiedName?): List<WSDLTypeInfo> =
+    map { it.withTypeMetadata(wsdlType) }
+
+private fun WSDLTypeInfo.withTypeMetadata(wsdlType: FullyQualifiedName?): WSDLTypeInfo {
+    return copy(
+        wsdlTypeNamespace = wsdlType?.namespace,
+        wsdlTypeName = wsdlType?.localName,
+    )
+}
+
+private fun XMLNode.typeMetadataName(wsdl: WSDL, wsdlTypeReference: String): FullyQualifiedName? {
+    return when {
+        name == "complexType" -> namedTypeFullyQualifiedName(wsdl)
+        attributes.containsKey("type") -> fullyQualifiedNameFromAttributeOrNull("type")
+        else -> fullyQualifiedNameFromQNameOrNull(wsdlTypeReference)
+    }
+}
+
+private fun XMLNode.fullyQualifiedNameFromAttributeOrNull(attributeName: String): FullyQualifiedName? =
+    try {
+        fullyQualifiedNameFromAttribute(attributeName)
+    } catch (e: ContractException) {
+        null
+    }
+
+private fun XMLNode.fullyQualifiedNameFromQNameOrNull(qName: String): FullyQualifiedName? =
+    try {
+        fullyQualifiedNameFromQName(qName)
+    } catch (e: ContractException) {
+        null
+    }
+
+private fun XMLNode.namedTypeFullyQualifiedName(wsdl: WSDL): FullyQualifiedName {
+    val namespace = schema?.attributes?.get("targetNamespace")?.toStringLiteral().orEmpty()
+    val prefix = namespace.takeIf { it.isNotBlank() }?.let(wsdl::getSchemaNamespacePrefix).orEmpty()
+    return FullyQualifiedName(prefix, namespace, getAttributeValue("name"))
 }
 
 data class ComplexType(val complexType: XMLNode, val wsdl: WSDL) {

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/message/ComplexTypeExtension.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/message/ComplexTypeExtension.kt
@@ -32,7 +32,7 @@ class ComplexTypeExtension(
         extension: XMLNode
     ): List<WSDLTypeInfo> {
         val parentComplexType = wsdl.findTypeFromAttribute(extension, "base")
-        val parentTypeVariants = generateChildren(parentTypeName, parentComplexType, existingTypes, typeStack, wsdl)
+        val parentTypeVariants = generateChildren(parentTypeName, parentComplexType.asComplexTypeNode(), existingTypes, typeStack, wsdl)
         val extensionChild = extension.childElementForDerivation()
 
         return wsdlTypeInfos.flatMap { current ->
@@ -46,7 +46,7 @@ class ComplexTypeExtension(
                     else -> listOf(combinedParent)
                 }
             }
-        }
+        }.withBaseTypeMetadata(extension)
     }
 
     private fun processRestriction(
@@ -58,15 +58,33 @@ class ComplexTypeExtension(
         wsdl.findTypeFromAttribute(restriction, "base")
 
         val restrictionChild = restriction.childElementForDerivation()
-        return when {
+        val restrictedTypeInfos = when {
             restrictionChild == null -> wsdlTypeInfos
             else -> combineVariants(
                 wsdlTypeInfos,
                 generateChildren(parentTypeName, restrictionChild, existingTypes, typeStack, wsdl)
             )
         }
+
+        return restrictedTypeInfos.withBaseTypeMetadata(restriction)
+    }
+
+    private fun XMLNode.asComplexTypeNode(): XMLNode =
+        when (name) {
+            "complexType" -> this
+            else -> wsdl.getComplexTypeNode(this).complexType
+        }
+}
+
+private fun List<WSDLTypeInfo>.withBaseTypeMetadata(derivation: XMLNode): List<WSDLTypeInfo> {
+    val baseType = derivation.resolvedBaseTypeName()
+    return map {
+        it.copy(wsdlBaseTypeNamespace = baseType?.namespace, wsdlBaseTypeName = baseType?.localName)
     }
 }
+
+private fun XMLNode.resolvedBaseTypeName() =
+    fullyQualifiedNameFromAttribute("base").takeIf { it.namespace.isNotBlank() }
 
 private fun XMLNode.findComplexContentDerivation(): XMLNode {
     return findFirstChildByName("extension")

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/message/SimpleContentDerivation.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/message/SimpleContentDerivation.kt
@@ -13,10 +13,13 @@ class SimpleContentDerivation(private var simpleContentNode: XMLNode, var wsdl: 
         typeStack: Set<String>
     ): List<WSDLTypeInfo> {
         val derivation = simpleContentNode.findSimpleContentDerivation()
+        val baseType = derivation.fullyQualifiedNameFromAttribute("base")
 
         val simpleTypeInfo = WSDLTypeInfo(
             nodes = listOf(simpleContentDerivationValue(derivation, wsdl)),
-            types = existingTypes
+            types = existingTypes,
+            wsdlBaseTypeNamespace = baseType.namespace,
+            wsdlBaseTypeName = baseType.localName,
         )
 
         return wsdlTypeInfos.map { it.plus(simpleTypeInfo) }

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/message/SimpleElement.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/message/SimpleElement.kt
@@ -23,12 +23,20 @@ data class SimpleElement(
     val simpleTypeNode: XMLNode? = null
 ) : WSDLElement {
     override fun deriveSpecmaticTypes(specmaticTypeName: String, existingTypes: Map<String, Pattern>, typeStack: Set<String>): WSDLTypeInfo {
-        return createSimpleTypeInfo(
+        val typeInfo = createSimpleTypeInfo(
             typeSourceNode = simpleTypeNode ?: element,
             wsdl = wsdl,
             existingTypes = existingTypes,
             actualElement = element
         )
+
+        return when {
+            (simpleTypeNode ?: element).name == "simpleType" -> {
+                val resolvedPattern = typeInfo.effectiveMembers.singleOrNull() ?: return typeInfo
+                typeInfo.copy(types = typeInfo.types.plus(specmaticTypeName to resolvedPattern))
+            }
+            else -> typeInfo
+        }
     }
 
     override fun getSOAPPayload(
@@ -107,9 +115,16 @@ fun createSimpleTypeInfo(
     val resolvedElement = actualElement ?: typeSourceNode
 
     val namespaceUri = resolvedElement.fullyQualifiedName(wsdl).namespace
-    return createSimpleType(typeSourceNode, wsdl, resolvedElement).let { (nodes, prefix) ->
-        toTypeInfo(nodes = nodes, existingTypes = existingTypes, prefix = prefix, namespaceUri = namespaceUri)
+    val typeInfo = createSimpleType(typeSourceNode, wsdl, resolvedElement).let { (nodes, prefix) ->
+        toTypeInfo(
+            nodes = nodes,
+            existingTypes = existingTypes,
+            prefix = prefix,
+            namespaceUri = namespaceUri,
+        )
     }
+
+    return typeInfo.withWSDLTypeMetadata(typeSourceNode, wsdl)
 }
 
 fun createSimpleType(element: XMLNode, wsdl: WSDL, actualElement: XMLNode? = null): Pair<List<XMLValue>, String?> {
@@ -124,15 +139,81 @@ fun createSimpleType(element: XMLNode, wsdl: WSDL, actualElement: XMLNode? = nul
     return Pair(listOf(XMLNode(fqname.qName, specmaticAttributes, listOf(value))), prefix)
 }
 
-private fun toTypeInfo(nodes: List<XMLValue>, existingTypes: Map<String, Pattern>, prefix: String?, namespaceUri: String? = null): WSDLTypeInfo {
+private fun toTypeInfo(
+    nodes: List<XMLValue>,
+    existingTypes: Map<String, Pattern>,
+    prefix: String?,
+    namespaceUri: String? = null,
+): WSDLTypeInfo {
     val members = nodes.map {
-        XMLPattern(it as XMLNode).plusNamespaceUri(namespaceUri)
+        XMLPattern(it as XMLNode)
+            .plusNamespaceUri(namespaceUri)
     }
 
     return if (prefix != null) {
-        WSDLTypeInfo(nodes = nodes, members = members, types = existingTypes, namespacePrefixes = setOf(prefix))
+        WSDLTypeInfo(
+            nodes = nodes,
+            members = members,
+            types = existingTypes,
+            namespacePrefixes = setOf(prefix),
+        )
     } else {
-        WSDLTypeInfo(nodes = nodes, members = members, types = existingTypes)
+        WSDLTypeInfo(
+            nodes = nodes,
+            members = members,
+            types = existingTypes,
+        )
+    }
+}
+
+private fun WSDLTypeInfo.withWSDLTypeMetadata(typeSourceNode: XMLNode, wsdl: WSDL): WSDLTypeInfo {
+    val wsdlType = typeSourceNode.typeMetadataName(wsdl)
+        ?.takeUnless { it.namespace == primitiveNamespace || (it.namespace.isBlank() && it.localName.isKnownPrimitiveType()) }
+    val baseType = typeSourceNode.baseTypeMetadataName()
+
+    return copy(
+        members = members.withWSDLTypeMetadata(wsdlType, baseType),
+        wsdlTypeNamespace = wsdlType?.namespace,
+        wsdlTypeName = wsdlType?.localName,
+        wsdlBaseTypeNamespace = baseType?.namespace,
+        wsdlBaseTypeName = baseType?.localName,
+    )
+}
+
+private fun List<Pattern>.withWSDLTypeMetadata(
+    wsdlType: FullyQualifiedName?,
+    baseType: FullyQualifiedName?
+): List<Pattern> =
+    map { pattern ->
+        when (pattern) {
+            is XMLPattern -> pattern.copy(
+                pattern = pattern.pattern.copy(
+                    wsdlTypeNamespace = wsdlType?.namespace,
+                    wsdlTypeName = wsdlType?.localName,
+                    wsdlBaseTypeNamespace = baseType?.namespace,
+                    wsdlBaseTypeName = baseType?.localName,
+                )
+            )
+            else -> pattern
+        }
+    }
+
+private fun XMLNode.typeMetadataName(wsdl: WSDL): FullyQualifiedName? {
+    return when (name) {
+        "simpleType" -> namedTypeFullyQualifiedName(wsdl)
+        else -> attributes["type"]?.let { simpleTypeQualifiedNameFromAttribute("type") }
+    }
+}
+
+private fun XMLNode.namedTypeFullyQualifiedName(wsdl: WSDL): FullyQualifiedName {
+    val namespace = schema?.attributes?.get("targetNamespace")?.toStringLiteral().orEmpty()
+    val prefix = namespace.takeIf { it.isNotBlank() }?.let(wsdl::getSchemaNamespacePrefix).orEmpty()
+    return FullyQualifiedName(prefix, namespace, getAttributeValue("name"))
+}
+
+private fun XMLNode.baseTypeMetadataName(): FullyQualifiedName? {
+    return restrictionNode(this)?.let { restriction ->
+        restriction.attributes["base"]?.let { restriction.simpleTypeQualifiedNameFromAttribute("base") }
     }
 }
 

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/message/SimpleElement.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/message/SimpleElement.kt
@@ -205,12 +205,6 @@ private fun XMLNode.typeMetadataName(wsdl: WSDL): FullyQualifiedName? {
     }
 }
 
-private fun XMLNode.namedTypeFullyQualifiedName(wsdl: WSDL): FullyQualifiedName {
-    val namespace = schema?.attributes?.get("targetNamespace")?.toStringLiteral().orEmpty()
-    val prefix = namespace.takeIf { it.isNotBlank() }?.let(wsdl::getSchemaNamespacePrefix).orEmpty()
-    return FullyQualifiedName(prefix, namespace, getAttributeValue("name"))
-}
-
 private fun XMLNode.baseTypeMetadataName(): FullyQualifiedName? {
     return restrictionNode(this)?.let { restriction ->
         restriction.attributes["base"]?.let { restriction.simpleTypeQualifiedNameFromAttribute("base") }

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/message/TypeReference.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/message/TypeReference.kt
@@ -3,11 +3,12 @@ package io.specmatic.core.wsdl.parser.message
 import io.specmatic.core.value.XMLNode
 import io.specmatic.core.wsdl.parser.WSDL
 import io.specmatic.core.wsdl.parser.hasSimpleTypeAttribute
+import io.specmatic.core.wsdl.parser.specmaticTypeName as toSpecmaticTypeName
 
 data class TypeReference(val child: XMLNode, val wsdl: WSDL): ChildElementType {
     override fun getWSDLElement(): Pair<String, WSDLElement> {
         val wsdlTypeReference = child.attributes.getValue("type").toStringLiteral()
-        val specmaticTypeName = wsdlTypeReference.replace(':', '_')
+        val specmaticTypeName = toSpecmaticTypeName(wsdlTypeReference)
 
         val element = when {
             hasSimpleTypeAttribute(child) -> SimpleElement(wsdlTypeReference, child, wsdl)

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/payload/EmptySOAPPayload.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/payload/EmptySOAPPayload.kt
@@ -20,5 +20,5 @@ data class EmptySOAPPayload(private val soapMessageType: SOAPMessageType): SOAPP
 internal fun emptySoapMessage(): XMLNode {
     val payload = soapSkeleton(emptyMap())
     val bodyNode = toXMLNode("<soapenv:Body/>")
-    return payload.copy(childNodes = payload.childNodes.plus(bodyNode))
+    return payload.withChildNodes(payload.childNodes.plus(bodyNode))
 }

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/payload/SoapMessage.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/payload/SoapMessage.kt
@@ -1,9 +1,8 @@
 package io.specmatic.core.wsdl.payload
 
 import io.specmatic.core.value.XMLNode
+import io.specmatic.core.value.XMLValue
 import io.specmatic.core.value.toXMLNode
-import io.specmatic.core.wsdl.parser.message.OCCURS_ATTRIBUTE_NAME
-import io.specmatic.core.wsdl.parser.message.OPTIONAL_ATTRIBUTE_VALUE
 import io.specmatic.core.wsdl.parser.message.primitiveNamespace
 
 fun soapMessage(bodyPayload: XMLNode, namespaces: Map<String, String>, headers: RequestHeaders): XMLNode {
@@ -17,7 +16,7 @@ fun soapMessage(bodyPayload: XMLNode, namespaces: Map<String, String>, headers: 
 
     val payloadNodes = listOfNotNull(headerNode, bodyNode)
 
-    return payload.copy(childNodes = payload.childNodes.plus(payloadNodes))
+    return payload.withChildNodes(payload.childNodes.plus(payloadNodes))
 }
 
 internal fun soapSkeleton(namespaces: Map<String, String>): XMLNode {
@@ -33,4 +32,8 @@ internal fun soapSkeleton(namespaces: Map<String, String>): XMLNode {
         """
             <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="$primitiveNamespace"$namespacesString></soapenv:Envelope>
         """)
+}
+
+internal fun XMLNode.withChildNodes(childNodes: List<XMLValue>): XMLNode {
+    return XMLNode(realName, attributes, childNodes, inheritNamespacesInChildren = true)
 }

--- a/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
+++ b/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
@@ -1573,9 +1573,11 @@ class LoadTestsFromExternalisedFiles {
             @Test
             fun `should complain when discriminator is present but invalid`() {
                 Flags.using(EXAMPLE_DIRECTORIES to exampleWithInvalidDisc.canonicalPath) {
-                    val feature = parseContractFileToFeature(discriminatorSpecFile).copy(strictMode = true).loadExternalisedExamples()
-                    val filteredFeature = feature.copy(scenarios = feature.scenarios.filter { it.method == "POST" })
-                    val exception = assertThrows<ContractException> { filteredFeature.validateExamplesOrException() }
+                    val exception = assertThrows<ContractException> {
+                        val feature = parseContractFileToFeature(discriminatorSpecFile).copy(strictMode = true).loadExternalisedExamples()
+                        val filteredFeature = feature.copy(scenarios = feature.scenarios.filter { it.method == "POST" })
+                        filteredFeature.validateExamplesOrException()
+                    }
 
                     assertThat(exception.report()).contains(
                         "Error loading example for POST /pets -> 201 from ${exampleWithInvalidDisc.resolve("partial_example.json").canonicalPath}",

--- a/core/src/test/kotlin/io/specmatic/conversions/WSDLConversionTests.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/WSDLConversionTests.kt
@@ -230,17 +230,29 @@ class WSDLConversionTests {
         Feature: simpleService
 
             Scenario: SimpleOperation
+                Given type SimpleOperation_SOAPPayload_Input
+                ""${'"'}
+                <SimpleRequest>(string) maxLength 1)</SimpleRequest>
+                ""${'"'}
                 When POST /SOAPService/SimpleSOAP
                 And enum SoapAction (string) values "http://specmatic.io/SOAPService/SimpleOperation",http://specmatic.io/SOAPService/SimpleOperation
                 And request-header SOAPAction (SoapAction)
                 And request-body
                 ""${'"'}
-                <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soapenv:Body><SimpleRequest>(string) maxLength 1)</SimpleRequest></soapenv:Body></soapenv:Envelope>
+                <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+                  <soapenv:Body>
+                    <SimpleRequest>(string) maxLength 1)</SimpleRequest>
+                  </soapenv:Body>
+                </soapenv:Envelope>
                 ""${'"'}
                 Then status 200
                 And response-body
                 ""${'"'}
-                <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soapenv:Body><SimpleResponse>(string)</SimpleResponse></soapenv:Body></soapenv:Envelope>
+                <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+                  <soapenv:Body>
+                    <SimpleResponse>(string)</SimpleResponse>
+                  </soapenv:Body>
+                </soapenv:Envelope>
                 ""${'"'}
         """.trimIndent().trim()
 

--- a/core/src/test/kotlin/io/specmatic/conversions/WsdlSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/WsdlSpecificationTest.kt
@@ -69,4 +69,407 @@ internal class WsdlSpecificationTest {
             assertThat(response.contentType()).isEqualTo("application/soap+xml")
         }
     }
+
+    @Test
+    fun `request matching uses compatible xsi type from wsdl complex type extension`() {
+        val wsdlContract = wsdlContentToFeature(animalWsdl(), "animal.wsdl")
+        val scenario = wsdlContract.scenarios.single()
+
+        assertThat(scenario.resolver.newPatterns.keys).contains("(tns_Dog)", "(tns_Vehicle)")
+
+        val dogRequest = animalRequest(
+            """
+            <tns:Animal xmlns:tns="http://example.com/animals"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xsi:type="tns:Dog">
+              <tns:name>Fido</tns:name>
+              <tns:breed>Beagle</tns:breed>
+            </tns:Animal>
+            """.trimIndent()
+        )
+        val vehicleRequest = animalRequest(
+            """
+            <tns:Animal xmlns:tns="http://example.com/animals"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xsi:type="tns:Vehicle">
+              <tns:registration>KA01AB1234</tns:registration>
+            </tns:Animal>
+            """.trimIndent()
+        )
+
+        assertThat(scenario.httpRequestPattern.matches(dogRequest, scenario.resolver)).isInstanceOf(Result.Success::class.java)
+        assertThat(scenario.httpRequestPattern.matches(vehicleRequest, scenario.resolver)).isInstanceOf(Result.Failure::class.java)
+    }
+
+    @Test
+    fun `request matching uses compatible xsi type from wsdl simple type restriction`() {
+        val wsdlContract = wsdlContentToFeature(codeWsdl(), "code.wsdl")
+        val scenario = wsdlContract.scenarios.single()
+
+        val validRequest = codeRequest(
+            """
+            <tns:Code xmlns:tns="http://example.com/codes"
+                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                      xsi:type="tns:ConstrainedCode">ABC123</tns:Code>
+            """.trimIndent()
+        )
+
+        assertThat(scenario.httpRequestPattern.matches(validRequest, scenario.resolver)).isInstanceOf(Result.Success::class.java)
+    }
+
+    @Test
+    fun `request matching uses compatible xsi type from wsdl simple content extension`() {
+        val wsdlContract = wsdlContentToFeature(taggedCodeWsdl(), "tagged-code.wsdl")
+        val scenario = wsdlContract.scenarios.single()
+
+        val validRequest = taggedCodeRequest(
+            """
+            <tns:Code xmlns:tns="http://example.com/tagged-codes"
+                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                      xsi:type="tns:TaggedCode"
+                      tag="primary">ABC123</tns:Code>
+            """.trimIndent()
+        )
+
+        assertThat(scenario.httpRequestPattern.matches(validRequest, scenario.resolver)).isInstanceOf(Result.Success::class.java)
+    }
+
+    @Test
+    fun `request matching allows valid repeated sibling nodes from wsdl sequence`() {
+        val wsdlContract = wsdlContentToFeature(peopleWsdl(), "people.wsdl")
+        val scenario = wsdlContract.scenarios.single()
+
+        val payloads = listOf(
+            "<tns:employee><tns:name>Ada</tns:name></tns:employee><tns:employee><tns:name>Grace</tns:name></tns:employee>",
+            "<tns:manager><tns:name>Linus</tns:name></tns:manager><tns:manager><tns:name>Margaret</tns:name></tns:manager>",
+            "<tns:employee><tns:name>Ada</tns:name></tns:employee><tns:manager><tns:name>Linus</tns:name></tns:manager>",
+            "<tns:employee><tns:name>Ada</tns:name></tns:employee><tns:employee><tns:name>Grace</tns:name></tns:employee><tns:manager><tns:name>Linus</tns:name></tns:manager>",
+            "<tns:employee><tns:name>Ada</tns:name></tns:employee><tns:manager><tns:name>Linus</tns:name></tns:manager><tns:manager><tns:name>Margaret</tns:name></tns:manager>",
+            "<tns:employee><tns:name>Ada</tns:name></tns:employee><tns:employee><tns:name>Grace</tns:name></tns:employee><tns:manager><tns:name>Linus</tns:name></tns:manager><tns:manager><tns:name>Margaret</tns:name></tns:manager>",
+        )
+
+        assertThat(payloads).allSatisfy { payload ->
+            assertThat(scenario.httpRequestPattern.matches(peopleRequest(payload), scenario.resolver))
+                .isInstanceOf(Result.Success::class.java)
+        }
+    }
+
+    private fun animalRequest(bodyNode: String): HttpRequest {
+        return HttpRequest(
+            method = "POST",
+            path = "/animals",
+            headers = mapOf("SOAPAction" to "\"http://example.com/animals/SubmitAnimal\""),
+            body = StringValue(
+                """
+                <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+                                  xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+                  <soapenv:Header/>
+                  <soapenv:Body>
+                    $bodyNode
+                  </soapenv:Body>
+                </soapenv:Envelope>
+                """.trimIndent()
+            )
+        )
+    }
+
+    private fun codeRequest(bodyNode: String): HttpRequest {
+        return soapRequest(
+            path = "/codes",
+            soapAction = "http://example.com/codes/SubmitCode",
+            bodyNode = bodyNode
+        )
+    }
+
+    private fun taggedCodeRequest(bodyNode: String): HttpRequest {
+        return soapRequest(
+            path = "/tagged-codes",
+            soapAction = "http://example.com/tagged-codes/SubmitCode",
+            bodyNode = bodyNode
+        )
+    }
+
+    private fun peopleRequest(bodyNodes: String): HttpRequest {
+        return soapRequest(
+            path = "/people",
+            soapAction = "http://example.com/people/SubmitPeople",
+            bodyNode = """
+                <tns:people xmlns:tns="http://example.com/people">
+                  $bodyNodes
+                </tns:people>
+            """.trimIndent()
+        )
+    }
+
+    private fun soapRequest(path: String, soapAction: String, bodyNode: String): HttpRequest {
+        return HttpRequest(
+            method = "POST",
+            path = path,
+            headers = mapOf("SOAPAction" to "\"$soapAction\""),
+            body = StringValue(
+                """
+                <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+                                  xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+                  <soapenv:Header/>
+                  <soapenv:Body>
+                    $bodyNode
+                  </soapenv:Body>
+                </soapenv:Envelope>
+                """.trimIndent()
+            )
+        )
+    }
+
+    private fun animalWsdl(): String {
+        return """
+            <wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                              xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                              xmlns:tns="http://example.com/animals"
+                              targetNamespace="http://example.com/animals">
+              <wsdl:types>
+                <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                           xmlns:tns="http://example.com/animals"
+                           targetNamespace="http://example.com/animals"
+                           elementFormDefault="qualified">
+                  <xs:element name="Animal" type="tns:Animal"/>
+                  <xs:element name="AnimalResponse" type="xs:string"/>
+
+                  <xs:complexType name="Animal">
+                    <xs:sequence>
+                      <xs:element name="name" type="xs:string"/>
+                    </xs:sequence>
+                  </xs:complexType>
+
+                  <xs:complexType name="Dog">
+                    <xs:complexContent>
+                      <xs:extension base="tns:Animal">
+                        <xs:sequence>
+                          <xs:element name="breed" type="xs:string"/>
+                        </xs:sequence>
+                      </xs:extension>
+                    </xs:complexContent>
+                  </xs:complexType>
+
+                  <xs:complexType name="Vehicle">
+                    <xs:sequence>
+                      <xs:element name="registration" type="xs:string"/>
+                    </xs:sequence>
+                  </xs:complexType>
+                </xs:schema>
+              </wsdl:types>
+
+              <wsdl:message name="submitAnimalInput">
+                <wsdl:part name="animal" element="tns:Animal"/>
+              </wsdl:message>
+              <wsdl:message name="submitAnimalOutput">
+                <wsdl:part name="animalResponse" element="tns:AnimalResponse"/>
+              </wsdl:message>
+
+              <wsdl:portType name="AnimalPortType">
+                <wsdl:operation name="SubmitAnimal">
+                  <wsdl:input message="tns:submitAnimalInput"/>
+                  <wsdl:output message="tns:submitAnimalOutput"/>
+                </wsdl:operation>
+              </wsdl:portType>
+
+              <wsdl:binding name="AnimalBinding" type="tns:AnimalPortType">
+                <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+                <wsdl:operation name="SubmitAnimal">
+                  <soap:operation soapAction="http://example.com/animals/SubmitAnimal"/>
+                  <wsdl:input><soap:body use="literal"/></wsdl:input>
+                  <wsdl:output><soap:body use="literal"/></wsdl:output>
+                </wsdl:operation>
+              </wsdl:binding>
+
+              <wsdl:service name="AnimalService">
+                <wsdl:port name="AnimalPort" binding="tns:AnimalBinding">
+                  <soap:address location="http://localhost/animals"/>
+                </wsdl:port>
+              </wsdl:service>
+            </wsdl:definitions>
+        """.trimIndent()
+    }
+
+    private fun codeWsdl(): String {
+        return """
+            <wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                              xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                              xmlns:tns="http://example.com/codes"
+                              targetNamespace="http://example.com/codes">
+              <wsdl:types>
+                <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                           xmlns:tns="http://example.com/codes"
+                           targetNamespace="http://example.com/codes"
+                           elementFormDefault="qualified">
+                  <xs:element name="Code" type="tns:BaseCode"/>
+                  <xs:element name="CodeResponse" type="xs:string"/>
+
+                  <xs:simpleType name="BaseCode">
+                    <xs:restriction base="xs:string"/>
+                  </xs:simpleType>
+
+                  <xs:simpleType name="ConstrainedCode">
+                    <xs:restriction base="tns:BaseCode">
+                      <xs:minLength value="6"/>
+                      <xs:maxLength value="12"/>
+                      <xs:pattern value="[A-Z0-9]+"/>
+                    </xs:restriction>
+                  </xs:simpleType>
+                </xs:schema>
+              </wsdl:types>
+
+              <wsdl:message name="submitCodeInput">
+                <wsdl:part name="code" element="tns:Code"/>
+              </wsdl:message>
+              <wsdl:message name="submitCodeOutput">
+                <wsdl:part name="codeResponse" element="tns:CodeResponse"/>
+              </wsdl:message>
+
+              <wsdl:portType name="CodePortType">
+                <wsdl:operation name="SubmitCode">
+                  <wsdl:input message="tns:submitCodeInput"/>
+                  <wsdl:output message="tns:submitCodeOutput"/>
+                </wsdl:operation>
+              </wsdl:portType>
+
+              <wsdl:binding name="CodeBinding" type="tns:CodePortType">
+                <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+                <wsdl:operation name="SubmitCode">
+                  <soap:operation soapAction="http://example.com/codes/SubmitCode"/>
+                  <wsdl:input><soap:body use="literal"/></wsdl:input>
+                  <wsdl:output><soap:body use="literal"/></wsdl:output>
+                </wsdl:operation>
+              </wsdl:binding>
+
+              <wsdl:service name="CodeService">
+                <wsdl:port name="CodePort" binding="tns:CodeBinding">
+                  <soap:address location="http://localhost/codes"/>
+                </wsdl:port>
+              </wsdl:service>
+            </wsdl:definitions>
+        """.trimIndent()
+    }
+
+    private fun taggedCodeWsdl(): String {
+        return """
+            <wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                              xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                              xmlns:tns="http://example.com/tagged-codes"
+                              targetNamespace="http://example.com/tagged-codes">
+              <wsdl:types>
+                <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                           xmlns:tns="http://example.com/tagged-codes"
+                           targetNamespace="http://example.com/tagged-codes"
+                           elementFormDefault="qualified">
+                  <xs:element name="Code" type="tns:BaseCode"/>
+                  <xs:element name="CodeResponse" type="xs:string"/>
+
+                  <xs:complexType name="BaseCode">
+                    <xs:simpleContent>
+                      <xs:extension base="xs:string"/>
+                    </xs:simpleContent>
+                  </xs:complexType>
+
+                  <xs:complexType name="TaggedCode">
+                    <xs:simpleContent>
+                      <xs:extension base="tns:BaseCode">
+                        <xs:attribute name="tag" type="xs:string" use="required"/>
+                      </xs:extension>
+                    </xs:simpleContent>
+                  </xs:complexType>
+                </xs:schema>
+              </wsdl:types>
+
+              <wsdl:message name="submitCodeInput">
+                <wsdl:part name="code" element="tns:Code"/>
+              </wsdl:message>
+              <wsdl:message name="submitCodeOutput">
+                <wsdl:part name="codeResponse" element="tns:CodeResponse"/>
+              </wsdl:message>
+
+              <wsdl:portType name="CodePortType">
+                <wsdl:operation name="SubmitCode">
+                  <wsdl:input message="tns:submitCodeInput"/>
+                  <wsdl:output message="tns:submitCodeOutput"/>
+                </wsdl:operation>
+              </wsdl:portType>
+
+              <wsdl:binding name="CodeBinding" type="tns:CodePortType">
+                <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+                <wsdl:operation name="SubmitCode">
+                  <soap:operation soapAction="http://example.com/tagged-codes/SubmitCode"/>
+                  <wsdl:input><soap:body use="literal"/></wsdl:input>
+                  <wsdl:output><soap:body use="literal"/></wsdl:output>
+                </wsdl:operation>
+              </wsdl:binding>
+
+              <wsdl:service name="CodeService">
+                <wsdl:port name="CodePort" binding="tns:CodeBinding">
+                  <soap:address location="http://localhost/tagged-codes"/>
+                </wsdl:port>
+              </wsdl:service>
+            </wsdl:definitions>
+        """.trimIndent()
+    }
+
+    private fun peopleWsdl(): String {
+        return """
+            <wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                              xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                              xmlns:tns="http://example.com/people"
+                              targetNamespace="http://example.com/people">
+              <wsdl:types>
+                <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                           xmlns:tns="http://example.com/people"
+                           targetNamespace="http://example.com/people"
+                           elementFormDefault="qualified">
+                  <xs:element name="people" type="tns:People"/>
+                  <xs:element name="peopleResponse" type="xs:string"/>
+
+                  <xs:complexType name="Person">
+                    <xs:sequence>
+                      <xs:element name="name" type="xs:string"/>
+                    </xs:sequence>
+                  </xs:complexType>
+
+                  <xs:complexType name="People">
+                    <xs:sequence>
+                      <xs:element name="employee" type="tns:Person" minOccurs="0" maxOccurs="unbounded"/>
+                      <xs:element name="manager" type="tns:Person" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                  </xs:complexType>
+                </xs:schema>
+              </wsdl:types>
+
+              <wsdl:message name="submitPeopleInput">
+                <wsdl:part name="people" element="tns:people"/>
+              </wsdl:message>
+              <wsdl:message name="submitPeopleOutput">
+                <wsdl:part name="peopleResponse" element="tns:peopleResponse"/>
+              </wsdl:message>
+
+              <wsdl:portType name="PeoplePortType">
+                <wsdl:operation name="SubmitPeople">
+                  <wsdl:input message="tns:submitPeopleInput"/>
+                  <wsdl:output message="tns:submitPeopleOutput"/>
+                </wsdl:operation>
+              </wsdl:portType>
+
+              <wsdl:binding name="PeopleBinding" type="tns:PeoplePortType">
+                <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+                <wsdl:operation name="SubmitPeople">
+                  <soap:operation soapAction="http://example.com/people/SubmitPeople"/>
+                  <wsdl:input><soap:body use="literal"/></wsdl:input>
+                  <wsdl:output><soap:body use="literal"/></wsdl:output>
+                </wsdl:operation>
+              </wsdl:binding>
+
+              <wsdl:service name="PeopleService">
+                <wsdl:port name="PeoplePort" binding="tns:PeopleBinding">
+                  <soap:address location="http://localhost/people"/>
+                </wsdl:port>
+              </wsdl:service>
+            </wsdl:definitions>
+        """.trimIndent()
+    }
 }

--- a/core/src/test/kotlin/io/specmatic/conversions/WsdlSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/WsdlSpecificationTest.kt
@@ -87,6 +87,16 @@ internal class WsdlSpecificationTest {
             </tns:Animal>
             """.trimIndent()
         )
+        val dogRequestWithAlternateSchemaInstancePrefix = animalRequest(
+            """
+            <tns:Animal xmlns:tns="http://example.com/animals"
+                        xmlns:typeNs="http://www.w3.org/2001/XMLSchema-instance"
+                        typeNs:type="tns:Dog">
+              <tns:name>Fido</tns:name>
+              <tns:breed>Beagle</tns:breed>
+            </tns:Animal>
+            """.trimIndent()
+        )
         val vehicleRequest = animalRequest(
             """
             <tns:Animal xmlns:tns="http://example.com/animals"
@@ -98,6 +108,7 @@ internal class WsdlSpecificationTest {
         )
 
         assertThat(scenario.httpRequestPattern.matches(dogRequest, scenario.resolver)).isInstanceOf(Result.Success::class.java)
+        assertThat(scenario.httpRequestPattern.matches(dogRequestWithAlternateSchemaInstancePrefix, scenario.resolver)).isInstanceOf(Result.Success::class.java)
         assertThat(scenario.httpRequestPattern.matches(vehicleRequest, scenario.resolver)).isInstanceOf(Result.Failure::class.java)
     }
 

--- a/core/src/test/kotlin/io/specmatic/conversions/WsdlSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/WsdlSpecificationTest.kt
@@ -113,6 +113,44 @@ internal class WsdlSpecificationTest {
     }
 
     @Test
+    fun `request matching rejects unknown xsi type even when wsdl has no derived types`() {
+        val wsdlContract = wsdlContentToFeature(animalWithoutDerivedTypesWsdl(), "animal-without-derived-types.wsdl")
+        val scenario = wsdlContract.scenarios.single()
+
+        val result = scenario.httpRequestPattern.matches(
+            animalRequest(
+                """
+                <tns:Animal xmlns:tns="http://example.com/animals"
+                            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                            xsi:type="tns:MissingAnimal">
+                  <tns:name>Leo</tns:name>
+                </tns:Animal>
+                """.trimIndent()
+            ),
+            scenario.resolver
+        )
+
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
+        assertThat(result.reportString()).contains("Unknown xsi:type")
+        assertThat(result.reportString()).contains("MissingAnimal")
+    }
+
+    @Test
+    fun `request generation uses wsdl leaf type from imported schema namespace`() {
+        val wsdlContract = wsdlContentToFeature(orderWithCrossNamespaceModelWsdl(), "order-service.wsdl")
+
+        val generatedBodies = wsdlContract.scenarios.single()
+            .generateTestScenarios(wsdlContract.flagsBased)
+            .map { it.value.generateHttpRequest(wsdlContract.flagsBased).body.toStringLiteral() }
+            .toList()
+
+        assertThat(generatedBodies).anySatisfy { body ->
+            assertThat(body).contains("xsi:type=\"Order-model:OnlineOrder\"")
+            assertThat(body).contains("<Order-model:channel>")
+        }
+    }
+
+    @Test
     fun `request matching uses compatible xsi type from wsdl simple type restriction`() {
         val wsdlContract = wsdlContentToFeature(codeWsdl(), "code.wsdl")
         val scenario = wsdlContract.scenarios.single()
@@ -428,6 +466,137 @@ internal class WsdlSpecificationTest {
               <wsdl:service name="AnimalService">
                 <wsdl:port name="AnimalPort" binding="tns:AnimalBinding">
                   <soap:address location="http://localhost/animals"/>
+                </wsdl:port>
+              </wsdl:service>
+            </wsdl:definitions>
+        """.trimIndent()
+    }
+
+    private fun animalWithoutDerivedTypesWsdl(): String {
+        return """
+            <wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                              xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                              xmlns:tns="http://example.com/animals"
+                              targetNamespace="http://example.com/animals">
+              <wsdl:types>
+                <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                           xmlns:tns="http://example.com/animals"
+                           targetNamespace="http://example.com/animals"
+                           elementFormDefault="qualified">
+                  <xs:element name="Animal" type="tns:Animal"/>
+                  <xs:element name="AnimalResponse" type="xs:string"/>
+
+                  <xs:complexType name="Animal">
+                    <xs:sequence>
+                      <xs:element name="name" type="xs:string"/>
+                    </xs:sequence>
+                  </xs:complexType>
+                </xs:schema>
+              </wsdl:types>
+
+              <wsdl:message name="submitAnimalInput">
+                <wsdl:part name="animal" element="tns:Animal"/>
+              </wsdl:message>
+              <wsdl:message name="submitAnimalOutput">
+                <wsdl:part name="animalResponse" element="tns:AnimalResponse"/>
+              </wsdl:message>
+
+              <wsdl:portType name="AnimalPortType">
+                <wsdl:operation name="SubmitAnimal">
+                  <wsdl:input message="tns:submitAnimalInput"/>
+                  <wsdl:output message="tns:submitAnimalOutput"/>
+                </wsdl:operation>
+              </wsdl:portType>
+
+              <wsdl:binding name="AnimalBinding" type="tns:AnimalPortType">
+                <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+                <wsdl:operation name="SubmitAnimal">
+                  <soap:operation soapAction="http://example.com/animals/SubmitAnimal"/>
+                  <wsdl:input><soap:body use="literal"/></wsdl:input>
+                  <wsdl:output><soap:body use="literal"/></wsdl:output>
+                </wsdl:operation>
+              </wsdl:binding>
+
+              <wsdl:service name="AnimalService">
+                <wsdl:port name="AnimalPort" binding="tns:AnimalBinding">
+                  <soap:address location="http://localhost/animals"/>
+                </wsdl:port>
+              </wsdl:service>
+            </wsdl:definitions>
+        """.trimIndent()
+    }
+
+    private fun orderWithCrossNamespaceModelWsdl(): String {
+        return """
+            <wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                              xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                              xmlns:svc="http://example.com/order-service"
+                              xmlns:model="http://example.com/order-model"
+                              targetNamespace="http://example.com/order-service">
+              <wsdl:types>
+                <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                           xmlns:svc="http://example.com/order-service"
+                           xmlns:model="http://example.com/order-model"
+                           targetNamespace="http://example.com/order-service"
+                           elementFormDefault="qualified">
+                  <xs:element name="SubmitOrder" type="svc:SubmitOrderRequest"/>
+                  <xs:element name="SubmitOrderResponse" type="xs:string"/>
+
+                  <xs:complexType name="SubmitOrderRequest">
+                    <xs:sequence>
+                      <xs:element name="order" type="model:Order"/>
+                    </xs:sequence>
+                  </xs:complexType>
+                </xs:schema>
+
+                <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                           xmlns:model="http://example.com/order-model"
+                           targetNamespace="http://example.com/order-model"
+                           elementFormDefault="qualified">
+                  <xs:complexType name="Order">
+                    <xs:sequence>
+                      <xs:element name="orderNumber" type="xs:string"/>
+                    </xs:sequence>
+                  </xs:complexType>
+
+                  <xs:complexType name="OnlineOrder">
+                    <xs:complexContent>
+                      <xs:extension base="model:Order">
+                        <xs:sequence>
+                          <xs:element name="channel" type="xs:string"/>
+                        </xs:sequence>
+                      </xs:extension>
+                    </xs:complexContent>
+                  </xs:complexType>
+                </xs:schema>
+              </wsdl:types>
+
+              <wsdl:message name="submitOrderInput">
+                <wsdl:part name="request" element="svc:SubmitOrder"/>
+              </wsdl:message>
+              <wsdl:message name="submitOrderOutput">
+                <wsdl:part name="response" element="svc:SubmitOrderResponse"/>
+              </wsdl:message>
+
+              <wsdl:portType name="OrderPortType">
+                <wsdl:operation name="SubmitOrder">
+                  <wsdl:input message="svc:submitOrderInput"/>
+                  <wsdl:output message="svc:submitOrderOutput"/>
+                </wsdl:operation>
+              </wsdl:portType>
+
+              <wsdl:binding name="OrderBinding" type="svc:OrderPortType">
+                <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+                <wsdl:operation name="SubmitOrder">
+                  <soap:operation soapAction="http://example.com/order-service/SubmitOrder"/>
+                  <wsdl:input><soap:body use="literal"/></wsdl:input>
+                  <wsdl:output><soap:body use="literal"/></wsdl:output>
+                </wsdl:operation>
+              </wsdl:binding>
+
+              <wsdl:service name="OrderService">
+                <wsdl:port name="OrderPort" binding="svc:OrderBinding">
+                  <soap:address location="http://localhost/order-service"/>
                 </wsdl:port>
               </wsdl:service>
             </wsdl:definitions>

--- a/core/src/test/kotlin/io/specmatic/conversions/WsdlSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/WsdlSpecificationTest.kt
@@ -165,6 +165,139 @@ internal class WsdlSpecificationTest {
         }
     }
 
+    @Test
+    fun `request matching uses compatible xsi type inside wsdl choice group`() {
+        val wsdlContract = wsdlContentToFeature(petChoiceWsdl(), "pet-choice.wsdl")
+        val scenario = wsdlContract.scenarios.single()
+
+        val result = scenario.httpRequestPattern.matches(
+            soapRequest(
+                path = "/pet-choice",
+                soapAction = "http://example.com/pet-choice/RegisterChoice",
+                bodyNode = """
+                    <tns:RegisterChoice xmlns:tns="http://example.com/pet-choice"
+                                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                      <tns:pet xsi:type="tns:Dog">
+                        <tns:name>Rover</tns:name>
+                        <tns:breed>Labrador</tns:breed>
+                      </tns:pet>
+                    </tns:RegisterChoice>
+                """.trimIndent()
+            ),
+            scenario.resolver
+        )
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+    }
+
+    @Test
+    fun `request matching rejects incompatible known xsi type inside wsdl choice group`() {
+        val wsdlContract = wsdlContentToFeature(petChoiceWsdl(), "pet-choice.wsdl")
+        val scenario = wsdlContract.scenarios.single()
+
+        val result = scenario.httpRequestPattern.matches(
+            soapRequest(
+                path = "/pet-choice",
+                soapAction = "http://example.com/pet-choice/RegisterChoice",
+                bodyNode = """
+                    <tns:RegisterChoice xmlns:tns="http://example.com/pet-choice"
+                                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                      <tns:pet xsi:type="tns:Crocodile">
+                        <tns:toothCount>64</tns:toothCount>
+                      </tns:pet>
+                    </tns:RegisterChoice>
+                """.trimIndent()
+            ),
+            scenario.resolver
+        )
+
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
+        assertThat(result.reportString()).contains("Invalid xsi:type")
+        assertThat(result.reportString()).contains("Crocodile")
+        assertThat(result.reportString()).contains("Pet")
+    }
+
+    @Test
+    fun `request matching uses compatible xsi type inside nested wsdl sequence`() {
+        val wsdlContract = wsdlContentToFeature(petNestedSequenceWsdl(), "pet-nested-sequence.wsdl")
+        val scenario = wsdlContract.scenarios.single()
+
+        val result = scenario.httpRequestPattern.matches(
+            soapRequest(
+                path = "/pet-nested-sequence",
+                soapAction = "http://example.com/pet-nested-sequence/RegisterNestedSequence",
+                bodyNode = """
+                    <tns:RegisterNestedSequence xmlns:tns="http://example.com/pet-nested-sequence"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                      <tns:payload>
+                        <tns:pet xsi:type="tns:Dog">
+                          <tns:name>Rover</tns:name>
+                          <tns:breed>Labrador</tns:breed>
+                        </tns:pet>
+                      </tns:payload>
+                    </tns:RegisterNestedSequence>
+                """.trimIndent()
+            ),
+            scenario.resolver
+        )
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+    }
+
+    @Test
+    fun `request matching rejects incompatible known xsi type inside nested wsdl sequence`() {
+        val wsdlContract = wsdlContentToFeature(petNestedSequenceWsdl(), "pet-nested-sequence.wsdl")
+        val scenario = wsdlContract.scenarios.single()
+
+        val result = scenario.httpRequestPattern.matches(
+            soapRequest(
+                path = "/pet-nested-sequence",
+                soapAction = "http://example.com/pet-nested-sequence/RegisterNestedSequence",
+                bodyNode = """
+                    <tns:RegisterNestedSequence xmlns:tns="http://example.com/pet-nested-sequence"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                      <tns:payload>
+                        <tns:pet xsi:type="tns:Crocodile">
+                          <tns:toothCount>64</tns:toothCount>
+                        </tns:pet>
+                      </tns:payload>
+                    </tns:RegisterNestedSequence>
+                """.trimIndent()
+            ),
+            scenario.resolver
+        )
+
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
+        assertThat(result.reportString()).contains("Invalid xsi:type")
+        assertThat(result.reportString()).contains("Crocodile")
+        assertThat(result.reportString()).contains("Pet")
+    }
+
+    @Test
+    fun `request matching keeps wsdl wildcard behavior independent of xsi type inheritance`() {
+        val wsdlContract = wsdlContentToFeature(petWildcardWsdl(), "pet-wildcard.wsdl")
+        val scenario = wsdlContract.scenarios.single()
+
+        val result = scenario.httpRequestPattern.matches(
+            soapRequest(
+                path = "/pet-wildcard",
+                soapAction = "http://example.com/pet-wildcard/RegisterWildcard",
+                bodyNode = """
+                    <tns:RegisterWildcard xmlns:tns="http://example.com/pet-wildcard"
+                                          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                          xmlns:other="http://example.com/other">
+                      <other:Anything xsi:type="tns:Crocodile">
+                        <other:unexpected>value</other:unexpected>
+                      </other:Anything>
+                    </tns:RegisterWildcard>
+                """.trimIndent()
+            ),
+            scenario.resolver
+        )
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+    }
+
     private fun animalRequest(bodyNode: String): HttpRequest {
         return HttpRequest(
             method = "POST",
@@ -295,6 +428,130 @@ internal class WsdlSpecificationTest {
               <wsdl:service name="AnimalService">
                 <wsdl:port name="AnimalPort" binding="tns:AnimalBinding">
                   <soap:address location="http://localhost/animals"/>
+                </wsdl:port>
+              </wsdl:service>
+            </wsdl:definitions>
+        """.trimIndent()
+    }
+
+    private fun petChoiceWsdl(): String {
+        return petWsdl(
+            namespace = "http://example.com/pet-choice",
+            path = "/pet-choice",
+            operation = "RegisterChoice",
+            requestType = """
+                <xs:complexType name="RegisterChoiceRequest">
+                  <xs:choice>
+                    <xs:element name="pet" type="tns:Pet"/>
+                    <xs:element name="comment" type="xs:string"/>
+                  </xs:choice>
+                </xs:complexType>
+            """.trimIndent()
+        )
+    }
+
+    private fun petNestedSequenceWsdl(): String {
+        return petWsdl(
+            namespace = "http://example.com/pet-nested-sequence",
+            path = "/pet-nested-sequence",
+            operation = "RegisterNestedSequence",
+            requestType = """
+                <xs:complexType name="RegisterNestedSequenceRequest">
+                  <xs:sequence>
+                    <xs:element name="payload" type="tns:PetPayload"/>
+                  </xs:sequence>
+                </xs:complexType>
+
+                <xs:complexType name="PetPayload">
+                  <xs:sequence>
+                    <xs:element name="pet" type="tns:Pet"/>
+                  </xs:sequence>
+                </xs:complexType>
+            """.trimIndent()
+        )
+    }
+
+    private fun petWildcardWsdl(): String {
+        return petWsdl(
+            namespace = "http://example.com/pet-wildcard",
+            path = "/pet-wildcard",
+            operation = "RegisterWildcard",
+            requestType = """
+                <xs:complexType name="RegisterWildcardRequest">
+                  <xs:sequence>
+                    <xs:any namespace="##any" processContents="skip"/>
+                  </xs:sequence>
+                </xs:complexType>
+            """.trimIndent()
+        )
+    }
+
+    private fun petWsdl(namespace: String, path: String, operation: String, requestType: String): String {
+        return """
+            <wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                              xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                              xmlns:tns="$namespace"
+                              targetNamespace="$namespace">
+              <wsdl:types>
+                <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                           xmlns:tns="$namespace"
+                           targetNamespace="$namespace"
+                           elementFormDefault="qualified">
+                  <xs:element name="$operation" type="tns:${operation}Request"/>
+                  <xs:element name="${operation}Response" type="xs:string"/>
+
+                  <xs:complexType name="Pet">
+                    <xs:sequence>
+                      <xs:element name="name" type="xs:string"/>
+                    </xs:sequence>
+                  </xs:complexType>
+
+                  <xs:complexType name="Dog">
+                    <xs:complexContent>
+                      <xs:extension base="tns:Pet">
+                        <xs:sequence>
+                          <xs:element name="breed" type="xs:string"/>
+                        </xs:sequence>
+                      </xs:extension>
+                    </xs:complexContent>
+                  </xs:complexType>
+
+                  <xs:complexType name="Crocodile">
+                    <xs:sequence>
+                      <xs:element name="toothCount" type="xs:integer"/>
+                    </xs:sequence>
+                  </xs:complexType>
+
+                  $requestType
+                </xs:schema>
+              </wsdl:types>
+
+              <wsdl:message name="${operation}Input">
+                <wsdl:part name="request" element="tns:$operation"/>
+              </wsdl:message>
+              <wsdl:message name="${operation}Output">
+                <wsdl:part name="response" element="tns:${operation}Response"/>
+              </wsdl:message>
+
+              <wsdl:portType name="${operation}PortType">
+                <wsdl:operation name="$operation">
+                  <wsdl:input message="tns:${operation}Input"/>
+                  <wsdl:output message="tns:${operation}Output"/>
+                </wsdl:operation>
+              </wsdl:portType>
+
+              <wsdl:binding name="${operation}Binding" type="tns:${operation}PortType">
+                <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+                <wsdl:operation name="$operation">
+                  <soap:operation soapAction="$namespace/$operation"/>
+                  <wsdl:input><soap:body use="literal"/></wsdl:input>
+                  <wsdl:output><soap:body use="literal"/></wsdl:output>
+                </wsdl:operation>
+              </wsdl:binding>
+
+              <wsdl:service name="${operation}Service">
+                <wsdl:port name="${operation}Port" binding="tns:${operation}Binding">
+                  <soap:address location="http://localhost$path"/>
                 </wsdl:port>
               </wsdl:service>
             </wsdl:definitions>

--- a/core/src/test/kotlin/io/specmatic/core/HttpResponsePatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpResponsePatternTest.kt
@@ -7,6 +7,7 @@ import io.specmatic.core.substitution.SubstitutionImpl
 import io.specmatic.core.value.JSONArrayValue
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.StringValue
+import io.specmatic.core.value.XMLNode
 import org.junit.jupiter.api.Nested
 
 internal class HttpResponsePatternTest {
@@ -62,6 +63,60 @@ internal class HttpResponsePatternTest {
         val resultText = result.reportString()
         assertThat(resultText).contains(">> RESPONSE.HEADER.X-Data")
         assertThat(resultText).contains(">> RESPONSE.BODY")
+    }
+
+    @Test
+    fun `matches XML response with schema instance type declared using an inherited non xsi prefix`() {
+        val namespace = "http://example.com/animals"
+        val animalType = XMLPattern(
+            XMLTypeData(
+                name = "Animal",
+                realName = "tns:Animal",
+                nodes = listOf(XMLPattern("<tns:name xmlns:tns=\"$namespace\">(string)</tns:name>")),
+                namespaceUri = namespace,
+                wsdlTypeNamespace = namespace,
+                wsdlTypeName = "Animal",
+            )
+        )
+        val bodyPattern = XMLPattern(
+            XMLTypeData(
+                name = "root",
+                realName = "root",
+                nodes = listOf(
+                    XMLPattern(
+                        XMLTypeData(
+                            name = "Animal",
+                            realName = "tns:Animal",
+                            attributes = mapOf(TYPE_ATTRIBUTE_NAME to ExactValuePattern(StringValue("tns_Animal"))),
+                            namespaceUri = namespace,
+                        )
+                    )
+                )
+            )
+        )
+        val responsePattern = HttpResponsePattern(
+            status = 200,
+            headersPattern = HttpHeadersPattern(mapOf(CONTENT_TYPE to ExactValuePattern(StringValue("text/xml")))),
+            body = bodyPattern,
+        )
+        val response = HttpResponse(
+            status = 200,
+            body = """
+                <root xmlns:typeNs="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="$namespace">
+                    <tns:Animal typeNs:type="tns:Animal">
+                        <tns:name>Leo</tns:name>
+                    </tns:Animal>
+                </root>
+            """.trimIndent(),
+            headers = mapOf(CONTENT_TYPE to "text/xml")
+        )
+
+        assertThat(responsePattern.matchesResponse(response, Resolver(newPatterns = mapOf("(tns_Animal)" to animalType))))
+            .isInstanceOf(Result.Success::class.java)
+        assertThat((response.body as XMLNode).getXMLNodeByPath("Animal").attributeNamespaceUri("typeNs:type"))
+            .isEqualTo("http://www.w3.org/2001/XMLSchema-instance")
+        assertThat(responsePattern.fillInTheBlanks(response, Resolver(newPatterns = mapOf("(tns_Animal)" to animalType))).body)
+            .isEqualTo(response.body)
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/core/pattern/XMLPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/XMLPatternTest.kt
@@ -4,6 +4,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.fail
 import io.specmatic.core.Resolver
 import io.specmatic.core.Result
 import io.specmatic.core.value.*
@@ -18,6 +19,8 @@ import java.util.function.Consumer
 
 private const val isOptional: String = "$OCCURS_ATTRIBUTE_NAME=\"$OPTIONAL_ATTRIBUTE_VALUE\""
 private const val occursMultipleTimes: String = "$OCCURS_ATTRIBUTE_NAME=\"$MULTIPLE_ATTRIBUTE_VALUE\""
+private const val ANIMAL_NAMESPACE: String = "http://example.com/animals"
+private const val XML_SCHEMA_NAMESPACE: String = "http://www.w3.org/2001/XMLSchema"
 
 internal class XMLPatternTest {
     @Nested
@@ -69,6 +72,187 @@ internal class XMLPatternTest {
 
             assertThat(xmlValue.childNodes.size).isOne()
             assertThat(xmlValue.childNodes.first()).isInstanceOf(StringValue::class.java)
+        }
+
+        @Test
+        fun `xsi type selects compatible WSDL derived pattern during generation`() {
+            val resolver = Resolver(newPatterns = animalPatterns())
+            val pattern = XMLPattern(
+                XMLTypeData(
+                    name = "Animal",
+                    realName = "tns:Animal",
+                    attributes = mapOf(
+                        TYPE_ATTRIBUTE_NAME to ExactValuePattern(StringValue("tns_Animal")),
+                        "xmlns:tns" to ExactValuePattern(StringValue(ANIMAL_NAMESPACE)),
+                        "xmlns:xsi" to ExactValuePattern(StringValue("http://www.w3.org/2001/XMLSchema-instance")),
+                        "xsi:type" to ExactValuePattern(StringValue("tns:Dog")),
+                    ),
+                    namespaceUri = ANIMAL_NAMESPACE,
+                )
+            )
+
+            val generated = pattern.generate(resolver)
+
+            assertThat(generated.realName).isEqualTo("tns:Animal")
+            assertThat(generated.attributes["xsi:type"]).isEqualTo(StringValue("tns:Dog"))
+            assertThat(generated.childNodes.filterIsInstance<XMLNode>().map(XMLNode::realName))
+                .containsExactly("tns:name", "tns:breed")
+        }
+
+        @Test
+        fun `generate uses compatible WSDL leaf complex type variants instead of base or intermediate types`() {
+            val resolver = Resolver(newPatterns = animalPatterns())
+            val pattern = XMLPattern(
+                XMLTypeData(
+                    name = "Animal",
+                    realName = "tns:Animal",
+                    attributes = mapOf(
+                        TYPE_ATTRIBUTE_NAME to ExactValuePattern(StringValue("tns_Animal")),
+                        "xmlns:tns" to ExactValuePattern(StringValue(ANIMAL_NAMESPACE)),
+                    ),
+                    namespaceUri = ANIMAL_NAMESPACE,
+                )
+            )
+
+            val generated = pattern.generate(resolver)
+
+            when (generated.attributes["xsi:type"]?.toStringLiteral()) {
+                "tns:WorkingDog" -> assertThat(generated.childNodes.filterIsInstance<XMLNode>().map(XMLNode::realName))
+                    .containsExactly("tns:name", "tns:breed", "tns:job")
+                "tns:Cat" -> assertThat(generated.childNodes.filterIsInstance<XMLNode>().map(XMLNode::realName))
+                    .containsExactly("tns:name", "tns:lives")
+                else -> fail("Expected generate to pick a leaf WSDL type")
+            }
+        }
+
+        @Test
+        fun `newBasedOn uses compatible WSDL leaf complex type variants instead of base or intermediate types`() {
+            val resolver = Resolver(newPatterns = animalPatterns())
+            val pattern = XMLPattern(
+                XMLTypeData(
+                    name = "Animal",
+                    realName = "tns:Animal",
+                    attributes = mapOf(
+                        TYPE_ATTRIBUTE_NAME to ExactValuePattern(StringValue("tns_Animal")),
+                        "xmlns:tns" to ExactValuePattern(StringValue(ANIMAL_NAMESPACE)),
+                    ),
+                    namespaceUri = ANIMAL_NAMESPACE,
+                )
+            )
+
+            val generated = pattern.newBasedOn(Row(), resolver)
+                .map { it.value as XMLPattern }
+                .map { it.generate(resolver) }
+                .toList()
+
+            assertThat(generated.map { it.attributes["xsi:type"]?.toStringLiteral() })
+                .containsExactlyInAnyOrder("tns:WorkingDog", "tns:Cat")
+            assertThat(generated).noneMatch { it.attributes["xsi:type"]?.toStringLiteral() == "tns:Dog" }
+            assertThat(generated).noneMatch { it.attributes["xsi:type"] == null }
+        }
+
+        @Test
+        fun `newBasedOn uses existing compatible xsi type instead of expanding every WSDL variant`() {
+            val resolver = Resolver(newPatterns = animalPatterns())
+            val pattern = XMLPattern(
+                XMLTypeData(
+                    name = "Animal",
+                    realName = "tns:Animal",
+                    attributes = mapOf(
+                        TYPE_ATTRIBUTE_NAME to ExactValuePattern(StringValue("tns_Animal")),
+                        "xmlns:tns" to ExactValuePattern(StringValue(ANIMAL_NAMESPACE)),
+                        "xmlns:xsi" to ExactValuePattern(StringValue("http://www.w3.org/2001/XMLSchema-instance")),
+                        "xsi:type" to ExactValuePattern(StringValue("tns:Dog")),
+                    ),
+                    namespaceUri = ANIMAL_NAMESPACE,
+                )
+            )
+
+            val generated = pattern.newBasedOn(Row(), resolver)
+                .map { it.value as XMLPattern }
+                .map { it.generate(resolver) }
+                .toList()
+
+            assertThat(generated).hasSize(1)
+            assertThat(generated.single().attributes["xsi:type"]?.toStringLiteral()).isEqualTo("tns:Dog")
+            assertThat(generated.single().childNodes.filterIsInstance<XMLNode>().map(XMLNode::realName))
+                .containsExactly("tns:name", "tns:breed")
+        }
+
+        @Test
+        fun `newBasedOn uses compatible WSDL simple restriction variants instead of base type`() {
+            val resolver = Resolver(newPatterns = codePatterns())
+            val pattern = XMLPattern(
+                XMLTypeData(
+                    name = "Code",
+                    realName = "tns:Code",
+                    attributes = mapOf(
+                        TYPE_ATTRIBUTE_NAME to ExactValuePattern(StringValue("tns_BaseCode")),
+                        "xmlns:tns" to ExactValuePattern(StringValue(ANIMAL_NAMESPACE)),
+                    ),
+                    namespaceUri = ANIMAL_NAMESPACE,
+                )
+            )
+
+            val generated = pattern.newBasedOn(Row(), resolver)
+                .map { it.value as XMLPattern }
+                .map { it.generate(resolver) }
+                .toList()
+
+            assertThat(generated.map { it.attributes["xsi:type"]?.toStringLiteral() })
+                .containsOnly("tns:ConstrainedCode")
+            assertThat(generated.map { it.childNodes.single().toStringLiteral() })
+                .allMatch { value -> value.matches(Regex("[A-Z0-9]{6,}")) }
+        }
+
+        @Test
+        fun `newBasedOn ignores WSDL simple variants from XML Schema namespace`() {
+            val resolver = Resolver(newPatterns = codePatternsWithXMLSchemaNamespaceVariant())
+            val pattern = XMLPattern(
+                XMLTypeData(
+                    name = "Code",
+                    realName = "tns:Code",
+                    attributes = mapOf(
+                        TYPE_ATTRIBUTE_NAME to ExactValuePattern(StringValue("tns_BaseCode")),
+                        "xmlns:tns" to ExactValuePattern(StringValue(ANIMAL_NAMESPACE)),
+                    ),
+                    namespaceUri = ANIMAL_NAMESPACE,
+                )
+            )
+
+            val generated = pattern.newBasedOn(Row(), resolver)
+                .map { it.value as XMLPattern }
+                .map { it.generate(resolver) }
+                .toList()
+
+            assertThat(generated.map { it.attributes["xsi:type"]?.toStringLiteral() })
+                .containsOnly("tns:ConstrainedCode")
+        }
+
+        @Test
+        fun `newBasedOn uses WSDL base type when no compatible derived variants exist`() {
+            val resolver = Resolver(newPatterns = animalWithoutDerivedPatterns())
+            val pattern = XMLPattern(
+                XMLTypeData(
+                    name = "Animal",
+                    realName = "tns:Animal",
+                    attributes = mapOf(
+                        TYPE_ATTRIBUTE_NAME to ExactValuePattern(StringValue("tns_Animal")),
+                        "xmlns:tns" to ExactValuePattern(StringValue(ANIMAL_NAMESPACE)),
+                    ),
+                    namespaceUri = ANIMAL_NAMESPACE,
+                )
+            )
+
+            val generated = pattern.newBasedOn(Row(), resolver)
+                .map { it.value as XMLPattern }
+                .map { it.generate(resolver) }
+                .toList()
+
+            assertThat(generated).hasSize(1)
+            assertThat(generated.single().attributes["xsi:type"]).isNull()
+            assertThat(generated.single().childNodes.filterIsInstance<XMLNode>().map(XMLNode::realName))
+                .containsExactly("tns:name")
         }
 
         @Test
@@ -354,6 +538,82 @@ internal class XMLPatternTest {
         }
 
         @Test
+        fun `xsi type selects compatible WSDL derived complex type`() {
+            val resolver = Resolver(newPatterns = animalPatterns())
+            val pattern = XMLPattern(
+                XMLTypeData(
+                    name = "Animal",
+                    realName = "tns:Animal",
+                    attributes = mapOf(TYPE_ATTRIBUTE_NAME to ExactValuePattern(StringValue("tns_Animal"))),
+                    namespaceUri = ANIMAL_NAMESPACE,
+                )
+            )
+            val value = toXMLNode(
+                """
+                <tns:Animal xmlns:tns="$ANIMAL_NAMESPACE"
+                            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                            xsi:type="tns:Dog">
+                  <tns:name>Fido</tns:name>
+                  <tns:breed>Beagle</tns:breed>
+                </tns:Animal>
+                """.trimIndent()
+            )
+
+            assertThat(pattern.matches(value, resolver)).isInstanceOf(Result.Success::class.java)
+        }
+
+        @Test
+        fun `xsi type fails when known WSDL type is incompatible with declared type`() {
+            val resolver = Resolver(newPatterns = animalPatterns())
+            val pattern = XMLPattern(
+                XMLTypeData(
+                    name = "Animal",
+                    realName = "tns:Animal",
+                    attributes = mapOf(TYPE_ATTRIBUTE_NAME to ExactValuePattern(StringValue("tns_Animal"))),
+                    namespaceUri = ANIMAL_NAMESPACE,
+                )
+            )
+            val value = toXMLNode(
+                """
+                <tns:Animal xmlns:tns="$ANIMAL_NAMESPACE"
+                            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                            xsi:type="tns:Vehicle">
+                  <tns:registration>KA01AB1234</tns:registration>
+                </tns:Animal>
+                """.trimIndent()
+            )
+
+            val result = pattern.matches(value, resolver)
+
+            assertThat(result).isInstanceOf(Result.Failure::class.java)
+            assertThat(result.reportString()).contains("Invalid xsi:type")
+        }
+
+        @Test
+        fun `xsi type is ignored when WSDL type is unknown`() {
+            val resolver = Resolver(newPatterns = animalPatterns())
+            val pattern = XMLPattern(
+                XMLTypeData(
+                    name = "Animal",
+                    realName = "tns:Animal",
+                    attributes = mapOf(TYPE_ATTRIBUTE_NAME to ExactValuePattern(StringValue("tns_Animal"))),
+                    namespaceUri = ANIMAL_NAMESPACE,
+                )
+            )
+            val value = toXMLNode(
+                """
+                <tns:Animal xmlns:tns="$ANIMAL_NAMESPACE"
+                            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                            xsi:type="tns:UnknownType">
+                  <tns:name>Fido</tns:name>
+                </tns:Animal>
+                """.trimIndent()
+            )
+
+            assertThat(pattern.matches(value, resolver)).isInstanceOf(Result.Success::class.java)
+        }
+
+        @Test
         fun `node with string should match empty node`() {
             val type = parsedPattern("""<name>(string)</name>""")
             val value = parsedValue("""<name/>""")
@@ -387,6 +647,160 @@ internal class XMLPatternTest {
             anything.matches(string)
             anything.matches(xml)
         }
+
+    }
+
+    private fun animalPatterns(): Map<String, Pattern> {
+        val animal = XMLPattern(
+            XMLTypeData(
+                name = "Animal",
+                realName = "tns:Animal",
+                nodes = listOf(XMLPattern("<tns:name xmlns:tns=\"$ANIMAL_NAMESPACE\">(string)</tns:name>")),
+                namespaceUri = ANIMAL_NAMESPACE,
+                wsdlTypeNamespace = ANIMAL_NAMESPACE,
+                wsdlTypeName = "Animal",
+            )
+        )
+        val dog = XMLPattern(
+            XMLTypeData(
+                name = "Dog",
+                realName = "tns:Dog",
+                nodes = listOf(
+                    XMLPattern("<tns:name xmlns:tns=\"$ANIMAL_NAMESPACE\">(string)</tns:name>"),
+                    XMLPattern("<tns:breed xmlns:tns=\"$ANIMAL_NAMESPACE\">(string)</tns:breed>")
+                ),
+                namespaceUri = ANIMAL_NAMESPACE,
+                wsdlTypeNamespace = ANIMAL_NAMESPACE,
+                wsdlTypeName = "Dog",
+                wsdlBaseTypeNamespace = ANIMAL_NAMESPACE,
+                wsdlBaseTypeName = "Animal",
+            )
+        )
+        val vehicle = XMLPattern(
+            XMLTypeData(
+                name = "Vehicle",
+                realName = "tns:Vehicle",
+                nodes = listOf(XMLPattern("<tns:registration xmlns:tns=\"$ANIMAL_NAMESPACE\">(string)</tns:registration>")),
+                namespaceUri = ANIMAL_NAMESPACE,
+                wsdlTypeNamespace = ANIMAL_NAMESPACE,
+                wsdlTypeName = "Vehicle",
+            )
+        )
+        val workingDog = XMLPattern(
+            XMLTypeData(
+                name = "WorkingDog",
+                realName = "tns:WorkingDog",
+                nodes = listOf(
+                    XMLPattern("<tns:name xmlns:tns=\"$ANIMAL_NAMESPACE\">(string)</tns:name>"),
+                    XMLPattern("<tns:breed xmlns:tns=\"$ANIMAL_NAMESPACE\">(string)</tns:breed>"),
+                    XMLPattern("<tns:job xmlns:tns=\"$ANIMAL_NAMESPACE\">(string)</tns:job>")
+                ),
+                namespaceUri = ANIMAL_NAMESPACE,
+                wsdlTypeNamespace = ANIMAL_NAMESPACE,
+                wsdlTypeName = "WorkingDog",
+                wsdlBaseTypeNamespace = ANIMAL_NAMESPACE,
+                wsdlBaseTypeName = "Dog",
+            )
+        )
+        val cat = XMLPattern(
+            XMLTypeData(
+                name = "Cat",
+                realName = "tns:Cat",
+                nodes = listOf(
+                    XMLPattern("<tns:name xmlns:tns=\"$ANIMAL_NAMESPACE\">(string)</tns:name>"),
+                    XMLPattern("<tns:lives xmlns:tns=\"$ANIMAL_NAMESPACE\">(number)</tns:lives>")
+                ),
+                namespaceUri = ANIMAL_NAMESPACE,
+                wsdlTypeNamespace = ANIMAL_NAMESPACE,
+                wsdlTypeName = "Cat",
+                wsdlBaseTypeNamespace = ANIMAL_NAMESPACE,
+                wsdlBaseTypeName = "Animal",
+            )
+        )
+
+        return mapOf(
+            "(tns_Animal)" to animal,
+            "(tns_Dog)" to dog,
+            "(tns_WorkingDog)" to workingDog,
+            "(tns_Cat)" to cat,
+            "(tns_Vehicle)" to vehicle,
+        )
+    }
+
+    private fun animalWithoutDerivedPatterns(): Map<String, Pattern> {
+        val animal = XMLPattern(
+            XMLTypeData(
+                name = "Animal",
+                realName = "tns:Animal",
+                nodes = listOf(XMLPattern("<tns:name xmlns:tns=\"$ANIMAL_NAMESPACE\">(string)</tns:name>")),
+                namespaceUri = ANIMAL_NAMESPACE,
+                wsdlTypeNamespace = ANIMAL_NAMESPACE,
+                wsdlTypeName = "Animal",
+            )
+        )
+
+        val vehicle = XMLPattern(
+            XMLTypeData(
+                name = "Vehicle",
+                realName = "tns:Vehicle",
+                nodes = listOf(XMLPattern("<tns:registration xmlns:tns=\"$ANIMAL_NAMESPACE\">(string)</tns:registration>")),
+                namespaceUri = ANIMAL_NAMESPACE,
+                wsdlTypeNamespace = ANIMAL_NAMESPACE,
+                wsdlTypeName = "Vehicle",
+            )
+        )
+
+        return mapOf(
+            "(tns_Animal)" to animal,
+            "(tns_Vehicle)" to vehicle,
+        )
+    }
+
+    private fun codePatterns(): Map<String, Pattern> {
+        val baseCode = XMLPattern(
+            XMLTypeData(
+                name = "BaseCode",
+                realName = "tns:BaseCode",
+                nodes = listOf(StringPattern()),
+                namespaceUri = ANIMAL_NAMESPACE,
+                wsdlTypeNamespace = ANIMAL_NAMESPACE,
+                wsdlTypeName = "BaseCode",
+            )
+        )
+        val constrainedCode = XMLPattern(
+            XMLTypeData(
+                name = "ConstrainedCode",
+                realName = "tns:ConstrainedCode",
+                nodes = listOf(StringPattern(minLength = 6, regex = "[A-Z0-9]+")),
+                namespaceUri = ANIMAL_NAMESPACE,
+                wsdlTypeNamespace = ANIMAL_NAMESPACE,
+                wsdlTypeName = "ConstrainedCode",
+                wsdlBaseTypeNamespace = ANIMAL_NAMESPACE,
+                wsdlBaseTypeName = "BaseCode",
+            )
+        )
+
+        return mapOf(
+            "(tns_BaseCode)" to baseCode,
+            "(tns_ConstrainedCode)" to constrainedCode,
+        )
+    }
+
+    private fun codePatternsWithXMLSchemaNamespaceVariant(): Map<String, Pattern> {
+        val xmlSchemaString = XMLPattern(
+            XMLTypeData(
+                name = "string",
+                realName = "xs:string",
+                nodes = listOf(StringPattern()),
+                namespaceUri = XML_SCHEMA_NAMESPACE,
+                wsdlTypeNamespace = XML_SCHEMA_NAMESPACE,
+                wsdlTypeName = "string",
+                wsdlBaseTypeNamespace = ANIMAL_NAMESPACE,
+                wsdlBaseTypeName = "BaseCode",
+            )
+        )
+
+        return codePatterns() + mapOf("(xs_string)" to xmlSchemaString)
     }
 
     @Nested

--- a/core/src/test/kotlin/io/specmatic/core/pattern/XMLPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/XMLPatternTest.kt
@@ -180,6 +180,63 @@ internal class XMLPatternTest {
         }
 
         @Test
+        fun `newBasedOn uses existing compatible schema instance type with non xsi prefix`() {
+            val resolver = Resolver(newPatterns = animalPatterns())
+            val pattern = XMLPattern(
+                XMLTypeData(
+                    name = "Animal",
+                    realName = "tns:Animal",
+                    attributes = mapOf(
+                        TYPE_ATTRIBUTE_NAME to ExactValuePattern(StringValue("tns_Animal")),
+                        "xmlns:tns" to ExactValuePattern(StringValue(ANIMAL_NAMESPACE)),
+                        "xmlns:typeNs" to ExactValuePattern(StringValue("http://www.w3.org/2001/XMLSchema-instance")),
+                        "typeNs:type" to ExactValuePattern(StringValue("tns:Dog")),
+                    ),
+                    namespaceUri = ANIMAL_NAMESPACE,
+                    attributeNamespaceUris = mapOf("typeNs:type" to "http://www.w3.org/2001/XMLSchema-instance"),
+                )
+            )
+
+            val generated = pattern.newBasedOn(Row(), resolver)
+                .map { it.value as XMLPattern }
+                .map { it.generate(resolver) }
+                .toList()
+
+            assertThat(generated).hasSize(1)
+            assertThat(generated.single().attributes["typeNs:type"]?.toStringLiteral()).isEqualTo("tns:Dog")
+            assertThat(generated.single().childNodes.filterIsInstance<XMLNode>().map(XMLNode::realName))
+                .containsExactly("tns:name", "tns:breed")
+        }
+
+        @Test
+        fun `generate avoids xsi prefix when it is already bound to a different namespace`() {
+            val resolver = Resolver(newPatterns = animalPatterns())
+            val pattern = XMLPattern(
+                XMLTypeData(
+                    name = "Animal",
+                    realName = "tns:Animal",
+                    attributes = mapOf(
+                        TYPE_ATTRIBUTE_NAME to ExactValuePattern(StringValue("tns_Animal")),
+                        "xmlns:tns" to ExactValuePattern(StringValue(ANIMAL_NAMESPACE)),
+                        "xmlns:xsi" to ExactValuePattern(StringValue("http://example.com/not-schema-instance")),
+                    ),
+                    namespaceUri = ANIMAL_NAMESPACE,
+                )
+            )
+
+            val generated = pattern.newBasedOn(Row(), resolver)
+                .map { it.value as XMLPattern }
+                .map { it.generate(resolver) }
+                .first()
+            val schemaInstanceTypeAttribute = generated.attributes.keys.single { it.endsWith(":type") }
+            val schemaInstancePrefix = schemaInstanceTypeAttribute.substringBefore(":")
+
+            assertThat(schemaInstancePrefix).isNotEqualTo("xsi")
+            assertThat(generated.namespaces["xsi"]).isEqualTo("http://example.com/not-schema-instance")
+            assertThat(generated.namespaces[schemaInstancePrefix]).isEqualTo("http://www.w3.org/2001/XMLSchema-instance")
+        }
+
+        @Test
         fun `newBasedOn uses compatible WSDL simple restriction variants instead of base type`() {
             val resolver = Resolver(newPatterns = codePatterns())
             val pattern = XMLPattern(
@@ -560,6 +617,59 @@ internal class XMLPatternTest {
             )
 
             assertThat(pattern.matches(value, resolver)).isInstanceOf(Result.Success::class.java)
+        }
+
+        @Test
+        fun `schema instance type with non xsi prefix selects compatible WSDL derived complex type`() {
+            val resolver = Resolver(newPatterns = animalPatterns())
+            val pattern = XMLPattern(
+                XMLTypeData(
+                    name = "Animal",
+                    realName = "tns:Animal",
+                    attributes = mapOf(TYPE_ATTRIBUTE_NAME to ExactValuePattern(StringValue("tns_Animal"))),
+                    namespaceUri = ANIMAL_NAMESPACE,
+                )
+            )
+            val value = toXMLNode(
+                """
+                <tns:Animal xmlns:tns="$ANIMAL_NAMESPACE"
+                            xmlns:typeNs="http://www.w3.org/2001/XMLSchema-instance"
+                            typeNs:type="tns:Dog">
+                  <tns:name>Fido</tns:name>
+                  <tns:breed>Beagle</tns:breed>
+                </tns:Animal>
+                """.trimIndent()
+            )
+
+            assertThat(pattern.matches(value, resolver)).isInstanceOf(Result.Success::class.java)
+        }
+
+        @Test
+        fun `type attribute with wrong namespace does not select WSDL derived complex type`() {
+            val resolver = Resolver(newPatterns = animalPatterns())
+            val pattern = XMLPattern(
+                XMLTypeData(
+                    name = "Animal",
+                    realName = "tns:Animal",
+                    attributes = mapOf(TYPE_ATTRIBUTE_NAME to ExactValuePattern(StringValue("tns_Animal"))),
+                    namespaceUri = ANIMAL_NAMESPACE,
+                )
+            )
+            val value = toXMLNode(
+                """
+                <tns:Animal xmlns:tns="$ANIMAL_NAMESPACE"
+                            xmlns:typeNs="http://example.com/not-schema-instance"
+                            typeNs:type="tns:Dog">
+                  <tns:name>Fido</tns:name>
+                  <tns:breed>Beagle</tns:breed>
+                </tns:Animal>
+                """.trimIndent()
+            )
+
+            val result = pattern.matches(value, resolver)
+
+            assertThat(result).isInstanceOf(Result.Failure::class.java)
+            assertThat(result.reportString()).contains("typeNs:type")
         }
 
         @Test

--- a/core/src/test/kotlin/io/specmatic/core/pattern/XMLPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/XMLPatternTest.kt
@@ -22,6 +22,41 @@ private const val occursMultipleTimes: String = "$OCCURS_ATTRIBUTE_NAME=\"$MULTI
 private const val ANIMAL_NAMESPACE: String = "http://example.com/animals"
 private const val XML_SCHEMA_NAMESPACE: String = "http://www.w3.org/2001/XMLSchema"
 
+private val ANIMAL_TYPE = WSDLTypeName(ANIMAL_NAMESPACE, "Animal")
+private val DOG_TYPE = WSDLTypeName(ANIMAL_NAMESPACE, "Dog")
+private val WORKING_DOG_TYPE = WSDLTypeName(ANIMAL_NAMESPACE, "WorkingDog")
+private val CAT_TYPE = WSDLTypeName(ANIMAL_NAMESPACE, "Cat")
+private val VEHICLE_TYPE = WSDLTypeName(ANIMAL_NAMESPACE, "Vehicle")
+private val BASE_CODE_TYPE = WSDLTypeName(ANIMAL_NAMESPACE, "BaseCode")
+private val CONSTRAINED_CODE_TYPE = WSDLTypeName(ANIMAL_NAMESPACE, "ConstrainedCode")
+private val XML_SCHEMA_STRING_TYPE = WSDLTypeName(XML_SCHEMA_NAMESPACE, "string")
+
+private const val ANIMAL_TYPE_KEY = "(tns_Animal)"
+private const val DOG_TYPE_KEY = "(tns_Dog)"
+private const val WORKING_DOG_TYPE_KEY = "(tns_WorkingDog)"
+private const val CAT_TYPE_KEY = "(tns_Cat)"
+private const val VEHICLE_TYPE_KEY = "(tns_Vehicle)"
+private const val BASE_CODE_TYPE_KEY = "(tns_BaseCode)"
+private const val CONSTRAINED_CODE_TYPE_KEY = "(tns_ConstrainedCode)"
+private const val XML_SCHEMA_STRING_TYPE_KEY = "(xs_string)"
+
+private val ANIMAL_TYPE_KEYS = mapOf(
+    ANIMAL_TYPE to ANIMAL_TYPE_KEY,
+    DOG_TYPE to DOG_TYPE_KEY,
+    WORKING_DOG_TYPE to WORKING_DOG_TYPE_KEY,
+    CAT_TYPE to CAT_TYPE_KEY,
+    VEHICLE_TYPE to VEHICLE_TYPE_KEY,
+)
+
+private val CODE_TYPE_KEYS = mapOf(
+    BASE_CODE_TYPE to BASE_CODE_TYPE_KEY,
+    CONSTRAINED_CODE_TYPE to CONSTRAINED_CODE_TYPE_KEY,
+)
+
+private val CODE_TYPE_KEYS_WITH_XML_SCHEMA_TYPE = CODE_TYPE_KEYS + mapOf(
+    XML_SCHEMA_STRING_TYPE to XML_SCHEMA_STRING_TYPE_KEY
+)
+
 internal class XMLPatternTest {
     @Nested
     inner class GenerateValues {
@@ -833,12 +868,40 @@ internal class XMLPatternTest {
         )
 
         return mapOf(
-            "(tns_Animal)" to animal,
-            "(tns_Dog)" to dog,
-            "(tns_WorkingDog)" to workingDog,
-            "(tns_Cat)" to cat,
-            "(tns_Vehicle)" to vehicle,
-        ).withTestWSDLTypeLookupMetadata()
+            ANIMAL_TYPE_KEY to animal.withWSDLTypeLookupMetadata(
+                knownTypeKeys = ANIMAL_TYPE_KEYS,
+                compatibleTypeKeys = mapOf(
+                    ANIMAL_TYPE to ANIMAL_TYPE_KEY,
+                    DOG_TYPE to DOG_TYPE_KEY,
+                    WORKING_DOG_TYPE to WORKING_DOG_TYPE_KEY,
+                    CAT_TYPE to CAT_TYPE_KEY,
+                ),
+                concreteSubtypeKeys = mapOf(
+                    WORKING_DOG_TYPE to WORKING_DOG_TYPE_KEY,
+                    CAT_TYPE to CAT_TYPE_KEY,
+                ),
+            ),
+            DOG_TYPE_KEY to dog.withWSDLTypeLookupMetadata(
+                knownTypeKeys = ANIMAL_TYPE_KEYS,
+                compatibleTypeKeys = mapOf(
+                    DOG_TYPE to DOG_TYPE_KEY,
+                    WORKING_DOG_TYPE to WORKING_DOG_TYPE_KEY,
+                ),
+                concreteSubtypeKeys = mapOf(WORKING_DOG_TYPE to WORKING_DOG_TYPE_KEY),
+            ),
+            WORKING_DOG_TYPE_KEY to workingDog.withWSDLTypeLookupMetadata(
+                knownTypeKeys = ANIMAL_TYPE_KEYS,
+                compatibleTypeKeys = mapOf(WORKING_DOG_TYPE to WORKING_DOG_TYPE_KEY),
+            ),
+            CAT_TYPE_KEY to cat.withWSDLTypeLookupMetadata(
+                knownTypeKeys = ANIMAL_TYPE_KEYS,
+                compatibleTypeKeys = mapOf(CAT_TYPE to CAT_TYPE_KEY),
+            ),
+            VEHICLE_TYPE_KEY to vehicle.withWSDLTypeLookupMetadata(
+                knownTypeKeys = ANIMAL_TYPE_KEYS,
+                compatibleTypeKeys = mapOf(VEHICLE_TYPE to VEHICLE_TYPE_KEY),
+            ),
+        )
     }
 
     private fun animalWithoutDerivedPatterns(): Map<String, Pattern> {
@@ -865,8 +928,8 @@ internal class XMLPatternTest {
         )
 
         return mapOf(
-            "(tns_Animal)" to animal,
-            "(tns_Vehicle)" to vehicle,
+            ANIMAL_TYPE_KEY to animal,
+            VEHICLE_TYPE_KEY to vehicle,
         )
     }
 
@@ -895,9 +958,19 @@ internal class XMLPatternTest {
         )
 
         return mapOf(
-            "(tns_BaseCode)" to baseCode,
-            "(tns_ConstrainedCode)" to constrainedCode,
-        ).withTestWSDLTypeLookupMetadata()
+            BASE_CODE_TYPE_KEY to baseCode.withWSDLTypeLookupMetadata(
+                knownTypeKeys = CODE_TYPE_KEYS,
+                compatibleTypeKeys = mapOf(
+                    BASE_CODE_TYPE to BASE_CODE_TYPE_KEY,
+                    CONSTRAINED_CODE_TYPE to CONSTRAINED_CODE_TYPE_KEY,
+                ),
+                concreteSubtypeKeys = mapOf(CONSTRAINED_CODE_TYPE to CONSTRAINED_CODE_TYPE_KEY),
+            ),
+            CONSTRAINED_CODE_TYPE_KEY to constrainedCode.withWSDLTypeLookupMetadata(
+                knownTypeKeys = CODE_TYPE_KEYS,
+                compatibleTypeKeys = mapOf(CONSTRAINED_CODE_TYPE to CONSTRAINED_CODE_TYPE_KEY),
+            ),
+        )
     }
 
     private fun codePatternsWithXMLSchemaNamespaceVariant(): Map<String, Pattern> {
@@ -914,41 +987,40 @@ internal class XMLPatternTest {
             )
         )
 
-        return (codePatterns() + mapOf("(xs_string)" to xmlSchemaString)).withTestWSDLTypeLookupMetadata()
-    }
+        return codePatterns().mapValues { (_, pattern) ->
+            when ((pattern as? XMLPattern)?.pattern?.wsdlTypeName()) {
+                BASE_CODE_TYPE -> pattern.withWSDLTypeLookupMetadata(
+                    knownTypeKeys = CODE_TYPE_KEYS_WITH_XML_SCHEMA_TYPE,
+                    compatibleTypeKeys = mapOf(
+                        BASE_CODE_TYPE to BASE_CODE_TYPE_KEY,
+                        CONSTRAINED_CODE_TYPE to CONSTRAINED_CODE_TYPE_KEY,
+                        XML_SCHEMA_STRING_TYPE to XML_SCHEMA_STRING_TYPE_KEY,
+                    ),
+                    concreteSubtypeKeys = mapOf(
+                        CONSTRAINED_CODE_TYPE to CONSTRAINED_CODE_TYPE_KEY,
+                        XML_SCHEMA_STRING_TYPE to XML_SCHEMA_STRING_TYPE_KEY,
+                    ),
+                )
 
-    private data class TestWSDLTypeLookupEntry(
-        val typeName: WSDLTypeName,
-        val typeKey: String,
-        val baseTypeName: WSDLTypeName?,
-    )
+                CONSTRAINED_CODE_TYPE -> pattern.withWSDLTypeLookupMetadata(
+                    knownTypeKeys = CODE_TYPE_KEYS_WITH_XML_SCHEMA_TYPE,
+                    compatibleTypeKeys = mapOf(CONSTRAINED_CODE_TYPE to CONSTRAINED_CODE_TYPE_KEY),
+                )
 
-    private fun Map<String, Pattern>.withTestWSDLTypeLookupMetadata(): Map<String, Pattern> {
-        val entries = mapNotNull { (key, pattern) -> pattern.testWSDLTypeLookupEntry(key) }
-        val typeKeys = entries.associate { entry -> entry.typeName to entry.typeKey }
-        val entriesByType = entries.associateBy { it.typeName }
-
-        return mapValues { (typeKey, pattern) ->
-            val entry = entries.firstOrNull { it.typeKey == typeKey } ?: return@mapValues pattern
-            pattern.withTestWSDLTypeLookupMetadata(
-                knownTypeKeys = typeKeys,
-                compatibleTypeKeys = testCompatibleTypeKeys(entry.typeName, entries, entriesByType, typeKeys),
-                concreteSubtypeKeys = testConcreteSubtypeKeys(entry.typeName, entries, entriesByType, typeKeys),
+                else -> pattern
+            }
+        } + mapOf(
+            XML_SCHEMA_STRING_TYPE_KEY to xmlSchemaString.withWSDLTypeLookupMetadata(
+                knownTypeKeys = CODE_TYPE_KEYS_WITH_XML_SCHEMA_TYPE,
+                compatibleTypeKeys = mapOf(XML_SCHEMA_STRING_TYPE to XML_SCHEMA_STRING_TYPE_KEY),
             )
-        }
+        )
     }
 
-    private fun Pattern.testWSDLTypeLookupEntry(typeKey: String): TestWSDLTypeLookupEntry? {
-        val typeData = (this as? XMLPattern)?.pattern ?: return null
-        val typeName = typeData.wsdlTypeName?.let { WSDLTypeName(typeData.wsdlTypeNamespace.orEmpty(), it) } ?: return null
-        val baseTypeName = typeData.wsdlBaseTypeName?.let { WSDLTypeName(typeData.wsdlBaseTypeNamespace.orEmpty(), it) }
-        return TestWSDLTypeLookupEntry(typeName, typeKey, baseTypeName)
-    }
-
-    private fun Pattern.withTestWSDLTypeLookupMetadata(
+    private fun Pattern.withWSDLTypeLookupMetadata(
         knownTypeKeys: Map<WSDLTypeName, String>,
         compatibleTypeKeys: Map<WSDLTypeName, String>,
-        concreteSubtypeKeys: Map<WSDLTypeName, String>,
+        concreteSubtypeKeys: Map<WSDLTypeName, String> = emptyMap(),
     ): Pattern {
         return when (this) {
             is XMLPattern -> copy(
@@ -961,7 +1033,7 @@ internal class XMLPatternTest {
 
             is AnyPattern -> copy(
                 pattern = pattern.map {
-                    it.withTestWSDLTypeLookupMetadata(
+                    it.withWSDLTypeLookupMetadata(
                         knownTypeKeys,
                         compatibleTypeKeys,
                         concreteSubtypeKeys,
@@ -971,46 +1043,6 @@ internal class XMLPatternTest {
 
             else -> this
         }
-    }
-
-    private fun testCompatibleTypeKeys(
-        baseType: WSDLTypeName,
-        entries: List<TestWSDLTypeLookupEntry>,
-        entriesByType: Map<WSDLTypeName, TestWSDLTypeLookupEntry>,
-        typeKeys: Map<WSDLTypeName, String>,
-    ): Map<WSDLTypeName, String> =
-        entries
-            .filter { entry -> entry.typeName == baseType || entry.isDerivedFrom(baseType, entriesByType) }
-            .mapNotNull { entry -> typeKeys[entry.typeName]?.let { key -> entry.typeName to key } }
-            .toMap()
-
-    private fun testConcreteSubtypeKeys(
-        baseType: WSDLTypeName,
-        entries: List<TestWSDLTypeLookupEntry>,
-        entriesByType: Map<WSDLTypeName, TestWSDLTypeLookupEntry>,
-        typeKeys: Map<WSDLTypeName, String>,
-    ): Map<WSDLTypeName, String> {
-        val descendants = entries
-            .filter { entry -> entry.typeName != baseType && entry.isDerivedFrom(baseType, entriesByType) }
-            .map { it.typeName }
-            .toSet()
-
-        return descendants
-            .filter { descendant -> entries.none { entry -> entry.typeName in descendants && entry.isDerivedFrom(descendant, entriesByType) } }
-            .mapNotNull { type -> typeKeys[type]?.let { key -> type to key } }
-            .toMap()
-    }
-
-    private fun TestWSDLTypeLookupEntry.isDerivedFrom(
-        baseType: WSDLTypeName,
-        entriesByType: Map<WSDLTypeName, TestWSDLTypeLookupEntry>,
-    ): Boolean {
-        val directBaseType = baseTypeName ?: return false
-        if (directBaseType == baseType) {
-            return true
-        }
-
-        return entriesByType[directBaseType]?.isDerivedFrom(baseType, entriesByType) == true
     }
 
     @Nested

--- a/core/src/test/kotlin/io/specmatic/core/pattern/XMLPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/XMLPatternTest.kt
@@ -700,7 +700,7 @@ internal class XMLPatternTest {
         }
 
         @Test
-        fun `xsi type is ignored when WSDL type is unknown`() {
+        fun `xsi type fails when WSDL type is unknown`() {
             val resolver = Resolver(newPatterns = animalPatterns())
             val pattern = XMLPattern(
                 XMLTypeData(
@@ -720,7 +720,11 @@ internal class XMLPatternTest {
                 """.trimIndent()
             )
 
-            assertThat(pattern.matches(value, resolver)).isInstanceOf(Result.Success::class.java)
+            val result = pattern.matches(value, resolver)
+
+            assertThat(result).isInstanceOf(Result.Failure::class.java)
+            assertThat(result.reportString()).contains("Unknown xsi:type")
+            assertThat(result.reportString()).contains("UnknownType")
         }
 
         @Test
@@ -834,7 +838,7 @@ internal class XMLPatternTest {
             "(tns_WorkingDog)" to workingDog,
             "(tns_Cat)" to cat,
             "(tns_Vehicle)" to vehicle,
-        )
+        ).withTestWSDLTypeLookupMetadata()
     }
 
     private fun animalWithoutDerivedPatterns(): Map<String, Pattern> {
@@ -893,7 +897,7 @@ internal class XMLPatternTest {
         return mapOf(
             "(tns_BaseCode)" to baseCode,
             "(tns_ConstrainedCode)" to constrainedCode,
-        )
+        ).withTestWSDLTypeLookupMetadata()
     }
 
     private fun codePatternsWithXMLSchemaNamespaceVariant(): Map<String, Pattern> {
@@ -910,7 +914,111 @@ internal class XMLPatternTest {
             )
         )
 
-        return codePatterns() + mapOf("(xs_string)" to xmlSchemaString)
+        return (codePatterns() + mapOf("(xs_string)" to xmlSchemaString)).withTestWSDLTypeLookupMetadata()
+    }
+
+    private data class TestWSDLTypeLookupEntry(
+        val typeName: WSDLTypeName,
+        val typeKey: String,
+        val baseTypeName: WSDLTypeName?,
+    )
+
+    private fun Map<String, Pattern>.withTestWSDLTypeLookupMetadata(): Map<String, Pattern> {
+        val entries = mapNotNull { (key, pattern) -> pattern.testWSDLTypeLookupEntry(key) }
+        val typeKeys = entries.associate { entry -> entry.typeName to entry.typeKey }
+        val entriesByType = entries.associateBy { it.typeName }
+
+        return mapValues { (typeKey, pattern) ->
+            val entry = entries.firstOrNull { it.typeKey == typeKey } ?: return@mapValues pattern
+            pattern.withTestWSDLTypeLookupMetadata(
+                typeKey = typeKey,
+                baseTypeKey = entry.baseTypeName?.let(typeKeys::get),
+                knownTypeKeys = typeKeys,
+                matchableTypeKeys = testMatchableTypeKeys(entry.typeName, entries, entriesByType, typeKeys),
+                leafTypeKeys = testLeafTypeKeys(entry.typeName, entries, entriesByType, typeKeys),
+            )
+        }
+    }
+
+    private fun Pattern.testWSDLTypeLookupEntry(typeKey: String): TestWSDLTypeLookupEntry? {
+        val typeData = (this as? XMLPattern)?.pattern ?: return null
+        val typeName = typeData.wsdlTypeName?.let { WSDLTypeName(typeData.wsdlTypeNamespace.orEmpty(), it) } ?: return null
+        val baseTypeName = typeData.wsdlBaseTypeName?.let { WSDLTypeName(typeData.wsdlBaseTypeNamespace.orEmpty(), it) }
+        return TestWSDLTypeLookupEntry(typeName, typeKey, baseTypeName)
+    }
+
+    private fun Pattern.withTestWSDLTypeLookupMetadata(
+        typeKey: String,
+        baseTypeKey: String?,
+        knownTypeKeys: Map<WSDLTypeName, String>,
+        matchableTypeKeys: Map<WSDLTypeName, String>,
+        leafTypeKeys: Map<WSDLTypeName, String>,
+    ): Pattern {
+        return when (this) {
+            is XMLPattern -> copy(
+                pattern = pattern.copy(
+                    wsdlTypeKey = typeKey,
+                    wsdlBaseTypeKey = baseTypeKey,
+                    wsdlKnownTypeKeys = knownTypeKeys,
+                    wsdlMatchableTypeKeys = matchableTypeKeys,
+                    wsdlLeafTypeKeys = leafTypeKeys,
+                )
+            )
+
+            is AnyPattern -> copy(
+                pattern = pattern.map {
+                    it.withTestWSDLTypeLookupMetadata(
+                        typeKey,
+                        baseTypeKey,
+                        knownTypeKeys,
+                        matchableTypeKeys,
+                        leafTypeKeys,
+                    )
+                }
+            )
+
+            else -> this
+        }
+    }
+
+    private fun testMatchableTypeKeys(
+        baseType: WSDLTypeName,
+        entries: List<TestWSDLTypeLookupEntry>,
+        entriesByType: Map<WSDLTypeName, TestWSDLTypeLookupEntry>,
+        typeKeys: Map<WSDLTypeName, String>,
+    ): Map<WSDLTypeName, String> =
+        entries
+            .filter { entry -> entry.typeName == baseType || entry.isDerivedFrom(baseType, entriesByType) }
+            .mapNotNull { entry -> typeKeys[entry.typeName]?.let { key -> entry.typeName to key } }
+            .toMap()
+
+    private fun testLeafTypeKeys(
+        baseType: WSDLTypeName,
+        entries: List<TestWSDLTypeLookupEntry>,
+        entriesByType: Map<WSDLTypeName, TestWSDLTypeLookupEntry>,
+        typeKeys: Map<WSDLTypeName, String>,
+    ): Map<WSDLTypeName, String> {
+        val descendants = entries
+            .filter { entry -> entry.typeName != baseType && entry.isDerivedFrom(baseType, entriesByType) }
+            .map { it.typeName }
+            .toSet()
+
+        return descendants
+            .filter { descendant -> entries.none { entry -> entry.typeName in descendants && entry.isDerivedFrom(descendant, entriesByType) } }
+            .mapNotNull { type -> typeKeys[type]?.let { key -> type to key } }
+            .toMap()
+    }
+
+    private fun TestWSDLTypeLookupEntry.isDerivedFrom(
+        baseType: WSDLTypeName,
+        entriesByType: Map<WSDLTypeName, TestWSDLTypeLookupEntry>,
+    ): Boolean {
+        val directBaseType = baseTypeName ?: return false
+        if (directBaseType == baseType) {
+            return true
+        }
+
+        return entriesByType[directBaseType]?.isDerivedFrom(baseType, entriesByType) == true
     }
 
     @Nested

--- a/core/src/test/kotlin/io/specmatic/core/pattern/XMLPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/XMLPatternTest.kt
@@ -100,7 +100,7 @@ internal class XMLPatternTest {
         }
 
         @Test
-        fun `generate uses compatible WSDL leaf complex type variants instead of base or intermediate types`() {
+        fun `generate uses compatible WSDL concrete subtype variants instead of base or intermediate types`() {
             val resolver = Resolver(newPatterns = animalPatterns())
             val pattern = XMLPattern(
                 XMLTypeData(
@@ -121,12 +121,12 @@ internal class XMLPatternTest {
                     .containsExactly("tns:name", "tns:breed", "tns:job")
                 "tns:Cat" -> assertThat(generated.childNodes.filterIsInstance<XMLNode>().map(XMLNode::realName))
                     .containsExactly("tns:name", "tns:lives")
-                else -> fail("Expected generate to pick a leaf WSDL type")
+                else -> fail("Expected generate to pick a concrete WSDL subtype")
             }
         }
 
         @Test
-        fun `newBasedOn uses compatible WSDL leaf complex type variants instead of base or intermediate types`() {
+        fun `newBasedOn uses compatible WSDL concrete subtype variants instead of base or intermediate types`() {
             val resolver = Resolver(newPatterns = animalPatterns())
             val pattern = XMLPattern(
                 XMLTypeData(
@@ -931,11 +931,9 @@ internal class XMLPatternTest {
         return mapValues { (typeKey, pattern) ->
             val entry = entries.firstOrNull { it.typeKey == typeKey } ?: return@mapValues pattern
             pattern.withTestWSDLTypeLookupMetadata(
-                typeKey = typeKey,
-                baseTypeKey = entry.baseTypeName?.let(typeKeys::get),
                 knownTypeKeys = typeKeys,
-                matchableTypeKeys = testMatchableTypeKeys(entry.typeName, entries, entriesByType, typeKeys),
-                leafTypeKeys = testLeafTypeKeys(entry.typeName, entries, entriesByType, typeKeys),
+                compatibleTypeKeys = testCompatibleTypeKeys(entry.typeName, entries, entriesByType, typeKeys),
+                concreteSubtypeKeys = testConcreteSubtypeKeys(entry.typeName, entries, entriesByType, typeKeys),
             )
         }
     }
@@ -948,31 +946,25 @@ internal class XMLPatternTest {
     }
 
     private fun Pattern.withTestWSDLTypeLookupMetadata(
-        typeKey: String,
-        baseTypeKey: String?,
         knownTypeKeys: Map<WSDLTypeName, String>,
-        matchableTypeKeys: Map<WSDLTypeName, String>,
-        leafTypeKeys: Map<WSDLTypeName, String>,
+        compatibleTypeKeys: Map<WSDLTypeName, String>,
+        concreteSubtypeKeys: Map<WSDLTypeName, String>,
     ): Pattern {
         return when (this) {
             is XMLPattern -> copy(
                 pattern = pattern.copy(
-                    wsdlTypeKey = typeKey,
-                    wsdlBaseTypeKey = baseTypeKey,
                     wsdlKnownTypeKeys = knownTypeKeys,
-                    wsdlMatchableTypeKeys = matchableTypeKeys,
-                    wsdlLeafTypeKeys = leafTypeKeys,
+                    wsdlCompatibleTypeKeys = compatibleTypeKeys,
+                    wsdlConcreteSubtypeKeys = concreteSubtypeKeys,
                 )
             )
 
             is AnyPattern -> copy(
                 pattern = pattern.map {
                     it.withTestWSDLTypeLookupMetadata(
-                        typeKey,
-                        baseTypeKey,
                         knownTypeKeys,
-                        matchableTypeKeys,
-                        leafTypeKeys,
+                        compatibleTypeKeys,
+                        concreteSubtypeKeys,
                     )
                 }
             )
@@ -981,7 +973,7 @@ internal class XMLPatternTest {
         }
     }
 
-    private fun testMatchableTypeKeys(
+    private fun testCompatibleTypeKeys(
         baseType: WSDLTypeName,
         entries: List<TestWSDLTypeLookupEntry>,
         entriesByType: Map<WSDLTypeName, TestWSDLTypeLookupEntry>,
@@ -992,7 +984,7 @@ internal class XMLPatternTest {
             .mapNotNull { entry -> typeKeys[entry.typeName]?.let { key -> entry.typeName to key } }
             .toMap()
 
-    private fun testLeafTypeKeys(
+    private fun testConcreteSubtypeKeys(
         baseType: WSDLTypeName,
         entries: List<TestWSDLTypeLookupEntry>,
         entriesByType: Map<WSDLTypeName, TestWSDLTypeLookupEntry>,

--- a/core/src/test/kotlin/io/specmatic/core/value/XMLNodeTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/value/XMLNodeTest.kt
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
+import io.specmatic.core.CONTENT_TYPE
+import io.specmatic.core.HttpResponse
 import io.specmatic.core.pattern.ContractException
 import io.specmatic.trimmedLinesList
 
@@ -61,6 +63,51 @@ internal class XMLNodeTest {
         val node = toXMLNode("<data xmlns=\"http://default\" code=\"ABC\"/>")
 
         assertThat(node.attributeNamespaceUri("code")).isNull()
+    }
+
+    @Test
+    fun `finds attribute value by namespace uri and local name`() {
+        val node = toXMLNode(
+            """
+            <data xmlns:typeNs="http://www.w3.org/2001/XMLSchema-instance"
+                  typeNs:type="pet:Dog"
+                  type="not-namespaced"/>
+            """.trimIndent()
+        )
+
+        assertThat(node.attributeValueByNamespace("http://www.w3.org/2001/XMLSchema-instance", "type"))
+            .isEqualTo(StringValue("pet:Dog"))
+    }
+
+    @Test
+    fun `does not use default namespace for attribute value lookup by namespace`() {
+        val node = toXMLNode(
+            """
+            <data xmlns="http://www.w3.org/2001/XMLSchema-instance"
+                  type="pet:Dog"/>
+            """.trimIndent()
+        )
+
+        assertThat(node.attributeValueByNamespace("http://www.w3.org/2001/XMLSchema-instance", "type")).isNull()
+    }
+
+    @Test
+    fun `keeps inherited attribute namespace lookup after XML content-type adjustment`() {
+        val response = HttpResponse(
+            status = 200,
+            body = """
+                <root xmlns:typeNs="http://www.w3.org/2001/XMLSchema-instance">
+                    <child typeNs:type="pet:Dog"/>
+                </root>
+            """.trimIndent(),
+            headers = mapOf(CONTENT_TYPE to "text/xml")
+        )
+
+        val root = response.body as XMLNode
+        val child = root.findFirstChildByName("child")!!
+
+        assertThat(child.attributeValueByNamespace("http://www.w3.org/2001/XMLSchema-instance", "type"))
+            .isEqualTo(StringValue("pet:Dog"))
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/core/wsdl/WSDLParserMockBlackBoxTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/wsdl/WSDLParserMockBlackBoxTest.kt
@@ -615,7 +615,6 @@ class WSDLParserMockBlackBoxTest {
         val wsdlFile = tempDir.resolve("order-service.wsdl")
             .apply { writeText(minimizedOrderServiceWsdl()) }
         val feature = parseContractFileToFeature(wsdlFile)
-
         listOf(
             "xsi:type=\"OrderDetails\"",
             "xsi:type=\"ord:OrderDetails\"",
@@ -816,7 +815,7 @@ private fun minimizedOrderServiceWsdl(): String =
               <xsd:element minOccurs="0" maxOccurs="1" name="retrieveOrderDetailsRequest">
                 <xsd:complexType>
                   <xsd:sequence minOccurs="0" maxOccurs="1">
-                    <xsd:element minOccurs="0" maxOccurs="unbounded" name="order" type="ord:OrderDetails"/>
+                    <xsd:element minOccurs="0" maxOccurs="unbounded" name="order" type="ord:Order"/>
                   </xsd:sequence>
                   <xsd:attribute name="id" type="xsd:string" use="required"/>
                 </xsd:complexType>
@@ -824,17 +823,22 @@ private fun minimizedOrderServiceWsdl(): String =
               <xsd:element minOccurs="0" maxOccurs="1" name="retrieveOrderDetailsResponse">
                 <xsd:complexType>
                   <xsd:sequence minOccurs="0" maxOccurs="1">
-                    <xsd:element minOccurs="0" maxOccurs="unbounded" name="order" type="ord:OrderDetails"/>
+                    <xsd:element minOccurs="0" maxOccurs="unbounded" name="order" type="ord:Order"/>
                   </xsd:sequence>
                   <xsd:attribute name="id" type="xsd:string" use="required"/>
                 </xsd:complexType>
               </xsd:element>
             </xsd:choice>
           </xsd:complexType>
-          <xsd:complexType name="OrderDetails">
+          <xsd:complexType name="Order">
             <xsd:sequence minOccurs="0" maxOccurs="1">
               <xsd:element minOccurs="0" maxOccurs="1" name="orderNumber" type="xsd:string"/>
             </xsd:sequence>
+          </xsd:complexType>
+          <xsd:complexType name="OrderDetails">
+            <xsd:complexContent>
+              <xsd:extension base="ord:Order"/>
+            </xsd:complexContent>
           </xsd:complexType>
           <xsd:element name="Message" type="ord:Message"/>
         </xsd:schema>

--- a/core/src/test/kotlin/io/specmatic/core/wsdl/WSDLParserMockBlackBoxTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/wsdl/WSDLParserMockBlackBoxTest.kt
@@ -16,6 +16,7 @@ import io.specmatic.stub.HttpStub
 import io.specmatic.stub.SpecmaticConfigSource
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
 import java.net.ServerSocket
@@ -638,6 +639,43 @@ class WSDLParserMockBlackBoxTest {
     }
 
     @Test
+    fun `mock for wsdl rejects request when xsi type is unknown`(@TempDir tempDir: File) {
+        val wsdlFile = tempDir.resolve("order-service.wsdl")
+            .apply { writeText(minimizedOrderServiceWsdl()) }
+        val feature = parseContractFileToFeature(wsdlFile)
+        val request = orderDetailsRequest("xsi:type=\"ord:MissingOrderDetails\"")
+
+        val response = HttpStub(feature, strictMode = true).use { stub ->
+            stub.client.execute(request)
+        }
+
+        assertThat(response.status).isEqualTo(400)
+        assertThat(response.body.toStringLiteral()).contains("No matching SOAP stub")
+    }
+
+    @Test
+    fun `mock for wsdl rejects example response when xsi type is unknown`(@TempDir tempDir: File) {
+        val wsdlFile = tempDir.resolve("order-service.wsdl")
+            .apply { writeText(minimizedOrderServiceWsdl()) }
+        val feature = parseContractFileToFeature(wsdlFile)
+        val scenarioStub = ScenarioStub(
+            request = orderDetailsRequest("xsi:type=\"ord:OrderDetails\""),
+            response = HttpResponse(
+                status = 200,
+                body = orderDetailsResponseBody("ord:MissingOrderDetails"),
+                headers = mapOf(CONTENT_TYPE to ContentType.Text.Xml.toString()),
+            ),
+        )
+
+        val exception = assertThrows<Exception> {
+            HttpStub(feature, listOf(scenarioStub)).close()
+        }
+
+        assertThat(exception.message).contains("Unknown xsi:type")
+        assertThat(exception.message).contains("MissingOrderDetails")
+    }
+
+    @Test
     fun `mock for soap version_1_2 wsdl returns the example soap response with appropriate content-type header`() {
         val wsdlSpecPath = "src/test/resources/wsdl/cdata_test_soap12/data_api.wsdl"
         val wsdlExamplesPath = "src/test/resources/wsdl/cdata_test_soap12/data_api_examples"
@@ -736,7 +774,7 @@ private fun orderDetailsRequest(orderTypeAttribute: String): HttpRequest =
         )
     )
 
-private fun orderDetailsResponseBody(): String =
+private fun orderDetailsResponseBody(orderType: String = "ord:OrderDetails"): String =
     """
     <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
       <s:Body>
@@ -744,7 +782,7 @@ private fun orderDetailsResponseBody(): String =
           <Message bodyType="XML" id="response-id" version="1.0" xmlns="http://example.com/order-model" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ord="http://example.com/order-model">
             <command>
               <retrieveOrderDetailsResponse id="response-command-id">
-                <order xsi:type="ord:OrderDetails">
+                <order xsi:type="$orderType">
                   <orderNumber>matched-from-external-example</orderNumber>
                 </order>
               </retrieveOrderDetailsResponse>


### PR DESCRIPTION
**What**:

Adds WSDL `xsi:type` support for XML payloads so request and response validation can resolve runtime XML types against known WSDL/XSD types.

**Why**:

WSDL payloads can legally use `xsi:type` to send a derived type through an element declared as its base type. Specmatic needs to validate those payloads strictly: compatible derived types should match, incompatible or unknown types should be rejected, and namespace prefixes should be resolved by namespace URI rather than hard-coded prefix text.

**How**:

The WSDL-to-pattern path now preserves type metadata for XML patterns, indexes subtype relationships for lookup, and uses that metadata during XML matching and generation. XML namespace handling was tightened so inherited namespace declarations are available after programmatic XML reconstruction. The parser and pattern tests cover compatible derived types, unknown `xsi:type`, alternate namespace prefixes, nested sequence/choice usage, imported namespaces, and WSDL mock/contract behavior.

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
