### PR TITLE
Deduplicate application API source discovery and refine coverage logging

### DIFF
--- a/junit5-support/src/main/kotlin/io/specmatic/test/ApplicationApiDiscovery.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/ApplicationApiDiscovery.kt
@@ -130,6 +130,7 @@ internal class ApplicationApiDiscovery(
         failure: ApplicationApiFetchResult.Failure,
     ) {
         if (source.isExplicitlyConfigured) {
+            logger.newLine()
             logger.log("WARNING: Could not use ${source.displayName()} at ${source.url}: ${failure.reason}")
         } else {
             logger.debug("Could not use inferred ${source.displayName()} at ${source.url}: ${failure.reason}")

--- a/junit5-support/src/main/kotlin/io/specmatic/test/ApplicationApiDiscovery.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/ApplicationApiDiscovery.kt
@@ -42,7 +42,8 @@ internal class ApplicationApiDiscovery(
     private val sourceClient: ApplicationApiSourceClient,
 ) {
     fun discover(sources: List<ApplicationApiSource>, coverage: OpenApiCoverage) {
-        val sourceFetches = sources.map { source ->
+        val uniqueSources = sources.distinct()
+        val sourceFetches = uniqueSources.map { source ->
             ApplicationApiSourceFetch(source, fetchApplicationApisFrom(source))
         }
 
@@ -56,7 +57,8 @@ internal class ApplicationApiDiscovery(
         val anySourceAvailable = sourceFetches.any { it.result is ApplicationApiFetchResult.Success }
         coverage.setEndpointsAPIFlag(anySourceAvailable)
 
-        if (!anySourceAvailable) {
+        val anyExplicitSourceConfigured = uniqueSources.any { it.isExplicitlyConfigured }
+        if (!anySourceAvailable && !anyExplicitSourceConfigured) {
             logger.boundary()
             logger.log("No application API source was exposed by the application, so cannot calculate actual coverage")
         }

--- a/junit5-support/src/test/kotlin/io/specmatic/test/ApplicationApiDiscoveryTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/ApplicationApiDiscoveryTest.kt
@@ -18,6 +18,9 @@ import java.net.ConnectException
 
 class ApplicationApiDiscoveryTest {
     companion object {
+        private const val NO_APPLICATION_API_SOURCE_MESSAGE =
+            "No application API source was exposed by the application, so cannot calculate actual coverage"
+
         @JvmStatic
         fun explicitApplicationApiSourceCases(): List<Arguments> =
             ApplicationApiSourceCase.entries.map { Arguments.of(it) }
@@ -48,7 +51,7 @@ class ApplicationApiDiscoveryTest {
 
         assertThat(output)
             .contains("WARNING: Could not use ${sourceCase.displayName} at $sourceUrl")
-            .doesNotContain("ERROR", "explicitly configured")
+            .doesNotContain("ERROR", "explicitly configured", NO_APPLICATION_API_SOURCE_MESSAGE)
             .containsIgnoringCase("connect")
         assertThat(coverage.isEndpointsApiSet()).isFalse()
     }
@@ -65,7 +68,7 @@ class ApplicationApiDiscoveryTest {
 
         assertThat(output)
             .contains("WARNING: Could not use ${sourceCase.displayName} at $sourceUrl: Received HTTP status 503")
-            .doesNotContain("ERROR", "explicitly configured")
+            .doesNotContain("ERROR", "explicitly configured", NO_APPLICATION_API_SOURCE_MESSAGE)
     }
 
     @Test
@@ -108,7 +111,61 @@ class ApplicationApiDiscoveryTest {
             )
         }
 
-        assertThat(output).doesNotContain("ERROR", "WARNING", "explicitly configured")
+        assertThat(output)
+            .containsOnlyOnce(NO_APPLICATION_API_SOURCE_MESSAGE)
+            .doesNotContain("ERROR", "WARNING", "explicitly configured")
+    }
+
+    @Test
+    fun `should report no application api source once when no sources are available`() {
+        val coverage = coverage()
+
+        val output = captureStdout {
+            discovery { error("No source should be fetched") }.discover(emptyList(), coverage)
+        }
+
+        assertThat(output).containsOnlyOnce(NO_APPLICATION_API_SOURCE_MESSAGE)
+        assertThat(coverage.isEndpointsApiSet()).isFalse()
+    }
+
+    @Test
+    fun `should fetch and report a duplicate explicit application api source once`() {
+        val source = ApplicationApiSource.Actuator("http://unavailable.example")
+        val requestedUrls = mutableListOf<String>()
+        val discovery = discovery { sourceUrl ->
+            requestedUrls.add(sourceUrl)
+            throw ConnectException("Connection refused")
+        }
+
+        val output = captureStdout {
+            discovery.discover(listOf(source, source), coverage())
+        }
+
+        assertThat(requestedUrls).containsExactly(source.url)
+        assertThat(output)
+            .containsOnlyOnce("WARNING: Could not use actuator URL at ${source.url}")
+            .doesNotContain(NO_APPLICATION_API_SOURCE_MESSAGE)
+    }
+
+    @Test
+    fun `should report each distinct explicit application api source once`() {
+        val actuatorSource = ApplicationApiSource.Actuator("http://actuator.example")
+        val swaggerSource = ApplicationApiSource.Swagger("http://swagger.example")
+        val requestedUrls = mutableListOf<String>()
+        val discovery = discovery { sourceUrl ->
+            requestedUrls.add(sourceUrl)
+            throw ConnectException("Connection refused")
+        }
+
+        val output = captureStdout {
+            discovery.discover(listOf(actuatorSource, swaggerSource), coverage())
+        }
+
+        assertThat(requestedUrls).containsExactly(actuatorSource.url, swaggerSource.url)
+        assertThat(output)
+            .containsOnlyOnce("WARNING: Could not use actuator URL at ${actuatorSource.url}")
+            .containsOnlyOnce("WARNING: Could not use Swagger URL at ${swaggerSource.url}")
+            .doesNotContain(NO_APPLICATION_API_SOURCE_MESSAGE)
     }
 
     @Test
@@ -140,7 +197,9 @@ class ApplicationApiDiscoveryTest {
         }
 
         assertThat(requestedUrls).containsExactly(unavailableUrl, successfulUrl)
-        assertThat(output).contains("WARNING", unavailableUrl).doesNotContain("ERROR")
+        assertThat(output)
+            .contains("WARNING", unavailableUrl)
+            .doesNotContain("ERROR", NO_APPLICATION_API_SOURCE_MESSAGE)
         assertThat(coverage.getApplicationAPIs()).contains(API("GET", "/customers/internal"))
         assertThat(coverage.isEndpointsApiSet()).isTrue()
     }

--- a/junit5-support/src/test/kotlin/io/specmatic/test/ApplicationApiDiscoveryTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/ApplicationApiDiscoveryTest.kt
@@ -49,8 +49,9 @@ class ApplicationApiDiscoveryTest {
             }
         }
 
+        val warning = "WARNING: Could not use ${sourceCase.displayName} at $sourceUrl"
         assertThat(output)
-            .contains("WARNING: Could not use ${sourceCase.displayName} at $sourceUrl")
+            .contains(System.lineSeparator() + warning)
             .doesNotContain("ERROR", "explicitly configured", NO_APPLICATION_API_SOURCE_MESSAGE)
             .containsIgnoringCase("connect")
         assertThat(coverage.isEndpointsApiSet()).isFalse()
@@ -66,8 +67,9 @@ class ApplicationApiDiscoveryTest {
             discovery.discover(listOf(sourceCase.source(sourceUrl)), coverage())
         }
 
+        val warning = "WARNING: Could not use ${sourceCase.displayName} at $sourceUrl: Received HTTP status 503"
         assertThat(output)
-            .contains("WARNING: Could not use ${sourceCase.displayName} at $sourceUrl: Received HTTP status 503")
+            .contains(System.lineSeparator() + warning)
             .doesNotContain("ERROR", "explicitly configured", NO_APPLICATION_API_SOURCE_MESSAGE)
     }
 
@@ -143,6 +145,7 @@ class ApplicationApiDiscoveryTest {
 
         assertThat(requestedUrls).containsExactly(source.url)
         assertThat(output)
+            .contains(System.lineSeparator() + "WARNING: Could not use actuator URL at ${source.url}")
             .containsOnlyOnce("WARNING: Could not use actuator URL at ${source.url}")
             .doesNotContain(NO_APPLICATION_API_SOURCE_MESSAGE)
     }
@@ -163,8 +166,13 @@ class ApplicationApiDiscoveryTest {
 
         assertThat(requestedUrls).containsExactly(actuatorSource.url, swaggerSource.url)
         assertThat(output)
+            .contains(System.lineSeparator() + "WARNING: Could not use actuator URL at ${actuatorSource.url}")
             .containsOnlyOnce("WARNING: Could not use actuator URL at ${actuatorSource.url}")
             .containsOnlyOnce("WARNING: Could not use Swagger URL at ${swaggerSource.url}")
+            .contains(
+                System.lineSeparator() + System.lineSeparator() +
+                    "WARNING: Could not use Swagger URL at ${swaggerSource.url}"
+            )
             .doesNotContain(NO_APPLICATION_API_SOURCE_MESSAGE)
     }
 


### PR DESCRIPTION
## Summary
- Deduplicate application API sources before fetching to avoid repeated requests and duplicate warnings.
- Suppress the generic "no application API source" message when an explicit source was configured.
- Add spacing before explicit-source warnings for clearer log output.
- Expand tests to cover duplicate sources, distinct explicit sources, empty source lists, and the updated logging behavior.

## Testing
- Added and updated unit tests covering discovery deduplication and log/message expectations.
- Not run (not requested).