### PR TITLE
feat: enable matcher extensions to use external example data

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
@@ -326,7 +326,10 @@ data class HttpRequestPattern(
             val bodyValue =
                 if (httpRequest.body is JSONObjectValue || httpRequest.body is JSONArrayValue || httpRequest.body is XMLNode) {
                     httpRequest.body
-                } else if (isPatternToken(httpRequest.bodyString) || isSubstitution(httpRequest.bodyString)) {
+                } else if (isPatternToken(httpRequest.bodyString) ||
+                    isDollarMethodOrLookup(httpRequest.bodyString) ||
+                    isSubstitution(httpRequest.bodyString)
+                ) {
                     StringValue(httpRequest.bodyString)
                 } else {
                     body.parse(httpRequest.bodyString, resolver)

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
@@ -30,6 +30,7 @@ import io.specmatic.core.pattern.isSubstitution
 import io.specmatic.core.pattern.newBasedOn
 import io.specmatic.core.pattern.newMapBasedOn
 import io.specmatic.core.pattern.parsedPattern
+import io.specmatic.core.pattern.patternFromValueUsing
 import io.specmatic.core.pattern.resolvedHop
 import io.specmatic.core.pattern.returnValue
 import io.specmatic.core.pattern.singleLineDescription
@@ -691,7 +692,8 @@ data class HttpRequestPattern(
     private fun exactEncompassedType(valueString: String, key: String?, type: Pattern, resolver: Resolver): Pattern {
         return when {
             isPatternToken(valueString) -> resolvedHop(parsedPattern(valueString, key), resolver)
-            isDollarMethodOrLookup(valueString) -> type.patternFrom(StringValue(valueString), resolver) { it.exactMatchElseType() }
+            isDollarMethodOrLookup(valueString) ->
+                patternFromValueUsing(type, StringValue(valueString), resolver) { it.exactMatchElseType() }
             else -> runCatching { type.parseToType(valueString, resolver) }.getOrElse { StringValue(valueString).exactMatchElseType() }
         }
     }

--- a/core/src/main/kotlin/io/specmatic/core/Resolver.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Resolver.kt
@@ -107,7 +107,7 @@ data class Resolver(
 
         val patternFromValue = when {
             isPatternToken(sampleData) -> patternFromTokenBased(sampleData)
-            sampleData.hasMatcherTemplate() -> pattern.patternFrom(sampleData, this)
+            sampleData.hasMatcherTemplate() -> patternFromValueUsing(pattern, sampleData, this) { it.deepPattern() }
             else -> null
         }
 

--- a/core/src/main/kotlin/io/specmatic/core/Resolver.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Resolver.kt
@@ -107,7 +107,7 @@ data class Resolver(
 
         val patternFromValue = when {
             isPatternToken(sampleData) -> patternFromTokenBased(sampleData)
-            sampleData.hasMatcherTemplate() -> patternFromValueUsing(pattern, sampleData, this) { it.deepPattern() }
+            sampleData.hasMatcherTemplate() -> patternFromValueUsing(pattern, sampleData, this) { pattern.patternFrom(it, this) }
             else -> null
         }
 

--- a/core/src/main/kotlin/io/specmatic/core/matchers/MatcherEngine.kt
+++ b/core/src/main/kotlin/io/specmatic/core/matchers/MatcherEngine.kt
@@ -3,6 +3,7 @@ package io.specmatic.core.matchers
 import io.specmatic.core.Resolver
 import io.specmatic.core.Result
 import io.specmatic.core.pattern.Pattern
+import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.ScalarValue
 import io.specmatic.core.value.Value
 import java.util.ServiceLoader
@@ -10,6 +11,12 @@ import java.util.ServiceLoader
 interface MatcherEngine {
     fun patternFrom(value: ScalarValue, originalPattern: Pattern, resolver: Resolver): Pattern
     fun matchResponseValue(expectedValue: Value, actualValue: Value, resolver: Resolver): Result
+    fun matchResponseValue(
+        expectedValue: Value,
+        actualValue: Value,
+        resolver: Resolver,
+        data: JSONObjectValue
+    ): Result = matchResponseValue(expectedValue, actualValue, resolver)
 
     companion object {
         fun load(): MatcherEngine? {

--- a/core/src/main/kotlin/io/specmatic/core/substitution/InterpolatedSubstitution.kt
+++ b/core/src/main/kotlin/io/specmatic/core/substitution/InterpolatedSubstitution.kt
@@ -5,6 +5,7 @@ import io.specmatic.core.pattern.isPatternToken
 import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.value.StringValue
 import io.specmatic.core.value.Value
+import io.specmatic.core.value.isMatcherTemplate
 
 internal object InterpolatedSubstitution {
     private val useRegex = Regex("\\$\\(([^()]+)\\)")
@@ -12,14 +13,16 @@ internal object InterpolatedSubstitution {
     private val dollarFunctionBeforeParenRegex = Regex("""\$\w+\s*$""")
 
     fun isLookup(value: String): Boolean {
-        return useRegex.matches(value)
+        return !value.isMatcherTemplate() && useRegex.matches(value)
     }
 
     fun containsLookup(value: String): Boolean {
-        return useRegex.containsMatchIn(value)
+        return !value.isMatcherTemplate() && useRegex.containsMatchIn(value)
     }
 
     fun resolve(value: String, resolveToken: (String) -> Value): Value {
+        if (value.isMatcherTemplate()) return StringValue(value)
+
         val entireMatch = useRegex.matchEntire(value)
         if (entireMatch != null) {
             return resolveToken(entireMatch.value)

--- a/core/src/main/kotlin/io/specmatic/core/value/Value.kt
+++ b/core/src/main/kotlin/io/specmatic/core/value/Value.kt
@@ -47,9 +47,7 @@ interface Value {
     }
 
     fun hasMatcherTemplate(): Boolean {
-        return this is StringValue
-                && this.string.startsWith("\$match(")
-                && this.string.endsWith(")")
+        return this is StringValue && this.string.isMatcherTemplate()
     }
 
     fun hasPatternTemplate(): Boolean {
@@ -93,4 +91,8 @@ fun Value.mergeWith(other: Value): Value {
 
 fun String.hasDataTemplate(): Boolean {
     return this.startsWith("$(") && this.endsWith(")")
+}
+
+internal fun String.isMatcherTemplate(): Boolean {
+    return this.startsWith("\$match(") && this.endsWith(")")
 }

--- a/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
@@ -237,7 +237,8 @@ data class ScenarioAsTest(
                     val matchesResult = it.matchResponseValue(
                         responseBodyFromExample,
                         response.body,
-                        testScenario.resolver
+                        testScenario.resolver,
+                        testScenario.exampleRow?.scenarioStub?.data ?: JSONObjectValue()
                     )
                     if(matchesResult is Result.Failure) {
                         return ContractTestExecutionResult(
@@ -379,6 +380,7 @@ data class ScenarioAsTest(
             substitution = substitution,
             executionMetadata = fixtureExecutionMetadata,
             fixtureDiscriminatorKey = fixtureDiscriminatorKey,
+            data = scenarioStub.data,
         ) ?: FixtureExecutionDetails(
             combinedResult = Result.Success(),
             updatedSubstitution = substitution

--- a/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
@@ -242,7 +242,7 @@ data class ScenarioAsTest(
                     )
                     if(matchesResult is Result.Failure) {
                         return ContractTestExecutionResult(
-                            result = matchesResult,
+                            result = matchesResult.breadCrumb("RESPONSE.BODY"),
                             request = request,
                             response = response,
                             beforeFixtureExecutionResult = beforeFixtureExecutionResult.fixtureExecutionResults

--- a/core/src/main/kotlin/io/specmatic/test/fixtures/OpenAPIFixtureExecutor.kt
+++ b/core/src/main/kotlin/io/specmatic/test/fixtures/OpenAPIFixtureExecutor.kt
@@ -1,6 +1,7 @@
 package io.specmatic.test.fixtures
 
 import io.specmatic.core.Substitution
+import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.Value
 import io.specmatic.test.FixtureExecutionDetails
 
@@ -12,4 +13,13 @@ interface OpenAPIFixtureExecutor {
         executionMetadata: FixtureExecutionMetadata,
         substitution: Substitution
     ): FixtureExecutionDetails
+
+    fun execute(
+        id: String,
+        fixtures: List<Value>,
+        fixtureDiscriminatorKey: String,
+        executionMetadata: FixtureExecutionMetadata,
+        substitution: Substitution,
+        data: JSONObjectValue
+    ): FixtureExecutionDetails = execute(id, fixtures, fixtureDiscriminatorKey, executionMetadata, substitution)
 }

--- a/core/src/main/kotlin/io/specmatic/test/fixtures/OpenAPIFixtureExecutor.kt
+++ b/core/src/main/kotlin/io/specmatic/test/fixtures/OpenAPIFixtureExecutor.kt
@@ -11,15 +11,7 @@ interface OpenAPIFixtureExecutor {
         fixtures: List<Value>,
         fixtureDiscriminatorKey: String,
         executionMetadata: FixtureExecutionMetadata,
-        substitution: Substitution
-    ): FixtureExecutionDetails
-
-    fun execute(
-        id: String,
-        fixtures: List<Value>,
-        fixtureDiscriminatorKey: String,
-        executionMetadata: FixtureExecutionMetadata,
         substitution: Substitution,
         data: JSONObjectValue
-    ): FixtureExecutionDetails = execute(id, fixtures, fixtureDiscriminatorKey, executionMetadata, substitution)
+    ): FixtureExecutionDetails
 }

--- a/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
+++ b/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
@@ -1653,7 +1653,8 @@ class RowValueLookupFixtureExecutor : OpenAPIFixtureExecutor {
         fixtures: List<Value>,
         fixtureDiscriminatorKey: String,
         executionMetadata: FixtureExecutionMetadata,
-        substitution: Substitution
+        substitution: Substitution,
+        data: JSONObjectValue,
     ): FixtureExecutionDetails {
         val updatedSubstitution = substitution
             .upsertStoreUsing(StringValue("(ORDER_ID:string)"), StringValue("order-123"))

--- a/core/src/test/kotlin/integration_tests/ResiliencyTests.kt
+++ b/core/src/test/kotlin/integration_tests/ResiliencyTests.kt
@@ -2457,7 +2457,7 @@ class GenerativeTests {
         var currentScenarioIsNegative = false
         mockkObject(MatcherEngine.Companion)
         every { MatcherEngine.load() } returns matcherEngine
-        every { matcherEngine.matchResponseValue(any(), any(), any()) } answers {
+        every { matcherEngine.matchResponseValue(any(), any(), any(), any()) } answers {
             if (currentScenarioIsNegative) negativeMatcherCallCount++
             Result.Success()
         }

--- a/core/src/test/kotlin/integration_tests/TestSubstitutionIntegrationTest.kt
+++ b/core/src/test/kotlin/integration_tests/TestSubstitutionIntegrationTest.kt
@@ -124,7 +124,8 @@ class SubstitutionFixtureExecutor : OpenAPIFixtureExecutor {
         fixtures: List<Value>,
         fixtureDiscriminatorKey: String,
         executionMetadata: FixtureExecutionMetadata,
-        substitution: Substitution
+        substitution: Substitution,
+        data: JSONObjectValue,
     ): FixtureExecutionDetails {
         val filteredFixtures = fixtures.filterFor(executionMetadata)
         calls.add(fixtureDiscriminatorKey)

--- a/core/src/test/kotlin/io/specmatic/core/HttpRequestPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpRequestPatternTest.kt
@@ -102,27 +102,36 @@ internal class HttpRequestPatternTest {
     }
 
     @Test
-    fun `should preserve a top level matcher expression for the matcher engine`() {
+    fun `should preserve a top level matcher expression for matching and deriving a stub pattern`() {
         val matcherEngine = mockk<MatcherEngine>()
         mockkObject(MatcherEngine.Companion)
         every { MatcherEngine.load() } returns matcherEngine
 
-        val matcherExpression = "\$match(contains: 10)"
-        val bodyPattern = JSONObjectPattern(mapOf("id" to NumberPattern()))
+        val matcherExpression = "\$match(contains: \$(data.product), value: each, times: 3)"
+        val bodyPattern = JSONObjectPattern(mapOf("type" to StringPattern()))
         every { matcherEngine.patternFrom(StringValue(matcherExpression), bodyPattern, any()) } returns bodyPattern
 
         try {
-            val result = HttpRequestPattern(
+            val requestPattern = HttpRequestPattern(
                 method = "POST",
-                httpPathPattern = buildHttpPathPattern("/"),
-                body = bodyPattern
-            ).matches(
-                HttpRequest(method = "POST", path = "/", body = StringValue(matcherExpression)),
-                Resolver(mockMode = true)
+                httpPathPattern = buildHttpPathPattern("/products"),
+                body = bodyPattern,
+            )
+            val request = HttpRequest(
+                method = "POST",
+                path = "/products",
+                body = StringValue(matcherExpression),
             )
 
+            val result = requestPattern.matches(
+                request,
+                Resolver(mockMode = true)
+            )
+            val exactPattern = requestPattern.generateExactRequestPatternForStub(request, Resolver())
+
             assertThat(result).isInstanceOf(Success::class.java)
-            verify(exactly = 1) {
+            assertThat(exactPattern.body).isSameAs(bodyPattern)
+            verify(exactly = 2) {
                 matcherEngine.patternFrom(StringValue(matcherExpression), bodyPattern, any())
             }
         } finally {

--- a/core/src/test/kotlin/io/specmatic/core/HttpRequestPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpRequestPatternTest.kt
@@ -1,10 +1,16 @@
 package io.specmatic.core
 
 import io.specmatic.conversions.*
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import io.specmatic.core.Result.Failure
 import io.specmatic.core.Result.Success
+import io.specmatic.core.matchers.MatcherEngine
 import io.specmatic.core.pattern.*
 import io.specmatic.core.substitution.SubstitutionImpl
 import io.specmatic.core.value.JSONArrayValue
@@ -93,6 +99,51 @@ internal class HttpRequestPatternTest {
             assertThat(it).isInstanceOf(Failure::class.java)
             assertThat((it as Failure).toMatchFailureDetails()).isEqualTo(MatchFailureDetails(listOf("REQUEST", "BODY", "name"), listOf(DefaultMismatchMessages.expectedKeyWasMissing("property", "name"))))
         }
+    }
+
+    @Test
+    fun `should preserve a top level matcher expression for the matcher engine`() {
+        val matcherEngine = mockk<MatcherEngine>()
+        mockkObject(MatcherEngine.Companion)
+        every { MatcherEngine.load() } returns matcherEngine
+
+        val matcherExpression = "\$match(contains: 10)"
+        val bodyPattern = JSONObjectPattern(mapOf("id" to NumberPattern()))
+        every { matcherEngine.patternFrom(StringValue(matcherExpression), bodyPattern, any()) } returns bodyPattern
+
+        try {
+            val result = HttpRequestPattern(
+                method = "POST",
+                httpPathPattern = buildHttpPathPattern("/"),
+                body = bodyPattern
+            ).matches(
+                HttpRequest(method = "POST", path = "/", body = StringValue(matcherExpression)),
+                Resolver(mockMode = true)
+            )
+
+            assertThat(result).isInstanceOf(Success::class.java)
+            verify(exactly = 1) {
+                matcherEngine.patternFrom(StringValue(matcherExpression), bodyPattern, any())
+            }
+        } finally {
+            unmockkObject(MatcherEngine.Companion)
+        }
+    }
+
+    @Test
+    fun `should reject an ordinary invalid request body`() {
+        val result = HttpRequestPattern(
+            method = "POST",
+            httpPathPattern = buildHttpPathPattern("/"),
+            body = JSONObjectPattern(mapOf("id" to NumberPattern()))
+        ).matches(
+            HttpRequest(method = "POST", path = "/", body = StringValue("not-json")),
+            Resolver(mockMode = true)
+        )
+
+        assertThat(result).isInstanceOf(Failure::class.java)
+        assertThat((result as Failure).toMatchFailureDetails().breadCrumbs)
+            .containsExactly("REQUEST", "BODY")
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/core/substitution/InterpolatedSubstitutionTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/substitution/InterpolatedSubstitutionTest.kt
@@ -10,6 +10,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 
 class InterpolatedSubstitutionTest {
     @Test
@@ -148,9 +150,56 @@ class InterpolatedSubstitutionTest {
     }
 
     @Test
-    fun `detects lookup tokens`() {
+    fun `detects ordinary exact and embedded lookup tokens`() {
+        assertThat(InterpolatedSubstitution.isLookup("$(ID)")).isTrue()
+        assertThat(InterpolatedSubstitution.containsLookup("$(ID)")).isTrue()
+        assertThat(InterpolatedSubstitution.isLookup("order-$(ID)")).isFalse()
         assertThat(InterpolatedSubstitution.containsLookup("order-$(ID)")).isTrue()
         assertThat(InterpolatedSubstitution.containsLookup("prefix-abc")).isFalse()
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = [
+            "\$match(contains: \$(data.person))",
+            "\$match(contains: [\$(data.person), \$(data.company)])",
+        ]
+    )
+    fun `does not detect matcher references as substitution lookups`(matcherExpression: String) {
+        assertThat(StringValue(matcherExpression).hasMatcherTemplate()).isTrue()
+        assertThat(InterpolatedSubstitution.isLookup(matcherExpression)).isFalse()
+        assertThat(InterpolatedSubstitution.containsLookup(matcherExpression)).isFalse()
+    }
+
+    @Test
+    fun `returns complete matcher expression unchanged without resolving its references`() {
+        val matcherExpression = "\$match(contains: \$(data.person))"
+        var tokenResolverInvoked = false
+
+        val result = InterpolatedSubstitution.resolve(matcherExpression) {
+            tokenResolverInvoked = true
+            StringValue("resolved")
+        }
+
+        assertThat(result).isEqualTo(StringValue(matcherExpression))
+        assertThat(tokenResolverInvoked).isFalse()
+    }
+
+    @Test
+    fun `does not protect matcher shaped text rejected by the existing matcher recognizer`() {
+        val incompleteMatcherExpression = "\$match(contains: \$(data.person) "
+        val resolvedTokens = mutableListOf<String>()
+
+        assertThat(StringValue(incompleteMatcherExpression).hasMatcherTemplate()).isFalse()
+        assertThat(InterpolatedSubstitution.containsLookup(incompleteMatcherExpression)).isTrue()
+
+        val result = InterpolatedSubstitution.resolve(incompleteMatcherExpression) { token ->
+            resolvedTokens.add(token)
+            StringValue("resolved")
+        }
+
+        assertThat(result).isEqualTo(StringValue("\$match(contains: resolved "))
+        assertThat(resolvedTokens).containsExactly("$(data.person)")
     }
 
     @Nested

--- a/core/src/test/kotlin/io/specmatic/core/substitution/SubstitutionImplTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/substitution/SubstitutionImplTest.kt
@@ -272,6 +272,15 @@ class SubstitutionImplTest {
         assertThat((result as HasValue<*>).value).isEqualTo(StringValue("one-two"))
     }
 
+    @Test
+    fun `complete matcher expression remains unchanged during substitution`() {
+        val matcherExpression = StringValue("\$match(contains: \$(data.person))")
+
+        val result = SubstitutionImpl.empty(strictMode = true).substitute(matcherExpression)
+
+        assertThat(result).isEqualTo(HasValue(matcherExpression))
+    }
+
     @Nested
     inner class ValueOnlySubstitution {
         @Test

--- a/core/src/test/kotlin/io/specmatic/test/ScenarioAsTestTest.kt
+++ b/core/src/test/kotlin/io/specmatic/test/ScenarioAsTestTest.kt
@@ -3,6 +3,7 @@ package io.specmatic.test
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
+import io.mockk.unmockkObject
 import io.mockk.verify
 import io.specmatic.core.Feature
 import io.specmatic.core.utilities.Decision
@@ -518,6 +519,53 @@ class ScenarioAsTestTest {
         )
 
         verify(exactly = 1) { matcherEngine.matchResponseValue(responseBody, responseBody, any(), data) }
+    }
+
+    @Test
+    fun `runTest should report positive response example matcher failures under response body`() {
+        val matcherEngine = mockk<MatcherEngine>()
+        mockkObject(MatcherEngine.Companion)
+        every { MatcherEngine.load() } returns matcherEngine
+        every { matcherEngine.matchResponseValue(any(), any(), any(), any()) } returns
+            Result.Failure("matcher failed").breadCrumb("items[0]")
+
+        val responseBody = parsedJSONObject("""{"items": [{"id": 10}]}""")
+        val scenario = Scenario(
+            ScenarioInfo(
+                specType = SpecType.OPENAPI,
+                protocol = SpecmaticProtocol.HTTP,
+                httpRequestPattern = HttpRequestPattern(httpPathPattern = buildHttpPathPattern("/resource"), method = "GET"),
+                httpResponsePattern = HttpResponsePattern(
+                    status = 200,
+                    body = JSONObjectPattern(mapOf("items" to parsedValue("""[{"id": 10}]""").deepPattern())),
+                    headersPattern = HttpHeadersPattern(contentType = "application/json")
+                ),
+            )
+        ).copy(
+            exampleRow = Row(
+                scenarioStub = ScenarioStub(
+                    response = HttpResponse(
+                        status = 200,
+                        headers = mapOf("Content-Type" to "application/json"),
+                        body = responseBody
+                    )
+                )
+            )
+        )
+
+        val executionResult = try {
+            scenarioAsTest(scenario).runTest(
+                fixedResponseExecutor(
+                    status = 200,
+                    body = """{"items": [{"id": 10}]}""",
+                    headers = mapOf("Content-Type" to "application/json")
+                )
+            )
+        } finally {
+            unmockkObject(MatcherEngine.Companion)
+        }
+
+        assertThat(executionResult.result.reportString()).contains(">> RESPONSE.BODY.items[0]")
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/test/ScenarioAsTestTest.kt
+++ b/core/src/test/kotlin/io/specmatic/test/ScenarioAsTestTest.kt
@@ -708,16 +708,6 @@ class ServiceLoaderTestFixtureExecutor : OpenAPIFixtureExecutor {
         data: JSONObjectValue
     ): FixtureExecutionDetails {
         receivedData[fixtureDiscriminatorKey] = data
-        return execute(id, fixtures, fixtureDiscriminatorKey, executionMetadata, substitution)
-    }
-
-    override fun execute(
-        id: String,
-        fixtures: List<Value>,
-        fixtureDiscriminatorKey: String,
-        executionMetadata: FixtureExecutionMetadata,
-        substitution: Substitution
-    ): FixtureExecutionDetails {
         val filteredFixtures = fixtures.filterFor(executionMetadata)
         calls.add(fixtureDiscriminatorKey)
         fixturesSeen.add(filteredFixtures)

--- a/core/src/test/kotlin/io/specmatic/test/ScenarioAsTestTest.kt
+++ b/core/src/test/kotlin/io/specmatic/test/ScenarioAsTestTest.kt
@@ -40,6 +40,7 @@ import io.ktor.server.response.respondText
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
 import io.specmatic.core.substitution.SubstitutionImpl
+import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.license.core.SpecmaticProtocol
 import io.specmatic.mock.ScenarioStub
 import io.specmatic.reporter.model.SpecType
@@ -52,6 +53,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import java.net.ServerSocket
 import java.net.URLClassLoader
 import java.nio.file.Files
@@ -89,6 +92,30 @@ class ScenarioAsTestTest {
                 FixtureExecutionMetadata(FixtureScenarioType.POSITIVE),
                 FixtureExecutionMetadata(FixtureScenarioType.POSITIVE)
             )
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = ["before", "after"])
+        fun `passes external example data to fixture execution`(fixtureDiscriminatorKey: String) {
+            ServiceLoaderTestFixtureExecutor.reset()
+            val data = parsedJSONObject("""{"people":{"alice":{"name":"Alice"}}}""")
+            val scenario = scenario(
+                Row(
+                    scenarioStub = ScenarioStub(
+                        beforeFixtures = listOf(StringValue("before")),
+                        afterFixtures = listOf(StringValue("after")),
+                        data = data
+                    )
+                )
+            )
+
+            withServiceLoaderEntries(
+                mapOf(OpenAPIFixtureExecutor::class.java to ServiceLoaderTestFixtureExecutor::class.java.name)
+            ) {
+                scenarioAsTest(scenario).runTest(fixedResponseExecutor(body = "anything"))
+            }
+
+            assertThat(ServiceLoaderTestFixtureExecutor.receivedData[fixtureDiscriminatorKey]).isEqualTo(data)
         }
 
         @Test
@@ -450,13 +477,14 @@ class ScenarioAsTestTest {
     }
 
     @Test
-    fun `runTest should call matcher when positive scenario has response body example`() {
+    fun `runTest should pass external example data to matcher when positive scenario has response body example`() {
         val matcherEngine = mockk<MatcherEngine>()
         mockkObject(MatcherEngine.Companion)
         every { MatcherEngine.load() } returns matcherEngine
-        every { matcherEngine.matchResponseValue(any(), any(), any()) } returns Result.Success()
+        every { matcherEngine.matchResponseValue(any(), any(), any(), any()) } returns Result.Success()
 
         val responseBody = parsedJSONObject("""{"id": 10}""")
+        val data = parsedJSONObject("""{"people":{"alice":{"name":"Alice"}}}""")
         val scenario = Scenario(
             ScenarioInfo(
                 specType = SpecType.OPENAPI,
@@ -475,7 +503,8 @@ class ScenarioAsTestTest {
                         status = 200,
                         headers = mapOf("Content-Type" to "application/json"),
                         body = responseBody
-                    )
+                    ),
+                    data = data
                 )
             )
         )
@@ -488,7 +517,7 @@ class ScenarioAsTestTest {
             )
         )
 
-        verify(exactly = 1) { matcherEngine.matchResponseValue(responseBody, responseBody, any()) }
+        verify(exactly = 1) { matcherEngine.matchResponseValue(responseBody, responseBody, any(), data) }
     }
 
     @Test
@@ -496,7 +525,7 @@ class ScenarioAsTestTest {
         val matcherEngine = mockk<MatcherEngine>()
         mockkObject(MatcherEngine.Companion)
         every { MatcherEngine.load() } returns matcherEngine
-        every { matcherEngine.matchResponseValue(any(), any(), any()) } returns Result.Success()
+        every { matcherEngine.matchResponseValue(any(), any(), any(), any()) } returns Result.Success()
 
         val scenario = Scenario(
             ScenarioInfo(
@@ -530,7 +559,7 @@ class ScenarioAsTestTest {
             )
         )
 
-        verify(exactly = 0) { matcherEngine.matchResponseValue(any(), any(), any()) }
+        verify(exactly = 0) { matcherEngine.matchResponseValue(any(), any(), any(), any()) }
     }
 
     @Test
@@ -675,6 +704,18 @@ class ServiceLoaderTestFixtureExecutor : OpenAPIFixtureExecutor {
         fixtures: List<Value>,
         fixtureDiscriminatorKey: String,
         executionMetadata: FixtureExecutionMetadata,
+        substitution: Substitution,
+        data: JSONObjectValue
+    ): FixtureExecutionDetails {
+        receivedData[fixtureDiscriminatorKey] = data
+        return execute(id, fixtures, fixtureDiscriminatorKey, executionMetadata, substitution)
+    }
+
+    override fun execute(
+        id: String,
+        fixtures: List<Value>,
+        fixtureDiscriminatorKey: String,
+        executionMetadata: FixtureExecutionMetadata,
         substitution: Substitution
     ): FixtureExecutionDetails {
         val filteredFixtures = fixtures.filterFor(executionMetadata)
@@ -700,12 +741,14 @@ class ServiceLoaderTestFixtureExecutor : OpenAPIFixtureExecutor {
         val calls: MutableList<String> = mutableListOf()
         val fixturesSeen: MutableList<List<Value>> = mutableListOf()
         val receivedContexts: MutableList<FixtureExecutionMetadata> = mutableListOf()
+        val receivedData: MutableMap<String, JSONObjectValue> = mutableMapOf()
         var receivedSubstitution: Substitution? = null
 
         fun reset() {
             calls.clear()
             fixturesSeen.clear()
             receivedContexts.clear()
+            receivedData.clear()
             receivedSubstitution = null
         }
     }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Adds OSS plumbing for matcher extensions to use external example data and preserve `$match(...)` expressions.

<!-- How were these changes implemented? -->

**How**:

- Passes `ScenarioStub.data` to matcher and fixture extensions.
- Keeps complete `$match(...)` expressions opaque during substitution and pattern derivation.
- Adds response-body breadcrumbs to matcher failures.
- Adds focused regression tests.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)