### PR TITLE
Bug: Match security credentials in requests to the mock against values in examples

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/APIKeyInQueryParamSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/APIKeyInQueryParamSecurityScheme.kt
@@ -25,7 +25,7 @@ data class APIKeyInQueryParamSecurityScheme(val name: String, private val apiKey
     override fun addTo(httpRequest: HttpRequest, resolver: Resolver): HttpRequest {
         val updatedResolver = resolver.updateLookupForParam(BreadCrumb.QUERY.value)
         val apiKeyValue = apiKey ?: updatedResolver.generate(null, name, StringPattern()).toStringLiteral()
-        return httpRequest.copy(queryParams = httpRequest.queryParams.plus(name to apiKeyValue))
+        return httpRequest.addSecurityQueryParam(name, apiKeyValue)
     }
 
     override fun addTo(requestPattern: HttpRequestPattern, row: Row): HttpRequestPattern {

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
@@ -413,6 +413,15 @@ data class HttpRequest(
         )
     }
 
+    internal fun withoutSpecmaticGeneratedSecurityHeaders(): HttpRequest {
+        val generatedSecurityHeaderNames = metadata.securityHeaderNames
+        return copy(
+            headers = headers.filterKeys { headerName ->
+                generatedSecurityHeaderNames.none { it.equals(headerName, ignoreCase = true) }
+            }
+        )
+    }
+
     fun expectedResponseCode(): Int? {
         return headers[SPECMATIC_RESPONSE_CODE_HEADER]?.toIntOrNull()
     }

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
@@ -39,7 +39,10 @@ fun urlToQueryParams(uri: URI): Map<String, String> {
     }
 }
 
-data class HttpRequestMetadata(val securityHeaderNames: Set<String> = emptySet())
+data class HttpRequestMetadata(
+    val securityHeaderNames: Set<String> = emptySet(),
+    val securityQueryParamNames: Set<String> = emptySet()
+)
 
 data class HttpRequest(
     val method: String? = null,
@@ -413,12 +416,29 @@ data class HttpRequest(
         )
     }
 
-    internal fun withoutSpecmaticGeneratedSecurityHeaders(): HttpRequest {
+    fun addSecurityQueryParam(queryParamName: String, queryParamValue: String): HttpRequest {
+        val updatedMetadata = metadata.copy(
+            securityQueryParamNames = metadata.securityQueryParamNames.plus(queryParamName)
+        )
+
+        return copy(
+            queryParams = queryParams.plus(queryParamName to queryParamValue),
+            metadata = updatedMetadata
+        )
+    }
+
+    internal fun withoutSpecmaticGeneratedSecurityParameters(): HttpRequest {
         val generatedSecurityHeaderNames = metadata.securityHeaderNames
+        val generatedSecurityQueryParamNames = metadata.securityQueryParamNames
         return copy(
             headers = headers.filterKeys { headerName ->
                 generatedSecurityHeaderNames.none { it.equals(headerName, ignoreCase = true) }
-            }
+            },
+            queryParams = QueryParameters(
+                queryParams.paramPairs.filterNot { (queryParamName, _) ->
+                    queryParamName in generatedSecurityQueryParamNames
+                }
+            )
         )
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
@@ -513,6 +513,7 @@ data class HttpRequestPattern(
     ): HttpRequestPattern {
         var requestPattern = HttpRequestPattern(undeclaredRequestVariantMetadata = undeclaredRequestVariantMetadata)
         val parseValueToType: (Value) -> Pattern = { it.exactMatchElseType() }
+        val authoredRequest = request.withoutSpecmaticGeneratedSecurityParameters()
 
         return attempt(breadCrumb = "REQUEST") {
             if (method == null) {
@@ -527,7 +528,7 @@ data class HttpRequestPattern(
             requestPattern = attempt(breadCrumb = "URL") {
                 val path = request.path ?: ""
                 val pathTypes = this.httpPathPattern.patternFrom(path, resolver, parseValueToType).allParameters()
-                val queryParamTypes = toExactTypeMapForQueryParameters(request.queryParams, httpQueryParamPattern, resolver)
+                val queryParamTypes = toExactTypeMapForQueryParameters(authoredRequest.queryParams, httpQueryParamPattern, resolver)
                 requestPattern.copy(
                     httpPathPattern = HttpPathPattern(pathTypes, path),
                     httpQueryParamPattern = HttpQueryParamPattern(
@@ -542,8 +543,7 @@ data class HttpRequestPattern(
             }
 
             requestPattern = attempt(breadCrumb = BreadCrumb.PARAM_HEADER.value) {
-                val authoredHeaders = request.withoutSpecmaticGeneratedSecurityHeaders().headers
-                val headersWithRelevantFields = headersPattern.removeContentType(authoredHeaders)
+                val headersWithRelevantFields = headersPattern.removeContentType(authoredRequest.headers)
 
                 val headersFromRequest = toExactTypeMap(
                     toLowerCaseKeys(headersWithRelevantFields),

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
@@ -542,12 +542,8 @@ data class HttpRequestPattern(
             }
 
             requestPattern = attempt(breadCrumb = BreadCrumb.PARAM_HEADER.value) {
-                val headersWithRelevantFields = securitySchemes.fold(request) { request, securityScheme ->
-                    securityScheme.removeParam(request)
-                }.headers
-                    .let {
-                        headersPattern.removeContentType(it)
-                    }
+                val authoredHeaders = request.withoutSpecmaticGeneratedSecurityHeaders().headers
+                val headersWithRelevantFields = headersPattern.removeContentType(authoredHeaders)
 
                 val headersFromRequest = toExactTypeMap(
                     toLowerCaseKeys(headersWithRelevantFields),

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStubData.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStubData.kt
@@ -59,7 +59,7 @@ data class HttpStubData(
     internal fun hasCompleteAuthoredSecurityRequirement(): Boolean {
         val request = resolveOriginalRequest() ?: return false
         val requestPattern = scenario?.httpRequestPattern ?: return false
-        val authoredRequest = request.withoutSpecmaticGeneratedSecurityHeaders()
+        val authoredRequest = request.withoutSpecmaticGeneratedSecurityParameters()
         return requestPattern.securitySchemes.any { securityScheme ->
             securityScheme.isInRequest(authoredRequest, complete = true)
         }

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStubData.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStubData.kt
@@ -56,6 +56,15 @@ data class HttpStubData(
         return partial?.request ?: originalRequest
     }
 
+    internal fun hasCompleteAuthoredSecurityRequirement(): Boolean {
+        val request = resolveOriginalRequest() ?: return false
+        val requestPattern = scenario?.httpRequestPattern ?: return false
+        val authoredRequest = request.withoutSpecmaticGeneratedSecurityHeaders()
+        return requestPattern.securitySchemes.any { securityScheme ->
+            securityScheme.isInRequest(authoredRequest, complete = true)
+        }
+    }
+
     val stubType: StubType get () {
         if(partial != null) {
             return StubType.Partial

--- a/core/src/main/kotlin/io/specmatic/stub/ThreadSafeListOfStubs.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/ThreadSafeListOfStubs.kt
@@ -75,7 +75,10 @@ class ThreadSafeListOfStubs(
             }
         }
 
-        val (_, queueMock) = queueMatchResults.findLast { (result, _) ->
+        val preferredMatch = queueMatchResults.findLast { (result, stubData) ->
+            result is Result.Success && stubData.hasCompleteAuthoredSecurityRequirement()
+        }
+        val (_, queueMock) = preferredMatch ?: queueMatchResults.findLast { (result, _) ->
             result is Result.Success
         } ?: return null
 
@@ -108,15 +111,19 @@ class ThreadSafeListOfStubs(
             stubData.stubType
         }
 
-        val exactMatch = grouped[StubType.Exact]
+        val exactMatches = grouped[StubType.Exact]
             .orEmpty()
             .sortedWith(comparator = compareBy(nullsLast()) { it.second.resolveOriginalRequest()?.generality })
-            .find { (result, _) -> result is Result.Success }
+        val exactMatch = exactMatches.find { (_, stubData) ->
+            stubData.hasCompleteAuthoredSecurityRequirement()
+        } ?: exactMatches.firstOrNull()
 
         if(exactMatch != null)
             return Pair(exactMatch.second, listMatchResults)
 
-        val partialMatch = ThreadSafeListOfStubs.getPartialBySpecificityAndGenerality(grouped[StubType.Partial].orEmpty().map { it.second })
+        val partials = grouped[StubType.Partial].orEmpty().map { it.second }
+        val preferredPartials = partials.filter { it.hasCompleteAuthoredSecurityRequirement() }
+        val partialMatch = ThreadSafeListOfStubs.getPartialBySpecificityAndGenerality(preferredPartials.ifEmpty { partials })
 
         if(partialMatch != null)
             return Pair(partialMatch, listMatchResults)
@@ -140,7 +147,9 @@ class ThreadSafeListOfStubs(
             substituteThenFillIn(httpRequest, stubData)
         }
 
-        val mock = mocks.find { (result, _) -> result is Result.Success }
+        val mock = mocks.find { (result, stubData) ->
+            result is Result.Success && stubData.hasCompleteAuthoredSecurityRequirement()
+        } ?: mocks.find { (result, _) -> result is Result.Success }
 
         return Pair(mock?.second, listMatchResults)
     }

--- a/core/src/test/kotlin/io/specmatic/core/HttpRequestPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpRequestPatternTest.kt
@@ -999,7 +999,7 @@ internal class HttpRequestPatternTest {
 
     @ParameterizedTest
     @MethodSource("headersBasedSecuritySchemesProvider")
-    fun `security schema headers should be ignored when converting headers from http request to pattern`(securityScheme: OpenAPISecurityScheme) {
+    fun `security scheme headers should be preserved when converting headers from http request to exact stub pattern`(securityScheme: OpenAPISecurityScheme) {
         val originalRequestPattern = HttpRequestPattern(
             httpPathPattern = buildHttpPathPattern("/"), method = "GET",
             headersPattern = HttpHeadersPattern(pattern = mapOf("X-Test-Header" to StringPattern()), contentType = "application/json"),
@@ -1012,8 +1012,52 @@ internal class HttpRequestPatternTest {
 
         assertThat(newRequestPattern.headersPattern.pattern).isEqualTo(mapOf(
             "x-test-header" to ExactValuePattern(StringValue("abc123")),
-            "x-extra-header" to ExactValuePattern(StringValue("def456"))
+            "x-extra-header" to ExactValuePattern(StringValue("def456")),
+            "authorization" to ExactValuePattern(StringValue("1234"))
         ))
+    }
+
+    @Test
+    fun `generated security headers should not become exact stub patterns`() {
+        val originalRequestPattern = HttpRequestPattern(
+            httpPathPattern = buildHttpPathPattern("/"),
+            method = "GET",
+            securitySchemes = listOf(APIKeyInHeaderSecurityScheme("X-Access-Key", null))
+        )
+        val generatedRequest = HttpRequest("GET", "/")
+            .addSecurityHeader("X-Access-Key", "generated-token")
+
+        val exactRequestPattern = originalRequestPattern.generateExactHttpRequestPatternFrom(
+            generatedRequest,
+            Resolver()
+        )
+
+        assertThat(exactRequestPattern.headersPattern.pattern).doesNotContainKey("x-access-key")
+    }
+
+    @Test
+    fun `security scheme query parameters should remain exact when converting an http request to an exact stub pattern`() {
+        val originalRequestPattern = HttpRequestPattern(
+            httpPathPattern = buildHttpPathPattern("/"),
+            method = "GET",
+            securitySchemes = listOf(APIKeyInQueryParamSecurityScheme("access_key", null))
+        )
+        val exactRequestPattern = originalRequestPattern.generateExactHttpRequestPatternFrom(
+            HttpRequest("GET", "/", queryParametersMap = mapOf("access_key" to "expected-query-token")),
+            Resolver()
+        )
+
+        val matchingResult = exactRequestPattern.matches(
+            HttpRequest("GET", "/", queryParametersMap = mapOf("access_key" to "expected-query-token")),
+            Resolver()
+        )
+        val mismatchingResult = exactRequestPattern.matches(
+            HttpRequest("GET", "/", queryParametersMap = mapOf("access_key" to "different-query-token")),
+            Resolver()
+        )
+
+        assertThat(matchingResult).isInstanceOf(Success::class.java)
+        assertThat(mismatchingResult).isInstanceOf(Failure::class.java)
     }
 
     @Test
@@ -1076,6 +1120,27 @@ internal class HttpRequestPatternTest {
             assertThat(negativePattern.httpQueryParamPattern.queryPatterns).doesNotContainKey("api_key")
             assertThat(negativePattern.securitySchemes).contains(APIKeyInHeaderSecurityScheme("X-Api-Key", null))
         }
+    }
+
+    @Test
+    fun `generation without examples should retain every top-level security alternative including composites`() {
+        val headerScheme = APIKeyInHeaderSecurityScheme("X-Access-Key", null)
+        val compositeScheme = CompositeSecurityScheme(
+            listOf(
+                APIKeyInHeaderSecurityScheme("X-Session-Key", null),
+                APIKeyInQueryParamSecurityScheme("session_key", null)
+            )
+        )
+        val requestPattern = HttpRequestPattern(
+            method = "GET",
+            httpPathPattern = buildHttpPathPattern("/products"),
+            securitySchemes = listOf(headerScheme, compositeScheme)
+        )
+
+        val generatedPatterns = requestPattern.newBasedOn(Resolver()).toList()
+
+        assertThat(generatedPatterns.map { it.securitySchemes.single() })
+            .containsExactly(headerScheme, compositeScheme)
     }
 
     @Nested

--- a/core/src/test/kotlin/io/specmatic/core/HttpRequestPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpRequestPatternTest.kt
@@ -1036,6 +1036,24 @@ internal class HttpRequestPatternTest {
     }
 
     @Test
+    fun `generated security query parameters should not become exact stub patterns`() {
+        val securityScheme = APIKeyInQueryParamSecurityScheme("access_key", "generated-token")
+        val originalRequestPattern = HttpRequestPattern(
+            httpPathPattern = buildHttpPathPattern("/"),
+            method = "GET",
+            securitySchemes = listOf(securityScheme)
+        )
+        val generatedRequest = securityScheme.addTo(HttpRequest("GET", "/"), Resolver())
+
+        val exactRequestPattern = originalRequestPattern.generateExactHttpRequestPatternFrom(
+            generatedRequest,
+            Resolver()
+        )
+
+        assertThat(exactRequestPattern.httpQueryParamPattern.queryPatterns).doesNotContainKey("access_key")
+    }
+
+    @Test
     fun `security scheme query parameters should remain exact when converting an http request to an exact stub pattern`() {
         val originalRequestPattern = HttpRequestPattern(
             httpPathPattern = buildHttpPathPattern("/"),

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
@@ -1056,7 +1056,46 @@ components:
     }
 
     @Test
-    fun `startup example should match the exact security header value`() {
+    fun `runtime expectations should match exact API key header and query parameter values`() {
+        val feature = OpenApiSpecification.fromFile(osAgnosticPath("src/test/resources/openapi/apiKeyAuthStub.yaml")).toFeature()
+
+        HttpStub(feature).use { stub ->
+            val headerRequestA = HttpRequest(
+                "GET",
+                "/hello/10",
+                mapOf("X-API-KEY" to "header-runtime-key-a")
+            )
+            val headerRequestB = headerRequestA.copy(
+                headers = headerRequestA.headers.plus("X-API-KEY" to "header-runtime-key-b")
+            )
+            val queryRequestA = HttpRequest(
+                "GET",
+                "/hello/10",
+                queryParametersMap = mapOf("apiKey" to "query-runtime-key-a")
+            )
+            val queryRequestB = queryRequestA.copy(
+                queryParams = QueryParameters(mapOf("apiKey" to "query-runtime-key-b"))
+            )
+            fun jsonStringResponse(body: String) = HttpResponse(
+                status = 200,
+                headers = mapOf(CONTENT_TYPE to "application/json"),
+                body = StringValue(body)
+            )
+
+            stub.setExpectation(ScenarioStub(headerRequestA, jsonStringResponse("header response a")))
+            stub.setExpectation(ScenarioStub(headerRequestB, jsonStringResponse("header response b")))
+            stub.setExpectation(ScenarioStub(queryRequestA, jsonStringResponse("query response a")))
+            stub.setExpectation(ScenarioStub(queryRequestB, jsonStringResponse("query response b")))
+
+            assertThat(stub.client.execute(headerRequestA).body).isEqualTo(StringValue("header response a"))
+            assertThat(stub.client.execute(headerRequestB).body).isEqualTo(StringValue("header response b"))
+            assertThat(stub.client.execute(queryRequestA).body).isEqualTo(StringValue("query response a"))
+            assertThat(stub.client.execute(queryRequestB).body).isEqualTo(StringValue("query response b"))
+        }
+    }
+
+    @Test
+    fun `startup examples should match exact API key header and query parameter values`() {
         val feature = OpenApiSpecification.fromFile(osAgnosticPath("src/test/resources/openapi/apiKeyAuthStub.yaml")).toFeature()
 
         val examples = File(osAgnosticPath("src/test/resources/openapi/apiKeyAuthStub_examples")).listFiles().orEmpty().map { file ->
@@ -1069,14 +1108,25 @@ components:
                 "/hello/10",
                 mapOf("X-API-KEY" to "abc123")
             )
-
-            val matchingResponse = stub.client.execute(request)
-            val mismatchingResponse = stub.client.execute(
-                request.copy(headers = request.headers.plus("X-API-KEY" to "different-key"))
+            val queryRequest = HttpRequest(
+                "GET",
+                "/hello/10",
+                queryParametersMap = mapOf("apiKey" to "query123")
             )
 
-            assertThat(matchingResponse.body.toStringLiteral()).isEqualTo("Hello, World!")
-            assertThat(mismatchingResponse.body.toStringLiteral()).isNotEqualTo("Hello, World!")
+            val matchingHeaderResponse = stub.client.execute(request)
+            val mismatchingHeaderResponse = stub.client.execute(
+                request.copy(headers = request.headers.plus("X-API-KEY" to "different-key"))
+            )
+            val matchingQueryResponse = stub.client.execute(queryRequest)
+            val mismatchingQueryResponse = stub.client.execute(
+                queryRequest.copy(queryParams = QueryParameters(mapOf("apiKey" to "different-key")))
+            )
+
+            assertThat(matchingHeaderResponse.body.toStringLiteral()).isEqualTo("Hello from header key!")
+            assertThat(mismatchingHeaderResponse.body.toStringLiteral()).isNotEqualTo("Hello from header key!")
+            assertThat(matchingQueryResponse.body.toStringLiteral()).isEqualTo("Hello from query key!")
+            assertThat(mismatchingQueryResponse.body.toStringLiteral()).isNotEqualTo("Hello from query key!")
         }
     }
 

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
@@ -980,7 +980,7 @@ paths:
     }
 
     @Test
-    fun `should be able to set expectations for an API with a security scheme`() {
+    fun `runtime expectations should match the exact security header value`() {
         val feature = OpenApiSpecification.fromYAML(
             """
 openapi: 3.0.0
@@ -1033,28 +1033,30 @@ components:
          """.trimIndent(), ""
         ).toFeature()
 
-        val credentials = "Basic " + Base64.getEncoder().encodeToString("user:password".toByteArray())
-
         HttpStub(feature).use { stub ->
-            val request = HttpRequest(
+            val firstRequest = HttpRequest(
                 "POST",
                 "/hello",
-                mapOf("Authorization" to "Bearer $credentials", "Content-Type" to "application/json"),
+                mapOf("Authorization" to "Bearer runtime-token-a", "Content-Type" to "application/json"),
                 parsedJSONObject("""{"message": "Hello there!"}""")
             )
+            val secondRequest = firstRequest.copy(
+                headers = firstRequest.headers.plus("Authorization" to "Bearer runtime-token-b")
+            )
 
-            val expectedResponse = HttpResponse.ok("success")
+            stub.setExpectation(ScenarioStub(firstRequest, HttpResponse.ok("first response")))
+            stub.setExpectation(ScenarioStub(secondRequest, HttpResponse.ok("second response")))
 
-            stub.setExpectation(ScenarioStub(request, expectedResponse))
+            val firstResponse = stub.client.execute(firstRequest)
+            val secondResponse = stub.client.execute(secondRequest)
 
-            val response = stub.client.execute(request)
-
-            assertThat(response.body).isEqualTo(StringValue("success"))
+            assertThat(firstResponse.body).isEqualTo(StringValue("first response"))
+            assertThat(secondResponse.body).isEqualTo(StringValue("second response"))
         }
     }
 
     @Test
-    fun `should be able to load an externalized stub with an auth key`() {
+    fun `startup example should match the exact security header value`() {
         val feature = OpenApiSpecification.fromFile(osAgnosticPath("src/test/resources/openapi/apiKeyAuthStub.yaml")).toFeature()
 
         val examples = File(osAgnosticPath("src/test/resources/openapi/apiKeyAuthStub_examples")).listFiles().orEmpty().map { file ->
@@ -1068,9 +1070,13 @@ components:
                 mapOf("X-API-KEY" to "abc123")
             )
 
-            val response = stub.client.execute(request)
+            val matchingResponse = stub.client.execute(request)
+            val mismatchingResponse = stub.client.execute(
+                request.copy(headers = request.headers.plus("X-API-KEY" to "different-key"))
+            )
 
-            assertThat(response.body.toStringLiteral()).isEqualTo("Hello, World!")
+            assertThat(matchingResponse.body.toStringLiteral()).isEqualTo("Hello, World!")
+            assertThat(mismatchingResponse.body.toStringLiteral()).isNotEqualTo("Hello, World!")
         }
     }
 

--- a/core/src/test/kotlin/io/specmatic/stub/ThreadSafeListOfStubsTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/ThreadSafeListOfStubsTest.kt
@@ -2,6 +2,10 @@ package io.specmatic.stub
 
 import io.mockk.every
 import io.mockk.mockk
+import io.specmatic.conversions.APIKeyInHeaderSecurityScheme
+import io.specmatic.conversions.APIKeyInQueryParamSecurityScheme
+import io.specmatic.conversions.CompositeSecurityScheme
+import io.specmatic.conversions.OpenAPISecurityScheme
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpResponse
 import io.specmatic.core.HttpHeadersPattern
@@ -10,17 +14,167 @@ import io.specmatic.core.HttpResponsePattern
 import io.specmatic.core.Resolver
 import io.specmatic.core.Result
 import io.specmatic.core.ACCEPT
+import io.specmatic.core.Scenario
 import io.specmatic.core.buildHttpPathPattern
+import io.specmatic.core.pattern.ExactValuePattern
+import io.specmatic.core.pattern.Pattern
 import io.specmatic.core.pattern.parsedJSONObject
 import io.specmatic.core.pattern.StringPattern
 import io.specmatic.core.value.JSONObjectValue
+import io.specmatic.core.value.StringValue
+import io.specmatic.license.core.SpecmaticProtocol
 import io.specmatic.mock.ScenarioStub
+import io.specmatic.reporter.model.SpecType
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class ThreadSafeListOfStubsTest {
+    @Test
+    fun `matching transient stubs should prefer a successful example with a complete security requirement`() {
+        val unsecured = stubWithAuthoredRequest("unsecured", HttpRequest("GET", "/products"))
+        val secured = stubWithAuthoredRequest(
+            "secured",
+            HttpRequest("GET", "/products", headers = mapOf(SECURITY_HEADER to "matching-token"))
+        )
+        val expectations = ThreadSafeListOfStubs(mutableListOf(secured, unsecured), emptyMap())
+
+        val result = expectations.matchingTransientStub(requestWithSecurityHeader())
+
+        assertThat(result?.first).isEqualTo(secured)
+    }
+
+    @Test
+    fun `matching dynamic stubs should prefer a successful example with a complete security requirement`() {
+        val unsecured = stubWithAuthoredRequest("unsecured", HttpRequest("GET", "/products"))
+        val secured = stubWithAuthoredRequest(
+            "secured",
+            HttpRequest("GET", "/products", headers = mapOf(SECURITY_HEADER to "matching-token"))
+        )
+        val expectations = ThreadSafeListOfStubs(mutableListOf(unsecured, secured), emptyMap())
+
+        val result = expectations.matchingDynamicStub(requestWithSecurityHeader())
+
+        assertThat(result.first).isEqualTo(secured)
+    }
+
+    @Test
+    fun `matching static stubs should prefer a successful example with a complete security requirement`() {
+        val unsecured = stubWithAuthoredRequest("unsecured", HttpRequest("GET", "/products"))
+        val secured = stubWithAuthoredRequest(
+            "secured",
+            HttpRequest("GET", "/products", headers = mapOf(SECURITY_HEADER to "matching-token"))
+        )
+        val expectations = ThreadSafeListOfStubs(mutableListOf(unsecured, secured), emptyMap())
+
+        val result = expectations.matchingStaticStub(requestWithSecurityHeader())
+
+        assertThat(result.first).isEqualTo(secured)
+    }
+
+    @Test
+    fun `multiple complete security examples should retain each matcher selection order`() {
+        val first = stubWithAuthoredRequest(
+            "first",
+            HttpRequest("GET", "/products", headers = mapOf(SECURITY_HEADER to "matching-token"))
+        )
+        val second = stubWithAuthoredRequest(
+            "second",
+            HttpRequest("GET", "/products", headers = mapOf(SECURITY_HEADER to "matching-token"))
+        )
+        val expectations = ThreadSafeListOfStubs(mutableListOf(first, second), emptyMap())
+
+        val transient = expectations.matchingTransientStub(requestWithSecurityHeader())
+        val dynamic = expectations.matchingDynamicStub(requestWithSecurityHeader())
+        val static = expectations.matchingStaticStub(requestWithSecurityHeader())
+
+        assertThat(transient?.first).isEqualTo(second)
+        assertThat(dynamic.first).isEqualTo(first)
+        assertThat(static.first).isEqualTo(first)
+    }
+
+    @Test
+    fun `partial and absent security requirements should have the same fallback priority`() {
+        val partial = stubWithAuthoredRequest(
+            "partial",
+            HttpRequest("GET", "/products", headers = mapOf(SECURITY_HEADER to "matching-token")),
+            securitySchemes = listOf(
+                CompositeSecurityScheme(
+                    listOf(
+                        APIKeyInHeaderSecurityScheme(SECURITY_HEADER, null),
+                        APIKeyInQueryParamSecurityScheme(SECURITY_QUERY_PARAMETER, null)
+                    )
+                )
+            )
+        )
+        val unsecured = stubWithAuthoredRequest("unsecured", HttpRequest("GET", "/products"))
+        val partialFirst = ThreadSafeListOfStubs(mutableListOf(partial, unsecured), emptyMap())
+        val unsecuredFirst = ThreadSafeListOfStubs(mutableListOf(unsecured, partial), emptyMap())
+
+        val partialFirstResult = partialFirst.matchingDynamicStub(requestWithSecurityHeader())
+        val unsecuredFirstResult = unsecuredFirst.matchingDynamicStub(requestWithSecurityHeader())
+
+        assertThat(partialFirstResult.first).isEqualTo(partial)
+        assertThat(unsecuredFirstResult.first).isEqualTo(unsecured)
+    }
+
+    @Test
+    fun `a composite security requirement should be complete only when every member is authored`() {
+        val securitySchemes = listOf(
+            CompositeSecurityScheme(
+                listOf(
+                    APIKeyInHeaderSecurityScheme(SECURITY_HEADER, null),
+                    APIKeyInQueryParamSecurityScheme(SECURITY_QUERY_PARAMETER, null)
+                )
+            )
+        )
+        val partial = stubWithAuthoredRequest(
+            "partial",
+            HttpRequest("GET", "/products", headers = mapOf(SECURITY_HEADER to "matching-token")),
+            securitySchemes = securitySchemes
+        )
+        val complete = stubWithAuthoredRequest(
+            "complete",
+            HttpRequest(
+                "GET",
+                "/products",
+                headers = mapOf(SECURITY_HEADER to "matching-token"),
+                queryParametersMap = mapOf(SECURITY_QUERY_PARAMETER to "matching-query-token")
+            ),
+            securitySchemes = securitySchemes
+        )
+
+        assertThat(partial.hasCompleteAuthoredSecurityRequirement()).isFalse()
+        assertThat(complete.hasCompleteAuthoredSecurityRequirement()).isTrue()
+    }
+
+    @Test
+    fun `a generated security header should not count as an authored security requirement`() {
+        val generatedSecurityRequest = HttpRequest("GET", "/products")
+            .addSecurityHeader(SECURITY_HEADER, "generated-token")
+        val stub = stubWithAuthoredRequest("generated", generatedSecurityRequest)
+
+        assertThat(stub.hasCompleteAuthoredSecurityRequirement()).isFalse()
+    }
+
+    @Test
+    fun `a complete security example with a mismatched credential should not be preferred`() {
+        val unsecured = stubWithAuthoredRequest("unsecured", HttpRequest("GET", "/products"))
+        val secured = stubWithAuthoredRequest(
+            "secured",
+            HttpRequest("GET", "/products", headers = mapOf(SECURITY_HEADER to "expected-token")),
+            requestType = matchingRequestPattern(
+                mapOf(SECURITY_HEADER to ExactValuePattern(StringValue("expected-token")))
+            )
+        )
+        val expectations = ThreadSafeListOfStubs(mutableListOf(secured, unsecured), emptyMap())
+
+        val result = expectations.matchingDynamicStub(requestWithSecurityHeader())
+
+        assertThat(result.first).isEqualTo(unsecured)
+    }
+
     @Test
     fun `matching transient stubs should honour setup order and ignore Accept q priority`() {
         val requestPattern = HttpRequestPattern(
@@ -451,5 +605,55 @@ class ThreadSafeListOfStubsTest {
 
             assertEquals(unresolvedStub1, result)
         }
+    }
+
+    private fun stubWithAuthoredRequest(
+        responseBody: String,
+        authoredRequest: HttpRequest,
+        securitySchemes: List<OpenAPISecurityScheme> = listOf(
+            APIKeyInHeaderSecurityScheme(SECURITY_HEADER, null)
+        ),
+        requestType: HttpRequestPattern = matchingRequestPattern()
+    ): HttpStubData {
+        val response = HttpResponse(status = 200, body = responseBody)
+        val scenario = Scenario(
+            name = responseBody,
+            httpRequestPattern = HttpRequestPattern(
+                method = "GET",
+                httpPathPattern = buildHttpPathPattern("/products"),
+                securitySchemes = securitySchemes
+            ),
+            httpResponsePattern = HttpResponsePattern(response),
+            protocol = SpecmaticProtocol.HTTP,
+            specType = SpecType.OPENAPI
+        )
+
+        return HttpStubData(
+            requestType = requestType,
+            response = response,
+            responsePattern = HttpResponsePattern(response),
+            resolver = Resolver(),
+            scenario = scenario,
+            originalRequest = authoredRequest
+        )
+    }
+
+    private fun matchingRequestPattern(
+        headers: Map<String, Pattern> = mapOf("$SECURITY_HEADER?" to StringPattern())
+    ): HttpRequestPattern = HttpRequestPattern(
+        method = "GET",
+        httpPathPattern = buildHttpPathPattern("/products"),
+        headersPattern = HttpHeadersPattern(headers)
+    )
+
+    private fun requestWithSecurityHeader(): HttpRequest = HttpRequest(
+        method = "GET",
+        path = "/products",
+        headers = mapOf(SECURITY_HEADER to "matching-token")
+    )
+
+    companion object {
+        private const val SECURITY_HEADER = "X-Access-Key"
+        private const val SECURITY_QUERY_PARAMETER = "access_key"
     }
 }

--- a/core/src/test/kotlin/io/specmatic/stub/ThreadSafeListOfStubsTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/ThreadSafeListOfStubsTest.kt
@@ -159,6 +159,25 @@ class ThreadSafeListOfStubsTest {
     }
 
     @Test
+    fun `a generated security query parameter should not count as an authored security requirement`() {
+        val securityScheme = APIKeyInQueryParamSecurityScheme(
+            SECURITY_QUERY_PARAMETER,
+            "generated-token"
+        )
+        val generatedSecurityRequest = securityScheme.addTo(
+            HttpRequest("GET", "/products"),
+            Resolver()
+        )
+        val stub = stubWithAuthoredRequest(
+            "generated",
+            generatedSecurityRequest,
+            securitySchemes = listOf(securityScheme)
+        )
+
+        assertThat(stub.hasCompleteAuthoredSecurityRequirement()).isFalse()
+    }
+
+    @Test
     fun `a complete security example with a mismatched credential should not be preferred`() {
         val unsecured = stubWithAuthoredRequest("unsecured", HttpRequest("GET", "/products"))
         val secured = stubWithAuthoredRequest(

--- a/core/src/test/resources/openapi/apiKeyAuthStub_examples/get_info_using_query_auth.json
+++ b/core/src/test/resources/openapi/apiKeyAuthStub_examples/get_info_using_query_auth.json
@@ -2,12 +2,12 @@
   "http-request": {
     "method": "GET",
     "path": "/hello/10",
-    "headers": {
-      "X-API-KEY": "abc123"
+    "query": {
+      "apiKey": "query123"
     }
   },
   "http-response": {
     "status": 200,
-    "body": "Hello from header key!"
+    "body": "Hello from query key!"
   }
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Preserve explicitly authored security-header and API-key query-parameter values when generating and matching exact mock patterns for startup examples and runtime expectations.

<!-- Why are these changes necessary? -->

**Why**:

Security parameters are validated separately and removed before ordinary request-schema matching. Exact mock generation was also discarding authored security-header values, which allowed examples with different credentials to become indistinguishable. 

<!-- How were these changes implemented? -->

**How**:

Exact mock-pattern generation preserves authored credentials as exact header or query patterns. Unit and integration coverage verifies startup examples, runtime expectations, API-key headers, API-key query parameters, composite requirements, generated-value filtering, and existing selection ordering.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
