### PR TITLE
fix: fix spec files path resolution and serialization issues encountered while running the mock via mcp tool

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -418,7 +418,7 @@ interface SpecmaticConfig {
     fun withStubFilter(filter: String? = null): SpecmaticConfig
     fun withGlobalMockDelay(delayInMilliseconds: Long): SpecmaticConfig
     fun withMatchBranch(matchBranch: Boolean): SpecmaticConfig
-    fun withResolvedFilesystemDirectories(workingDirectory: File): SpecmaticConfig
+    fun withCanonicalizedDefinitionFilesystemSources(workingDirectory: File): SpecmaticConfig
     fun toYaml(): String
 
     @JsonIgnore

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -418,6 +418,8 @@ interface SpecmaticConfig {
     fun withStubFilter(filter: String? = null): SpecmaticConfig
     fun withGlobalMockDelay(delayInMilliseconds: Long): SpecmaticConfig
     fun withMatchBranch(matchBranch: Boolean): SpecmaticConfig
+    fun withResolvedFilesystemDirectories(workingDirectory: File): SpecmaticConfig
+    fun toYaml(): String
 
     @JsonIgnore
     fun testSpecPathFromConfigFor(specFile: File): String?

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfigV1V2Common.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfigV1V2Common.kt
@@ -1368,6 +1368,24 @@ data class SpecmaticConfigV1V2Common(
         return this.copy(sources = transformedSources)
     }
 
+    override fun withResolvedFilesystemDirectories(workingDirectory: File): SpecmaticConfig {
+        val transformedSources = this.sources.map { source ->
+            if (source.provider == SourceProvider.filesystem) {
+                val dir = source.directory ?: "."
+                val resolvedDir = if (File(dir).isAbsolute) File(dir) else workingDirectory.resolve(dir).normalize()
+                source.copy(directory = resolvedDir.canonicalPath)
+            } else {
+                source
+            }
+        }
+        return this.copy(sources = transformedSources)
+    }
+
+    override fun toYaml(): String {
+        val versionedConfig = SpecmaticConfigVersion.convertToVersionedConfig(this, getVersion())
+        return yamlMapper.writeValueAsString(versionedConfig)
+    }
+
     @JsonIgnore
     override fun testSpecPathFromConfigFor(specFile: File): String? {
         val source = testSourceFromConfig(specFile) ?: return null

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfigV1V2Common.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfigV1V2Common.kt
@@ -1368,15 +1368,9 @@ data class SpecmaticConfigV1V2Common(
         return this.copy(sources = transformedSources)
     }
 
-    override fun withResolvedFilesystemDirectories(workingDirectory: File): SpecmaticConfig {
+    override fun withCanonicalizedDefinitionFilesystemSources(workingDirectory: File): SpecmaticConfig {
         val transformedSources = this.sources.map { source ->
-            if (source.provider == SourceProvider.filesystem) {
-                val dir = source.directory ?: "."
-                val resolvedDir = if (File(dir).isAbsolute) File(dir) else workingDirectory.resolve(dir).normalize()
-                source.copy(directory = resolvedDir.canonicalPath)
-            } else {
-                source
-            }
+            source.withResolvedFilesystemDirectory(workingDirectory)
         }
         return this.copy(sources = transformedSources)
     }
@@ -1682,6 +1676,15 @@ data class Source(
                 sourceBaseDir.resolve("web").resolve(url.hostOrAuthority()).resolve(url.rawPath.removePrefix("/")).canonicalFile
             } ?: sourceBaseDir.resolve(specPath).canonicalFile
         }
+    }
+
+    fun withResolvedFilesystemDirectory(workingDirectory: File): Source {
+        if (this.provider == SourceProvider.filesystem) {
+            val dir = this.directory ?: "."
+            val resolvedDir = if (File(dir).isAbsolute) File(dir) else workingDirectory.resolve(dir).normalize()
+            return this.copy(directory = resolvedDir.canonicalPath)
+        }
+        return this
     }
 }
 

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3Impl.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3Impl.kt
@@ -26,6 +26,7 @@ import io.specmatic.core.SourceProvider
 import io.specmatic.core.SpecificationSource
 import io.specmatic.core.SpecificationSourceEntry
 import io.specmatic.core.SpecmaticConfig
+import io.specmatic.core.utilities.yamlMapper
 import io.specmatic.core.SpecmaticConfigV1V2Common.Companion.getEffectiveBranchForSource
 import io.specmatic.core.TESTS_DIRECTORY_ENV_VAR
 import io.specmatic.core.TESTS_DIRECTORY_PROPERTY
@@ -805,6 +806,26 @@ data class SpecmaticConfigV3Impl(val file: File? = null, val specmaticConfig: Sp
 
         val updatedConfig = specmaticConfig.copy(systemUnderTest = updatedSut, dependencies = updatedDependencies)
         return this.copy(specmaticConfig = updatedConfig)
+    }
+
+    override fun withResolvedFilesystemDirectories(workingDirectory: File): SpecmaticConfig {
+        val systemUnderTest = specmaticConfig.systemUnderTest ?: emptyTestServiceConfig()
+        val updatedSut = systemUnderTest.withResolvedFilesystemDirectories(resolver, workingDirectory)
+
+        val dependencies = specmaticConfig.dependencies ?: emptyMockServiceConfig()
+        val updatedDependencies = dependencies.withResolvedFilesystemDirectories(resolver, workingDirectory)
+
+        val updatedComponents = specmaticConfig.components?.let { components ->
+            val updatedSources = components.sources?.mapValues { (_, source) -> source.withResolvedFilesystemDirectories(workingDirectory) }
+            components.copy(sources = updatedSources)
+        }
+
+        val updatedConfig = specmaticConfig.copy(systemUnderTest = updatedSut, dependencies = updatedDependencies, components = updatedComponents)
+        return this.copy(specmaticConfig = updatedConfig)
+    }
+
+    override fun toYaml(): String {
+        return yamlMapper.writeValueAsString(this.specmaticConfig)
     }
 
     override fun testSpecPathFromConfigFor(specFile: File): String? {

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3Impl.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3Impl.kt
@@ -808,15 +808,15 @@ data class SpecmaticConfigV3Impl(val file: File? = null, val specmaticConfig: Sp
         return this.copy(specmaticConfig = updatedConfig)
     }
 
-    override fun withResolvedFilesystemDirectories(workingDirectory: File): SpecmaticConfig {
+    override fun withCanonicalizedDefinitionFilesystemSources(workingDirectory: File): SpecmaticConfig {
         val systemUnderTest = specmaticConfig.systemUnderTest ?: emptyTestServiceConfig()
-        val updatedSut = systemUnderTest.withResolvedFilesystemDirectories(resolver, workingDirectory)
+        val updatedSut = systemUnderTest.withCanonicalizedDefinitionFilesystemSources(resolver, workingDirectory)
 
         val dependencies = specmaticConfig.dependencies ?: emptyMockServiceConfig()
-        val updatedDependencies = dependencies.withResolvedFilesystemDirectories(resolver, workingDirectory)
+        val updatedDependencies = dependencies.withCanonicalizedDefinitionFilesystemSources(resolver, workingDirectory)
 
         val updatedComponents = specmaticConfig.components?.let { components ->
-            val updatedSources = components.sources?.mapValues { (_, source) -> source.withResolvedFilesystemDirectories(workingDirectory) }
+            val updatedSources = components.sources?.mapValues { (_, source) -> source.withCanonicalizedSources(workingDirectory) }
             components.copy(sources = updatedSources)
         }
 

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/AsyncApiRunOptions.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/AsyncApiRunOptions.kt
@@ -3,7 +3,7 @@ package io.specmatic.core.config.v3.components.runOptions
 import com.fasterxml.jackson.annotation.*
 import io.specmatic.core.config.v3.ServerOrigin
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type", visible = true)
 @JsonSubTypes(JsonSubTypes.Type(AsyncApiTestConfig::class, name = "test"), JsonSubTypes.Type(AsyncApiMockConfig::class, name = "mock"))
 sealed interface AsyncApiRunOptions : IRunOptions {
     val type: RunOptionType?
@@ -17,18 +17,15 @@ sealed interface AsyncApiRunOptions : IRunOptions {
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 data class AsyncApiTestConfig(
+    override val type: RunOptionType? = null,
     override val specs: List<RunOptionsSpecifications>? = null,
     @JsonIgnore private val _config: MutableMap<String, Any> = linkedMapOf()
 ) : AsyncApiRunOptions {
-    @JsonIgnore
-    override val type: RunOptionType? = null
-
     fun withConfig(newConfig: Map<String, Any>): AsyncApiTestConfig = copy(_config = LinkedHashMap(newConfig))
 
-    @JsonProperty("type")
-    private fun setType(input: RunOptionType?) {
-        require(input == null || input == RunOptionType.TEST) {
-            "Invalid type '$input' for AsyncApiTestConfig, expected '${RunOptionType.TEST.value}'"
+    init {
+        require(type == null || type == RunOptionType.TEST) {
+            "Invalid type '$type' for AsyncApiTestConfig, expected '${RunOptionType.TEST.value}'"
         }
     }
 
@@ -43,18 +40,15 @@ data class AsyncApiTestConfig(
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 data class AsyncApiMockConfig(
+    override val type: RunOptionType? = null,
     override val specs: List<RunOptionsSpecifications>? = null,
     @JsonIgnore private val _config: MutableMap<String, Any> = linkedMapOf()
 ) : AsyncApiRunOptions {
-    @JsonIgnore
-    override val type: RunOptionType? = null
-
     fun withConfig(newConfig: Map<String, Any>): AsyncApiMockConfig = copy(_config = LinkedHashMap(newConfig))
 
-    @JsonProperty("type")
-    private fun setType(input: RunOptionType?) {
-        require(input == null || input == RunOptionType.MOCK) {
-            "Invalid type '$input' for AsyncApiMockConfig, expected '${RunOptionType.MOCK.value}'"
+    init {
+        require(type == null || type == RunOptionType.MOCK) {
+            "Invalid type '$type' for AsyncApiMockConfig, expected '${RunOptionType.MOCK.value}'"
         }
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/GraphQLSdlRunOptions.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/GraphQLSdlRunOptions.kt
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import io.specmatic.core.config.v3.ServerOrigin
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type", visible = true)
 @JsonSubTypes(JsonSubTypes.Type(GraphQLSdlTestConfig::class, name = "test"), JsonSubTypes.Type(GraphQLSdlMockConfig::class, name = "mock"))
 sealed interface GraphQLSdlRunOptions : IRunOptions {
     val type: RunOptionType?
@@ -21,16 +21,15 @@ sealed interface GraphQLSdlRunOptions : IRunOptions {
 }
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
-data class GraphQLSdlTestConfig(override val specs: List<RunOptionsSpecifications>? = null) : GraphQLSdlRunOptions {
+data class GraphQLSdlTestConfig(
+    override val type: RunOptionType? = null,
+    override val specs: List<RunOptionsSpecifications>? = null
+) : GraphQLSdlRunOptions {
     private val _config: MutableMap<String, Any> = linkedMapOf()
 
-    @JsonIgnore
-    override val type: RunOptionType? = null
-
-    @JsonProperty("type")
-    private fun setType(input: RunOptionType?) {
-        require(input == null || input == RunOptionType.TEST) {
-            "Invalid type '$input' for GraphQLSdlTestConfig, expected '${RunOptionType.TEST.value}'"
+    init {
+        require(type == null || type == RunOptionType.TEST) {
+            "Invalid type '$type' for GraphQLSdlTestConfig, expected '${RunOptionType.TEST.value}'"
         }
     }
 
@@ -44,16 +43,15 @@ data class GraphQLSdlTestConfig(override val specs: List<RunOptionsSpecification
 }
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
-data class GraphQLSdlMockConfig(override val specs: List<RunOptionsSpecifications>? = null) : GraphQLSdlRunOptions {
+data class GraphQLSdlMockConfig(
+    override val type: RunOptionType? = null,
+    override val specs: List<RunOptionsSpecifications>? = null
+) : GraphQLSdlRunOptions {
     private val _config: MutableMap<String, Any> = linkedMapOf()
 
-    @JsonIgnore
-    override val type: RunOptionType? = null
-
-    @JsonProperty("type")
-    private fun setType(input: RunOptionType?) {
-        require(input == null || input == RunOptionType.MOCK) {
-            "Invalid type '$input' for GraphQLSdlMockConfig, expected '${RunOptionType.MOCK.value}'"
+    init {
+        require(type == null || type == RunOptionType.MOCK) {
+            "Invalid type '$type' for GraphQLSdlMockConfig, expected '${RunOptionType.MOCK.value}'"
         }
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/ProtobufRunOptions.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/ProtobufRunOptions.kt
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import io.specmatic.core.config.v3.ServerOrigin
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type", visible = true)
 @JsonSubTypes(JsonSubTypes.Type(ProtobufTestConfig::class, name = "test"), JsonSubTypes.Type(ProtobufMockConfig::class, name = "mock"))
 sealed interface ProtobufRunOptions : IRunOptions {
     val type: RunOptionType?
@@ -21,16 +21,15 @@ sealed interface ProtobufRunOptions : IRunOptions {
 }
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
-data class ProtobufTestConfig(override val specs: List<RunOptionsSpecifications>? = null) : ProtobufRunOptions {
+data class ProtobufTestConfig(
+    override val type: RunOptionType? = null,
+    override val specs: List<RunOptionsSpecifications>? = null
+) : ProtobufRunOptions {
     private val _config: MutableMap<String, Any> = linkedMapOf()
 
-    @JsonIgnore
-    override val type: RunOptionType? = null
-
-    @JsonProperty("type")
-    private fun setType(input: RunOptionType?) {
-        require(input == null || input == RunOptionType.TEST) {
-            "Invalid type '$input' for ProtobufTestConfig, expected '${RunOptionType.TEST.value}'"
+    init {
+        require(type == null || type == RunOptionType.TEST) {
+            "Invalid type '$type' for ProtobufTestConfig, expected '${RunOptionType.TEST.value}'"
         }
     }
 
@@ -44,16 +43,15 @@ data class ProtobufTestConfig(override val specs: List<RunOptionsSpecifications>
 }
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
-data class ProtobufMockConfig(override val specs: List<RunOptionsSpecifications>? = null) : ProtobufRunOptions {
+data class ProtobufMockConfig(
+    override val type: RunOptionType? = null,
+    override val specs: List<RunOptionsSpecifications>? = null
+) : ProtobufRunOptions {
     private val _config: MutableMap<String, Any> = linkedMapOf()
 
-    @JsonIgnore
-    override val type: RunOptionType? = null
-
-    @JsonProperty("type")
-    private fun setType(input: RunOptionType?) {
-        require(input == null || input == RunOptionType.MOCK) {
-            "Invalid type '$input' for ProtobufMockConfig, expected '${RunOptionType.MOCK.value}'"
+    init {
+        require(type == null || type == RunOptionType.MOCK) {
+            "Invalid type '$type' for ProtobufMockConfig, expected '${RunOptionType.MOCK.value}'"
         }
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/WsdlRunOptions.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/WsdlRunOptions.kt
@@ -5,12 +5,13 @@ import io.specmatic.core.config.HttpsConfiguration
 import io.specmatic.core.config.v3.RefOrValue
 import io.specmatic.core.config.v3.ServerOrigin
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type", visible = true)
 @JsonSubTypes(JsonSubTypes.Type(WsdlTestConfig::class, name = "test"), JsonSubTypes.Type(WsdlMockConfig::class, name = "mock"))
 sealed interface WsdlRunOptions : IRunOptions { val type: RunOptionType? }
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 data class WsdlTestConfig(
+    override val type: RunOptionType? = null,
     val baseUrl: String? = null,
     val host: String? = null,
     val port: Int? = null,
@@ -26,13 +27,9 @@ data class WsdlTestConfig(
         return ServerOrigin.from("http", host ?: "localhost", port)
     }
 
-    @JsonIgnore
-    override val type: RunOptionType? = null
-
-    @JsonProperty("type")
-    private fun setType(input: RunOptionType?) {
-        require(input == null || input == RunOptionType.TEST) {
-            "Invalid type '$input' for AsyncApiTestConfig, expected '${RunOptionType.TEST.value}'"
+    init {
+        require(type == null || type == RunOptionType.TEST) {
+            "Invalid type '$type' for WsdlTestConfig, expected '${RunOptionType.TEST.value}'"
         }
     }
 
@@ -47,6 +44,7 @@ data class WsdlTestConfig(
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 data class WsdlMockConfig(
+    override val type: RunOptionType? = null,
     val baseUrl: String? = null,
     val host: String? = null,
     val port: Int? = null,
@@ -63,13 +61,9 @@ data class WsdlMockConfig(
         return ServerOrigin.from(scheme, host ?: "0.0.0.0", port)
     }
 
-    @JsonIgnore
-    override val type: RunOptionType? = null
-
-    @JsonProperty("type")
-    private fun setType(input: RunOptionType?) {
-        require(input == null || input == RunOptionType.MOCK) {
-            "Invalid type '$input' for AsyncApiMockConfig, expected '${RunOptionType.MOCK.value}'"
+    init {
+        require(type == null || type == RunOptionType.MOCK) {
+            "Invalid type '$type' for WsdlMockConfig, expected '${RunOptionType.MOCK.value}'"
         }
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/CommonServiceConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/CommonServiceConfig.kt
@@ -2,11 +2,27 @@ package io.specmatic.core.config.v3.components.services
 
 import io.specmatic.core.config.v3.Data
 import io.specmatic.core.config.v3.RefOrValue
+import io.specmatic.core.config.v3.RefOrValueResolver
+import io.specmatic.core.config.v3.resolveElseThrow
+import java.io.File
 
-data class CommonServiceConfig<RunOptions : Any, Settings: Any>(
+data class CommonServiceConfig<RunOptions : Any, Settings : Any>(
     val description: String? = null,
     val definitions: List<Definition>,
     val runOptions: RefOrValue<RunOptions>? = null,
     val data: Data? = null,
     val settings: RefOrValue<Settings>? = null
-)
+) {
+    fun withCanonicalizedDefinitionFilesystemSources(
+        resolver: RefOrValueResolver,
+        workingDirectory: File
+    ): CommonServiceConfig<RunOptions, Settings> {
+        val updatedDefinitions = definitions.map { wrappedDefinition ->
+            val definition = wrappedDefinition.definition
+            val source = definition.source.resolveElseThrow(resolver). withCanonicalizedSources(workingDirectory)
+            wrappedDefinition.copy(definition = definition.copy(source = RefOrValue.Value(source)))
+        }
+
+        return copy(definitions = updatedDefinitions)
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/MockServiceConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/MockServiceConfig.kt
@@ -193,16 +193,13 @@ data class MockServiceConfig(val services: List<Value>, val data: Data? = null, 
         )
     }
 
-    fun withResolvedFilesystemDirectories(resolver: RefOrValueResolver, workingDirectory: File): MockServiceConfig {
+    fun withCanonicalizedDefinitionFilesystemSources(resolver: RefOrValueResolver, workingDirectory: File): MockServiceConfig {
         return copy(
             services = services.map { value ->
-                val service = value.service.resolveElseThrow(resolver)
-                val updatedDefinitions = service.definitions.map { wrappedDefinition ->
-                    val definition = wrappedDefinition.definition
-                    val source = definition.source.resolveElseThrow(resolver).withResolvedFilesystemDirectories(workingDirectory)
-                    wrappedDefinition.copy(definition = definition.copy(source = RefOrValue.Value(source)))
-                }
-                value.copy(service = RefOrValue.Value(service.copy(definitions = updatedDefinitions)))
+                val updatedService = value.service
+                    .resolveElseThrow(resolver)
+                    .withCanonicalizedDefinitionFilesystemSources(resolver,workingDirectory)
+                value.copy(service = RefOrValue.Value(updatedService))
             }
         )
     }

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/MockServiceConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/MockServiceConfig.kt
@@ -193,6 +193,20 @@ data class MockServiceConfig(val services: List<Value>, val data: Data? = null, 
         )
     }
 
+    fun withResolvedFilesystemDirectories(resolver: RefOrValueResolver, workingDirectory: File): MockServiceConfig {
+        return copy(
+            services = services.map { value ->
+                val service = value.service.resolveElseThrow(resolver)
+                val updatedDefinitions = service.definitions.map { wrappedDefinition ->
+                    val definition = wrappedDefinition.definition
+                    val source = definition.source.resolveElseThrow(resolver).withResolvedFilesystemDirectories(workingDirectory)
+                    wrappedDefinition.copy(definition = definition.copy(source = RefOrValue.Value(source)))
+                }
+                value.copy(service = RefOrValue.Value(service.copy(definitions = updatedDefinitions)))
+            }
+        )
+    }
+
     fun withExamples(resolver: SpecmaticConfigV3Resolver, exampleDirectories: List<String>): MockServiceConfig {
         return copy(
             services = services.map { value ->

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/TestServiceConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/TestServiceConfig.kt
@@ -174,14 +174,11 @@ data class TestServiceConfig(val service: RefOrValue<CommonServiceConfig<TestRun
         return this.copy(service = RefOrValue.Value(service.copy(definitions = updatedDefinition)))
     }
 
-    fun withResolvedFilesystemDirectories(resolver: RefOrValueResolver, workingDirectory: File): TestServiceConfig {
-        val service = this.service.resolveElseThrow(resolver)
-        val updatedDefinition = service.definitions.map { wrappedDefinition ->
-            val definition = wrappedDefinition.definition
-            val source = definition.source.resolveElseThrow(resolver).withResolvedFilesystemDirectories(workingDirectory)
-            wrappedDefinition.copy(definition = definition.copy(source = RefOrValue.Value(source)))
-        }
-        return this.copy(service = RefOrValue.Value(service.copy(definitions = updatedDefinition)))
+    fun withCanonicalizedDefinitionFilesystemSources(resolver: RefOrValueResolver, workingDirectory: File): TestServiceConfig {
+        val updatedService = this.service
+            .resolveElseThrow(resolver)
+            .withCanonicalizedDefinitionFilesystemSources(resolver,workingDirectory)
+        return this.copy(service = RefOrValue.Value(updatedService))
     }
 
     fun withExamples(resolver: SpecmaticConfigV3Resolver, exampleDirectories: List<String>): TestServiceConfig {

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/TestServiceConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/TestServiceConfig.kt
@@ -174,6 +174,16 @@ data class TestServiceConfig(val service: RefOrValue<CommonServiceConfig<TestRun
         return this.copy(service = RefOrValue.Value(service.copy(definitions = updatedDefinition)))
     }
 
+    fun withResolvedFilesystemDirectories(resolver: RefOrValueResolver, workingDirectory: File): TestServiceConfig {
+        val service = this.service.resolveElseThrow(resolver)
+        val updatedDefinition = service.definitions.map { wrappedDefinition ->
+            val definition = wrappedDefinition.definition
+            val source = definition.source.resolveElseThrow(resolver).withResolvedFilesystemDirectories(workingDirectory)
+            wrappedDefinition.copy(definition = definition.copy(source = RefOrValue.Value(source)))
+        }
+        return this.copy(service = RefOrValue.Value(service.copy(definitions = updatedDefinition)))
+    }
+
     fun withExamples(resolver: SpecmaticConfigV3Resolver, exampleDirectories: List<String>): TestServiceConfig {
         val service = this.service.resolveElseThrow(resolver)
         val existingData = service.data ?: Data()

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/sources/SourceV3.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/sources/SourceV3.kt
@@ -79,6 +79,13 @@ data class SourceV3(private val git: Git?, private val fileSystem: FileSystem?, 
         return this.copy(git = this.git.copy(matchBranch = matchBranch))
     }
 
+    fun withResolvedFilesystemDirectories(workingDirectory: File): SourceV3 {
+        if (this.fileSystem == null) return this
+        val dir = this.fileSystem.directory ?: "."
+        val resolvedDir = if (File(dir).isAbsolute) File(dir) else workingDirectory.resolve(dir).normalize()
+        return this.copy(fileSystem = this.fileSystem.copy(directory = resolvedDir.canonicalPath))
+    }
+
     data class Git(val url: String? = null, val branch: String? = null, val matchBranch: Boolean? = null, val auth: GitAuthentication? = null) {
         fun resolveSpecification(specification: File): File {
             val workingDirectory = File(getConfigFilePath()).parentFile ?: File(".")

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/sources/SourceV3.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/sources/SourceV3.kt
@@ -79,7 +79,7 @@ data class SourceV3(private val git: Git?, private val fileSystem: FileSystem?, 
         return this.copy(git = this.git.copy(matchBranch = matchBranch))
     }
 
-    fun withResolvedFilesystemDirectories(workingDirectory: File): SourceV3 {
+    fun  withCanonicalizedSources(workingDirectory: File): SourceV3 {
         if (this.fileSystem == null) return this
         val dir = this.fileSystem.directory ?: "."
         val resolvedDir = if (File(dir).isAbsolute) File(dir) else workingDirectory.resolve(dir).normalize()

--- a/core/src/test/kotlin/io/specmatic/core/SourceTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/SourceTest.kt
@@ -1,0 +1,49 @@
+package io.specmatic.core
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class SourceTest {
+    @Test
+    fun `withResolvedFilesystemDirectory should resolve relative filesystem directory against working directory`(@TempDir tempDir: File) {
+        val workingDir = tempDir.resolve("working").apply { mkdirs() }.canonicalFile
+        val source = Source(provider = SourceProvider.filesystem, directory = "./specs")
+
+        val resolved = source.withResolvedFilesystemDirectory(workingDir)
+
+        assertThat(resolved.directory).isEqualTo(workingDir.resolve("specs").canonicalPath)
+    }
+
+    @Test
+    fun `withResolvedFilesystemDirectory should keep source unchanged when provider is not filesystem`(@TempDir tempDir: File) {
+        val source = Source(provider = SourceProvider.git, directory = "./specs")
+
+        val resolved = source.withResolvedFilesystemDirectory(tempDir)
+
+        assertThat(resolved).isEqualTo(source)
+    }
+
+    @Test
+    fun `withResolvedFilesystemDirectory should resolve default filesystem directory against working directory`(@TempDir tempDir: File) {
+        val workingDir = tempDir.resolve("working").apply { mkdirs() }.canonicalFile
+        val source = Source(provider = SourceProvider.filesystem)
+
+        val resolved = source.withResolvedFilesystemDirectory(workingDir)
+
+        assertThat(resolved.directory).isEqualTo(workingDir.canonicalPath)
+    }
+
+    @Test
+    fun `withResolvedFilesystemDirectory should keep absolute filesystem directory unchanged`(@TempDir tempDir: File) {
+        val workingDir = tempDir.resolve("working").apply { mkdirs() }.canonicalFile
+        val absoluteDir = tempDir.resolve("absolute/specs").apply { mkdirs() }.canonicalFile
+        val source = Source(provider = SourceProvider.filesystem, directory = absoluteDir.path)
+
+        val resolved = source.withResolvedFilesystemDirectory(workingDir)
+
+        assertThat(resolved.directory).isEqualTo(absoluteDir.canonicalPath)
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/config/VersionAwareConfigParserTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/VersionAwareConfigParserTest.kt
@@ -260,7 +260,7 @@ class VersionAwareConfigParserTest {
         }
         val config = configFile.toSpecmaticConfig()
         val workingDir = File("/tmp/specmatic-test-workdir-v2").canonicalFile
-        val resolved = config.withResolvedFilesystemDirectories(workingDir)
+        val resolved = config.withCanonicalizedDefinitionFilesystemSources(workingDir)
         val sources = SpecmaticConfigV1V2Common.getSources(resolved as SpecmaticConfigV1V2Common)
         assertThat(sources).hasSize(1)
         assertThat(sources.first().directory).isEqualTo(workingDir.resolve("specs").canonicalPath)

--- a/core/src/test/kotlin/io/specmatic/core/config/VersionAwareConfigParserTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/VersionAwareConfigParserTest.kt
@@ -246,6 +246,27 @@ class VersionAwareConfigParserTest {
             .isEqualTo("prefix-$propertyValue-suffix")
     }
 
+    @Test
+    fun `withResolvedFilesystemDirectories on V2 config`() {
+        val configFile = tempDir.resolve("specmatic.yaml").apply {
+            writeText("""
+            version: 2
+            contracts:
+              - filesystem:
+                  directory: ./specs
+                provides:
+                  - simple.yaml
+            """.trimIndent())
+        }
+        val config = configFile.toSpecmaticConfig()
+        val workingDir = File("/tmp/specmatic-test-workdir-v2").canonicalFile
+        val resolved = config.withResolvedFilesystemDirectories(workingDir)
+        val sources = SpecmaticConfigV1V2Common.getSources(resolved as SpecmaticConfigV1V2Common)
+        assertThat(sources).hasSize(1)
+        assertThat(sources.first().directory).isEqualTo(workingDir.resolve("specs").canonicalPath)
+        assertThat(resolved.toYaml()).contains(workingDir.resolve("specs").canonicalPath)
+    }
+
     @ParameterizedTest(name = "isConfigTemplate({0}) -> {1}")
     @MethodSource("isConfigTemplateCases")
     fun `isConfigTemplate identifies template expressions`(value: String, expected: Boolean) {

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3ImplTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3ImplTest.kt
@@ -737,7 +737,7 @@ class SpecmaticConfigV3ImplTest {
                         - test.yaml
             """.trimIndent())
 
-            val resolved = config.withResolvedFilesystemDirectories(workingDir)
+            val resolved = config.withCanonicalizedDefinitionFilesystemSources(workingDir)
             val entries = resolved.getSpecificationSources().flatMap { it.test }
             assertThat(entries).isNotEmpty()
             assertThat(entries.map { it.directory }).containsOnly(workingDir.resolve("specs").canonicalPath)

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3ImplTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3ImplTest.kt
@@ -721,6 +721,84 @@ class SpecmaticConfigV3ImplTest {
         }
 
         @Test
+        fun `withResolvedFilesystemDirectories should resolve relative directories against working directory`() {
+            writeSpec("specs/test.yaml")
+            val workingDir = File("/tmp/specmatic-test-workdir").canonicalFile
+            val config = v3Config("""
+            version: 3
+            systemUnderTest:
+              service:
+                definitions:
+                  - definition:
+                      source:
+                        filesystem:
+                          directory: ./specs
+                      specs:
+                        - test.yaml
+            """.trimIndent())
+
+            val resolved = config.withResolvedFilesystemDirectories(workingDir)
+            val entries = resolved.getSpecificationSources().flatMap { it.test }
+            assertThat(entries).isNotEmpty()
+            assertThat(entries.map { it.directory }).containsOnly(workingDir.resolve("specs").canonicalPath)
+
+            val yaml = resolved.toYaml()
+            assertThat(yaml).contains(workingDir.resolve("specs").canonicalPath)
+        }
+
+        @Test
+        fun `toYaml should serialize and deserialize protobuf runOptions correctly`(@TempDir tempDir: File) {
+            val file = tempDir.resolve("test_proto.yaml").apply {
+                writeText("""
+                version: 3
+                components:
+                  runOptions:
+                    orderAndProductGrpcServiceMock:
+                      protobuf:
+                        type: mock
+                        host: localhost
+                        port: 10000
+                """.trimIndent())
+            }
+            val config = file.toSpecmaticConfig()
+            val serialized = config.toYaml()
+            println("SERIALIZED YAML:\n${serialized}")
+            val serializedFile = tempDir.resolve("serialized_proto.yaml").apply { writeText(serialized) }
+            val deserialized = serializedFile.toSpecmaticConfig()
+            assertThat(deserialized).isNotNull
+        }
+
+        @Test
+        fun `toYaml should serialize and deserialize wsdl, asyncapi, and graphql runOptions correctly`(@TempDir tempDir: File) {
+            val file = tempDir.resolve("test_all.yaml").apply {
+                writeText("""
+                version: 3
+                components:
+                  runOptions:
+                    myServiceMock:
+                      wsdl:
+                        type: mock
+                        host: localhost
+                        port: 8080
+                      asyncapi:
+                        type: mock
+                        inMemoryBroker:
+                          host: localhost
+                          port: 9092
+                      graphqlsdl:
+                        type: mock
+                        host: localhost
+                        port: 4000
+                """.trimIndent())
+            }
+            val config = file.toSpecmaticConfig()
+            val serialized = config.toYaml()
+            val serializedFile = tempDir.resolve("serialized_all.yaml").apply { writeText(serialized) }
+            val deserialized = serializedFile.toSpecmaticConfig()
+            assertThat(deserialized).isNotNull
+        }
+
+        @Test
         fun `plusExamples should append examples to test and mock sources`() {
             writeSpec("specs/test.yaml")
             writeSpec("specs/stub.yaml")

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/components/sources/SourceV3Test.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/components/sources/SourceV3Test.kt
@@ -1,0 +1,49 @@
+package io.specmatic.core.config.v3.components.sources
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class SourceV3Test {
+    @Test
+    fun `withResolvedFilesystemDirectories should resolve relative filesystem directory against working directory`(@TempDir tempDir: File) {
+        val workingDir = tempDir.resolve("working").apply { mkdirs() }.canonicalFile
+        val source = SourceV3.create(filesystem = SourceV3.FileSystem(directory = "./specs"))
+
+        val resolved = source.withCanonicalizedSources(workingDir)
+
+        assertThat(resolved.getFileSystem()?.directory).isEqualTo(workingDir.resolve("specs").canonicalPath)
+        assertThat(source.getFileSystem()?.directory).isEqualTo("./specs")
+    }
+
+    @Test
+    fun `withResolvedFilesystemDirectories should keep source unchanged when filesystem source is absent`(@TempDir tempDir: File) {
+        val source = SourceV3.create(git = SourceV3.Git(url = "https://example.com/contracts.git"))
+
+        val resolved = source.withCanonicalizedSources(tempDir)
+
+        assertThat(resolved).isEqualTo(source)
+    }
+
+    @Test
+    fun `withResolvedFilesystemDirectories should resolve default filesystem directory against working directory`(@TempDir tempDir: File) {
+        val workingDir = tempDir.resolve("working").apply { mkdirs() }.canonicalFile
+        val source = SourceV3.create(filesystem = SourceV3.FileSystem())
+
+        val resolved = source.withCanonicalizedSources(workingDir)
+
+        assertThat(resolved.getFileSystem()?.directory).isEqualTo(workingDir.canonicalPath)
+    }
+
+    @Test
+    fun `withResolvedFilesystemDirectories should keep absolute filesystem directory unchanged`(@TempDir tempDir: File) {
+        val workingDir = tempDir.resolve("working").apply { mkdirs() }.canonicalFile
+        val absoluteDir = tempDir.resolve("absolute/specs").apply { mkdirs() }.canonicalFile
+        val source = SourceV3.create(filesystem = SourceV3.FileSystem(directory = absoluteDir.path))
+
+        val resolved = source.withCanonicalizedSources(workingDir)
+
+        assertThat(resolved.getFileSystem()?.directory).isEqualTo(absoluteDir.canonicalPath)
+    }
+}

--- a/junit5-support/src/test/kotlin/io/specmatic/test/reports/TestHooksTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/reports/TestHooksTest.kt
@@ -2,7 +2,7 @@ package io.specmatic.test.reports
 
 import io.ktor.http.HttpHeaders
 import io.specmatic.core.HttpResponse
-import io.specmatic.core.SpecmaticConfig
+import io.specmatic.core.config.toSpecmaticConfig
 import io.specmatic.reporter.model.TestResult
 import io.specmatic.test.utils.ContractTestScope
 import org.assertj.core.api.Assertions.assertThat
@@ -34,7 +34,7 @@ class TestHooksTest {
                   description: Bad request
         """.trimIndent()
 
-        ContractTestScope.from(specYaml, tempDir).execute(SpecmaticConfig().enableResiliencyTests()) { server ->
+        ContractTestScope.from(specYaml, tempDir).execute(v3Config(tempDir).enableResiliencyTests()) { server ->
             server.on("/products", "GET") {
                 header("X-Header", "(number)")
                 respond(200); otherwise(400)
@@ -85,7 +85,7 @@ class TestHooksTest {
                           value: 0
         """.trimIndent()
 
-        ContractTestScope.from(specYaml, tempDir).execute { server ->
+        ContractTestScope.from(specYaml, tempDir).execute(v3Config(tempDir)) { server ->
             server.on("/products", "GET") {
                 header("X-Header", "0")
                 respond(HttpResponse(status = 429, headers = mapOf(HttpHeaders.RetryAfter to "0")))
@@ -106,3 +106,8 @@ class TestHooksTest {
         }
     }
 }
+
+private fun v3Config(tempDir: File) =
+    tempDir.resolve("specmatic.yaml").apply {
+        writeText("version: 3")
+    }.toSpecmaticConfig()

--- a/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageIntegrationTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageIntegrationTest.kt
@@ -7,6 +7,7 @@ import io.specmatic.core.TestConfig
 import io.specmatic.core.filters.ScenarioMetadataFilter
 import io.specmatic.core.pattern.parsedJsonValue
 import io.specmatic.core.utilities.contractTestPathsFrom
+import io.specmatic.core.config.toSpecmaticConfig
 import io.specmatic.core.value.StringValue
 import io.specmatic.core.value.toXML
 import io.specmatic.license.core.SpecmaticProtocol
@@ -92,7 +93,7 @@ class OpenApiCoverageIntegrationTest {
             )
         }
 
-        ContractTestScope(specFile, tempDir).execute { server ->
+        ContractTestScope(specFile, tempDir).execute(v3Config(tempDir)) { server ->
             server.on("/orders", "PATCH") {
                 body("""{"data":"found"}""")
                 respond(HttpResponse(status = 405, headers = mapOf("Content-Type" to "application/json"), body = parsedJsonValue("""{"error":"occurred"}""")))
@@ -174,7 +175,7 @@ class OpenApiCoverageIntegrationTest {
             )
         }
 
-        ContractTestScope(specFile, tempDir).execute { server ->
+        ContractTestScope(specFile, tempDir).execute(v3Config(tempDir)) { server ->
             server.on("/orders", "POST") {
                 header("Content-Type", "text/plain")
                 body("request sent here")
@@ -327,7 +328,7 @@ class OpenApiCoverageIntegrationTest {
                             type: string
         """.trimIndent()
 
-        ContractTestScope.from(specYaml, tempDir).execute(SpecmaticConfig().enableResiliencyTests()) { server ->
+        ContractTestScope.from(specYaml, tempDir).execute(v3Config(tempDir).enableResiliencyTests()) { server ->
             server.on("/orders", "GET") {
                 header("X-Header", "(number)")
                 respond(200)
@@ -403,7 +404,7 @@ class OpenApiCoverageIntegrationTest {
                   description: OK
         """.trimIndent()
 
-        ContractTestScope.from(specYaml, tempDir).execute { server ->
+        ContractTestScope.from(specYaml, tempDir).execute(v3Config(tempDir)) { server ->
             server.on("/orders", "GET") { respond(405) }
         }.verifyOpenApiCoverage {
             assertThat(totalOperations).isEqualTo(1)
@@ -433,7 +434,7 @@ class OpenApiCoverageIntegrationTest {
                   description: OK
         """.trimIndent()
 
-        ContractTestScope.from(specYaml, tempDir).execute { server ->
+        ContractTestScope.from(specYaml, tempDir).execute(v3Config(tempDir)) { server ->
             server.on("/orders", "GET") {
                 respond(500)
             }
@@ -479,7 +480,7 @@ class OpenApiCoverageIntegrationTest {
             </soap:Envelope>""".toXML()
         )
 
-        ContractTestScope(wsdlSpecFile, tempDir).execute { server ->
+        ContractTestScope(wsdlSpecFile, tempDir).execute(v3Config(tempDir)) { server ->
             server.on("/ws", "POST") {
                 header("SOAPAction", "/addInventory")
                 body("(anything)")
@@ -518,3 +519,8 @@ class OpenApiCoverageIntegrationTest {
     }
 
 }
+
+private fun v3Config(tempDir: File) =
+    tempDir.resolve("specmatic.yaml").apply {
+        writeText("version: 3")
+    }.toSpecmaticConfig()


### PR DESCRIPTION
Reason to change: 
     This PR ensures that spec files paths  are resolved correctly while starting the mock server via mcp mock tool and also includes the fix to the serialization issue for specmatic.yaml for grpc and graphql which was failing the startup of the mock when run by mcp tool.
