### PR TITLE
Mcp tool spec file input

### DIFF
--- a/application/src/main/kotlin/application/mcp/server/DefaultSpecmaticMcpToolProvider.kt
+++ b/application/src/main/kotlin/application/mcp/server/DefaultSpecmaticMcpToolProvider.kt
@@ -53,7 +53,7 @@ class DefaultSpecmaticMcpToolProvider(
             inputSchema = toolSchema(
                 properties = mapOf(
                     "command" to stringProperty("The action to perform: start, stop, or list"),
-                    "openApiSpec" to stringProperty("The OpenAPI specification content (required for 'start')"),
+                    "specFilePath" to stringProperty("Path to the OpenAPI specification file (required for 'start')"),
                     "port" to typedProperty("integer", "Port number for the mock server"),
                     "specFormat" to stringProperty("Format of the OpenAPI spec (yaml or json)")
                 ),

--- a/application/src/main/kotlin/application/mcp/server/DefaultSpecmaticMcpToolProvider.kt
+++ b/application/src/main/kotlin/application/mcp/server/DefaultSpecmaticMcpToolProvider.kt
@@ -32,11 +32,11 @@ class DefaultSpecmaticMcpToolProvider(
             description = "Run Specmatic contract tests against an API using OpenAPI specification",
             inputSchema = toolSchema(
                 properties = mapOf(
-                    "openApiSpec" to stringProperty("The OpenAPI specification content (YAML or JSON)"),
+                    "specFilePath" to stringProperty("Path to the OpenAPI specification file (yaml or json)"),
                     "apiBaseUrl" to stringProperty("The base URL of the API to test against"),
                     "specFormat" to stringProperty("Format of the OpenAPI spec (yaml or json)")
                 ),
-                required = listOf("openApiSpec", "apiBaseUrl")
+                required = listOf("specFilePath", "apiBaseUrl")
             )
         ) { request ->
             safeToolCall {
@@ -93,11 +93,11 @@ class DefaultSpecmaticMcpToolProvider(
             description = "Run Specmatic resiliency tests against an API using OpenAPI specification",
             inputSchema = toolSchema(
                 properties = mapOf(
-                    "openApiSpec" to stringProperty("The OpenAPI specification content (YAML or JSON)"),
+                    "specFilePath" to stringProperty("Path to the OpenAPI specification file (yaml or json)"),
                     "apiBaseUrl" to stringProperty("The base URL of the API to test against"),
                     "specFormat" to stringProperty("Format of the OpenAPI spec (yaml or json)")
                 ),
-                required = listOf("openApiSpec", "apiBaseUrl")
+                required = listOf("specFilePath", "apiBaseUrl")
             )
         ) { request ->
             safeToolCall {

--- a/application/src/main/kotlin/application/mcp/server/tools/ContractTestTool.kt
+++ b/application/src/main/kotlin/application/mcp/server/tools/ContractTestTool.kt
@@ -10,7 +10,7 @@ import kotlin.io.path.createTempDirectory
 
 @Serializable
 data class RunTestArgs(
-    val openApiSpec: String,
+    val specFilePath: String,
     val apiBaseUrl: String,
     val specFormat: String = "yaml"
 )
@@ -20,8 +20,6 @@ class ContractTestTool(
 ) {
 
     internal fun runContractTest(args: RunTestArgs, resiliency: Boolean): String {
-        val tempDir = createTempDirectory(if (resiliency) "specmatic-resiliency-" else "specmatic-contract-").toFile()
-        val specFile = tempDir.resolve("spec.${args.specFormat}").apply { writeText(args.openApiSpec) }
         val junitReportDir = junitReportDirectoryFactory(resiliency)
         val junitReportFile = junitReportDir.resolve(JUNIT_REPORT_FILE_NAME)
 
@@ -38,7 +36,7 @@ class ContractTestTool(
                 argsList.add(args.apiBaseUrl)
                 argsList.add("--junitReportDir")
                 argsList.add(junitReportDir.canonicalPath)
-                argsList.add(specFile.canonicalPath)
+                argsList.add(args.specFilePath)
 
                 CommandLine(command).execute(*argsList.toTypedArray())
             }
@@ -59,7 +57,6 @@ class ContractTestTool(
             } else {
                 System.clearProperty(SPECMATIC_GENERATIVE_TESTS)
             }
-            tempDir.deleteRecursively()
         }
     }
 

--- a/application/src/main/kotlin/application/mcp/server/tools/MockServerTool.kt
+++ b/application/src/main/kotlin/application/mcp/server/tools/MockServerTool.kt
@@ -15,7 +15,7 @@ import kotlin.time.Duration.Companion.seconds
 @Serializable
 data class ManageMockServerArgs(
     val command: String,
-    val openApiSpec: String? = null,
+    val specFilePath: String? = null,
     val port: Int = 9000,
     val specFormat: String = "yaml"
 )
@@ -25,8 +25,8 @@ class MockServerTool {
 
     internal fun manageMockServer(args: ManageMockServerArgs): String = when (args.command) {
         "start" -> startMockServer(
-            openApiSpec = args.openApiSpec
-                ?: throw IllegalArgumentException("openApiSpec is required for 'start' command"),
+            specFilePath = args.specFilePath
+                ?: throw IllegalArgumentException("specFilePath is required for 'start' command"),
             port = args.port,
             specFormat = args.specFormat
         )
@@ -35,15 +35,12 @@ class MockServerTool {
         else -> throw IllegalArgumentException("command must be one of: start, stop, list")
     }
 
-    private fun startMockServer(openApiSpec: String, port: Int, specFormat: String): String {
+    private fun startMockServer(specFilePath: String, port: Int, specFormat: String): String {
         validatePortAvailability(port)?.let { return it }
-
-        val tempDir = createTempDirectory("specmatic-mock-").toFile()
-        val specFile = tempDir.resolve("spec.$specFormat").apply { writeText(openApiSpec) }
 
         return try {
             val command = StubCommand()
-            val argsList = stubCommandArgs(port, specFile)
+            val argsList = stubCommandArgs(port, File(specFilePath))
 
             command.registerShutdownHook = false
 
@@ -56,7 +53,7 @@ class MockServerTool {
 
             if (!ready) {
                 System.err.println("[MockServerTool] Timeout waiting for mock server on port $port.")
-                cleanupFailedStart(command, tempDir)
+                cleanupFailedStart(command)
                 return startFailure("The mock server did not become reachable on port $port within 10 seconds.")
             }
 
@@ -66,14 +63,14 @@ class MockServerTool {
             mockServerMessage(
                 "Mock server started successfully",
                 listOf(
-                    "Server URL: http://localhost:$port",
-                    "Port: $port",
-                    "Status: Running in-process",
-                    "Log directory: ${tempDir.canonicalPath}"
-                )
+                "Server URL: http://localhost:$port",
+                "Port: $port",
+                "Status: Running in-process",
+                "Spec file: ${File(specFilePath).canonicalPath}"
+            )
             )
         } catch (e: Throwable) {
-            cleanupFailedStart(tempDir = tempDir)
+            cleanupFailedStart()
             startFailure(e.message ?: "Unknown error")
         }
     }
@@ -143,9 +140,8 @@ class MockServerTool {
         )
     }
 
-    private fun cleanupFailedStart(command: StubCommand? = null, tempDir: File) {
+    private fun cleanupFailedStart(command: StubCommand? = null) {
         command?.close()
-        tempDir.deleteRecursively()
     }
 
     private fun stopServer(port: Int) {

--- a/application/src/test/kotlin/application/mcp/server/DefaultSpecmaticMcpToolProviderTest.kt
+++ b/application/src/test/kotlin/application/mcp/server/DefaultSpecmaticMcpToolProviderTest.kt
@@ -33,7 +33,7 @@ class DefaultSpecmaticMcpToolProviderTest {
         val tool = tools.first { it.tool().name() == "run_contract_test" }
         
         val args = mapOf(
-            "openApiSpec" to "openapi: 3.0.0",
+            "specFilePath" to "spec.yaml",
             "apiBaseUrl" to "http://localhost:8080",
             "specFormat" to "yaml"
         )
@@ -49,7 +49,7 @@ class DefaultSpecmaticMcpToolProviderTest {
         
         verify { 
             contractTestTool.runContractTest(
-                RunTestArgs(openApiSpec = "openapi: 3.0.0", apiBaseUrl = "http://localhost:8080", specFormat = "yaml"),
+                RunTestArgs(specFilePath = "spec.yaml", apiBaseUrl = "http://localhost:8080", specFormat = "yaml"),
                 resiliency = false
             ) 
         }
@@ -61,7 +61,7 @@ class DefaultSpecmaticMcpToolProviderTest {
         val tool = tools.first { it.tool().name() == "run_resiliency_test" }
         
         val args = mapOf(
-            "openApiSpec" to "openapi: 3.0.0",
+            "specFilePath" to "spec.yaml",
             "apiBaseUrl" to "http://localhost:8080"
         )
         val request = McpSchema.CallToolRequest("run_resiliency_test", args)
@@ -75,7 +75,7 @@ class DefaultSpecmaticMcpToolProviderTest {
         
         verify { 
             contractTestTool.runContractTest(
-                RunTestArgs(openApiSpec = "openapi: 3.0.0", apiBaseUrl = "http://localhost:8080"),
+                RunTestArgs(specFilePath = "spec.yaml", apiBaseUrl = "http://localhost:8080"),
                 resiliency = true
             ) 
         }
@@ -138,7 +138,7 @@ class DefaultSpecmaticMcpToolProviderTest {
         val tool = tools.first { it.tool().name() == "run_contract_test" }
         
         val args = mapOf(
-            "openApiSpec" to "openapi: 3.0.0",
+            "specFilePath" to "spec.yaml",
             "apiBaseUrl" to "http://localhost:8080"
         )
         val request = McpSchema.CallToolRequest("run_contract_test", args)
@@ -149,7 +149,7 @@ class DefaultSpecmaticMcpToolProviderTest {
 
         verify { 
             contractTestTool.runContractTest(
-                RunTestArgs(openApiSpec = "openapi: 3.0.0", apiBaseUrl = "http://localhost:8080", specFormat = "yaml"),
+                RunTestArgs(specFilePath = "spec.yaml", apiBaseUrl = "http://localhost:8080", specFormat = "yaml"),
                 resiliency = false
             ) 
         }

--- a/application/src/test/kotlin/application/mcp/server/DefaultSpecmaticMcpToolProviderTest.kt
+++ b/application/src/test/kotlin/application/mcp/server/DefaultSpecmaticMcpToolProviderTest.kt
@@ -88,7 +88,7 @@ class DefaultSpecmaticMcpToolProviderTest {
         
         val args = mapOf(
             "command" to "start",
-            "openApiSpec" to "openapi: 3.0.0",
+            "specFilePath" to "spec.yaml",
             "port" to 9000
         )
         val request = McpSchema.CallToolRequest("manage_mock_server", args)
@@ -102,7 +102,7 @@ class DefaultSpecmaticMcpToolProviderTest {
         
         verify { 
             mockServerTool.manageMockServer(
-                ManageMockServerArgs(command = "start", openApiSpec = "openapi: 3.0.0", port = 9000)
+                ManageMockServerArgs(command = "start", specFilePath = "spec.yaml", port = 9000)
             ) 
         }
     }

--- a/application/src/test/kotlin/application/mcp/server/tools/ContractTestToolTest.kt
+++ b/application/src/test/kotlin/application/mcp/server/tools/ContractTestToolTest.kt
@@ -33,7 +33,7 @@ class ContractTestToolTest {
     }
 
     @Test
-    fun `runContractTest should invoke TestCommand with generated spec and junit report directory`() {
+        fun `runContractTest should invoke TestCommand with spec file path and junit report directory`() {
         var capturedArgs: List<String> = emptyList()
         var generatedSpecFileName = ""
         var generatedSpecFileContent = ""
@@ -62,8 +62,9 @@ class ContractTestToolTest {
         }
 
         val specContent = "openapi: 3.0.0\ninfo:\n  title: API\n  version: 1.0.0\npaths: {}"
+        val specFile = tempDir.resolve("spec.yaml").apply { writeText(specContent) }
         val args = RunTestArgs(
-            openApiSpec = specContent,
+            specFilePath = specFile.canonicalPath,
             apiBaseUrl = "http://localhost:8080",
             specFormat = "yaml"
         )
@@ -103,7 +104,7 @@ class ContractTestToolTest {
         }
 
         val args = RunTestArgs(
-            openApiSpec = "openapi: 3.0.0...",
+            specFilePath = tempDir.resolve("spec.yaml").apply { writeText("openapi: 3.0.0...") }.canonicalPath,
             apiBaseUrl = "http://localhost:8080"
         )
 
@@ -128,7 +129,10 @@ class ContractTestToolTest {
         
         System.setProperty(SPECMATIC_GENERATIVE_TESTS, "original_value")
 
-        val args = RunTestArgs(openApiSpec = "...", apiBaseUrl = "...")
+        val args = RunTestArgs(
+            specFilePath = tempDir.resolve("spec.yaml").apply { writeText("...") }.canonicalPath,
+            apiBaseUrl = "..."
+        )
         
         try {
             tool.runContractTest(args, resiliency = true)
@@ -149,7 +153,10 @@ class ContractTestToolTest {
             0
         }
 
-        val args = RunTestArgs(openApiSpec = "...", apiBaseUrl = "...")
+        val args = RunTestArgs(
+            specFilePath = tempDir.resolve("spec.yaml").apply { writeText("...") }.canonicalPath,
+            apiBaseUrl = "..."
+        )
         val result = tool.runContractTest(args, resiliency = false)
 
         assertThat(result).contains("truncated 1000 characters")

--- a/application/src/test/kotlin/application/mcp/server/tools/MockServerToolTest.kt
+++ b/application/src/test/kotlin/application/mcp/server/tools/MockServerToolTest.kt
@@ -38,9 +38,9 @@ class MockServerToolTest {
         return field.get(tool) as ConcurrentHashMap<Int, StubCommand>
     }
 
-    private fun extractLogDir(result: String): String {
-        return result.lines().find { it.contains("Log directory:") }
-            ?.substringAfter("Log directory: ")
+    private fun extractSpecFile(result: String): String {
+        return result.lines().find { it.contains("Spec file:") }
+            ?.substringAfter("Spec file: ")
             ?.trim() ?: ""
     }
 
@@ -61,9 +61,10 @@ class MockServerToolTest {
         
         coEvery { waitUntilConnectable(any(), any(), any()) } returns true
 
+        val specFile = tempDir.resolve("spec.yaml").apply { writeText("openapi: 3.0.0...") }
         val args = ManageMockServerArgs(
             command = "start",
-            openApiSpec = "openapi: 3.0.0...",
+            specFilePath = specFile.canonicalPath,
             port = 9001
         )
         
@@ -71,10 +72,10 @@ class MockServerToolTest {
 
         assertThat(result).contains("Mock server started successfully")
         assertThat(result).contains("Server URL: http://localhost:9001")
-        assertThat(result).contains("Log directory:")
+        assertThat(result).contains("Spec file:")
         
-        val logDir = extractLogDir(result)
-        assertThat(File(logDir)).isDirectory()
+        val specPath = extractSpecFile(result)
+        assertThat(File(specPath)).exists()
         
         // Verify tool internal state
         assertThat(getRunningMocks()).containsKey(9001)
@@ -113,7 +114,8 @@ class MockServerToolTest {
         coEvery { waitUntilConnectable(any(), any(), any()) } returns true
 
         // Start a server first
-        tool.manageMockServer(ManageMockServerArgs(command = "start", openApiSpec = "...", port = 9006))
+        val specFile = tempDir.resolve("spec.yaml").apply { writeText("...") }
+        tool.manageMockServer(ManageMockServerArgs(command = "start", specFilePath = specFile.canonicalPath, port = 9006))
         assertThat(getRunningMocks()).containsKey(9006)
         
         // Stop it
@@ -133,8 +135,10 @@ class MockServerToolTest {
         every { anyConstructed<StubCommand>().close() } just Runs
         coEvery { waitUntilConnectable(any(), any(), any()) } returns true
 
-        tool.manageMockServer(ManageMockServerArgs(command = "start", openApiSpec = "...", port = 9010))
-        tool.manageMockServer(ManageMockServerArgs(command = "start", openApiSpec = "...", port = 9011))
+        val specFile1 = tempDir.resolve("spec1.yaml").apply { writeText("...") }
+        val specFile2 = tempDir.resolve("spec2.yaml").apply { writeText("...") }
+        tool.manageMockServer(ManageMockServerArgs(command = "start", specFilePath = specFile1.canonicalPath, port = 9010))
+        tool.manageMockServer(ManageMockServerArgs(command = "start", specFilePath = specFile2.canonicalPath, port = 9011))
         
         val result = tool.manageMockServer(ManageMockServerArgs(command = "list"))
 
@@ -152,9 +156,10 @@ class MockServerToolTest {
         // Simulate timeout
         coEvery { waitUntilConnectable(any(), any(), any()) } returns false
 
+        val specFile = tempDir.resolve("spec.yaml").apply { writeText("openapi: 3.0.0...") }
         val args = ManageMockServerArgs(
             command = "start",
-            openApiSpec = "openapi: 3.0.0...",
+            specFilePath = specFile.canonicalPath,
             port = 9025
         )
         
@@ -176,22 +181,23 @@ class MockServerToolTest {
         every { anyConstructed<StubCommand>().close() } just Runs
         coEvery { waitUntilConnectable(any(), any(), any()) } returns true
 
-        tool.manageMockServer(ManageMockServerArgs(command = "start", openApiSpec = "...", port = 9020))
+        val specFile = tempDir.resolve("spec.yaml").apply { writeText("...") }
+        tool.manageMockServer(ManageMockServerArgs(command = "start", specFilePath = specFile.canonicalPath, port = 9020))
         
-        val result = tool.manageMockServer(ManageMockServerArgs(command = "start", openApiSpec = "...", port = 9020))
+        val result = tool.manageMockServer(ManageMockServerArgs(command = "start", specFilePath = specFile.canonicalPath, port = 9020))
 
         assertThat(result).contains("Failed to start mock server")
         assertThat(result).contains("Port 9020 is already in use by a mock server running in this process.")
     }
 
     @Test
-    fun `manageMockServer start should fail if openApiSpec is missing`() {
+    fun `manageMockServer start should fail if specFilePath is missing`() {
         val args = ManageMockServerArgs(command = "start", port = 9000)
         
         try {
             tool.manageMockServer(args)
         } catch (e: IllegalArgumentException) {
-            assertThat(e.message).isEqualTo("openApiSpec is required for 'start' command")
+            assertThat(e.message).isEqualTo("specFilePath is required for 'start' command")
         }
     }
 }


### PR DESCRIPTION
Reason to change: 
 Mock server MCP tool  and Contract testing MCP tool use to accept spec file's content as input. 
 Tools now accept spec file's path as input to avoid any complexities caused by large spec files.