### PR TITLE
Add WSDL substitution group support

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
@@ -12,7 +12,7 @@ data class ListPattern(
     override val example: List<String?>? = null,
     override val extensions: Map<String, Any>  = emptyMap(),
     val itemsPointer: String? = null
-) : Pattern, SequenceType, HasDefaultExample, PossibleJsonObjectPatternContainer {
+) : Pattern, SequenceType, HasDefaultExample, PossibleJsonObjectPatternContainer, XMLChildGenerationPattern {
     override val memberList: MemberList
         get() = MemberList(emptyList(), pattern)
 
@@ -134,6 +134,10 @@ data class ListPattern(
     override fun generate(resolver: Resolver): Value {
         val resolverWithEmptyType = withEmptyType(pattern, resolver)
         return resolver.resolveExample(example, pattern) ?: dictionaryLookup(resolverWithEmptyType)
+    }
+
+    override fun generateXMLChildValues(resolver: Resolver): List<XMLValue> {
+        return (generate(resolver) as XMLNode).childNodes
     }
 
     private fun dictionaryLookup(resolver: Resolver): Value {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
@@ -137,7 +137,7 @@ data class ListPattern(
     }
 
     override fun generateXMLChildValues(resolver: Resolver): List<XMLValue> {
-        return (generate(resolver) as XMLNode).childNodes
+        return generatedContainerChildValues(resolver)
     }
 
     private fun dictionaryLookup(resolver: Resolver): Value {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLChildGenerationPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLChildGenerationPattern.kt
@@ -1,0 +1,8 @@
+package io.specmatic.core.pattern
+
+import io.specmatic.core.Resolver
+import io.specmatic.core.value.XMLValue
+
+sealed interface XMLChildGenerationPattern : Pattern {
+    fun generateXMLChildValues(resolver: Resolver): List<XMLValue>
+}

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLChildGenerationPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLChildGenerationPattern.kt
@@ -1,8 +1,22 @@
 package io.specmatic.core.pattern
 
 import io.specmatic.core.Resolver
+import io.specmatic.core.value.StringValue
+import io.specmatic.core.value.Value
+import io.specmatic.core.value.XMLNode
 import io.specmatic.core.value.XMLValue
 
 sealed interface XMLChildGenerationPattern : Pattern {
     fun generateXMLChildValues(resolver: Resolver): List<XMLValue>
+
+    fun generatedValueAsXMLChildValues(generated: Value): List<XMLValue> {
+        return when (generated) {
+            is XMLNode, is XMLValue -> listOf(generated)
+            else -> listOf(StringValue(generated.toStringLiteral()))
+        }
+    }
+
+    fun generatedContainerChildValues(resolver: Resolver): List<XMLValue> {
+        return (generate(resolver) as XMLNode).childNodes
+    }
 }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLChoiceGroupPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLChoiceGroupPattern.kt
@@ -16,7 +16,7 @@ data class XMLChoiceGroupPattern(
     val minOccurs: Int = 1,
     val maxOccurs: Int? = 1,
     override val typeAlias: String? = null
-) : Pattern, SequenceType {
+) : Pattern, SequenceType, XMLChildGenerationPattern {
     override val pattern: Any
         get() = choices
 
@@ -106,7 +106,11 @@ data class XMLChoiceGroupPattern(
     }
 
     override fun generate(resolver: Resolver): Value {
-        val generatedNodes = generateOccurrenceSequence(resolver).flatMap { alternative ->
+        return XMLNode("", "", emptyMap(), generateXMLChildValues(resolver), "", emptyMap())
+    }
+
+    override fun generateXMLChildValues(resolver: Resolver): List<XMLValue> {
+        return generateOccurrenceSequence(resolver).flatMap { alternative ->
             alternative.flatMap { pattern ->
                 if (pattern.hasXMLChoiceReferenceCycle(resolver)) {
                     return@flatMap emptyList()
@@ -129,8 +133,6 @@ data class XMLChoiceGroupPattern(
                 }
             }
         }
-
-        return XMLNode("", "", emptyMap(), generatedNodes, "", emptyMap())
     }
 
     private fun generateOccurrenceSequence(resolver: Resolver): List<List<Pattern>> {
@@ -475,7 +477,7 @@ data class XMLChoiceGroupPattern(
 data class XMLSequencePattern(
     val members: List<Pattern>,
     override val typeAlias: String? = null
-) : Pattern, SequenceType {
+) : Pattern, SequenceType, XMLChildGenerationPattern {
     override val pattern: Any
         get() = members
 
@@ -502,25 +504,23 @@ data class XMLSequencePattern(
     }
 
     override fun generate(resolver: Resolver): Value {
-        val generatedNodes = members.flatMap { pattern ->
-            pattern.generateXMLSequenceNodes(resolver)
-        }
-
-        return XMLNode("", "", emptyMap(), generatedNodes, "", emptyMap())
+        return XMLNode("", "", emptyMap(), generateXMLChildValues(resolver), "", emptyMap())
     }
 
-    private fun Pattern.generateXMLSequenceNodes(resolver: Resolver): List<XMLValue> {
-        val generated = generate(resolver)
+    override fun generateXMLChildValues(resolver: Resolver): List<XMLValue> {
+        return members.flatMap { pattern ->
+            when (pattern) {
+                is XMLChildGenerationPattern -> pattern.generateXMLChildValues(resolver)
+                else -> {
+                    val generated = pattern.generate(resolver)
 
-        return when {
-            this is XMLSequencePattern -> (generated as XMLNode).childNodes
-            this is XMLChoiceGroupPattern -> (generated as XMLNode).childNodes
-            this is XMLSubstitutionGroupPattern -> listOf(generated as XMLValue)
-            this is XMLWildcardPattern -> (generated as XMLNode).childNodes
-            this is ListPattern -> (generated as XMLNode).childNodes
-            generated is XMLNode -> listOf(generated)
-            generated is XMLValue -> listOf(generated)
-            else -> listOf(StringValue(generated.toStringLiteral()))
+                    when (generated) {
+                        is XMLNode -> listOf(generated)
+                        is XMLValue -> listOf(generated)
+                        else -> listOf(StringValue(generated.toStringLiteral()))
+                    }
+                }
+            }
         }
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLChoiceGroupPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLChoiceGroupPattern.kt
@@ -5,7 +5,6 @@ import io.specmatic.core.Result
 import io.specmatic.core.Result.Failure
 import io.specmatic.core.Result.Success
 import io.specmatic.core.pattern.config.NegativePatternConfiguration
-import io.specmatic.core.value.StringValue
 import io.specmatic.core.value.Value
 import io.specmatic.core.value.XMLNode
 import io.specmatic.core.value.XMLValue
@@ -126,11 +125,7 @@ data class XMLChoiceGroupPattern(
                     } ?: return@flatMap emptyList()
                 }
 
-                when (generated) {
-                    is XMLNode -> listOf(generated)
-                    is XMLValue -> listOf(generated)
-                    else -> listOf(StringValue(generated.toStringLiteral()))
-                }
+                generatedValueAsXMLChildValues(generated)
             }
         }
     }
@@ -511,15 +506,7 @@ data class XMLSequencePattern(
         return members.flatMap { pattern ->
             when (pattern) {
                 is XMLChildGenerationPattern -> pattern.generateXMLChildValues(resolver)
-                else -> {
-                    val generated = pattern.generate(resolver)
-
-                    when (generated) {
-                        is XMLNode -> listOf(generated)
-                        is XMLValue -> listOf(generated)
-                        else -> listOf(StringValue(generated.toStringLiteral()))
-                    }
-                }
+                else -> generatedValueAsXMLChildValues(pattern.generate(resolver))
             }
         }
     }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLChoiceGroupPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLChoiceGroupPattern.kt
@@ -515,6 +515,7 @@ data class XMLSequencePattern(
         return when {
             this is XMLSequencePattern -> (generated as XMLNode).childNodes
             this is XMLChoiceGroupPattern -> (generated as XMLNode).childNodes
+            this is XMLSubstitutionGroupPattern -> listOf(generated as XMLValue)
             this is XMLWildcardPattern -> (generated as XMLNode).childNodes
             this is ListPattern -> (generated as XMLNode).childNodes
             generated is XMLNode -> listOf(generated)

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLNamespaceConstraint.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLNamespaceConstraint.kt
@@ -146,7 +146,7 @@ data class XMLWildcardPattern(
     val maxOccurs: Int? = 1,
     val targetNamespace: String? = null,
     override val typeAlias: String? = null
-) : Pattern {
+) : Pattern, XMLChildGenerationPattern {
     override fun matches(sampleData: Value?, resolver: Resolver): Result {
         return when {
             sampleData !is XMLNode -> dataTypeMismatchResult("xml wildcard", sampleData, resolver.mismatchMessages)
@@ -202,6 +202,10 @@ data class XMLWildcardPattern(
     override fun generate(resolver: Resolver): Value {
         val generatedNodes = 0.until(minOccurs).map { generatedNode() }
         return XMLNode("", "", emptyMap(), generatedNodes, "", emptyMap())
+    }
+
+    override fun generateXMLChildValues(resolver: Resolver): List<XMLValue> {
+        return (generate(resolver) as XMLNode).childNodes
     }
 
     private fun generatedNode(): XMLNode {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLNamespaceConstraint.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLNamespaceConstraint.kt
@@ -205,7 +205,7 @@ data class XMLWildcardPattern(
     }
 
     override fun generateXMLChildValues(resolver: Resolver): List<XMLValue> {
-        return (generate(resolver) as XMLNode).childNodes
+        return generatedContainerChildValues(resolver)
     }
 
     private fun generatedNode(): XMLNode {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLPattern.kt
@@ -86,7 +86,7 @@ data class XMLPattern(
     override val typeAlias: String? = null,
     val schemaPointer: String? = null,
     val attributePointers: Map<String, String> = emptyMap()
-) : Pattern, SequenceType {
+) : Pattern, SequenceType, XMLChildGenerationPattern {
     constructor(
         node: XMLNode,
         typeAlias: String? = null,
@@ -1062,12 +1062,20 @@ data class XMLPattern(
         return cyclePreventionPattern != this && resolver.hasCycle(cyclePreventionPattern)
     }
 
+    override fun generateXMLChildValues(resolver: Resolver): List<XMLValue> {
+        return when {
+            occurMultipleTimes() ->
+                0.until(randomNumber(XML_RANDOM_NUMBER_CEILING)).map {
+                    generate(resolver) as XMLValue
+                }
+
+            else -> listOf(generate(resolver) as XMLValue)
+        }
+    }
+
     private fun Pattern.generateNodes(resolver: Resolver): List<Value> {
         return when {
             this is XMLChildGenerationPattern -> generateXMLChildValues(resolver)
-            this is XMLPattern && occurMultipleTimes() ->
-                0.until(randomNumber(XML_RANDOM_NUMBER_CEILING)).map { generate(resolver) }
-
             else -> listOf(generate(resolver))
         }
     }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLPattern.kt
@@ -284,22 +284,30 @@ data class XMLPattern(
     }
 
     private fun invalidXSITypeResult(assertedType: WSDLTypeName, declaredType: WSDLTypeName): Failure {
-        val declaredDescription = "${declaredType.namespace}#${declaredType.localName}"
-        return Failure("Invalid xsi:type ${assertedType.namespace}#${assertedType.localName}; it is known to Specmatic but is not compatible with $declaredDescription.")
+        return Failure(
+            "Invalid type ${assertedType.displayNameForError()}; " +
+                "it is not compatible with base type ${declaredType.displayNameForError()}."
+        )
     }
 
     private fun unknownXSITypeResult(assertedType: WSDLTypeName, declaredType: WSDLTypeName): Failure {
-        val declaredDescription = "${declaredType.namespace}#${declaredType.localName}"
-        return Failure("Unknown xsi:type ${assertedType.namespace}#${assertedType.localName}; no matching type was found in the WSDL/schema set for $declaredDescription.")
+        return Failure(
+            "Unknown type ${assertedType.displayNameForError()}; " +
+                "no matching type was found in the WSDL/schema set for base type ${declaredType.displayNameForError()}."
+        )
     }
 
     private fun abstractXSITypeResult(assertedType: WSDLTypeName, declaredType: WSDLTypeName): Failure {
-        val declaredDescription = "${declaredType.namespace}#${declaredType.localName}"
-        return Failure("Invalid xsi:type ${assertedType.namespace}#${assertedType.localName}; it is abstract and cannot be used as a concrete WSDL type for $declaredDescription.")
+        return Failure(
+            "Invalid type ${assertedType.displayNameForError()}; " +
+                "it is abstract and cannot be used as a concrete WSDL type for the ${declaredType.displayNameForError()} element."
+        )
     }
 
     private fun missingXSITypeForAbstractTypeResult(declaredType: WSDLTypeName): Failure {
-        return Failure("Missing xsi:type for abstract WSDL type ${declaredType.namespace}#${declaredType.localName}; a concrete subtype is required.")
+        return Failure(
+            "Missing type for abstract WSDL type ${declaredType.displayNameForError()}; a concrete subtype is required."
+        )
     }
 
     private fun failureForWSDLTypeSelection(selectedType: WSDLTypeSelection): Failure {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLPattern.kt
@@ -1401,7 +1401,7 @@ private fun XMLNode.xsiTypeName(): WSDLTypeName? {
             value.namespacePrefix().isBlank() -> elementNamespaceUriOrNull().orEmpty()
             else -> resolveNamespace(value)
         }
-        WSDLTypeName(namespace, value.localName())
+        WSDLTypeName(namespace, value.localName(), value.namespacePrefix().ifBlank { null })
     }.getOrNull()
 }
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLPattern.kt
@@ -1065,11 +1065,11 @@ data class XMLPattern(
     override fun generateXMLChildValues(resolver: Resolver): List<XMLValue> {
         return when {
             occurMultipleTimes() ->
-                0.until(randomNumber(XML_RANDOM_NUMBER_CEILING)).map {
-                    generate(resolver) as XMLValue
+                0.until(randomNumber(XML_RANDOM_NUMBER_CEILING)).flatMap {
+                    generatedValueAsXMLChildValues(generate(resolver))
                 }
 
-            else -> listOf(generate(resolver) as XMLValue)
+            else -> generatedValueAsXMLChildValues(generate(resolver))
         }
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLPattern.kt
@@ -1066,6 +1066,7 @@ data class XMLPattern(
         return when {
             this is ListPattern -> (generate(resolver) as XMLNode).childNodes
             this is XMLChoiceGroupPattern -> (generate(resolver) as XMLNode).childNodes
+            this is XMLSubstitutionGroupPattern -> listOf(generate(resolver))
             this is XMLSequencePattern -> (generate(resolver) as XMLNode).childNodes
             this is XMLWildcardPattern -> (generate(resolver) as XMLNode).childNodes
             this is XMLPattern && occurMultipleTimes() ->

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLPattern.kt
@@ -1064,11 +1064,7 @@ data class XMLPattern(
 
     private fun Pattern.generateNodes(resolver: Resolver): List<Value> {
         return when {
-            this is ListPattern -> (generate(resolver) as XMLNode).childNodes
-            this is XMLChoiceGroupPattern -> (generate(resolver) as XMLNode).childNodes
-            this is XMLSubstitutionGroupPattern -> listOf(generate(resolver))
-            this is XMLSequencePattern -> (generate(resolver) as XMLNode).childNodes
-            this is XMLWildcardPattern -> (generate(resolver) as XMLNode).childNodes
+            this is XMLChildGenerationPattern -> generateXMLChildValues(resolver)
             this is XMLPattern && occurMultipleTimes() ->
                 0.until(randomNumber(XML_RANDOM_NUMBER_CEILING)).map { generate(resolver) }
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLSubstitutionGroupPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLSubstitutionGroupPattern.kt
@@ -27,7 +27,7 @@ data class XMLSubstitutionGroupPattern(
     override fun matches(sampleData: Value?, resolver: Resolver): Result {
         return when (sampleData) {
             is XMLNode -> matchCandidates(listOf(sampleData), resolver).result
-            else -> Failure("Expected XML but got ${sampleData?.displayableType() ?: "nothing"}")
+            else -> xmlTypeMismatch(sampleData)
         }
     }
 
@@ -40,8 +40,10 @@ data class XMLSubstitutionGroupPattern(
         return matchCandidates(xmlValues, resolver)
     }
 
-    private fun matchCandidates(sampleData: List<XMLValue>, resolver: Resolver): ConsumeResult<Value, Value> {
-        val candidateMatches = candidates.map { candidate -> CandidateMatch(candidate, candidate.matches(sampleData, resolver)) }
+    private fun matchCandidates(xmlValues: List<XMLValue>, resolver: Resolver): ConsumeResult<Value, Value> {
+        val candidateMatches = candidates.map { candidate ->
+            CandidateMatch(candidate, candidate.matches(xmlValues, resolver))
+        }
         val successfulMatch = candidateMatches
             .map(CandidateMatch::match)
             .filter { it.result is Success }
@@ -50,10 +52,10 @@ data class XMLSubstitutionGroupPattern(
             return successfulMatch
         }
 
-        val firstNode = sampleData.firstOrNull()
-        if (firstNode is XMLNode) {
+        val actualNode = xmlValues.firstOrNull() as? XMLNode
+        if (actualNode != null) {
             val matchingNameFailure = candidateMatches
-                .firstOrNull { it.matchesElementName(firstNode) }
+                .firstOrNull { it.matchesElementName(actualNode) }
                 ?.match
 
             if (matchingNameFailure != null) {
@@ -61,7 +63,7 @@ data class XMLSubstitutionGroupPattern(
             }
         }
 
-        return ConsumeResult(substitutionGroupMismatch(firstNode), sampleData)
+        return ConsumeResult(substitutionGroupMismatch(actualNode), xmlValues)
     }
 
     override fun generate(resolver: Resolver): Value {
@@ -75,9 +77,7 @@ data class XMLSubstitutionGroupPattern(
     }
 
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> =
-        candidates.asSequence().flatMap { candidate ->
-            candidate.newBasedOn(row, resolver)
-        }
+        candidates.asSequence().flatMap { it.newBasedOn(row, resolver) }
 
     override fun negativeBasedOn(
         row: Row,
@@ -85,10 +85,10 @@ data class XMLSubstitutionGroupPattern(
         config: NegativePatternConfiguration
     ): Sequence<ReturnValue<Pattern>> =
         candidates.asSequence()
-            .flatMap { candidate -> candidate.negativeBasedOn(row, resolver, config) }
+            .flatMap { it.negativeBasedOn(row, resolver, config) }
 
     override fun newBasedOn(resolver: Resolver): Sequence<Pattern> =
-        candidates.asSequence().flatMap { candidate -> candidate.newBasedOn(resolver) }
+        candidates.asSequence().flatMap { it.newBasedOn(resolver) }
 
     override fun parse(value: String, resolver: Resolver): Value {
         return toXMLNode(parseXML(value))
@@ -139,6 +139,9 @@ data class XMLSubstitutionGroupPattern(
             "Expected one of the substitutionGroup members for $headElementName: ${candidateDisplayNames()}, but got $actual."
         )
     }
+
+    private fun xmlTypeMismatch(actualValue: Value?): Failure =
+        Failure("Expected XML but got ${actualValue?.displayableType() ?: "nothing"}")
 
     private fun candidateDisplayNames(): String =
         candidateElementNames().joinToString(", ").ifBlank { "<none>" }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLSubstitutionGroupPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLSubstitutionGroupPattern.kt
@@ -71,7 +71,7 @@ data class XMLSubstitutionGroupPattern(
     }
 
     override fun generateXMLChildValues(resolver: Resolver): List<XMLValue> {
-        return listOf(generate(resolver) as XMLValue)
+        return generatedValueAsXMLChildValues(generate(resolver))
     }
 
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> =

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLSubstitutionGroupPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLSubstitutionGroupPattern.kt
@@ -147,7 +147,7 @@ data class XMLSubstitutionGroupPattern(
         candidateElementNames().joinToString(", ").ifBlank { "<none>" }
 
     private fun candidateElementNames(): Set<String> =
-        candidates.flatMap(::elementNames).toSet()
+        candidates.flatMap(::elementDisplayNames).toSet()
 
     private data class CandidateMatch(
         val candidate: Pattern,
@@ -165,6 +165,15 @@ data class XMLSubstitutionGroupPattern(
             is XMLPattern -> listOf(candidate.pattern.name, candidate.pattern.realName)
             is AnyPattern -> candidate.pattern.flatMap(::elementNames)
             is XMLSequencePattern -> candidate.members.flatMap(::elementNames)
+            else -> listOf(candidate.typeName)
+        }
+    }
+
+    private fun elementDisplayNames(candidate: Pattern): List<String> {
+        return when (candidate) {
+            is XMLPattern -> listOf(candidate.pattern.realName)
+            is AnyPattern -> candidate.pattern.flatMap(::elementDisplayNames)
+            is XMLSequencePattern -> candidate.members.flatMap(::elementDisplayNames)
             else -> listOf(candidate.typeName)
         }
     }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLSubstitutionGroupPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLSubstitutionGroupPattern.kt
@@ -1,0 +1,164 @@
+package io.specmatic.core.pattern
+
+import io.specmatic.core.Resolver
+import io.specmatic.core.Result
+import io.specmatic.core.Result.Failure
+import io.specmatic.core.Result.Success
+import io.specmatic.core.pattern.config.NegativePatternConfiguration
+import io.specmatic.core.utilities.parseXML
+import io.specmatic.core.value.Value
+import io.specmatic.core.value.XMLNode
+import io.specmatic.core.value.XMLValue
+import io.specmatic.core.value.toXMLNode
+
+data class XMLSubstitutionGroupPattern(
+    val headElementName: String,
+    val candidates: List<Pattern>,
+    override val typeAlias: String? = null
+) : Pattern, SequenceType {
+    override val pattern: Any
+        get() = candidates
+
+    override val typeName: String = "xml-substitution-group"
+
+    override val memberList: MemberList
+        get() = MemberList(candidates, null)
+
+    override fun matches(sampleData: Value?, resolver: Resolver): Result {
+        return when (sampleData) {
+            is XMLNode -> matchCandidates(listOf(sampleData), resolver).result
+            else -> Failure("Expected XML but got ${sampleData?.displayableType() ?: "nothing"}")
+        }
+    }
+
+    override fun matches(sampleData: List<Value>, resolver: Resolver): ConsumeResult<Value, Value> {
+        val xmlValues = sampleData.filterIsInstance<XMLValue>()
+        if (xmlValues.size != sampleData.size) {
+            return ConsumeResult(Failure("XMLSubstitutionGroupPattern can only match XML values"), sampleData)
+        }
+
+        return matchCandidates(xmlValues, resolver)
+    }
+
+    private fun matchCandidates(sampleData: List<XMLValue>, resolver: Resolver): ConsumeResult<Value, Value> {
+        val candidateMatches = candidates.map { candidate -> CandidateMatch(candidate, candidate.matches(sampleData, resolver)) }
+        val successfulMatch = candidateMatches
+            .map(CandidateMatch::match)
+            .filter { it.result is Success }
+            .minByOrNull { it.remainder.size }
+        if (successfulMatch != null) {
+            return successfulMatch
+        }
+
+        val firstNode = sampleData.firstOrNull()
+        if (firstNode is XMLNode) {
+            val matchingNameFailure = candidateMatches
+                .firstOrNull { it.matchesElementName(firstNode) }
+                ?.match
+
+            if (matchingNameFailure != null) {
+                return matchingNameFailure
+            }
+        }
+
+        return ConsumeResult(substitutionGroupMismatch(firstNode), sampleData)
+    }
+
+    override fun generate(resolver: Resolver): Value {
+        val candidate = candidates.firstOrNull()
+            ?: throw ContractException("Cannot generate XML for substitutionGroup $headElementName because it has no candidates.")
+        return candidate.generate(resolver)
+    }
+
+    override fun newBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> =
+        candidates.asSequence().flatMap { candidate ->
+            candidate.newBasedOn(row, resolver)
+        }
+
+    override fun negativeBasedOn(
+        row: Row,
+        resolver: Resolver,
+        config: NegativePatternConfiguration
+    ): Sequence<ReturnValue<Pattern>> =
+        candidates.asSequence()
+            .flatMap { candidate -> candidate.negativeBasedOn(row, resolver, config) }
+
+    override fun newBasedOn(resolver: Resolver): Sequence<Pattern> =
+        candidates.asSequence().flatMap { candidate -> candidate.newBasedOn(resolver) }
+
+    override fun parse(value: String, resolver: Resolver): Value {
+        return toXMLNode(parseXML(value))
+    }
+
+    override fun listOf(valueList: List<Value>, resolver: Resolver): Value {
+        return XMLNode("", "", emptyMap(), valueList.map { it as XMLValue }, "", emptyMap())
+    }
+
+    override fun encompasses(
+        otherPattern: Pattern,
+        thisResolver: Resolver,
+        otherResolver: Resolver,
+        typeStack: TypeStack
+    ): Result {
+        val otherResolvedPattern = resolvedHop(otherPattern, otherResolver)
+        return when (otherResolvedPattern) {
+            is XMLSubstitutionGroupPattern -> Result.fromResults(
+                otherResolvedPattern.candidates.map { otherCandidate ->
+                    candidates.hasCandidateThatEncompasses(otherCandidate, thisResolver, otherResolver, typeStack)
+                }
+            )
+
+            else -> candidates.hasCandidateThatEncompasses(otherResolvedPattern, thisResolver, otherResolver, typeStack)
+        }
+    }
+
+    private fun List<Pattern>.hasCandidateThatEncompasses(
+        otherCandidate: Pattern,
+        thisResolver: Resolver,
+        otherResolver: Resolver,
+        typeStack: TypeStack
+    ): Result {
+        return asSequence()
+            .map { candidate -> candidate.encompasses(otherCandidate, thisResolver, otherResolver, typeStack) }
+            .find { it is Success }
+            ?: Failure("substitutionGroup $headElementName does not encompass ${otherCandidate.typeName}")
+    }
+
+    private fun substitutionGroupMismatch(actualValue: XMLValue? = null): Failure {
+        val actual = when (actualValue) {
+            is XMLNode -> actualValue.realName
+            null -> "nothing"
+            else -> actualValue.displayableType()
+        }
+
+        return Failure(
+            "Expected one of the substitutionGroup members for $headElementName: ${candidateDisplayNames()}, but got $actual."
+        )
+    }
+
+    private fun candidateDisplayNames(): String =
+        candidateElementNames().joinToString(", ").ifBlank { "<none>" }
+
+    private fun candidateElementNames(): Set<String> =
+        candidates.flatMap(::elementNames).toSet()
+
+    private data class CandidateMatch(
+        val candidate: Pattern,
+        val match: ConsumeResult<Value, Value>
+    )
+
+    private fun CandidateMatch.matchesElementName(node: XMLNode): Boolean {
+        return elementNames(candidate).any { candidateName ->
+            candidateName == node.name || candidateName == node.realName
+        }
+    }
+
+    private fun elementNames(candidate: Pattern): List<String> {
+        return when (candidate) {
+            is XMLPattern -> listOf(candidate.pattern.name, candidate.pattern.realName)
+            is AnyPattern -> candidate.pattern.flatMap(::elementNames)
+            is XMLSequencePattern -> candidate.members.flatMap(::elementNames)
+            else -> listOf(candidate.typeName)
+        }
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLSubstitutionGroupPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLSubstitutionGroupPattern.kt
@@ -15,7 +15,7 @@ data class XMLSubstitutionGroupPattern(
     val headElementName: String,
     val candidates: List<Pattern>,
     override val typeAlias: String? = null
-) : Pattern, SequenceType {
+) : Pattern, SequenceType, XMLChildGenerationPattern {
     override val pattern: Any
         get() = candidates
 
@@ -68,6 +68,10 @@ data class XMLSubstitutionGroupPattern(
         val candidate = candidates.firstOrNull()
             ?: throw ContractException("Cannot generate XML for substitutionGroup $headElementName because it has no candidates.")
         return candidate.generate(resolver)
+    }
+
+    override fun generateXMLChildValues(resolver: Resolver): List<XMLValue> {
+        return listOf(generate(resolver) as XMLValue)
     }
 
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> =

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLSubstitutionGroupPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLSubstitutionGroupPattern.kt
@@ -136,7 +136,7 @@ data class XMLSubstitutionGroupPattern(
         }
 
         return Failure(
-            "Expected one of the substitutionGroup members for $headElementName: ${candidateDisplayNames()}, but got $actual."
+            "Expected one of the substitutionGroup members for $headElementName (${candidateDisplayNames()}), but got $actual."
         )
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLTypeData.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLTypeData.kt
@@ -10,13 +10,32 @@ import io.specmatic.core.wsdl.parser.message.*
 internal const val XML_SCHEMA_INSTANCE_NAMESPACE = "http://www.w3.org/2001/XMLSchema-instance"
 internal const val XML_SCHEMA_NAMESPACE = "http://www.w3.org/2001/XMLSchema"
 
-data class WSDLTypeName(val namespace: String, val localName: String) {
+data class WSDLTypeName(
+    val namespace: String,
+    val localName: String,
+    val prefix: String? = null
+) {
     fun displayNameForError(): String {
-        return if (namespace.isNotBlank()) {
+        return if (!prefix.isNullOrBlank()) {
+            "$prefix:$localName"
+        } else if (namespace.isNotBlank()) {
             "$localName (namespace: $namespace)"
         } else {
             localName
         }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is WSDLTypeName) return false
+
+        return namespace == other.namespace && localName == other.localName
+    }
+
+    override fun hashCode(): Int {
+        var result = namespace.hashCode()
+        result = 31 * result + localName.hashCode()
+        return result
     }
 }
 
@@ -179,13 +198,14 @@ data class XMLTypeData(
             else -> attributes["xmlns:$prefix"]?.let { (it as? ExactValuePattern)?.pattern?.toStringLiteral() }.orEmpty()
         }
 
-        return WSDLTypeName(namespace, value.localName())
+        return WSDLTypeName(namespace, value.localName(), value.namespacePrefix().ifBlank { null })
     }
 
     internal fun wsdlTypeName(): WSDLTypeName? {
         val namespace = wsdlTypeNamespace ?: return null
         val name = wsdlTypeName ?: return null
-        return WSDLTypeName(namespace, name)
+        return wsdlKnownTypeKeys.keys.firstOrNull { it.namespace == namespace && it.localName == name }
+            ?: WSDLTypeName(namespace, name)
     }
 
     internal fun namespaceAttributesForXSIType(

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLTypeData.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLTypeData.kt
@@ -82,6 +82,9 @@ data class XMLTypeData(
                 val childNodeText = nodes.flatMap {
                     when (it) {
                         is XMLPattern -> listOf(it.toGherkinString(additionalIndent, indent + additionalIndent))
+                        is XMLSubstitutionGroupPattern -> listOf(
+                            XMLPattern(it.generate(Resolver()) as XMLNode).toGherkinString(additionalIndent, indent + additionalIndent)
+                        )
                         is XMLWildcardPattern -> (it.generate(Resolver()) as XMLNode).childNodes.map { generated ->
                             XMLPattern(generated as XMLNode).toGherkinString(additionalIndent, indent + additionalIndent)
                         }
@@ -101,6 +104,7 @@ data class XMLTypeData(
         val childXMLNodes = nodes.map {
             when(it) {
                 is XMLPattern -> it.toGherkinXMLNode()
+                is XMLSubstitutionGroupPattern -> it.generate(Resolver()) as XMLNode
                 is XMLWildcardPattern -> null
                 else -> StringValue(it.pattern.toString())
             }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLTypeData.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLTypeData.kt
@@ -10,7 +10,15 @@ import io.specmatic.core.wsdl.parser.message.*
 internal const val XML_SCHEMA_INSTANCE_NAMESPACE = "http://www.w3.org/2001/XMLSchema-instance"
 internal const val XML_SCHEMA_NAMESPACE = "http://www.w3.org/2001/XMLSchema"
 
-data class WSDLTypeName(val namespace: String, val localName: String)
+data class WSDLTypeName(val namespace: String, val localName: String) {
+    fun displayNameForError(): String {
+        return if (namespace.isNotBlank()) {
+            "$localName (namespace: $namespace)"
+        } else {
+            localName
+        }
+    }
+}
 
 enum class WSDLTypeSelectionMode {
     Polymorphic,

--- a/core/src/main/kotlin/io/specmatic/core/value/XMLNode.kt
+++ b/core/src/main/kotlin/io/specmatic/core/value/XMLNode.kt
@@ -103,6 +103,22 @@ data class FullyQualifiedName(val prefix: String, val namespace: String, val loc
             else
                 localName
         }
+
+    fun displayNameForError(): String {
+        return if (prefix.isNotBlank()) {
+            qName
+        } else {
+            qualifyLocalNameForError(localName, namespace)
+        }
+    }
+
+    private fun qualifyLocalNameForError(localName: String, namespace: String): String {
+        return if (namespace.isNotBlank()) {
+            "$localName (namespace: $namespace)"
+        } else {
+            localName
+        }
+    }
 }
 
 data class XMLNode(val name: String, val realName: String, val attributes: Map<String, StringValue>, val childNodes: List<XMLValue>, val namespacePrefix: String, val namespaces: Map<String, String>, val schema: XMLNode? = null) : XMLValue, ListValue {

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/SOAP11Parser.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/SOAP11Parser.kt
@@ -399,12 +399,12 @@ class SOAP11Parser(private val wsdl: WSDL): SOAPParser {
             val namespace = typeNode.schemaTargetNamespace()
             val schemaTypeName = FullyQualifiedName(typeNode.prefixFor(namespace), namespace, name)
             WSDLTypeLookupEntry(
-                typeName = WSDLTypeName(schemaTypeName.namespace, schemaTypeName.localName),
+                typeName = WSDLTypeName(schemaTypeName.namespace, schemaTypeName.localName, schemaTypeName.prefix.ifBlank { null }),
                 typeKey = "(${specmaticTypeName(schemaTypeName.qName)})",
                 baseTypeName = typeNode.derivationNode()
                     ?.fullyQualifiedNameFromAttribute("base")
                     ?.takeUnless { it.namespace == XML_SCHEMA_NAMESPACE }
-                    ?.let { WSDLTypeName(it.namespace, it.localName) },
+                    ?.let { WSDLTypeName(it.namespace, it.localName, it.prefix.ifBlank { null }) },
                 isAbstract = typeNode.isAbstractNamedComplexType(),
             )
         }
@@ -472,7 +472,9 @@ class SOAP11Parser(private val wsdl: WSDL): SOAPParser {
     private fun Pattern.wsdlTypeNameForLookup(): WSDLTypeName? {
         return when (this) {
             is XMLPattern -> pattern.wsdlTypeName?.let { typeName ->
-                WSDLTypeName(pattern.wsdlTypeNamespace.orEmpty(), typeName)
+                pattern.wsdlKnownTypeKeys.keys.firstOrNull { knownType ->
+                    knownType.namespace == pattern.wsdlTypeNamespace.orEmpty() && knownType.localName == typeName
+                } ?: WSDLTypeName(pattern.wsdlTypeNamespace.orEmpty(), typeName)
             }
             is AnyPattern -> pattern.asSequence().mapNotNull { it.wsdlTypeNameForLookup() }.firstOrNull()
             else -> null

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/WSDL.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/WSDL.kt
@@ -121,7 +121,7 @@ fun WSDL(rootDefinition: XMLNode, wsdlPath: String): WSDL {
     val reversedSchemaPrefixes: Map<String, String> = schemaPrefixes.entries.associate { it.value to it.key }
     val rootPrefixes: Map<String, String> = prefixToNamespaceMap(rootDefinition)
 
-    return WSDL(rootDefinition, definitions, populatedSchemas, typesNode, namespaceToPrefixMap(rootDefinition).plus(schemaPrefixes), reversedSchemaPrefixes.plus(rootPrefixes), prefixToNamespaceMap(rootDefinition))
+    return WSDL(rootDefinition, definitions, populatedSchemas, typesNode, schemaPrefixes.plus(namespaceToPrefixMap(rootDefinition)), reversedSchemaPrefixes.plus(rootPrefixes), prefixToNamespaceMap(rootDefinition))
 }
 
 fun schemaPrefixesFrom(schemas: Map<String, XMLNode>): Map<String, String> {

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/WSDL.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/WSDL.kt
@@ -14,23 +14,35 @@ import io.specmatic.license.core.SpecmaticProtocol
 import java.io.File
 
 private fun namespaceToPrefixMap(wsdlNode: XMLNode): Map<String, String> {
-    return wsdlNode.attributes.filterKeys {
+    val explicitPrefixes = wsdlNode.attributes.filterKeys {
         it.startsWith("xmlns:")
     }.mapValues {
         it.value.toStringLiteral()
     }.map {
         Pair(it.value, it.key.removePrefix("xmlns:"))
     }.toMap()
+
+    val defaultNamespace = wsdlNode.attributes["xmlns"]?.toStringLiteral()
+        ?.let { namespace -> mapOf(namespace to "") }
+        .orEmpty()
+
+    return defaultNamespace.plus(explicitPrefixes)
 }
 
 private fun prefixToNamespaceMap(wsdlNode: XMLNode): Map<String, String> {
-    return wsdlNode.attributes.filterKeys {
+    val explicitPrefixes = wsdlNode.attributes.filterKeys {
         it.startsWith("xmlns:")
     }.mapValues {
         it.value.toStringLiteral()
     }.mapKeys {
         it.key.removePrefix("xmlns:")
     }
+
+    val defaultNamespace = wsdlNode.attributes["xmlns"]?.toStringLiteral()
+        ?.let { namespace -> mapOf("" to namespace) }
+        .orEmpty()
+
+    return defaultNamespace.plus(explicitPrefixes)
 }
 
 private fun definitionsFrom(rootDefinitionXML: XMLNode, parentWSDL: File): List<XMLNode> {
@@ -107,9 +119,7 @@ fun WSDL(rootDefinition: XMLNode, wsdlPath: String): WSDL {
 
     val schemaPrefixes: Map<String, String> = schemaPrefixesFrom(schemas)
     val reversedSchemaPrefixes: Map<String, String> = schemaPrefixes.entries.associate { it.value to it.key }
-    val rootPrefixes: Map<String, String> = rootDefinition.attributes.filterKeys { it.startsWith("xmlns:") }.map {
-        it.key.split(":")[1] to it.value.string
-    }.toMap()
+    val rootPrefixes: Map<String, String> = prefixToNamespaceMap(rootDefinition)
 
     return WSDL(rootDefinition, definitions, populatedSchemas, typesNode, namespaceToPrefixMap(rootDefinition).plus(schemaPrefixes), reversedSchemaPrefixes.plus(rootPrefixes), prefixToNamespaceMap(rootDefinition))
 }
@@ -176,7 +186,8 @@ private data class SchemaLookupKey(
 private data class WsdlIndexes(
     val definitions: Map<DefinitionLookupKey, XMLNode>,
     val schemas: Map<SchemaLookupKey, XMLNode>,
-    val namedSchemas: Map<NamedSchemaLookupKey, XMLNode>
+    val namedSchemas: Map<NamedSchemaLookupKey, XMLNode>,
+    val substitutionGroups: Map<NamedSchemaLookupKey, List<XMLNode>>
 )
 
 private data class NamedSchemaLookupKey(
@@ -188,7 +199,8 @@ data class WSDL(private val rootDefinition: XMLNode, val definitions: Map<String
     private val indexes = WsdlIndexes(
         definitions = indexDefinitions(definitions),
         schemas = indexSchemas(schemas),
-        namedSchemas = indexNamedSchemas(schemas)
+        namedSchemas = indexNamedSchemas(schemas),
+        substitutionGroups = indexSubstitutionGroups(schemas)
     )
 
     fun allNamespaces(): Map<String, String> {
@@ -340,10 +352,14 @@ data class WSDL(private val rootDefinition: XMLNode, val definitions: Map<String
         return findNamedSchemaNode(namespace, typeName, localSchema)
     }
 
+    private fun findGlobalElement(typeName: String, namespace: String, localSchema: XMLNode? = null): XMLNode {
+        return findSchemaNode("element", namespace, typeName, localSchema)
+    }
+
     fun getSOAPElement(fullyQualifiedName: FullyQualifiedName, localSchema: XMLNode? = null, otherRefAttributes: Map<String, StringValue> = emptyMap()): WSDLElement {
         val schema = findSchema(fullyQualifiedName.namespace, localSchema)
 
-        val node = findElement(fullyQualifiedName.localName, fullyQualifiedName.namespace, localSchema).addSchema(schema).let {
+        val node = findGlobalElement(fullyQualifiedName.localName, fullyQualifiedName.namespace, localSchema).addSchema(schema).let {
             it.copy(attributes = it.attributes.plus(otherRefAttributes))
         }
 
@@ -352,6 +368,11 @@ data class WSDL(private val rootDefinition: XMLNode, val definitions: Map<String
         } else {
             ReferredType(fullyQualifiedName.qName, node, this)
         }
+    }
+
+    fun getSubstitutionGroupMembers(fullyQualifiedName: FullyQualifiedName, localSchema: XMLNode? = null): List<XMLNode> {
+        val resolvedNamespace = resolvedSchemaNamespace(fullyQualifiedName.namespace, localSchema)
+        return indexes.substitutionGroups[NamedSchemaLookupKey(resolvedNamespace, fullyQualifiedName.localName)].orEmpty()
     }
 
     fun namedTypeNodes(namespace: String, localSchema: XMLNode? = null): List<XMLNode> {
@@ -537,6 +558,16 @@ private fun indexNamedSchemas(schemas: Map<String, XMLNode>): Map<NamedSchemaLoo
                 }
             }
     }.firstByKey()
+}
+
+private fun indexSubstitutionGroups(schemas: Map<String, XMLNode>): Map<NamedSchemaLookupKey, List<XMLNode>> {
+    return schemas.values
+        .flatMap { schema -> schema.childNodes.filterIsInstance<XMLNode>() }
+        .filter { node -> node.name == "element" && node.attributes.containsKey("substitutionGroup") }
+        .groupBy { node ->
+            val head = node.fullyQualifiedNameFromAttribute("substitutionGroup")
+            NamedSchemaLookupKey(head.namespace, head.localName)
+        }
 }
 
 private fun <K, V> List<Pair<K, V>>.firstByKey(): Map<K, V> =

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/message/ElementReference.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/message/ElementReference.kt
@@ -117,6 +117,10 @@ private fun XMLNode.isAbstractGlobalElement(): Boolean =
 
 private fun XMLNode.fullyQualifiedNameFromGlobalElement(): FullyQualifiedName {
     val namespace = schema?.attributes?.get("targetNamespace")?.toStringLiteral().orEmpty()
-    val prefix = namespaces.entries.firstOrNull { (_, uri) -> uri == namespace }?.key.orEmpty()
+    val prefix = attributes.entries.firstNotNullOfOrNull { (attributeName, value) ->
+        attributeName
+            .removePrefix("xmlns:")
+            .takeIf { attributeName.startsWith("xmlns:") && value.toStringLiteral() == namespace }
+    } ?: namespaces.entries.firstOrNull { (_, uri) -> uri == namespace }?.key.orEmpty()
     return FullyQualifiedName(prefix, namespace, getAttributeValue("name"))
 }

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/message/ElementReference.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/message/ElementReference.kt
@@ -1,7 +1,14 @@
 package io.specmatic.core.wsdl.parser.message
 
+import io.specmatic.core.pattern.ContractException
+import io.specmatic.core.pattern.Pattern
+import io.specmatic.core.pattern.XMLSubstitutionGroupPattern
+import io.specmatic.core.value.FullyQualifiedName
 import io.specmatic.core.value.XMLNode
+import io.specmatic.core.wsdl.parser.SOAPMessageType
 import io.specmatic.core.wsdl.parser.WSDL
+import io.specmatic.core.wsdl.parser.WSDLTypeInfo
+import io.specmatic.core.wsdl.payload.SOAPPayload
 
 data class ElementReference(val child: XMLNode, val wsdl: WSDL) : ChildElementType {
     override fun getWSDLElement(): Pair<String, WSDLElement> {
@@ -12,6 +19,107 @@ data class ElementReference(val child: XMLNode, val wsdl: WSDL) : ChildElementTy
         val otherRefAttributes = child.attributes.minus("ref")
 
         val resolvedChild = wsdl.getSOAPElement(fullyQualifiedName, child.schema, otherRefAttributes)
-        return Pair(specmaticTypeName, resolvedChild)
+        val substitutionMembers = wsdl.getSubstitutionGroupMembers(fullyQualifiedName, child.schema)
+        if (substitutionMembers.isEmpty()) {
+            if (resolvedChild.isAbstractSubstitutionHead()) {
+                throw ContractException("Expected substitutionGroup members for ${fullyQualifiedName.displayName}, but none were found.")
+            }
+
+            return Pair(specmaticTypeName, resolvedChild)
+        }
+
+        val substitutionGroup = SubstitutionGroupElement(
+            head = SubstitutionCandidate(fullyQualifiedName, resolvedChild),
+            substitutes = substitutionMembers.map { member ->
+                val memberName = member.fullyQualifiedNameFromGlobalElement()
+                val memberAttributes = member.attributes
+                    .minus("substitutionGroup")
+                    .plus(otherRefAttributes)
+                SubstitutionCandidate(memberName, wsdl.getSOAPElement(memberName, member.schema, memberAttributes))
+            }
+        )
+
+        return Pair(specmaticTypeName, substitutionGroup)
     }
 }
+
+private data class SubstitutionCandidate(
+    val name: FullyQualifiedName,
+    val element: WSDLElement
+)
+
+private data class SubstitutionGroupElement(
+    val head: SubstitutionCandidate,
+    val substitutes: List<SubstitutionCandidate>
+) : WSDLElement {
+    override fun deriveSpecmaticTypes(
+        specmaticTypeName: String,
+        existingTypes: Map<String, Pattern>,
+        typeStack: Set<String>
+    ): WSDLTypeInfo {
+        val headTypeInfo = head.element.deriveSpecmaticTypes(specmaticTypeName, existingTypes, typeStack)
+        val candidates = when {
+            head.element.isAbstractSubstitutionHead() -> substitutes
+            else -> listOf(head) + substitutes
+        }
+
+        if (candidates.isEmpty()) {
+            throw ContractException("Expected substitutionGroup members for ${head.name.displayName}, but none were found.")
+        }
+
+        val candidateInfo = candidates.runningFold(
+            CandidateTypeInfo(emptyList(), emptyMap(), emptySet())
+        ) { accumulator, candidate ->
+            val candidateTypeInfo = candidate.element.deriveSpecmaticTypes(
+                candidate.name.qName.replace(':', '_'),
+                existingTypes.plus(accumulator.types),
+                typeStack
+            )
+
+            CandidateTypeInfo(
+                patterns = accumulator.patterns.plus(candidateTypeInfo.effectiveMembers),
+                types = accumulator.types.plus(candidateTypeInfo.types),
+                namespacePrefixes = accumulator.namespacePrefixes.plus(candidateTypeInfo.namespacePrefixes)
+            )
+        }.last()
+
+        return headTypeInfo.copy(
+            members = listOf(XMLSubstitutionGroupPattern(head.name.displayName, candidateInfo.patterns)),
+            types = headTypeInfo.types.plus(candidateInfo.types),
+            namespacePrefixes = headTypeInfo.namespacePrefixes.plus(candidateInfo.namespacePrefixes),
+        )
+    }
+
+    override fun getSOAPPayload(
+        soapMessageType: SOAPMessageType,
+        nodeNameForSOAPBody: String,
+        specmaticTypeName: String,
+        namespaces: Map<String, String>,
+        typeInfo: WSDLTypeInfo
+    ): SOAPPayload = head.element.getSOAPPayload(soapMessageType, nodeNameForSOAPBody, specmaticTypeName, namespaces, typeInfo)
+}
+
+private data class CandidateTypeInfo(
+    val patterns: List<Pattern>,
+    val types: Map<String, Pattern>,
+    val namespacePrefixes: Set<String>,
+)
+
+private fun WSDLElement.isAbstractSubstitutionHead(): Boolean =
+    when (this) {
+        is ReferredType -> element.isAbstractGlobalElement()
+        is SimpleElement -> element.isAbstractGlobalElement()
+        else -> false
+    }
+
+private fun XMLNode.isAbstractGlobalElement(): Boolean =
+    name == "element" && attributes["abstract"]?.toStringLiteral()?.lowercase() == "true"
+
+private fun XMLNode.fullyQualifiedNameFromGlobalElement(): FullyQualifiedName {
+    val namespace = schema?.attributes?.get("targetNamespace")?.toStringLiteral().orEmpty()
+    val prefix = namespaces.entries.firstOrNull { (_, uri) -> uri == namespace }?.key.orEmpty()
+    return FullyQualifiedName(prefix, namespace, getAttributeValue("name"))
+}
+
+private val FullyQualifiedName.displayName: String
+    get() = "{${namespace}}$localName"

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/message/ElementReference.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/message/ElementReference.kt
@@ -22,7 +22,7 @@ data class ElementReference(val child: XMLNode, val wsdl: WSDL) : ChildElementTy
         val substitutionMembers = wsdl.getSubstitutionGroupMembers(fullyQualifiedName, child.schema)
         if (substitutionMembers.isEmpty()) {
             if (resolvedChild.isAbstractSubstitutionHead()) {
-                throw ContractException("Expected substitutionGroup members for ${fullyQualifiedName.displayName}, but none were found.")
+                throw ContractException("Expected substitutionGroup members for ${fullyQualifiedName.displayNameForError()}, but none were found.")
             }
 
             return Pair(specmaticTypeName, resolvedChild)
@@ -64,7 +64,7 @@ private data class SubstitutionGroupElement(
         }
 
         if (candidates.isEmpty()) {
-            throw ContractException("Expected substitutionGroup members for ${head.name.displayName}, but none were found.")
+            throw ContractException("Expected substitutionGroup members for ${head.name.displayNameForError()}, but none were found.")
         }
 
         val candidateInfo = candidates.runningFold(
@@ -84,7 +84,7 @@ private data class SubstitutionGroupElement(
         }.last()
 
         return headTypeInfo.copy(
-            members = listOf(XMLSubstitutionGroupPattern(head.name.displayName, candidateInfo.patterns)),
+            members = listOf(XMLSubstitutionGroupPattern(head.name.displayNameForError(), candidateInfo.patterns)),
             types = headTypeInfo.types.plus(candidateInfo.types),
             namespacePrefixes = headTypeInfo.namespacePrefixes.plus(candidateInfo.namespacePrefixes),
         )
@@ -120,6 +120,3 @@ private fun XMLNode.fullyQualifiedNameFromGlobalElement(): FullyQualifiedName {
     val prefix = namespaces.entries.firstOrNull { (_, uri) -> uri == namespace }?.key.orEmpty()
     return FullyQualifiedName(prefix, namespace, getAttributeValue("name"))
 }
-
-private val FullyQualifiedName.displayName: String
-    get() = "{${namespace}}$localName"

--- a/core/src/test/kotlin/io/specmatic/conversions/WSDLConversionTests.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/WSDLConversionTests.kt
@@ -538,7 +538,7 @@ class WSDLConversionTests {
                     And request-header SOAPAction (SoapAction)
                     And request-body
                     ""${'"'}
-                    <soapenv:Envelope xmlns:SOAPService="http://specmatic.io/SOAPService/" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+                    <soapenv:Envelope xmlns:qr="http://specmatic.io/SOAPService/" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
                       <soapenv:Body>
                         <qr:simpleInputMessage specmatic_type="SimpleOperationInput"/>
                       </soapenv:Body>

--- a/core/src/test/kotlin/io/specmatic/conversions/WsdlSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/WsdlSpecificationTest.kt
@@ -134,7 +134,30 @@ internal class WsdlSpecificationTest {
 
         assertThat(result).isInstanceOf(Result.Failure::class.java)
         assertThat(result.reportString()).contains("Unknown type")
-        assertThat(result.reportString()).contains("MissingAnimal")
+        assertThat(result.reportString()).contains("tns:MissingAnimal")
+    }
+
+    @Test
+    fun `request matching reports unknown unprefixed xsi type using namespace fallback`() {
+        val wsdlContract = wsdlContentToFeature(animalWithoutDerivedTypesWsdl(), "animal-without-derived-types.wsdl")
+        val scenario = wsdlContract.scenarios.single()
+
+        val result = scenario.httpRequestPattern.matches(
+            animalRequest(
+                """
+                <Animal xmlns="http://example.com/animals"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xsi:type="MissingAnimal">
+                  <name>Leo</name>
+                </Animal>
+                """.trimIndent()
+            ),
+            scenario.resolver
+        )
+
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
+        assertThat(result.reportString()).contains("Unknown type MissingAnimal (namespace: http://example.com/animals)")
+        assertThat(result.reportString()).contains("base type Animal (namespace: http://example.com/animals)")
     }
 
     @Test
@@ -147,8 +170,8 @@ internal class WsdlSpecificationTest {
             .toList()
 
         assertThat(generatedBodies).anySatisfy { body ->
-            assertThat(body).contains("xsi:type=\"Order-model:OnlineOrder\"")
-            assertThat(body).contains("<Order-model:channel>")
+            assertThat(body).contains("xsi:type=\"model:OnlineOrder\"")
+            assertThat(body).contains(":channel>")
         }
     }
 
@@ -292,7 +315,8 @@ internal class WsdlSpecificationTest {
 
         assertThat(result).isInstanceOf(Result.Failure::class.java)
         assertThat(result.reportString()).contains("Missing type for abstract WSDL type")
-        assertThat(result.reportString()).contains("Pet")
+        assertThat(result.reportString()).contains("tns:Pet")
+        assertThat(result.reportString()).doesNotContain("namespace:")
     }
 
     @Test
@@ -318,7 +342,8 @@ internal class WsdlSpecificationTest {
 
         assertThat(result).isInstanceOf(Result.Failure::class.java)
         assertThat(result.reportString()).contains("abstract")
-        assertThat(result.reportString()).contains("Pet")
+        assertThat(result.reportString()).contains("tns:Pet")
+        assertThat(result.reportString()).doesNotContain("namespace:")
     }
 
     @Test
@@ -347,8 +372,9 @@ internal class WsdlSpecificationTest {
 
         assertThat(result).isInstanceOf(Result.Failure::class.java)
         assertThat(result.reportString()).contains("Invalid type")
-        assertThat(result.reportString()).contains("Crocodile")
+        assertThat(result.reportString()).contains("tns:Crocodile")
         assertThat(result.reportString()).doesNotContain("it is abstract")
+        assertThat(result.reportString()).doesNotContain("namespace:")
     }
 
     @Test
@@ -374,7 +400,8 @@ internal class WsdlSpecificationTest {
 
         assertThat(result).isInstanceOf(Result.Failure::class.java)
         assertThat(result.reportString()).contains("Missing type for abstract WSDL type")
-        assertThat(result.reportString()).contains("Pet")
+        assertThat(result.reportString()).contains("tns:Pet")
+        assertThat(result.reportString()).doesNotContain("namespace:")
     }
 
     @Test
@@ -400,8 +427,9 @@ internal class WsdlSpecificationTest {
 
         assertThat(result).isInstanceOf(Result.Failure::class.java)
         assertThat(result.reportString()).contains("Invalid type")
-        assertThat(result.reportString()).contains("Crocodile")
-        assertThat(result.reportString()).contains("Pet")
+        assertThat(result.reportString()).contains("tns:Crocodile")
+        assertThat(result.reportString()).contains("tns:Pet")
+        assertThat(result.reportString()).doesNotContain("namespace:")
     }
 
     @Test
@@ -444,11 +472,11 @@ internal class WsdlSpecificationTest {
             assertThat(body).doesNotContain(":lives>")
         }
         assertThat(generatedBodies).anySatisfy { body ->
-            assertThat(body).contains("xsi:type=\"Pet-sequence:Dog\"")
+            assertThat(body).contains("xsi:type=\"tns:Dog\"")
             assertThat(body).contains(":breed>")
         }
         assertThat(generatedBodies).anySatisfy { body ->
-            assertThat(body).contains("xsi:type=\"Pet-sequence:Cat\"")
+            assertThat(body).contains("xsi:type=\"tns:Cat\"")
             assertThat(body).contains(":lives>")
         }
     }
@@ -488,11 +516,11 @@ internal class WsdlSpecificationTest {
             assertThat(body).doesNotContain(":lives>")
         }
         assertThat(generatedBodies).anySatisfy { body ->
-            assertThat(body).contains("xsi:type=\"Pet-sequence:Dog\"")
+            assertThat(body).contains("xsi:type=\"tns:Dog\"")
             assertThat(body).contains(":breed>")
         }
         assertThat(generatedBodies).anySatisfy { body ->
-            assertThat(body).contains("xsi:type=\"Pet-sequence:Cat\"")
+            assertThat(body).contains("xsi:type=\"tns:Cat\"")
             assertThat(body).contains(":lives>")
         }
     }
@@ -521,7 +549,7 @@ internal class WsdlSpecificationTest {
     fun `pinned derived wsdl complex type candidate generates only derived shape with xsi type`() {
         val wsdlContract = wsdlContentToFeature(petSequenceWsdl(), "pet-sequence.wsdl")
         val dogScenario = generatedScenarios(wsdlContract).first { scenario ->
-            generatedRequestBody(scenario, wsdlContract).contains("xsi:type=\"Pet-sequence:Dog\"")
+            generatedRequestBody(scenario, wsdlContract).contains("xsi:type=\"tns:Dog\"")
         }
 
         val regeneratedBodies = (1..5).map {
@@ -529,7 +557,7 @@ internal class WsdlSpecificationTest {
         }
 
         assertThat(regeneratedBodies).allSatisfy { body ->
-            assertThat(body).contains("xsi:type=\"Pet-sequence:Dog\"")
+            assertThat(body).contains("xsi:type=\"tns:Dog\"")
             assertThat(body).contains(":breed>")
             assertThat(body).doesNotContain(":lives>")
         }
@@ -586,8 +614,9 @@ internal class WsdlSpecificationTest {
 
         assertThat(result).isInstanceOf(Result.Failure::class.java)
         assertThat(result.reportString()).contains("Invalid type")
-        assertThat(result.reportString()).contains("Crocodile")
-        assertThat(result.reportString()).contains("Pet")
+        assertThat(result.reportString()).contains("tns:Crocodile")
+        assertThat(result.reportString()).contains("tns:Pet")
+        assertThat(result.reportString()).doesNotContain("namespace:")
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/conversions/WsdlSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/WsdlSpecificationTest.kt
@@ -133,7 +133,7 @@ internal class WsdlSpecificationTest {
         )
 
         assertThat(result).isInstanceOf(Result.Failure::class.java)
-        assertThat(result.reportString()).contains("Unknown xsi:type")
+        assertThat(result.reportString()).contains("Unknown type")
         assertThat(result.reportString()).contains("MissingAnimal")
     }
 
@@ -291,7 +291,7 @@ internal class WsdlSpecificationTest {
         )
 
         assertThat(result).isInstanceOf(Result.Failure::class.java)
-        assertThat(result.reportString()).contains("Missing xsi:type")
+        assertThat(result.reportString()).contains("Missing type for abstract WSDL type")
         assertThat(result.reportString()).contains("Pet")
     }
 
@@ -346,7 +346,7 @@ internal class WsdlSpecificationTest {
         )
 
         assertThat(result).isInstanceOf(Result.Failure::class.java)
-        assertThat(result.reportString()).contains("Invalid xsi:type")
+        assertThat(result.reportString()).contains("Invalid type")
         assertThat(result.reportString()).contains("Crocodile")
         assertThat(result.reportString()).doesNotContain("it is abstract")
     }
@@ -373,7 +373,7 @@ internal class WsdlSpecificationTest {
         )
 
         assertThat(result).isInstanceOf(Result.Failure::class.java)
-        assertThat(result.reportString()).contains("Missing xsi:type")
+        assertThat(result.reportString()).contains("Missing type for abstract WSDL type")
         assertThat(result.reportString()).contains("Pet")
     }
 
@@ -399,7 +399,7 @@ internal class WsdlSpecificationTest {
         )
 
         assertThat(result).isInstanceOf(Result.Failure::class.java)
-        assertThat(result.reportString()).contains("Invalid xsi:type")
+        assertThat(result.reportString()).contains("Invalid type")
         assertThat(result.reportString()).contains("Crocodile")
         assertThat(result.reportString()).contains("Pet")
     }
@@ -585,7 +585,7 @@ internal class WsdlSpecificationTest {
         )
 
         assertThat(result).isInstanceOf(Result.Failure::class.java)
-        assertThat(result.reportString()).contains("Invalid xsi:type")
+        assertThat(result.reportString()).contains("Invalid type")
         assertThat(result.reportString()).contains("Crocodile")
         assertThat(result.reportString()).contains("Pet")
     }

--- a/core/src/test/kotlin/io/specmatic/core/pattern/XMLPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/XMLPatternTest.kt
@@ -734,7 +734,8 @@ internal class XMLPatternTest {
             val result = pattern.matches(value, resolver)
 
             assertThat(result).isInstanceOf(Result.Failure::class.java)
-            assertThat(result.reportString()).contains("Invalid xsi:type")
+            assertThat(result.reportString()).contains("Invalid type")
+            assertThat(result.reportString()).contains("base type")
         }
 
         @Test
@@ -761,7 +762,7 @@ internal class XMLPatternTest {
             val result = pattern.matches(value, resolver)
 
             assertThat(result).isInstanceOf(Result.Failure::class.java)
-            assertThat(result.reportString()).contains("Unknown xsi:type")
+            assertThat(result.reportString()).contains("Unknown type")
             assertThat(result.reportString()).contains("UnknownType")
         }
 

--- a/core/src/test/kotlin/io/specmatic/core/pattern/XMLPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/XMLPatternTest.kt
@@ -735,7 +735,9 @@ internal class XMLPatternTest {
 
             assertThat(result).isInstanceOf(Result.Failure::class.java)
             assertThat(result.reportString()).contains("Invalid type")
+            assertThat(result.reportString()).contains("tns:Vehicle")
             assertThat(result.reportString()).contains("base type")
+            assertThat(result.reportString()).contains("Animal")
         }
 
         @Test
@@ -763,7 +765,7 @@ internal class XMLPatternTest {
 
             assertThat(result).isInstanceOf(Result.Failure::class.java)
             assertThat(result.reportString()).contains("Unknown type")
-            assertThat(result.reportString()).contains("UnknownType")
+            assertThat(result.reportString()).contains("tns:UnknownType")
         }
 
         @Test

--- a/core/src/test/kotlin/io/specmatic/core/pattern/XMLPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/XMLPatternTest.kt
@@ -1726,6 +1726,19 @@ internal class XMLPatternTest {
         }
 
         @Test
+        fun `repeated xml child projects generated child nodes through xml child generation interface`() {
+            val repeatedTitle = XMLPattern("<title $occursMultipleTimes>(number)</title>")
+            val generatedChildren = repeatedTitle.generateXMLChildValues(Resolver())
+
+            assertThat(generatedChildren).hasSizeBetween(1, 2)
+            assertThat(generatedChildren).allSatisfy(Consumer { generatedChild ->
+                val title = generatedChild as XMLNode
+                assertThat(title.name).isEqualTo("title")
+                assertThat(title.attributes).doesNotContainKey(OCCURS_ATTRIBUTE_NAME)
+            })
+        }
+
+        @Test
         fun `xml with a typed node that occurs multiple times generates multiple nodes`() {
             val nameType = XMLPattern("<name><nameid $occursMultipleTimes $TYPE_ATTRIBUTE_NAME=\"Nameid\" /></name>")
             val nameIdType = XMLPattern("<nameid>(number)</nameid>")

--- a/core/src/test/kotlin/io/specmatic/core/pattern/XMLSubstitutionGroupPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/XMLSubstitutionGroupPatternTest.kt
@@ -1,0 +1,46 @@
+package io.specmatic.core.pattern
+
+import io.specmatic.core.Resolver
+import io.specmatic.core.Result
+import io.specmatic.core.value.XMLNode
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class XMLSubstitutionGroupPatternTest {
+    private val resolver = Resolver()
+
+    @Test
+    fun `matches fails when value is null`() {
+        val pattern = petSubstitutionGroup()
+
+        val result = pattern.matches(null, resolver)
+
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
+        assertThat((result as Result.Failure).reportString()).contains("Expected XML but got nothing")
+    }
+
+    @Test
+    fun `negativeBasedOn delegates to candidate negatives`() {
+        val pattern = petSubstitutionGroup()
+
+        val generatedNegativePatterns = pattern.negativeBasedOn(Row(), resolver)
+            .map { it.value }
+            .toList()
+
+        assertThat(generatedNegativePatterns).isNotEmpty
+        assertThat(generatedNegativePatterns)
+            .allSatisfy { negativePattern -> assertThat(negativePattern).isInstanceOf(XMLPattern::class.java) }
+        assertThat(generatedNegativePatterns.map { (it as XMLPattern).pattern.name })
+            .contains("Dog", "Cat")
+    }
+
+    private fun petSubstitutionGroup(): XMLSubstitutionGroupPattern {
+        return XMLSubstitutionGroupPattern(
+            headElementName = "{http://example.com/pets}Pet",
+            candidates = listOf(
+                XMLPattern("<Dog><name>(string)</name></Dog>"),
+                XMLPattern("<Cat><name>(string)</name></Cat>")
+            )
+        )
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/pattern/XMLTypeDataTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/XMLTypeDataTest.kt
@@ -5,6 +5,20 @@ import org.junit.jupiter.api.Test
 
 internal class XMLTypeDataTest {
     @Test
+    fun `prints a WSDL type name without a prefix using the namespace fallback`() {
+        val typeName = WSDLTypeName("http://example.com/animals", "Animal")
+
+        assertThat(typeName.displayNameForError()).isEqualTo("Animal (namespace: http://example.com/animals)")
+    }
+
+    @Test
+    fun `prints a WSDL type name without a prefix or namespace using the local name`() {
+        val typeName = WSDLTypeName("", "Animal")
+
+        assertThat(typeName.displayNameForError()).isEqualTo("Animal")
+    }
+
+    @Test
     fun `prints an empty XML type correctly`() {
         assertThat(XMLTypeData("person", "person").toGherkinString()).isEqualTo("<person/>")
     }

--- a/core/src/test/kotlin/io/specmatic/core/wsdl/WSDLParserMockBlackBoxTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/wsdl/WSDLParserMockBlackBoxTest.kt
@@ -671,7 +671,7 @@ class WSDLParserMockBlackBoxTest {
             HttpStub(feature, listOf(scenarioStub)).close()
         }
 
-        assertThat(exception.message).contains("Unknown xsi:type")
+        assertThat(exception.message).contains("Unknown type")
         assertThat(exception.message).contains("MissingOrderDetails")
     }
 

--- a/core/src/test/kotlin/io/specmatic/core/wsdl/WSDLSubstitutionGroupTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/wsdl/WSDLSubstitutionGroupTest.kt
@@ -1,0 +1,563 @@
+package io.specmatic.core.wsdl
+
+import io.ktor.http.ContentType
+import io.specmatic.core.CONTENT_TYPE
+import io.specmatic.core.HttpRequest
+import io.specmatic.core.HttpResponse
+import io.specmatic.core.Resolver
+import io.specmatic.core.Result
+import io.specmatic.core.SpecmaticConfig
+import io.specmatic.core.parseContractFileToFeature
+import io.specmatic.core.utilities.ContractPathData
+import io.specmatic.core.value.StringValue
+import io.specmatic.stub.FeatureStubsResult
+import io.specmatic.stub.HttpStub
+import io.specmatic.stub.loadContractStubsFromFilesAsResults
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class WSDLSubstitutionGroupTest {
+    @Test
+    fun `mock accepts substitution members for an abstract imported head element`(@TempDir tempDir: File) {
+        val wsdlFile = writePetService(tempDir, abstractHead = true)
+        val feature = parseContractFileToFeature(wsdlFile)
+
+        HttpStub(feature).use { stub ->
+            val dogResponse = stub.client.execute(registerPetRequest("Dog", "Barkley", "Collie"))
+            val catResponse = stub.client.execute(registerPetRequest("Cat", "Misty", "Tabby"))
+            val petResponse = stub.client.execute(registerPetRequest("Pet", "Base", "Ignored"))
+
+            assertThat(dogResponse.status).isEqualTo(200)
+            assertThat(catResponse.status).isEqualTo(200)
+            assertThat(petResponse.status).isEqualTo(400)
+        }
+    }
+
+    @Test
+    fun `mock rejects abstract substitution group head declared in the same schema`(@TempDir tempDir: File) {
+        val wsdlFile = writeInlinePetService(tempDir, abstractHead = true)
+        val feature = parseContractFileToFeature(wsdlFile)
+
+        HttpStub(feature).use { stub ->
+            val dogResponse = stub.client.execute(registerPetRequest("Dog", "Barkley", "Collie", "tns", """/pets/registerPet"""))
+            val catResponse = stub.client.execute(registerPetRequest("Cat", "Misty", "Tabby", "tns", """/pets/registerPet"""))
+            val petResponse = stub.client.execute(registerPetRequest("Pet", "Base", "Ignored", "tns", """/pets/registerPet"""))
+
+            assertThat(dogResponse.status).isEqualTo(200)
+            assertThat(catResponse.status).isEqualTo(200)
+            assertThat(petResponse.status).isEqualTo(400)
+        }
+    }
+
+    @Test
+    fun `mock rejects abstract substitution group head when element and type have the same name`(@TempDir tempDir: File) {
+        val wsdlFile = writeInlinePetService(tempDir, abstractHead = true, elementAndTypeShareNames = true)
+        val feature = parseContractFileToFeature(wsdlFile)
+
+        HttpStub(feature).use { stub ->
+            val dogResponse = stub.client.execute(registerPetRequest("Dog", "Barkley", "Collie", "tns", """/pets/registerPet"""))
+            val catResponse = stub.client.execute(registerPetRequest("Cat", "Misty", "Tabby", "tns", """/pets/registerPet"""))
+            val petResponse = stub.client.execute(registerPetRequest("Pet", "Base", "Ignored", "tns", """/pets/registerPet"""))
+
+            assertThat(dogResponse.status).isEqualTo(200)
+            assertThat(catResponse.status).isEqualTo(200)
+            assertThat(petResponse.status).isEqualTo(400)
+        }
+    }
+
+    @Test
+    fun `mock rejects abstract substitution group head in default namespace wsdl`(@TempDir tempDir: File) {
+        val wsdlFile = writeDemoStylePetService(tempDir)
+        val feature = parseContractFileToFeature(wsdlFile)
+
+        val response = HttpStub(feature).use { stub ->
+            stub.client.execute(registerPetRequest("Pet", "Base", "Ignored", "tns", """/pets/registerPet""", lowerCaseChildElementNames = true))
+        }
+
+        assertThat(response.status).isEqualTo(400)
+        assertThat(response.headers["X-Specmatic-Type"]).isNotEqualTo("random")
+    }
+
+    @Test
+    fun `mock with external examples rejects abstract substitution group head`(@TempDir tempDir: File) {
+        val wsdlFile = writeDemoStylePetService(tempDir)
+        val examplesDir = tempDir.resolve("pet_examples").apply { mkdirs() }
+        val dogRequest = registerPetRequest("Dog", "Barkley", "Collie", "tns", """/pets/registerPet""", lowerCaseChildElementNames = true)
+        val catRequest = registerPetRequest("Cat", "Misty", "Tabby", "tns", """/pets/registerPet""", lowerCaseChildElementNames = true)
+        val petRequest = registerPetRequest("Pet", "Base", "Ignored", "tns", """/pets/registerPet""", lowerCaseChildElementNames = true)
+        writeScenarioStub(examplesDir.resolve("dog.json"), "registerDog", dogRequest, registerPetResponse(101))
+        writeScenarioStub(examplesDir.resolve("cat.json"), "registerCat", catRequest, registerPetResponse(202))
+        val loadedStubs = loadContractStubsFromFilesAsResults(
+            listOf(ContractPathData("", wsdlFile.path, exampleDirPaths = listOf(examplesDir.path))),
+            dataDirPaths = emptyList(),
+            specmaticConfig = SpecmaticConfig(),
+            withImplicitStubs = false,
+        ).filterIsInstance<FeatureStubsResult.Success>().single()
+
+        HttpStub(loadedStubs.feature, loadedStubs.scenarioStubs).use { stub ->
+            val dogResponse = stub.client.execute(dogRequest)
+            val catResponse = stub.client.execute(catRequest)
+            val petResponse = stub.client.execute(petRequest)
+
+            assertThat(dogResponse.status).isEqualTo(200)
+            assertThat(catResponse.status).isEqualTo(200)
+            assertThat(petResponse.status).isEqualTo(400)
+            assertThat(petResponse.headers["X-Specmatic-Type"]).isNotEqualTo("random")
+        }
+    }
+
+    @Test
+    fun `mock accepts the head element when the substitution group head is not abstract`(@TempDir tempDir: File) {
+        val wsdlFile = writePetService(tempDir, abstractHead = false)
+        val feature = parseContractFileToFeature(wsdlFile)
+
+        val response = HttpStub(feature).use { stub ->
+            stub.client.execute(registerPetRequest("Pet", "Base", "Ignored"))
+        }
+
+        assertThat(response.status).isEqualTo(200)
+    }
+
+    @Test
+    fun `invalid substitution member reports substitutionGroup in the request mismatch`(@TempDir tempDir: File) {
+        val wsdlFile = writePetService(tempDir, abstractHead = true)
+        val feature = parseContractFileToFeature(wsdlFile)
+        val scenario = feature.scenarios.single()
+
+        val result = scenario.httpRequestPattern.matches(
+            registerPetRequest("Crocodile", "Snap", "Marsh"),
+            Resolver(newPatterns = scenario.patterns)
+        )
+
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
+        assertThat((result as Result.Failure).toFailureReport().toText())
+            .contains("substitutionGroup")
+            .contains("{http://example.com/animals}Pet")
+            .contains("Dog")
+            .contains("Cat")
+    }
+
+    @Test
+    fun `contract generation emits concrete substitution members for an abstract head`(@TempDir tempDir: File) {
+        val wsdlFile = writePetService(tempDir, abstractHead = true)
+        val feature = parseContractFileToFeature(wsdlFile)
+
+        val generatedBodies = feature.scenarios.single()
+            .generateTestScenarios(feature.flagsBased)
+            .map { it.value.generateHttpRequest(feature.flagsBased).body.toStringLiteral() }
+            .toList()
+
+        assertThat(generatedBodies).hasSize(2)
+        assertThat(generatedBodies).anySatisfy {
+            assertThat(it).contains("Dog").doesNotContain("<animals:Pet")
+        }
+        assertThat(generatedBodies).anySatisfy {
+            assertThat(it).contains("Cat").doesNotContain("<animals:Pet")
+        }
+    }
+
+    @Test
+    fun `abstract substitution group head without members fails clearly`(@TempDir tempDir: File) {
+        val wsdlFile = writePetService(tempDir, abstractHead = true, includeSubstitutes = false)
+
+        val exception = assertThrows<Exception> {
+            parseContractFileToFeature(wsdlFile)
+        }
+
+        assertThat(exception.message)
+            .contains("substitutionGroup")
+            .contains("{http://example.com/animals}Pet")
+    }
+
+    private fun writePetService(
+        tempDir: File,
+        abstractHead: Boolean,
+        includeSubstitutes: Boolean = true
+    ): File {
+        tempDir.resolve("animals.xsd").writeText(animalsSchema(abstractHead, includeSubstitutes))
+        return tempDir.resolve("pet-service.wsdl").apply {
+            writeText(petServiceWsdl())
+        }
+    }
+
+    private fun registerPetRequest(
+        elementName: String,
+        petName: String,
+        detail: String,
+        petPrefix: String = "animals",
+        soapAction: String = "http://example.com/pets/registerPet",
+        lowerCaseChildElementNames: Boolean = false,
+    ): HttpRequest {
+        val nameElement = if (lowerCaseChildElementNames) "name" else "Name"
+        val breedElement = if (lowerCaseChildElementNames) "breed" else "Breed"
+        val colorElement = if (lowerCaseChildElementNames) "color" else "Color"
+        val habitatElement = if (lowerCaseChildElementNames) "habitat" else "Habitat"
+        val detailElement = when (elementName) {
+            "Dog" -> "<$petPrefix:$breedElement>$detail</$petPrefix:$breedElement>"
+            "Cat" -> "<$petPrefix:$colorElement>$detail</$petPrefix:$colorElement>"
+            "Pet" -> ""
+            else -> "<$petPrefix:$habitatElement>$detail</$petPrefix:$habitatElement>"
+        }
+
+        return HttpRequest(
+            method = "POST",
+            path = "/pets",
+            headers = mapOf(
+                "SOAPAction" to "\"$soapAction\"",
+                CONTENT_TYPE to ContentType.Text.Xml.toString(),
+            ),
+            body = StringValue(
+                """
+                <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:tns="http://example.com/pets" xmlns:animals="http://example.com/animals">
+                  <soapenv:Body>
+                    <tns:RegisterPet>
+                      <$petPrefix:$elementName>
+                        <$petPrefix:$nameElement>$petName</$petPrefix:$nameElement>
+                        $detailElement
+                      </$petPrefix:$elementName>
+                    </tns:RegisterPet>
+                  </soapenv:Body>
+                </soapenv:Envelope>
+                """.trimIndent()
+            )
+        )
+    }
+
+    private fun registerPetResponse(registrationId: Int): HttpResponse =
+        HttpResponse(
+            status = 200,
+            headers = mapOf(CONTENT_TYPE to ContentType.Text.Xml.toString()),
+            body = StringValue(
+                """
+                <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+                  <soapenv:Body>
+                    <tns:RegisterPetResponse xmlns:tns="http://example.com/pets">
+                      <tns:registrationId>$registrationId</tns:registrationId>
+                      <tns:status>REGISTERED</tns:status>
+                    </tns:RegisterPetResponse>
+                  </soapenv:Body>
+                </soapenv:Envelope>
+                """.trimIndent()
+            )
+        )
+
+    private fun writeScenarioStub(file: File, name: String, request: HttpRequest, response: HttpResponse) {
+        file.writeText(
+            """
+            {
+              "name": "$name",
+              "http-request": {
+                "method": "${request.method}",
+                "path": "${request.path}",
+                "headers": {
+                  "SOAPAction": "${request.headers.getValue("SOAPAction")}",
+                  "Content-Type": "${request.headers.getValue(CONTENT_TYPE)}"
+                },
+                "body": ${request.body.toStringLiteral().jsonString()}
+              },
+              "http-response": {
+                "status": ${response.status},
+                "headers": {
+                  "Content-Type": "${response.headers.getValue(CONTENT_TYPE)}"
+                },
+                "body": ${response.body.toStringLiteral().jsonString()}
+              }
+            }
+            """.trimIndent()
+        )
+    }
+
+    private fun String.jsonString(): String =
+        "\"" + flatMap { char ->
+            when (char) {
+                '\\' -> "\\\\"
+                '"' -> "\\\""
+                '\n' -> "\\n"
+                '\r' -> "\\r"
+                '\t' -> "\\t"
+                else -> char.toString()
+            }.toList()
+        }.joinToString("") + "\""
+
+    private fun petServiceWsdl(): String =
+        """
+        <wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                          xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                          xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                          xmlns:tns="http://example.com/pets"
+                          xmlns:animals="http://example.com/animals"
+                          targetNamespace="http://example.com/pets">
+            <wsdl:types>
+                <xsd:schema targetNamespace="http://example.com/pets" elementFormDefault="qualified">
+                    <xsd:import namespace="http://example.com/animals" schemaLocation="animals.xsd"/>
+                    <xsd:element name="RegisterPet" type="tns:RegisterPetRequest"/>
+                    <xsd:element name="RegisterPetResponse" type="xsd:string"/>
+                    <xsd:complexType name="RegisterPetRequest">
+                        <xsd:sequence>
+                            <xsd:element ref="animals:Pet"/>
+                        </xsd:sequence>
+                    </xsd:complexType>
+                </xsd:schema>
+            </wsdl:types>
+            <wsdl:message name="registerPetInputMessage">
+                <wsdl:part name="parameters" element="tns:RegisterPet"/>
+            </wsdl:message>
+            <wsdl:message name="registerPetOutputMessage">
+                <wsdl:part name="parameters" element="tns:RegisterPetResponse"/>
+            </wsdl:message>
+            <wsdl:portType name="petPortType">
+                <wsdl:operation name="registerPet">
+                    <wsdl:input message="tns:registerPetInputMessage"/>
+                    <wsdl:output message="tns:registerPetOutputMessage"/>
+                </wsdl:operation>
+            </wsdl:portType>
+            <wsdl:binding name="petBinding" type="tns:petPortType">
+                <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+                <wsdl:operation name="registerPet">
+                    <soap:operation soapAction="http://example.com/pets/registerPet"/>
+                    <wsdl:input><soap:body use="literal"/></wsdl:input>
+                    <wsdl:output><soap:body use="literal"/></wsdl:output>
+                </wsdl:operation>
+            </wsdl:binding>
+            <wsdl:service name="petService">
+                <wsdl:port name="petPort" binding="tns:petBinding">
+                    <soap:address location="http://localhost:9000/pets"/>
+                </wsdl:port>
+            </wsdl:service>
+        </wsdl:definitions>
+        """.trimIndent()
+
+    private fun writeInlinePetService(
+        tempDir: File,
+        abstractHead: Boolean,
+        elementAndTypeShareNames: Boolean = false,
+        lowerCaseChildElementNames: Boolean = false,
+    ): File {
+        return tempDir.resolve("pet-service.wsdl").apply {
+            writeText(inlinePetServiceWsdl(abstractHead, elementAndTypeShareNames, lowerCaseChildElementNames))
+        }
+    }
+
+    private fun inlinePetServiceWsdl(
+        abstractHead: Boolean,
+        elementAndTypeShareNames: Boolean,
+        lowerCaseChildElementNames: Boolean
+    ): String {
+        val abstractAttribute = if (abstractHead) """ abstract="true"""" else ""
+        val petTypeName = if (elementAndTypeShareNames) "Pet" else "PetType"
+        val dogTypeName = if (elementAndTypeShareNames) "Dog" else "DogType"
+        val catTypeName = if (elementAndTypeShareNames) "Cat" else "CatType"
+        val nameElement = if (lowerCaseChildElementNames) "name" else "Name"
+        val breedElement = if (lowerCaseChildElementNames) "breed" else "Breed"
+        val colorElement = if (lowerCaseChildElementNames) "color" else "Color"
+
+        return """
+        <wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                          xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                          xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                          xmlns:tns="http://example.com/pets"
+                          targetNamespace="http://example.com/pets">
+            <wsdl:types>
+                <xsd:schema targetNamespace="http://example.com/pets" elementFormDefault="qualified">
+                    <xsd:element name="RegisterPet" type="tns:RegisterPetRequest"/>
+                    <xsd:element name="RegisterPetResponse" type="tns:RegisterPetResponse"/>
+                    <xsd:element name="Pet" type="tns:$petTypeName"$abstractAttribute/>
+                    <xsd:element name="Dog" type="tns:$dogTypeName" substitutionGroup="tns:Pet"/>
+                    <xsd:element name="Cat" type="tns:$catTypeName" substitutionGroup="tns:Pet"/>
+                    <xsd:complexType name="RegisterPetRequest">
+                        <xsd:sequence>
+                            <xsd:element ref="tns:Pet"/>
+                        </xsd:sequence>
+                    </xsd:complexType>
+                    <xsd:complexType name="$petTypeName">
+                        <xsd:sequence>
+                            <xsd:element name="$nameElement" type="xsd:string"/>
+                        </xsd:sequence>
+                    </xsd:complexType>
+                    <xsd:complexType name="$dogTypeName">
+                        <xsd:complexContent>
+                            <xsd:extension base="tns:$petTypeName">
+                                <xsd:sequence>
+                                    <xsd:element name="$breedElement" type="xsd:string"/>
+                                </xsd:sequence>
+                            </xsd:extension>
+                        </xsd:complexContent>
+                    </xsd:complexType>
+                    <xsd:complexType name="$catTypeName">
+                        <xsd:complexContent>
+                            <xsd:extension base="tns:$petTypeName">
+                                <xsd:sequence>
+                                    <xsd:element name="$colorElement" type="xsd:string"/>
+                                </xsd:sequence>
+                            </xsd:extension>
+                        </xsd:complexContent>
+                    </xsd:complexType>
+                    <xsd:complexType name="RegisterPetResponse">
+                        <xsd:sequence>
+                            <xsd:element name="registrationId" type="xsd:int"/>
+                            <xsd:element name="status" type="xsd:string"/>
+                        </xsd:sequence>
+                    </xsd:complexType>
+                </xsd:schema>
+            </wsdl:types>
+            <wsdl:message name="registerPetInputMessage">
+                <wsdl:part name="parameters" element="tns:RegisterPet"/>
+            </wsdl:message>
+            <wsdl:message name="registerPetOutputMessage">
+                <wsdl:part name="parameters" element="tns:RegisterPetResponse"/>
+            </wsdl:message>
+            <wsdl:portType name="petPortType">
+                <wsdl:operation name="registerPet">
+                    <wsdl:input message="tns:registerPetInputMessage"/>
+                    <wsdl:output message="tns:registerPetOutputMessage"/>
+                </wsdl:operation>
+            </wsdl:portType>
+            <wsdl:binding name="petBinding" type="tns:petPortType">
+                <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+                <wsdl:operation name="registerPet">
+                    <soap:operation soapAction="/pets/registerPet"/>
+                    <wsdl:input><soap:body use="literal"/></wsdl:input>
+                    <wsdl:output><soap:body use="literal"/></wsdl:output>
+                </wsdl:operation>
+            </wsdl:binding>
+            <wsdl:service name="petService">
+                <wsdl:port name="petPort" binding="tns:petBinding">
+                    <soap:address location="http://localhost:9000/pets"/>
+                </wsdl:port>
+            </wsdl:service>
+        </wsdl:definitions>
+        """.trimIndent()
+    }
+
+    private fun writeDemoStylePetService(tempDir: File): File {
+        return tempDir.resolve("pet.wsdl").apply {
+            writeText(
+                """
+                <definitions name="PetService"
+                             targetNamespace="http://example.com/pets"
+                             xmlns="http://schemas.xmlsoap.org/wsdl/"
+                             xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                             xmlns:tns="http://example.com/pets"
+                             xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+                    <types>
+                        <xsd:schema targetNamespace="http://example.com/pets" elementFormDefault="qualified">
+                            <xsd:complexType name="Pet">
+                                <xsd:sequence>
+                                    <xsd:element name="name" type="xsd:string"/>
+                                </xsd:sequence>
+                            </xsd:complexType>
+                            <xsd:complexType name="Dog">
+                                <xsd:complexContent>
+                                    <xsd:extension base="tns:Pet">
+                                        <xsd:sequence>
+                                            <xsd:element name="breed" type="xsd:string"/>
+                                        </xsd:sequence>
+                                    </xsd:extension>
+                                </xsd:complexContent>
+                            </xsd:complexType>
+                            <xsd:complexType name="Cat">
+                                <xsd:complexContent>
+                                    <xsd:extension base="tns:Pet">
+                                        <xsd:sequence>
+                                            <xsd:element name="color" type="xsd:string"/>
+                                        </xsd:sequence>
+                                    </xsd:extension>
+                                </xsd:complexContent>
+                            </xsd:complexType>
+                            <xsd:element name="Pet" type="tns:Pet" abstract="true"/>
+                            <xsd:element name="Dog" type="tns:Dog" substitutionGroup="tns:Pet"/>
+                            <xsd:element name="Cat" type="tns:Cat" substitutionGroup="tns:Pet"/>
+                            <xsd:complexType name="RegisterPet">
+                                <xsd:sequence>
+                                    <xsd:element ref="tns:Pet"/>
+                                </xsd:sequence>
+                            </xsd:complexType>
+                            <xsd:element name="RegisterPet" type="tns:RegisterPet"/>
+                            <xsd:complexType name="RegisterPetResponse">
+                                <xsd:sequence>
+                                    <xsd:element name="registrationId" type="xsd:int"/>
+                                    <xsd:element name="status" type="xsd:string"/>
+                                </xsd:sequence>
+                            </xsd:complexType>
+                            <xsd:element name="RegisterPetResponse" type="tns:RegisterPetResponse"/>
+                        </xsd:schema>
+                    </types>
+                    <message name="RegisterPetInput">
+                        <part name="parameters" element="tns:RegisterPet"/>
+                    </message>
+                    <message name="RegisterPetOutput">
+                        <part name="parameters" element="tns:RegisterPetResponse"/>
+                    </message>
+                    <portType name="PetPortType">
+                        <operation name="registerPet">
+                            <input message="tns:RegisterPetInput"/>
+                            <output message="tns:RegisterPetOutput"/>
+                        </operation>
+                    </portType>
+                    <binding name="PetBinding" type="tns:PetPortType">
+                        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+                        <operation name="registerPet">
+                            <soap:operation soapAction="/pets/registerPet"/>
+                            <input><soap:body use="literal"/></input>
+                            <output><soap:body use="literal"/></output>
+                        </operation>
+                    </binding>
+                    <service name="PetService">
+                        <port name="PetPort" binding="tns:PetBinding">
+                            <soap:address location="http://localhost:9000/pets"/>
+                        </port>
+                    </service>
+                </definitions>
+                """.trimIndent()
+            )
+        }
+    }
+
+    private fun animalsSchema(abstractHead: Boolean, includeSubstitutes: Boolean): String {
+        val abstractAttribute = if (abstractHead) """ abstract="true"""" else ""
+        val substitutes = if (includeSubstitutes) {
+            """
+            <xsd:element name="Dog" type="animals:DogType" substitutionGroup="animals:Pet"/>
+            <xsd:element name="Cat" type="animals:CatType" substitutionGroup="animals:Pet"/>
+            """.trimIndent()
+        } else {
+            ""
+        }
+
+        return """
+        <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                    xmlns:animals="http://example.com/animals"
+                    targetNamespace="http://example.com/animals"
+                    elementFormDefault="qualified">
+            <xsd:element name="Pet" type="animals:PetType"$abstractAttribute/>
+            $substitutes
+            <xsd:complexType name="PetType">
+                <xsd:sequence>
+                    <xsd:element name="Name" type="xsd:string"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="DogType">
+                <xsd:complexContent>
+                    <xsd:extension base="animals:PetType">
+                        <xsd:sequence>
+                            <xsd:element name="Breed" type="xsd:string"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="CatType">
+                <xsd:complexContent>
+                    <xsd:extension base="animals:PetType">
+                        <xsd:sequence>
+                            <xsd:element name="Color" type="xsd:string"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+        </xsd:schema>
+        """.trimIndent()
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/wsdl/WSDLSubstitutionGroupTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/wsdl/WSDLSubstitutionGroupTest.kt
@@ -135,9 +135,10 @@ class WSDLSubstitutionGroupTest {
         assertThat(result).isInstanceOf(Result.Failure::class.java)
         assertThat((result as Result.Failure).toFailureReport().toText())
             .contains("substitutionGroup")
-            .contains("{http://example.com/animals}Pet")
+            .contains("Pet")
             .contains("Dog")
             .contains("Cat")
+            .doesNotContain("{http://example.com/animals}Pet")
     }
 
     @Test
@@ -169,7 +170,8 @@ class WSDLSubstitutionGroupTest {
 
         assertThat(exception.message)
             .contains("substitutionGroup")
-            .contains("{http://example.com/animals}Pet")
+            .contains("Pet")
+            .doesNotContain("{http://example.com/animals}Pet")
     }
 
     private fun writePetService(


### PR DESCRIPTION
**What**:

Add XSD/WSDL `substitutionGroup` support to Specmatic's XML/WSDL runtime.

**Why**:

WSDL polymorphism was already being extended for `xsi:type`, but `substitutionGroup` is a separate XSD mechanism with different runtime semantics. A referenced head element such as `Pet` should be satisfiable by valid substitution members such as `Dog` or `Cat`, and diagnostics should explicitly describe substitution-group behavior rather than leaking `choice` terminology.

**How**:

- Added a dedicated `XMLSubstitutionGroupPattern` for element-level polymorphism.
- Indexed substitution-group members during WSDL/XSD parsing and resolved them when handling `xs:element ref=...`.
- Built candidate sets from the substitution-group head plus members, respecting `abstract="true"` heads.
- Kept `xsi:type` generation/type-selection behavior scoped to type-level polymorphism, while keeping `choice` and `substitutionGroup` structural.
- Normalized XML child generation across relevant XML patterns so substitution-group candidates generate and compose correctly.
- Added focused pattern, WSDL conversion, and mock/runtime tests, including abstract-head rejection, imported-schema resolution, generation, and error-message coverage.

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate N/A
- [ ] Security scans don't report any vulnerabilities N/A
- [ ] Documentation added/updated (share link) N/A
- [ ] Sample Project added/updated (share link) N/A
- [ ] Demo video (share link) N/A
- [ ] Article on Website (share link) N/A
- [ ] Roadmpap updated (share link) N/A
- [ ] Conference Talk (share link) N/A
