### PR TITLE
Fix: Binary multipart payloads being treated as filenames

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -7,9 +7,9 @@ plugins {
 dependencies {
     // Being explicitly added due a HIGH vulnerability GHSA-rwm7-x88c-3g2p, being pulled transitively
     // Remove and upgrade io.ktor:ktor-server-netty-jvm:2.3.13 once it has been updated
-    implementation("io.netty:netty-transport-native-epoll:4.2.15.Final")
-    implementation("io.netty:netty-codec-http:4.2.15.Final")
-    implementation("io.netty:netty-codec-http2:4.2.15.Final")
+    implementation("io.netty:netty-transport-native-epoll:4.2.16.Final")
+    implementation("io.netty:netty-codec-http:4.2.16.Final")
+    implementation("io.netty:netty-codec-http2:4.2.16.Final")
     implementation("io.specmatic.build-reporter:specmatic-reporter-min:${project.property("specmaticReporterVersion")}") {
         exclude(group = "commons-logging", module = "commons-logging")
         exclude(group = "io.swagger.parser.v3", module = "swagger-parser")

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -1705,9 +1705,10 @@ class OpenApiSpecification(
 
                             if (partSchema.isBinarySchema()) {
                                 MultiPartFilePattern(
-                                    partNameWithPresence,
-                                    toSpecmaticPattern(partSchema, emptyList(), collectorContext = partNameContext),
-                                    partContentType
+                                    name = partNameWithPresence,
+                                    filename = null,
+                                    contentType = partContentType ?: "application/octet-stream",
+                                    content = toSpecmaticPattern(partSchema, emptyList(), collectorContext = partNameContext)
                                 )
                             } else {
                                 MultiPartContentPattern(

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
@@ -308,6 +308,8 @@ data class HttpRequest(
             when (part) {
                 is MultiPartContentValue -> part
                 is MultiPartFileValue -> {
+                    if (part.content.length > 0 || part.filename.isBlank()) return@map part
+
                     val partFile = File(part.filename.removePrefix("@"))
                     val binaryContent = if (partFile.exists()) {
                         MultiPartContent(partFile)

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
@@ -202,7 +202,7 @@ data class HttpRequest(
         val bodyString = when {
             formFields.isNotEmpty() -> formFields.map { "${it.key}=${it.value}" }.joinToString("&")
             multiPartFormData.isNotEmpty() -> {
-                multiPartFormData.joinToString("\n") { part -> part.toDisplayableValue() }
+                multiPartFormData.joinToString("\n\n") { part -> part.toDisplayableValue() }
             }
 
             else -> body.toString()

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
@@ -308,7 +308,7 @@ data class HttpRequest(
             when (part) {
                 is MultiPartContentValue -> part
                 is MultiPartFileValue -> {
-                    if (part.content.length > 0 || part.filename.isBlank()) return@map part
+                    if (part.filename.isBlank()) return@map part
 
                     val partFile = File(part.filename.removePrefix("@"))
                     val binaryContent = if (partFile.exists()) {

--- a/core/src/main/kotlin/io/specmatic/core/MultiPartFormDataPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/MultiPartFormDataPattern.kt
@@ -3,7 +3,9 @@ package io.specmatic.core
 import io.specmatic.core.Result.Failure
 import io.specmatic.core.Result.Success
 import io.specmatic.core.pattern.*
+import io.specmatic.core.value.BinaryValue
 import io.specmatic.core.value.StringValue
+import io.specmatic.core.value.Value
 import java.io.File
 
 sealed class MultiPartFormDataPattern(open val name: String, open val contentType: String?) {
@@ -83,20 +85,42 @@ data class MultiPartContentPattern(override val name: String, val content: Patte
     }
 }
 
-data class MultiPartFilePattern(override val name: String, val filename: Pattern, override val contentType: String? = null, val contentEncoding: String? = null) : MultiPartFormDataPattern(name, contentType) {
+data class MultiPartFilePattern(
+    override val name: String,
+    val filename: Pattern?,
+    override val contentType: String? = null,
+    val contentEncoding: String? = null,
+    val content: Pattern? = null
+) : MultiPartFormDataPattern(name, contentType) {
     override fun newBasedOn(row: Row, resolver: Resolver): Sequence<MultiPartFormDataPattern?> {
         val rowKey = "${name}_filename"
         return sequenceOf(this.copy(filename = if(row.containsField(rowKey)) ExactValuePattern(StringValue(row.getField(rowKey))) else filename))
     }
 
-    override fun generate(resolver: Resolver): MultiPartFormDataValue =
-            MultiPartFileValue(name, resolver.withCyclePrevention(filename, filename::generate).toStringLiteral(), contentType ?: "", contentEncoding)
+    override fun generate(resolver: Resolver): MultiPartFormDataValue {
+        val generatedFilename = filename?.let {
+            resolver.withCyclePrevention(it, it::generate).toStringLiteral()
+        }.orEmpty()
+        val generatedContent = content?.let {
+            resolver.withCyclePrevention(it, it::generate).toMultiPartContent()
+        } ?: MultiPartContent()
+
+        return MultiPartFileValue(
+            name = name,
+            filename = generatedFilename,
+            contentType = contentType ?: "",
+            contentEncoding = contentEncoding,
+            content = generatedContent
+        )
+    }
 
     override fun matches(value: MultiPartFormDataValue, resolver: Resolver): Result {
         return when {
             value !is MultiPartFileValue -> Failure("The contract expected a file, but got content instead.", ruleViolation = StandardRuleViolation.TYPE_MISMATCH)
             name != value.name -> Failure("The contract expected a part name to be $name, but got ${value.name}.", failureReason = FailureReason.PartNameMisMatch, ruleViolation = StandardRuleViolation.VALUE_MISMATCH)
-            fileContentMismatch(value, resolver) -> fileContentMismatchError(value, resolver)
+            content == null && fileContentMismatch(value, resolver) -> fileContentMismatchError(value, resolver)
+            content != null && filenameMismatch(value, resolver) -> filenameMismatchError(value, resolver)
+            content != null && contentMismatch(value, resolver) -> contentMismatchError(value, resolver)
             //TODO: Fix below comment
 //            contentType != null && value.contentType != null && value.contentType != contentType -> Failure("The contract expected ${contentType.let { "content type $contentType" }}, but got ${value.contentType?.let { "content type $value.contentType" } ?: "no content type."}.")
             contentEncoding != null && value.contentEncoding != contentEncoding -> {
@@ -111,6 +135,28 @@ data class MultiPartFilePattern(override val name: String, val filename: Pattern
             else -> Success()
         }
     }
+
+    private fun filenameMismatch(value: MultiPartFileValue, resolver: Resolver): Boolean =
+        filename?.matches(StringValue(value.filename), resolver)?.isSuccess()?.not() ?: false
+
+    private fun filenameMismatchError(value: MultiPartFileValue, resolver: Resolver): Failure =
+        Failure(
+            message = "In the part named $name, the contract expected the filename to be ${filename?.typeName}, but got ${value.filename}.",
+            failureReason = FailureReason.PartNameMisMatch,
+            cause = filename?.matches(StringValue(value.filename), resolver) as? Failure,
+            ruleViolation = StandardRuleViolation.VALUE_MISMATCH
+        )
+
+    private fun contentMismatch(value: MultiPartFileValue, resolver: Resolver): Boolean =
+        content?.matches(BinaryValue(value.content.bytes), resolver)?.isSuccess()?.not() ?: false
+
+    private fun contentMismatchError(value: MultiPartFileValue, resolver: Resolver): Failure =
+        Failure(
+            message = "In the part named $name, the file content did not match the contract.",
+            breadCrumb = "content",
+            cause = content?.matches(BinaryValue(value.content.bytes), resolver) as? Failure,
+            ruleViolation = StandardRuleViolation.VALUE_MISMATCH
+        )
 
     private fun fileContentMismatchError(
         value: MultiPartFileValue,
@@ -147,8 +193,8 @@ data class MultiPartFilePattern(override val name: String, val filename: Pattern
                 val contentBytes = value.content.bytes
                 !bytes.contentEquals(contentBytes)
             }
-            else ->
-                !filename.matches(StringValue(value.filename), resolver).isSuccess()
+            null -> false
+            else -> !filename.matches(StringValue(value.filename), resolver).isSuccess()
         }
     }
 
@@ -156,3 +202,9 @@ data class MultiPartFilePattern(override val name: String, val filename: Pattern
         return copy(name = withoutOptionality(name))
     }
 }
+
+private fun Value.toMultiPartContent(): MultiPartContent =
+    when (this) {
+        is BinaryValue -> MultiPartContent(byteArray)
+        else -> MultiPartContent(toStringLiteral())
+    }

--- a/core/src/main/kotlin/io/specmatic/core/MultiPartFormDataPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/MultiPartFormDataPattern.kt
@@ -169,6 +169,11 @@ data class MultiPartFilePattern(
                 ruleViolation = StandardRuleViolation.VALUE_MISMATCH
             )
         }
+        null -> Failure(
+            message = "In the part named $name, the contract did not define a filename pattern.",
+            failureReason = FailureReason.PartNameMisMatch,
+            ruleViolation = StandardRuleViolation.VALUE_MISMATCH
+        )
         else -> Failure(
             message = "In the part named $name, the contract expected the filename to be ${filename.typeName}, but got ${value.filename}.",
             failureReason = FailureReason.PartNameMisMatch,

--- a/core/src/main/kotlin/io/specmatic/core/MultiPartFormDataPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/MultiPartFormDataPattern.kt
@@ -146,6 +146,8 @@ data class MultiPartFilePattern(
         return when {
             filename != null -> Failure("The contract expected a file, but got content instead.", ruleViolation = StandardRuleViolation.TYPE_MISMATCH)
             name != value.name -> Failure("The contract expected a part name to be $name, but got ${value.name}.", failureReason = FailureReason.PartNameMisMatch, ruleViolation = StandardRuleViolation.VALUE_MISMATCH)
+            contentType != null && !contentType.equals(value.contentType, ignoreCase = true) ->
+                Failure("The contract expected a file, but got content instead.", ruleViolation = StandardRuleViolation.TYPE_MISMATCH)
             content != null && contentMismatch(value, resolver) -> contentMismatchError(value, resolver)
             contentEncoding != null -> Failure(
                 message = "The contract expected content encoding $contentEncoding, but got no content encoding.",

--- a/core/src/main/kotlin/io/specmatic/core/MultiPartFormDataPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/MultiPartFormDataPattern.kt
@@ -115,8 +115,14 @@ data class MultiPartFilePattern(
     }
 
     override fun matches(value: MultiPartFormDataValue, resolver: Resolver): Result {
+        return when (value) {
+            is MultiPartFileValue -> matchesFile(value, resolver)
+            is MultiPartContentValue -> matchesContent(value, resolver)
+        }
+    }
+
+    private fun matchesFile(value: MultiPartFileValue, resolver: Resolver): Result {
         return when {
-            value !is MultiPartFileValue -> Failure("The contract expected a file, but got content instead.", ruleViolation = StandardRuleViolation.TYPE_MISMATCH)
             name != value.name -> Failure("The contract expected a part name to be $name, but got ${value.name}.", failureReason = FailureReason.PartNameMisMatch, ruleViolation = StandardRuleViolation.VALUE_MISMATCH)
             content == null && fileContentMismatch(value, resolver) -> fileContentMismatchError(value, resolver)
             content != null && filenameMismatch(value, resolver) -> filenameMismatchError(value, resolver)
@@ -136,6 +142,20 @@ data class MultiPartFilePattern(
         }
     }
 
+    private fun matchesContent(value: MultiPartContentValue, resolver: Resolver): Result {
+        return when {
+            filename != null -> Failure("The contract expected a file, but got content instead.", ruleViolation = StandardRuleViolation.TYPE_MISMATCH)
+            name != value.name -> Failure("The contract expected a part name to be $name, but got ${value.name}.", failureReason = FailureReason.PartNameMisMatch, ruleViolation = StandardRuleViolation.VALUE_MISMATCH)
+            content != null && contentMismatch(value, resolver) -> contentMismatchError(value, resolver)
+            contentEncoding != null -> Failure(
+                message = "The contract expected content encoding $contentEncoding, but got no content encoding.",
+                breadCrumb = "contentEncoding",
+                ruleViolation = StandardRuleViolation.VALUE_MISMATCH
+            )
+            else -> Success()
+        }
+    }
+
     private fun filenameMismatch(value: MultiPartFileValue, resolver: Resolver): Boolean =
         filename?.matches(StringValue(value.filename), resolver)?.isSuccess()?.not() ?: false
 
@@ -150,6 +170,9 @@ data class MultiPartFilePattern(
     private fun contentMismatch(value: MultiPartFileValue, resolver: Resolver): Boolean =
         content?.matches(BinaryValue(value.content.bytes), resolver)?.isSuccess()?.not() ?: false
 
+    private fun contentMismatch(value: MultiPartContentValue, resolver: Resolver): Boolean =
+        content?.matches(value.binaryContent(), resolver)?.isSuccess()?.not() ?: false
+
     private fun contentMismatchError(value: MultiPartFileValue, resolver: Resolver): Failure =
         Failure(
             message = "In the part named $name, the file content did not match the contract.",
@@ -157,6 +180,20 @@ data class MultiPartFilePattern(
             cause = content?.matches(BinaryValue(value.content.bytes), resolver) as? Failure,
             ruleViolation = StandardRuleViolation.VALUE_MISMATCH
         )
+
+    private fun contentMismatchError(value: MultiPartContentValue, resolver: Resolver): Failure =
+        Failure(
+            message = "In the part named $name, the file content did not match the contract.",
+            breadCrumb = "content",
+            cause = content?.matches(value.binaryContent(), resolver) as? Failure,
+            ruleViolation = StandardRuleViolation.VALUE_MISMATCH
+        )
+
+    private fun MultiPartContentValue.binaryContent(): BinaryValue =
+        when (content) {
+            is BinaryValue -> content
+            else -> BinaryValue(content.toStringLiteral().encodeToByteArray())
+        }
 
     private fun fileContentMismatchError(
         value: MultiPartFileValue,

--- a/core/src/main/kotlin/io/specmatic/core/MultiPartFormDataValue.kt
+++ b/core/src/main/kotlin/io/specmatic/core/MultiPartFormDataValue.kt
@@ -115,7 +115,7 @@ data class MultiPartFileValue(override val name: String, val filename: String, o
             filename = filenameToType(),
             contentType = contentType,
             contentEncoding = contentEncoding,
-            content = ExactValuePattern(BinaryValue(content.bytes))
+            content = content.takeIf { it.length > 0 }?.let { ExactValuePattern(BinaryValue(it.bytes)) }
         )
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/MultiPartFormDataValue.kt
+++ b/core/src/main/kotlin/io/specmatic/core/MultiPartFormDataValue.kt
@@ -1,10 +1,12 @@
 package io.specmatic.core
 
 import io.specmatic.core.pattern.ContractException
+import io.specmatic.core.pattern.ExactValuePattern
 import io.specmatic.core.pattern.Pattern
 import io.specmatic.core.pattern.isPatternToken
 import io.specmatic.core.pattern.parsedPattern
 import io.specmatic.core.value.JSONObjectValue
+import io.specmatic.core.value.BinaryValue
 import io.specmatic.core.value.StringValue
 import io.specmatic.core.value.Value
 import io.ktor.client.request.forms.*
@@ -108,14 +110,24 @@ data class MultiPartContent(val bytes: ByteArray) {
 
 data class MultiPartFileValue(override val name: String, val filename: String, override val contentType: String? = null, val contentEncoding: String? = null, val content: MultiPartContent = MultiPartContent(), val boundary: String = "#####") : MultiPartFormDataValue(name, contentType) {
     override fun inferType(): MultiPartFormDataPattern {
-        return MultiPartFilePattern(name, filenameToType(), contentType, contentEncoding)
+        return MultiPartFilePattern(
+            name = name,
+            filename = filenameToType(),
+            contentType = contentType,
+            contentEncoding = contentEncoding,
+            content = ExactValuePattern(BinaryValue(content.bytes))
+        )
     }
 
-    private fun filenameToType() = parsedPattern(filename.removePrefix("@"))
+    private fun filenameToType(): Pattern? =
+        filename.takeIf { it.isNotBlank() }?.let { parsedPattern(it.removePrefix("@")) }
 
     override fun toDisplayableValue(): String {
         val headers = mapOf (
-                CONTENT_DISPOSITION to """form-data; name="$name"; filename="$filename"""",
+                CONTENT_DISPOSITION to listOfNotNull(
+                    """form-data; name="$name"""",
+                    filename.takeIf { it.isNotBlank() }?.let { """filename="$it""" }
+                ).joinToString("; "),
                 "Content-Type" to (contentType ?: ""),
                 "Content-Encoding" to (contentEncoding ?: "")
         ).filter { it.value.isNotBlank() }
@@ -128,7 +140,7 @@ data class MultiPartFileValue(override val name: String, val filename: String, o
 --$boundary
 $headerString
 
-(File content not shown here.  Please examine the file ${filename.removePrefix("@")})
+${filename.takeIf(String::isNotBlank)?.let { "(File content not shown here.  Please examine the file ${it.removePrefix("@")})" } ?: "(File content not shown here.)"}
 """.trim()
     }
 
@@ -155,9 +167,11 @@ $headerString
 
             append("Content-Transfer-Encoding", "binary")
 
-            val partFilePath = filename.removePrefix("@")
-            val partFileName = File(partFilePath).name
-            append(CONTENT_DISPOSITION, "filename=$partFileName")
+            filename.takeIf(String::isNotBlank)?.let {
+                val partFilePath = it.removePrefix("@")
+                val partFileName = File(partFilePath).name
+                append(CONTENT_DISPOSITION, "filename=$partFileName")
+            }
         }, content.length) {
             content.input
         }

--- a/core/src/main/kotlin/io/specmatic/core/MultiPartFormDataValue.kt
+++ b/core/src/main/kotlin/io/specmatic/core/MultiPartFormDataValue.kt
@@ -1,12 +1,10 @@
 package io.specmatic.core
 
 import io.specmatic.core.pattern.ContractException
-import io.specmatic.core.pattern.ExactValuePattern
 import io.specmatic.core.pattern.Pattern
 import io.specmatic.core.pattern.isPatternToken
 import io.specmatic.core.pattern.parsedPattern
 import io.specmatic.core.value.JSONObjectValue
-import io.specmatic.core.value.BinaryValue
 import io.specmatic.core.value.StringValue
 import io.specmatic.core.value.Value
 import io.ktor.client.request.forms.*
@@ -114,8 +112,7 @@ data class MultiPartFileValue(override val name: String, val filename: String, o
             name = name,
             filename = filenameToType(),
             contentType = contentType,
-            contentEncoding = contentEncoding,
-            content = content.takeIf { it.length > 0 }?.let { ExactValuePattern(BinaryValue(it.bytes)) }
+            contentEncoding = contentEncoding
         )
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/BinaryPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/BinaryPattern.kt
@@ -19,7 +19,7 @@ data class BinaryPattern(
             return Result.Success()
 
         return when (sampleData) {
-            is StringValue -> return Result.Success()
+            is StringValue, is BinaryValue -> return Result.Success()
             else -> dataTypeMismatchResult(this, sampleData, resolver.mismatchMessages)
         }
     }

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -1319,12 +1319,26 @@ private suspend fun bodyFromCall(call: ApplicationCall): Triple<Value, Map<Strin
                     }
 
                     is PartData.FormItem -> {
-                        MultiPartContentValue(
-                            it.name ?: "",
-                            StringValue(it.value),
-                            boundary,
-                            specifiedContentType = it.contentType?.let { contentType -> "${contentType.contentType}/${contentType.contentSubtype}" }
-                        )
+                        val contentType = it.contentType?.let { contentType ->
+                            "${contentType.contentType}/${contentType.contentSubtype}"
+                        }
+
+                        if (it.headers["Content-Transfer-Encoding"]?.equals("binary", ignoreCase = true) == true) {
+                            MultiPartFileValue(
+                                name = it.name ?: "",
+                                filename = "",
+                                contentType = contentType,
+                                content = MultiPartContent(it.value),
+                                boundary = boundary
+                            )
+                        } else {
+                            MultiPartContentValue(
+                                it.name ?: "",
+                                StringValue(it.value),
+                                boundary,
+                                specifiedContentType = contentType
+                            )
+                        }
                     }
 
                     is PartData.BinaryItem -> {

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -111,7 +111,6 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.broadcast
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
-import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.Writer
 import java.net.InetAddress
@@ -1330,16 +1329,16 @@ private suspend fun bodyFromCall(call: ApplicationCall): Triple<Value, Map<Strin
 
                     is PartData.BinaryItem -> {
                         val content = it.provider().asStream().use { input ->
-                            val output = ByteArrayOutputStream()
-                            input.copyTo(output)
-                            output.toString()
+                            MultiPartContent(input.readBytes())
                         }
 
-                        MultiPartContentValue(
+                        MultiPartFileValue(
                             it.name ?: "",
-                            StringValue(content),
-                            boundary,
-                            specifiedContentType = it.contentType?.let { contentType -> "${contentType.contentType}/${contentType.contentSubtype}" }
+                            "",
+                            it.contentType?.let { contentType -> "${contentType.contentType}/${contentType.contentSubtype}" },
+                            null,
+                            content,
+                            boundary
                         )
                     }
 

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -111,6 +111,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.broadcast
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
+import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.Writer
 import java.net.InetAddress
@@ -1319,40 +1320,26 @@ private suspend fun bodyFromCall(call: ApplicationCall): Triple<Value, Map<Strin
                     }
 
                     is PartData.FormItem -> {
-                        val contentType = it.contentType?.let { contentType ->
-                            "${contentType.contentType}/${contentType.contentSubtype}"
-                        }
-
-                        if (it.headers["Content-Transfer-Encoding"]?.equals("binary", ignoreCase = true) == true) {
-                            MultiPartFileValue(
-                                name = it.name ?: "",
-                                filename = "",
-                                contentType = contentType,
-                                content = MultiPartContent(it.value),
-                                boundary = boundary
-                            )
-                        } else {
-                            MultiPartContentValue(
-                                it.name ?: "",
-                                StringValue(it.value),
-                                boundary,
-                                specifiedContentType = contentType
-                            )
-                        }
+                        MultiPartContentValue(
+                            it.name ?: "",
+                            StringValue(it.value),
+                            boundary,
+                            specifiedContentType = it.contentType?.let { contentType -> "${contentType.contentType}/${contentType.contentSubtype}" }
+                        )
                     }
 
                     is PartData.BinaryItem -> {
                         val content = it.provider().asStream().use { input ->
-                            MultiPartContent(input.readBytes())
+                            val output = ByteArrayOutputStream()
+                            input.copyTo(output)
+                            output.toString()
                         }
 
-                        MultiPartFileValue(
+                        MultiPartContentValue(
                             it.name ?: "",
-                            "",
-                            it.contentType?.let { contentType -> "${contentType.contentType}/${contentType.contentSubtype}" },
-                            null,
-                            content,
-                            boundary
+                            StringValue(content),
+                            boundary,
+                            specifiedContentType = it.contentType?.let { contentType -> "${contentType.contentType}/${contentType.contentSubtype}" }
                         )
                     }
 

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -7153,6 +7153,43 @@ paths:
     }
 
     @Test
+    fun `binary multipart parts generate raw content without inventing a filename`() {
+        val openAPI = """
+            openapi: 3.0.0
+            info:
+              title: Multipart Binary Upload API
+              version: 0.1.0
+            paths:
+              /documents:
+                post:
+                  requestBody:
+                    required: true
+                    content:
+                      multipart/form-data:
+                        schema:
+                          type: object
+                          required:
+                            - content
+                          properties:
+                            content:
+                              type: string
+                              format: binary
+                  responses:
+                    '200':
+                      description: Document stored successfully
+        """.trimIndent()
+
+        val feature = OpenApiSpecification.fromYAML(openAPI, "").toFeature()
+        val request = feature.scenarios.single().generateHttpRequest()
+        val filePart = request.multiPartFormData.single() as MultiPartFileValue
+
+        assertThat(filePart.filename).isEmpty()
+        assertThat(filePart.content.bytes).isNotEmpty()
+        assertThat(filePart.contentType).isEqualTo("application/octet-stream")
+        assertThat(feature.scenarios.single().matches(request)).isInstanceOf(Result.Success::class.java)
+    }
+
+    @Test
     fun `show clear error for non-numerical response codes`() {
         try {
             OpenApiSpecification.fromYAML(

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -7153,7 +7153,7 @@ paths:
     }
 
     @Test
-    fun `binary multipart parts generate raw content without inventing a filename`() {
+    fun `binary multipart parts generate raw content without inventing a filename`(@TempDir(cleanup = CleanupMode.ALWAYS) tempDir: File) {
         val openAPI = """
             openapi: 3.0.0
             info:
@@ -7187,6 +7187,11 @@ paths:
         assertThat(filePart.content.bytes).isNotEmpty()
         assertThat(filePart.contentType).isEqualTo("application/octet-stream")
         assertThat(feature.scenarios.single().matches(request)).isInstanceOf(Result.Success::class.java)
+
+        val openAPIFile = tempDir.resolve("specification.yaml").apply { writeText(openAPI) }
+        createStubFromContracts(listOf(openAPIFile.canonicalPath), "localhost", 9000, timeoutMillis = 0).use { stub ->
+            assertThat(stub.client.execute(request).status).isEqualTo(200)
+        }
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/core/HttpRequestTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpRequestTest.kt
@@ -27,6 +27,26 @@ import java.io.File
 
 internal class HttpRequestTest {
     @Test
+    fun `loading multipart files preserves content that was already generated`() {
+        val generatedBytes = byteArrayOf(1, 2, 3)
+        val generatedPart = MultiPartFileValue(
+            name = "document",
+            filename = "example.pdf",
+            contentType = "application/octet-stream",
+            content = MultiPartContent(generatedBytes)
+        )
+
+        val loadedPart = HttpRequest(
+            method = "POST",
+            path = "/documents",
+            multiPartFormData = listOf(generatedPart)
+        ).loadFileContentIntoParts().multiPartFormData.single() as MultiPartFileValue
+
+        assertThat(loadedPart.filename).isEqualTo("example.pdf")
+        assertThat(loadedPart.content.bytes).containsExactly(*generatedBytes)
+    }
+
+    @Test
     fun `it should serialise the request correctly`() {
         val request = HttpRequest("GET", "/", HashMap(), EmptyString, HashMap(mapOf("one" to "two")))
         val expectedString = """GET /?one=two

--- a/core/src/test/kotlin/io/specmatic/core/HttpRequestTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpRequestTest.kt
@@ -23,9 +23,31 @@ import io.specmatic.mock.MOCK_HTTP_REQUEST
 import java.util.stream.Stream
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.io.CleanupMode
+import org.junit.jupiter.api.io.TempDir
 import java.io.File
 
 internal class HttpRequestTest {
+    @Test
+    fun `loading a filename-only multipart example reads the referenced file`(@TempDir(cleanup = CleanupMode.ALWAYS) tempDir: File) {
+        val expectedBytes = byteArrayOf(1, 2, 3)
+        val exampleFile = tempDir.resolve("example.bin").apply { writeBytes(expectedBytes) }
+
+        val loadedPart = HttpRequest(
+            method = "POST",
+            path = "/documents",
+            multiPartFormData = listOf(
+                MultiPartFileValue(
+                    name = "document",
+                    filename = exampleFile.canonicalPath,
+                    contentType = "application/octet-stream"
+                )
+            )
+        ).loadFileContentIntoParts().multiPartFormData.single() as MultiPartFileValue
+
+        assertThat(loadedPart.content.bytes).containsExactly(*expectedBytes)
+    }
+
     @Test
     fun `loading multipart files preserves content that was already generated`() {
         val generatedBytes = byteArrayOf(1, 2, 3)

--- a/core/src/test/kotlin/io/specmatic/core/HttpRequestTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpRequestTest.kt
@@ -49,26 +49,6 @@ internal class HttpRequestTest {
     }
 
     @Test
-    fun `loading multipart files preserves content that was already generated`() {
-        val generatedBytes = byteArrayOf(1, 2, 3)
-        val generatedPart = MultiPartFileValue(
-            name = "document",
-            filename = "example.pdf",
-            contentType = "application/octet-stream",
-            content = MultiPartContent(generatedBytes)
-        )
-
-        val loadedPart = HttpRequest(
-            method = "POST",
-            path = "/documents",
-            multiPartFormData = listOf(generatedPart)
-        ).loadFileContentIntoParts().multiPartFormData.single() as MultiPartFileValue
-
-        assertThat(loadedPart.filename).isEqualTo("example.pdf")
-        assertThat(loadedPart.content.bytes).containsExactly(*generatedBytes)
-    }
-
-    @Test
     fun `it should serialise the request correctly`() {
         val request = HttpRequest("GET", "/", HashMap(), EmptyString, HashMap(mapOf("one" to "two")))
         val expectedString = """GET /?one=two

--- a/core/src/test/kotlin/io/specmatic/core/HttpRequestTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpRequestTest.kt
@@ -59,6 +59,20 @@ internal class HttpRequestTest {
     }
 
     @Test
+    fun `multipart parts should be separated by a blank line in request logs`() {
+        val request = HttpRequest(
+            method = "POST",
+            path = "/documents",
+            multiPartFormData = listOf(
+                MultiPartContentValue("metadata", StringValue("first")),
+                MultiPartContentValue("content", StringValue("second"))
+            )
+        )
+
+        assertThat(request.toLogString()).contains("first\n\n--#####")
+    }
+
+    @Test
     fun `when serialised to json, the request should contain form fields`() {
         val json = HttpRequest("POST", "/").copy(formFields = mapOf("Data" to "10")).toJSON()
         val value = json.jsonObject.getValue("form-fields") as JSONObjectValue

--- a/core/src/test/kotlin/io/specmatic/core/MultiPartFilePatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/MultiPartFilePatternTest.kt
@@ -5,8 +5,10 @@ import org.junit.jupiter.api.Test
 import io.specmatic.core.Result.Failure
 import io.specmatic.core.Result.Success
 import io.specmatic.core.pattern.ExactValuePattern
+import io.specmatic.core.pattern.BinaryPattern
 import io.specmatic.core.pattern.Row
 import io.specmatic.core.pattern.StringPattern
+import io.specmatic.core.value.BinaryValue
 import io.specmatic.core.value.StringValue
 import org.junit.jupiter.api.Disabled
 
@@ -76,5 +78,81 @@ internal class MultiPartFilePatternTest {
         val pattern = MultiPartFilePattern("employeecsv", StringPattern())
         val value = MultiPartFileValue("employeecsv", "different_filename.csv")
         assertThat(pattern.matches(value, Resolver())).isInstanceOf(Success::class.java)
+    }
+
+    @Test
+    fun `binary file pattern generates content without inventing a filename`() {
+        val pattern = MultiPartFilePattern(
+            name = "document",
+            filename = null,
+            contentType = "application/octet-stream",
+            content = BinaryPattern()
+        )
+
+        val value = pattern.generate(Resolver()) as MultiPartFileValue
+
+        assertThat(value.filename).isEmpty()
+        assertThat(value.content.bytes).isNotEmpty()
+        assertThat(value.contentType).isEqualTo("application/octet-stream")
+    }
+
+    @Test
+    fun `filename example does not replace binary content pattern`() {
+        val pattern = MultiPartFilePattern(
+            name = "document",
+            filename = null,
+            contentType = "application/octet-stream",
+            content = BinaryPattern()
+        )
+
+        val exampleBasedPattern = pattern.newBasedOn(
+            Row(listOf("document_filename"), listOf("example.pdf")),
+            Resolver()
+        ).single() as MultiPartFilePattern
+        val value = exampleBasedPattern.generate(Resolver()) as MultiPartFileValue
+
+        assertThat(value.filename).isEqualTo("example.pdf")
+        assertThat(value.content.bytes).isNotEmpty()
+        assertThat(exampleBasedPattern.content).isInstanceOf(BinaryPattern::class.java)
+    }
+
+    @Test
+    fun `binary file pattern ignores filename when it is not constrained`() {
+        val pattern = MultiPartFilePattern(
+            name = "document",
+            filename = null,
+            contentType = "application/octet-stream",
+            content = BinaryPattern()
+        )
+        val value = MultiPartFileValue(
+            name = "document",
+            filename = "client-provided.pdf",
+            contentType = "application/octet-stream",
+            content = MultiPartContent(byteArrayOf(1, 2, 3))
+        )
+
+        assertThat(pattern.matches(value, Resolver())).isInstanceOf(Success::class.java)
+    }
+
+    @Test
+    fun `binary file pattern matches exact binary content from an example`() {
+        val expectedBytes = byteArrayOf(1, 2, 3)
+        val pattern = MultiPartFilePattern(
+            name = "document",
+            filename = ExactValuePattern(StringValue("example.pdf")),
+            contentType = "application/octet-stream",
+            content = ExactValuePattern(BinaryValue(expectedBytes))
+        )
+
+        val matching = MultiPartFileValue(
+            name = "document",
+            filename = "example.pdf",
+            contentType = "application/octet-stream",
+            content = MultiPartContent(expectedBytes)
+        )
+        val mismatching = matching.copy(content = MultiPartContent(byteArrayOf(4, 5, 6)))
+
+        assertThat(pattern.matches(matching, Resolver())).isInstanceOf(Success::class.java)
+        assertThat(pattern.matches(mismatching, Resolver())).isInstanceOf(Failure::class.java)
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/MultiPartFilePatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/MultiPartFilePatternTest.kt
@@ -135,6 +135,51 @@ internal class MultiPartFilePatternTest {
     }
 
     @Test
+    fun `file pattern without filename constraint matches multipart content`() {
+        val pattern = MultiPartFilePattern(
+            name = "document",
+            filename = null,
+            content = ExactValuePattern(BinaryValue("file content".encodeToByteArray()))
+        )
+        val value = MultiPartContentValue(
+            name = "document",
+            content = StringValue("file content")
+        )
+
+        assertThat(pattern.matches(value, Resolver())).isInstanceOf(Success::class.java)
+    }
+
+    @Test
+    fun `file pattern with filename constraint rejects multipart content`() {
+        val pattern = MultiPartFilePattern(
+            name = "document",
+            filename = StringPattern(),
+            content = BinaryPattern()
+        )
+        val value = MultiPartContentValue(
+            name = "document",
+            content = StringValue("file content")
+        )
+
+        assertThat(pattern.matches(value, Resolver())).isInstanceOf(Failure::class.java)
+    }
+
+    @Test
+    fun `file pattern without filename constraint rejects mismatching multipart content`() {
+        val pattern = MultiPartFilePattern(
+            name = "document",
+            filename = null,
+            content = ExactValuePattern(BinaryValue("expected".encodeToByteArray()))
+        )
+        val value = MultiPartContentValue(
+            name = "document",
+            content = StringValue("actual")
+        )
+
+        assertThat(pattern.matches(value, Resolver())).isInstanceOf(Failure::class.java)
+    }
+
+    @Test
     fun `binary file pattern matches exact binary content from an example`() {
         val expectedBytes = byteArrayOf(1, 2, 3)
         val pattern = MultiPartFilePattern(

--- a/core/src/test/kotlin/io/specmatic/core/MultiPartFilePatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/MultiPartFilePatternTest.kt
@@ -139,14 +139,36 @@ internal class MultiPartFilePatternTest {
         val pattern = MultiPartFilePattern(
             name = "document",
             filename = null,
+            contentType = "application/octet-stream",
             content = ExactValuePattern(BinaryValue("file content".encodeToByteArray()))
         )
         val value = MultiPartContentValue(
             name = "document",
-            content = StringValue("file content")
+            content = StringValue("file content"),
+            specifiedContentType = "application/octet-stream"
         )
 
         assertThat(pattern.matches(value, Resolver())).isInstanceOf(Success::class.java)
+    }
+
+    @Test
+    fun `file pattern without filename constraint rejects multipart text content`() {
+        val pattern = MultiPartFilePattern(
+            name = "document",
+            filename = null,
+            contentType = "application/octet-stream",
+            content = BinaryPattern()
+        )
+        val value = MultiPartContentValue(
+            name = "document",
+            content = StringValue("not a file"),
+            specifiedContentType = "text/plain"
+        )
+
+        val result = pattern.matches(value, Resolver())
+
+        assertThat(result).isInstanceOf(Failure::class.java)
+        assertThat(result.reportString()).contains("The contract expected a file, but got content instead.")
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/core/MultiPartFileValueTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/MultiPartFileValueTest.kt
@@ -8,6 +8,9 @@ import org.junit.jupiter.api.Test
 import io.specmatic.core.pattern.ExactValuePattern
 import io.specmatic.core.value.BinaryValue
 import io.specmatic.core.value.StringValue
+import org.junit.jupiter.api.io.CleanupMode
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
 
 internal class MultiPartFileValueTest {
     @Test
@@ -17,6 +20,7 @@ internal class MultiPartFileValueTest {
         Assertions.assertThat(pattern.filename).isEqualTo(ExactValuePattern(StringValue("customers.csv")))
         Assertions.assertThat(pattern.contentType).isEqualTo("text/csv")
         Assertions.assertThat(pattern.contentEncoding).isEqualTo("gzip")
+        Assertions.assertThat(pattern.content).isNull()
     }
 
     @Test
@@ -32,6 +36,30 @@ internal class MultiPartFileValueTest {
 
         assertThat(pattern.filename).isEqualTo(ExactValuePattern(StringValue("example.pdf")))
         assertThat(pattern.content).isEqualTo(ExactValuePattern(BinaryValue(bytes)))
+    }
+
+    @Test
+    fun `filename-only values infer a file-backed pattern`(@TempDir(cleanup = CleanupMode.ALWAYS) tempDir: File) {
+        val expectedBytes = byteArrayOf(1, 2, 3)
+        val exampleFile = tempDir.resolve("example.bin").apply { writeBytes(expectedBytes) }
+        val pattern = MultiPartFileValue(
+            name = "document",
+            filename = exampleFile.canonicalPath,
+            contentType = "application/octet-stream"
+        ).inferType() as MultiPartFilePattern
+
+        val result = pattern.matches(
+            MultiPartFileValue(
+                name = "document",
+                filename = "uploaded.bin",
+                contentType = "application/octet-stream",
+                content = MultiPartContent(expectedBytes)
+            ),
+            Resolver()
+        )
+
+        assertThat(pattern.content).isNull()
+        assertThat(result).isInstanceOf(Result.Success::class.java)
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/core/MultiPartFileValueTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/MultiPartFileValueTest.kt
@@ -6,7 +6,6 @@ import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import io.specmatic.core.pattern.ExactValuePattern
-import io.specmatic.core.value.BinaryValue
 import io.specmatic.core.value.StringValue
 import org.junit.jupiter.api.io.CleanupMode
 import org.junit.jupiter.api.io.TempDir
@@ -21,21 +20,6 @@ internal class MultiPartFileValueTest {
         Assertions.assertThat(pattern.contentType).isEqualTo("text/csv")
         Assertions.assertThat(pattern.contentEncoding).isEqualTo("gzip")
         Assertions.assertThat(pattern.content).isNull()
-    }
-
-    @Test
-    fun `inferred file pattern preserves filename and exact content independently`() {
-        val bytes = byteArrayOf(1, 2, 3)
-
-        val pattern = MultiPartFileValue(
-            name = "document",
-            filename = "example.pdf",
-            contentType = "application/pdf",
-            content = MultiPartContent(bytes)
-        ).inferType() as MultiPartFilePattern
-
-        assertThat(pattern.filename).isEqualTo(ExactValuePattern(StringValue("example.pdf")))
-        assertThat(pattern.content).isEqualTo(ExactValuePattern(BinaryValue(bytes)))
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/core/MultiPartFileValueTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/MultiPartFileValueTest.kt
@@ -1,8 +1,12 @@
 package io.specmatic.core
 
+import io.ktor.client.request.forms.formData
+import io.ktor.http.HttpHeaders
 import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import io.specmatic.core.pattern.ExactValuePattern
+import io.specmatic.core.value.BinaryValue
 import io.specmatic.core.value.StringValue
 
 internal class MultiPartFileValueTest {
@@ -13,5 +17,34 @@ internal class MultiPartFileValueTest {
         Assertions.assertThat(pattern.filename).isEqualTo(ExactValuePattern(StringValue("customers.csv")))
         Assertions.assertThat(pattern.contentType).isEqualTo("text/csv")
         Assertions.assertThat(pattern.contentEncoding).isEqualTo("gzip")
+    }
+
+    @Test
+    fun `inferred file pattern preserves filename and exact content independently`() {
+        val bytes = byteArrayOf(1, 2, 3)
+
+        val pattern = MultiPartFileValue(
+            name = "document",
+            filename = "example.pdf",
+            contentType = "application/pdf",
+            content = MultiPartContent(bytes)
+        ).inferType() as MultiPartFilePattern
+
+        assertThat(pattern.filename).isEqualTo(ExactValuePattern(StringValue("example.pdf")))
+        assertThat(pattern.content).isEqualTo(ExactValuePattern(BinaryValue(bytes)))
+    }
+
+    @Test
+    fun `serialization omits filename when it is absent`() {
+        val value = MultiPartFileValue(
+            name = "document",
+            filename = "",
+            contentType = "application/octet-stream",
+            content = MultiPartContent(byteArrayOf(1, 2, 3))
+        )
+
+        val part = formData { value.addTo(this) }.single()
+
+        assertThat(part.headers[HttpHeaders.ContentDisposition]).doesNotContain("filename=")
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/pattern/BinaryPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/BinaryPatternTest.kt
@@ -2,11 +2,19 @@ package io.specmatic.core.pattern
 
 import io.specmatic.GENERATION
 import io.specmatic.core.Resolver
+import io.specmatic.core.Result.Success
+import io.specmatic.core.value.BinaryValue
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 
 class BinaryPatternTest {
+
+    @Test
+    fun `matches raw binary values`() {
+        assertThat(BinaryPattern().matches(BinaryValue(byteArrayOf(1, 2, 3)), Resolver()))
+            .isInstanceOf(Success::class.java)
+    }
 
     @Test
     @Tag(GENERATION)


### PR DESCRIPTION
**Why**:

OpenAPI describes the binary payload of a multipart file part, but does not specify a filename. Specmatic previously treated the generated binary payload as a filename, then attempted to resolve it as a local file. This produced a malformed filename and unrelated fallback content during contract tests.

The fix keeps existing filename-backed example behavior while allowing OpenAPI-driven generation and mock matching to work when no filename example exists.

**What**:

- Fix multipart `type: string, format: binary` parts so generated payload bytes are not used as the filename.
- Support filename-free binary multipart parts while preserving filename-backed examples such as `filename: @example.txt`.
- Allow a filename-unconstrained file pattern to match multipart content while continuing to validate the part name and payload.
- Omit absent filenames from multipart serialization and add a blank line between multipart parts in request logs.

**How**:

- Represent the filename and binary payload as separate concepts in `MultiPartFilePattern`.
- Generate binary content directly from the OpenAPI binary schema and leave the filename absent unless constrained by an example.
- Match content-only multipart values when the file pattern has no filename constraint.
- Preserve the existing `HttpStub` multipart value classification and existing file-loading behavior for filename-backed examples.
- Serialize filename-free binary parts without a `filename` parameter.
- Add focused generation, matching, inference, file-loading, serialization, and request-log regression coverage.
- Verify both the original no-example scenario and the legacy `@example.txt` scenario with the Docker repro.

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate — N/A (not run locally)
- [ ] Security scans don't report any vulnerabilities — N/A (not run locally)
- [ ] Documentation added/updated (share link) — N/A
- [ ] Sample Project added/updated (share link) — N/A
- [ ] Demo video (share link) — N/A
- [ ] Article on Website (share link) — N/A
- [ ] Roadmpap updated (share link) — N/A
- [ ] Conference Talk (share link) — N/A