### PR TITLE
Support abstract xsi:type handling in WSDL XML parsing

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLPattern.kt
@@ -198,7 +198,7 @@ data class XMLPattern(
         if (cyclePreventionPattern != this && !resolver.hasCycle(cyclePreventionPattern)) {
             return resolver.withCyclePrevention(cyclePreventionPattern) { cyclePreventedResolver ->
                 matchesXMLNode(sampleData, cyclePreventedResolver)
-            } ?: Success()
+            }
         }
 
         return matchesXMLNode(sampleData, resolver)
@@ -216,9 +216,10 @@ data class XMLPattern(
         if (matchingType.wsdlTypeSelectionMode() == WSDLTypeSelectionMode.Polymorphic) {
             selectWSDLType(sampleData, matchingType, resolver)?.let { selectedType ->
                 val matchResult = when (selectedType) {
-                    is WSDLTypeSelection.Unknown -> unknownXSITypeResult(selectedType.assertedType, selectedType.declaredType)
-                    is WSDLTypeSelection.Invalid -> invalidXSITypeResult(selectedType.assertedType, selectedType.declaredType)
-                    is WSDLTypeSelection.Abstract -> abstractXSITypeResult(selectedType.assertedType, selectedType.declaredType)
+                    is WSDLTypeSelection.Unknown,
+                    is WSDLTypeSelection.Invalid,
+                    is WSDLTypeSelection.Abstract -> failureForWSDLTypeSelection(selectedType)
+
                     is WSDLTypeSelection.Use -> matchWithType(selectedType.pattern, sampleDataWithoutEmptyHeader, resolver)
                 }
 
@@ -299,6 +300,15 @@ data class XMLPattern(
 
     private fun missingXSITypeForAbstractTypeResult(declaredType: WSDLTypeName): Failure {
         return Failure("Missing xsi:type for abstract WSDL type ${declaredType.namespace}#${declaredType.localName}; a concrete subtype is required.")
+    }
+
+    private fun failureForWSDLTypeSelection(selectedType: WSDLTypeSelection): Failure {
+        return when (selectedType) {
+            is WSDLTypeSelection.Unknown -> unknownXSITypeResult(selectedType.assertedType, selectedType.declaredType)
+            is WSDLTypeSelection.Invalid -> invalidXSITypeResult(selectedType.assertedType, selectedType.declaredType)
+            is WSDLTypeSelection.Abstract -> abstractXSITypeResult(selectedType.assertedType, selectedType.declaredType)
+            is WSDLTypeSelection.Use -> error("Cannot convert a valid WSDL type selection to a failure")
+        }
     }
 
     private fun selectWSDLType(sampleData: XMLNode, declaredType: Pattern, resolver: Resolver): WSDLTypeSelection? {
@@ -560,7 +570,7 @@ data class XMLPattern(
         attributes: Map<String, T>,
         attributeNamespaceUri: (String) -> String?,
     ): Map<String, T> {
-        if (!canDropPolymorphicXSITypeAttribute()) {
+        if (!shouldDropPolymorphicXSITypeAttribute()) {
             return attributes
         }
 
@@ -570,7 +580,7 @@ data class XMLPattern(
         }
     }
 
-    private fun canDropPolymorphicXSITypeAttribute(): Boolean =
+    private fun shouldDropPolymorphicXSITypeAttribute(): Boolean =
         pattern.wsdlTypeSelectionMode == WSDLTypeSelectionMode.Polymorphic
 
     private fun matchName(sampleData: XMLNode, resolver: Resolver): Result {
@@ -914,18 +924,6 @@ data class XMLPattern(
         }
 
         when (val selectedType = selectWSDLType(pattern.xsiTypeName(), declaredPattern, resolver)) {
-            is WSDLTypeSelection.Unknown -> throw ContractException(
-                unknownXSITypeResult(selectedType.assertedType, selectedType.declaredType).toFailureReport()
-            )
-
-            is WSDLTypeSelection.Invalid -> throw ContractException(
-                invalidXSITypeResult(selectedType.assertedType, selectedType.declaredType).toFailureReport()
-            )
-
-            is WSDLTypeSelection.Abstract -> throw ContractException(
-                abstractXSITypeResult(selectedType.assertedType, selectedType.declaredType).toFailureReport()
-            )
-
             is WSDLTypeSelection.Use -> {
                 if (pattern.xsiTypeName() == declaredWSDLType) {
                     return emptyList()
@@ -933,6 +931,12 @@ data class XMLPattern(
 
                 return listOfNotNull((selectedType.pattern as? XMLPattern)?.withCurrentWSDLTypeOnly())
             }
+
+            is WSDLTypeSelection.Unknown,
+            is WSDLTypeSelection.Invalid,
+            is WSDLTypeSelection.Abstract -> throw ContractException(
+                failureForWSDLTypeSelection(selectedType).toFailureReport()
+            )
 
             null -> Unit
         }
@@ -959,8 +963,19 @@ data class XMLPattern(
             return null
         }
 
+        if (!declaredPattern.hasComplexXMLShape()) {
+            return null
+        }
+
         return declaredPattern.withCurrentWSDLTypeOnly()
     }
+
+    private fun XMLPattern.hasComplexXMLShape(): Boolean =
+        pattern.nodes.any { it is XMLPattern } ||
+                pattern.attributes.keys.any { key ->
+                    !key.startsWith(SPECMATIC_XML_ATTRIBUTE_PREFIX) && !isNamespaceDeclarationAttribute(key)
+                } ||
+                pattern.attributeWildcards.isNotEmpty()
 
     override fun negativeBasedOn(
         row: Row,

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLPattern.kt
@@ -205,11 +205,6 @@ data class XMLPattern(
     }
 
     private fun matchesXMLNode(sampleData: XMLNode, resolver: Resolver): Result {
-        if (pattern.isNillable()) {
-            if (sampleData.childNodes.isEmpty())
-                return Success()
-        }
-
         val matchingType = dereferenceType(resolver)
         val sampleDataWithoutEmptyHeader = dropEmptySOAPHeader(sampleData)
 
@@ -233,6 +228,11 @@ data class XMLPattern(
                         .breadCrumb(pattern.name, resolver.locate(schemaPointer))
                 }
             }
+        }
+
+        if (pattern.isNillable()) {
+            if (sampleData.childNodes.isEmpty())
+                return Success()
         }
 
         return when (matchingType) {
@@ -323,30 +323,28 @@ data class XMLPattern(
         }
 
         val declaredWSDLType = declaredType.wsdlTypeName() ?: return null
-        val assertedWSDLPattern = resolver.findPatternForWSDLType(assertedType)
-        val assertedPattern = declaredType.findPatternForWSDLType(assertedType, resolver)
-            ?: assertedWSDLPattern
+        val payloadAssertedTypePattern = resolver.findPatternForWSDLType(assertedType)
+        val payloadAssertedTypePatternCompatibleWithDeclaredType = declaredType.findPatternForWSDLType(assertedType, resolver)
+            ?: payloadAssertedTypePattern
                 ?.takeIf { it.wsdlTypeName() == declaredWSDLType || it.isDerivedFrom(declaredWSDLType, resolver) }
         val assertedTypeIsKnown = declaredType.knowsWSDLType(assertedType) ||
-                assertedWSDLPattern != null
+                payloadAssertedTypePattern != null
 
         return when {
             assertedType == declaredWSDLType && declaredType.isAbstractWSDLType() ->
                 WSDLTypeSelection.Abstract(assertedType, declaredWSDLType)
 
-            assertedWSDLPattern?.isAbstractWSDLType() == true ->
-                WSDLTypeSelection.Abstract(assertedType, declaredWSDLType)
-
-            assertedPattern == null && !assertedTypeIsKnown ->
+            payloadAssertedTypePatternCompatibleWithDeclaredType == null && !assertedTypeIsKnown ->
                 WSDLTypeSelection.Unknown(assertedType, declaredWSDLType)
 
-            assertedType == declaredWSDLType ->
-                WSDLTypeSelection.Use(mergeReferredPattern(assertedPattern ?: declaredType))
+            payloadAssertedTypePatternCompatibleWithDeclaredType == null ->
+                WSDLTypeSelection.Invalid(assertedType, declaredWSDLType)
 
-            assertedPattern != null ->
-                WSDLTypeSelection.Use(mergeReferredPattern(assertedPattern))
+            payloadAssertedTypePatternCompatibleWithDeclaredType.isAbstractWSDLType() ->
+                WSDLTypeSelection.Abstract(assertedType, declaredWSDLType)
 
-            else -> WSDLTypeSelection.Invalid(assertedType, declaredWSDLType)
+            else ->
+                WSDLTypeSelection.Use(mergeReferredPattern(payloadAssertedTypePatternCompatibleWithDeclaredType))
         }
     }
 
@@ -917,13 +915,19 @@ data class XMLPattern(
             return emptyList()
         }
 
-        val declaredWSDLType = declaredPattern.pattern.wsdlTypeName() ?: return emptyList()
+        val lookupPattern = when {
+            declaredPattern.hasWSDLTypeLookupMetadata() -> declaredPattern
+            hasWSDLTypeLookupMetadata() -> this
+            else -> declaredPattern
+        }
 
-        if (declaredPattern.pattern.wsdlTypeSelectionMode == WSDLTypeSelectionMode.CurrentTypeOnly) {
+        val declaredWSDLType = lookupPattern.pattern.wsdlTypeName() ?: return emptyList()
+
+        if (lookupPattern.pattern.wsdlTypeSelectionMode == WSDLTypeSelectionMode.CurrentTypeOnly) {
             return emptyList()
         }
 
-        when (val selectedType = selectWSDLType(pattern.xsiTypeName(), declaredPattern, resolver)) {
+        when (val selectedType = selectWSDLType(pattern.xsiTypeName(), lookupPattern, resolver)) {
             is WSDLTypeSelection.Use -> {
                 if (pattern.xsiTypeName() == declaredWSDLType) {
                     return emptyList()
@@ -941,17 +945,16 @@ data class XMLPattern(
             null -> Unit
         }
 
-        val basePattern = concreteBaseWSDLTypeCandidate(declaredPattern)
+        val basePattern = concreteBaseWSDLTypeCandidate(lookupPattern)
 
-        val derivedPatterns = declaredPattern.concreteDerivedWSDLPatterns(resolver).mapNotNull { derivedPattern ->
-            val derivedType = derivedPattern.pattern.wsdlTypeName() ?: return@mapNotNull null
-            val mergedPattern = declaredPattern.mergeReferredPattern(derivedPattern) as? XMLPattern ?: return@mapNotNull null
+        val derivedPatterns = lookupPattern.concreteDerivedWSDLPatterns(resolver).mapNotNull { (derivedType, derivedPattern) ->
+            val mergedPattern = lookupPattern.mergeWSDLDerivedPattern(derivedPattern) ?: return@mapNotNull null
             mergedPattern.withXSIType(derivedType).withCurrentWSDLTypeOnly()
         }
 
         val candidatePatterns = listOfNotNull(basePattern) + derivedPatterns
 
-        if (candidatePatterns.isEmpty() && declaredPattern.pattern.wsdlTypeIsAbstract) {
+        if (candidatePatterns.isEmpty() && lookupPattern.pattern.wsdlTypeIsAbstract) {
             throw ContractException("Cannot select a concrete WSDL type for abstract type ${declaredWSDLType.namespace}#${declaredWSDLType.localName}; no concrete derived types were found.")
         }
 
@@ -963,19 +966,28 @@ data class XMLPattern(
             return null
         }
 
-        if (!declaredPattern.hasComplexXMLShape()) {
+        val declaredType = declaredPattern.pattern.wsdlTypeName() ?: return null
+        if (declaredType.namespace == XML_SCHEMA_NAMESPACE) {
             return null
         }
 
         return declaredPattern.withCurrentWSDLTypeOnly()
     }
 
-    private fun XMLPattern.hasComplexXMLShape(): Boolean =
-        pattern.nodes.any { it is XMLPattern } ||
-                pattern.attributes.keys.any { key ->
-                    !key.startsWith(SPECMATIC_XML_ATTRIBUTE_PREFIX) && !isNamespaceDeclarationAttribute(key)
-                } ||
-                pattern.attributeWildcards.isNotEmpty()
+    private fun hasWSDLTypeLookupMetadata(): Boolean =
+        pattern.wsdlKnownTypeKeys.isNotEmpty() ||
+                pattern.wsdlCompatibleTypeKeys.isNotEmpty() ||
+                pattern.wsdlConcreteSubtypeKeys.isNotEmpty()
+
+    private fun mergeWSDLDerivedPattern(derivedPattern: Pattern): XMLPattern? {
+        return when (derivedPattern) {
+            is XMLPattern -> mergeReferredPattern(derivedPattern) as? XMLPattern
+            else -> wrapDerivedSimpleContentInDeclaredElement(derivedPattern)
+        }
+    }
+
+    private fun wrapDerivedSimpleContentInDeclaredElement(derivedPattern: Pattern): XMLPattern =
+        copy(pattern = pattern.copy(nodes = listOf(derivedPattern)))
 
     override fun negativeBasedOn(
         row: Row,
@@ -1394,27 +1406,20 @@ private fun Resolver.findPatternForWSDLType(typeName: WSDLTypeName): Pattern? {
 private fun Pattern.knowsWSDLType(typeName: WSDLTypeName): Boolean =
     wsdlKnownTypeKeys().containsKey(typeName)
 
-private fun Pattern.concreteDerivedWSDLPatterns(resolver: Resolver): List<XMLPattern> {
-    return wsdlConcreteSubtypeKeys().values.flatMap { typeKey ->
-        resolver.patternForWSDLKey(typeKey)?.xmlPatternVariants().orEmpty()
-    }.filter { pattern ->
-        pattern.pattern.wsdlTypeName()?.namespace != XML_SCHEMA_NAMESPACE
-    }.filterNot { pattern ->
-        pattern.pattern.wsdlTypeIsAbstract
+private fun Pattern.concreteDerivedWSDLPatterns(resolver: Resolver): List<Pair<WSDLTypeName, Pattern>> {
+    return wsdlConcreteSubtypeKeys().mapNotNull { (typeName, typeKey) ->
+        if (typeName.namespace == XML_SCHEMA_NAMESPACE) return@mapNotNull null
+
+        val pattern = resolver.patternForWSDLKey(typeKey) ?: return@mapNotNull null
+        if (pattern.isAbstractWSDLType()) return@mapNotNull null
+
+        typeName to pattern
     }
 }
 
 private fun Resolver.patternForWSDLKey(typeKey: String): Pattern? {
     val rawTypeKey = withoutPatternDelimiters(typeKey)
     return newPatterns[typeKey] ?: newPatterns[withPatternDelimiters(rawTypeKey)] ?: newPatterns[rawTypeKey]
-}
-
-private fun Pattern.xmlPatternVariants(): List<XMLPattern> {
-    return when (this) {
-        is XMLPattern -> listOf(this)
-        is AnyPattern -> pattern.flatMap { it.xmlPatternVariants() }
-        else -> emptyList()
-    }
 }
 
 private fun Pattern.wsdlKnownTypeKeys(): Map<WSDLTypeName, String> {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLPattern.kt
@@ -23,6 +23,7 @@ private sealed class WSDLTypeSelection {
     data class Use(val pattern: Pattern) : WSDLTypeSelection()
     data class Unknown(val assertedType: WSDLTypeName, val declaredType: WSDLTypeName) : WSDLTypeSelection()
     data class Invalid(val assertedType: WSDLTypeName, val declaredType: WSDLTypeName) : WSDLTypeSelection()
+    data class Abstract(val assertedType: WSDLTypeName, val declaredType: WSDLTypeName) : WSDLTypeSelection()
 }
 
 private data class XMLHeaderName(
@@ -107,6 +108,9 @@ data class XMLPattern(
     fun plusNamespaceUri(namespaceUri: String?): XMLPattern {
         return copy(pattern = pattern.copy(namespaceUri = namespaceUri?.takeIf { it.isNotBlank() }))
     }
+
+    fun withCurrentWSDLTypeOnly(): XMLPattern =
+        copy(pattern = pattern.copy(wsdlTypeSelectionMode = WSDLTypeSelectionMode.CurrentTypeOnly))
 
     override fun matches(sampleData: List<Value>, resolver: Resolver): ConsumeResult<Value, Value> {
         val xmlValues = sampleData.filterIsInstance<XMLValue>()
@@ -209,14 +213,25 @@ data class XMLPattern(
         val matchingType = dereferenceType(resolver)
         val sampleDataWithoutEmptyHeader = dropEmptySOAPHeader(sampleData)
 
-        selectWSDLType(sampleData, matchingType, resolver)?.let { selectedType ->
-            val matchResult = when (selectedType) {
-                is WSDLTypeSelection.Unknown -> unknownXSITypeResult(selectedType.assertedType, selectedType.declaredType)
-                is WSDLTypeSelection.Invalid -> invalidXSITypeResult(selectedType.assertedType, selectedType.declaredType)
-                is WSDLTypeSelection.Use -> matchWithType(selectedType.pattern, sampleDataWithoutEmptyHeader, resolver)
+        if (matchingType.wsdlTypeSelectionMode() == WSDLTypeSelectionMode.Polymorphic) {
+            selectWSDLType(sampleData, matchingType, resolver)?.let { selectedType ->
+                val matchResult = when (selectedType) {
+                    is WSDLTypeSelection.Unknown -> unknownXSITypeResult(selectedType.assertedType, selectedType.declaredType)
+                    is WSDLTypeSelection.Invalid -> invalidXSITypeResult(selectedType.assertedType, selectedType.declaredType)
+                    is WSDLTypeSelection.Abstract -> abstractXSITypeResult(selectedType.assertedType, selectedType.declaredType)
+                    is WSDLTypeSelection.Use -> matchWithType(selectedType.pattern, sampleDataWithoutEmptyHeader, resolver)
+                }
+
+                return matchResult.breadCrumb(pattern.name, resolver.locate(schemaPointer))
             }
 
-            return matchResult.breadCrumb(pattern.name, resolver.locate(schemaPointer))
+            if (matchingType.isAbstractWSDLType()) {
+                val declaredType = matchingType.wsdlTypeName()
+                if (declaredType != null) {
+                    return missingXSITypeForAbstractTypeResult(declaredType)
+                        .breadCrumb(pattern.name, resolver.locate(schemaPointer))
+                }
+            }
         }
 
         return when (matchingType) {
@@ -277,6 +292,15 @@ data class XMLPattern(
         return Failure("Unknown xsi:type ${assertedType.namespace}#${assertedType.localName}; no matching type was found in the WSDL/schema set for $declaredDescription.")
     }
 
+    private fun abstractXSITypeResult(assertedType: WSDLTypeName, declaredType: WSDLTypeName): Failure {
+        val declaredDescription = "${declaredType.namespace}#${declaredType.localName}"
+        return Failure("Invalid xsi:type ${assertedType.namespace}#${assertedType.localName}; it is abstract and cannot be used as a concrete WSDL type for $declaredDescription.")
+    }
+
+    private fun missingXSITypeForAbstractTypeResult(declaredType: WSDLTypeName): Failure {
+        return Failure("Missing xsi:type for abstract WSDL type ${declaredType.namespace}#${declaredType.localName}; a concrete subtype is required.")
+    }
+
     private fun selectWSDLType(sampleData: XMLNode, declaredType: Pattern, resolver: Resolver): WSDLTypeSelection? {
         return selectWSDLType(sampleData.xsiTypeName(), declaredType, resolver)
     }
@@ -289,13 +313,20 @@ data class XMLPattern(
         }
 
         val declaredWSDLType = declaredType.wsdlTypeName() ?: return null
+        val assertedWSDLPattern = resolver.findPatternForWSDLType(assertedType)
         val assertedPattern = declaredType.findPatternForWSDLType(assertedType, resolver)
-            ?: resolver.findPatternForWSDLType(assertedType)
+            ?: assertedWSDLPattern
                 ?.takeIf { it.wsdlTypeName() == declaredWSDLType || it.isDerivedFrom(declaredWSDLType, resolver) }
         val assertedTypeIsKnown = declaredType.knowsWSDLType(assertedType) ||
-                resolver.findPatternForWSDLType(assertedType) != null
+                assertedWSDLPattern != null
 
         return when {
+            assertedType == declaredWSDLType && declaredType.isAbstractWSDLType() ->
+                WSDLTypeSelection.Abstract(assertedType, declaredWSDLType)
+
+            assertedWSDLPattern?.isAbstractWSDLType() == true ->
+                WSDLTypeSelection.Abstract(assertedType, declaredWSDLType)
+
             assertedPattern == null && !assertedTypeIsKnown ->
                 WSDLTypeSelection.Unknown(assertedType, declaredWSDLType)
 
@@ -466,6 +497,8 @@ data class XMLPattern(
             it.key == "xmlns" || it.key.startsWith("xmlns:") || it.key.startsWith(SPECMATIC_XML_ATTRIBUTE_PREFIX)
         }.let { attributesWithoutXmlns ->
             dropSOAP11MetadataAttributes(attributesWithoutXmlns, pattern::attributeNamespaceUri)
+        }.let { attributesWithoutXmlns ->
+            dropPolymorphicXSITypeAttribute(attributesWithoutXmlns, pattern::attributeNamespaceUri)
         }
         val sampleAttributesWithoutXmlns: Map<String, StringValue> = sampleData.attributes.filterNot {
             it.key == "xmlns" ||
@@ -473,6 +506,8 @@ data class XMLPattern(
                     it.key.startsWith(SPECMATIC_XML_ATTRIBUTE_PREFIX)
         }.let { attributesWithoutXmlns ->
             dropSOAP11MetadataAttributes(attributesWithoutXmlns, sampleData::attributeNamespaceUri)
+        }.let { attributesWithoutXmlns ->
+            dropPolymorphicXSITypeAttribute(attributesWithoutXmlns, sampleData::attributeNamespaceUri)
         }
 
         val sampleAttributesForKeyCheck = sampleAttributesWithoutXmlns.filterNot { (key, _) ->
@@ -517,10 +552,26 @@ data class XMLPattern(
 
         return when (name) {
             "encodingStyle" -> namespaceUri == SOAP_ENVELOPE_NAMESPACE
-            "type" -> isXMLSchemaInstanceTypeAttribute(attributeName, namespaceUri)
             else -> false
         }
     }
+
+    private fun <T> dropPolymorphicXSITypeAttribute(
+        attributes: Map<String, T>,
+        attributeNamespaceUri: (String) -> String?,
+    ): Map<String, T> {
+        if (!canDropPolymorphicXSITypeAttribute()) {
+            return attributes
+        }
+
+        return attributes.filterNot { (key, _) ->
+            val namespaceUri = runCatching { attributeNamespaceUri(key) }.getOrNull()
+            isXMLSchemaInstanceTypeAttribute(key, namespaceUri)
+        }
+    }
+
+    private fun canDropPolymorphicXSITypeAttribute(): Boolean =
+        pattern.wsdlTypeSelectionMode == WSDLTypeSelectionMode.Polymorphic
 
     private fun matchName(sampleData: XMLNode, resolver: Resolver): Result {
         if (sampleData.name != pattern.name)
@@ -593,9 +644,9 @@ data class XMLPattern(
 
         val name = pattern.name
 
-        val wsdlVariants = wsdlSubtypePatternsForGeneration(resolver)
-        if (wsdlVariants.isNotEmpty()) {
-            return wsdlVariants.random().generateXML(resolver)
+        val concreteWSDLTypeCandidates = concreteWSDLTypeCandidates(resolver)
+        if (concreteWSDLTypeCandidates.isNotEmpty()) {
+            return concreteWSDLTypeCandidates.random().generateXML(resolver)
         }
 
         val resolvedPattern = dereferenceType(resolver) as XMLPattern
@@ -654,9 +705,9 @@ data class XMLPattern(
             }
         }
 
-        val wsdlVariants = wsdlSubtypePatternsForGeneration(resolver)
-        if (wsdlVariants.isNotEmpty()) {
-            return wsdlVariants.asSequence().flatMap { selectedPattern ->
+        val concreteWSDLTypeCandidates = concreteWSDLTypeCandidates(resolver)
+        if (concreteWSDLTypeCandidates.isNotEmpty()) {
+            return concreteWSDLTypeCandidates.asSequence().flatMap { selectedPattern ->
                 selectedPattern.newBasedOn(row, resolver)
             }
         }
@@ -770,9 +821,9 @@ data class XMLPattern(
     }
 
     override fun newBasedOn(resolver: Resolver): Sequence<XMLPattern> {
-        val wsdlVariants = wsdlSubtypePatternsForGeneration(resolver)
-        if (wsdlVariants.isNotEmpty()) {
-            return wsdlVariants.asSequence().flatMap { selectedPattern ->
+        val concreteWSDLTypeCandidates = concreteWSDLTypeCandidates(resolver)
+        if (concreteWSDLTypeCandidates.isNotEmpty()) {
+            return concreteWSDLTypeCandidates.asSequence().flatMap { selectedPattern ->
                 selectedPattern.newBasedOn(resolver)
             }
         }
@@ -845,7 +896,7 @@ data class XMLPattern(
         }
     }
 
-    private fun wsdlSubtypePatternsForGeneration(resolver: Resolver): List<XMLPattern> {
+    private fun concreteWSDLTypeCandidates(resolver: Resolver): List<XMLPattern> {
         val declaredPattern = try {
             dereferenceType(resolver)
         } catch (e: ContractException) {
@@ -857,6 +908,11 @@ data class XMLPattern(
         }
 
         val declaredWSDLType = declaredPattern.pattern.wsdlTypeName() ?: return emptyList()
+
+        if (declaredPattern.pattern.wsdlTypeSelectionMode == WSDLTypeSelectionMode.CurrentTypeOnly) {
+            return emptyList()
+        }
+
         when (val selectedType = selectWSDLType(pattern.xsiTypeName(), declaredPattern, resolver)) {
             is WSDLTypeSelection.Unknown -> throw ContractException(
                 unknownXSITypeResult(selectedType.assertedType, selectedType.declaredType).toFailureReport()
@@ -866,24 +922,44 @@ data class XMLPattern(
                 invalidXSITypeResult(selectedType.assertedType, selectedType.declaredType).toFailureReport()
             )
 
+            is WSDLTypeSelection.Abstract -> throw ContractException(
+                abstractXSITypeResult(selectedType.assertedType, selectedType.declaredType).toFailureReport()
+            )
+
             is WSDLTypeSelection.Use -> {
                 if (pattern.xsiTypeName() == declaredWSDLType) {
                     return emptyList()
                 }
 
-                return listOfNotNull(selectedType.pattern as? XMLPattern)
+                return listOfNotNull((selectedType.pattern as? XMLPattern)?.withCurrentWSDLTypeOnly())
             }
 
             null -> Unit
         }
 
-        val derivedPatterns = declaredPattern.concreteSubtypeWSDLPatterns(resolver).mapNotNull { derivedPattern ->
+        val basePattern = concreteBaseWSDLTypeCandidate(declaredPattern)
+
+        val derivedPatterns = declaredPattern.concreteDerivedWSDLPatterns(resolver).mapNotNull { derivedPattern ->
             val derivedType = derivedPattern.pattern.wsdlTypeName() ?: return@mapNotNull null
             val mergedPattern = declaredPattern.mergeReferredPattern(derivedPattern) as? XMLPattern ?: return@mapNotNull null
-            mergedPattern.withXSIType(derivedType)
+            mergedPattern.withXSIType(derivedType).withCurrentWSDLTypeOnly()
         }
 
-        return derivedPatterns
+        val candidatePatterns = listOfNotNull(basePattern) + derivedPatterns
+
+        if (candidatePatterns.isEmpty() && declaredPattern.pattern.wsdlTypeIsAbstract) {
+            throw ContractException("Cannot select a concrete WSDL type for abstract type ${declaredWSDLType.namespace}#${declaredWSDLType.localName}; no concrete derived types were found.")
+        }
+
+        return candidatePatterns
+    }
+
+    private fun concreteBaseWSDLTypeCandidate(declaredPattern: XMLPattern): XMLPattern? {
+        if (declaredPattern.pattern.wsdlTypeIsAbstract) {
+            return null
+        }
+
+        return declaredPattern.withCurrentWSDLTypeOnly()
     }
 
     override fun negativeBasedOn(
@@ -1303,11 +1379,13 @@ private fun Resolver.findPatternForWSDLType(typeName: WSDLTypeName): Pattern? {
 private fun Pattern.knowsWSDLType(typeName: WSDLTypeName): Boolean =
     wsdlKnownTypeKeys().containsKey(typeName)
 
-private fun Pattern.concreteSubtypeWSDLPatterns(resolver: Resolver): List<XMLPattern> {
+private fun Pattern.concreteDerivedWSDLPatterns(resolver: Resolver): List<XMLPattern> {
     return wsdlConcreteSubtypeKeys().values.flatMap { typeKey ->
         resolver.patternForWSDLKey(typeKey)?.xmlPatternVariants().orEmpty()
     }.filter { pattern ->
         pattern.pattern.wsdlTypeName()?.namespace != XML_SCHEMA_NAMESPACE
+    }.filterNot { pattern ->
+        pattern.pattern.wsdlTypeIsAbstract
     }
 }
 
@@ -1353,6 +1431,26 @@ private fun Pattern.wsdlTypeName(): WSDLTypeName? {
         is XMLPattern -> pattern.wsdlTypeName()
         is AnyPattern -> pattern.asSequence().mapNotNull { it.wsdlTypeName() }.firstOrNull()
         else -> null
+    }
+}
+
+private fun Pattern.isAbstractWSDLType(): Boolean {
+    return when (this) {
+        is XMLPattern -> pattern.wsdlTypeIsAbstract
+        is AnyPattern -> pattern.any { it.isAbstractWSDLType() }
+        else -> false
+    }
+}
+
+private fun Pattern.wsdlTypeSelectionMode(): WSDLTypeSelectionMode {
+    return when (this) {
+        is XMLPattern -> pattern.wsdlTypeSelectionMode
+        is AnyPattern -> pattern.asSequence()
+            .map { it.wsdlTypeSelectionMode() }
+            .firstOrNull { it == WSDLTypeSelectionMode.CurrentTypeOnly }
+            ?: WSDLTypeSelectionMode.Polymorphic
+
+        else -> WSDLTypeSelectionMode.Polymorphic
     }
 }
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLTypeData.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLTypeData.kt
@@ -12,6 +12,11 @@ internal const val XML_SCHEMA_NAMESPACE = "http://www.w3.org/2001/XMLSchema"
 
 data class WSDLTypeName(val namespace: String, val localName: String)
 
+enum class WSDLTypeSelectionMode {
+    Polymorphic,
+    CurrentTypeOnly
+}
+
 internal fun isXMLSchemaInstanceTypeAttribute(attributeName: String, namespaceUri: String?): Boolean =
     attributeName.localName() == "type" && namespaceUri == XML_SCHEMA_INSTANCE_NAMESPACE
 
@@ -29,6 +34,8 @@ data class XMLTypeData(
     val wsdlTypeName: String? = null,
     val wsdlBaseTypeNamespace: String? = null,
     val wsdlBaseTypeName: String? = null,
+    val wsdlTypeIsAbstract: Boolean = false,
+    val wsdlTypeSelectionMode: WSDLTypeSelectionMode = WSDLTypeSelectionMode.Polymorphic,
     val wsdlKnownTypeKeys: Map<WSDLTypeName, String> = emptyMap(),
     val wsdlCompatibleTypeKeys: Map<WSDLTypeName, String> = emptyMap(),
     val wsdlConcreteSubtypeKeys: Map<WSDLTypeName, String> = emptyMap(),

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/SOAP11Parser.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/SOAP11Parser.kt
@@ -49,6 +49,7 @@ private data class WSDLTypeLookupEntry(
     val typeName: WSDLTypeName,
     val typeKey: String,
     val baseTypeName: WSDLTypeName?,
+    val isAbstract: Boolean,
 )
 
 class SOAP11Parser(private val wsdl: WSDL): SOAPParser {
@@ -404,6 +405,7 @@ class SOAP11Parser(private val wsdl: WSDL): SOAPParser {
                     ?.fullyQualifiedNameFromAttribute("base")
                     ?.takeUnless { it.namespace == XML_SCHEMA_NAMESPACE }
                     ?.let { WSDLTypeName(it.namespace, it.localName) },
+                isAbstract = typeNode.isAbstractNamedComplexType(),
             )
         }
     }
@@ -426,6 +428,7 @@ class SOAP11Parser(private val wsdl: WSDL): SOAPParser {
                 knownTypeKeys = typeKeys,
                 compatibleTypeKeys = compatibleTypeKeys(typeEntry.typeName, entries, entriesByType, typeKeys),
                 concreteSubtypeKeys = concreteSubtypeKeys(typeEntry.typeName, entries, entriesByType, typeKeys),
+                isAbstract = typeEntry.isAbstract,
             )
         }
     }
@@ -446,6 +449,7 @@ class SOAP11Parser(private val wsdl: WSDL): SOAPParser {
                 knownTypeKeys = typeKeys,
                 compatibleTypeKeys = compatibleTypeKeys(typeEntry.typeName, entries, entriesByType, typeKeys),
                 concreteSubtypeKeys = concreteSubtypeKeys(typeEntry.typeName, entries, entriesByType, typeKeys),
+                isAbstract = typeEntry.isAbstract,
             )
         }
     }
@@ -481,6 +485,7 @@ class SOAP11Parser(private val wsdl: WSDL): SOAPParser {
         knownTypeKeys: Map<WSDLTypeName, String>,
         compatibleTypeKeys: Map<WSDLTypeName, String>,
         concreteSubtypeKeys: Map<WSDLTypeName, String>,
+        isAbstract: Boolean,
     ): Pattern {
         return when (this) {
             is XMLPattern -> copy(
@@ -489,6 +494,7 @@ class SOAP11Parser(private val wsdl: WSDL): SOAPParser {
                     wsdlTypeName = pattern.wsdlTypeName ?: typeName.localName,
                     wsdlBaseTypeNamespace = pattern.wsdlBaseTypeNamespace ?: baseTypeName?.namespace,
                     wsdlBaseTypeName = pattern.wsdlBaseTypeName ?: baseTypeName?.localName,
+                    wsdlTypeIsAbstract = isAbstract,
                     wsdlKnownTypeKeys = knownTypeKeys,
                     wsdlCompatibleTypeKeys = compatibleTypeKeys,
                     wsdlConcreteSubtypeKeys = concreteSubtypeKeys,
@@ -503,6 +509,7 @@ class SOAP11Parser(private val wsdl: WSDL): SOAPParser {
                         knownTypeKeys,
                         compatibleTypeKeys,
                         concreteSubtypeKeys,
+                        isAbstract,
                     )
                 }
             )
@@ -519,6 +526,7 @@ class SOAP11Parser(private val wsdl: WSDL): SOAPParser {
     ): Map<WSDLTypeName, String> =
         entries
             .filter { entry -> entry.typeName == baseType || entry.isDerivedFrom(baseType, entriesByType) }
+            .filterNot(WSDLTypeLookupEntry::isAbstract)
             .mapNotNull { entry -> typeKeys[entry.typeName]?.let { key -> entry.typeName to key } }
             .toMap()
 
@@ -530,6 +538,7 @@ class SOAP11Parser(private val wsdl: WSDL): SOAPParser {
     ): Map<WSDLTypeName, String> {
         val descendants = entries
             .filter { entry -> entry.typeName != baseType && entry.isDerivedFrom(baseType, entriesByType) }
+            .filterNot(WSDLTypeLookupEntry::isAbstract)
             .map { it.typeName }
             .toSet()
 
@@ -597,6 +606,11 @@ class SOAP11Parser(private val wsdl: WSDL): SOAPParser {
     private fun XMLNode.hasActionableDerivation(): Boolean {
         return derivationNode()?.hasBaseOutsideXMLSchemaNamespace() == true
     }
+
+    private fun XMLNode.isAbstractNamedComplexType(): Boolean =
+        name == "complexType" &&
+                attributes.containsKey("name") &&
+                attributes["abstract"]?.toStringLiteral()?.lowercase() == "true"
 
     private fun XMLNode.derivationNode(): XMLNode? {
         val directRestriction = findFirstChildByName("restriction")

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/SOAP11Parser.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/SOAP11Parser.kt
@@ -535,18 +535,12 @@ class SOAP11Parser(private val wsdl: WSDL): SOAPParser {
         entries: List<WSDLTypeLookupEntry>,
         entriesByType: Map<WSDLTypeName, WSDLTypeLookupEntry>,
         typeKeys: Map<WSDLTypeName, String>,
-    ): Map<WSDLTypeName, String> {
-        val descendants = entries
+    ): Map<WSDLTypeName, String> =
+        entries
             .filter { entry -> entry.typeName != baseType && entry.isDerivedFrom(baseType, entriesByType) }
             .filterNot(WSDLTypeLookupEntry::isAbstract)
-            .map { it.typeName }
-            .toSet()
-
-        return descendants
-            .filter { descendant -> entries.none { entry -> entry.typeName in descendants && entry.isDerivedFrom(descendant, entriesByType) } }
-            .mapNotNull { type -> typeKeys[type]?.let { key -> type to key } }
+            .mapNotNull { entry -> typeKeys[entry.typeName]?.let { key -> entry.typeName to key } }
             .toMap()
-    }
 
     private fun WSDLTypeLookupEntry.isDerivedFrom(
         baseType: WSDLTypeName,

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/SOAP11Parser.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/SOAP11Parser.kt
@@ -607,11 +607,6 @@ class SOAP11Parser(private val wsdl: WSDL): SOAPParser {
         return derivationNode()?.hasBaseOutsideXMLSchemaNamespace() == true
     }
 
-    private fun XMLNode.isAbstractNamedComplexType(): Boolean =
-        name == "complexType" &&
-                attributes.containsKey("name") &&
-                attributes["abstract"]?.toStringLiteral()?.lowercase() == "true"
-
     private fun XMLNode.derivationNode(): XMLNode? {
         val directRestriction = findFirstChildByName("restriction")
         val complexContent = findFirstChildByName("complexContent")

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/WSDLTypeInfo.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/WSDLTypeInfo.kt
@@ -19,6 +19,7 @@ data class WSDLTypeInfo(
     val wsdlTypeName: String? = null,
     val wsdlBaseTypeNamespace: String? = null,
     val wsdlBaseTypeName: String? = null,
+    val wsdlTypeIsAbstract: Boolean = false,
 ) {
     fun getNamespaces(wsdlNamespaces: Map<String, String>): Map<String, String> {
         logger.debug(wsdlNamespaces.toString())
@@ -39,6 +40,7 @@ data class WSDLTypeInfo(
             this.wsdlTypeName ?: otherWSDLTypeInfo.wsdlTypeName,
             this.wsdlBaseTypeNamespace ?: otherWSDLTypeInfo.wsdlBaseTypeNamespace,
             this.wsdlBaseTypeName ?: otherWSDLTypeInfo.wsdlBaseTypeName,
+            this.wsdlTypeIsAbstract || otherWSDLTypeInfo.wsdlTypeIsAbstract,
         )
     }
 
@@ -55,6 +57,7 @@ data class WSDLTypeInfo(
                 wsdlTypeName = wsdlTypeName,
                 wsdlBaseTypeNamespace = wsdlBaseTypeNamespace,
                 wsdlBaseTypeName = wsdlBaseTypeName,
+                wsdlTypeIsAbstract = wsdlTypeIsAbstract,
             )
         }
 

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/WSDLTypeInfo.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/WSDLTypeInfo.kt
@@ -68,3 +68,8 @@ data class WSDLTypeInfo(
         }
     }
 }
+
+internal fun XMLNode.isAbstractNamedComplexType(): Boolean =
+    name == "complexType" &&
+            attributes.containsKey("name") &&
+            attributes["abstract"]?.toStringLiteral()?.lowercase() == "true"

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/message/ComplexElement.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/message/ComplexElement.kt
@@ -52,7 +52,8 @@ data class ComplexElement(val wsdlTypeReference: String, val element: XMLNode, v
             accumulated.plus(childTypeInfo.types)
         }
         val wsdlType = element.typeMetadataName(wsdl, wsdlTypeReference)
-        val childTypeInfosWithWSDLTypeMetadata = childTypeInfos.withWSDLTypeMetadata(wsdlType)
+        val wsdlTypeIsAbstract = complexType.complexType.isAbstractNamedComplexType()
+        val childTypeInfosWithWSDLTypeMetadata = childTypeInfos.withWSDLTypeMetadata(wsdlType, wsdlTypeIsAbstract)
         val resolvedPattern: Pattern = when (childTypeInfos.size) {
             1 -> XMLPattern(childTypeInfosWithWSDLTypeMetadata.single().xmlTypeData.copy(
                 attributes = attributePatterns,
@@ -81,6 +82,7 @@ data class ComplexElement(val wsdlTypeReference: String, val element: XMLNode, v
             namespaces,
             wsdlTypeNamespace = wsdlType?.namespace,
             wsdlTypeName = wsdlType?.localName,
+            wsdlTypeIsAbstract = wsdlTypeIsAbstract,
         )
     }
 
@@ -128,13 +130,14 @@ data class ComplexElement(val wsdlTypeReference: String, val element: XMLNode, v
     }
 }
 
-private fun List<WSDLTypeInfo>.withWSDLTypeMetadata(wsdlType: FullyQualifiedName?): List<WSDLTypeInfo> =
-    map { it.withTypeMetadata(wsdlType) }
+private fun List<WSDLTypeInfo>.withWSDLTypeMetadata(wsdlType: FullyQualifiedName?, wsdlTypeIsAbstract: Boolean): List<WSDLTypeInfo> =
+    map { it.withTypeMetadata(wsdlType, wsdlTypeIsAbstract) }
 
-private fun WSDLTypeInfo.withTypeMetadata(wsdlType: FullyQualifiedName?): WSDLTypeInfo {
+private fun WSDLTypeInfo.withTypeMetadata(wsdlType: FullyQualifiedName?, wsdlTypeIsAbstract: Boolean): WSDLTypeInfo {
     return copy(
         wsdlTypeNamespace = wsdlType?.namespace,
         wsdlTypeName = wsdlType?.localName,
+        wsdlTypeIsAbstract = wsdlTypeIsAbstract,
     )
 }
 
@@ -167,6 +170,11 @@ private fun XMLNode.fullyQualifiedNameFromQNameOrNull(qName: String): FullyQuali
     } catch (e: ContractException) {
         null
     }
+
+private fun XMLNode.isAbstractNamedComplexType(): Boolean =
+    name == "complexType" &&
+            attributes.containsKey("name") &&
+            attributes["abstract"]?.toStringLiteral()?.lowercase() == "true"
 
 internal fun XMLNode.namedTypeFullyQualifiedName(wsdl: WSDL): FullyQualifiedName {
     val namespace = schema?.attributes?.get("targetNamespace")?.toStringLiteral().orEmpty()

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/message/ComplexElement.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/message/ComplexElement.kt
@@ -13,6 +13,7 @@ import io.specmatic.core.value.toXMLNode
 import io.specmatic.core.wsdl.parser.SOAPMessageType
 import io.specmatic.core.wsdl.parser.WSDL
 import io.specmatic.core.wsdl.parser.WSDLTypeInfo
+import io.specmatic.core.wsdl.parser.isAbstractNamedComplexType
 import io.specmatic.core.wsdl.payload.ComplexTypedSOAPPayload
 import io.specmatic.core.wsdl.payload.SOAPPayload
 
@@ -170,11 +171,6 @@ private fun XMLNode.fullyQualifiedNameFromQNameOrNull(qName: String): FullyQuali
     } catch (e: ContractException) {
         null
     }
-
-private fun XMLNode.isAbstractNamedComplexType(): Boolean =
-    name == "complexType" &&
-            attributes.containsKey("name") &&
-            attributes["abstract"]?.toStringLiteral()?.lowercase() == "true"
 
 internal fun XMLNode.namedTypeFullyQualifiedName(wsdl: WSDL): FullyQualifiedName {
     val namespace = schema?.attributes?.get("targetNamespace")?.toStringLiteral().orEmpty()

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/message/SimpleElement.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/message/SimpleElement.kt
@@ -46,7 +46,13 @@ data class SimpleElement(
         namespaces: Map<String, String>,
         typeInfo: WSDLTypeInfo
     ): SOAPPayload {
-        return SimpleTypedSOAPPayload(soapMessageType, typeInfo.nodes.first() as XMLNode, namespaces)
+        val bodyNode = typeInfo.nodes.first() as XMLNode
+        return SimpleTypedSOAPPayload(
+            soapMessageType,
+            bodyNode,
+            namespaces,
+            typeInfo.members.firstOrNull() as? XMLPattern ?: XMLPattern(bodyNode),
+        )
     }
 
 }

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/payload/SimpleTypedSOAPPayload.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/payload/SimpleTypedSOAPPayload.kt
@@ -5,7 +5,12 @@ import io.specmatic.core.pattern.XMLPattern
 import io.specmatic.core.value.XMLNode
 import io.specmatic.core.wsdl.parser.SOAPMessageType
 
-data class SimpleTypedSOAPPayload(val soapMessageType: SOAPMessageType, val node: XMLNode, val namespaces: Map<String, String>) :
+data class SimpleTypedSOAPPayload(
+    val soapMessageType: SOAPMessageType,
+    val node: XMLNode,
+    val namespaces: Map<String, String>,
+    val bodyPattern: XMLPattern = XMLPattern(node),
+) :
     SOAPPayload {
     override fun specmaticStatement(headers: RequestHeaders): List<String> {
         val body = soapMessage(node, namespaces, headers)
@@ -13,6 +18,18 @@ data class SimpleTypedSOAPPayload(val soapMessageType: SOAPMessageType, val node
     }
 
     override fun toPattern(headers: RequestHeaders): Pattern {
-        return XMLPattern(soapMessage(node, namespaces, headers), isSOAP = true)
+        val envelope = XMLPattern(soapMessage(node, namespaces, headers), isSOAP = true)
+        return envelope.copy(
+            pattern = envelope.pattern.copy(
+                nodes = envelope.pattern.nodes.map { childPattern ->
+                    when {
+                        childPattern is XMLPattern && childPattern.pattern.name == "Body" ->
+                            childPattern.copy(pattern = childPattern.pattern.copy(nodes = listOf(bodyPattern)))
+
+                        else -> childPattern
+                    }
+                }
+            )
+        )
     }
 }

--- a/core/src/test/kotlin/io/specmatic/conversions/WsdlSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/WsdlSpecificationTest.kt
@@ -169,6 +169,21 @@ internal class WsdlSpecificationTest {
     }
 
     @Test
+    fun `new based on includes named simple type base and derived candidates`() {
+        val wsdlContract = wsdlContentToFeature(codeWsdl(), "code.wsdl")
+
+        val generatedBodies = generatedRequestBodies(wsdlContract)
+
+        assertThat(generatedBodies).anySatisfy { body ->
+            assertThat(body).contains(":Code>")
+            assertThat(body).doesNotContain("xsi:type")
+        }
+        assertThat(generatedBodies).anySatisfy { body ->
+            assertThat(body).containsPattern("xsi:type=\"[^\"]+:ConstrainedCode\"")
+        }
+    }
+
+    @Test
     fun `request matching uses compatible xsi type from wsdl simple content extension`() {
         val wsdlContract = wsdlContentToFeature(taggedCodeWsdl(), "tagged-code.wsdl")
         val scenario = wsdlContract.scenarios.single()
@@ -307,6 +322,62 @@ internal class WsdlSpecificationTest {
     }
 
     @Test
+    fun `request matching reports incompatible abstract xsi type as invalid`() {
+        val wsdlContract = wsdlContentToFeature(
+            petSequenceWsdl(crocodileIsAbstract = true),
+            "pet-sequence.wsdl"
+        )
+        val scenario = wsdlContract.scenarios.single()
+
+        val result = scenario.httpRequestPattern.matches(
+            soapRequest(
+                path = "/pet-sequence",
+                soapAction = "http://example.com/pet-sequence/RegisterSequence",
+                bodyNode = """
+                    <tns:RegisterSequence xmlns:tns="http://example.com/pet-sequence"
+                                          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                      <tns:pet xsi:type="tns:Crocodile">
+                        <tns:toothCount>64</tns:toothCount>
+                      </tns:pet>
+                    </tns:RegisterSequence>
+                """.trimIndent()
+            ),
+            scenario.resolver
+        )
+
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
+        assertThat(result.reportString()).contains("Invalid xsi:type")
+        assertThat(result.reportString()).contains("Crocodile")
+        assertThat(result.reportString()).doesNotContain("it is abstract")
+    }
+
+    @Test
+    fun `request matching rejects nillable abstract wsdl complex type without xsi type`() {
+        val wsdlContract = wsdlContentToFeature(
+            petNillableSequenceWsdl(petIsAbstract = true),
+            "pet-nillable-sequence.wsdl"
+        )
+        val scenario = wsdlContract.scenarios.single()
+
+        val result = scenario.httpRequestPattern.matches(
+            soapRequest(
+                path = "/pet-nillable-sequence",
+                soapAction = "http://example.com/pet-nillable-sequence/RegisterNillableSequence",
+                bodyNode = """
+                    <tns:RegisterNillableSequence xmlns:tns="http://example.com/pet-nillable-sequence">
+                      <tns:pet/>
+                    </tns:RegisterNillableSequence>
+                """.trimIndent()
+            ),
+            scenario.resolver
+        )
+
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
+        assertThat(result.reportString()).contains("Missing xsi:type")
+        assertThat(result.reportString()).contains("Pet")
+    }
+
+    @Test
     fun `request matching rejects incompatible known xsi type inside wsdl choice group`() {
         val wsdlContract = wsdlContentToFeature(petChoiceWsdl(), "pet-choice.wsdl")
         val scenario = wsdlContract.scenarios.single()
@@ -379,6 +450,28 @@ internal class WsdlSpecificationTest {
         assertThat(generatedBodies).anySatisfy { body ->
             assertThat(body).contains("xsi:type=\"Pet-sequence:Cat\"")
             assertThat(body).contains(":lives>")
+        }
+    }
+
+    @Test
+    fun `new based on includes intermediate and leaf concrete wsdl complex type candidates`() {
+        val wsdlContract = wsdlContentToFeature(animalWsdl(), "animal.wsdl")
+
+        val generatedBodies = generatedRequestBodies(wsdlContract)
+
+        assertThat(generatedBodies).anySatisfy { body ->
+            assertThat(body).contains(":Animal>")
+            assertThat(body).doesNotContain("xsi:type")
+        }
+        assertThat(generatedBodies).anySatisfy { body ->
+            assertThat(body).containsPattern("xsi:type=\"[^\"]+:Dog\"")
+            assertThat(body).contains(":breed>")
+            assertThat(body).doesNotContain(":job>")
+        }
+        assertThat(generatedBodies).anySatisfy { body ->
+            assertThat(body).containsPattern("xsi:type=\"[^\"]+:WorkingDog\"")
+            assertThat(body).contains(":breed>")
+            assertThat(body).contains(":job>")
         }
     }
 
@@ -632,6 +725,16 @@ internal class WsdlSpecificationTest {
                     </xs:complexContent>
                   </xs:complexType>
 
+                  <xs:complexType name="WorkingDog">
+                    <xs:complexContent>
+                      <xs:extension base="tns:Dog">
+                        <xs:sequence>
+                          <xs:element name="job" type="xs:string"/>
+                        </xs:sequence>
+                      </xs:extension>
+                    </xs:complexContent>
+                  </xs:complexType>
+
                   <xs:complexType name="Vehicle">
                     <xs:sequence>
                       <xs:element name="registration" type="xs:string"/>
@@ -805,7 +908,7 @@ internal class WsdlSpecificationTest {
         """.trimIndent()
     }
 
-    private fun petSequenceWsdl(petIsAbstract: Boolean = false): String {
+    private fun petSequenceWsdl(petIsAbstract: Boolean = false, crocodileIsAbstract: Boolean = false): String {
         return petWsdl(
             namespace = "http://example.com/pet-sequence",
             path = "/pet-sequence",
@@ -814,6 +917,23 @@ internal class WsdlSpecificationTest {
                 <xs:complexType name="RegisterSequenceRequest">
                   <xs:sequence>
                     <xs:element name="pet" type="tns:Pet"/>
+                  </xs:sequence>
+                </xs:complexType>
+            """.trimIndent(),
+            petIsAbstract = petIsAbstract,
+            crocodileIsAbstract = crocodileIsAbstract,
+        )
+    }
+
+    private fun petNillableSequenceWsdl(petIsAbstract: Boolean = false): String {
+        return petWsdl(
+            namespace = "http://example.com/pet-nillable-sequence",
+            path = "/pet-nillable-sequence",
+            operation = "RegisterNillableSequence",
+            requestType = """
+                <xs:complexType name="RegisterNillableSequenceRequest">
+                  <xs:sequence>
+                    <xs:element name="pet" type="tns:Pet" nillable="true"/>
                   </xs:sequence>
                 </xs:complexType>
             """.trimIndent(),
@@ -879,8 +999,10 @@ internal class WsdlSpecificationTest {
         operation: String,
         requestType: String,
         petIsAbstract: Boolean = false,
+        crocodileIsAbstract: Boolean = false,
     ): String {
         val petAbstractAttribute = if (petIsAbstract) """ abstract="true"""" else ""
+        val crocodileAbstractAttribute = if (crocodileIsAbstract) """ abstract="true"""" else ""
 
         return """
             <wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
@@ -921,7 +1043,7 @@ internal class WsdlSpecificationTest {
                     </xs:complexContent>
                   </xs:complexType>
 
-                  <xs:complexType name="Crocodile">
+                  <xs:complexType name="Crocodile"$crocodileAbstractAttribute>
                     <xs:sequence>
                       <xs:element name="toothCount" type="xs:integer"/>
                     </xs:sequence>

--- a/core/src/test/kotlin/io/specmatic/conversions/WsdlSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/WsdlSpecificationTest.kt
@@ -1,7 +1,9 @@
 package io.specmatic.conversions
 
+import io.specmatic.core.Feature
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.Result
+import io.specmatic.core.Scenario
 import io.specmatic.core.value.StringValue
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -362,10 +364,7 @@ internal class WsdlSpecificationTest {
     fun `new based on includes base and derived concrete wsdl complex type candidates`() {
         val wsdlContract = wsdlContentToFeature(petSequenceWsdl(), "pet-sequence.wsdl")
 
-        val generatedBodies = wsdlContract.scenarios.single()
-            .generateTestScenarios(wsdlContract.flagsBased)
-            .map { it.value.generateHttpRequest(wsdlContract.flagsBased).body.toStringLiteral() }
-            .toList()
+        val generatedBodies = generatedRequestBodies(wsdlContract)
 
         assertThat(generatedBodies).anySatisfy { body ->
             assertThat(body).contains(":pet>")
@@ -387,10 +386,7 @@ internal class WsdlSpecificationTest {
     fun `new based on excludes abstract declared wsdl complex type and pins derived candidates with xsi type`() {
         val wsdlContract = wsdlContentToFeature(petSequenceWsdl(petIsAbstract = true), "pet-sequence.wsdl")
 
-        val generatedBodies = wsdlContract.scenarios.single()
-            .generateTestScenarios(wsdlContract.flagsBased)
-            .map { it.value.generateHttpRequest(wsdlContract.flagsBased).body.toStringLiteral() }
-            .toList()
+        val generatedBodies = generatedRequestBodies(wsdlContract)
 
         assertThat(generatedBodies).noneSatisfy { body ->
             assertThat(body).contains(":pet>")
@@ -411,17 +407,13 @@ internal class WsdlSpecificationTest {
     @Test
     fun `pinned base wsdl complex type candidate generates only base shape`() {
         val wsdlContract = wsdlContentToFeature(petSequenceWsdl(), "pet-sequence.wsdl")
-        val scenarios = wsdlContract.scenarios.single()
-            .generateTestScenarios(wsdlContract.flagsBased)
-            .map { it.value }
-            .toList()
-        val baseScenario = scenarios.first { scenario ->
-            val body = scenario.generateHttpRequest(wsdlContract.flagsBased).body.toStringLiteral()
+        val baseScenario = generatedScenarios(wsdlContract).first { scenario ->
+            val body = generatedRequestBody(scenario, wsdlContract)
             body.contains(":pet>") && !body.contains("xsi:type")
         }
 
         val regeneratedBodies = (1..5).map {
-            baseScenario.generateHttpRequest(wsdlContract.flagsBased).body.toStringLiteral()
+            generatedRequestBody(baseScenario, wsdlContract)
         }
 
         assertThat(regeneratedBodies).allSatisfy { body ->
@@ -435,16 +427,12 @@ internal class WsdlSpecificationTest {
     @Test
     fun `pinned derived wsdl complex type candidate generates only derived shape with xsi type`() {
         val wsdlContract = wsdlContentToFeature(petSequenceWsdl(), "pet-sequence.wsdl")
-        val scenarios = wsdlContract.scenarios.single()
-            .generateTestScenarios(wsdlContract.flagsBased)
-            .map { it.value }
-            .toList()
-        val dogScenario = scenarios.first { scenario ->
-            scenario.generateHttpRequest(wsdlContract.flagsBased).body.toStringLiteral().contains("xsi:type=\"Pet-sequence:Dog\"")
+        val dogScenario = generatedScenarios(wsdlContract).first { scenario ->
+            generatedRequestBody(scenario, wsdlContract).contains("xsi:type=\"Pet-sequence:Dog\"")
         }
 
         val regeneratedBodies = (1..5).map {
-            dogScenario.generateHttpRequest(wsdlContract.flagsBased).body.toStringLiteral()
+            generatedRequestBody(dogScenario, wsdlContract)
         }
 
         assertThat(regeneratedBodies).allSatisfy { body ->
@@ -599,6 +587,20 @@ internal class WsdlSpecificationTest {
             )
         )
     }
+
+    private fun generatedRequestBodies(wsdlContract: Feature): List<String> =
+        generatedScenarios(wsdlContract).map { scenario ->
+            generatedRequestBody(scenario, wsdlContract)
+        }
+
+    private fun generatedScenarios(wsdlContract: Feature): List<Scenario> =
+        wsdlContract.scenarios.single()
+            .generateTestScenarios(wsdlContract.flagsBased)
+            .map { it.value }
+            .toList()
+
+    private fun generatedRequestBody(scenario: Scenario, wsdlContract: Feature): String =
+        scenario.generateHttpRequest(wsdlContract.flagsBased).body.toStringLiteral()
 
     private fun animalWsdl(): String {
         return """

--- a/core/src/test/kotlin/io/specmatic/conversions/WsdlSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/WsdlSpecificationTest.kt
@@ -229,6 +229,82 @@ internal class WsdlSpecificationTest {
     }
 
     @Test
+    fun `request matching uses concrete xsi type when declared wsdl complex type is abstract`() {
+        val wsdlContract = wsdlContentToFeature(petSequenceWsdl(petIsAbstract = true), "pet-sequence.wsdl")
+        val scenario = wsdlContract.scenarios.single()
+
+        val result = scenario.httpRequestPattern.matches(
+            soapRequest(
+                path = "/pet-sequence",
+                soapAction = "http://example.com/pet-sequence/RegisterSequence",
+                bodyNode = """
+                    <tns:RegisterSequence xmlns:tns="http://example.com/pet-sequence"
+                                          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                      <tns:pet xsi:type="tns:Dog">
+                        <tns:name>Rover</tns:name>
+                        <tns:breed>Labrador</tns:breed>
+                      </tns:pet>
+                    </tns:RegisterSequence>
+                """.trimIndent()
+            ),
+            scenario.resolver
+        )
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+    }
+
+    @Test
+    fun `request matching rejects abstract wsdl complex type without xsi type`() {
+        val wsdlContract = wsdlContentToFeature(petSequenceWsdl(petIsAbstract = true), "pet-sequence.wsdl")
+        val scenario = wsdlContract.scenarios.single()
+
+        val result = scenario.httpRequestPattern.matches(
+            soapRequest(
+                path = "/pet-sequence",
+                soapAction = "http://example.com/pet-sequence/RegisterSequence",
+                bodyNode = """
+                    <tns:RegisterSequence xmlns:tns="http://example.com/pet-sequence">
+                      <tns:pet>
+                        <tns:name>Rover</tns:name>
+                      </tns:pet>
+                    </tns:RegisterSequence>
+                """.trimIndent()
+            ),
+            scenario.resolver
+        )
+
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
+        assertThat(result.reportString()).contains("Missing xsi:type")
+        assertThat(result.reportString()).contains("Pet")
+    }
+
+    @Test
+    fun `request matching rejects abstract wsdl complex type asserted through xsi type`() {
+        val wsdlContract = wsdlContentToFeature(petSequenceWsdl(petIsAbstract = true), "pet-sequence.wsdl")
+        val scenario = wsdlContract.scenarios.single()
+
+        val result = scenario.httpRequestPattern.matches(
+            soapRequest(
+                path = "/pet-sequence",
+                soapAction = "http://example.com/pet-sequence/RegisterSequence",
+                bodyNode = """
+                    <tns:RegisterSequence xmlns:tns="http://example.com/pet-sequence"
+                                          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                      <tns:pet xsi:type="tns:Pet">
+                        <tns:name>Rover</tns:name>
+                      </tns:pet>
+                    </tns:RegisterSequence>
+                """.trimIndent()
+            ),
+            scenario.resolver
+        )
+
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
+        assertThat(result.reportString()).contains("abstract")
+        assertThat(result.reportString()).contains("Pet")
+    }
+
+    @Test
     fun `request matching rejects incompatible known xsi type inside wsdl choice group`() {
         val wsdlContract = wsdlContentToFeature(petChoiceWsdl(), "pet-choice.wsdl")
         val scenario = wsdlContract.scenarios.single()
@@ -274,6 +350,128 @@ internal class WsdlSpecificationTest {
                         </tns:pet>
                       </tns:payload>
                     </tns:RegisterNestedSequence>
+                """.trimIndent()
+            ),
+            scenario.resolver
+        )
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+    }
+
+    @Test
+    fun `new based on includes base and derived concrete wsdl complex type candidates`() {
+        val wsdlContract = wsdlContentToFeature(petSequenceWsdl(), "pet-sequence.wsdl")
+
+        val generatedBodies = wsdlContract.scenarios.single()
+            .generateTestScenarios(wsdlContract.flagsBased)
+            .map { it.value.generateHttpRequest(wsdlContract.flagsBased).body.toStringLiteral() }
+            .toList()
+
+        assertThat(generatedBodies).anySatisfy { body ->
+            assertThat(body).contains(":pet>")
+            assertThat(body).doesNotContain("xsi:type")
+            assertThat(body).doesNotContain(":breed>")
+            assertThat(body).doesNotContain(":lives>")
+        }
+        assertThat(generatedBodies).anySatisfy { body ->
+            assertThat(body).contains("xsi:type=\"Pet-sequence:Dog\"")
+            assertThat(body).contains(":breed>")
+        }
+        assertThat(generatedBodies).anySatisfy { body ->
+            assertThat(body).contains("xsi:type=\"Pet-sequence:Cat\"")
+            assertThat(body).contains(":lives>")
+        }
+    }
+
+    @Test
+    fun `new based on excludes abstract declared wsdl complex type and pins derived candidates with xsi type`() {
+        val wsdlContract = wsdlContentToFeature(petSequenceWsdl(petIsAbstract = true), "pet-sequence.wsdl")
+
+        val generatedBodies = wsdlContract.scenarios.single()
+            .generateTestScenarios(wsdlContract.flagsBased)
+            .map { it.value.generateHttpRequest(wsdlContract.flagsBased).body.toStringLiteral() }
+            .toList()
+
+        assertThat(generatedBodies).noneSatisfy { body ->
+            assertThat(body).contains(":pet>")
+            assertThat(body).doesNotContain("xsi:type")
+            assertThat(body).doesNotContain(":breed>")
+            assertThat(body).doesNotContain(":lives>")
+        }
+        assertThat(generatedBodies).anySatisfy { body ->
+            assertThat(body).contains("xsi:type=\"Pet-sequence:Dog\"")
+            assertThat(body).contains(":breed>")
+        }
+        assertThat(generatedBodies).anySatisfy { body ->
+            assertThat(body).contains("xsi:type=\"Pet-sequence:Cat\"")
+            assertThat(body).contains(":lives>")
+        }
+    }
+
+    @Test
+    fun `pinned base wsdl complex type candidate generates only base shape`() {
+        val wsdlContract = wsdlContentToFeature(petSequenceWsdl(), "pet-sequence.wsdl")
+        val scenarios = wsdlContract.scenarios.single()
+            .generateTestScenarios(wsdlContract.flagsBased)
+            .map { it.value }
+            .toList()
+        val baseScenario = scenarios.first { scenario ->
+            val body = scenario.generateHttpRequest(wsdlContract.flagsBased).body.toStringLiteral()
+            body.contains(":pet>") && !body.contains("xsi:type")
+        }
+
+        val regeneratedBodies = (1..5).map {
+            baseScenario.generateHttpRequest(wsdlContract.flagsBased).body.toStringLiteral()
+        }
+
+        assertThat(regeneratedBodies).allSatisfy { body ->
+            assertThat(body).contains(":pet>")
+            assertThat(body).doesNotContain("xsi:type")
+            assertThat(body).doesNotContain(":breed>")
+            assertThat(body).doesNotContain(":lives>")
+        }
+    }
+
+    @Test
+    fun `pinned derived wsdl complex type candidate generates only derived shape with xsi type`() {
+        val wsdlContract = wsdlContentToFeature(petSequenceWsdl(), "pet-sequence.wsdl")
+        val scenarios = wsdlContract.scenarios.single()
+            .generateTestScenarios(wsdlContract.flagsBased)
+            .map { it.value }
+            .toList()
+        val dogScenario = scenarios.first { scenario ->
+            scenario.generateHttpRequest(wsdlContract.flagsBased).body.toStringLiteral().contains("xsi:type=\"Pet-sequence:Dog\"")
+        }
+
+        val regeneratedBodies = (1..5).map {
+            dogScenario.generateHttpRequest(wsdlContract.flagsBased).body.toStringLiteral()
+        }
+
+        assertThat(regeneratedBodies).allSatisfy { body ->
+            assertThat(body).contains("xsi:type=\"Pet-sequence:Dog\"")
+            assertThat(body).contains(":breed>")
+            assertThat(body).doesNotContain(":lives>")
+        }
+    }
+
+    @Test
+    fun `request matching uses cross namespace concrete xsi type when declared wsdl complex type is abstract`() {
+        val wsdlContract = wsdlContentToFeature(orderWithCrossNamespaceModelWsdl(orderIsAbstract = true), "order-service.wsdl")
+        val scenario = wsdlContract.scenarios.single()
+
+        val result = scenario.httpRequestPattern.matches(
+            soapRequest(
+                path = "/order-service",
+                soapAction = "http://example.com/order-service/SubmitOrder",
+                bodyNode = """
+                    <svc:SubmitOrder xmlns:svc="http://example.com/order-service"
+                                     xmlns:model="http://example.com/order-model"
+                                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                      <svc:order xsi:type="model:OnlineOrder">
+                        <model:orderNumber>O-123</model:orderNumber>
+                        <model:channel>web</model:channel>
+                      </svc:order>
+                    </svc:SubmitOrder>
                 """.trimIndent()
             ),
             scenario.resolver
@@ -526,7 +724,9 @@ internal class WsdlSpecificationTest {
         """.trimIndent()
     }
 
-    private fun orderWithCrossNamespaceModelWsdl(): String {
+    private fun orderWithCrossNamespaceModelWsdl(orderIsAbstract: Boolean = false): String {
+        val orderAbstractAttribute = if (orderIsAbstract) """ abstract="true"""" else ""
+
         return """
             <wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
                               xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
@@ -553,7 +753,7 @@ internal class WsdlSpecificationTest {
                            xmlns:model="http://example.com/order-model"
                            targetNamespace="http://example.com/order-model"
                            elementFormDefault="qualified">
-                  <xs:complexType name="Order">
+                  <xs:complexType name="Order"$orderAbstractAttribute>
                     <xs:sequence>
                       <xs:element name="orderNumber" type="xs:string"/>
                     </xs:sequence>
@@ -601,6 +801,22 @@ internal class WsdlSpecificationTest {
               </wsdl:service>
             </wsdl:definitions>
         """.trimIndent()
+    }
+
+    private fun petSequenceWsdl(petIsAbstract: Boolean = false): String {
+        return petWsdl(
+            namespace = "http://example.com/pet-sequence",
+            path = "/pet-sequence",
+            operation = "RegisterSequence",
+            requestType = """
+                <xs:complexType name="RegisterSequenceRequest">
+                  <xs:sequence>
+                    <xs:element name="pet" type="tns:Pet"/>
+                  </xs:sequence>
+                </xs:complexType>
+            """.trimIndent(),
+            petIsAbstract = petIsAbstract,
+        )
     }
 
     private fun petChoiceWsdl(): String {
@@ -655,7 +871,15 @@ internal class WsdlSpecificationTest {
         )
     }
 
-    private fun petWsdl(namespace: String, path: String, operation: String, requestType: String): String {
+    private fun petWsdl(
+        namespace: String,
+        path: String,
+        operation: String,
+        requestType: String,
+        petIsAbstract: Boolean = false,
+    ): String {
+        val petAbstractAttribute = if (petIsAbstract) """ abstract="true"""" else ""
+
         return """
             <wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
                               xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
@@ -669,7 +893,7 @@ internal class WsdlSpecificationTest {
                   <xs:element name="$operation" type="tns:${operation}Request"/>
                   <xs:element name="${operation}Response" type="xs:string"/>
 
-                  <xs:complexType name="Pet">
+                  <xs:complexType name="Pet"$petAbstractAttribute>
                     <xs:sequence>
                       <xs:element name="name" type="xs:string"/>
                     </xs:sequence>
@@ -680,6 +904,16 @@ internal class WsdlSpecificationTest {
                       <xs:extension base="tns:Pet">
                         <xs:sequence>
                           <xs:element name="breed" type="xs:string"/>
+                        </xs:sequence>
+                      </xs:extension>
+                    </xs:complexContent>
+                  </xs:complexType>
+
+                  <xs:complexType name="Cat">
+                    <xs:complexContent>
+                      <xs:extension base="tns:Pet">
+                        <xs:sequence>
+                          <xs:element name="lives" type="xs:integer"/>
                         </xs:sequence>
                       </xs:extension>
                     </xs:complexContent>

--- a/core/src/test/kotlin/io/specmatic/core/pattern/XMLPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/XMLPatternTest.kt
@@ -135,8 +135,8 @@ internal class XMLPatternTest {
         }
 
         @Test
-        fun `generate uses compatible WSDL concrete subtype variants instead of base or intermediate types`() {
-            val resolver = Resolver(newPatterns = animalPatterns())
+        fun `generate uses compatible WSDL concrete subtype variants instead of abstract base or intermediate types`() {
+            val resolver = Resolver(newPatterns = animalPatterns(animalIsAbstract = true))
             val pattern = XMLPattern(
                 XMLTypeData(
                     name = "Animal",
@@ -161,8 +161,8 @@ internal class XMLPatternTest {
         }
 
         @Test
-        fun `newBasedOn uses compatible WSDL concrete subtype variants instead of base or intermediate types`() {
-            val resolver = Resolver(newPatterns = animalPatterns())
+        fun `newBasedOn uses compatible WSDL concrete subtype variants instead of abstract base or intermediate types`() {
+            val resolver = Resolver(newPatterns = animalPatterns(animalIsAbstract = true))
             val pattern = XMLPattern(
                 XMLTypeData(
                     name = "Animal",
@@ -245,7 +245,7 @@ internal class XMLPatternTest {
 
         @Test
         fun `generate avoids xsi prefix when it is already bound to a different namespace`() {
-            val resolver = Resolver(newPatterns = animalPatterns())
+            val resolver = Resolver(newPatterns = animalPatterns(animalIsAbstract = true))
             val pattern = XMLPattern(
                 XMLTypeData(
                     name = "Animal",
@@ -799,7 +799,7 @@ internal class XMLPatternTest {
 
     }
 
-    private fun animalPatterns(): Map<String, Pattern> {
+    private fun animalPatterns(animalIsAbstract: Boolean = false): Map<String, Pattern> {
         val animal = XMLPattern(
             XMLTypeData(
                 name = "Animal",
@@ -808,6 +808,7 @@ internal class XMLPatternTest {
                 namespaceUri = ANIMAL_NAMESPACE,
                 wsdlTypeNamespace = ANIMAL_NAMESPACE,
                 wsdlTypeName = "Animal",
+                wsdlTypeIsAbstract = animalIsAbstract,
             )
         )
         val dog = XMLPattern(

--- a/core/src/test/kotlin/io/specmatic/core/pattern/XMLPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/XMLPatternTest.kt
@@ -135,7 +135,7 @@ internal class XMLPatternTest {
         }
 
         @Test
-        fun `generate uses compatible WSDL concrete subtype variants instead of abstract base or intermediate types`() {
+        fun `generate uses compatible WSDL concrete subtype variants instead of abstract base type`() {
             val resolver = Resolver(newPatterns = animalPatterns(animalIsAbstract = true))
             val pattern = XMLPattern(
                 XMLTypeData(
@@ -152,6 +152,8 @@ internal class XMLPatternTest {
             val generated = pattern.generate(resolver)
 
             when (generated.attributes["xsi:type"]?.toStringLiteral()) {
+                "tns:Dog" -> assertThat(generated.childNodes.filterIsInstance<XMLNode>().map(XMLNode::realName))
+                    .containsExactly("tns:name", "tns:breed")
                 "tns:WorkingDog" -> assertThat(generated.childNodes.filterIsInstance<XMLNode>().map(XMLNode::realName))
                     .containsExactly("tns:name", "tns:breed", "tns:job")
                 "tns:Cat" -> assertThat(generated.childNodes.filterIsInstance<XMLNode>().map(XMLNode::realName))
@@ -161,7 +163,7 @@ internal class XMLPatternTest {
         }
 
         @Test
-        fun `newBasedOn uses compatible WSDL concrete subtype variants instead of abstract base or intermediate types`() {
+        fun `newBasedOn uses compatible WSDL concrete subtype variants instead of abstract base type`() {
             val resolver = Resolver(newPatterns = animalPatterns(animalIsAbstract = true))
             val pattern = XMLPattern(
                 XMLTypeData(
@@ -181,8 +183,7 @@ internal class XMLPatternTest {
                 .toList()
 
             assertThat(generated.map { it.attributes["xsi:type"]?.toStringLiteral() })
-                .containsExactlyInAnyOrder("tns:WorkingDog", "tns:Cat")
-            assertThat(generated).noneMatch { it.attributes["xsi:type"]?.toStringLiteral() == "tns:Dog" }
+                .containsExactlyInAnyOrder("tns:Dog", "tns:WorkingDog", "tns:Cat")
             assertThat(generated).noneMatch { it.attributes["xsi:type"] == null }
         }
 
@@ -272,7 +273,7 @@ internal class XMLPatternTest {
         }
 
         @Test
-        fun `newBasedOn uses compatible WSDL simple restriction variants instead of base type`() {
+        fun `newBasedOn includes named WSDL simple base type and compatible variants`() {
             val resolver = Resolver(newPatterns = codePatterns())
             val pattern = XMLPattern(
                 XMLTypeData(
@@ -292,8 +293,9 @@ internal class XMLPatternTest {
                 .toList()
 
             assertThat(generated.map { it.attributes["xsi:type"]?.toStringLiteral() })
-                .containsOnly("tns:ConstrainedCode")
-            assertThat(generated.map { it.childNodes.single().toStringLiteral() })
+                .contains(null, "tns:ConstrainedCode")
+            assertThat(generated.filter { it.attributes["xsi:type"]?.toStringLiteral() == "tns:ConstrainedCode" }
+                .map { it.childNodes.single().toStringLiteral() })
                 .allMatch { value -> value.matches(Regex("[A-Z0-9]{6,}")) }
         }
 
@@ -318,7 +320,8 @@ internal class XMLPatternTest {
                 .toList()
 
             assertThat(generated.map { it.attributes["xsi:type"]?.toStringLiteral() })
-                .containsOnly("tns:ConstrainedCode")
+                .contains(null, "tns:ConstrainedCode")
+                .doesNotContain("xs:string")
         }
 
         @Test
@@ -878,6 +881,7 @@ internal class XMLPatternTest {
                     CAT_TYPE to CAT_TYPE_KEY,
                 ),
                 concreteSubtypeKeys = mapOf(
+                    DOG_TYPE to DOG_TYPE_KEY,
                     WORKING_DOG_TYPE to WORKING_DOG_TYPE_KEY,
                     CAT_TYPE to CAT_TYPE_KEY,
                 ),

--- a/core/src/test/kotlin/io/specmatic/core/wsdl/parser/message/ComplexElementTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/wsdl/parser/message/ComplexElementTest.kt
@@ -53,6 +53,9 @@ internal class ComplexElementTest {
             complexType2.getAttributeWildcards()
         } returns emptyList()
         every {
+            complexType2.complexType
+        } returns toXMLNode("<complexType/>")
+        every {
             wsdl.getComplexTypeNode(element)
         } returns complexType2
 
@@ -97,6 +100,9 @@ internal class ComplexElementTest {
         every {
             complexType2.getAttributeWildcards()
         } returns emptyList()
+        every {
+            complexType2.complexType
+        } returns toXMLNode("<complexType/>")
         every {
             wsdl.getComplexTypeNode(element)
         } returns complexType2


### PR DESCRIPTION
**What**:

Support WSDL/XSD abstract complex types in `xsi:type` polymorphism.

This propagates abstract WSDL type metadata into XML pattern metadata, excludes abstract types from concrete subtype selection, pins expanded polymorphic candidates to the selected WSDL type, and stamps explicit `xsi:type` values on derived candidates created under a declared base element.

**Why**:

Abstract WSDL base types should not match or generate as concrete XML payloads. When a payload asserts `xsi:type`, Specmatic needs to resolve the asserted type strictly, reject unknown, incompatible, or abstract asserted types, and match or generate the selected concrete shape without reopening subtype selection later.

**How**:

The WSDL parser now captures `abstract="true"` for named complex types and carries that metadata through `WSDLTypeInfo`, `XMLTypeData`, and `XMLPattern`. XML pattern matching and generation now distinguish polymorphic lookup from current-type-only pinned candidates, use concrete subtype metadata for valid candidate selection, and preserve SOAP envelope/header handling while retaining WSDL metadata for typed payloads. Focused WSDL/XML tests cover abstract base matching, missing or abstract `xsi:type`, derived candidate generation, pinned candidate behavior, and cross-namespace derived types.

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
