### PR TITLE
Distinguish explicit and inferred application API sources

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/ApplicationApiSource.kt
+++ b/core/src/main/kotlin/io/specmatic/core/ApplicationApiSource.kt
@@ -4,8 +4,20 @@ const val DEFAULT_SWAGGER_SPEC_YAML_PATH = "/swagger/v1/swagger.yaml"
 
 sealed interface ApplicationApiSource {
     val url: String
+    val isExplicitlyConfigured: Boolean
 
-    data class Actuator(override val url: String) : ApplicationApiSource
-    data class Swagger(override val url: String) : ApplicationApiSource
-    data class SwaggerUi(override val url: String) : ApplicationApiSource
+    data class Actuator @JvmOverloads constructor(
+        override val url: String,
+        override val isExplicitlyConfigured: Boolean = true,
+    ) : ApplicationApiSource
+
+    data class Swagger @JvmOverloads constructor(
+        override val url: String,
+        override val isExplicitlyConfigured: Boolean = true,
+    ) : ApplicationApiSource
+
+    data class SwaggerUi @JvmOverloads constructor(
+        override val url: String,
+        override val isExplicitlyConfigured: Boolean = true,
+    ) : ApplicationApiSource
 }

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfigV1V2Common.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfigV1V2Common.kt
@@ -931,7 +931,8 @@ data class SpecmaticConfigV1V2Common(
 
         return getActuatorUrl()?.let(ApplicationApiSource::Actuator)
             ?: getTestSwaggerUrl()?.let(ApplicationApiSource::Swagger)
-            ?: (getTestSwaggerUIBaseUrl() ?: fallbackSwaggerUiBaseUrl)?.let(ApplicationApiSource::SwaggerUi)
+            ?: getTestSwaggerUIBaseUrl()?.let(ApplicationApiSource::SwaggerUi)
+            ?: fallbackSwaggerUiBaseUrl?.let { ApplicationApiSource.SwaggerUi(it, isExplicitlyConfigured = false) }
     }
 
     @JsonIgnore

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3Impl.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3Impl.kt
@@ -486,7 +486,8 @@ data class SpecmaticConfigV3Impl(val file: File? = null, val specmaticConfig: Sp
         return specSpecificOpenApiTestConfig?.let(::applicationApiSourceFor)
             ?: getActuatorUrl()?.let(ApplicationApiSource::Actuator)
             ?: openApiTestConfig?.swaggerUrl?.let(ApplicationApiSource::Swagger)
-            ?: (openApiTestConfig?.swaggerUiBaseUrl ?: fallbackSwaggerUiBaseUrl)?.let(ApplicationApiSource::SwaggerUi)
+            ?: openApiTestConfig?.swaggerUiBaseUrl?.let(ApplicationApiSource::SwaggerUi)
+            ?: fallbackSwaggerUiBaseUrl?.let { ApplicationApiSource.SwaggerUi(it, isExplicitlyConfigured = false) }
     }
 
     override fun enableResiliencyTests(onlyPositive: Boolean): SpecmaticConfig {
@@ -901,6 +902,8 @@ private fun defaultSwaggerUrlFor(baseUrl: String): String {
 private fun applicationApiSourceFor(runOptions: OpenApiRunOptionsSpecifications): ApplicationApiSource? {
     return runOptions.spec.actuatorUrl?.let(ApplicationApiSource::Actuator)
         ?: runOptions.spec.swaggerUrl?.let(ApplicationApiSource::Swagger)
-        ?: runOptions.getServerOrigin("localhost")?.toBaseUrl()?.let(::defaultSwaggerUrlFor)?.let(ApplicationApiSource::Swagger)
+        ?: runOptions.getServerOrigin("localhost")?.toBaseUrl()?.let(::defaultSwaggerUrlFor)?.let {
+            ApplicationApiSource.Swagger(it, isExplicitlyConfigured = false)
+        }
         ?: runOptions.spec.swaggerUiBaseUrl?.let(ApplicationApiSource::SwaggerUi)
 }

--- a/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigKtTest.kt
@@ -2086,7 +2086,7 @@ internal class SpecmaticConfigKtTest {
                 Arguments.of(
                     V2ApplicationApiSourceCase(
                         fallbackSwaggerUiBaseUrl = "http://fallback.example",
-                        expectedSource = ApplicationApiSource.SwaggerUi("http://fallback.example")
+                        expectedSource = ApplicationApiSource.SwaggerUi("http://fallback.example", isExplicitlyConfigured = false)
                     )
                 )
             )

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3ImplTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3ImplTest.kt
@@ -194,11 +194,11 @@ class SpecmaticConfigV3ImplTest {
         assertThat(config.getTestApplicationApiSource(swaggerUiSpec, SpecType.OPENAPI, "http://runtime.example"))
             .isEqualTo(ApplicationApiSource.SwaggerUi("http://swagger-ui.example"))
         assertThat(config.getTestApplicationApiSource(baseUrlSpec, SpecType.OPENAPI, "http://runtime.example"))
-            .isEqualTo(ApplicationApiSource.Swagger("http://base-url.example$DEFAULT_SWAGGER_SPEC_YAML_PATH"))
+            .isEqualTo(ApplicationApiSource.Swagger("http://base-url.example$DEFAULT_SWAGGER_SPEC_YAML_PATH", isExplicitlyConfigured = false))
         assertThat(config.getTestApplicationApiSource(hostAndPortSpec, SpecType.OPENAPI, "http://runtime.example"))
-            .isEqualTo(ApplicationApiSource.Swagger("http://host-and-port.example:8083$DEFAULT_SWAGGER_SPEC_YAML_PATH"))
+            .isEqualTo(ApplicationApiSource.Swagger("http://host-and-port.example:8083$DEFAULT_SWAGGER_SPEC_YAML_PATH", isExplicitlyConfigured = false))
         assertThat(config.getTestApplicationApiSource(portOnlySpec, SpecType.OPENAPI, "http://runtime.example"))
-            .isEqualTo(ApplicationApiSource.Swagger("http://localhost:8084$DEFAULT_SWAGGER_SPEC_YAML_PATH"))
+            .isEqualTo(ApplicationApiSource.Swagger("http://localhost:8084$DEFAULT_SWAGGER_SPEC_YAML_PATH", isExplicitlyConfigured = false))
         assertThat(config.getTestApplicationApiSource(actuatorSpec, SpecType.OPENAPI, "http://runtime.example"))
             .isEqualTo(ApplicationApiSource.Actuator("http://actuator.example/mappings"))
         assertThat(config.getTestApplicationApiSource(hostOnlySpec, SpecType.OPENAPI, "http://runtime.example"))
@@ -347,7 +347,7 @@ class SpecmaticConfigV3ImplTest {
         )
 
         assertThat(config.getTestApplicationApiSource(orderSpec, SpecType.OPENAPI, "http://localhost:9000"))
-            .isEqualTo(ApplicationApiSource.Swagger("http://localhost:9090$DEFAULT_SWAGGER_SPEC_YAML_PATH"))
+            .isEqualTo(ApplicationApiSource.Swagger("http://localhost:9090$DEFAULT_SWAGGER_SPEC_YAML_PATH", isExplicitlyConfigured = false))
         assertThat(config.getTestApplicationApiSource(cartSpec, SpecType.OPENAPI, "http://localhost:9000"))
             .isEqualTo(ApplicationApiSource.Swagger("http://localhost:8080/default-api-docs"))
     }
@@ -474,7 +474,7 @@ class SpecmaticConfigV3ImplTest {
         )
 
         assertThat(config.getTestApplicationApiSource(specFile, SpecType.OPENAPI, "http://localhost:9000"))
-            .isEqualTo(ApplicationApiSource.SwaggerUi("http://localhost:9000"))
+            .isEqualTo(ApplicationApiSource.SwaggerUi("http://localhost:9000", isExplicitlyConfigured = false))
     }
 
     @Test

--- a/junit5-support/src/main/kotlin/io/specmatic/test/ApplicationApiDiscovery.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/ApplicationApiDiscovery.kt
@@ -5,6 +5,7 @@ import io.specmatic.conversions.convertPathParameterStyle
 import io.specmatic.core.ApplicationApiSource
 import io.specmatic.core.DEFAULT_SWAGGER_SPEC_YAML_PATH
 import io.specmatic.core.HttpRequest
+import io.specmatic.core.HttpResponse
 import io.specmatic.core.KeyData
 import io.specmatic.core.log.ignoreLog
 import io.specmatic.core.log.logger
@@ -14,9 +15,32 @@ import io.specmatic.core.value.JSONArrayValue
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.test.reports.coverage.OpenApiCoverage
 
-internal class ApplicationApiDiscovery(
+internal fun interface ApplicationApiSourceClient {
+    fun get(applicationApiSourceUrl: String): HttpResponse
+}
+
+internal fun interface ApplicationApiSourceKeyDataProvider {
+    fun get(applicationApiSourceUrl: String): KeyData?
+}
+
+internal class HttpApplicationApiSourceClient(
     private val prettyPrint: Boolean,
-    private val keyDataFor: (String) -> KeyData?,
+    private val keyDataProvider: ApplicationApiSourceKeyDataProvider,
+) : ApplicationApiSourceClient {
+    override fun get(applicationApiSourceUrl: String): HttpResponse {
+        return HttpClient(
+            applicationApiSourceUrl,
+            log = ignoreLog,
+            prettyPrint = prettyPrint,
+            keyData = keyDataProvider.get(applicationApiSourceUrl),
+        ).use { httpClient ->
+            httpClient.execute(HttpRequest("GET"))
+        }
+    }
+}
+
+internal class ApplicationApiDiscovery(
+    private val sourceClient: ApplicationApiSourceClient,
 ) {
     fun discover(sources: List<ApplicationApiSource>, coverage: OpenApiCoverage) {
         val sourceFetches = sources.map { source ->
@@ -54,7 +78,7 @@ internal class ApplicationApiDiscovery(
     }
 
     private fun fetchApplicationApisFromOpenApiDocument(swaggerDocUrl: String): ApplicationApiFetchResult {
-        val response = executeGet(swaggerDocUrl, HttpRequest(path = "/", method = "GET"))
+        val response = sourceClient.get(swaggerDocUrl)
         if (response.status != 200) {
             return ApplicationApiFetchResult.Failure("Received HTTP status ${response.status}")
         }
@@ -68,7 +92,7 @@ internal class ApplicationApiDiscovery(
     }
 
     private fun fetchApplicationApisFromActuator(source: ApplicationApiSource.Actuator): ApplicationApiFetchResult {
-        val response = executeGet(source.url, HttpRequest("GET"))
+        val response = sourceClient.get(source.url)
         if (response.status != 200) {
             return ApplicationApiFetchResult.Failure("Received HTTP status ${response.status}")
         }
@@ -98,15 +122,6 @@ internal class ApplicationApiDiscovery(
                 }
             }
         )
-    }
-
-    private fun executeGet(url: String, request: HttpRequest) = HttpClient(
-        url,
-        log = ignoreLog,
-        prettyPrint = prettyPrint,
-        keyData = keyDataFor(url),
-    ).use { httpClient ->
-        httpClient.execute(request)
     }
 
     private fun reportApplicationApiFetchFailure(

--- a/junit5-support/src/main/kotlin/io/specmatic/test/ApplicationApiDiscovery.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/ApplicationApiDiscovery.kt
@@ -1,0 +1,143 @@
+package io.specmatic.test
+
+import io.specmatic.conversions.OpenApiSpecification
+import io.specmatic.conversions.convertPathParameterStyle
+import io.specmatic.core.ApplicationApiSource
+import io.specmatic.core.DEFAULT_SWAGGER_SPEC_YAML_PATH
+import io.specmatic.core.HttpRequest
+import io.specmatic.core.KeyData
+import io.specmatic.core.log.ignoreLog
+import io.specmatic.core.log.logger
+import io.specmatic.core.pattern.ContractException
+import io.specmatic.core.utilities.exceptionCauseMessage
+import io.specmatic.core.value.JSONArrayValue
+import io.specmatic.core.value.JSONObjectValue
+import io.specmatic.test.reports.coverage.OpenApiCoverage
+
+internal class ApplicationApiDiscovery(
+    private val prettyPrint: Boolean,
+    private val keyDataFor: (String) -> KeyData?,
+) {
+    fun discover(sources: List<ApplicationApiSource>, coverage: OpenApiCoverage) {
+        val sourceFetches = sources.map { source ->
+            ApplicationApiSourceFetch(source, fetchApplicationApisFrom(source))
+        }
+
+        sourceFetches.forEach { sourceFetch ->
+            when (val result = sourceFetch.result) {
+                is ApplicationApiFetchResult.Success -> coverage.addAPIs(result.apis)
+                is ApplicationApiFetchResult.Failure -> reportApplicationApiFetchFailure(sourceFetch.source, result)
+            }
+        }
+
+        val anySourceAvailable = sourceFetches.any { it.result is ApplicationApiFetchResult.Success }
+        coverage.setEndpointsAPIFlag(anySourceAvailable)
+
+        if (!anySourceAvailable) {
+            logger.boundary()
+            logger.log("No application API source was exposed by the application, so cannot calculate actual coverage")
+        }
+    }
+
+    private fun fetchApplicationApisFrom(source: ApplicationApiSource): ApplicationApiFetchResult {
+        return try {
+            when (source) {
+                is ApplicationApiSource.Actuator -> fetchApplicationApisFromActuator(source)
+                is ApplicationApiSource.Swagger -> fetchApplicationApisFromOpenApiDocument(source.url)
+                is ApplicationApiSource.SwaggerUi -> fetchApplicationApisFromOpenApiDocument(
+                    source.url.trimEnd('/') + DEFAULT_SWAGGER_SPEC_YAML_PATH
+                )
+            }
+        } catch (exception: Throwable) {
+            ApplicationApiFetchResult.Failure(exceptionCauseMessage(exception))
+        }
+    }
+
+    private fun fetchApplicationApisFromOpenApiDocument(swaggerDocUrl: String): ApplicationApiFetchResult {
+        val response = executeGet(swaggerDocUrl, HttpRequest(path = "/", method = "GET"))
+        if (response.status != 200) {
+            return ApplicationApiFetchResult.Failure("Received HTTP status ${response.status}")
+        }
+
+        val featureFromJson = OpenApiSpecification.fromYAML(response.body.toStringLiteral(), "").toFeature()
+        return ApplicationApiFetchResult.Success(
+            featureFromJson.scenarios.map { scenario ->
+                API(method = scenario.method, path = convertPathParameterStyle(scenario.path))
+            }.distinct()
+        )
+    }
+
+    private fun fetchApplicationApisFromActuator(source: ApplicationApiSource.Actuator): ApplicationApiFetchResult {
+        val response = executeGet(source.url, HttpRequest("GET"))
+        if (response.status != 200) {
+            return ApplicationApiFetchResult.Failure("Received HTTP status ${response.status}")
+        }
+
+        logger.debug(response.toLogString())
+        val endpointData = response.body as JSONObjectValue
+        return ApplicationApiFetchResult.Success(
+            endpointData.getJSONObject("contexts").entries.flatMap { entry ->
+                val mappings =
+                    (entry.value as JSONObjectValue).findFirstChildByPath("mappings.dispatcherServlets.dispatcherServlet") as JSONArrayValue
+                mappings.list.map { it as JSONObjectValue }.filter {
+                    it.findFirstChildByPath("details.handlerMethod.className")?.toStringLiteral()
+                        ?.contains("springframework") != true
+                }.flatMap {
+                    val methods = it.findFirstChildByPath("details.requestMappingConditions.methods") as JSONArrayValue?
+                    val paths = it.findFirstChildByPath("details.requestMappingConditions.patterns") as JSONArrayValue?
+
+                    if (methods != null && paths != null) {
+                        methods.list.flatMap { method ->
+                            paths.list.map { path ->
+                                API(method.toStringLiteral(), path.toStringLiteral())
+                            }
+                        }
+                    } else {
+                        emptyList()
+                    }
+                }
+            }
+        )
+    }
+
+    private fun executeGet(url: String, request: HttpRequest) = HttpClient(
+        url,
+        log = ignoreLog,
+        prettyPrint = prettyPrint,
+        keyData = keyDataFor(url),
+    ).use { httpClient ->
+        httpClient.execute(request)
+    }
+
+    private fun reportApplicationApiFetchFailure(
+        source: ApplicationApiSource,
+        failure: ApplicationApiFetchResult.Failure,
+    ) {
+        val message = "Could not use ${source.displayName()} at ${source.url}: ${failure.reason}"
+        if (source.isExplicitlyConfigured) {
+            logger.logError(ContractException(message))
+        } else {
+            logger.debug(message)
+        }
+    }
+
+    private fun ApplicationApiSource.displayName(): String {
+        val sourceType = when (this) {
+            is ApplicationApiSource.Actuator -> "actuator URL"
+            is ApplicationApiSource.Swagger -> "Swagger URL"
+            is ApplicationApiSource.SwaggerUi -> "Swagger UI base URL"
+        }
+        val origin = if (isExplicitlyConfigured) "explicitly configured" else "inferred"
+        return "$origin $sourceType"
+    }
+
+    private sealed interface ApplicationApiFetchResult {
+        data class Success(val apis: List<API>) : ApplicationApiFetchResult
+        data class Failure(val reason: String) : ApplicationApiFetchResult
+    }
+
+    private data class ApplicationApiSourceFetch(
+        val source: ApplicationApiSource,
+        val result: ApplicationApiFetchResult,
+    )
+}

--- a/junit5-support/src/main/kotlin/io/specmatic/test/ApplicationApiDiscovery.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/ApplicationApiDiscovery.kt
@@ -9,7 +9,6 @@ import io.specmatic.core.HttpResponse
 import io.specmatic.core.KeyData
 import io.specmatic.core.log.ignoreLog
 import io.specmatic.core.log.logger
-import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.utilities.exceptionCauseMessage
 import io.specmatic.core.value.JSONArrayValue
 import io.specmatic.core.value.JSONObjectValue
@@ -128,11 +127,10 @@ internal class ApplicationApiDiscovery(
         source: ApplicationApiSource,
         failure: ApplicationApiFetchResult.Failure,
     ) {
-        val message = "Could not use ${source.displayName()} at ${source.url}: ${failure.reason}"
         if (source.isExplicitlyConfigured) {
-            logger.logError(ContractException(message))
+            logger.log("WARNING: Could not use ${source.displayName()} at ${source.url}: ${failure.reason}")
         } else {
-            logger.debug(message)
+            logger.debug("Could not use inferred ${source.displayName()} at ${source.url}: ${failure.reason}")
         }
     }
 
@@ -142,8 +140,7 @@ internal class ApplicationApiDiscovery(
             is ApplicationApiSource.Swagger -> "Swagger URL"
             is ApplicationApiSource.SwaggerUi -> "Swagger UI base URL"
         }
-        val origin = if (isExplicitlyConfigured) "explicitly configured" else "inferred"
-        return "$origin $sourceType"
+        return sourceType
     }
 
     private sealed interface ApplicationApiFetchResult {

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -1,13 +1,11 @@
 package io.specmatic.test
 
-import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.conversions.convertPathParameterStyle
 import io.specmatic.core.*
 import io.specmatic.core.filters.ScenarioMetadataFilter
 import io.specmatic.core.filters.ScenarioMetadataFilter.Companion.filterUsingDecisions
 import io.specmatic.core.log.LogMessage
 import io.specmatic.core.log.consoleLog
-import io.specmatic.core.log.ignoreLog
 import io.specmatic.core.log.logger
 import io.specmatic.core.log.setLoggerUsing
 import io.specmatic.core.pattern.ContractException
@@ -61,16 +59,6 @@ data class API(
     val path: String,
 )
 
-private sealed interface ApplicationApiFetchResult {
-    data class Success(val apis: List<API>) : ApplicationApiFetchResult
-    data class Failure(val reason: String) : ApplicationApiFetchResult
-}
-
-private data class ApplicationApiSourceFetch(
-    val source: ApplicationApiSource,
-    val result: ApplicationApiFetchResult,
-)
-
 @Execution(ExecutionMode.CONCURRENT)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 open class SpecmaticJUnitSupport {
@@ -117,126 +105,6 @@ open class SpecmaticJUnitSupport {
             return ReportConfiguration.default
         }
         return reportConfiguration
-    }
-
-    private fun fetchApplicationApisFromOpenApiDocument(swaggerDocUrl: String): ApplicationApiFetchResult {
-        val request = HttpRequest(path = "/", method = "GET")
-        val response = HttpClient(
-            swaggerDocUrl,
-            log = ignoreLog,
-            prettyPrint = prettyPrint,
-            keyData = keyDataFor(swaggerDocUrl)
-        ).use { httpClient ->
-            httpClient.execute(request)
-        }
-
-        if (response.status != 200) {
-            return ApplicationApiFetchResult.Failure("Received HTTP status ${response.status}")
-        }
-
-        val featureFromJson = OpenApiSpecification.fromYAML(response.body.toStringLiteral(), "").toFeature()
-        return ApplicationApiFetchResult.Success(
-            featureFromJson.scenarios.map { scenario ->
-                API(method = scenario.method, path = convertPathParameterStyle(scenario.path))
-            }.distinct()
-        )
-    }
-
-    private fun fetchApplicationApisFrom(source: ApplicationApiSource): ApplicationApiFetchResult {
-        return try {
-            when (source) {
-                is ApplicationApiSource.Actuator -> fetchApplicationApisFromActuator(source)
-                is ApplicationApiSource.Swagger -> fetchApplicationApisFromOpenApiDocument(source.url)
-                is ApplicationApiSource.SwaggerUi -> fetchApplicationApisFromOpenApiDocument(source.url.trimEnd('/') + DEFAULT_SWAGGER_SPEC_YAML_PATH)
-            }
-        } catch (exception: Throwable) {
-            ApplicationApiFetchResult.Failure(exceptionCauseMessage(exception))
-        }
-    }
-
-    private fun fetchApplicationApisFromActuator(source: ApplicationApiSource.Actuator): ApplicationApiFetchResult {
-        val endpointsAPI = source.url
-        val request = HttpRequest("GET")
-        val response = HttpClient(
-            endpointsAPI,
-            log = ignoreLog,
-            prettyPrint = prettyPrint,
-            keyData = keyDataFor(endpointsAPI)
-        ).use { httpClient ->
-            httpClient.execute(request)
-        }
-
-        if (response.status != 200) {
-            return ApplicationApiFetchResult.Failure("Received HTTP status ${response.status}")
-        }
-
-        logger.debug(response.toLogString())
-        val endpointData = response.body as JSONObjectValue
-        return ApplicationApiFetchResult.Success(
-            endpointData.getJSONObject("contexts").entries.flatMap { entry ->
-                val mappings: JSONArrayValue =
-                    (entry.value as JSONObjectValue).findFirstChildByPath("mappings.dispatcherServlets.dispatcherServlet") as JSONArrayValue
-                mappings.list.map { it as JSONObjectValue }.filter {
-                    it.findFirstChildByPath("details.handlerMethod.className")?.toStringLiteral()
-                        ?.contains("springframework") != true
-                }.flatMap {
-                    val methods: JSONArrayValue? =
-                        it.findFirstChildByPath("details.requestMappingConditions.methods") as JSONArrayValue?
-                    val paths: JSONArrayValue? =
-                        it.findFirstChildByPath("details.requestMappingConditions.patterns") as JSONArrayValue?
-
-                    if (methods != null && paths != null) {
-                        methods.list.flatMap { method ->
-                            paths.list.map { path ->
-                                API(method.toStringLiteral(), path.toStringLiteral())
-                            }
-                        }
-                    } else {
-                        emptyList()
-                    }
-                }
-            }
-        )
-    }
-
-    private fun addApplicationApisFromConfiguredSources(applicationApiSources: List<ApplicationApiSource>) {
-        val sourceFetches = applicationApiSources.map { source ->
-            ApplicationApiSourceFetch(source, fetchApplicationApisFrom(source))
-        }
-
-        sourceFetches.forEach { sourceFetch ->
-            when (val result = sourceFetch.result) {
-                is ApplicationApiFetchResult.Success -> openApiCoverage.addAPIs(result.apis)
-                is ApplicationApiFetchResult.Failure -> reportApplicationApiFetchFailure(sourceFetch.source, result)
-            }
-        }
-
-        val anySourceAvailable = sourceFetches.any { it.result is ApplicationApiFetchResult.Success }
-        openApiCoverage.setEndpointsAPIFlag(anySourceAvailable)
-
-        if (!anySourceAvailable) {
-            logger.boundary()
-            logger.log("No application API source was exposed by the application, so cannot calculate actual coverage")
-        }
-    }
-
-    private fun reportApplicationApiFetchFailure(source: ApplicationApiSource, failure: ApplicationApiFetchResult.Failure) {
-        val message = "Could not use ${source.displayName()} at ${source.url}: ${failure.reason}"
-        if (source.isExplicitlyConfigured) {
-            logger.logError(ContractException(message))
-        } else {
-            logger.debug(message)
-        }
-    }
-
-    private fun ApplicationApiSource.displayName(): String {
-        val sourceType = when (this) {
-            is ApplicationApiSource.Actuator -> "actuator URL"
-            is ApplicationApiSource.Swagger -> "Swagger URL"
-            is ApplicationApiSource.SwaggerUi -> "Swagger UI base URL"
-        }
-        val origin = if (isExplicitlyConfigured) "explicitly configured" else "inferred"
-        return "$origin $sourceType"
     }
 
     private fun applicationApiSourceFor(contractPath: String, resolvedBaseURL: String): ApplicationApiSource? {
@@ -499,7 +367,7 @@ open class SpecmaticJUnitSupport {
         val suiteAbortMessage = AtomicReference<String?>(null)
 
         try {
-            addApplicationApisFromConfiguredSources(applicationApiSources)
+            ApplicationApiDiscovery(prettyPrint, ::keyDataFor).discover(applicationApiSources, openApiCoverage)
         } catch (exception: Throwable) {
             openApiCoverage.setEndpointsAPIFlag(false)
             logger.debug(exception, "Failed to query application API source with error")

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -95,6 +95,13 @@ open class SpecmaticJUnitSupport {
         httpInteractionsLog = httpInteractionsLog
     )
 
+    private val applicationApiDiscovery = ApplicationApiDiscovery(
+        HttpApplicationApiSourceClient(
+            prettyPrint = prettyPrint,
+            keyDataProvider = ApplicationApiSourceKeyDataProvider(::keyDataFor),
+        )
+    )
+
     private val threads: Vector<String> = Vector<String>()
 
     private fun getReportConfiguration(): ReportConfiguration {
@@ -367,7 +374,7 @@ open class SpecmaticJUnitSupport {
         val suiteAbortMessage = AtomicReference<String?>(null)
 
         try {
-            ApplicationApiDiscovery(prettyPrint, ::keyDataFor).discover(applicationApiSources, openApiCoverage)
+            applicationApiDiscovery.discover(applicationApiSources, openApiCoverage)
         } catch (exception: Throwable) {
             openApiCoverage.setEndpointsAPIFlag(false)
             logger.debug(exception, "Failed to query application API source with error")

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -61,6 +61,16 @@ data class API(
     val path: String,
 )
 
+private sealed interface ApplicationApiFetchResult {
+    data class Success(val apis: List<API>) : ApplicationApiFetchResult
+    data class Failure(val reason: String) : ApplicationApiFetchResult
+}
+
+private data class ApplicationApiSourceFetch(
+    val source: ApplicationApiSource,
+    val result: ApplicationApiFetchResult,
+)
+
 @Execution(ExecutionMode.CONCURRENT)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 open class SpecmaticJUnitSupport {
@@ -109,7 +119,7 @@ open class SpecmaticJUnitSupport {
         return reportConfiguration
     }
 
-    private fun fetchApplicationApisFromOpenApiDocument(swaggerDocUrl: String): List<API>? {
+    private fun fetchApplicationApisFromOpenApiDocument(swaggerDocUrl: String): ApplicationApiFetchResult {
         val request = HttpRequest(path = "/", method = "GET")
         val response = HttpClient(
             swaggerDocUrl,
@@ -121,25 +131,30 @@ open class SpecmaticJUnitSupport {
         }
 
         if (response.status != 200) {
-            logger.debug("Failed to query OpenAPI document source, status code: ${response.status}")
-            return null
+            return ApplicationApiFetchResult.Failure("Received HTTP status ${response.status}")
         }
 
         val featureFromJson = OpenApiSpecification.fromYAML(response.body.toStringLiteral(), "").toFeature()
-        return featureFromJson.scenarios.map { scenario ->
-            API(method = scenario.method, path = convertPathParameterStyle(scenario.path))
-        }.distinct()
+        return ApplicationApiFetchResult.Success(
+            featureFromJson.scenarios.map { scenario ->
+                API(method = scenario.method, path = convertPathParameterStyle(scenario.path))
+            }.distinct()
+        )
     }
 
-    private fun fetchApplicationApisFrom(source: ApplicationApiSource): List<API>? {
-        return when (source) {
-            is ApplicationApiSource.Actuator -> fetchApplicationApisFromActuator(source)
-            is ApplicationApiSource.Swagger -> fetchApplicationApisFromOpenApiDocument(source.url)
-            is ApplicationApiSource.SwaggerUi -> fetchApplicationApisFromOpenApiDocument(source.url.trimEnd('/') + DEFAULT_SWAGGER_SPEC_YAML_PATH)
+    private fun fetchApplicationApisFrom(source: ApplicationApiSource): ApplicationApiFetchResult {
+        return try {
+            when (source) {
+                is ApplicationApiSource.Actuator -> fetchApplicationApisFromActuator(source)
+                is ApplicationApiSource.Swagger -> fetchApplicationApisFromOpenApiDocument(source.url)
+                is ApplicationApiSource.SwaggerUi -> fetchApplicationApisFromOpenApiDocument(source.url.trimEnd('/') + DEFAULT_SWAGGER_SPEC_YAML_PATH)
+            }
+        } catch (exception: Throwable) {
+            ApplicationApiFetchResult.Failure(exceptionCauseMessage(exception))
         }
     }
 
-    private fun fetchApplicationApisFromActuator(source: ApplicationApiSource.Actuator): List<API>? {
+    private fun fetchApplicationApisFromActuator(source: ApplicationApiSource.Actuator): ApplicationApiFetchResult {
         val endpointsAPI = source.url
         val request = HttpRequest("GET")
         val response = HttpClient(
@@ -152,51 +167,76 @@ open class SpecmaticJUnitSupport {
         }
 
         if (response.status != 200) {
-            logger.debug("Failed to query actuator, status code: ${response.status}")
-            return null
+            return ApplicationApiFetchResult.Failure("Received HTTP status ${response.status}")
         }
 
         logger.debug(response.toLogString())
         val endpointData = response.body as JSONObjectValue
-        return endpointData.getJSONObject("contexts").entries.flatMap { entry ->
-            val mappings: JSONArrayValue =
-                (entry.value as JSONObjectValue).findFirstChildByPath("mappings.dispatcherServlets.dispatcherServlet") as JSONArrayValue
-            mappings.list.map { it as JSONObjectValue }.filter {
-                it.findFirstChildByPath("details.handlerMethod.className")?.toStringLiteral()
-                    ?.contains("springframework") != true
-            }.flatMap {
-                val methods: JSONArrayValue? =
-                    it.findFirstChildByPath("details.requestMappingConditions.methods") as JSONArrayValue?
-                val paths: JSONArrayValue? =
-                    it.findFirstChildByPath("details.requestMappingConditions.patterns") as JSONArrayValue?
+        return ApplicationApiFetchResult.Success(
+            endpointData.getJSONObject("contexts").entries.flatMap { entry ->
+                val mappings: JSONArrayValue =
+                    (entry.value as JSONObjectValue).findFirstChildByPath("mappings.dispatcherServlets.dispatcherServlet") as JSONArrayValue
+                mappings.list.map { it as JSONObjectValue }.filter {
+                    it.findFirstChildByPath("details.handlerMethod.className")?.toStringLiteral()
+                        ?.contains("springframework") != true
+                }.flatMap {
+                    val methods: JSONArrayValue? =
+                        it.findFirstChildByPath("details.requestMappingConditions.methods") as JSONArrayValue?
+                    val paths: JSONArrayValue? =
+                        it.findFirstChildByPath("details.requestMappingConditions.patterns") as JSONArrayValue?
 
-                if (methods != null && paths != null) {
-                    methods.list.flatMap { method ->
-                        paths.list.map { path ->
-                            API(method.toStringLiteral(), path.toStringLiteral())
+                    if (methods != null && paths != null) {
+                        methods.list.flatMap { method ->
+                            paths.list.map { path ->
+                                API(method.toStringLiteral(), path.toStringLiteral())
+                            }
                         }
+                    } else {
+                        emptyList()
                     }
-                } else {
-                    emptyList()
                 }
             }
-        }
+        )
     }
 
     private fun addApplicationApisFromConfiguredSources(applicationApiSources: List<ApplicationApiSource>) {
-        val applicationApisByAvailableSource = applicationApiSources.mapNotNull(::fetchApplicationApisFrom)
-
-        applicationApisByAvailableSource.forEach { apis ->
-            openApiCoverage.addAPIs(apis)
+        val sourceFetches = applicationApiSources.map { source ->
+            ApplicationApiSourceFetch(source, fetchApplicationApisFrom(source))
         }
 
-        val anySourceAvailable = applicationApisByAvailableSource.isNotEmpty()
+        sourceFetches.forEach { sourceFetch ->
+            when (val result = sourceFetch.result) {
+                is ApplicationApiFetchResult.Success -> openApiCoverage.addAPIs(result.apis)
+                is ApplicationApiFetchResult.Failure -> reportApplicationApiFetchFailure(sourceFetch.source, result)
+            }
+        }
+
+        val anySourceAvailable = sourceFetches.any { it.result is ApplicationApiFetchResult.Success }
         openApiCoverage.setEndpointsAPIFlag(anySourceAvailable)
 
         if (!anySourceAvailable) {
             logger.boundary()
             logger.log("No application API source was exposed by the application, so cannot calculate actual coverage")
         }
+    }
+
+    private fun reportApplicationApiFetchFailure(source: ApplicationApiSource, failure: ApplicationApiFetchResult.Failure) {
+        val message = "Could not use ${source.displayName()} at ${source.url}: ${failure.reason}"
+        if (source.isExplicitlyConfigured) {
+            logger.logError(ContractException(message))
+        } else {
+            logger.debug(message)
+        }
+    }
+
+    private fun ApplicationApiSource.displayName(): String {
+        val sourceType = when (this) {
+            is ApplicationApiSource.Actuator -> "actuator URL"
+            is ApplicationApiSource.Swagger -> "Swagger URL"
+            is ApplicationApiSource.SwaggerUi -> "Swagger UI base URL"
+        }
+        val origin = if (isExplicitlyConfigured) "explicitly configured" else "inferred"
+        return "$origin $sourceType"
     }
 
     private fun applicationApiSourceFor(contractPath: String, resolvedBaseURL: String): ApplicationApiSource? {

--- a/junit5-support/src/test/kotlin/io/specmatic/test/ApplicationApiDiscoveryTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/ApplicationApiDiscoveryTest.kt
@@ -1,0 +1,208 @@
+package io.specmatic.test
+
+import io.specmatic.core.ApplicationApiSource
+import io.specmatic.core.HttpResponse
+import io.specmatic.core.log.InfoLogger
+import io.specmatic.core.log.withLogger
+import io.specmatic.core.pattern.parsedJsonValue
+import io.specmatic.test.reports.coverage.OpenApiCoverage
+import io.specmatic.test.utils.MockHttpServer
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import java.net.ServerSocket
+
+class ApplicationApiDiscoveryTest {
+    companion object {
+        @JvmStatic
+        fun explicitApplicationApiSourceCases(): List<Arguments> =
+            ApplicationApiSourceCase.entries.map { Arguments.of(it) }
+
+        @JvmStatic
+        fun emptyApplicationApiSourceCases(): List<Arguments> =
+            listOf(
+                Arguments.of(ApplicationApiSourceCase.ACTUATOR, """{"contexts":{}}"""),
+                Arguments.of(
+                    ApplicationApiSourceCase.SWAGGER,
+                    """{"openapi":"3.0.0","info":{"title":"empty","version":"1.0.0"},"paths":{}}""",
+                ),
+            )
+    }
+
+    @ParameterizedTest
+    @MethodSource("explicitApplicationApiSourceCases")
+    fun `should report connectivity errors for explicit application api sources`(sourceCase: ApplicationApiSourceCase) {
+        val unusedPort = ServerSocket(0).use { it.localPort }
+        val sourceUrl = "http://localhost:$unusedPort"
+        val coverage = coverage()
+
+        val output = captureStdout {
+            assertDoesNotThrow {
+                discovery().discover(listOf(sourceCase.source(sourceUrl)), coverage)
+            }
+        }
+
+        assertThat(output)
+            .contains("ERROR", "explicitly configured ${sourceCase.displayName}", sourceUrl)
+            .containsIgnoringCase("connect")
+        assertThat(coverage.isEndpointsApiSet()).isFalse()
+    }
+
+    @ParameterizedTest
+    @MethodSource("explicitApplicationApiSourceCases")
+    fun `should report non-200 responses for explicit application api sources`(sourceCase: ApplicationApiSourceCase) {
+        MockHttpServer().use { server ->
+            server.on(sourceCase.requestPath, "GET") { respond(503) }
+
+            val output = captureStdout {
+                discovery().discover(listOf(sourceCase.source(server.baseUrl)), coverage())
+            }
+
+            assertThat(output).contains(
+                "ERROR",
+                "explicitly configured ${sourceCase.displayName}",
+                server.baseUrl,
+                "Received HTTP status 503",
+            )
+        }
+    }
+
+    @Test
+    fun `should report malformed Swagger documents from an explicit URL`() {
+        MockHttpServer().use { server ->
+            server.on("/", "GET") {
+                respond(HttpResponse(status = 200, body = parsedJsonValue("""{"not":"openapi"}""")))
+            }
+
+            val output = captureStdout {
+                discovery().discover(listOf(ApplicationApiSource.Swagger(server.baseUrl)), coverage())
+            }
+
+            assertThat(output).contains("ERROR", "explicitly configured Swagger URL", server.baseUrl)
+        }
+    }
+
+    @Test
+    fun `should report malformed actuator responses from an explicit URL`() {
+        MockHttpServer().use { server ->
+            server.on("/", "GET") {
+                respond(HttpResponse(status = 200, body = parsedJsonValue("""{"not":"actuator"}""")))
+            }
+
+            val output = captureStdout {
+                discovery().discover(listOf(ApplicationApiSource.Actuator(server.baseUrl)), coverage())
+            }
+
+            assertThat(output).contains("ERROR", "explicitly configured actuator URL", server.baseUrl)
+        }
+    }
+
+    @Test
+    fun `should not report connectivity errors for an inferred application api source`() {
+        val unusedPort = ServerSocket(0).use { it.localPort }
+        val sourceUrl = "http://localhost:$unusedPort"
+
+        val output = captureStdout {
+            discovery().discover(
+                listOf(ApplicationApiSource.Swagger(sourceUrl, isExplicitlyConfigured = false)),
+                coverage(),
+            )
+        }
+
+        assertThat(output).doesNotContain("ERROR", "explicitly configured")
+    }
+
+    @Test
+    fun `should retain APIs from successful sources when another explicit source is unreachable`() {
+        val unusedPort = ServerSocket(0).use { it.localPort }
+        MockHttpServer().use { server ->
+            server.on("/", "GET") {
+                respond(HttpResponse(status = 200, body = parsedJsonValue(openApiJson("customers-app", "/customers/internal"))))
+            }
+            val unreachableUrl = "http://localhost:$unusedPort"
+            val coverage = coverage()
+
+            val output = captureStdout {
+                discovery().discover(
+                    listOf(
+                        ApplicationApiSource.Swagger(unreachableUrl),
+                        ApplicationApiSource.Swagger(server.baseUrl),
+                    ),
+                    coverage,
+                )
+            }
+
+            assertThat(output).contains("ERROR", unreachableUrl)
+            assertThat(coverage.getApplicationAPIs()).contains(API("GET", "/customers/internal"))
+            assertThat(coverage.isEndpointsApiSet()).isTrue()
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("emptyApplicationApiSourceCases")
+    fun `should accept valid application api responses containing no APIs`(
+        sourceCase: ApplicationApiSourceCase,
+        responseBody: String,
+    ) {
+        MockHttpServer().use { server ->
+            server.on(sourceCase.requestPath, "GET") {
+                respond(HttpResponse(status = 200, body = parsedJsonValue(responseBody)))
+            }
+            val coverage = coverage()
+
+            val output = captureStdout {
+                discovery().discover(listOf(sourceCase.source(server.baseUrl)), coverage)
+            }
+
+            assertThat(output).doesNotContain("ERROR")
+            assertThat(coverage.isEndpointsApiSet()).isTrue()
+            assertThat(coverage.getApplicationAPIs()).isEmpty()
+        }
+    }
+
+    private fun discovery() = ApplicationApiDiscovery(prettyPrint = true, keyDataFor = { null })
+
+    private fun coverage() = OpenApiCoverage(configFilePath = "")
+
+    private fun captureStdout(block: () -> Unit): String {
+        val originalOut = System.out
+        val outputStream = ByteArrayOutputStream()
+        System.setOut(PrintStream(outputStream))
+        return try {
+            withLogger(InfoLogger, block)
+            outputStream.toString()
+        } finally {
+            System.out.flush()
+            System.setOut(originalOut)
+        }
+    }
+
+    private fun openApiJson(title: String, vararg paths: String): String {
+        val pathsJson = paths.joinToString(",") { path ->
+            """"$path":{"get":{"responses":{"200":{"description":"OK"}}}}"""
+        }
+        return """{"openapi":"3.0.0","info":{"title":"$title","version":"1.0.0"},"paths":{$pathsJson}}"""
+    }
+}
+
+enum class ApplicationApiSourceCase(
+    val displayName: String,
+    val requestPath: String,
+) {
+    ACTUATOR("actuator URL", "/"),
+    SWAGGER("Swagger URL", "/"),
+    SWAGGER_UI("Swagger UI base URL", "/swagger/v1/swagger.yaml");
+
+    fun source(url: String): ApplicationApiSource {
+        return when (this) {
+            ACTUATOR -> ApplicationApiSource.Actuator(url)
+            SWAGGER -> ApplicationApiSource.Swagger(url)
+            SWAGGER_UI -> ApplicationApiSource.SwaggerUi(url)
+        }
+    }
+}

--- a/junit5-support/src/test/kotlin/io/specmatic/test/ApplicationApiDiscoveryTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/ApplicationApiDiscoveryTest.kt
@@ -6,7 +6,6 @@ import io.specmatic.core.log.InfoLogger
 import io.specmatic.core.log.withLogger
 import io.specmatic.core.pattern.parsedJsonValue
 import io.specmatic.test.reports.coverage.OpenApiCoverage
-import io.specmatic.test.utils.MockHttpServer
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -15,7 +14,7 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
-import java.net.ServerSocket
+import java.net.ConnectException
 
 class ApplicationApiDiscoveryTest {
     companion object {
@@ -37,13 +36,13 @@ class ApplicationApiDiscoveryTest {
     @ParameterizedTest
     @MethodSource("explicitApplicationApiSourceCases")
     fun `should report connectivity errors for explicit application api sources`(sourceCase: ApplicationApiSourceCase) {
-        val unusedPort = ServerSocket(0).use { it.localPort }
-        val sourceUrl = "http://localhost:$unusedPort"
+        val sourceUrl = "http://unavailable.example"
         val coverage = coverage()
+        val discovery = discovery { throw ConnectException("Connection refused") }
 
         val output = captureStdout {
             assertDoesNotThrow {
-                discovery().discover(listOf(sourceCase.source(sourceUrl)), coverage)
+                discovery.discover(listOf(sourceCase.source(sourceUrl)), coverage)
             }
         }
 
@@ -56,59 +55,56 @@ class ApplicationApiDiscoveryTest {
     @ParameterizedTest
     @MethodSource("explicitApplicationApiSourceCases")
     fun `should report non-200 responses for explicit application api sources`(sourceCase: ApplicationApiSourceCase) {
-        MockHttpServer().use { server ->
-            server.on(sourceCase.requestPath, "GET") { respond(503) }
+        val sourceUrl = "http://unavailable.example"
+        val discovery = discovery { HttpResponse(status = 503) }
 
-            val output = captureStdout {
-                discovery().discover(listOf(sourceCase.source(server.baseUrl)), coverage())
-            }
-
-            assertThat(output).contains(
-                "ERROR",
-                "explicitly configured ${sourceCase.displayName}",
-                server.baseUrl,
-                "Received HTTP status 503",
-            )
+        val output = captureStdout {
+            discovery.discover(listOf(sourceCase.source(sourceUrl)), coverage())
         }
+
+        assertThat(output).contains(
+            "ERROR",
+            "explicitly configured ${sourceCase.displayName}",
+            sourceUrl,
+            "Received HTTP status 503",
+        )
     }
 
     @Test
     fun `should report malformed Swagger documents from an explicit URL`() {
-        MockHttpServer().use { server ->
-            server.on("/", "GET") {
-                respond(HttpResponse(status = 200, body = parsedJsonValue("""{"not":"openapi"}""")))
-            }
-
-            val output = captureStdout {
-                discovery().discover(listOf(ApplicationApiSource.Swagger(server.baseUrl)), coverage())
-            }
-
-            assertThat(output).contains("ERROR", "explicitly configured Swagger URL", server.baseUrl)
+        val sourceUrl = "http://swagger.example"
+        val discovery = discovery {
+            HttpResponse(status = 200, body = parsedJsonValue("""{"not":"openapi"}"""))
         }
+
+        val output = captureStdout {
+            discovery.discover(listOf(ApplicationApiSource.Swagger(sourceUrl)), coverage())
+        }
+
+        assertThat(output).contains("ERROR", "explicitly configured Swagger URL", sourceUrl)
     }
 
     @Test
     fun `should report malformed actuator responses from an explicit URL`() {
-        MockHttpServer().use { server ->
-            server.on("/", "GET") {
-                respond(HttpResponse(status = 200, body = parsedJsonValue("""{"not":"actuator"}""")))
-            }
-
-            val output = captureStdout {
-                discovery().discover(listOf(ApplicationApiSource.Actuator(server.baseUrl)), coverage())
-            }
-
-            assertThat(output).contains("ERROR", "explicitly configured actuator URL", server.baseUrl)
+        val sourceUrl = "http://actuator.example"
+        val discovery = discovery {
+            HttpResponse(status = 200, body = parsedJsonValue("""{"not":"actuator"}"""))
         }
+
+        val output = captureStdout {
+            discovery.discover(listOf(ApplicationApiSource.Actuator(sourceUrl)), coverage())
+        }
+
+        assertThat(output).contains("ERROR", "explicitly configured actuator URL", sourceUrl)
     }
 
     @Test
     fun `should not report connectivity errors for an inferred application api source`() {
-        val unusedPort = ServerSocket(0).use { it.localPort }
-        val sourceUrl = "http://localhost:$unusedPort"
+        val sourceUrl = "http://inferred.example"
+        val discovery = discovery { throw ConnectException("Connection refused") }
 
         val output = captureStdout {
-            discovery().discover(
+            discovery.discover(
                 listOf(ApplicationApiSource.Swagger(sourceUrl, isExplicitlyConfigured = false)),
                 coverage(),
             )
@@ -118,29 +114,37 @@ class ApplicationApiDiscoveryTest {
     }
 
     @Test
-    fun `should retain APIs from successful sources when another explicit source is unreachable`() {
-        val unusedPort = ServerSocket(0).use { it.localPort }
-        MockHttpServer().use { server ->
-            server.on("/", "GET") {
-                respond(HttpResponse(status = 200, body = parsedJsonValue(openApiJson("customers-app", "/customers/internal"))))
-            }
-            val unreachableUrl = "http://localhost:$unusedPort"
-            val coverage = coverage()
-
-            val output = captureStdout {
-                discovery().discover(
-                    listOf(
-                        ApplicationApiSource.Swagger(unreachableUrl),
-                        ApplicationApiSource.Swagger(server.baseUrl),
-                    ),
-                    coverage,
+    fun `should continue to successful source after an explicit source is unreachable`() {
+        val unavailableUrl = "http://unavailable.example/openapi.yaml"
+        val successfulUrl = "http://successful.example/openapi.yaml"
+        val requestedUrls = mutableListOf<String>()
+        val sourceClient = ApplicationApiSourceClient { applicationApiSourceUrl ->
+            requestedUrls.add(applicationApiSourceUrl)
+            when (applicationApiSourceUrl) {
+                unavailableUrl -> throw ConnectException("Connection refused")
+                successfulUrl -> HttpResponse(
+                    status = 200,
+                    body = parsedJsonValue(openApiJson("customers-app", "/customers/internal")),
                 )
+                else -> error("Unexpected application API source URL $applicationApiSourceUrl")
             }
-
-            assertThat(output).contains("ERROR", unreachableUrl)
-            assertThat(coverage.getApplicationAPIs()).contains(API("GET", "/customers/internal"))
-            assertThat(coverage.isEndpointsApiSet()).isTrue()
         }
+        val coverage = coverage()
+
+        val output = captureStdout {
+            ApplicationApiDiscovery(sourceClient).discover(
+                listOf(
+                    ApplicationApiSource.Swagger(unavailableUrl),
+                    ApplicationApiSource.Swagger(successfulUrl),
+                ),
+                coverage,
+            )
+        }
+
+        assertThat(requestedUrls).containsExactly(unavailableUrl, successfulUrl)
+        assertThat(output).contains("ERROR", unavailableUrl)
+        assertThat(coverage.getApplicationAPIs()).contains(API("GET", "/customers/internal"))
+        assertThat(coverage.isEndpointsApiSet()).isTrue()
     }
 
     @ParameterizedTest
@@ -149,23 +153,23 @@ class ApplicationApiDiscoveryTest {
         sourceCase: ApplicationApiSourceCase,
         responseBody: String,
     ) {
-        MockHttpServer().use { server ->
-            server.on(sourceCase.requestPath, "GET") {
-                respond(HttpResponse(status = 200, body = parsedJsonValue(responseBody)))
-            }
-            val coverage = coverage()
-
-            val output = captureStdout {
-                discovery().discover(listOf(sourceCase.source(server.baseUrl)), coverage)
-            }
-
-            assertThat(output).doesNotContain("ERROR")
-            assertThat(coverage.isEndpointsApiSet()).isTrue()
-            assertThat(coverage.getApplicationAPIs()).isEmpty()
+        val discovery = discovery {
+            HttpResponse(status = 200, body = parsedJsonValue(responseBody))
         }
+        val coverage = coverage()
+
+        val output = captureStdout {
+            discovery.discover(listOf(sourceCase.source("http://application.example")), coverage)
+        }
+
+        assertThat(output).doesNotContain("ERROR")
+        assertThat(coverage.isEndpointsApiSet()).isTrue()
+        assertThat(coverage.getApplicationAPIs()).isEmpty()
     }
 
-    private fun discovery() = ApplicationApiDiscovery(prettyPrint = true, keyDataFor = { null })
+    private fun discovery(sourceClient: ApplicationApiSourceClient): ApplicationApiDiscovery {
+        return ApplicationApiDiscovery(sourceClient)
+    }
 
     private fun coverage() = OpenApiCoverage(configFilePath = "")
 
@@ -190,13 +194,10 @@ class ApplicationApiDiscoveryTest {
     }
 }
 
-enum class ApplicationApiSourceCase(
-    val displayName: String,
-    val requestPath: String,
-) {
-    ACTUATOR("actuator URL", "/"),
-    SWAGGER("Swagger URL", "/"),
-    SWAGGER_UI("Swagger UI base URL", "/swagger/v1/swagger.yaml");
+enum class ApplicationApiSourceCase(val displayName: String) {
+    ACTUATOR("actuator URL"),
+    SWAGGER("Swagger URL"),
+    SWAGGER_UI("Swagger UI base URL");
 
     fun source(url: String): ApplicationApiSource {
         return when (this) {

--- a/junit5-support/src/test/kotlin/io/specmatic/test/ApplicationApiDiscoveryTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/ApplicationApiDiscoveryTest.kt
@@ -47,7 +47,8 @@ class ApplicationApiDiscoveryTest {
         }
 
         assertThat(output)
-            .contains("ERROR", "explicitly configured ${sourceCase.displayName}", sourceUrl)
+            .contains("WARNING: Could not use ${sourceCase.displayName} at $sourceUrl")
+            .doesNotContain("ERROR", "explicitly configured")
             .containsIgnoringCase("connect")
         assertThat(coverage.isEndpointsApiSet()).isFalse()
     }
@@ -62,12 +63,9 @@ class ApplicationApiDiscoveryTest {
             discovery.discover(listOf(sourceCase.source(sourceUrl)), coverage())
         }
 
-        assertThat(output).contains(
-            "ERROR",
-            "explicitly configured ${sourceCase.displayName}",
-            sourceUrl,
-            "Received HTTP status 503",
-        )
+        assertThat(output)
+            .contains("WARNING: Could not use ${sourceCase.displayName} at $sourceUrl: Received HTTP status 503")
+            .doesNotContain("ERROR", "explicitly configured")
     }
 
     @Test
@@ -81,7 +79,7 @@ class ApplicationApiDiscoveryTest {
             discovery.discover(listOf(ApplicationApiSource.Swagger(sourceUrl)), coverage())
         }
 
-        assertThat(output).contains("ERROR", "explicitly configured Swagger URL", sourceUrl)
+        assertThat(output).contains("WARNING", "Swagger URL", sourceUrl).doesNotContain("ERROR")
     }
 
     @Test
@@ -95,7 +93,7 @@ class ApplicationApiDiscoveryTest {
             discovery.discover(listOf(ApplicationApiSource.Actuator(sourceUrl)), coverage())
         }
 
-        assertThat(output).contains("ERROR", "explicitly configured actuator URL", sourceUrl)
+        assertThat(output).contains("WARNING", "actuator URL", sourceUrl).doesNotContain("ERROR")
     }
 
     @Test
@@ -110,7 +108,7 @@ class ApplicationApiDiscoveryTest {
             )
         }
 
-        assertThat(output).doesNotContain("ERROR", "explicitly configured")
+        assertThat(output).doesNotContain("ERROR", "WARNING", "explicitly configured")
     }
 
     @Test
@@ -142,7 +140,7 @@ class ApplicationApiDiscoveryTest {
         }
 
         assertThat(requestedUrls).containsExactly(unavailableUrl, successfulUrl)
-        assertThat(output).contains("ERROR", unavailableUrl)
+        assertThat(output).contains("WARNING", unavailableUrl).doesNotContain("ERROR")
         assertThat(coverage.getApplicationAPIs()).contains(API("GET", "/customers/internal"))
         assertThat(coverage.isEndpointsApiSet()).isTrue()
     }
@@ -162,7 +160,7 @@ class ApplicationApiDiscoveryTest {
             discovery.discover(listOf(sourceCase.source("http://application.example")), coverage)
         }
 
-        assertThat(output).doesNotContain("ERROR")
+        assertThat(output).doesNotContain("ERROR", "WARNING")
         assertThat(coverage.isEndpointsApiSet()).isTrue()
         assertThat(coverage.getApplicationAPIs()).isEmpty()
     }

--- a/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
@@ -61,6 +61,23 @@ import java.io.PrintStream
 import java.net.ServerSocket
 import java.util.*
 
+enum class ExplicitApplicationApiSource(
+    val displayName: String,
+    val requestPath: String,
+) {
+    ACTUATOR("actuator URL", "/"),
+    SWAGGER("Swagger URL", "/"),
+    SWAGGER_UI("Swagger UI base URL", "/swagger/v1/swagger.yaml");
+
+    fun openApiConfig(url: String): OpenApiTestConfig {
+        return when (this) {
+            ACTUATOR -> OpenApiTestConfig(actuatorUrl = url)
+            SWAGGER -> OpenApiTestConfig(swaggerUrl = url)
+            SWAGGER_UI -> OpenApiTestConfig(swaggerUiBaseUrl = url)
+        }
+    }
+}
+
 class SpecmaticJunitSupportTest {
     companion object {
         val initialPropertyKeys = System.getProperties().mapKeys { it.key.toString() }.keys
@@ -103,6 +120,20 @@ class SpecmaticJunitSupportTest {
                 Arguments.of("http://override.example", "http://config.example", "http://spec.example", "http://override.example"),
                 Arguments.of(null, "http://config.example", "http://spec.example", "http://config.example"),
                 Arguments.of(null, null, "http://spec.example", "http://spec.example")
+            )
+
+        @JvmStatic
+        fun explicitApplicationApiSourceCases(): List<Arguments> =
+            ExplicitApplicationApiSource.entries.map { Arguments.of(it) }
+
+        @JvmStatic
+        fun emptyApplicationApiSourceCases(): List<Arguments> =
+            listOf(
+                Arguments.of(ExplicitApplicationApiSource.ACTUATOR, """{"contexts":{}}"""),
+                Arguments.of(
+                    ExplicitApplicationApiSource.SWAGGER,
+                    """{"openapi":"3.0.0","info":{"title":"empty","version":"1.0.0"},"paths":{}}""",
+                ),
             )
     }
 
@@ -481,6 +512,188 @@ class SpecmaticJunitSupportTest {
                     SpecmaticJUnitSupport.settingsStaging.remove()
                 }
             }
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("explicitApplicationApiSourceCases")
+    fun `should report connectivity errors for explicit application api sources`(
+        source: ExplicitApplicationApiSource,
+        @TempDir tempDir: File,
+    ) {
+        val specFile = writeOpenApiSpec(tempDir, "orders.yaml")
+        val unusedPort = ServerSocket(0).use { it.localPort }
+        val sourceUrl = "http://localhost:$unusedPort"
+        val configFile = writeSpecmaticConfig(tempDir, openApiConfig = source.openApiConfig(sourceUrl))
+        SpecmaticJUnitSupport.settingsStaging.set(
+            ContractTestSettings(contractPaths = specFile.canonicalPath, configFile = configFile.canonicalPath)
+        )
+
+        val output = captureStdout {
+            assertDoesNotThrow { SpecmaticJUnitSupport().contractTest().toList() }
+        }
+
+        assertThat(output)
+            .contains("ERROR", "explicitly configured ${source.displayName}", sourceUrl)
+            .containsIgnoringCase("connect")
+    }
+
+    @ParameterizedTest
+    @MethodSource("explicitApplicationApiSourceCases")
+    fun `should report non-200 responses for explicit application api sources`(
+        source: ExplicitApplicationApiSource,
+        @TempDir tempDir: File,
+    ) {
+        val specFile = writeOpenApiSpec(tempDir, "orders.yaml")
+        MockHttpServer().use { server ->
+            server.on(source.requestPath, "GET") { respond(503) }
+            val configFile = writeSpecmaticConfig(tempDir, openApiConfig = source.openApiConfig(server.baseUrl))
+            SpecmaticJUnitSupport.settingsStaging.set(
+                ContractTestSettings(contractPaths = specFile.canonicalPath, configFile = configFile.canonicalPath)
+            )
+
+            val output = captureStdout { SpecmaticJUnitSupport().contractTest().toList() }
+
+            assertThat(output).contains(
+                "ERROR",
+                "explicitly configured ${source.displayName}",
+                server.baseUrl,
+                "Received HTTP status 503",
+            )
+        }
+    }
+
+    @Test
+    fun `should report malformed Swagger documents from an explicit URL`(@TempDir tempDir: File) {
+        val specFile = writeOpenApiSpec(tempDir, "orders.yaml")
+        MockHttpServer().use { server ->
+            server.on("/", "GET") {
+                respond(HttpResponse(status = 200, body = parsedJsonValue("""{"not":"openapi"}""")))
+            }
+            val configFile = writeSpecmaticConfig(
+                tempDir,
+                openApiConfig = OpenApiTestConfig(swaggerUrl = server.baseUrl),
+            )
+            SpecmaticJUnitSupport.settingsStaging.set(
+                ContractTestSettings(contractPaths = specFile.canonicalPath, configFile = configFile.canonicalPath)
+            )
+
+            val output = captureStdout { SpecmaticJUnitSupport().contractTest().toList() }
+
+            assertThat(output).contains("ERROR", "explicitly configured Swagger URL", server.baseUrl)
+        }
+    }
+
+    @Test
+    fun `should report malformed actuator responses from an explicit URL`(@TempDir tempDir: File) {
+        val specFile = writeOpenApiSpec(tempDir, "orders.yaml")
+        MockHttpServer().use { server ->
+            server.on("/", "GET") {
+                respond(HttpResponse(status = 200, body = parsedJsonValue("""{"not":"actuator"}""")))
+            }
+            val configFile = writeSpecmaticConfig(
+                tempDir,
+                openApiConfig = OpenApiTestConfig(actuatorUrl = server.baseUrl),
+            )
+            SpecmaticJUnitSupport.settingsStaging.set(
+                ContractTestSettings(contractPaths = specFile.canonicalPath, configFile = configFile.canonicalPath)
+            )
+
+            val output = captureStdout { SpecmaticJUnitSupport().contractTest().toList() }
+
+            assertThat(output).contains("ERROR", "explicitly configured actuator URL", server.baseUrl)
+        }
+    }
+
+    @Test
+    fun `should not report connectivity errors for an inferred application api source`(@TempDir tempDir: File) {
+        val specFile = writeOpenApiSpec(tempDir, "orders.yaml")
+        val unusedPort = ServerSocket(0).use { it.localPort }
+        SpecmaticJUnitSupport.settingsStaging.set(
+            ContractTestSettings(contractPaths = specFile.canonicalPath, testBaseURL = "http://localhost:$unusedPort")
+        )
+
+        val output = captureStdout { SpecmaticJUnitSupport().contractTest().toList() }
+
+        assertThat(output).doesNotContain("ERROR", "explicitly configured")
+    }
+
+    @Test
+    fun `should retain APIs from successful sources when another explicit source is unreachable`(@TempDir tempDir: File) {
+        val specDir = tempDir.resolve("specs").apply { mkdirs() }
+        specDir.resolve("orders.yaml").writeText(openApiSpec("orders", "/orders"))
+        specDir.resolve("customers.yaml").writeText(openApiSpec("customers", "/customers"))
+        val unusedPort = ServerSocket(0).use { it.localPort }
+
+        MockHttpServer().use { customerSwagger ->
+            customerSwagger.on("/", "GET") {
+                respond(HttpResponse(status = 200, body = parsedJsonValue(openApiJson("customers-app", "/customers/internal"))))
+            }
+            val unreachableUrl = "http://localhost:$unusedPort"
+            val configFile = tempDir.resolve("specmatic.yaml").apply {
+                writeText(
+                    """
+                    version: 3
+                    systemUnderTest:
+                      service:
+                        definitions:
+                          - definition:
+                              source:
+                                filesystem:
+                                  directory: ${specDir.canonicalPath}
+                              specs:
+                                - spec:
+                                    id: orders
+                                    path: orders.yaml
+                                - spec:
+                                    id: customers
+                                    path: customers.yaml
+                        runOptions:
+                          openapi:
+                            specs:
+                              - spec:
+                                  id: orders
+                                  swaggerUrl: $unreachableUrl
+                              - spec:
+                                  id: customers
+                                  swaggerUrl: ${customerSwagger.baseUrl}
+                    """.trimIndent()
+                )
+            }
+            SpecmaticJUnitSupport.settingsStaging.set(ContractTestSettings(configFile = configFile.canonicalPath))
+            val support = SpecmaticJUnitSupport()
+
+            val output = captureStdout { support.contractTest().toList() }
+
+            assertThat(output).contains("ERROR", unreachableUrl)
+            assertThat(support.openApiCoverage.getApplicationAPIs()).contains(API("GET", "/customers/internal"))
+            assertThat(support.openApiCoverage.isEndpointsApiSet()).isTrue()
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("emptyApplicationApiSourceCases")
+    fun `should accept valid application api responses containing no APIs`(
+        source: ExplicitApplicationApiSource,
+        responseBody: String,
+        @TempDir tempDir: File,
+    ) {
+        val specFile = writeOpenApiSpec(tempDir, "orders.yaml")
+        MockHttpServer().use { server ->
+            server.on(source.requestPath, "GET") {
+                respond(HttpResponse(status = 200, body = parsedJsonValue(responseBody)))
+            }
+            val configFile = writeSpecmaticConfig(tempDir, openApiConfig = source.openApiConfig(server.baseUrl))
+            SpecmaticJUnitSupport.settingsStaging.set(
+                ContractTestSettings(contractPaths = specFile.canonicalPath, configFile = configFile.canonicalPath)
+            )
+            val support = SpecmaticJUnitSupport()
+
+            val output = captureStdout { support.contractTest().toList() }
+
+            assertThat(output).doesNotContain("ERROR")
+            assertThat(support.openApiCoverage.isEndpointsApiSet()).isTrue()
+            assertThat(support.openApiCoverage.getApplicationAPIs()).isEmpty()
         }
     }
 
@@ -1356,7 +1569,12 @@ paths:
         }
     }
 
-    private fun writeSpecmaticConfig(tempDir: File, baseUrl: String? = null, maxTestCount: Int? = null): File {
+    private fun writeSpecmaticConfig(
+        tempDir: File,
+        baseUrl: String? = null,
+        maxTestCount: Int? = null,
+        openApiConfig: OpenApiTestConfig = OpenApiTestConfig(baseUrl = baseUrl),
+    ): File {
         val configFile = tempDir.resolve("specmatic.yaml")
         val config = SpecmaticConfigV3(
             version = SpecmaticConfigVersion.VERSION_3,
@@ -1364,7 +1582,7 @@ paths:
                 service = RefOrValue.Value(
                     CommonServiceConfig(
                         definitions = emptyList(),
-                        runOptions = RefOrValue.Value(TestRunOptions(openapi = OpenApiTestConfig(baseUrl = baseUrl))),
+                        runOptions = RefOrValue.Value(TestRunOptions(openapi = openApiConfig)),
                         settings = RefOrValue.Value(TestSettings(maxTestCount = maxTestCount))
                     )
                 )

--- a/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
@@ -61,23 +61,6 @@ import java.io.PrintStream
 import java.net.ServerSocket
 import java.util.*
 
-enum class ExplicitApplicationApiSource(
-    val displayName: String,
-    val requestPath: String,
-) {
-    ACTUATOR("actuator URL", "/"),
-    SWAGGER("Swagger URL", "/"),
-    SWAGGER_UI("Swagger UI base URL", "/swagger/v1/swagger.yaml");
-
-    fun openApiConfig(url: String): OpenApiTestConfig {
-        return when (this) {
-            ACTUATOR -> OpenApiTestConfig(actuatorUrl = url)
-            SWAGGER -> OpenApiTestConfig(swaggerUrl = url)
-            SWAGGER_UI -> OpenApiTestConfig(swaggerUiBaseUrl = url)
-        }
-    }
-}
-
 class SpecmaticJunitSupportTest {
     companion object {
         val initialPropertyKeys = System.getProperties().mapKeys { it.key.toString() }.keys
@@ -122,19 +105,6 @@ class SpecmaticJunitSupportTest {
                 Arguments.of(null, null, "http://spec.example", "http://spec.example")
             )
 
-        @JvmStatic
-        fun explicitApplicationApiSourceCases(): List<Arguments> =
-            ExplicitApplicationApiSource.entries.map { Arguments.of(it) }
-
-        @JvmStatic
-        fun emptyApplicationApiSourceCases(): List<Arguments> =
-            listOf(
-                Arguments.of(ExplicitApplicationApiSource.ACTUATOR, """{"contexts":{}}"""),
-                Arguments.of(
-                    ExplicitApplicationApiSource.SWAGGER,
-                    """{"openapi":"3.0.0","info":{"title":"empty","version":"1.0.0"},"paths":{}}""",
-                ),
-            )
     }
 
     @Test
@@ -512,188 +482,6 @@ class SpecmaticJunitSupportTest {
                     SpecmaticJUnitSupport.settingsStaging.remove()
                 }
             }
-        }
-    }
-
-    @ParameterizedTest
-    @MethodSource("explicitApplicationApiSourceCases")
-    fun `should report connectivity errors for explicit application api sources`(
-        source: ExplicitApplicationApiSource,
-        @TempDir tempDir: File,
-    ) {
-        val specFile = writeOpenApiSpec(tempDir, "orders.yaml")
-        val unusedPort = ServerSocket(0).use { it.localPort }
-        val sourceUrl = "http://localhost:$unusedPort"
-        val configFile = writeSpecmaticConfig(tempDir, openApiConfig = source.openApiConfig(sourceUrl))
-        SpecmaticJUnitSupport.settingsStaging.set(
-            ContractTestSettings(contractPaths = specFile.canonicalPath, configFile = configFile.canonicalPath)
-        )
-
-        val output = captureStdout {
-            assertDoesNotThrow { SpecmaticJUnitSupport().contractTest().toList() }
-        }
-
-        assertThat(output)
-            .contains("ERROR", "explicitly configured ${source.displayName}", sourceUrl)
-            .containsIgnoringCase("connect")
-    }
-
-    @ParameterizedTest
-    @MethodSource("explicitApplicationApiSourceCases")
-    fun `should report non-200 responses for explicit application api sources`(
-        source: ExplicitApplicationApiSource,
-        @TempDir tempDir: File,
-    ) {
-        val specFile = writeOpenApiSpec(tempDir, "orders.yaml")
-        MockHttpServer().use { server ->
-            server.on(source.requestPath, "GET") { respond(503) }
-            val configFile = writeSpecmaticConfig(tempDir, openApiConfig = source.openApiConfig(server.baseUrl))
-            SpecmaticJUnitSupport.settingsStaging.set(
-                ContractTestSettings(contractPaths = specFile.canonicalPath, configFile = configFile.canonicalPath)
-            )
-
-            val output = captureStdout { SpecmaticJUnitSupport().contractTest().toList() }
-
-            assertThat(output).contains(
-                "ERROR",
-                "explicitly configured ${source.displayName}",
-                server.baseUrl,
-                "Received HTTP status 503",
-            )
-        }
-    }
-
-    @Test
-    fun `should report malformed Swagger documents from an explicit URL`(@TempDir tempDir: File) {
-        val specFile = writeOpenApiSpec(tempDir, "orders.yaml")
-        MockHttpServer().use { server ->
-            server.on("/", "GET") {
-                respond(HttpResponse(status = 200, body = parsedJsonValue("""{"not":"openapi"}""")))
-            }
-            val configFile = writeSpecmaticConfig(
-                tempDir,
-                openApiConfig = OpenApiTestConfig(swaggerUrl = server.baseUrl),
-            )
-            SpecmaticJUnitSupport.settingsStaging.set(
-                ContractTestSettings(contractPaths = specFile.canonicalPath, configFile = configFile.canonicalPath)
-            )
-
-            val output = captureStdout { SpecmaticJUnitSupport().contractTest().toList() }
-
-            assertThat(output).contains("ERROR", "explicitly configured Swagger URL", server.baseUrl)
-        }
-    }
-
-    @Test
-    fun `should report malformed actuator responses from an explicit URL`(@TempDir tempDir: File) {
-        val specFile = writeOpenApiSpec(tempDir, "orders.yaml")
-        MockHttpServer().use { server ->
-            server.on("/", "GET") {
-                respond(HttpResponse(status = 200, body = parsedJsonValue("""{"not":"actuator"}""")))
-            }
-            val configFile = writeSpecmaticConfig(
-                tempDir,
-                openApiConfig = OpenApiTestConfig(actuatorUrl = server.baseUrl),
-            )
-            SpecmaticJUnitSupport.settingsStaging.set(
-                ContractTestSettings(contractPaths = specFile.canonicalPath, configFile = configFile.canonicalPath)
-            )
-
-            val output = captureStdout { SpecmaticJUnitSupport().contractTest().toList() }
-
-            assertThat(output).contains("ERROR", "explicitly configured actuator URL", server.baseUrl)
-        }
-    }
-
-    @Test
-    fun `should not report connectivity errors for an inferred application api source`(@TempDir tempDir: File) {
-        val specFile = writeOpenApiSpec(tempDir, "orders.yaml")
-        val unusedPort = ServerSocket(0).use { it.localPort }
-        SpecmaticJUnitSupport.settingsStaging.set(
-            ContractTestSettings(contractPaths = specFile.canonicalPath, testBaseURL = "http://localhost:$unusedPort")
-        )
-
-        val output = captureStdout { SpecmaticJUnitSupport().contractTest().toList() }
-
-        assertThat(output).doesNotContain("ERROR", "explicitly configured")
-    }
-
-    @Test
-    fun `should retain APIs from successful sources when another explicit source is unreachable`(@TempDir tempDir: File) {
-        val specDir = tempDir.resolve("specs").apply { mkdirs() }
-        specDir.resolve("orders.yaml").writeText(openApiSpec("orders", "/orders"))
-        specDir.resolve("customers.yaml").writeText(openApiSpec("customers", "/customers"))
-        val unusedPort = ServerSocket(0).use { it.localPort }
-
-        MockHttpServer().use { customerSwagger ->
-            customerSwagger.on("/", "GET") {
-                respond(HttpResponse(status = 200, body = parsedJsonValue(openApiJson("customers-app", "/customers/internal"))))
-            }
-            val unreachableUrl = "http://localhost:$unusedPort"
-            val configFile = tempDir.resolve("specmatic.yaml").apply {
-                writeText(
-                    """
-                    version: 3
-                    systemUnderTest:
-                      service:
-                        definitions:
-                          - definition:
-                              source:
-                                filesystem:
-                                  directory: ${specDir.canonicalPath}
-                              specs:
-                                - spec:
-                                    id: orders
-                                    path: orders.yaml
-                                - spec:
-                                    id: customers
-                                    path: customers.yaml
-                        runOptions:
-                          openapi:
-                            specs:
-                              - spec:
-                                  id: orders
-                                  swaggerUrl: $unreachableUrl
-                              - spec:
-                                  id: customers
-                                  swaggerUrl: ${customerSwagger.baseUrl}
-                    """.trimIndent()
-                )
-            }
-            SpecmaticJUnitSupport.settingsStaging.set(ContractTestSettings(configFile = configFile.canonicalPath))
-            val support = SpecmaticJUnitSupport()
-
-            val output = captureStdout { support.contractTest().toList() }
-
-            assertThat(output).contains("ERROR", unreachableUrl)
-            assertThat(support.openApiCoverage.getApplicationAPIs()).contains(API("GET", "/customers/internal"))
-            assertThat(support.openApiCoverage.isEndpointsApiSet()).isTrue()
-        }
-    }
-
-    @ParameterizedTest
-    @MethodSource("emptyApplicationApiSourceCases")
-    fun `should accept valid application api responses containing no APIs`(
-        source: ExplicitApplicationApiSource,
-        responseBody: String,
-        @TempDir tempDir: File,
-    ) {
-        val specFile = writeOpenApiSpec(tempDir, "orders.yaml")
-        MockHttpServer().use { server ->
-            server.on(source.requestPath, "GET") {
-                respond(HttpResponse(status = 200, body = parsedJsonValue(responseBody)))
-            }
-            val configFile = writeSpecmaticConfig(tempDir, openApiConfig = source.openApiConfig(server.baseUrl))
-            SpecmaticJUnitSupport.settingsStaging.set(
-                ContractTestSettings(contractPaths = specFile.canonicalPath, configFile = configFile.canonicalPath)
-            )
-            val support = SpecmaticJUnitSupport()
-
-            val output = captureStdout { support.contractTest().toList() }
-
-            assertThat(output).doesNotContain("ERROR")
-            assertThat(support.openApiCoverage.isEndpointsApiSet()).isTrue()
-            assertThat(support.openApiCoverage.getApplicationAPIs()).isEmpty()
         }
     }
 
@@ -1573,7 +1361,6 @@ paths:
         tempDir: File,
         baseUrl: String? = null,
         maxTestCount: Int? = null,
-        openApiConfig: OpenApiTestConfig = OpenApiTestConfig(baseUrl = baseUrl),
     ): File {
         val configFile = tempDir.resolve("specmatic.yaml")
         val config = SpecmaticConfigV3(
@@ -1582,7 +1369,7 @@ paths:
                 service = RefOrValue.Value(
                     CommonServiceConfig(
                         definitions = emptyList(),
-                        runOptions = RefOrValue.Value(TestRunOptions(openapi = openApiConfig)),
+                        runOptions = RefOrValue.Value(TestRunOptions(openapi = OpenApiTestConfig(baseUrl = baseUrl))),
                         settings = RefOrValue.Value(TestSettings(maxTestCount = maxTestCount))
                     )
                 )


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Application API discovery now distinguishes explicitly configured actuator, Swagger, and Swagger UI URLs from inferred fallbacks. An unusable explicit source produces a warning containing its type, URL, and failure reason, while inferred discovery remains best-effort and debug-only.

<!-- Why are these changes necessary? -->

**Why**:

Previously, a typo, connectivity problem, non-200 response, or malformed response from an explicitly configured discovery URL could be silently ignored. This made coverage gaps difficult to diagnose even though the user had deliberately configured that source.

<!-- How were these changes implemented? -->

**How**:

- Added compatibility-preserving explicitness metadata to `ApplicationApiSource`.
- Extracted fetching, parsing, failure reporting, and coverage updates from `SpecmaticJUnitSupport` into an internal `ApplicationApiDiscovery` component.
- Added an injectable application API source client while retaining production TLS key-data wiring.
- Processed distinct sources independently so one failure does not prevent later successful sources from contributing APIs.
- Treated successful empty responses as available discovery and retained failure reasons for connectivity, HTTP status, URL, parsing, and actuator-shape failures.
- Added focused unit coverage for explicit and inferred behavior, failure diagnostics, partial success, and empty success.


<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link) — N/A
- [ ] Sample Project added/updated (share link) — N/A
- [ ] Demo video (share link) — N/A
- [ ] Article on Website (share link) — N/A
- [ ] Roadmpap updated (share link) — N/A
- [ ] Conference Talk (share link) — N/A
