### PR TITLE
chore: bump specmatic reporter version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 group=io.specmatic
 version=2.50.1-SNAPSHOT
 specmaticGradlePluginVersion=0.15.15
-specmaticReporterVersion=0.3.35
+specmaticReporterVersion=0.3.36
 swaggerParserVersion=2.1.35
 kotlin.daemon.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m
 org.gradle.jvmargs=-Xmx3g -XX:MaxMetaspaceSize=768m


### PR DESCRIPTION
Update specmatic reporter version which fixes incorrect coverage percentages when combining multiple test reports.
Updated the HTML reporter library