### PR TITLE
Normalize SOAPAction handling and expand WSDL example coverage

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/ExampleFromFile.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/ExampleFromFile.kt
@@ -36,7 +36,11 @@ class ExampleFromFile(private val scenarioStub: ScenarioStub, val file: File) {
     fun toRow(specmaticConfig: SpecmaticConfig = SpecmaticConfig(), logger: LogStrategy = io.specmatic.core.log.logger): Row {
         logger.log("Loading test file ${this.expectationFilePath}")
 
-        val examples: Map<String, String> = request.headers
+        val normalizedHeaders = request.headers.mapKeys { (key, _) ->
+            if (key.equals("SOAPAction", ignoreCase = true)) "SOAPAction" else key
+        }
+
+        val examples: Map<String, String> = normalizedHeaders
             .plus(queryParams)
             .plus(requestBody?.let { mapOf("(REQUEST-BODY)" to it.toStringLiteral()) } ?: emptyMap())
 

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
@@ -544,7 +544,10 @@ fun requestFromJSON(json: Map<String, Value>): HttpRequest {
 }
 
 fun adjustForSOAP(headers: Map<String, String>): Map<String, String> {
-    if (headers.containsKey("SOAPAction")) return headers
+    val soapActionHeader = headers.entries.find { it.key.equals("SOAPAction", ignoreCase = true) }
+    if (soapActionHeader != null) {
+        return headers.minus(soapActionHeader.key) + ("SOAPAction" to soapActionHeader.value)
+    }
 
     val rawContentType = headers["Content-Type"] ?: return headers
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLPattern.kt
@@ -215,7 +215,7 @@ data class XMLPattern(
                     is WSDLTypeSelection.Invalid,
                     is WSDLTypeSelection.Abstract -> failureForWSDLTypeSelection(selectedType)
 
-                    is WSDLTypeSelection.Use -> matchWithType(selectedType.pattern, sampleDataWithoutEmptyHeader, resolver)
+                    is WSDLTypeSelection.Use -> matchWithSelectedType(selectedType.pattern, sampleDataWithoutEmptyHeader, resolver)
                 }
 
                 return matchResult.breadCrumb(pattern.name, resolver.locate(schemaPointer))
@@ -259,10 +259,10 @@ data class XMLPattern(
         }.breadCrumb(pattern.name, resolver.locate(schemaPointer))
     }
 
-    private fun matchWithType(matchingType: Pattern, sampleData: XMLNode, resolver: Resolver): Result {
+    private fun matchWithSelectedType(matchingType: Pattern, sampleData: XMLNode, resolver: Resolver): Result {
         return when (matchingType) {
             is XMLPattern -> {
-                matchName(sampleData, resolver).ifSuccess {
+                matchingType.matchName(sampleData, resolver).ifSuccess {
                     matchingType.matchNamespaces(sampleData)
                 }.ifSuccess {
                     matchingType.matchAttributes(sampleData, resolver)
@@ -270,6 +270,14 @@ data class XMLPattern(
                     matchingType.matchNodes(sampleData, resolver)
                 }
             }
+
+            else -> matchWithType(matchingType, sampleData, resolver)
+        }
+    }
+
+    private fun matchWithType(matchingType: Pattern, sampleData: XMLNode, resolver: Resolver): Result {
+        return when (matchingType) {
+            is XMLPattern -> matchWithSelectedType(matchingType.withElementNameFrom(pattern), sampleData, resolver)
 
             is AnyPattern -> matchingType.matches(sampleData, resolver)
             else -> {
@@ -312,7 +320,11 @@ data class XMLPattern(
     }
 
     private fun selectWSDLType(sampleData: XMLNode, declaredType: Pattern, resolver: Resolver): WSDLTypeSelection? {
-        return selectWSDLType(sampleData.xsiTypeName(), declaredType, resolver)
+        sampleData.xsiTypeName()?.let { assertedType ->
+            return selectWSDLType(assertedType, declaredType, resolver)
+        }
+
+        return selectWSDLTypeByElementName(sampleData, declaredType, resolver)
     }
 
     private fun selectWSDLType(assertedType: WSDLTypeName?, declaredType: Pattern, resolver: Resolver): WSDLTypeSelection? {
@@ -345,6 +357,25 @@ data class XMLPattern(
 
             else ->
                 WSDLTypeSelection.Use(mergeReferredPattern(payloadAssertedTypePatternCompatibleWithDeclaredType))
+        }
+    }
+
+    private fun selectWSDLTypeByElementName(sampleData: XMLNode, declaredType: Pattern, resolver: Resolver): WSDLTypeSelection? {
+        val declaredWSDLType = declaredType.wsdlTypeName() ?: return null
+        val payloadElementName = sampleData.wsdlElementName()
+        val declaredXMLPattern = declaredType as? XMLPattern ?: return null
+        val selectedPattern = declaredType.concreteDerivedWSDLPatterns(resolver)
+            .firstOrNull { (typeName, _) -> typeName == payloadElementName }
+            ?.second
+            ?: return null
+
+        val mergedPattern = declaredXMLPattern.mergeWSDLDerivedPattern(selectedPattern)
+            ?.withElementNameFrom(sampleData)
+            ?: return WSDLTypeSelection.Invalid(payloadElementName, declaredWSDLType)
+
+        return when {
+            mergedPattern.pattern.wsdlTypeIsAbstract -> WSDLTypeSelection.Abstract(payloadElementName, declaredWSDLType)
+            else -> WSDLTypeSelection.Use(mergedPattern)
         }
     }
 
@@ -1392,6 +1423,9 @@ private fun XMLNode.xsiTypeName(): WSDLTypeName? {
     }.getOrNull()
 }
 
+private fun XMLNode.wsdlElementName(): WSDLTypeName =
+    WSDLTypeName(elementNamespaceUriOrNull().orEmpty(), name)
+
 private fun Pattern.findPatternForWSDLType(typeName: WSDLTypeName, resolver: Resolver): Pattern? {
     val typeKey = wsdlCompatibleTypeKeys()[typeName] ?: return null
     return resolver.patternForWSDLKey(typeKey)
@@ -1510,6 +1544,21 @@ private fun XMLPattern.withXSIType(typeName: WSDLTypeName): XMLPattern {
         )
     )
 }
+
+private fun XMLPattern.withElementNameFrom(node: XMLNode): XMLPattern =
+    withElementName(node.name, node.realName, node.elementNamespaceUriOrNull())
+
+private fun XMLPattern.withElementNameFrom(typeData: XMLTypeData): XMLPattern =
+    withElementName(typeData.name, typeData.realName, typeData.namespaceUri)
+
+private fun XMLPattern.withElementName(name: String, realName: String, namespaceUri: String?): XMLPattern =
+    copy(
+        pattern = pattern.copy(
+            name = name,
+            realName = realName,
+            namespaceUri = namespaceUri,
+        )
+    )
 
 private fun <T> PLACEHOLDER_USE_GIT_BLAME_TO_FIND_RELEVANT_COMMIT(value: T, s: String): T {
     return value

--- a/core/src/test/kotlin/io/specmatic/conversions/ExampleFromFileTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/ExampleFromFileTest.kt
@@ -198,6 +198,41 @@ class ExampleFromFileTest {
     }
 
     @Test
+    fun `should normalize soapaction header casing in example rows`() {
+        val jsonContent = """
+            {
+                "name": "soap-example",
+                "http-request": {
+                    "method": "POST",
+                    "path": "/soap",
+                    "headers": {
+                        "Content-Type": "text/xml; charset=utf-8",
+                        "Soapaction": "\"urn:test-action\""
+                    },
+                    "body": "<Envelope />"
+                },
+                "http-response": {
+                    "status": 200,
+                    "body": "<Envelope />"
+                }
+            }
+        """.trimIndent()
+
+        val file = createTempFile(jsonContent)
+        val exampleFromFile = (ExampleFromFile.fromFile(file) as HasValue).value
+
+        val row = exampleFromFile.toRow()
+
+        assertThat(row.containsField("SOAPAction")).isTrue()
+        assertThat(row.getField("SOAPAction")).isEqualTo("\"urn:test-action\"")
+        assertThat(row.containsField("Soapaction")).isFalse()
+
+        val requestExample = row.requestExample!!
+        assertThat(requestExample.headers).containsEntry("SOAPAction", "\"urn:test-action\"")
+        assertThat(requestExample.headers).doesNotContainKey("Soapaction")
+    }
+
+    @Test
     fun `should handle string request and response bodies`() {
         val jsonContent = """
             {

--- a/core/src/test/kotlin/io/specmatic/core/wsdl/WSDLTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/wsdl/WSDLTest.kt
@@ -174,9 +174,409 @@ class WSDLTest {
             .contains("<id>123</id>")
     }
 
+    @Test
+    fun `simple complex type wsdl loop passes without examples`() {
+        val feature = wsdlContentToFeature(simpleComplexTypeWsdl(), "simple-complex.wsdl")
+
+        val result = HttpStub(feature).use { stub ->
+            feature.executeTests(object : TestExecutor {
+                override fun execute(request: HttpRequest): HttpResponse = stub.client.execute(request)
+            })
+        }
+
+        assertThat(result.success()).withFailMessage(result.report()).isTrue()
+        assertThat(result.successCount).isGreaterThan(0)
+    }
+
+    @Test
+    fun `simple complex type wsdl loop passes with examples`(@TempDir tempDir: File) {
+        val wsdlFile = tempDir.resolve("simple-complex.wsdl").apply { writeText(simpleComplexTypeWsdl()) }
+        val examplesDir = tempDir.resolve("examples").apply { mkdirs() }
+        examplesDir.resolve("create_product.json").writeText(simpleComplexTypeExample())
+
+        val result = executeWsdlLoopWithExamples(wsdlFile, examplesDir)
+
+        assertThat(result.success()).withFailMessage(result.report()).isTrue()
+        assertThat(result.successCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `abstract complex type wsdl loop passes without examples`() {
+        val feature = wsdlContentToFeature(abstractDerivedTypeWsdl(), "abstract-derived.wsdl")
+
+        val result = HttpStub(feature).use { stub ->
+            feature.executeTests(object : TestExecutor {
+                override fun execute(request: HttpRequest): HttpResponse = stub.client.execute(request)
+            })
+        }
+
+        assertThat(result.success()).withFailMessage(result.report()).isTrue()
+        assertThat(result.successCount).isGreaterThan(0)
+    }
+
+    @Test
+    fun `abstract complex type wsdl loop passes with examples`(@TempDir tempDir: File) {
+        val wsdlFile = tempDir.resolve("abstract-derived.wsdl").apply { writeText(abstractDerivedTypeWsdl()) }
+        val examplesDir = tempDir.resolve("examples").apply { mkdirs() }
+        examplesDir.resolve("retrieve_order.json").writeText(abstractDerivedTypeExample())
+
+        val result = executeWsdlLoopWithExamples(wsdlFile, examplesDir)
+
+        assertThat(result.success()).withFailMessage(result.report()).isTrue()
+        assertThat(result.successCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `substitution group wsdl loop passes without examples`() {
+        val feature = wsdlContentToFeature(substitutionGroupWsdl(), "substitution-group.wsdl")
+
+        val result = HttpStub(feature).use { stub ->
+            feature.executeTests(object : TestExecutor {
+                override fun execute(request: HttpRequest): HttpResponse = stub.client.execute(request)
+            })
+        }
+
+        assertThat(result.success()).withFailMessage(result.report()).isTrue()
+        assertThat(result.successCount).isGreaterThan(0)
+    }
+
+    @Test
+    fun `substitution group wsdl loop passes with examples`(@TempDir tempDir: File) {
+        val wsdlFile = tempDir.resolve("substitution-group.wsdl").apply { writeText(substitutionGroupWsdl()) }
+        val examplesDir = tempDir.resolve("examples").apply { mkdirs() }
+        examplesDir.resolve("register_animal.json").writeText(substitutionGroupExample())
+
+        val result = executeWsdlLoopWithExamples(wsdlFile, examplesDir)
+
+        assertThat(result.success()).withFailMessage(result.report()).isTrue()
+        assertThat(result.successCount).isEqualTo(1)
+    }
+
     private fun readContracts(filename: String): Pair<String, String> {
         val wsdlContent = readTextResource("wsdl/$filename.wsdl")
         val expectedGherkin = readTextResource("wsdl/$filename.$CONTRACT_EXTENSION").trimIndent().trim()
         return Pair(wsdlContent, expectedGherkin)
     }
 }
+
+private fun executeWsdlLoopWithExamples(wsdlFile: File, examplesDir: File): Results {
+    val feature = parseContractFileToFeature(wsdlFile, exampleDirPaths = listOf(examplesDir.canonicalPath))
+        .loadExternalisedExamples()
+    val scenarioStubs = examplesDir.listFiles()?.sortedBy(File::getName)?.map(ScenarioStub::readFromFile).orEmpty()
+
+    assertDoesNotThrow { feature.validateExamplesOrException() }
+
+    return HttpStub(feature, scenarioStubs).use { stub ->
+        feature.executeTests(object : TestExecutor {
+            override fun execute(request: HttpRequest): HttpResponse = stub.client.execute(request)
+        })
+    }
+}
+
+private fun simpleComplexTypeWsdl(): String =
+    """
+    <wsdl:definitions xmlns:tns="http://example.com/simple-service"
+                      xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                      xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                      xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                      targetNamespace="http://example.com/simple-service">
+      <wsdl:binding name="ProductServiceBinding" type="tns:ProductService">
+        <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="CreateProduct">
+          <soap:operation soapAction="http://example.com/simple-service/CreateProduct" style="document"/>
+          <wsdl:input><soap:body use="literal"/></wsdl:input>
+          <wsdl:output><soap:body use="literal"/></wsdl:output>
+        </wsdl:operation>
+      </wsdl:binding>
+      <wsdl:message name="CreateProductSoapIn">
+        <wsdl:part name="parameters" element="tns:CreateProduct"/>
+      </wsdl:message>
+      <wsdl:message name="CreateProductSoapOut">
+        <wsdl:part name="parameters" element="tns:CreateProductResponse"/>
+      </wsdl:message>
+      <wsdl:portType name="ProductService">
+        <wsdl:operation name="CreateProduct">
+          <wsdl:input message="tns:CreateProductSoapIn"/>
+          <wsdl:output message="tns:CreateProductSoapOut"/>
+        </wsdl:operation>
+      </wsdl:portType>
+      <wsdl:service name="ProductService">
+        <wsdl:port name="ProductServicePort" binding="tns:ProductServiceBinding">
+          <soap:address location="/CreateProduct"/>
+        </wsdl:port>
+      </wsdl:service>
+      <wsdl:types>
+        <xsd:schema targetNamespace="http://example.com/simple-service" elementFormDefault="qualified">
+          <xsd:complexType name="Product">
+            <xsd:sequence>
+              <xsd:element name="name" type="xsd:string"/>
+              <xsd:element name="type" type="xsd:string"/>
+            </xsd:sequence>
+          </xsd:complexType>
+          <xsd:element name="CreateProduct">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="product" type="tns:Product"/>
+              </xsd:sequence>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="CreateProductResponse">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="product" type="tns:Product"/>
+              </xsd:sequence>
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:schema>
+      </wsdl:types>
+    </wsdl:definitions>
+    """.trimIndent()
+
+private fun simpleComplexTypeExample(): String =
+    """
+    {
+      "http-request": {
+        "path": "/CreateProduct",
+        "method": "POST",
+        "headers": {
+          "Content-Type": "text/xml; charset=utf-8",
+          "SOAPAction": "\"http://example.com/simple-service/CreateProduct\""
+        },
+        "body": "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\"><s:Body><CreateProduct xmlns=\"http://example.com/simple-service\"><product><name>Phone</name><type>Gadget</type></product></CreateProduct></s:Body></s:Envelope>"
+      },
+      "http-response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "text/xml"
+        },
+        "body": "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\"><s:Body><CreateProductResponse xmlns=\"http://example.com/simple-service\"><product><name>Phone</name><type>Gadget</type></product></CreateProductResponse></s:Body></s:Envelope>"
+      }
+    }
+    """.trimIndent()
+
+private fun abstractDerivedTypeWsdl(): String =
+    """
+    <wsdl:definitions xmlns:tns="http://example.com/order-service"
+                      xmlns:ord="http://example.com/order-model"
+                      xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                      xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                      xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                      targetNamespace="http://example.com/order-service">
+      <wsdl:binding name="OrderServiceBinding" type="tns:OrderService">
+        <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="RetrieveOrderDetails">
+          <soap:operation soapAction="http://example.com/order-service/RetrieveOrderDetails" style="document"/>
+          <wsdl:input><soap:body use="literal"/></wsdl:input>
+          <wsdl:output><soap:body use="literal"/></wsdl:output>
+        </wsdl:operation>
+      </wsdl:binding>
+      <wsdl:message name="RetrieveOrderDetailsSoapIn">
+        <wsdl:part name="parameters" element="tns:RetrieveOrderDetails"/>
+      </wsdl:message>
+      <wsdl:message name="RetrieveOrderDetailsSoapOut">
+        <wsdl:part name="parameters" element="tns:RetrieveOrderDetailsResponse"/>
+      </wsdl:message>
+      <wsdl:portType name="OrderService">
+        <wsdl:operation name="RetrieveOrderDetails">
+          <wsdl:input message="tns:RetrieveOrderDetailsSoapIn"/>
+          <wsdl:output message="tns:RetrieveOrderDetailsSoapOut"/>
+        </wsdl:operation>
+      </wsdl:portType>
+      <wsdl:service name="OrderService">
+        <wsdl:port name="OrderServicePort" binding="tns:OrderServiceBinding">
+          <soap:address location="/RetrieveOrderDetails"/>
+        </wsdl:port>
+      </wsdl:service>
+      <wsdl:types>
+        <xsd:schema targetNamespace="http://example.com/order-service" elementFormDefault="qualified">
+          <xsd:element name="RetrieveOrderDetails">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element ref="ord:Message"/>
+              </xsd:sequence>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="RetrieveOrderDetailsResponse">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element ref="ord:Message"/>
+              </xsd:sequence>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:import namespace="http://example.com/order-model"/>
+        </xsd:schema>
+        <xsd:schema targetNamespace="http://example.com/order-model" elementFormDefault="qualified">
+          <xsd:complexType name="Message">
+            <xsd:sequence>
+              <xsd:element name="command" type="ord:Command"/>
+            </xsd:sequence>
+          </xsd:complexType>
+          <xsd:complexType name="Command">
+            <xsd:choice minOccurs="1" maxOccurs="1">
+              <xsd:element name="retrieveOrderDetailsRequest">
+                <xsd:complexType>
+                  <xsd:sequence>
+                    <xsd:element name="order" type="ord:Order"/>
+                  </xsd:sequence>
+                </xsd:complexType>
+              </xsd:element>
+              <xsd:element name="retrieveOrderDetailsResponse">
+                <xsd:complexType>
+                  <xsd:sequence>
+                    <xsd:element name="order" type="ord:Order"/>
+                  </xsd:sequence>
+                </xsd:complexType>
+              </xsd:element>
+            </xsd:choice>
+          </xsd:complexType>
+          <xsd:complexType name="Order" abstract="true">
+            <xsd:sequence>
+              <xsd:element name="orderNumber" type="xsd:string"/>
+            </xsd:sequence>
+          </xsd:complexType>
+          <xsd:complexType name="OrderDetails">
+            <xsd:complexContent>
+              <xsd:extension base="ord:Order">
+                <xsd:sequence>
+                  <xsd:element name="productName" type="xsd:string" minOccurs="0"/>
+                </xsd:sequence>
+              </xsd:extension>
+            </xsd:complexContent>
+          </xsd:complexType>
+          <xsd:complexType name="OrderSummary">
+            <xsd:complexContent>
+              <xsd:extension base="ord:Order">
+                <xsd:sequence>
+                  <xsd:element name="status" type="xsd:string" minOccurs="0"/>
+                </xsd:sequence>
+              </xsd:extension>
+            </xsd:complexContent>
+          </xsd:complexType>
+          <xsd:element name="Message" type="ord:Message"/>
+        </xsd:schema>
+      </wsdl:types>
+    </wsdl:definitions>
+    """.trimIndent()
+
+private fun abstractDerivedTypeExample(): String =
+    """
+    {
+      "http-request": {
+        "path": "/RetrieveOrderDetails",
+        "method": "POST",
+        "headers": {
+          "Content-Type": "text/xml; charset=utf-8",
+          "SOAPAction": "\"http://example.com/order-service/RetrieveOrderDetails\""
+        },
+        "body": "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\"><s:Body xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"><RetrieveOrderDetails xmlns=\"http://example.com/order-service\"><Message xmlns=\"http://example.com/order-model\" xmlns:ord=\"http://example.com/order-model\"><command><retrieveOrderDetailsRequest><order xsi:type=\"ord:OrderDetails\"><orderNumber>100234569</orderNumber><productName>Phone</productName></order></retrieveOrderDetailsRequest></command></Message></RetrieveOrderDetails></s:Body></s:Envelope>"
+      },
+      "http-response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "text/xml"
+        },
+        "body": "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\"><s:Body><RetrieveOrderDetailsResponse xmlns=\"http://example.com/order-service\"><Message xmlns=\"http://example.com/order-model\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:ord=\"http://example.com/order-model\"><command><retrieveOrderDetailsResponse><order xsi:type=\"ord:OrderDetails\"><orderNumber>100234569</orderNumber><productName>Phone</productName></order></retrieveOrderDetailsResponse></command></Message></RetrieveOrderDetailsResponse></s:Body></s:Envelope>"
+      }
+    }
+    """.trimIndent()
+
+private fun substitutionGroupWsdl(): String =
+    """
+    <wsdl:definitions xmlns:tns="http://example.com/animal-service"
+                      xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                      xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                      xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                      targetNamespace="http://example.com/animal-service">
+      <wsdl:binding name="AnimalServiceBinding" type="tns:AnimalService">
+        <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="RegisterAnimal">
+          <soap:operation soapAction="http://example.com/animal-service/RegisterAnimal" style="document"/>
+          <wsdl:input><soap:body use="literal"/></wsdl:input>
+          <wsdl:output><soap:body use="literal"/></wsdl:output>
+        </wsdl:operation>
+      </wsdl:binding>
+      <wsdl:message name="RegisterAnimalSoapIn">
+        <wsdl:part name="parameters" element="tns:RegisterAnimal"/>
+      </wsdl:message>
+      <wsdl:message name="RegisterAnimalSoapOut">
+        <wsdl:part name="parameters" element="tns:RegisterAnimalResponse"/>
+      </wsdl:message>
+      <wsdl:portType name="AnimalService">
+        <wsdl:operation name="RegisterAnimal">
+          <wsdl:input message="tns:RegisterAnimalSoapIn"/>
+          <wsdl:output message="tns:RegisterAnimalSoapOut"/>
+        </wsdl:operation>
+      </wsdl:portType>
+      <wsdl:service name="AnimalService">
+        <wsdl:port name="AnimalServicePort" binding="tns:AnimalServiceBinding">
+          <soap:address location="/RegisterAnimal"/>
+        </wsdl:port>
+      </wsdl:service>
+      <wsdl:types>
+        <xsd:schema targetNamespace="http://example.com/animal-service" elementFormDefault="qualified">
+          <xsd:complexType name="Animal" abstract="true">
+            <xsd:sequence>
+              <xsd:element name="name" type="xsd:string"/>
+            </xsd:sequence>
+          </xsd:complexType>
+          <xsd:complexType name="Dog">
+            <xsd:complexContent>
+              <xsd:extension base="tns:Animal">
+                <xsd:sequence>
+                  <xsd:element name="breed" type="xsd:string" minOccurs="0"/>
+                </xsd:sequence>
+              </xsd:extension>
+            </xsd:complexContent>
+          </xsd:complexType>
+          <xsd:complexType name="Cat">
+            <xsd:complexContent>
+              <xsd:extension base="tns:Animal">
+                <xsd:sequence>
+                  <xsd:element name="indoor" type="xsd:string" minOccurs="0"/>
+                </xsd:sequence>
+              </xsd:extension>
+            </xsd:complexContent>
+          </xsd:complexType>
+          <xsd:element name="Animal" type="tns:Animal" abstract="true"/>
+          <xsd:element name="Dog" substitutionGroup="tns:Animal" type="tns:Dog"/>
+          <xsd:element name="Cat" substitutionGroup="tns:Animal" type="tns:Cat"/>
+          <xsd:element name="RegisterAnimal">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element ref="tns:Animal"/>
+              </xsd:sequence>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="RegisterAnimalResponse">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element ref="tns:Animal"/>
+              </xsd:sequence>
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:schema>
+      </wsdl:types>
+    </wsdl:definitions>
+    """.trimIndent()
+
+private fun substitutionGroupExample(): String =
+    """
+    {
+      "http-request": {
+        "path": "/RegisterAnimal",
+        "method": "POST",
+        "headers": {
+          "Content-Type": "text/xml; charset=utf-8",
+          "SOAPAction": "\"http://example.com/animal-service/RegisterAnimal\""
+        },
+        "body": "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\"><s:Body><RegisterAnimal xmlns=\"http://example.com/animal-service\"><Dog><name>Pepper</name><breed>Beagle</breed></Dog></RegisterAnimal></s:Body></s:Envelope>"
+      },
+      "http-response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "text/xml"
+        },
+        "body": "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\"><s:Body><RegisterAnimalResponse xmlns=\"http://example.com/animal-service\"><Dog><name>Pepper</name><breed>Beagle</breed></Dog></RegisterAnimalResponse></s:Body></s:Envelope>"
+      }
+    }
+    """.trimIndent()

--- a/core/src/test/kotlin/io/specmatic/core/wsdl/WSDLTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/wsdl/WSDLTest.kt
@@ -201,6 +201,36 @@ class WSDLTest {
     }
 
     @Test
+    fun `wsdl examples run once against mock without generating optional request data`(@TempDir tempDir: File) {
+        val wsdlFile = tempDir.resolve("optional-request.wsdl").apply { writeText(optionalRequestElementWsdl()) }
+        val examplesDir = tempDir.resolve("optional-request_examples").apply { mkdirs() }
+        examplesDir.resolve("submit_ticket.json").writeText(optionalRequestElementExample())
+
+        val feature = parseContractFileToFeature(wsdlFile, exampleDirPaths = listOf(examplesDir.canonicalPath))
+            .loadExternalisedExamples()
+        val scenarioStubs = examplesDir.listFiles()?.sortedBy(File::getName)?.map(ScenarioStub::readFromFile).orEmpty()
+
+        assertDoesNotThrow { feature.validateExamplesOrException() }
+
+        val requestBodies = mutableListOf<String>()
+        val result = HttpStub(feature, scenarioStubs).use { stub ->
+            feature.executeTests(object : TestExecutor {
+                override fun execute(request: HttpRequest): HttpResponse {
+                    requestBodies.add(request.body.toStringLiteral())
+                    return stub.client.execute(request)
+                }
+            })
+        }
+
+        assertThat(result.success()).withFailMessage(result.report()).isTrue()
+        assertThat(result.successCount).isEqualTo(1)
+        assertThat(requestBodies).hasSize(1)
+        assertThat(requestBodies.single())
+            .contains("<ticketId>TCK-123</ticketId>")
+            .doesNotContain("comment")
+    }
+
+    @Test
     fun `abstract complex type wsdl loop passes without examples`() {
         val feature = wsdlContentToFeature(abstractDerivedTypeWsdl(), "abstract-derived.wsdl")
 
@@ -350,6 +380,82 @@ private fun simpleComplexTypeExample(): String =
           "Content-Type": "text/xml"
         },
         "body": "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\"><s:Body><CreateProductResponse xmlns=\"http://example.com/simple-service\"><product><name>Phone</name><type>Gadget</type></product></CreateProductResponse></s:Body></s:Envelope>"
+      }
+    }
+    """.trimIndent()
+
+private fun optionalRequestElementWsdl(): String =
+    """
+    <wsdl:definitions xmlns:tns="http://example.com/ticket-service"
+                      xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                      xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                      xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                      targetNamespace="http://example.com/ticket-service">
+      <wsdl:binding name="TicketServiceBinding" type="tns:TicketService">
+        <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="SubmitTicket">
+          <soap:operation soapAction="http://example.com/ticket-service/SubmitTicket" style="document"/>
+          <wsdl:input><soap:body use="literal"/></wsdl:input>
+          <wsdl:output><soap:body use="literal"/></wsdl:output>
+        </wsdl:operation>
+      </wsdl:binding>
+      <wsdl:message name="SubmitTicketSoapIn">
+        <wsdl:part name="parameters" element="tns:SubmitTicket"/>
+      </wsdl:message>
+      <wsdl:message name="SubmitTicketSoapOut">
+        <wsdl:part name="parameters" element="tns:SubmitTicketResponse"/>
+      </wsdl:message>
+      <wsdl:portType name="TicketService">
+        <wsdl:operation name="SubmitTicket">
+          <wsdl:input message="tns:SubmitTicketSoapIn"/>
+          <wsdl:output message="tns:SubmitTicketSoapOut"/>
+        </wsdl:operation>
+      </wsdl:portType>
+      <wsdl:service name="TicketService">
+        <wsdl:port name="TicketServicePort" binding="tns:TicketServiceBinding">
+          <soap:address location="/SubmitTicket"/>
+        </wsdl:port>
+      </wsdl:service>
+      <wsdl:types>
+        <xsd:schema targetNamespace="http://example.com/ticket-service" elementFormDefault="qualified">
+          <xsd:element name="SubmitTicket">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="ticketId" type="xsd:string"/>
+                <xsd:element name="comment" type="xsd:string" minOccurs="0"/>
+              </xsd:sequence>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="SubmitTicketResponse">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="confirmation" type="xsd:string"/>
+              </xsd:sequence>
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:schema>
+      </wsdl:types>
+    </wsdl:definitions>
+    """.trimIndent()
+
+private fun optionalRequestElementExample(): String =
+    """
+    {
+      "http-request": {
+        "path": "/SubmitTicket",
+        "method": "POST",
+        "headers": {
+          "Content-Type": "text/xml; charset=utf-8",
+          "SOAPAction": "\"http://example.com/ticket-service/SubmitTicket\""
+        },
+        "body": "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\"><s:Body><SubmitTicket xmlns=\"http://example.com/ticket-service\"><ticketId>TCK-123</ticketId></SubmitTicket></s:Body></s:Envelope>"
+      },
+      "http-response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "text/xml"
+        },
+        "body": "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\"><s:Body><SubmitTicketResponse xmlns=\"http://example.com/ticket-service\"><confirmation>accepted</confirmation></SubmitTicketResponse></s:Body></s:Envelope>"
       }
     }
     """.trimIndent()


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

- Normalize `SOAPAction` request header handling so SOAP examples and requests are treated consistently across header casing variants such as `SOAPAction`, `Soapaction`, and `soapAction`.
- Support WSDL substitution-group examples where the payload uses the concrete member element name instead of forcing `xsi:type`.
- Add WSDL loop coverage for examples, abstract derived types, substitution groups, and example-driven request execution with optional request fields omitted.

<!-- Why are these changes necessary? -->

**Why**:

- SOAP header names are case-insensitive, but mismatched `SOAPAction` casing could prevent examples from being loaded or matched consistently.
- Some valid WSDL/XML payloads express polymorphism through substitution-group element names rather than `xsi:type`; these should validate and run when the schema allows them.
- When examples are present for WSDL contract tests, the example request should be used directly instead of generating extra request data, including optional request elements not present in the example.

<!-- How were these changes implemented? -->

**How**:

- Canonicalized `SOAPAction` casing during example row loading and SOAP request adjustment.
- Extended WSDL XML type selection so it first honors `xsi:type`, then falls back to concrete WSDL type selection by payload element name for substitution-group-style payloads.
- Kept selected XML type matching on a common path after the selected pattern has been adapted to the correct element name.
- Added focused core tests using WSDL + `ScenarioStub`-style examples through `HttpStub` and `executeTests`.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate N/A
- [ ] Security scans don't report any vulnerabilities N/A
- [ ] Documentation added/updated (share link) N/A
- [ ] Sample Project added/updated (share link) N/A
- [ ] Demo video (share link) N/A
- [ ] Article on Website (share link) N/A
- [ ] Roadmpap updated (share link) N/A
- [ ] Conference Talk (share link) N/A
