### PR TITLE
Rollback Specmatic Gradle plugin to 0.15.15

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 group=io.specmatic
 version=2.50.1-SNAPSHOT
-specmaticGradlePluginVersion=0.15.21
+specmaticGradlePluginVersion=0.15.15
 specmaticReporterVersion=0.3.36
 swaggerParserVersion=2.1.35
 kotlin.daemon.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m


### PR DESCRIPTION
## Summary
- Roll back `specmaticGradlePluginVersion` from `0.15.21` to `0.15.15` due to issues in the latest version.

## Verification
- `git diff --check`
- Tests not run; dependency version-only change.