### PR TITLE
Respect per-spec OpenAPI source fields when resolving application APIs

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3Impl.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3Impl.kt
@@ -450,7 +450,7 @@ data class SpecmaticConfigV3Impl(val file: File? = null, val specmaticConfig: Sp
     }
 
     override fun getTestSwaggerUrl(): String? {
-        return specmaticConfig.systemUnderTest?.getOpenApiTestConfig(resolver)?.firstConfiguredSwaggerUrl()
+        return specmaticConfig.systemUnderTest?.getOpenApiTestConfig(resolver)?.swaggerUrl
     }
 
     override fun getTestSwaggerUIBaseUrl(): String? {
@@ -472,21 +472,20 @@ data class SpecmaticConfigV3Impl(val file: File? = null, val specmaticConfig: Sp
     ): ApplicationApiSource? {
         if (specType != SpecType.OPENAPI) return null
 
-        getActuatorUrl()?.let { return ApplicationApiSource.Actuator(it) }
-
         val openApiTestConfig = specmaticConfig.systemUnderTest?.getOpenApiTestConfig(resolver)
-            ?: return fallbackSwaggerUiBaseUrl?.let(ApplicationApiSource::SwaggerUi)
 
-        val specSpecificOpenApiTestConfig = specmaticConfig.systemUnderTest
-            .getSpecDefinitionFor(specFile, resolver)
-            ?.getSpecificationId()
-            ?.let(openApiTestConfig::getMatchingSpecification)
-            ?.let { it as? OpenApiRunOptionsSpecifications }
+        val specSpecificOpenApiTestConfig = openApiTestConfig?.let { openApiConfig ->
+            specmaticConfig.systemUnderTest
+                .getSpecDefinitionFor(specFile, resolver)
+                ?.getSpecificationId()
+                ?.let(openApiConfig::getMatchingSpecification)
+                ?.let { it as? OpenApiRunOptionsSpecifications }
+        }
 
-        return specSpecificOpenApiTestConfig?.spec?.swaggerUrl?.let(ApplicationApiSource::Swagger)
-            ?: specSpecificOpenApiTestConfig?.spec?.baseUrl?.let(::defaultSwaggerUrlFor)?.let(ApplicationApiSource::Swagger)
-            ?: openApiTestConfig.swaggerUrl?.let(ApplicationApiSource::Swagger)
-            ?: (openApiTestConfig.swaggerUiBaseUrl ?: fallbackSwaggerUiBaseUrl)?.let(ApplicationApiSource::SwaggerUi)
+        return specSpecificOpenApiTestConfig?.let(::applicationApiSourceFor)
+            ?: getActuatorUrl()?.let(ApplicationApiSource::Actuator)
+            ?: openApiTestConfig?.swaggerUrl?.let(ApplicationApiSource::Swagger)
+            ?: (openApiTestConfig?.swaggerUiBaseUrl ?: fallbackSwaggerUiBaseUrl)?.let(ApplicationApiSource::SwaggerUi)
     }
 
     override fun enableResiliencyTests(onlyPositive: Boolean): SpecmaticConfig {
@@ -876,4 +875,11 @@ data class SpecmaticConfigV3Impl(val file: File? = null, val specmaticConfig: Sp
 
 private fun defaultSwaggerUrlFor(baseUrl: String): String {
     return baseUrl.trimEnd('/') + DEFAULT_SWAGGER_SPEC_YAML_PATH
+}
+
+private fun applicationApiSourceFor(runOptions: OpenApiRunOptionsSpecifications): ApplicationApiSource? {
+    return runOptions.spec.actuatorUrl?.let(ApplicationApiSource::Actuator)
+        ?: runOptions.spec.swaggerUrl?.let(ApplicationApiSource::Swagger)
+        ?: runOptions.getServerOrigin("localhost")?.toBaseUrl()?.let(::defaultSwaggerUrlFor)?.let(ApplicationApiSource::Swagger)
+        ?: runOptions.spec.swaggerUiBaseUrl?.let(ApplicationApiSource::SwaggerUi)
 }

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/OpenApiRunOptions.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/OpenApiRunOptions.kt
@@ -31,11 +31,6 @@ data class OpenApiTestConfig(
     override val config: Map<String, Any> = emptyMap()
 
     @JsonIgnore
-    fun firstConfiguredSwaggerUrl(): String? {
-        return swaggerUrl ?: specs?.firstNotNullOfOrNull { it.spec.swaggerUrl }
-    }
-
-    @JsonIgnore
     override fun gerServerOrigin(): ServerOrigin? {
         if (baseUrl != null) return ServerOrigin.from(baseUrl)
         if (port == null) return null

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/RunOptionsSpecifications.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/RunOptionsSpecifications.kt
@@ -132,7 +132,9 @@ data class OpenApiRunOptionsSpecifications(val spec: Value) : IRunOptionSpecific
             spec.port == null &&
             spec.overlayFilePath == null &&
             spec.securitySchemes == null &&
-            spec.swaggerUrl == null
+            spec.swaggerUrl == null &&
+            spec.swaggerUiBaseUrl == null &&
+            spec.actuatorUrl == null
     }
 
     @JsonIgnore
@@ -155,5 +157,7 @@ data class OpenApiRunOptionsSpecifications(val spec: Value) : IRunOptionSpecific
         val overlayFilePath: String? = null,
         val securitySchemes: Map<String, SecuritySchemeConfigurationV3>? = null,
         val swaggerUrl: String? = null,
+        val swaggerUiBaseUrl: String? = null,
+        val actuatorUrl: String? = null,
     )
 }

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3ImplTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3ImplTest.kt
@@ -60,7 +60,7 @@ class SpecmaticConfigV3ImplTest {
     fun `should return similar values between v2 and v3 test data`(testCase: TestCase) = testCase.run(tempDir)
 
     @Test
-    fun `should resolve swagger url from openapi run options spec`() {
+    fun `should not resolve swagger url from an arbitrary openapi run options spec`() {
         val config = v3Config(
             """
             version: 3
@@ -84,7 +84,7 @@ class SpecmaticConfigV3ImplTest {
             """.trimIndent()
         )
 
-        assertThat(config.getTestSwaggerUrl()).isEqualTo("http://localhost:8080/v3/api-docs")
+        assertThat(config.getTestSwaggerUrl()).isNull()
     }
 
     @Test
@@ -117,7 +117,126 @@ class SpecmaticConfigV3ImplTest {
     }
 
     @Test
-    fun `should resolve application api source using actuator before swagger urls`() {
+    fun `should use matching spec application api sources before top level sources`() {
+        val specDir = tempDir.resolve("spec-application-api-sources").apply { mkdirs() }
+        val swaggerSpec = specDir.resolve("swagger.yaml").apply { writeText("openapi: 3.0.0") }
+        val swaggerUiSpec = specDir.resolve("swagger-ui.yaml").apply { writeText("openapi: 3.0.0") }
+        val baseUrlSpec = specDir.resolve("base-url.yaml").apply { writeText("openapi: 3.0.0") }
+        val hostAndPortSpec = specDir.resolve("host-and-port.yaml").apply { writeText("openapi: 3.0.0") }
+        val portOnlySpec = specDir.resolve("port-only.yaml").apply { writeText("openapi: 3.0.0") }
+        val actuatorSpec = specDir.resolve("actuator.yaml").apply { writeText("openapi: 3.0.0") }
+        val hostOnlySpec = specDir.resolve("host-only.yaml").apply { writeText("openapi: 3.0.0") }
+        val config = v3Config(
+            """
+            version: 3
+            systemUnderTest:
+              service:
+                definitions:
+                  - definition:
+                      source:
+                        filesystem:
+                          directory: ${specDir.canonicalPath}
+                      specs:
+                        - spec:
+                            id: swagger
+                            path: swagger.yaml
+                        - spec:
+                            id: swagger-ui
+                            path: swagger-ui.yaml
+                        - spec:
+                            id: base-url
+                            path: base-url.yaml
+                        - spec:
+                            id: host-and-port
+                            path: host-and-port.yaml
+                        - spec:
+                            id: port-only
+                            path: port-only.yaml
+                        - spec:
+                            id: actuator
+                            path: actuator.yaml
+                        - spec:
+                            id: host-only
+                            path: host-only.yaml
+                runOptions:
+                  openapi:
+                    actuatorUrl: http://top.example/actuator
+                    swaggerUrl: http://top.example/openapi.yaml
+                    swaggerUiBaseUrl: http://top.example/swagger-ui
+                    specs:
+                      - spec:
+                          id: swagger
+                          swaggerUrl: http://swagger.example/openapi.yaml
+                      - spec:
+                          id: swagger-ui
+                          swaggerUiBaseUrl: http://swagger-ui.example
+                      - spec:
+                          id: base-url
+                          baseUrl: http://base-url.example
+                      - spec:
+                          id: host-and-port
+                          host: host-and-port.example
+                          port: 8083
+                      - spec:
+                          id: port-only
+                          port: 8084
+                      - spec:
+                          id: actuator
+                          actuatorUrl: http://actuator.example/mappings
+                      - spec:
+                          id: host-only
+                          host: host-only.example
+            """.trimIndent()
+        )
+
+        assertThat(config.getTestApplicationApiSource(swaggerSpec, SpecType.OPENAPI, "http://runtime.example"))
+            .isEqualTo(ApplicationApiSource.Swagger("http://swagger.example/openapi.yaml"))
+        assertThat(config.getTestApplicationApiSource(swaggerUiSpec, SpecType.OPENAPI, "http://runtime.example"))
+            .isEqualTo(ApplicationApiSource.SwaggerUi("http://swagger-ui.example"))
+        assertThat(config.getTestApplicationApiSource(baseUrlSpec, SpecType.OPENAPI, "http://runtime.example"))
+            .isEqualTo(ApplicationApiSource.Swagger("http://base-url.example$DEFAULT_SWAGGER_SPEC_YAML_PATH"))
+        assertThat(config.getTestApplicationApiSource(hostAndPortSpec, SpecType.OPENAPI, "http://runtime.example"))
+            .isEqualTo(ApplicationApiSource.Swagger("http://host-and-port.example:8083$DEFAULT_SWAGGER_SPEC_YAML_PATH"))
+        assertThat(config.getTestApplicationApiSource(portOnlySpec, SpecType.OPENAPI, "http://runtime.example"))
+            .isEqualTo(ApplicationApiSource.Swagger("http://localhost:8084$DEFAULT_SWAGGER_SPEC_YAML_PATH"))
+        assertThat(config.getTestApplicationApiSource(actuatorSpec, SpecType.OPENAPI, "http://runtime.example"))
+            .isEqualTo(ApplicationApiSource.Actuator("http://actuator.example/mappings"))
+        assertThat(config.getTestApplicationApiSource(hostOnlySpec, SpecType.OPENAPI, "http://runtime.example"))
+            .isEqualTo(ApplicationApiSource.Actuator("http://top.example/actuator"))
+    }
+
+    @Test
+    fun `should not return spec application api sources from top level getters`() {
+        val config = v3Config(
+            """
+            version: 3
+            systemUnderTest:
+              service:
+                definitions:
+                  - definition:
+                      source:
+                        filesystem:
+                          directory: ./specs
+                      specs:
+                        - spec:
+                            id: api
+                            path: api.yaml
+                runOptions:
+                  openapi:
+                    specs:
+                      - spec:
+                          id: api
+                          actuatorUrl: http://spec.example/actuator
+                          swaggerUiBaseUrl: http://spec.example/swagger-ui
+            """.trimIndent()
+        )
+
+        assertThat(config.getActuatorUrl()).isNull()
+        assertThat(config.getTestSwaggerUIBaseUrl()).isNull()
+    }
+
+    @Test
+    fun `should resolve matching spec swagger url before top level actuator`() {
         val specDir = tempDir.resolve("specs").apply { mkdirs() }
         val orderSpec = specDir.resolve("order.yaml").apply { writeText("openapi: 3.0.0") }
         val cartSpec = specDir.resolve("cart.yaml").apply { writeText("openapi: 3.0.0") }
@@ -151,7 +270,7 @@ class SpecmaticConfigV3ImplTest {
         )
 
         assertThat(config.getTestApplicationApiSource(orderSpec, SpecType.OPENAPI, "http://localhost:9000"))
-            .isEqualTo(ApplicationApiSource.Actuator("http://localhost:8080/actuator"))
+            .isEqualTo(ApplicationApiSource.Swagger("http://localhost:9090/order-and-cart-api-docs"))
         assertThat(config.getTestApplicationApiSource(cartSpec, SpecType.OPENAPI, "http://localhost:9000"))
             .isEqualTo(ApplicationApiSource.Actuator("http://localhost:8080/actuator"))
     }

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/components/runOptions/RunOptionsSpecificationsTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/components/runOptions/RunOptionsSpecificationsTest.kt
@@ -2,6 +2,7 @@ package io.specmatic.core.config.v3.components.runOptions
 
 import io.specmatic.core.config.v3.ServerOrigin
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Test
 
 class RunOptionsSpecificationsTest {
@@ -18,6 +19,24 @@ class RunOptionsSpecificationsTest {
 
         val portOnly = OpenApiRunOptionsSpecifications(OpenApiRunOptionsSpecifications.Value(port = 9000))
         assertEquals(ServerOrigin.from("http", "0.0.0.0", 9000), portOnly.getServerOrigin("0.0.0.0"))
+    }
+
+    @Test
+    fun `openapi actuator url should be treated as a spec override`() {
+        val runOptions = OpenApiRunOptionsSpecifications(
+            OpenApiRunOptionsSpecifications.Value(actuatorUrl = "http://example.com/actuator")
+        )
+
+        assertFalse(runOptions.isNoOpOverride())
+    }
+
+    @Test
+    fun `openapi swagger UI base url should be treated as a spec override`() {
+        val runOptions = OpenApiRunOptionsSpecifications(
+            OpenApiRunOptionsSpecifications.Value(swaggerUiBaseUrl = "http://example.com/swagger-ui")
+        )
+
+        assertFalse(runOptions.isNoOpOverride())
     }
 
     @Test

--- a/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
@@ -427,6 +427,64 @@ class SpecmaticJunitSupportTest {
     }
 
     @Test
+    fun `should fetch application apis from swagger UI base urls configured per spec`(@TempDir tempDir: File) {
+        val specDir = tempDir.resolve("specs").apply { mkdirs() }
+        specDir.resolve("orders.yaml").writeText(openApiSpec("orders", "/orders", "/cart"))
+        specDir.resolve("customers.yaml").writeText(openApiSpec("customers", "/customers"))
+
+        MockHttpServer().use { orderSwaggerUi ->
+            MockHttpServer().use { customerSwaggerUi ->
+                orderSwaggerUi.serveSwagger("/findAvailableProducts/{date_time}")
+                customerSwaggerUi.serveSwagger("/customers/internal")
+
+                val configFile = tempDir.resolve("specmatic.yaml").apply {
+                    writeText(
+                        """
+                        version: 3
+                        systemUnderTest:
+                          service:
+                            definitions:
+                              - definition:
+                                  source:
+                                    filesystem:
+                                      directory: ${specDir.canonicalPath}
+                                  specs:
+                                    - spec:
+                                        id: orders
+                                        path: orders.yaml
+                                    - spec:
+                                        id: customers
+                                        path: customers.yaml
+                            runOptions:
+                              openapi:
+                                specs:
+                                  - spec:
+                                      id: orders
+                                      swaggerUiBaseUrl: ${orderSwaggerUi.baseUrl}
+                                  - spec:
+                                      id: customers
+                                      swaggerUiBaseUrl: ${customerSwaggerUi.baseUrl}
+                        """.trimIndent()
+                    )
+                }
+
+                SpecmaticJUnitSupport.settingsStaging.set(ContractTestSettings(configFile = configFile.canonicalPath))
+                try {
+                    val support = SpecmaticJUnitSupport()
+                    support.contractTest().toList()
+
+                    assertThat(support.openApiCoverage.getApplicationAPIs()).contains(
+                        API("GET", "/findAvailableProducts/{date_time}"),
+                        API("GET", "/customers/internal"),
+                    )
+                } finally {
+                    SpecmaticJUnitSupport.settingsStaging.remove()
+                }
+            }
+        }
+    }
+
+    @Test
     fun `strict mode only runs tests for APIs with external examples`(@TempDir tempDir: File) {
         // Create OpenAPI spec with 2 endpoints
         val openApiSpec = """


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Make `actuatorUrl` and `swaggerUiBaseUrl` available as per-spec OpenAPI run-option fields, alongside `swaggerUrl`, and use matching spec-level application API sources before top-level sources.

<!-- Why are these changes necessary? -->

**Why**:

Services can expose different actuator, Swagger document, or Swagger UI endpoints for different OpenAPI specifications. Applying a top-level source before a matching spec-level source can query the wrong application endpoint and produce inaccurate API coverage. Spec-level configuration must remain isolated to its matching specification and must always take precedence over top-level defaults.

<!-- How were these changes implemented? -->

**How**:

- Added `actuatorUrl` and `swaggerUiBaseUrl` to per-spec OpenAPI run options and included them in no-op override detection.
- Resolve application API sources by matching the contract file to its specification ID before considering top-level configuration.
- Apply spec-level precedence in this order: actuator, explicit Swagger URL, Swagger URL derived from `baseUrl` or `host`/`port`, then Swagger UI base URL.
- Keep aggregate v3 getters top-level-only so one specification's values cannot leak into another.
- Added coverage for per-spec actuator and Swagger UI values, source precedence, unmatched-spec fallback, host/port derivation, no-op detection, and JUnit API discovery.
- Verified the API coverage lab with a freshly built executable: the baseline reports 50% coverage and the learner correction reaches 100% coverage.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)

<!-- feel free to add additional comments -->
