### PR TITLE
Resolve default Swagger URL fallback from spec base URLs

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/ApplicationApiSource.kt
+++ b/core/src/main/kotlin/io/specmatic/core/ApplicationApiSource.kt
@@ -1,5 +1,7 @@
 package io.specmatic.core
 
+const val DEFAULT_SWAGGER_SPEC_YAML_PATH = "/swagger/v1/swagger.yaml"
+
 sealed interface ApplicationApiSource {
     val url: String
 

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3Impl.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3Impl.kt
@@ -10,6 +10,7 @@ import io.specmatic.core.Auth
 import io.specmatic.core.BasicAuthSecuritySchemeConfiguration
 import io.specmatic.core.CUSTOM_IMPLICIT_STUB_BASE_ENV_VAR
 import io.specmatic.core.CUSTOM_IMPLICIT_STUB_BASE_PROPERTY
+import io.specmatic.core.DEFAULT_SWAGGER_SPEC_YAML_PATH
 import io.specmatic.core.CertRegistry
 import io.specmatic.core.Configuration
 import io.specmatic.core.OpenAPISecurityConfiguration
@@ -476,16 +477,15 @@ data class SpecmaticConfigV3Impl(val file: File? = null, val specmaticConfig: Sp
         val openApiTestConfig = specmaticConfig.systemUnderTest?.getOpenApiTestConfig(resolver)
             ?: return fallbackSwaggerUiBaseUrl?.let(ApplicationApiSource::SwaggerUi)
 
-        val specSpecificSwaggerUrl = specmaticConfig.systemUnderTest
+        val specSpecificOpenApiTestConfig = specmaticConfig.systemUnderTest
             .getSpecDefinitionFor(specFile, resolver)
             ?.getSpecificationId()
             ?.let(openApiTestConfig::getMatchingSpecification)
             ?.let { it as? OpenApiRunOptionsSpecifications }
-            ?.spec
-            ?.swaggerUrl
-        val swaggerUrlForSpec = specSpecificSwaggerUrl ?: openApiTestConfig.swaggerUrl
 
-        return swaggerUrlForSpec?.let(ApplicationApiSource::Swagger)
+        return specSpecificOpenApiTestConfig?.spec?.swaggerUrl?.let(ApplicationApiSource::Swagger)
+            ?: specSpecificOpenApiTestConfig?.spec?.baseUrl?.let(::defaultSwaggerUrlFor)?.let(ApplicationApiSource::Swagger)
+            ?: openApiTestConfig.swaggerUrl?.let(ApplicationApiSource::Swagger)
             ?: (openApiTestConfig.swaggerUiBaseUrl ?: fallbackSwaggerUiBaseUrl)?.let(ApplicationApiSource::SwaggerUi)
     }
 
@@ -872,4 +872,8 @@ data class SpecmaticConfigV3Impl(val file: File? = null, val specmaticConfig: Sp
         val schemes = specData.getSecuritySchemes()?.mapValues { it.value.toSecuritySchemeConfiguration() } ?: return null
         return SecurityConfiguration(OpenAPI = OpenAPISecurityConfiguration(schemes))
     }
+}
+
+private fun defaultSwaggerUrlFor(baseUrl: String): String {
+    return baseUrl.trimEnd('/') + DEFAULT_SWAGGER_SPEC_YAML_PATH
 }

--- a/core/src/main/kotlin/io/specmatic/core/log/HttpLogMessage.kt
+++ b/core/src/main/kotlin/io/specmatic/core/log/HttpLogMessage.kt
@@ -159,7 +159,7 @@ data class HttpLogMessage(
         val method = request.method
 
         return path.startsWith("/_$APPLICATION_NAME_LOWER_CASE/") ||
-            path == "/swagger/v1/swagger.yaml" ||
+            path == DEFAULT_SWAGGER_SPEC_YAML_PATH ||
             (method.equals("HEAD", ignoreCase = true) && path == "/") ||
             (method.equals("GET", ignoreCase = true) && path == "/actuator/health")
     }

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -18,6 +18,7 @@ import io.specmatic.conversions.convertPathParameterStyle
 import io.swagger.v3.core.util.Yaml
 import io.specmatic.core.APPLICATION_NAME
 import io.specmatic.core.APPLICATION_NAME_LOWER_CASE
+import io.specmatic.core.DEFAULT_SWAGGER_SPEC_YAML_PATH
 import io.specmatic.core.Feature
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpResponse
@@ -1001,7 +1002,7 @@ class HttpStub(
 
     private fun swaggerSpecResponseFormat(httpRequest: HttpRequest): SwaggerSpecResponseFormat? =
         when (httpRequest.path) {
-            SWAGGER_SPEC_YAML_PATH -> SwaggerSpecResponseFormat.YAML
+            DEFAULT_SWAGGER_SPEC_YAML_PATH -> SwaggerSpecResponseFormat.YAML
             SWAGGER_SPEC_JSON_PATH -> SwaggerSpecResponseFormat.JSON
             else -> null
         }
@@ -1926,11 +1927,10 @@ internal fun isFetchContractsRequest(httpRequest: HttpRequest): Boolean =
 internal fun isFetchLoadLogRequest(httpRequest: HttpRequest): Boolean =
     isPath(httpRequest.path, "load_log") && httpRequest.method == "GET"
 
-private const val SWAGGER_SPEC_YAML_PATH = "/swagger/v1/swagger.yaml"
 private const val SWAGGER_SPEC_JSON_PATH = "/swagger/v1/swagger.json"
 
 internal fun isSwaggerSpecRequest(httpRequest: HttpRequest): Boolean =
-    httpRequest.method == "GET" && (httpRequest.path == SWAGGER_SPEC_YAML_PATH || httpRequest.path == SWAGGER_SPEC_JSON_PATH)
+    httpRequest.method == "GET" && (httpRequest.path == DEFAULT_SWAGGER_SPEC_YAML_PATH || httpRequest.path == SWAGGER_SPEC_JSON_PATH)
 
 internal fun isExpectationCreation(httpRequest: HttpRequest) =
     isPath(httpRequest.path, "expectations") && httpRequest.method == "POST"

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3ImplTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3ImplTest.kt
@@ -2,6 +2,7 @@ package io.specmatic.core.config.v3
 
 import io.specmatic.core.ApplicationApiSource
 import io.specmatic.core.Configuration
+import io.specmatic.core.DEFAULT_SWAGGER_SPEC_YAML_PATH
 import io.specmatic.core.KeyData
 import io.specmatic.core.ResiliencyTestSuite
 import io.specmatic.core.SourceProvider
@@ -190,6 +191,44 @@ class SpecmaticConfigV3ImplTest {
 
         assertThat(config.getTestApplicationApiSource(orderSpec, SpecType.OPENAPI, "http://localhost:9000"))
             .isEqualTo(ApplicationApiSource.Swagger("http://localhost:9090/order-and-cart-api-docs"))
+        assertThat(config.getTestApplicationApiSource(cartSpec, SpecType.OPENAPI, "http://localhost:9000"))
+            .isEqualTo(ApplicationApiSource.Swagger("http://localhost:8080/default-api-docs"))
+    }
+
+    @Test
+    fun `should derive application api source from spec base url before openapi swagger url`() {
+        val specDir = tempDir.resolve("spec-base-url").apply { mkdirs() }
+        val orderSpec = specDir.resolve("order.yaml").apply { writeText("openapi: 3.0.0") }
+        val cartSpec = specDir.resolve("cart.yaml").apply { writeText("openapi: 3.0.0") }
+        val config = v3Config(
+            """
+            version: 3
+            systemUnderTest:
+              service:
+                definitions:
+                  - definition:
+                      source:
+                        filesystem:
+                          directory: ${specDir.canonicalPath}
+                      specs:
+                        - spec:
+                            id: order
+                            path: order.yaml
+                        - spec:
+                            id: cart
+                            path: cart.yaml
+                runOptions:
+                  openapi:
+                    swaggerUrl: http://localhost:8080/default-api-docs
+                    specs:
+                      - spec:
+                          id: order
+                          baseUrl: http://localhost:9090/
+            """.trimIndent()
+        )
+
+        assertThat(config.getTestApplicationApiSource(orderSpec, SpecType.OPENAPI, "http://localhost:9000"))
+            .isEqualTo(ApplicationApiSource.Swagger("http://localhost:9090$DEFAULT_SWAGGER_SPEC_YAML_PATH"))
         assertThat(config.getTestApplicationApiSource(cartSpec, SpecType.OPENAPI, "http://localhost:9000"))
             .isEqualTo(ApplicationApiSource.Swagger("http://localhost:8080/default-api-docs"))
     }

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -135,7 +135,7 @@ open class SpecmaticJUnitSupport {
         return when (source) {
             is ApplicationApiSource.Actuator -> fetchApplicationApisFromActuator(source)
             is ApplicationApiSource.Swagger -> fetchApplicationApisFromOpenApiDocument(source.url)
-            is ApplicationApiSource.SwaggerUi -> fetchApplicationApisFromOpenApiDocument("${source.url}/swagger/v1/swagger.yaml")
+            is ApplicationApiSource.SwaggerUi -> fetchApplicationApisFromOpenApiDocument(source.url.trimEnd('/') + DEFAULT_SWAGGER_SPEC_YAML_PATH)
         }
     }
 


### PR DESCRIPTION
**What**:

Resolve default Swagger document discovery for v3 OpenAPI specs that configure a spec-level `baseUrl` without an explicit `swaggerUrl`.

**Why**:

Contract tests already resolve the per-spec `baseUrl`, but application API discovery could still fall back through the top-level OpenAPI configuration. That meant a spec like `customer-api` could run tests against `http://localhost:9090` while Swagger discovery still looked under the top-level `http://localhost:8080` base URL.

**How**:

The v3 config implementation now derives an exact default Swagger URL from a spec-level `baseUrl` when that spec has no explicit `swaggerUrl`. The default Swagger path is centralized and reused by JUnit support, HTTP logging, and stub request handling so the fallback path stays consistent.

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
