### PR TITLE
refactor: Streamline traffic-to-spec conversion

### DIFF
--- a/application/src/main/kotlin/application/ImportCommand.kt
+++ b/application/src/main/kotlin/application/ImportCommand.kt
@@ -1,7 +1,7 @@
 package application
 
 import picocli.CommandLine.*
-import io.specmatic.conversions.postmanCollectionToGherkin
+import io.specmatic.conversions.postmanCollectionToContracts
 import io.specmatic.conversions.runTests
 import io.specmatic.conversions.toFragment
 import io.specmatic.core.*
@@ -10,6 +10,7 @@ import io.specmatic.core.log.configureLogging
 import io.specmatic.core.log.logger
 import io.specmatic.core.log.logException
 import io.specmatic.core.utilities.jsonStringToValueMap
+import io.specmatic.core.utilities.openApiFromTraffic
 import io.specmatic.license.core.LicenseResolver
 import io.specmatic.license.core.LicensedProduct
 import io.specmatic.license.core.SpecmaticFeature
@@ -52,8 +53,8 @@ class ImportCommand : Callable<Int> {
 fun convertStub(path: String, userSpecifiedOutFile: String?) {
     val inputFile = File(path)
     val stub = mockFromJSON(jsonStringToValueMap(inputFile.readText()))
-    val gherkin = toGherkinFeature(NamedStub("New scenario", stub))
-    val openApiYAML = gherkinToOpenApiYAML(gherkin)
+    val openApi = openApiFromTraffic("New Feature", listOf(NamedStub("New scenario", stub)))
+    val openApiYAML = Yaml.pretty(openApi)
 
     val outFile = userSpecifiedOutFile ?: "${inputFile.nameWithoutExtension}.yaml"
 
@@ -66,38 +67,33 @@ fun convertStub(path: String, userSpecifiedOutFile: String?) {
     writeOut(openApiYAML, outFile)
 }
 
-private fun gherkinToOpenApiYAML(gherkin: String): String {
-    val openApi = parseGherkinStringToFeature(gherkin).toOpenApi()
-    return Yaml.pretty(openApi)
-}
-
 fun convertPostman(path: String, userSpecifiedOutPath: String?) {
     val inputFile = File(path)
-    val contracts = postmanCollectionToGherkin(inputFile.readText())
+    val contracts = postmanCollectionToContracts(inputFile.readText())
 
     for (contract in contracts) runTests(contract)
 
     when (contracts.size) {
         1 -> {
             val outPath = userSpecifiedOutPath ?: "${inputFile.nameWithoutExtension}.yaml"
-            writeOut(gherkinToOpenApiYAML(contracts.first().gherkin), outPath, toFragment(contracts.first().baseURLInfo))
+            writeOut(Yaml.pretty(contracts.first().feature.toOpenApi()), outPath, toFragment(contracts.first().baseURLInfo))
         }
         else -> {
             for (contract in contracts) {
-                val (_, gherkin, baseURLInfo, _) = contract
+                val (_, feature, baseURLInfo, _) = contract
                 val outFilePath = userSpecifiedOutPath ?: "${inputFile.nameWithoutExtension}.yaml"
-                writeOut(gherkinToOpenApiYAML(gherkin), outFilePath, toFragment(baseURLInfo))
+                writeOut(Yaml.pretty(feature.toOpenApi()), outFilePath, toFragment(baseURLInfo))
             }
         }
     }
 }
 
-private fun writeOut(gherkin: String, outputFilePath: String, hostAndPort: String? = null) {
+private fun writeOut(content: String, outputFilePath: String, hostAndPort: String? = null) {
     val outputFile = File(outputFilePath)
 
     val tag = if(hostAndPort != null) "-${hostAndPort.replace(":", "-")}" else ""
 
-    fileWithTag(outputFile, tag).writeText(gherkin)
+    fileWithTag(outputFile, tag).writeText(content)
     logger.log("Written to file ${fileWithTag(outputFile, tag).path}")
 }
 

--- a/application/src/test/kotlin/application/ImportCommandTest.kt
+++ b/application/src/test/kotlin/application/ImportCommandTest.kt
@@ -1,0 +1,98 @@
+package application
+
+import io.specmatic.core.HttpRequest
+import io.specmatic.core.HttpResponse
+import io.specmatic.core.NamedStub
+import io.specmatic.core.pattern.parsedJSON
+import io.specmatic.core.utilities.openApiFromTraffic
+import io.specmatic.core.value.StringValue
+import io.specmatic.mock.ScenarioStub
+import io.swagger.v3.core.util.Yaml
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class ImportCommandTest {
+    @Test
+    fun `stub import writes the structured traffic OpenAPI to the requested path`(@TempDir tempDir: File) {
+        val stub = ScenarioStub(
+            request = HttpRequest(
+                method = "POST",
+                path = "/items",
+                headers = mapOf("Content-Type" to "application/json; charset=utf-8"),
+                body = parsedJSON("""{"name":"tea"}"""),
+            ),
+            response = HttpResponse(
+                status = 201,
+                headers = mapOf("Content-Type" to "text/plain; charset=utf-8"),
+                body = StringValue("created"),
+            ),
+        )
+        val input = tempDir.resolve("item.json").apply { writeText(stub.toJSON().toStringLiteral()) }
+        val output = tempDir.resolve("custom.yaml")
+
+        convertStub(input.absolutePath, output.absolutePath)
+
+        val expected = Yaml.pretty(openApiFromTraffic("New Feature", listOf(NamedStub("New scenario", stub))))
+        assertThat(output).exists()
+        assertThat(output.readText()).isEqualTo(expected)
+        assertThat(output.readText()).contains("title: New Feature", "summary: New scenario")
+    }
+
+    @Test
+    fun `Postman import writes the structured contract OpenAPI using the base URL tagged name`(@TempDir tempDir: File) {
+        val postmanCollection = """
+            {
+              "info": {
+                "name": "Imported Collection",
+                "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+              },
+              "item": [
+                {
+                  "name": "ignored live request",
+                  "request": {
+                    "method": "GET",
+                    "header": [],
+                    "url": { "raw": "http://localhost:65530/items" }
+                  },
+                  "response": [
+                    {
+                      "name": "saved response",
+                      "originalRequest": {
+                        "method": "GET",
+                        "header": [],
+                        "url": { "raw": "http://localhost:65530/items" }
+                      },
+                      "code": 201,
+                      "header": [
+                        { "key": "Content-Type", "value": "application/json" }
+                      ],
+                      "body": "{\"id\":10}"
+                    }
+                  ]
+                }
+              ]
+            }
+        """.trimIndent()
+        val input = tempDir.resolve("collection.postman_collection.json").apply { writeText(postmanCollection) }
+        val requestedOutput = tempDir.resolve("postman.yaml")
+        val expectedStub = ScenarioStub(
+            request = HttpRequest(method = "GET", path = "/items"),
+            response = HttpResponse(
+                status = 201,
+                headers = mapOf("Content-Type" to "application/json"),
+                body = parsedJSON("""{"id":10}"""),
+            ),
+        )
+
+        convertPostman(input.absolutePath, requestedOutput.absolutePath)
+
+        val output = tempDir.resolve("postman-localhost-65530.yaml")
+        val expected = Yaml.pretty(
+            openApiFromTraffic("Imported Collection", listOf(NamedStub("saved response", expectedStub)))
+        )
+        assertThat(output).exists()
+        assertThat(output.readText()).isEqualTo(expected)
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/conversions/Postman.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/Postman.kt
@@ -5,6 +5,7 @@ import io.specmatic.core.log.logger
 import io.specmatic.core.pattern.*
 import io.specmatic.core.utilities.jsonStringToValueMap
 import io.specmatic.core.utilities.parseXML
+import io.specmatic.core.utilities.featureFromTraffic
 import io.specmatic.core.value.*
 import io.specmatic.mock.ScenarioStub
 import io.specmatic.core.log.dontPrintToConsole
@@ -19,16 +20,18 @@ fun hostAndPort(uriString: String): BaseURLInfo {
     return BaseURLInfo(uri.host, uri.port, uri.scheme, uriString.removeSuffix("/"))
 }
 
-data class ImportedPostmanContracts(val name: String, val gherkin: String, val baseURLInfo: BaseURLInfo, val stubs: List<NamedStub>)
+data class ImportedPostmanContracts(val name: String, val feature: Feature, val baseURLInfo: BaseURLInfo, val stubs: List<NamedStub>)
 
-fun postmanCollectionToGherkin(postmanContent: String): List<ImportedPostmanContracts> {
-    val postmanCollection = stubsFromPostmanCollection(postmanContent)
+fun postmanCollectionToContracts(postmanContent: String): List<ImportedPostmanContracts> {
+    return contractsFromPostmanCollection(stubsFromPostmanCollection(postmanContent))
+}
 
+internal fun contractsFromPostmanCollection(postmanCollection: PostmanCollection): List<ImportedPostmanContracts> {
     val groups = postmanCollection.stubs.groupBy { it.first }
 
     return groups.entries.map { (baseURLInfo, stubInfo) ->
-        val collection = PostmanCollection(postmanCollection.name, stubInfo)
-        val gherkinString = toGherkinFeature(collection)
+        val namedStubs = stubInfo.map { (_, namedStub) -> namedStub }
+        val feature = featureFromTraffic(postmanCollection.name, namedStubs)
 
         val protocolsInUse = stubInfo.map { (_, namedStub) -> namedStub.protocol }
 
@@ -37,15 +40,14 @@ fun postmanCollectionToGherkin(postmanContent: String): List<ImportedPostmanCont
             feature = SpecmaticFeature.EXAMPLES_IMPORTED_FROM_POSTMAN,
             protocol = protocolsInUse,
         )
-        ImportedPostmanContracts(collection.name, gherkinString, baseURLInfo, postmanCollection.stubs.map { it.second })
+        ImportedPostmanContracts(postmanCollection.name, feature, baseURLInfo, namedStubs)
     }
 }
 
 fun runTests(contract: ImportedPostmanContracts) {
-    val (name, gherkin, baseURLInfo, _) = contract
+    val (name, feature, baseURLInfo, _) = contract
     logger.log("Testing contract \"$name\" with base URL ${baseURLInfo.originalBaseURL}")
     try {
-        val feature = parseGherkinStringToFeature(gherkin)
         val results = feature.executeTests(LegacyHttpClient(baseURL = baseURLInfo.originalBaseURL))
 
         logger.log("Test result for contract \"$name\" ###")
@@ -58,9 +60,6 @@ fun runTests(contract: ImportedPostmanContracts) {
         logger.log(e, "Test reported an exception")
     }
 }
-
-fun toGherkinFeature(postmanCollection: PostmanCollection): String =
-        toGherkinFeature(postmanCollection.name, postmanCollection.stubs.map { it.second })
 
 data class PostmanCollection(val name: String, val stubs: List<Pair<BaseURLInfo, NamedStub>>)
 

--- a/core/src/main/kotlin/io/specmatic/core/utilities/StubExamplesToOpenApi.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/StubExamplesToOpenApi.kt
@@ -1,14 +1,8 @@
 package io.specmatic.core.utilities
 
-import io.specmatic.core.*
-import io.specmatic.core.pattern.*
-import io.specmatic.core.value.EmptyString
-import io.specmatic.core.value.StringValue
-import io.specmatic.core.value.Value
-import io.specmatic.license.core.SpecmaticProtocol
+import io.specmatic.core.NamedStub
 import io.specmatic.mock.ScenarioStub
 import io.specmatic.proxy.ProxyOperation
-import io.specmatic.reporter.model.SpecType
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.core.util.Yaml
 import java.io.File
@@ -31,132 +25,9 @@ fun openApiYamlFromExampleDir(examplesDir: File, featureName: String = "New feat
 fun openApiFromTraffic(featureName: String, namedStubs: List<NamedStub>, sortOrder: List<ProxyOperation> = emptyList()): OpenAPI? {
     if (namedStubs.isEmpty()) return null
 
-    val scenarios = orderStubsByProxyOperations(namedStubs, sortOrder).map(::scenarioFromTraffic)
-    return Feature(scenarios = scenarios, name = featureName, protocol = SpecmaticProtocol.HTTP).toOpenApi()
+    val orderedStubs = orderStubsByProxyOperations(namedStubs, sortOrder)
+    return featureFromTraffic(featureName, orderedStubs).toOpenApi()
 }
-
-private data class RequestInference(
-    val pattern: HttpRequestPattern,
-    val types: Map<String, Pattern>,
-)
-
-private data class ResponseInference(
-    val pattern: HttpResponsePattern,
-    val types: Map<String, Pattern>,
-)
-
-private data class ResponseBodyInference(
-    val pattern: Pattern,
-    val types: Map<String, Pattern>,
-)
-
-private fun scenarioFromTraffic(namedStub: NamedStub): Scenario {
-    val request = namedStub.stub.requestElsePartialRequest()
-    val response = namedStub.stub.response
-    val requestInference = inferRequest(request)
-    val responseInference = inferResponse(response, requestInference.types)
-    val namedPatterns = responseInference.types.mapKeys { (name, _) -> withPatternDelimiters(withoutPatternDelimiters(name)) }
-    val exampleRow = Row(
-        name = namedStub.name,
-        requestExample = request,
-        responseExample = response,
-        scenarioStub = namedStub.stub,
-    )
-
-    return Scenario(
-        name = namedStub.name,
-        httpRequestPattern = requestInference.pattern,
-        httpResponsePattern = responseInference.pattern,
-        examples = listOf(Examples(exampleRow.columnNames, listOf(exampleRow))),
-        patterns = namedPatterns,
-        protocol = SpecmaticProtocol.HTTP,
-        specType = SpecType.OPENAPI,
-    )
-}
-
-private fun inferRequest(request: HttpRequest): RequestInference {
-    val method = request.method ?: throw ContractException("Can't generate a spec file without the http method.")
-    val path = request.path ?: throw ContractException("Can't generate a contract without the url.")
-    val (queryPatterns, queryTypes) = inferPatterns(queryParamsToScalarMap(request.queryParams), emptyMap())
-    val (contentType, otherHeaders) = partitionOnContentType(request.headers)
-    val (headerPatterns, headerTypes) = inferPatterns(stringMapToScalarMap(otherHeaders), queryTypes)
-    val headersWithContentType = contentType?.value?.substringBefore(';')?.let { value ->
-        headerPatterns + (contentType.key to ExactValuePattern(StringValue(value)))
-    } ?: headerPatterns
-
-    val bodyInference = inferRequestPayload(request, headerTypes)
-    return RequestInference(
-        pattern = HttpRequestPattern(
-            headersPattern = HttpHeadersPattern(headersWithContentType),
-            httpPathPattern = buildHttpPathPattern(path.replace(" ", "%20")),
-            httpQueryParamPattern = HttpQueryParamPattern(queryPatterns.mapValues { (_, pattern) ->
-                QueryParameterScalarPattern(pattern)
-            }),
-            method = method,
-            body = bodyInference.body,
-            formFieldsPattern = bodyInference.formFields,
-            multiPartFormDataPattern = bodyInference.multiPart,
-        ),
-        types = bodyInference.types,
-    )
-}
-
-private data class RequestPayloadInference(
-    val body: Pattern = EmptyStringPattern,
-    val formFields: Map<String, Pattern> = emptyMap(),
-    val multiPart: List<MultiPartFormDataPattern> = emptyList(),
-    val types: Map<String, Pattern>,
-)
-
-private fun inferRequestPayload(
-    request: HttpRequest,
-    types: Map<String, Pattern>,
-): RequestPayloadInference = when {
-    request.multiPartFormData.isNotEmpty() -> RequestPayloadInference(
-        multiPart = request.multiPartFormData.map { it.inferType() },
-        types = types,
-    )
-    request.formFields.isNotEmpty() -> {
-        val (patterns, updatedTypes) = inferPatterns(stringMapToValueMap(request.formFields), types)
-        RequestPayloadInference(formFields = patterns, types = updatedTypes)
-    }
-    request.body == EmptyString || request.body == NoBodyValue -> RequestPayloadInference(types = types)
-    else -> {
-        val declaration = request.body.toPatternDeclaration("RequestBody", types)
-        RequestPayloadInference(
-            body = declaration.pattern,
-            types = declaration.types,
-        )
-    }
-}
-
-private fun inferResponse(response: HttpResponse, initialTypes: Map<String, Pattern>): ResponseInference {
-    if (response.status <= 0) throw ContractException("Can't generate a contract without a response status")
-
-    val (contentType, otherHeaders) = partitionOnContentType(response.headers)
-    val (headerPatterns, headerTypes) = inferPatterns(stringMapToScalarMap(otherHeaders), initialTypes)
-    val headersWithContentType = contentType?.value?.substringBefore(';')?.let { value ->
-        headerPatterns + (contentType.key to ExactValuePattern(StringValue(value)))
-    } ?: headerPatterns
-    val payload = adjustPayloadForContentType(response.body, response.headers)
-    val bodyInference = if (payload == EmptyString) {
-        ResponseBodyInference(EmptyStringPattern, headerTypes)
-    } else {
-        val declaration = payload.toPatternDeclaration("ResponseBody", headerTypes)
-        ResponseBodyInference(declaration.pattern, declaration.types)
-    }
-
-    return ResponseInference(
-        pattern = HttpResponsePattern(HttpHeadersPattern(headersWithContentType), response.status, bodyInference.pattern),
-        types = bodyInference.types,
-    )
-}
-
-private fun inferPatterns(values: Map<String, Value>, initialTypes: Map<String, Pattern>): Pair<Map<String, Pattern>, Map<String, Pattern>> =
-    values.entries.fold(emptyMap<String, Pattern>() to initialTypes) { (patterns, types), (name, value) ->
-        val declaration = value.toPatternDeclaration(name, types)
-        patterns + (name to declaration.pattern) to declaration.types
-    }
 
 private fun indexOperationsByMethod(sortOrder: List<ProxyOperation>): Map<String, List<IndexedValue<ProxyOperation>>> {
     return sortOrder.withIndex().groupBy(keySelector = { it.value.method.lowercase() }, valueTransform = { it })

--- a/core/src/main/kotlin/io/specmatic/core/utilities/StubExamplesToOpenApi.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/StubExamplesToOpenApi.kt
@@ -1,10 +1,16 @@
 package io.specmatic.core.utilities
 
-import io.specmatic.core.NamedStub
-import io.specmatic.core.parseGherkinStringToFeature
-import io.specmatic.core.toGherkinFeature
+import io.specmatic.core.*
+import io.specmatic.core.pattern.*
+import io.specmatic.core.value.EmptyString
+import io.specmatic.core.value.StringValue
+import io.specmatic.core.value.UseExampleDeclarations
+import io.specmatic.core.value.dictionaryToDeclarations
+import io.specmatic.license.core.SpecmaticProtocol
 import io.specmatic.mock.ScenarioStub
 import io.specmatic.proxy.ProxyOperation
+import io.specmatic.reporter.model.SpecType
+import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.core.util.Yaml
 import java.io.File
 import kotlin.collections.flatten
@@ -16,16 +22,155 @@ fun openApiYamlFromExampleDir(examplesDir: File, featureName: String = "New feat
         val stub = ScenarioStub.readFromFile(file)
         val name = stub.name ?: file.nameWithoutExtension
         NamedStub(name, file.nameWithoutExtension, stub)
-    }.let {
-        orderStubsByProxyOperations(it, sortOrder)
     }
 
     if (namedStubs.isEmpty()) return null
 
-    val gherkin = toGherkinFeature(featureName, namedStubs)
-    val feature = parseGherkinStringToFeature(gherkin)
-    val openApi = feature.toOpenApi()
-    return Yaml.pretty(openApi)
+    return Yaml.pretty(openApiFromTraffic(featureName, namedStubs, sortOrder))
+}
+
+fun openApiFromTraffic(featureName: String, namedStubs: List<NamedStub>, sortOrder: List<ProxyOperation> = emptyList()): OpenAPI? {
+    if (namedStubs.isEmpty()) return null
+
+    val scenarios = orderStubsByProxyOperations(namedStubs, sortOrder).map(::scenarioFromTraffic)
+    return Feature(scenarios = scenarios, name = featureName, protocol = SpecmaticProtocol.HTTP).toOpenApi()
+}
+
+private data class RequestInference(
+    val pattern: HttpRequestPattern,
+    val types: Map<String, Pattern>,
+    val examples: ExampleDeclarations,
+)
+
+private data class ResponseInference(
+    val pattern: HttpResponsePattern,
+    val types: Map<String, Pattern>,
+)
+
+private data class ResponseBodyInference(
+    val pattern: Pattern,
+    val types: Map<String, Pattern>,
+)
+
+private fun scenarioFromTraffic(namedStub: NamedStub): Scenario {
+    val request = namedStub.stub.requestElsePartialRequest()
+    val response = namedStub.stub.response
+    val requestInference = inferRequest(request)
+    val responseInference = inferResponse(response, requestInference.types)
+    val exampleRow = Row(
+        columnNames = requestInference.examples.examples.keys.toList(),
+        values = requestInference.examples.examples.values.toList(),
+        name = namedStub.name,
+        requestExample = request,
+        responseExample = response,
+        scenarioStub = namedStub.stub,
+    )
+
+    return Scenario(
+        name = namedStub.name,
+        httpRequestPattern = requestInference.pattern,
+        httpResponsePattern = responseInference.pattern,
+        examples = listOf(Examples(exampleRow.columnNames, listOf(exampleRow))),
+        patterns = responseInference.types.mapKeys { (name, _) -> withPatternDelimiters(withoutPatternDelimiters(name)) },
+        protocol = SpecmaticProtocol.HTTP,
+        specType = SpecType.OPENAPI,
+    )
+}
+
+private fun inferRequest(request: HttpRequest): RequestInference {
+    val method = request.method ?: throw ContractException("Can't generate a spec file without the http method.")
+    val path = request.path ?: throw ContractException("Can't generate a contract without the url.")
+    val initialExamples = UseExampleDeclarations()
+    val (queryPatterns, queryTypes, queryExamples) = dictionaryToDeclarations(
+        queryParamsToScalarMap(request.queryParams),
+        emptyMap(),
+        initialExamples,
+    )
+    val (contentType, otherHeaders) = partitionOnContentType(request.headers)
+    val (headerPatterns, headerTypes, headerExamples) = dictionaryToDeclarations(
+        stringMapToScalarMap(otherHeaders),
+        queryTypes,
+        queryExamples,
+    )
+    val headersWithContentType = contentType?.value?.substringBefore(';')?.let { value ->
+        headerPatterns + (contentType.key to ExactValuePattern(StringValue(value)))
+    } ?: headerPatterns
+
+    val bodyInference = inferRequestPayload(request, headerTypes, headerExamples)
+    return RequestInference(
+        pattern = HttpRequestPattern(
+            headersPattern = HttpHeadersPattern(headersWithContentType),
+            httpPathPattern = buildHttpPathPattern(path.replace(" ", "%20")),
+            httpQueryParamPattern = HttpQueryParamPattern(queryPatterns.mapValues { (_, pattern) ->
+                QueryParameterScalarPattern(pattern)
+            }),
+            method = method,
+            body = bodyInference.body,
+            formFieldsPattern = bodyInference.formFields,
+            multiPartFormDataPattern = bodyInference.multiPart,
+        ),
+        types = bodyInference.types,
+        examples = bodyInference.examples,
+    )
+}
+
+private data class RequestPayloadInference(
+    val body: Pattern = EmptyStringPattern,
+    val formFields: Map<String, Pattern> = emptyMap(),
+    val multiPart: List<MultiPartFormDataPattern> = emptyList(),
+    val types: Map<String, Pattern>,
+    val examples: ExampleDeclarations,
+)
+
+private fun inferRequestPayload(
+    request: HttpRequest,
+    types: Map<String, Pattern>,
+    examples: ExampleDeclarations,
+): RequestPayloadInference = when {
+    request.multiPartFormData.isNotEmpty() -> RequestPayloadInference(
+        multiPart = request.multiPartFormData.map { it.inferType() },
+        types = types,
+        examples = examples,
+    )
+    request.formFields.isNotEmpty() -> {
+        val (patterns, updatedTypes, updatedExamples) = dictionaryToDeclarations(
+            stringMapToValueMap(request.formFields), types, examples,
+        )
+        RequestPayloadInference(formFields = patterns, types = updatedTypes, examples = updatedExamples)
+    }
+    request.body == EmptyString || request.body == NoBodyValue -> RequestPayloadInference(types = types, examples = examples)
+    else -> {
+        val (declaration, updatedExamples) = request.body.typeDeclarationWithoutKey("RequestBody", types, examples)
+        RequestPayloadInference(
+            body = DeferredPattern(declaration.typeValue),
+            types = declaration.types,
+            examples = updatedExamples,
+        )
+    }
+}
+
+private fun inferResponse(response: HttpResponse, initialTypes: Map<String, Pattern>): ResponseInference {
+    if (response.status <= 0) throw ContractException("Can't generate a contract without a response status")
+
+    val (contentType, otherHeaders) = partitionOnContentType(response.headers)
+    val (headerPatterns, headerTypes, _) = dictionaryToDeclarations(
+        stringMapToScalarMap(otherHeaders), initialTypes, DiscardExampleDeclarations(),
+    )
+    val headersWithContentType = contentType?.value?.substringBefore(';')?.let { value ->
+        headerPatterns + (contentType.key to ExactValuePattern(StringValue(value)))
+    } ?: headerPatterns
+    val payload = adjustPayloadForContentType(response.body, response.headers)
+    val bodyInference = if (payload == EmptyString) {
+        ResponseBodyInference(EmptyStringPattern, headerTypes)
+    } else {
+        val (declaration, _) = payload.typeDeclarationWithKey("ResponseBody", headerTypes, DiscardExampleDeclarations())
+        ResponseBodyInference(DeferredPattern(declaration.typeValue), declaration.types)
+    }
+
+    return ResponseInference(
+        pattern = HttpResponsePattern(HttpHeadersPattern(headersWithContentType), response.status, bodyInference.pattern),
+        types = bodyInference.types,
+    )
 }
 
 private fun indexOperationsByMethod(sortOrder: List<ProxyOperation>): Map<String, List<IndexedValue<ProxyOperation>>> {

--- a/core/src/main/kotlin/io/specmatic/core/utilities/StubExamplesToOpenApi.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/StubExamplesToOpenApi.kt
@@ -4,8 +4,7 @@ import io.specmatic.core.*
 import io.specmatic.core.pattern.*
 import io.specmatic.core.value.EmptyString
 import io.specmatic.core.value.StringValue
-import io.specmatic.core.value.UseExampleDeclarations
-import io.specmatic.core.value.dictionaryToDeclarations
+import io.specmatic.core.value.Value
 import io.specmatic.license.core.SpecmaticProtocol
 import io.specmatic.mock.ScenarioStub
 import io.specmatic.proxy.ProxyOperation
@@ -39,7 +38,6 @@ fun openApiFromTraffic(featureName: String, namedStubs: List<NamedStub>, sortOrd
 private data class RequestInference(
     val pattern: HttpRequestPattern,
     val types: Map<String, Pattern>,
-    val examples: ExampleDeclarations,
 )
 
 private data class ResponseInference(
@@ -58,12 +56,7 @@ private fun scenarioFromTraffic(namedStub: NamedStub): Scenario {
     val requestInference = inferRequest(request)
     val responseInference = inferResponse(response, requestInference.types)
     val namedPatterns = responseInference.types.mapKeys { (name, _) -> withPatternDelimiters(withoutPatternDelimiters(name)) }
-    val materializedPatterns = namedPatterns.mapValues { (_, pattern) ->
-        materializeGeneratedPattern(pattern, namedPatterns.keys)
-    }
     val exampleRow = Row(
-        columnNames = requestInference.examples.examples.keys.toList(),
-        values = requestInference.examples.examples.values.toList(),
         name = namedStub.name,
         requestExample = request,
         responseExample = response,
@@ -72,68 +65,26 @@ private fun scenarioFromTraffic(namedStub: NamedStub): Scenario {
 
     return Scenario(
         name = namedStub.name,
-        httpRequestPattern = requestInference.pattern.copy(
-            headersPattern = requestInference.pattern.headersPattern.copy(
-                pattern = materializeGeneratedPatterns(requestInference.pattern.headersPattern.pattern, namedPatterns.keys),
-            ),
-            body = materializeGeneratedPattern(requestInference.pattern.body, namedPatterns.keys),
-            formFieldsPattern = materializeGeneratedPatterns(requestInference.pattern.formFieldsPattern, namedPatterns.keys),
-        ),
-        httpResponsePattern = responseInference.pattern.copy(
-            headersPattern = responseInference.pattern.headersPattern.copy(
-                pattern = materializeGeneratedPatterns(responseInference.pattern.headersPattern.pattern, namedPatterns.keys),
-            ),
-            body = materializeGeneratedPattern(responseInference.pattern.body, namedPatterns.keys),
-        ),
+        httpRequestPattern = requestInference.pattern,
+        httpResponsePattern = responseInference.pattern,
         examples = listOf(Examples(exampleRow.columnNames, listOf(exampleRow))),
-        patterns = materializedPatterns,
+        patterns = namedPatterns,
         protocol = SpecmaticProtocol.HTTP,
         specType = SpecType.OPENAPI,
     )
 }
 
-private fun materializeGeneratedPatterns(patterns: Map<String, Pattern>, namedPatterns: Set<String>): Map<String, Pattern> =
-    patterns.mapValues { (_, pattern) -> materializeGeneratedPattern(pattern, namedPatterns) }
-
-private fun materializeGeneratedPattern(pattern: Pattern, namedPatterns: Set<String>): Pattern = when (pattern) {
-    is DeferredPattern -> when (pattern.pattern) {
-        in namedPatterns -> pattern
-        else -> parsedPattern(pattern.pattern)
-    }
-    is TabularPattern -> pattern.copy(pattern = pattern.pattern.mapValues { (_, child) ->
-        materializeGeneratedPattern(child, namedPatterns)
-    })
-    is JSONObjectPattern -> pattern.copy(pattern = pattern.pattern.mapValues { (_, child) ->
-        materializeGeneratedPattern(child, namedPatterns)
-    })
-    is JSONArrayPattern -> pattern.copy(pattern = pattern.pattern.map { child ->
-        materializeGeneratedPattern(child, namedPatterns)
-    })
-    is ListPattern -> pattern.copy(pattern = materializeGeneratedPattern(pattern.pattern, namedPatterns))
-    is LookupRowPattern -> pattern.copy(pattern = materializeGeneratedPattern(pattern.pattern, namedPatterns))
-    else -> pattern
-}
-
 private fun inferRequest(request: HttpRequest): RequestInference {
     val method = request.method ?: throw ContractException("Can't generate a spec file without the http method.")
     val path = request.path ?: throw ContractException("Can't generate a contract without the url.")
-    val initialExamples = UseExampleDeclarations()
-    val (queryPatterns, queryTypes, queryExamples) = dictionaryToDeclarations(
-        queryParamsToScalarMap(request.queryParams),
-        emptyMap(),
-        initialExamples,
-    )
+    val (queryPatterns, queryTypes) = inferPatterns(queryParamsToScalarMap(request.queryParams), emptyMap())
     val (contentType, otherHeaders) = partitionOnContentType(request.headers)
-    val (headerPatterns, headerTypes, headerExamples) = dictionaryToDeclarations(
-        stringMapToScalarMap(otherHeaders),
-        queryTypes,
-        queryExamples,
-    )
+    val (headerPatterns, headerTypes) = inferPatterns(stringMapToScalarMap(otherHeaders), queryTypes)
     val headersWithContentType = contentType?.value?.substringBefore(';')?.let { value ->
         headerPatterns + (contentType.key to ExactValuePattern(StringValue(value)))
     } ?: headerPatterns
 
-    val bodyInference = inferRequestPayload(request, headerTypes, headerExamples)
+    val bodyInference = inferRequestPayload(request, headerTypes)
     return RequestInference(
         pattern = HttpRequestPattern(
             headersPattern = HttpHeadersPattern(headersWithContentType),
@@ -147,7 +98,6 @@ private fun inferRequest(request: HttpRequest): RequestInference {
             multiPartFormDataPattern = bodyInference.multiPart,
         ),
         types = bodyInference.types,
-        examples = bodyInference.examples,
     )
 }
 
@@ -156,32 +106,26 @@ private data class RequestPayloadInference(
     val formFields: Map<String, Pattern> = emptyMap(),
     val multiPart: List<MultiPartFormDataPattern> = emptyList(),
     val types: Map<String, Pattern>,
-    val examples: ExampleDeclarations,
 )
 
 private fun inferRequestPayload(
     request: HttpRequest,
     types: Map<String, Pattern>,
-    examples: ExampleDeclarations,
 ): RequestPayloadInference = when {
     request.multiPartFormData.isNotEmpty() -> RequestPayloadInference(
         multiPart = request.multiPartFormData.map { it.inferType() },
         types = types,
-        examples = examples,
     )
     request.formFields.isNotEmpty() -> {
-        val (patterns, updatedTypes, updatedExamples) = dictionaryToDeclarations(
-            stringMapToValueMap(request.formFields), types, examples,
-        )
-        RequestPayloadInference(formFields = patterns, types = updatedTypes, examples = updatedExamples)
+        val (patterns, updatedTypes) = inferPatterns(stringMapToValueMap(request.formFields), types)
+        RequestPayloadInference(formFields = patterns, types = updatedTypes)
     }
-    request.body == EmptyString || request.body == NoBodyValue -> RequestPayloadInference(types = types, examples = examples)
+    request.body == EmptyString || request.body == NoBodyValue -> RequestPayloadInference(types = types)
     else -> {
-        val (declaration, updatedExamples) = request.body.typeDeclarationWithoutKey("RequestBody", types, examples)
+        val declaration = request.body.toPatternDeclaration("RequestBody", types)
         RequestPayloadInference(
-            body = DeferredPattern(declaration.typeValue),
+            body = declaration.pattern,
             types = declaration.types,
-            examples = updatedExamples,
         )
     }
 }
@@ -190,9 +134,7 @@ private fun inferResponse(response: HttpResponse, initialTypes: Map<String, Patt
     if (response.status <= 0) throw ContractException("Can't generate a contract without a response status")
 
     val (contentType, otherHeaders) = partitionOnContentType(response.headers)
-    val (headerPatterns, headerTypes, _) = dictionaryToDeclarations(
-        stringMapToScalarMap(otherHeaders), initialTypes, DiscardExampleDeclarations(),
-    )
+    val (headerPatterns, headerTypes) = inferPatterns(stringMapToScalarMap(otherHeaders), initialTypes)
     val headersWithContentType = contentType?.value?.substringBefore(';')?.let { value ->
         headerPatterns + (contentType.key to ExactValuePattern(StringValue(value)))
     } ?: headerPatterns
@@ -200,8 +142,8 @@ private fun inferResponse(response: HttpResponse, initialTypes: Map<String, Patt
     val bodyInference = if (payload == EmptyString) {
         ResponseBodyInference(EmptyStringPattern, headerTypes)
     } else {
-        val (declaration, _) = payload.typeDeclarationWithKey("ResponseBody", headerTypes, DiscardExampleDeclarations())
-        ResponseBodyInference(DeferredPattern(declaration.typeValue), declaration.types)
+        val declaration = payload.toPatternDeclaration("ResponseBody", headerTypes)
+        ResponseBodyInference(declaration.pattern, declaration.types)
     }
 
     return ResponseInference(
@@ -209,6 +151,12 @@ private fun inferResponse(response: HttpResponse, initialTypes: Map<String, Patt
         types = bodyInference.types,
     )
 }
+
+private fun inferPatterns(values: Map<String, Value>, initialTypes: Map<String, Pattern>): Pair<Map<String, Pattern>, Map<String, Pattern>> =
+    values.entries.fold(emptyMap<String, Pattern>() to initialTypes) { (patterns, types), (name, value) ->
+        val declaration = value.toPatternDeclaration(name, types)
+        patterns + (name to declaration.pattern) to declaration.types
+    }
 
 private fun indexOperationsByMethod(sortOrder: List<ProxyOperation>): Map<String, List<IndexedValue<ProxyOperation>>> {
     return sortOrder.withIndex().groupBy(keySelector = { it.value.method.lowercase() }, valueTransform = { it })

--- a/core/src/main/kotlin/io/specmatic/core/utilities/StubExamplesToOpenApi.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/StubExamplesToOpenApi.kt
@@ -57,6 +57,10 @@ private fun scenarioFromTraffic(namedStub: NamedStub): Scenario {
     val response = namedStub.stub.response
     val requestInference = inferRequest(request)
     val responseInference = inferResponse(response, requestInference.types)
+    val namedPatterns = responseInference.types.mapKeys { (name, _) -> withPatternDelimiters(withoutPatternDelimiters(name)) }
+    val materializedPatterns = namedPatterns.mapValues { (_, pattern) ->
+        materializeGeneratedPattern(pattern, namedPatterns.keys)
+    }
     val exampleRow = Row(
         columnNames = requestInference.examples.examples.keys.toList(),
         values = requestInference.examples.examples.values.toList(),
@@ -68,13 +72,46 @@ private fun scenarioFromTraffic(namedStub: NamedStub): Scenario {
 
     return Scenario(
         name = namedStub.name,
-        httpRequestPattern = requestInference.pattern,
-        httpResponsePattern = responseInference.pattern,
+        httpRequestPattern = requestInference.pattern.copy(
+            headersPattern = requestInference.pattern.headersPattern.copy(
+                pattern = materializeGeneratedPatterns(requestInference.pattern.headersPattern.pattern, namedPatterns.keys),
+            ),
+            body = materializeGeneratedPattern(requestInference.pattern.body, namedPatterns.keys),
+            formFieldsPattern = materializeGeneratedPatterns(requestInference.pattern.formFieldsPattern, namedPatterns.keys),
+        ),
+        httpResponsePattern = responseInference.pattern.copy(
+            headersPattern = responseInference.pattern.headersPattern.copy(
+                pattern = materializeGeneratedPatterns(responseInference.pattern.headersPattern.pattern, namedPatterns.keys),
+            ),
+            body = materializeGeneratedPattern(responseInference.pattern.body, namedPatterns.keys),
+        ),
         examples = listOf(Examples(exampleRow.columnNames, listOf(exampleRow))),
-        patterns = responseInference.types.mapKeys { (name, _) -> withPatternDelimiters(withoutPatternDelimiters(name)) },
+        patterns = materializedPatterns,
         protocol = SpecmaticProtocol.HTTP,
         specType = SpecType.OPENAPI,
     )
+}
+
+private fun materializeGeneratedPatterns(patterns: Map<String, Pattern>, namedPatterns: Set<String>): Map<String, Pattern> =
+    patterns.mapValues { (_, pattern) -> materializeGeneratedPattern(pattern, namedPatterns) }
+
+private fun materializeGeneratedPattern(pattern: Pattern, namedPatterns: Set<String>): Pattern = when (pattern) {
+    is DeferredPattern -> when (pattern.pattern) {
+        in namedPatterns -> pattern
+        else -> parsedPattern(pattern.pattern)
+    }
+    is TabularPattern -> pattern.copy(pattern = pattern.pattern.mapValues { (_, child) ->
+        materializeGeneratedPattern(child, namedPatterns)
+    })
+    is JSONObjectPattern -> pattern.copy(pattern = pattern.pattern.mapValues { (_, child) ->
+        materializeGeneratedPattern(child, namedPatterns)
+    })
+    is JSONArrayPattern -> pattern.copy(pattern = pattern.pattern.map { child ->
+        materializeGeneratedPattern(child, namedPatterns)
+    })
+    is ListPattern -> pattern.copy(pattern = materializeGeneratedPattern(pattern.pattern, namedPatterns))
+    is LookupRowPattern -> pattern.copy(pattern = materializeGeneratedPattern(pattern.pattern, namedPatterns))
+    else -> pattern
 }
 
 private fun inferRequest(request: HttpRequest): RequestInference {

--- a/core/src/main/kotlin/io/specmatic/core/utilities/TrafficPatternInference.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/TrafficPatternInference.kt
@@ -1,0 +1,176 @@
+package io.specmatic.core.utilities
+
+import io.specmatic.core.NoBodyValue
+import io.specmatic.core.pattern.AnyPattern
+import io.specmatic.core.pattern.AnythingPattern
+import io.specmatic.core.pattern.ContractException
+import io.specmatic.core.pattern.DeferredPattern
+import io.specmatic.core.pattern.EmptyStringPattern
+import io.specmatic.core.pattern.ExactValuePattern
+import io.specmatic.core.pattern.JSONArrayPattern
+import io.specmatic.core.pattern.JSONObjectPattern
+import io.specmatic.core.pattern.ListPattern
+import io.specmatic.core.pattern.NullPattern
+import io.specmatic.core.pattern.NumberPattern
+import io.specmatic.core.pattern.Pattern
+import io.specmatic.core.pattern.XMLPattern
+import io.specmatic.core.pattern.extractCombinedExtensions
+import io.specmatic.core.pattern.withoutOptionality
+import io.specmatic.core.value.NumberValue
+import io.specmatic.core.value.StringValue
+import io.specmatic.core.value.Value
+import io.specmatic.core.value.XMLNode
+import io.specmatic.core.value.XMLValue
+import io.specmatic.core.value.fold.FieldObjectValueCase
+import io.specmatic.core.value.fold.IndexedListValueCase
+import io.specmatic.core.value.fold.OpaqueValueCase
+import io.specmatic.core.value.fold.ScalarValueCase
+import io.specmatic.core.value.fold.TextValueCase
+import io.specmatic.core.value.fold.ValueVisitor
+import io.specmatic.core.value.fold.XmlElementValueCase
+
+internal data class PatternDeclaration(
+    val pattern: Pattern,
+    val types: Map<String, Pattern> = emptyMap(),
+)
+
+private data class PatternInferenceContext(
+    val name: String,
+    val types: Map<String, Pattern> = emptyMap(),
+)
+
+private data class FieldInference(
+    val patterns: Map<String, Pattern> = emptyMap(),
+    val types: Map<String, Pattern> = emptyMap(),
+) {
+    fun add(name: String, declaration: PatternDeclaration): FieldInference = copy(
+        patterns = patterns + (name to declaration.pattern),
+        types = declaration.types,
+    )
+}
+
+/**
+ * Infers the structured pattern used when converting recorded traffic to OpenAPI.
+ * New Value shapes must participate in ValueVisitor traversal or they will fail through opaque().
+ */
+internal fun Value.toPatternDeclaration(
+    name: String,
+    types: Map<String, Pattern> = emptyMap(),
+): PatternDeclaration = accept(TrafficPatternInferenceVisitor(PatternInferenceContext(name, types)))
+
+private class TrafficPatternInferenceVisitor(
+    override val rootContext: PatternInferenceContext,
+) : ValueVisitor<PatternInferenceContext, PatternDeclaration> {
+    override fun scalar(case: ScalarValueCase<out Value, PatternInferenceContext>): PatternDeclaration =
+        PatternDeclaration(case.value.trafficScalarPattern(), case.context.types)
+
+    override fun text(case: TextValueCase<out Value, PatternInferenceContext>): PatternDeclaration =
+        PatternDeclaration(case.value.type(), case.context.types)
+
+    override fun fieldObject(case: FieldObjectValueCase<out Value, PatternInferenceContext>): PatternDeclaration {
+        val fields = case.fields().fold(FieldInference(types = case.context.types)) { inference, field ->
+            val declaration = field.value.accept(
+                visitor = this,
+                context = PatternInferenceContext(field.name, inference.types),
+            )
+            inference.add(field.name, declaration)
+        }
+
+        return namedPattern(case.context.name, JSONObjectPattern(fields.patterns), fields.types)
+    }
+
+    override fun indexedList(case: IndexedListValueCase<out Value, PatternInferenceContext>): PatternDeclaration {
+        val declarations = case.items().map { item ->
+            item.value.accept(visitor = this, context = case.context)
+        }
+
+        if (declarations.isEmpty()) {
+            return PatternDeclaration(JSONArrayPattern(), case.context.types)
+        }
+
+        val element = declarations.reduce(::convergePatternDeclarations)
+        return PatternDeclaration(ListPattern(element.pattern), element.types)
+    }
+
+    override fun xmlElement(case: XmlElementValueCase<out XMLValue, PatternInferenceContext>): PatternDeclaration {
+        val xmlNode = case.value as? XMLNode
+            ?: throw ContractException("Cannot infer an OpenAPI pattern from ${case.value::class.simpleName ?: "XML value"}")
+        return namedPattern(case.context.name, XMLPattern(xmlNode, case.context.name), case.context.types)
+    }
+
+    override fun opaque(case: OpaqueValueCase<out Value, PatternInferenceContext>): PatternDeclaration =
+        when (case.value) {
+            NoBodyValue -> PatternDeclaration(ExactValuePattern(StringValue("No body")), case.context.types)
+            else -> throw ContractException("Cannot infer an OpenAPI pattern from ${case.kind}")
+        }
+}
+
+private fun Value.trafficScalarPattern(): Pattern = when (this) {
+    is NumberValue -> when (number) {
+        is Int, is Long -> NumberPattern()
+        else -> NumberPattern(isDoubleFormat = true)
+    }
+    else -> type()
+}
+
+private fun namedPattern(name: String, pattern: Pattern, types: Map<String, Pattern>): PatternDeclaration {
+    val typeName = generateSequence(name.capitalizeFirstChar()) { "${it}_" }.first { it !in types }
+    return PatternDeclaration(
+        pattern = DeferredPattern("($typeName)"),
+        types = types + (typeName to pattern),
+    )
+}
+
+private fun convergePatternDeclarations(first: PatternDeclaration, second: PatternDeclaration): PatternDeclaration =
+    PatternDeclaration(
+        pattern = first.pattern,
+        types = convergeNamedPatterns(first.types, second.types),
+    )
+
+private fun convergeNamedPatterns(first: Map<String, Pattern>, second: Map<String, Pattern>): Map<String, Pattern> {
+    val secondOnly = second.filterKeys { it !in first }
+    return first.mapValues { (name, pattern) ->
+        second[name]?.let { convergePatterns(pattern, it) } ?: pattern
+    } + secondOnly
+}
+
+private fun convergePatterns(first: Pattern, second: Pattern): Pattern = when {
+    first is JSONObjectPattern && second is JSONObjectPattern -> JSONObjectPattern(
+        convergeObjectFields(first.pattern, second.pattern),
+    )
+    first is JSONArrayPattern && first.pattern.isEmpty() && second is ListPattern -> second
+    first is ListPattern && second is JSONArrayPattern && second.pattern.isEmpty() -> first
+    first is ListPattern && second is ListPattern && first.pattern === AnythingPattern -> second
+    first is ListPattern && second is ListPattern && second.pattern === AnythingPattern -> first
+    first is ListPattern && second is ListPattern -> ListPattern(convergePatterns(first.pattern, second.pattern))
+    first is NullPattern && second !is NullPattern -> nullablePattern(second)
+    second is NullPattern && first !is NullPattern -> nullablePattern(first)
+    samePatternType(first, second) -> second
+    else -> first
+}
+
+private fun convergeObjectFields(first: Map<String, Pattern>, second: Map<String, Pattern>): Map<String, Pattern> {
+    val firstByName = first.entries.associateBy { withoutOptionality(it.key) }
+    val secondByName = second.entries.associateBy { withoutOptionality(it.key) }
+    val commonNames = firstByName.keys.filter { it in secondByName }
+
+    val common = commonNames.associateWith { name ->
+        convergePatterns(firstByName.getValue(name).value, secondByName.getValue(name).value)
+    }.mapKeys { (name, _) ->
+        if (firstByName.getValue(name).key.endsWith("?") || secondByName.getValue(name).key.endsWith("?")) "$name?" else name
+    }
+    val secondOnly = secondByName.filterKeys { it !in firstByName }.map { (name, entry) -> "$name?" to entry.value }.toMap()
+    val firstOnly = firstByName.filterKeys { it !in secondByName }.map { (name, entry) -> "$name?" to entry.value }.toMap()
+
+    return common + secondOnly + firstOnly
+}
+
+private fun samePatternType(first: Pattern, second: Pattern): Boolean = when {
+    first is DeferredPattern && second is DeferredPattern -> first.pattern == second.pattern
+    else -> first::class == second::class
+}
+
+private fun nullablePattern(pattern: Pattern): Pattern {
+    val patterns = listOf(EmptyStringPattern, pattern)
+    return AnyPattern(pattern = patterns, extensions = patterns.extractCombinedExtensions())
+}

--- a/core/src/main/kotlin/io/specmatic/core/utilities/TrafficToFeature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/TrafficToFeature.kt
@@ -1,0 +1,170 @@
+package io.specmatic.core.utilities
+
+import io.specmatic.core.Feature
+import io.specmatic.core.HttpRequest
+import io.specmatic.core.HttpResponse
+import io.specmatic.core.HttpHeadersPattern
+import io.specmatic.core.HttpQueryParamPattern
+import io.specmatic.core.HttpRequestPattern
+import io.specmatic.core.HttpResponsePattern
+import io.specmatic.core.MultiPartFormDataPattern
+import io.specmatic.core.NamedStub
+import io.specmatic.core.NoBodyValue
+import io.specmatic.core.Scenario
+import io.specmatic.core.adjustPayloadForContentType
+import io.specmatic.core.buildHttpPathPattern
+import io.specmatic.core.partitionOnContentType
+import io.specmatic.core.pattern.ContractException
+import io.specmatic.core.pattern.EmptyStringPattern
+import io.specmatic.core.pattern.ExactValuePattern
+import io.specmatic.core.pattern.Examples
+import io.specmatic.core.pattern.Pattern
+import io.specmatic.core.pattern.QueryParameterScalarPattern
+import io.specmatic.core.pattern.Row
+import io.specmatic.core.pattern.withPatternDelimiters
+import io.specmatic.core.pattern.withoutPatternDelimiters
+import io.specmatic.core.queryParamsToScalarMap
+import io.specmatic.core.stringMapToScalarMap
+import io.specmatic.core.stringMapToValueMap
+import io.specmatic.core.value.EmptyString
+import io.specmatic.core.value.StringValue
+import io.specmatic.core.value.Value
+import io.specmatic.license.core.SpecmaticProtocol
+import io.specmatic.reporter.model.SpecType
+
+internal fun featureFromTraffic(featureName: String, namedStubs: List<NamedStub>): Feature = Feature(
+    scenarios = namedStubs.map(::scenarioFromTraffic),
+    name = featureName,
+    protocol = SpecmaticProtocol.HTTP,
+)
+
+private data class RequestInference(
+    val pattern: HttpRequestPattern,
+    val types: Map<String, Pattern>,
+)
+
+private data class ResponseInference(
+    val pattern: HttpResponsePattern,
+    val types: Map<String, Pattern>,
+)
+
+private data class ResponseBodyInference(
+    val pattern: Pattern,
+    val types: Map<String, Pattern>,
+)
+
+private fun scenarioFromTraffic(namedStub: NamedStub): Scenario {
+    val request = namedStub.stub.requestElsePartialRequest()
+    val response = namedStub.stub.response
+    val requestInference = inferRequest(request)
+    val responseInference = inferResponse(response, requestInference.types)
+    val namedPatterns = responseInference.types.mapKeys { (name, _) ->
+        withPatternDelimiters(withoutPatternDelimiters(name))
+    }
+    val exampleRow = Row(
+        name = namedStub.name,
+        requestExample = request.asTrafficExample(),
+        responseExample = response.copy(headers = response.headers.withoutContentTypeParameters()),
+        scenarioStub = namedStub.stub,
+    )
+
+    return Scenario(
+        name = namedStub.name,
+        httpRequestPattern = requestInference.pattern,
+        httpResponsePattern = responseInference.pattern,
+        examples = listOf(Examples(exampleRow.columnNames, listOf(exampleRow))),
+        patterns = namedPatterns,
+        protocol = SpecmaticProtocol.HTTP,
+        specType = SpecType.OPENAPI,
+    )
+}
+
+private fun HttpRequest.asTrafficExample(): HttpRequest = copy(
+    headers = headers.withoutContentTypeParameters(),
+    body = if (body == NoBodyValue) EmptyString else body,
+)
+
+private fun Map<String, String>.withoutContentTypeParameters(): Map<String, String> = mapValues { (name, value) ->
+    if (name.equals("Content-Type", ignoreCase = true)) value.substringBefore(';').trim() else value
+}
+
+private fun inferRequest(request: HttpRequest): RequestInference {
+    val method = request.method ?: throw ContractException("Can't generate a spec file without the http method.")
+    val path = request.path ?: throw ContractException("Can't generate a contract without the url.")
+    val (queryPatterns, queryTypes) = inferPatterns(queryParamsToScalarMap(request.queryParams), emptyMap())
+    val (contentType, otherHeaders) = partitionOnContentType(request.headers)
+    val (headerPatterns, headerTypes) = inferPatterns(stringMapToScalarMap(otherHeaders), queryTypes)
+    val headersWithContentType = contentType?.value?.substringBefore(';')?.let { value ->
+        headerPatterns + (contentType.key to ExactValuePattern(StringValue(value)))
+    } ?: headerPatterns
+
+    val bodyInference = inferRequestPayload(request, headerTypes)
+    return RequestInference(
+        pattern = HttpRequestPattern(
+            headersPattern = HttpHeadersPattern(headersWithContentType),
+            httpPathPattern = buildHttpPathPattern(path.replace(" ", "%20")),
+            httpQueryParamPattern = HttpQueryParamPattern(queryPatterns.mapValues { (_, pattern) ->
+                QueryParameterScalarPattern(pattern)
+            }),
+            method = method,
+            body = bodyInference.body,
+            formFieldsPattern = bodyInference.formFields,
+            multiPartFormDataPattern = bodyInference.multiPart,
+        ),
+        types = bodyInference.types,
+    )
+}
+
+private data class RequestPayloadInference(
+    val body: Pattern = EmptyStringPattern,
+    val formFields: Map<String, Pattern> = emptyMap(),
+    val multiPart: List<MultiPartFormDataPattern> = emptyList(),
+    val types: Map<String, Pattern>,
+)
+
+private fun inferRequestPayload(request: HttpRequest, types: Map<String, Pattern>): RequestPayloadInference = when {
+    request.multiPartFormData.isNotEmpty() -> RequestPayloadInference(
+        multiPart = request.multiPartFormData.map { it.inferType() },
+        types = types,
+    )
+    request.formFields.isNotEmpty() -> {
+        val (patterns, updatedTypes) = inferPatterns(stringMapToValueMap(request.formFields), types)
+        RequestPayloadInference(formFields = patterns, types = updatedTypes)
+    }
+    request.body == EmptyString || request.body == NoBodyValue -> RequestPayloadInference(types = types)
+    else -> {
+        val declaration = request.body.toPatternDeclaration("RequestBody", types)
+        RequestPayloadInference(body = declaration.pattern, types = declaration.types)
+    }
+}
+
+private fun inferResponse(response: HttpResponse, initialTypes: Map<String, Pattern>): ResponseInference {
+    if (response.status <= 0) throw ContractException("Can't generate a contract without a response status")
+
+    val (contentType, otherHeaders) = partitionOnContentType(response.headers)
+    val (headerPatterns, headerTypes) = inferPatterns(stringMapToScalarMap(otherHeaders), initialTypes)
+    val headersWithContentType = contentType?.value?.substringBefore(';')?.let { value ->
+        headerPatterns + (contentType.key to ExactValuePattern(StringValue(value)))
+    } ?: headerPatterns
+    val payload = adjustPayloadForContentType(response.body, response.headers)
+    val bodyInference = if (payload == EmptyString) {
+        ResponseBodyInference(EmptyStringPattern, headerTypes)
+    } else {
+        val declaration = payload.toPatternDeclaration("ResponseBody", headerTypes)
+        ResponseBodyInference(declaration.pattern, declaration.types)
+    }
+
+    return ResponseInference(
+        pattern = HttpResponsePattern(HttpHeadersPattern(headersWithContentType), response.status, bodyInference.pattern),
+        types = bodyInference.types,
+    )
+}
+
+private fun inferPatterns(
+    values: Map<String, Value>,
+    initialTypes: Map<String, Pattern>,
+): Pair<Map<String, Pattern>, Map<String, Pattern>> =
+    values.entries.fold(emptyMap<String, Pattern>() to initialTypes) { (patterns, types), (name, value) ->
+        val declaration = value.toPatternDeclaration(name, types)
+        patterns + (name to declaration.pattern) to declaration.types
+    }

--- a/core/src/test/kotlin/io/specmatic/core/PostmanKtTests.kt
+++ b/core/src/test/kotlin/io/specmatic/core/PostmanKtTests.kt
@@ -10,9 +10,53 @@ import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.pattern.parsedJSON
 import io.specmatic.core.pattern.parsedValue
 import io.specmatic.core.value.*
+import io.specmatic.mock.ScenarioStub
 import io.specmatic.stub.HttpStub
 
 class PostmanKtTests {
+    @Test
+    fun `Postman conversion preserves parsed example row columns values and order`() {
+        val baseUrl = BaseURLInfo("localhost", 9000, "http", "http://localhost:9000")
+        val stubs = listOf(
+            NamedStub(
+                "create item",
+                ScenarioStub(
+                    HttpRequest(
+                        "POST",
+                        "/items",
+                        headers = mapOf("X-Trace" to "first"),
+                        body = parsedJSON("""{"name":"tea","note":"hot"}"""),
+                        queryParams = QueryParameters(mapOf("page" to "1")),
+                    ),
+                    HttpResponse(201, headers = mapOf("Date" to "Monday"), body = StringValue("created")),
+                ),
+            ),
+            NamedStub(
+                "create item",
+                ScenarioStub(
+                    HttpRequest(
+                        "POST",
+                        "/items",
+                        headers = mapOf("X-Trace" to "second"),
+                        body = parsedJSON("""{"name":"coffee","note":"iced"}"""),
+                        queryParams = QueryParameters(mapOf("page" to "2")),
+                    ),
+                    HttpResponse(201, headers = mapOf("Date" to "Tuesday"), body = StringValue("accepted")),
+                ),
+            ),
+        )
+        val postmanCollection = PostmanCollection("Rows", stubs.map { baseUrl to it })
+
+        val feature = parseGherkinStringToFeature(toGherkinFeature(postmanCollection))
+        val examples = feature.scenarios.single().examples.single()
+
+        assertThat(examples.columnNames).containsExactly("page", "X-Trace", "name", "note", "__comment__")
+        assertThat(examples.rows.map { it.values }).containsExactly(
+            listOf("1", "first", "tea", "hot", "Monday"),
+            listOf("2", "second", "coffee", "iced", "Tuesday"),
+        )
+    }
+
     @Test
     fun `should be able to guess a boolean value`() {
         assertThat(guessType(StringValue("true"))).isEqualTo(BooleanValue(true))

--- a/core/src/test/kotlin/io/specmatic/core/PostmanKtTests.kt
+++ b/core/src/test/kotlin/io/specmatic/core/PostmanKtTests.kt
@@ -9,14 +9,14 @@ import io.specmatic.conversions.*
 import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.pattern.parsedJSON
 import io.specmatic.core.pattern.parsedValue
+import io.specmatic.core.utilities.featureFromTraffic
 import io.specmatic.core.value.*
 import io.specmatic.mock.ScenarioStub
 import io.specmatic.stub.HttpStub
 
 class PostmanKtTests {
     @Test
-    fun `Postman conversion preserves parsed example row columns values and order`() {
-        val baseUrl = BaseURLInfo("localhost", 9000, "http", "http://localhost:9000")
+    fun `Postman structured examples retain traffic and generate original requests in order`() {
         val stubs = listOf(
             NamedStub(
                 "create item",
@@ -45,16 +45,35 @@ class PostmanKtTests {
                 ),
             ),
         )
-        val postmanCollection = PostmanCollection("Rows", stubs.map { baseUrl to it })
+        val feature = featureFromTraffic("Rows", stubs)
+        val rows = feature.scenarios.map { it.examples.single().rows.single() }
 
-        val feature = parseGherkinStringToFeature(toGherkinFeature(postmanCollection))
-        val examples = feature.scenarios.single().examples.single()
+        assertThat(rows.map { it.name }).containsExactly("create item", "create item")
+        assertThat(rows.map { it.requestExample }).containsExactlyElementsOf(stubs.map { it.stub.request })
+        assertThat(rows.map { it.responseExample }).containsExactlyElementsOf(stubs.map { it.stub.response })
+        assertThat(rows.map { it.scenarioStub }).containsExactlyElementsOf(stubs.map { it.stub })
+        assertThat(feature.generateContractTestScenarios(emptyList()).map { it.second.value.generateHttpRequest() }.toList())
+            .containsExactlyElementsOf(stubs.map { it.stub.request })
+    }
 
-        assertThat(examples.columnNames).containsExactly("page", "X-Trace", "name", "note", "__comment__")
-        assertThat(examples.rows.map { it.values }).containsExactly(
-            listOf("1", "first", "tea", "hot", "Monday"),
-            listOf("2", "second", "coffee", "iced", "Tuesday"),
+    @Test
+    fun `Postman contracts retain base URL group order and membership`() {
+        val firstBaseUrl = BaseURLInfo("first.example", 80, "http", "http://first.example")
+        val secondBaseUrl = BaseURLInfo("second.example", 443, "https", "https://second.example")
+        val firstStub = NamedStub("first", ScenarioStub(HttpRequest("GET", "/one"), HttpResponse(200)))
+        val secondStub = NamedStub("second", ScenarioStub(HttpRequest("GET", "/two"), HttpResponse(201)))
+        val thirdStub = NamedStub("third", ScenarioStub(HttpRequest("GET", "/three"), HttpResponse(202)))
+        val collection = PostmanCollection(
+            "Grouped",
+            listOf(firstBaseUrl to firstStub, secondBaseUrl to secondStub, firstBaseUrl to thirdStub),
         )
+
+        val contracts = contractsFromPostmanCollection(collection)
+
+        assertThat(contracts.map { it.baseURLInfo }).containsExactly(firstBaseUrl, secondBaseUrl)
+        assertThat(contracts.map { it.stubs }).containsExactly(listOf(firstStub, thirdStub), listOf(secondStub))
+        assertThat(contracts.map { contract -> contract.feature.scenarios.map { it.name } })
+            .containsExactly(listOf("first", "third"), listOf("second"))
     }
 
     @Test
@@ -535,83 +554,19 @@ class PostmanKtTests {
 	"protocolProfileBehavior": {}
 }"""
 
-        val info = postmanCollectionToGherkin(postmanContent)
-        val (_, gherkinString, _, stubs) = info.first()
+        val contract = postmanCollectionToContracts(postmanContent).single()
 
-        println(gherkinString)
-
-        val expectedGherkinString = """Feature: Test API
-  Scenario: With no body or params
-    When GET /stuff
-    Then status 200
-    And response-header Connection (string)
-    And response-header Content-Type application/json
-    And response-body (integer)
-  
-  Scenario: With JSON body
-    Given type RequestBody
-      | data | (string) |
-    When POST /stuff
-    And request-body (RequestBody)
-    Then status 200
-    And response-header Connection (string)
-    And response-header Content-Type application/json
-    And response-body (integer)
-  
-    Examples:
-    | data |
-    | value |
-  
-  Scenario: With query
-    When GET /stuff?one=(integer)
-    Then status 200
-    And response-header Connection (string)
-    And response-header Content-Type application/json
-    And response-body (integer)
-  
-    Examples:
-    | one |
-    | 1 |
-  
-  Scenario: Square Of A Number 2
-    When POST /square
-    And request-body (RequestBody: integer)
-    Then status 200
-    And response-header Connection (integer)
-    And response-header Content-Type text/plain
-    And response-body (integer)
-  
-    Examples:
-    | RequestBody |
-    | 10 |
-  
-  Scenario: With form fields
-    When POST /stuff
-    And form-field field1 (integer)
-    Then status 200
-    And response-header Connection (string)
-    And response-header Content-Type application/json
-    And response-body (integer)
-  
-    Examples:
-    | field1 |
-    | 10 |
-  
-  Scenario: With form data
-    When POST /stuff
-    And request-part part1 (integer)
-    Then status 200
-    And response-header Connection (string)
-    And response-header Content-Type application/json
-    And response-body (integer)
-  
-    Examples:
-    | part1 |
-    | 10 |"""
-
-        assertThat(gherkinString.trim()).isEqualTo(expectedGherkinString.trim())
-
-        validate(gherkinString, stubs, mapOf("Content-Type" to "text/plain"))
+        assertThat(contract.feature.name).isEqualTo("Test API")
+        assertThat(contract.baseURLInfo.originalBaseURL).isEqualTo("http://localhost:9000")
+        assertThat(contract.stubs.map { it.name }).containsExactly(
+            "With no body or params",
+            "With JSON body",
+            "With query",
+            "Square Of A Number 2",
+            "With form fields",
+            "With form data",
+        )
+        validate(contract.feature, contract.stubs, mapOf("Content-Type" to "text/plain"))
     }
 
     @Test
@@ -698,8 +653,7 @@ class PostmanKtTests {
         assertThat(response.headers.getOrDefault("X-Header", "does not exist")).isEqualTo("right value")
     }
 
-    private fun validate(gherkinString: String, stubs: List<NamedStub>, additionalHeaders: Map<String, String> = emptyMap()) {
-        val behaviour = parseGherkinStringToFeature(gherkinString)
+    private fun validate(behaviour: Feature, stubs: List<NamedStub>, additionalHeaders: Map<String, String> = emptyMap()) {
         val cleanedUpStubs = stubs.map { it.stub }.map {
             it.copy(
                 response = it.response.copy(

--- a/core/src/test/kotlin/io/specmatic/core/PostmanKtTests.kt
+++ b/core/src/test/kotlin/io/specmatic/core/PostmanKtTests.kt
@@ -52,7 +52,7 @@ class PostmanKtTests {
         assertThat(rows.map { it.requestExample }).containsExactlyElementsOf(stubs.map { it.stub.request })
         assertThat(rows.map { it.responseExample }).containsExactlyElementsOf(stubs.map { it.stub.response })
         assertThat(rows.map { it.scenarioStub }).containsExactlyElementsOf(stubs.map { it.stub })
-        assertThat(feature.generateContractTestScenarios(emptyList()).map { it.second.value.generateHttpRequest() }.toList())
+        assertThat(feature.generateContractTestScenarios().map { it.second.value.generateHttpRequest() }.toList())
             .containsExactlyElementsOf(stubs.map { it.stub.request })
     }
 

--- a/core/src/test/kotlin/io/specmatic/core/utilities/OpenApiYamlFromExampleDirTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/utilities/OpenApiYamlFromExampleDirTest.kt
@@ -4,7 +4,9 @@ import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpResponse
 import io.specmatic.core.NamedStub
 import io.specmatic.core.QueryParameters
+import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.pattern.parsedJSON
+import io.specmatic.core.value.StringValue
 import io.specmatic.mock.ScenarioStub
 import io.specmatic.proxy.ProxyOperation
 import io.swagger.v3.oas.models.OpenAPI
@@ -16,6 +18,154 @@ import org.junit.jupiter.api.io.TempDir
 import java.io.File
 
 class OpenApiYamlFromExampleDirTest {
+    @Test
+    fun `infers scalar request bodies without creating a dangling component reference`() {
+        val openApi = openApiFromTraffic(
+            "Scalar",
+            listOf(namedStub(
+                "echo",
+                HttpRequest("POST", "/echo", mapOf("Content-Type" to "text/plain"), StringValue("hello")),
+                HttpResponse.ok("world"),
+            )),
+        )!!
+
+        val schema = openApi.paths["/echo"]!!.post.requestBody.content["text/plain"]!!.schema
+        assertThat(schema.type).isEqualTo("string")
+        assertThat(schema.`$ref`).isNull()
+    }
+
+    @Test
+    fun `infers arrays nested inside json bodies as array schemas`() {
+        val openApi = openApiFromTraffic(
+            "Arrays",
+            listOf(namedStub(
+                "create",
+                HttpRequest("POST", "/items", body = parsedJSON("""{"tags":["one","two"]}""")),
+                HttpResponse.ok("created"),
+            )),
+        )!!
+
+        val requestSchema = openApi.components.schemas.entries.single { (name, _) -> name.contains("RequestBody") }.value
+        val tagsSchema = requestSchema.properties["tags"]!!
+        assertThat(tagsSchema.type).isEqualTo("array")
+        assertThat(tagsSchema.items!!.type).isEqualTo("string")
+    }
+
+    @Test
+    fun `infers scalar types when example names collide across request locations`() {
+        val request = HttpRequest(
+            method = "POST",
+            path = "/collisions",
+            headers = mapOf("id" to "2"),
+            body = parsedJSON("""{"id":3}"""),
+            queryParams = QueryParameters(mapOf("id" to "1")),
+        )
+
+        val openApi = openApiFromTraffic(
+            "Collisions",
+            listOf(namedStub("collisions", request, HttpResponse.ok("done"))),
+        )!!
+
+        val headerSchema = openApi.paths["/collisions"]!!.post.parameters.single { it.`in` == "header" }.schema
+        assertThat(headerSchema.type).isEqualTo("integer")
+        assertThat(headerSchema.`$ref`).isNull()
+    }
+
+    @Test
+    fun `infers form field schemas`() {
+        val request = HttpRequest(
+            method = "POST",
+            path = "/login",
+            formFields = mapOf("attempt" to "2", "remember" to "true"),
+        )
+
+        val openApi = openApiFromTraffic(
+            "Forms",
+            listOf(namedStub("login", request, HttpResponse.ok("accepted"))),
+        )!!
+
+        val schema = openApi.paths["/login"]!!.post.requestBody.content["application/x-www-form-urlencoded"]!!.schema
+        assertThat(schema.properties["attempt"]!!.type).isEqualTo("integer")
+        assertThat(schema.properties["remember"]!!.type).isEqualTo("boolean")
+    }
+
+    @Test
+    fun `parses json response strings using the recorded content type`() {
+        val response = HttpResponse(
+            400,
+            mapOf("content-type" to "application/problem+json; charset=utf-8"),
+            StringValue("""{"message":"bad"}"""),
+        )
+
+        val openApi = openApiFromTraffic(
+            "Errors",
+            listOf(namedStub("error", HttpRequest("GET", "/errors"), response)),
+        )!!
+
+        val operationResponse = openApi.paths["/errors"]!!.get.responses["400"]!!
+        assertThat(operationResponse.content).containsKey("application/problem+json")
+        val responseSchema = openApi.components.schemas.entries.single { (name, _) -> name.contains("ResponseBody") }.value
+        assertThat(responseSchema.properties["message"]!!.type).isEqualTo("string")
+    }
+
+    @Test
+    fun `makes fields optional when they are absent from another recording`() {
+        val openApi = openApiFromTraffic(
+            "Orders",
+            listOf(
+                namedStub(
+                    "create",
+                    HttpRequest("POST", "/orders", body = parsedJSON("""{"name":"coffee","note":"hot"}""")),
+                    HttpResponse(201, body = parsedJSON("""{"id":1,"state":"created"}""")),
+                ),
+                namedStub(
+                    "create",
+                    HttpRequest("POST", "/orders", body = parsedJSON("""{"name":"tea"}""")),
+                    HttpResponse(201, body = parsedJSON("""{"id":2}""")),
+                ),
+            ),
+        )!!
+
+        val requestSchema = openApi.components.schemas.entries.single { (name, _) -> name.contains("RequestBody") }.value
+        val responseSchema = openApi.components.schemas.entries.single { (name, _) -> name.contains("ResponseBody") }.value
+        assertThat(requestSchema.required).contains("name").doesNotContain("note")
+        assertThat(responseSchema.required).contains("id").doesNotContain("state")
+    }
+
+    @Test
+    fun `rejects traffic without a request method`() {
+        val exception = assertThrows(ContractException::class.java) {
+            openApiFromTraffic("Invalid", listOf(namedStub("invalid", HttpRequest(path = "/items"), HttpResponse.ok("ok"))))
+        }
+
+        assertThat(exception.message).contains("without the http method")
+    }
+
+    @Test
+    fun `rejects traffic without a request path`() {
+        val exception = assertThrows(ContractException::class.java) {
+            openApiFromTraffic("Invalid", listOf(namedStub("invalid", HttpRequest(method = "GET"), HttpResponse.ok("ok"))))
+        }
+
+        assertThat(exception.message).contains("without the url")
+    }
+
+    @Test
+    fun `rejects traffic without a response status`() {
+        val exception = assertThrows(ContractException::class.java) {
+            openApiFromTraffic("Invalid", listOf(namedStub("invalid", HttpRequest("GET", "/items"), HttpResponse())))
+        }
+
+        assertThat(exception.message).contains("without a response status")
+    }
+
+    @Test
+    fun `returns null when the example directory does not exist`(@TempDir tempDir: File) {
+        val missingDirectory = tempDir.resolve("missing")
+
+        assertThat(openApiYamlFromExampleDir(missingDirectory, sortOrder = emptyList())).isNull()
+    }
+
     @Test
     fun `infers an openapi operation directly from recorded traffic`() {
         val request = HttpRequest(
@@ -94,6 +244,9 @@ class OpenApiYamlFromExampleDirTest {
         val stub = ScenarioStub(request = HttpRequest(method = httpMethod, path = path), response = HttpResponse.ok("ok"))
         dir.resolve(fileName).writeText(stub.toJSON().toStringLiteral())
     }
+
+    private fun namedStub(name: String, request: HttpRequest, response: HttpResponse): NamedStub =
+        NamedStub(name, ScenarioStub(request, response))
 
     private fun proxyOperation(method: String, path: String): ProxyOperation =
         ProxyOperation(method = method, pathPattern = OpenApiPath.from(path).toHttpPathPattern())

--- a/core/src/test/kotlin/io/specmatic/core/utilities/OpenApiYamlFromExampleDirTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/utilities/OpenApiYamlFromExampleDirTest.kt
@@ -3,9 +3,11 @@ package io.specmatic.core.utilities
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpResponse
 import io.specmatic.core.NamedStub
+import io.specmatic.core.NoBodyValue
 import io.specmatic.core.QueryParameters
 import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.pattern.parsedJSON
+import io.specmatic.core.value.NumberValue
 import io.specmatic.core.value.StringValue
 import io.specmatic.mock.ScenarioStub
 import io.specmatic.proxy.ProxyOperation
@@ -18,6 +20,110 @@ import org.junit.jupiter.api.io.TempDir
 import java.io.File
 
 class OpenApiYamlFromExampleDirTest {
+    @Test
+    fun `omits a request body for the default empty body`() {
+        val openApi = openApiFromTraffic(
+            "Empty body",
+            listOf(namedStub("empty", HttpRequest("GET", "/empty"), HttpResponse.ok("done"))),
+        )!!
+
+        assertThat(openApi.paths["/empty"]!!.get.requestBody).isNull()
+    }
+
+    @Test
+    fun `omits response content for the default empty body`() {
+        val openApi = openApiFromTraffic(
+            "Empty body",
+            listOf(namedStub("empty", HttpRequest("GET", "/empty"), HttpResponse(204))),
+        )!!
+
+        assertThat(openApi.paths["/empty"]!!.get.responses["204"]!!.content).isNull()
+    }
+
+    @Test
+    fun `converges fields across objects in a top level array`() {
+        val openApi = openApiFromTraffic(
+            "Items",
+            listOf(namedStub(
+                "create items",
+                HttpRequest("POST", "/items", body = parsedJSON("""[{"id":1},{"id":2,"enabled":true}]""")),
+                HttpResponse.ok("created"),
+            )),
+        )!!
+
+        val requestSchema = openApi.paths["/items"]!!.post.requestBody.content["application/json"]!!.schema
+        val itemSchemaName = requestSchema.items.`$ref`.substringAfterLast('/')
+        val itemSchema = openApi.components.schemas[itemSchemaName]!!
+        assertThat(requestSchema.type).isEqualTo("array")
+        assertThat(itemSchema.properties.keys).containsExactly("id", "enabled")
+        assertThat(itemSchema.required).contains("id").doesNotContain("enabled")
+    }
+
+    @Test
+    fun `converges an empty nested array with a later object array`() {
+        val openApi = openApiFromTraffic(
+            "Groups",
+            listOf(namedStub(
+                "create groups",
+                HttpRequest("POST", "/groups", body = parsedJSON("""[{"members":[]},{"members":[{"id":1}]}]""")),
+                HttpResponse.ok("created"),
+            )),
+        )!!
+
+        val requestSchema = openApi.paths["/groups"]!!.post.requestBody.content["application/json"]!!.schema
+        val groupSchema = openApi.components.schemas[requestSchema.items.`$ref`.substringAfterLast('/')]!!
+        val membersSchema = groupSchema.properties["members"]!!
+        val memberSchema = openApi.components.schemas[membersSchema.items.`$ref`.substringAfterLast('/')]!!
+        assertThat(membersSchema.type).isEqualTo("array")
+        assertThat(memberSchema.properties.keys).containsExactly("id")
+    }
+
+    @Test
+    fun `infers empty arrays without creating a dangling component reference`() {
+        val openApi = openApiFromTraffic(
+            "Items",
+            listOf(namedStub(
+                "create items",
+                HttpRequest("POST", "/items", body = parsedJSON("[]")),
+                HttpResponse.ok("created"),
+            )),
+        )!!
+
+        val schema = openApi.paths["/items"]!!.post.requestBody.content["application/json"]!!.schema
+        assertThat(schema.type).isEqualTo("array")
+        assertThat(schema.items.type).isEqualTo("string")
+        assertThat(schema.`$ref`).isNull()
+    }
+
+    @Test
+    fun `omits a request body for NoBodyValue`() {
+        val openApi = openApiFromTraffic(
+            "No body",
+            listOf(namedStub(
+                "without body",
+                HttpRequest("POST", "/actions", body = NoBodyValue),
+                HttpResponse.ok("done"),
+            )),
+        )!!
+
+        assertThat(openApi.paths["/actions"]!!.post.requestBody).isNull()
+    }
+
+    @Test
+    fun `preserves the recorded response behavior for NoBodyValue`() {
+        val openApi = openApiFromTraffic(
+            "No body",
+            listOf(namedStub(
+                "without response body",
+                HttpRequest("GET", "/actions"),
+                HttpResponse(204, headers = emptyMap(), body = NoBodyValue, externalisedResponseCommand = ""),
+            )),
+        )!!
+
+        val schema = openApi.paths["/actions"]!!.get.responses["204"]!!.content["text/plain"]!!.schema
+        assertThat(schema.enum).containsExactly("No body")
+    }
+
     @Test
     fun `infers scalar request bodies without creating a dangling component reference`() {
         val openApi = openApiFromTraffic(
@@ -32,6 +138,51 @@ class OpenApiYamlFromExampleDirTest {
         val schema = openApi.paths["/echo"]!!.post.requestBody.content["text/plain"]!!.schema
         assertThat(schema.type).isEqualTo("string")
         assertThat(schema.`$ref`).isNull()
+    }
+
+    @Test
+    fun `infers decimal request bodies as number schemas`() {
+        val openApi = openApiFromTraffic(
+            "Decimal",
+            listOf(namedStub(
+                "decimal",
+                HttpRequest("POST", "/decimal", body = NumberValue(1.5)),
+                HttpResponse.ok("done"),
+            )),
+        )!!
+
+        val schema = openApi.paths["/decimal"]!!.post.requestBody.content["text/plain"]!!.schema
+        assertThat(schema.type).isEqualTo("number")
+    }
+
+    @Test
+    fun `infers null object fields as nullable schemas`() {
+        val openApi = openApiFromTraffic(
+            "Nullable",
+            listOf(namedStub(
+                "nullable object",
+                HttpRequest("POST", "/nullable", body = parsedJSON("""{"id":1,"note":null}""")),
+                HttpResponse.ok("done"),
+            )),
+        )!!
+
+        val requestSchema = openApi.components.schemas.entries.single { (name, _) -> name.contains("RequestBody") }.value
+        assertThat(requestSchema.properties["note"]!!.nullable).isTrue()
+    }
+
+    @Test
+    fun `infers arrays containing null and a value as nullable item schemas`() {
+        val openApi = openApiFromTraffic(
+            "Nullable",
+            listOf(namedStub(
+                "nullable array",
+                HttpRequest("POST", "/nullable", body = parsedJSON("""[null,"value"]""")),
+                HttpResponse.ok("done"),
+            )),
+        )!!
+
+        val schema = openApi.paths["/nullable"]!!.post.requestBody.content["application/json"]!!.schema
+        assertThat(schema.items.nullable).isTrue()
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/core/utilities/OpenApiYamlFromExampleDirTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/utilities/OpenApiYamlFromExampleDirTest.kt
@@ -7,8 +7,10 @@ import io.specmatic.core.NoBodyValue
 import io.specmatic.core.QueryParameters
 import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.pattern.parsedJSON
+import io.specmatic.core.value.BooleanValue
 import io.specmatic.core.value.NumberValue
 import io.specmatic.core.value.StringValue
+import io.specmatic.core.value.Value
 import io.specmatic.mock.ScenarioStub
 import io.specmatic.proxy.ProxyOperation
 import io.swagger.v3.oas.models.OpenAPI
@@ -17,7 +19,11 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 import java.io.File
+import java.util.stream.Stream
 
 class OpenApiYamlFromExampleDirTest {
     @Test
@@ -140,6 +146,23 @@ class OpenApiYamlFromExampleDirTest {
         assertThat(schema.`$ref`).isNull()
     }
 
+    @ParameterizedTest
+    @MethodSource("scalarBodyCases")
+    fun `infers each scalar request body type`(body: Value, expectedType: String) {
+        val openApi = openApiFromTraffic(
+            "Scalar",
+            listOf(namedStub(
+                "echo",
+                HttpRequest("POST", "/echo", body = body),
+                HttpResponse.ok("done"),
+            )),
+        )!!
+
+        val schema = openApi.paths["/echo"]!!.post.requestBody.content["text/plain"]!!.schema
+        assertThat(schema.type).isEqualTo(expectedType)
+        assertThat(schema.`$ref`).isNull()
+    }
+
     @Test
     fun `infers decimal request bodies as number schemas`() {
         val openApi = openApiFromTraffic(
@@ -223,6 +246,69 @@ class OpenApiYamlFromExampleDirTest {
     }
 
     @Test
+    fun `infers non-string scalar types for header and query parameters`() {
+        val request = HttpRequest(
+            method = "GET",
+            path = "/search",
+            headers = mapOf(
+                "X-Count" to "10",
+                "X-Ratio" to "1.5",
+                "X-Enabled" to "true",
+            ),
+            queryParams = QueryParameters(
+                mapOf(
+                    "count" to "10",
+                    "ratio" to "1.5",
+                    "enabled" to "true",
+                ),
+            ),
+        )
+
+        val openApi = openApiFromTraffic(
+            "Search",
+            listOf(namedStub("search", request, HttpResponse.ok("done"))),
+        )!!
+        val parameters = openApi.paths["/search"]!!.get.parameters
+
+        assertThat(parameters.single { it.`in` == "header" && it.name == "X-Count" }.schema.type).isEqualTo("integer")
+        assertThat(parameters.single { it.`in` == "header" && it.name == "X-Ratio" }.schema.type).isEqualTo("number")
+        assertThat(parameters.single { it.`in` == "header" && it.name == "X-Enabled" }.schema.type).isEqualTo("boolean")
+        assertThat(parameters.single { it.`in` == "query" && it.name == "count" }.schema.type).isEqualTo("integer")
+        assertThat(parameters.single { it.`in` == "query" && it.name == "ratio" }.schema.type).isEqualTo("number")
+        assertThat(parameters.single { it.`in` == "query" && it.name == "enabled" }.schema.type).isEqualTo("boolean")
+    }
+
+    @Test
+    fun `infers header optionality and preserves optional query parameters across recordings`() {
+        val firstRequest = HttpRequest(
+            method = "GET",
+            path = "/search",
+            headers = mapOf("X-Mandatory" to "one", "X-Optional" to "present"),
+            queryParams = QueryParameters(mapOf("mandatory" to "one", "optional" to "present")),
+        )
+        val secondRequest = HttpRequest(
+            method = "GET",
+            path = "/search",
+            headers = mapOf("X-Mandatory" to "two"),
+            queryParams = QueryParameters(mapOf("mandatory" to "two")),
+        )
+
+        val openApi = openApiFromTraffic(
+            "Search",
+            listOf(
+                namedStub("search", firstRequest, HttpResponse.ok("done")),
+                namedStub("search", secondRequest, HttpResponse.ok("done")),
+            ),
+        )!!
+        val parameters = openApi.paths["/search"]!!.get.parameters
+
+        assertThat(parameters.single { it.name == "X-Mandatory" }.required).isTrue()
+        assertThat(parameters.single { it.name == "X-Optional" }.required).isFalse()
+        assertThat(parameters.single { it.name == "mandatory" }.required != true).isTrue()
+        assertThat(parameters.single { it.name == "optional" }.required != true).isTrue()
+    }
+
+    @Test
     fun `infers form field schemas`() {
         val request = HttpRequest(
             method = "POST",
@@ -281,6 +367,76 @@ class OpenApiYamlFromExampleDirTest {
         val responseSchema = openApi.components.schemas.entries.single { (name, _) -> name.contains("ResponseBody") }.value
         assertThat(requestSchema.required).contains("name").doesNotContain("note")
         assertThat(responseSchema.required).contains("id").doesNotContain("state")
+    }
+
+    @Test
+    fun `preserves the root path in the generated operation`() {
+        val openApi = openApiFromTraffic(
+            "Root",
+            listOf(namedStub("root", HttpRequest("GET", "/"), HttpResponse.ok("done"))),
+        )!!
+
+        assertThat(openApi.paths.keys).containsExactly("/")
+        assertThat(openApi.paths["/"]!!.get).isNotNull()
+    }
+
+    @ParameterizedTest
+    @MethodSource("scalarBodyCases")
+    fun `infers each scalar response body type`(body: Value, expectedType: String) {
+        val openApi = openApiFromTraffic(
+            "Scalar",
+            listOf(namedStub(
+                "result",
+                HttpRequest("GET", "/result"),
+                HttpResponse(200, body = body),
+            )),
+        )!!
+
+        val schema = openApi.paths["/result"]!!.get.responses["200"]!!.content["text/plain"]!!.schema
+        assertThat(schema.type).isEqualTo(expectedType)
+        assertThat(schema.`$ref`).isNull()
+    }
+
+    @Test
+    fun `infers a top level array response body`() {
+        val openApi = openApiFromTraffic(
+            "Items",
+            listOf(namedStub(
+                "items",
+                HttpRequest("GET", "/items"),
+                HttpResponse(200, body = parsedJSON("""[{"id":1},{"id":2}]""")),
+            )),
+        )!!
+
+        val responseSchema = openApi.paths["/items"]!!.get.responses["200"]!!.content["application/json"]!!.schema
+        val itemSchema = openApi.components.schemas[responseSchema.items.`$ref`.substringAfterLast('/')]!!
+        assertThat(responseSchema.type).isEqualTo("array")
+        assertThat(itemSchema.type).isEqualTo("object")
+        assertThat(itemSchema.properties["id"]!!.type).isEqualTo("integer")
+    }
+
+    @Test
+    fun `infers mandatory and optional response headers across recordings`() {
+        val firstResponse = HttpResponse(
+            200,
+            headers = mapOf("X-Mandatory" to "one", "X-Optional" to "present"),
+        )
+        val secondResponse = HttpResponse(
+            200,
+            headers = mapOf("X-Mandatory" to "two"),
+        )
+
+        val openApi = openApiFromTraffic(
+            "Results",
+            listOf(
+                namedStub("result", HttpRequest("GET", "/result"), firstResponse),
+                namedStub("result", HttpRequest("GET", "/result"), secondResponse),
+            ),
+        )!!
+        val headers = openApi.paths["/result"]!!.get.responses["200"]!!.headers
+
+        assertThat(headers["X-Mandatory"]!!.required).isTrue()
+        assertThat(headers["X-Optional"]!!.required).isFalse()
     }
 
     @Test
@@ -416,5 +572,14 @@ class OpenApiYamlFromExampleDirTest {
         }
 
         return result
+    }
+
+    companion object {
+        @JvmStatic
+        private fun scalarBodyCases(): Stream<Arguments> = Stream.of(
+            Arguments.of(StringValue("hello"), "string"),
+            Arguments.of(NumberValue(10), "integer"),
+            Arguments.of(BooleanValue(true), "boolean"),
+        )
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/utilities/OpenApiYamlFromExampleDirTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/utilities/OpenApiYamlFromExampleDirTest.kt
@@ -2,6 +2,9 @@ package io.specmatic.core.utilities
 
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpResponse
+import io.specmatic.core.NamedStub
+import io.specmatic.core.QueryParameters
+import io.specmatic.core.pattern.parsedJSON
 import io.specmatic.mock.ScenarioStub
 import io.specmatic.proxy.ProxyOperation
 import io.swagger.v3.oas.models.OpenAPI
@@ -13,6 +16,40 @@ import org.junit.jupiter.api.io.TempDir
 import java.io.File
 
 class OpenApiYamlFromExampleDirTest {
+    @Test
+    fun `infers an openapi operation directly from recorded traffic`() {
+        val request = HttpRequest(
+            method = "POST",
+            path = "/orders/(id:number)",
+            headers = mapOf("Content-Type" to "application/json; charset=utf-8", "X-Retry" to "3"),
+            body = parsedJSON("""{"name":"coffee","quantity":2}"""),
+            queryParams = QueryParameters(mapOf("active" to "true")),
+        )
+        val response = HttpResponse(
+            status = 201,
+            headers = mapOf("Content-Type" to "application/json"),
+            body = parsedJSON("""{"id":10,"accepted":true}"""),
+        )
+
+        val openApi = openApiFromTraffic(
+            featureName = "Orders",
+            namedStubs = listOf(NamedStub("create order", ScenarioStub(request, response))),
+        )
+
+        assertThat(openApi).isNotNull
+        val operation = openApi!!.paths["/orders/{id}"]!!.post
+        assertThat(operation.parameters.map { it.name }).contains("id", "active", "X-Retry")
+        assertThat(operation.requestBody.content).containsKey("application/json")
+        assertThat(operation.responses).containsKey("201")
+        assertThat(operation.responses["201"]!!.content).containsKey("application/json")
+        assertThat(openApi.components.schemas).isNotEmpty
+    }
+
+    @Test
+    fun `returns null when there is no recorded traffic`() {
+        assertThat(openApiFromTraffic("Empty", emptyList())).isNull()
+    }
+
     @Test
     fun `openapi spec should respect proxy operation path sort order`(@TempDir tempDir: File) {
         writeStub(tempDir, "a.json", httpMethod = "GET", path = "/orders")

--- a/core/src/test/kotlin/io/specmatic/core/utilities/TrafficPatternInferenceTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/utilities/TrafficPatternInferenceTest.kt
@@ -1,0 +1,18 @@
+package io.specmatic.core.utilities
+
+import io.specmatic.core.pattern.ContractException
+import io.specmatic.core.value.fold.UnknownValue
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class TrafficPatternInferenceTest {
+    @Test
+    fun `rejects value shapes that do not participate in visitor traversal`() {
+        val exception = assertThrows<ContractException> {
+            UnknownValue().toPatternDeclaration("RequestBody")
+        }
+
+        assertThat(exception.message).contains("Cannot infer an OpenAPI pattern from UnknownValue")
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/utilities/TrafficToFeatureTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/utilities/TrafficToFeatureTest.kt
@@ -1,0 +1,42 @@
+package io.specmatic.core.utilities
+
+import io.specmatic.core.HttpRequest
+import io.specmatic.core.HttpResponse
+import io.specmatic.core.NamedStub
+import io.specmatic.core.NoBodyValue
+import io.specmatic.core.value.EmptyString
+import io.specmatic.mock.ScenarioStub
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class TrafficToFeatureTest {
+    @Test
+    fun `normalizes generated traffic examples without changing the retained stub`() {
+        val stub = ScenarioStub(
+            request = HttpRequest(
+                method = "POST",
+                path = "/items",
+                headers = mapOf("Content-Type" to "application/json; charset=utf-8"),
+                body = NoBodyValue,
+            ),
+            response = HttpResponse(
+                status = 204,
+                headers = mapOf("Content-Type" to "text/plain; charset=utf-8"),
+            ),
+        )
+
+        val feature = featureFromTraffic("Traffic", listOf(NamedStub("empty body", stub)))
+        val row = feature.scenarios.single().examples.single().rows.single()
+        val generatedRequest = feature.generateContractTestScenarios(emptyList())
+            .single().second.value.generateHttpRequest()
+
+        assertThat(row.requestExample).isEqualTo(
+            stub.request.copy(headers = mapOf("Content-Type" to "application/json"), body = EmptyString)
+        )
+        assertThat(row.responseExample).isEqualTo(
+            stub.response.copy(headers = mapOf("Content-Type" to "text/plain"))
+        )
+        assertThat(row.scenarioStub).isEqualTo(stub)
+        assertThat(generatedRequest).isEqualTo(row.requestExample)
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/utilities/TrafficToFeatureTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/utilities/TrafficToFeatureTest.kt
@@ -27,7 +27,7 @@ class TrafficToFeatureTest {
 
         val feature = featureFromTraffic("Traffic", listOf(NamedStub("empty body", stub)))
         val row = feature.scenarios.single().examples.single().rows.single()
-        val generatedRequest = feature.generateContractTestScenarios(emptyList())
+        val generatedRequest = feature.generateContractTestScenarios()
             .single().second.value.generateHttpRequest()
 
         assertThat(row.requestExample).isEqualTo(


### PR DESCRIPTION
## Summary

- Eliminate the need for Gherkin while converting traffic to a spec
- Update Postman and import flows to use the streamlined conversion path
- Extend coverage for traffic inference, feature generation, OpenAPI examples, and imports
