### PR TITLE
Add path remapping support for Specmatic config

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/ProxyConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/ProxyConfig.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import io.specmatic.core.Configuration.Companion.DEFAULT_PROXY_HOST
 import io.specmatic.core.Configuration.Companion.DEFAULT_PROXY_PORT
 import io.specmatic.core.config.HttpsConfiguration
+import io.specmatic.core.config.ConfigPathMapper
 import io.specmatic.core.config.v3.components.Adapter
 import io.specmatic.stub.extractHost
 import io.specmatic.stub.extractPort
@@ -20,6 +21,19 @@ data class ProxyConfig(
     val https: HttpsConfiguration? = null,
     val outputDirectory: String? = null,
 ) {
+    fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): ProxyConfig {
+        return copy(
+            adapters = adapters?.mapPaths(mapper.child("adapters"), configDirectory),
+            https = https?.mapPaths(mapper.child("https"), configDirectory),
+            outputDirectory = outputDirectory?.let {
+                mapper.child("outputDirectory").map(it, configDirectory)
+            },
+            consumes = consumes?.mapIndexed { index, path ->
+                mapper.child("consumes").child(index).map(path, configDirectory)
+            },
+        )
+    }
+
     @JsonIgnore
     fun getHostOrDefault(default: String = DEFAULT_PROXY_HOST): String {
         val hostFromBaseUrl = baseUrl?.let(::extractHost)

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfigV1V2Common.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfigV1V2Common.kt
@@ -142,6 +142,13 @@ data class StubConfiguration(
     private val https: HttpsConfiguration? = null,
     private val lenientMode: Boolean? = null
 ) {
+    fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): StubConfiguration {
+        return copy(
+            https = https?.mapPaths(mapper.child("https"), configDirectory),
+            dictionary = dictionary?.let { mapper.child("dictionary").map(it, configDirectory) },
+        )
+    }
+
     fun getLenientMode(): Boolean? {
         return lenientMode
     }
@@ -204,6 +211,16 @@ data class VirtualServiceConfiguration(
     private val logMode: VSLogMode? = null,
     private val nonPatchableKeys: Set<String> = emptySet()
 ) {
+    fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): VirtualServiceConfiguration {
+        return copy(
+            logsDirPath = logsDirPath?.let { mapper.child("logsDirPath").map(it, configDirectory) },
+            specsDirPath = specsDirPath?.let { mapper.child("specsDirPath").map(it, configDirectory) },
+            specs = specs?.mapIndexed { index, path ->
+                mapper.child("specs").child(index).map(path, configDirectory)
+            },
+        )
+    }
+
 
     enum class VSLogMode {
         ALL,
@@ -1466,7 +1483,16 @@ data class TestConfiguration(
     val overlayFilePath: String? = null,
     val junitReportDir: String? = null,
     val https: HttpsConfiguration? = null,
-)
+) {
+    fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): TestConfiguration {
+        return copy(
+            https = https?.mapPaths(mapper.child("https"), configDirectory),
+            testsDirectory = testsDirectory?.let { mapper.child("testsDirectory").map(it, configDirectory) },
+            junitReportDir = junitReportDir?.let { mapper.child("junitReportDir").map(it, configDirectory) },
+            overlayFilePath = overlayFilePath?.let { mapper.child("overlayFilePath").map(it, configDirectory) },
+        )
+    }
+}
 
 enum class ResiliencyTestSuite {
     all, positiveOnly, none
@@ -1502,7 +1528,11 @@ data class Auth(
     @param:JsonProperty("bearer-file") val bearerFile: String = "bearer.txt",
     @param:JsonProperty("bearer-environment-variable") val bearerEnvironmentVariable: String? = null,
     @param:JsonProperty("personal-access-token") @JsonAlias("personalAccessToken") val personalAccessToken: String? = null
-)
+) {
+    fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): Auth {
+        return copy(bearerFile = mapper.child("bearerFile").map(bearerFile, configDirectory))
+    }
+}
 
 enum class PipelineProvider { azure }
 

--- a/core/src/main/kotlin/io/specmatic/core/config/BackwardCompatibilityConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/BackwardCompatibilityConfig.kt
@@ -1,8 +1,17 @@
 package io.specmatic.core.config
 
+import java.io.File
+
 data class BackwardCompatibilityConfig(
     val baseBranch: String? = null,
     val targetPath: String? = null,
     val repoDirectory: String? = null,
     val strictMode: Boolean? = null
-)
+) {
+    fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): BackwardCompatibilityConfig {
+        return copy(
+            targetPath = targetPath?.let { mapper.child("targetPath").map(it, configDirectory) },
+            repoDirectory = repoDirectory?.let { mapper.child("repoDirectory").map(it, configDirectory) }
+        )
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/core/config/ConfigPathMapper.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/ConfigPathMapper.kt
@@ -1,0 +1,9 @@
+package io.specmatic.core.config
+
+import java.io.File
+
+interface ConfigPathMapper {
+    fun child(index: Int): ConfigPathMapper
+    fun child(segment: String): ConfigPathMapper
+    fun map(path: String, baseDirectory: File): String
+}

--- a/core/src/main/kotlin/io/specmatic/core/config/HttpsConfiguration.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/HttpsConfiguration.kt
@@ -99,6 +99,10 @@ data class HttpsConfiguration(
     val keyStorePassword: String? = null,
     val mtlsEnabled: Boolean? = null
 ) {
+    fun mapPaths(location: ConfigPathMapper, configDirectory: File): HttpsConfiguration {
+        return copy(keyStore = keyStore?.mapPaths(location.child("keyStore"), configDirectory))
+    }
+
     fun keyStoreFile(): String? = keyStore?.getFilePath()
 
     fun keyStoreDir(): String? = keyStore?.getDirectoryPath()
@@ -143,4 +147,10 @@ data class HttpsConfiguration(
             )
         }
     }
+}
+
+private fun KeyStoreConfiguration.mapPaths(location: ConfigPathMapper, base: File): KeyStoreConfiguration = when (this) {
+    is KeyStoreConfiguration.PartialConfig -> this
+    is KeyStoreConfiguration.FileBasedConfig -> copy(file = location.child("file").map(file, base))
+    is KeyStoreConfiguration.DirectoryBasedConfig -> copy(directory = location.child("directory").map(directory, base))
 }

--- a/core/src/main/kotlin/io/specmatic/core/config/LoggingConfiguration.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/LoggingConfiguration.kt
@@ -21,6 +21,10 @@ enum class ConfigLoggingLevel(private val level: String) {
 }
 
 data class LogOutputConfig(val directory: String?, val console: Boolean?, @field:JsonAlias("logPrefix") val logFilePrefix: String? = null) {
+    fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): LogOutputConfig {
+        return copy(directory = directory?.let { mapper.map(it, configDirectory) })
+    }
+
     @JsonIgnore
     fun getLogDirectory(): File? = directory?.let(::File)
 
@@ -51,6 +55,13 @@ data class LoggingConfiguration(
     val json: LogOutputConfig? = null,
     val text: LogOutputConfig? = null
 ) {
+    fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): LoggingConfiguration {
+        return copy(
+            json = json?.mapPaths(mapper.child("json"), configDirectory),
+            text = text?.mapPaths(mapper.child("text"), configDirectory),
+        )
+    }
+
     fun levelOrDefault(): ConfigLoggingLevel = level ?: ConfigLoggingLevel.INFO
 
     fun hasJsonConfiguration(): Boolean = json != null

--- a/core/src/main/kotlin/io/specmatic/core/config/McpConfiguration.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/McpConfiguration.kt
@@ -27,8 +27,16 @@ data class McpTestConfiguration(
     val filterTools: List<String>? = null,
     val skipTools: List<String>? = null,
 ) {
+    fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): McpTestConfiguration {
+        return copy(dictionaryFile = dictionaryFile?.let { mapper.child("dictionaryFile").map(it, configDirectory) })
+    }
+
     @JsonIgnore
     fun getDictionaryIfExists(): File? = dictionaryFile?.let(::File)
 }
 
-data class McpConfiguration(val test: McpTestConfiguration)
+data class McpConfiguration(val test: McpTestConfiguration) {
+    fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): McpConfiguration {
+        return copy(test = test.mapPaths(mapper.child("test"), configDirectory))
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/core/config/v2/ContractConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v2/ContractConfig.kt
@@ -7,6 +7,8 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.specmatic.core.Source
 import io.specmatic.core.SourceProvider
 import io.specmatic.core.pattern.ContractException
+import io.specmatic.core.config.ConfigPathMapper
+import java.io.File
 
 data class ContractConfig(
     @JsonIgnore
@@ -32,7 +34,7 @@ data class ContractConfig(
     constructor(source: Source) : this(
         contractSource = when {
             source.provider == SourceProvider.git -> GitContractSource(source)
-            source.directory != null -> FileSystemContractSource(source)
+            source.provider == SourceProvider.filesystem -> FileSystemContractSource(source)
             source.provider == SourceProvider.web && source.webBaseUrl != null -> WebContractSource(source.webBaseUrl)
             else -> null
         },
@@ -63,7 +65,28 @@ data class ContractConfig(
             ?: Source(test = provides, stub = consumes)
     }
 
+    fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): ContractConfig {
+        val source = contractSource?.mapPaths(mapper.child("filesystem"), configDirectory)
+        val sourceBase = (source as? FileSystemContractSource)?.directory?.let { directory ->
+            val file = File(directory)
+            if (file.isAbsolute) file else configDirectory.resolve(file)
+        }
+
+        return copy(
+            contractSource = source,
+            provides = provides?.mapIndexed { i, value ->
+                val childMapper = mapper.child("provides").child(i)
+                value.mapPaths(childMapper, sourceBase, configDirectory)
+            },
+            consumes = consumes?.mapIndexed { i, value ->
+                val childMapper = mapper.child("consumes").child(i)
+                value.mapPaths(childMapper, sourceBase, configDirectory)
+            }
+        )
+    }
+
     fun interface ContractSource {
+        fun mapPaths(mapper: ConfigPathMapper, base: File): ContractSource = this
         fun transform(provides: List<SpecExecutionConfig>?, consumes: List<SpecExecutionConfig>?): Source
     }
 
@@ -89,6 +112,7 @@ data class ContractConfig(
     data class FileSystemContractSource(
         val directory: String = "."
     ) : ContractSource {
+        override fun mapPaths(mapper: ConfigPathMapper, base: File) = copy(directory = mapper.child("directory").map(directory, base))
         constructor(source: Source) : this(source.directory ?: ".")
 
         override fun transform(provides: List<SpecExecutionConfig>?, consumes: List<SpecExecutionConfig>?): Source {

--- a/core/src/main/kotlin/io/specmatic/core/config/v2/SpecExecutionConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v2/SpecExecutionConfig.kt
@@ -15,11 +15,17 @@ import io.specmatic.core.SpecificationSourceEntry
 import io.specmatic.core.SourceProvider
 import io.specmatic.core.utilities.ResolvedWebSource
 import io.specmatic.core.utilities.Flags
+import io.specmatic.core.config.ConfigPathMapper
 import java.io.File
 import java.net.URI
 
 sealed class SpecExecutionConfig {
     data class StringValue(@get:JsonValue val value: String) : SpecExecutionConfig() {
+        override fun mapPaths(mapper: ConfigPathMapper, baseDirectory: File?, configDirectory: File): StringValue {
+            if (baseDirectory == null) return this
+            return copy(value = mapper.map(value, baseDirectory))
+        }
+
         override fun resolveAgainst(baseDirectory: File): SpecExecutionConfig {
             return StringValue(baseDirectory.resolve(value).canonicalPath)
         }
@@ -57,6 +63,15 @@ sealed class SpecExecutionConfig {
             override val specs: List<String>,
             override val resiliencyTests: ResiliencyTestsConfig? = null,
         ) : ObjectValue() {
+            override fun mapPaths(mapper: ConfigPathMapper, baseDirectory: File?, configDirectory: File): FullUrl {
+                if (baseDirectory == null) return this
+                return copy(
+                    specs = specs.mapIndexed { index, path ->
+                        mapper.child("specs").child(index).map(path, baseDirectory)
+                    }
+                )
+            }
+
             override fun toUrl(default: URI) = URI(baseUrl)
 
             override fun resolveAgainst(baseDirectory: File): SpecExecutionConfig {
@@ -88,6 +103,15 @@ sealed class SpecExecutionConfig {
             override val specs: List<String>,
             override val resiliencyTests: ResiliencyTestsConfig? = null,
         ) : ObjectValue() {
+            override fun mapPaths(mapper: ConfigPathMapper, baseDirectory: File?, configDirectory: File): PartialUrl {
+                if (baseDirectory == null) return this
+                return copy(
+                    specs = specs.mapIndexed { index, path ->
+                        mapper.child("specs").child(index).map(path, baseDirectory)
+                    }
+                )
+            }
+
             override fun toUrl(default: URI): URI {
                 return URI(
                     default.scheme,
@@ -128,6 +152,27 @@ sealed class SpecExecutionConfig {
         val specType: String,
         val config: Map<String, Any>
     ) : SpecExecutionConfig() {
+        override fun mapPaths(mapper: ConfigPathMapper, baseDirectory: File?, configDirectory: File): SpecExecutionConfig {
+            if (baseDirectory == null) return copy(config = mapConfigPaths(mapper, configDirectory))
+            return copy(
+                config = mapConfigPaths(mapper, configDirectory),
+                specs = baseDirectory.let { base ->
+                    specs.mapIndexed { i, path ->
+                        mapper.child("specs").child(i).map(path, base)
+                    }
+                },
+            )
+        }
+
+        private fun mapConfigPaths(mapper: ConfigPathMapper, configDirectory: File): Map<String, Any> = config.mapValues { (key, value) ->
+            if (key !in setOf("examples", "importPaths")) return@mapValues value
+            if (value !is List<*>) return@mapValues value
+            value.mapIndexed { index, item ->
+                if (item !is String) return@mapIndexed item
+                mapper.child("config").child(key).child(index).map(item, configDirectory)
+            }
+        }
+
         fun contains(specPath: String, specType: String): Boolean {
             return specPath in this.specs.toSet() && specType == this.specType
         }
@@ -182,6 +227,8 @@ sealed class SpecExecutionConfig {
             }
         }
     }
+
+    abstract fun mapPaths(mapper: ConfigPathMapper, baseDirectory: File?, configDirectory: File): SpecExecutionConfig
 
     abstract fun resolveAgainst(baseDirectory: File): SpecExecutionConfig
 

--- a/core/src/main/kotlin/io/specmatic/core/config/v2/SpecmaticConfigV2.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v2/SpecmaticConfigV2.kt
@@ -12,6 +12,7 @@ import io.specmatic.core.SpecmaticConfigV1V2Common.Companion.getWorkflowConfigur
 import io.specmatic.core.SpecmaticConfigV1V2Common.Companion.getTestConfigOrNull
 import io.specmatic.core.SpecmaticConfigV1V2Common.Companion.getVirtualServiceConfigOrNull
 import io.specmatic.core.config.BackwardCompatibilityConfig
+import io.specmatic.core.config.ConfigPathMapper
 import io.specmatic.core.config.LoggingConfiguration
 import io.specmatic.core.config.McpConfiguration
 import io.specmatic.core.config.SpecmaticConfigVersion
@@ -24,6 +25,7 @@ import io.specmatic.core.utilities.Flags.Companion.EXAMPLE_DIRECTORIES
 import io.specmatic.core.utilities.Flags.Companion.getStringValue
 import java.io.File
 import java.nio.file.Path
+import kotlin.io.path.pathString
 
 data class SpecmaticConfigV2(
     val version: SpecmaticConfigVersion,
@@ -59,7 +61,7 @@ data class SpecmaticConfigV2(
     @field:JsonAlias("disable_telemetry")
     val disableTelemetry: Boolean? = null,
     private val logging: LoggingConfiguration? = null,
-    private val mcp: McpConfiguration? = null,
+    val mcp: McpConfiguration? = null,
     @field:JsonAlias("license_path")
     val licensePath: Path? = null,
     @field:JsonAlias("report_dir_path")
@@ -102,6 +104,35 @@ data class SpecmaticConfigV2(
             globalSettings = this.globalSettings
         )
     }
+
+    fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): SpecmaticConfigV2 = copy(
+        mcp = mcp?.mapPaths(mapper.child("mcp"), configDirectory),
+        auth = auth?.mapPaths(mapper.child("auth"), configDirectory),
+        test = test?.mapPaths(mapper.child("test"), configDirectory),
+        stub = stub?.mapPaths(mapper.child("stub"), configDirectory),
+        proxy = proxy?.mapPaths(mapper.child("proxy"), configDirectory),
+        virtualService = virtualService?.mapPaths(mapper.child("virtualService"), configDirectory),
+        backwardCompatibility = backwardCompatibility?.mapPaths(mapper.child("backwardCompatibility"), configDirectory),
+        logging = logging?.mapPaths(mapper.child("logging"), configDirectory),
+        hooks = hooks.mapValues { (key, value) ->
+            mapper.child("hooks").child(key).map(path = value, baseDirectory = configDirectory)
+        },
+        additionalExampleParamsFilePath = additionalExampleParamsFilePath?.let { path ->
+            mapper.child("additionalExampleParamsFilePath").map(path = path, baseDirectory = configDirectory)
+        },
+        licensePath = licensePath?.let { path ->
+            Path.of(mapper.child("licensePath").map(path = path.pathString, baseDirectory = configDirectory))
+        },
+        reportDirPath = reportDirPath?.let { path ->
+            Path.of(mapper.child("reportDirPath").map(path = path.pathString, baseDirectory = configDirectory))
+        },
+        examples = examples.mapIndexed { i, value ->
+            mapper.child("examples").child(i).map(path = value, baseDirectory = configDirectory)
+        },
+        contracts = contracts.mapIndexed { i, value ->
+            value.mapPaths(mapper = mapper.child("contracts").child(i), configDirectory = configDirectory)
+        },
+    )
 
     companion object : SpecmaticVersionedConfigLoader {
         private fun currentConfigVersion(): SpecmaticConfigVersion {

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/Components.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/Components.kt
@@ -1,6 +1,8 @@
 package io.specmatic.core.config.v3
 
 import io.specmatic.core.config.HttpsConfiguration
+import io.specmatic.core.config.ConfigPathMapper
+import java.io.File
 import io.specmatic.core.config.v3.components.Adapter
 import io.specmatic.core.config.v3.components.services.CommonServiceConfig
 import io.specmatic.core.config.v3.components.Dictionary
@@ -18,4 +20,42 @@ data class Components(
     val adapters: Map<String, Adapter>? = null,
     val certificates: Map<String, HttpsConfiguration>? = null,
     val settings: Map<String, Settings>? = null,
-)
+) {
+    fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): Components {
+        val mappedSources = sources?.mapValues { (name, source) ->
+            source.mapPaths(mapper.child("sources").child(name), configDirectory)
+        }
+
+        val mappedServices = services?.mapValues { (name, service) ->
+            service.mapPaths(
+                configDirectory = configDirectory,
+                sourceReferences = mappedSources.orEmpty(),
+                mapper = mapper.child("services").child(name),
+            )
+        }
+
+        return copy(
+            sources = mappedSources,
+            services = mappedServices,
+            examples = examples?.mapPaths(mapper.child("examples"), configDirectory),
+            adapters = adapters?.mapValues { (name, adapter) ->
+                adapter.mapPaths(mapper.child("adapters").child(name), configDirectory)
+            },
+            runOptions = runOptions?.mapValues { (name, options) ->
+                options.mapPaths(mapper.child("runOptions").child(name), configDirectory)
+            },
+            certificates = certificates?.mapValues { (name, certificate) ->
+                certificate.mapPaths(mapper.child("certificates").child(name), configDirectory)
+            },
+            dictionaries = dictionaries?.mapValues { (name, dictionary) ->
+                dictionary.mapPaths(mapper.child("dictionaries").child(name).child("path"), configDirectory)
+            },
+            settings = settings?.mapValues { (name, settings) ->
+                when (settings) {
+                    is ContextDependentSettings -> settings
+                    is ConcreteSettings -> settings.mapPaths(mapper.child("settings").child(name), configDirectory)
+                }
+            },
+        )
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/Data.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/Data.kt
@@ -3,12 +3,26 @@ package io.specmatic.core.config.v3
 import io.specmatic.core.config.v3.components.Adapter
 import io.specmatic.core.config.v3.components.Dictionary
 import io.specmatic.core.config.v3.components.ExampleDirectories
+import io.specmatic.core.config.ConfigPathMapper
+import java.io.File
 
 data class Data(
     val examples: RefOrValue<List<RefOrValue<ExampleDirectories>>>? = null,
     val dictionary: RefOrValue<Dictionary>? = null,
     val adapters: RefOrValue<Adapter>? = null,
 ) {
+    fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): Data {
+        return copy(
+            adapters = adapters?.mapValue { it.mapPaths(mapper.child("adapters"), configDirectory) },
+            dictionary = dictionary?.mapValue {
+                it.mapPaths(mapper.child("dictionary").child("path"), configDirectory)
+            },
+            examples = examples?.mapValue { list -> list.mapIndexed { i, value ->
+                value.mapValue { it.mapPaths(mapper.child("examples").child(i), configDirectory) } }
+            },
+        )
+    }
+
     fun toExampleDirs(resolver: RefOrValueResolver): List<String> {
         if (examples == null) return emptyList()
         return examples.resolveElseThrow(resolver).flatMap { example ->

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/Proxy.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/Proxy.kt
@@ -2,7 +2,9 @@ package io.specmatic.core.config.v3
 
 import io.specmatic.core.ProxyConfig
 import io.specmatic.core.config.HttpsConfiguration
+import io.specmatic.core.config.ConfigPathMapper
 import io.specmatic.core.config.v3.components.Adapter
+import java.io.File
 
 data class Proxy(val proxy: ProxyConfigV3)
 data class ProxyConfigV3(
@@ -14,6 +16,19 @@ data class ProxyConfigV3(
     val cert: RefOrValue<HttpsConfiguration>? = null,
     val recordingsDirectory: String? = null,
 ) {
+    fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): ProxyConfigV3  {
+        return copy(
+            cert = cert?.mapValue { it.mapPaths(mapper.child("cert"), configDirectory) },
+            adapters = adapters?.mapValue { it.mapPaths(mapper.child("adapters"), configDirectory) },
+            mock = mock?.mapIndexed { i, path ->
+                mapper.child("mock").child(i).map(path, configDirectory)
+            },
+            recordingsDirectory = recordingsDirectory?.let {
+                mapper.child("recordingsDirectory").map(it, configDirectory)
+            },
+        )
+    }
+
     fun toCommonConfig(resolver: RefOrValueResolver): ProxyConfig {
         return ProxyConfig(
             targetUrl = target,

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/RefOrValue.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/RefOrValue.kt
@@ -1,6 +1,7 @@
 package io.specmatic.core.config.v3
 
 import com.fasterxml.jackson.annotation.*
+import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.JavaType
 import io.specmatic.core.config.v3.components.ExampleDirectories
 import io.specmatic.core.config.v3.components.services.CommonServiceConfig
@@ -55,6 +56,29 @@ sealed interface RefOrValue<out T: Any> {
     }
 }
 
+fun <T : Any> RefOrValue<T>.mapValue(transform: (T) -> T): RefOrValue<T> = when (this) {
+    is RefOrValue.Reference -> this
+    is RefOrValue.Value -> RefOrValue.Value(transform(value))
+}
+
+fun <T : Any> RefOrValue<T>.mapValueOrReference(
+    transform: (T) -> T,
+    resolver: RefOrValueResolver,
+    resolve: (RefOrValue<T>, RefOrValueResolver) -> T,
+    transformReference: (T) -> T = transform,
+): RefOrValue<T> = when (this) {
+    is RefOrValue.Value -> RefOrValue.Value(transform(value))
+    is RefOrValue.Reference -> {
+        if (extra.isEmpty()) return this
+        val mappedValue = transformReference(resolve(this, resolver))
+        val mappedFields: Map<String, Any?> = yamlMapper.convertValue(mappedValue, object : TypeReference<Map<String, Any?>>() {})
+        RefOrValue.Reference(
+            ref = ref,
+            extra = extra.mapValues { (key, value) -> if (mappedFields.containsKey(key)) mappedFields[key] else value }
+        )
+    }
+}
+
 inline fun <reified T : Any> RefOrValue<T>.resolveElseThrow(resolver: RefOrValueResolver): T {
     val type = yamlMapper.typeFactory.constructType(T::class.java)
     return resolveElseThrowWithType(resolver, type, T::class.simpleName ?: T::class.jvmName)
@@ -95,7 +119,7 @@ fun <T : Any> RefOrValue<T>.resolveElseThrowWithType(resolver: RefOrValueResolve
     }
 
     return runCatching {
-        yamlMapper.convertValue(combined, type) as T
+        yamlMapper.convertValue<T>(combined, type)
     }.getOrElse { e ->
         throw IllegalStateException("Failed to convert resolved value to $typeLabel", e)
     }

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/Settings.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/Settings.kt
@@ -9,6 +9,8 @@ import com.fasterxml.jackson.databind.JsonDeserializer
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.node.ObjectNode
 import io.specmatic.core.config.BackwardCompatibilityConfig
+import io.specmatic.core.config.ConfigPathMapper
+import java.io.File
 import io.specmatic.core.config.v3.components.settings.GeneralSettings
 import io.specmatic.core.config.v3.components.settings.MockSettings
 import io.specmatic.core.config.v3.components.settings.ProxySettings
@@ -48,4 +50,11 @@ data class ConcreteSettings(
     val mock: MockSettings? = null,
     val proxy: ProxySettings? = null,
     val backwardCompatibility: BackwardCompatibilityConfig? = null,
-): Settings
+): Settings {
+    fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): ConcreteSettings {
+        return copy(
+            general = general?.mapPaths(mapper.child("general"), configDirectory),
+            backwardCompatibility = backwardCompatibility?.mapPaths(mapper.child("backwardCompatibility"), configDirectory),
+        )
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/Specmatic.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/Specmatic.kt
@@ -2,9 +2,19 @@ package io.specmatic.core.config.v3
 
 import io.specmatic.core.config.v3.specmatic.Governance
 import io.specmatic.core.config.v3.specmatic.License
+import io.specmatic.core.config.ConfigPathMapper
+import java.io.File
 
 data class Specmatic(
     val license: License? = null,
     val governance: Governance? = null,
     val settings: RefOrValue<ConcreteSettings>? = null
-)
+) {
+    fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): Specmatic {
+        return copy(
+            governance = governance?.mapPaths(mapper.child("governance"), configDirectory),
+            settings = settings?.mapValue { it.mapPaths(mapper.child("settings"), configDirectory) },
+            license = license?.mapPaths(mapper.child("license").child("path"), configDirectory),
+        )
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3.kt
@@ -3,6 +3,7 @@ package io.specmatic.core.config.v3
 import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.SpecmaticConfigV1V2Common
 import io.specmatic.core.config.McpConfiguration
+import io.specmatic.core.config.ConfigPathMapper
 import io.specmatic.core.config.SpecmaticConfigVersion
 import io.specmatic.core.config.SpecmaticVersionedConfig
 import io.specmatic.core.config.SpecmaticVersionedConfigLoader
@@ -21,6 +22,29 @@ data class SpecmaticConfigV3(
     val specmatic: Specmatic? = null,
     val components: Components? = null,
 ) : SpecmaticVersionedConfig {
+    fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): SpecmaticConfigV3 {
+        val resolver = SpecmaticConfigV3Resolver(components ?: Components(), configDirectory.toPath())
+        val mappedComponents = components?.mapPaths(mapper.child("components"), configDirectory)
+        val sourceReferences = mappedComponents?.sources.orEmpty()
+
+        val mappedProxies = proxies?.mapIndexed { index, proxy ->
+            proxy.copy(
+                proxy = proxy.proxy.mapPaths(
+                    mapper.child("proxies").child(index).child("proxy"), configDirectory
+                )
+            )
+        }
+
+        return copy(
+            proxies = mappedProxies,
+            components = mappedComponents,
+            mcp = mcp?.mapPaths(mapper.child("mcp"), configDirectory),
+            specmatic = specmatic?.mapPaths(mapper.child("specmatic"), configDirectory),
+            dependencies = dependencies?.mapPaths(mapper.child("dependencies"), configDirectory, sourceReferences, resolver),
+            systemUnderTest = systemUnderTest?.mapPaths(mapper.child("systemUnderTest"), configDirectory, sourceReferences, resolver),
+        )
+    }
+
     override fun transform(file: File?): SpecmaticConfig {
         return SpecmaticConfigV3Impl(file, this)
     }

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/Adapter.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/Adapter.kt
@@ -1,5 +1,15 @@
 package io.specmatic.core.config.v3.components
 
 import com.fasterxml.jackson.annotation.JsonValue
+import io.specmatic.core.config.ConfigPathMapper
+import java.io.File
 
-data class Adapter(@JsonValue val hooks: Map<String, String>)
+data class Adapter(@JsonValue val hooks: Map<String, String>) {
+    fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): Adapter {
+        return copy(
+            hooks = hooks.mapValues { (name, path) ->
+                mapper.child("hooks").child(name).map(path, configDirectory)
+            }
+        )
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/Dictionary.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/Dictionary.kt
@@ -1,3 +1,10 @@
 package io.specmatic.core.config.v3.components
 
-class Dictionary(val path: String)
+import io.specmatic.core.config.ConfigPathMapper
+import java.io.File
+
+class Dictionary(val path: String) {
+    fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): Dictionary {
+        return Dictionary(mapper.map(path, configDirectory))
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/Example.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/Example.kt
@@ -1,10 +1,31 @@
 package io.specmatic.core.config.v3.components
 
 import io.specmatic.core.config.v3.RefOrValue
+import io.specmatic.core.config.v3.mapValue
+import io.specmatic.core.config.ConfigPathMapper
+import java.io.File
 
-class ExampleDirectories(val directories: List<String>)
+class ExampleDirectories(val directories: List<String>) {
+    fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): ExampleDirectories {
+        return ExampleDirectories(
+            directories.mapIndexed { i, path ->
+                mapper.child("directories").child(i).map(path, configDirectory)
+            }
+        )
+    }
+}
 data class Examples(
     val testExamples: List<RefOrValue<ExampleDirectories>>? = null,
     val mockExamples: List<RefOrValue<ExampleDirectories>>? = null,
     val commonExamples: ExampleDirectories? = null,
-)
+) {
+    fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): Examples = copy(
+        commonExamples = commonExamples?.mapPaths(mapper.child("commonExamples"), configDirectory),
+        testExamples = testExamples?.mapIndexed { i, value ->
+            value.mapValue { it.mapPaths(mapper.child("testExamples").child(i), configDirectory) }
+        },
+        mockExamples = mockExamples?.mapIndexed { i, value -> value.mapValue {
+            it.mapPaths(mapper.child("mockExamples").child(i), configDirectory) }
+        },
+    )
+}

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/AsyncApiRunOptions.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/AsyncApiRunOptions.kt
@@ -1,12 +1,15 @@
 package io.specmatic.core.config.v3.components.runOptions
 
 import com.fasterxml.jackson.annotation.*
+import io.specmatic.core.config.ConfigPathMapper
 import io.specmatic.core.config.v3.ServerOrigin
+import java.io.File
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type", visible = true)
 @JsonSubTypes(JsonSubTypes.Type(AsyncApiTestConfig::class, name = "test"), JsonSubTypes.Type(AsyncApiMockConfig::class, name = "mock"))
 sealed interface AsyncApiRunOptions : IRunOptions {
     val type: RunOptionType?
+    override fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): AsyncApiRunOptions
 
     @JsonIgnore
     override fun gerServerOrigin(): ServerOrigin? {
@@ -22,6 +25,11 @@ data class AsyncApiTestConfig(
     @JsonIgnore private val _config: MutableMap<String, Any> = linkedMapOf()
 ) : AsyncApiRunOptions {
     fun withConfig(newConfig: Map<String, Any>): AsyncApiTestConfig = copy(_config = LinkedHashMap(newConfig))
+    override fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): AsyncApiTestConfig = copy(
+        specs = specs?.mapIndexed { index, spec ->
+            spec.mapPaths(mapper.child("specs").child(index), configDirectory)
+        }
+    )
 
     init {
         require(type == null || type == RunOptionType.TEST) {
@@ -45,6 +53,11 @@ data class AsyncApiMockConfig(
     @JsonIgnore private val _config: MutableMap<String, Any> = linkedMapOf()
 ) : AsyncApiRunOptions {
     fun withConfig(newConfig: Map<String, Any>): AsyncApiMockConfig = copy(_config = LinkedHashMap(newConfig))
+    override fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): AsyncApiMockConfig = copy(
+        specs = specs?.mapIndexed { index, spec ->
+            spec.mapPaths(mapper.child("specs").child(index), configDirectory)
+        }
+    )
 
     init {
         require(type == null || type == RunOptionType.MOCK) {

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/GraphQLSdlRunOptions.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/GraphQLSdlRunOptions.kt
@@ -3,15 +3,17 @@ package io.specmatic.core.config.v3.components.runOptions
 import com.fasterxml.jackson.annotation.JsonAnyGetter
 import com.fasterxml.jackson.annotation.JsonAnySetter
 import com.fasterxml.jackson.annotation.JsonIgnore
-import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
+import io.specmatic.core.config.ConfigPathMapper
 import io.specmatic.core.config.v3.ServerOrigin
+import java.io.File
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type", visible = true)
 @JsonSubTypes(JsonSubTypes.Type(GraphQLSdlTestConfig::class, name = "test"), JsonSubTypes.Type(GraphQLSdlMockConfig::class, name = "mock"))
 sealed interface GraphQLSdlRunOptions : IRunOptions {
     val type: RunOptionType?
+    override fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): GraphQLSdlRunOptions
 
     @JsonIgnore
     override fun gerServerOrigin(): ServerOrigin? {
@@ -23,9 +25,14 @@ sealed interface GraphQLSdlRunOptions : IRunOptions {
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 data class GraphQLSdlTestConfig(
     override val type: RunOptionType? = null,
-    override val specs: List<RunOptionsSpecifications>? = null
+    override val specs: List<RunOptionsSpecifications>? = null,
+    @JsonIgnore private val _config: MutableMap<String, Any> = linkedMapOf()
 ) : GraphQLSdlRunOptions {
-    private val _config: MutableMap<String, Any> = linkedMapOf()
+    override fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): GraphQLSdlTestConfig = copy(
+        specs = specs?.mapIndexed { index, spec ->
+            spec.mapPaths(mapper.child("specs").child(index), configDirectory)
+        }
+    )
 
     init {
         require(type == null || type == RunOptionType.TEST) {
@@ -45,9 +52,14 @@ data class GraphQLSdlTestConfig(
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 data class GraphQLSdlMockConfig(
     override val type: RunOptionType? = null,
-    override val specs: List<RunOptionsSpecifications>? = null
+    override val specs: List<RunOptionsSpecifications>? = null,
+    @JsonIgnore private val _config: MutableMap<String, Any> = linkedMapOf()
 ) : GraphQLSdlRunOptions {
-    private val _config: MutableMap<String, Any> = linkedMapOf()
+    override fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): GraphQLSdlMockConfig = copy(
+        specs = specs?.mapIndexed { index, spec ->
+            spec.mapPaths(mapper.child("specs").child(index), configDirectory)
+        }
+    )
 
     init {
         require(type == null || type == RunOptionType.MOCK) {

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/OpenApiRunOptions.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/OpenApiRunOptions.kt
@@ -7,12 +7,18 @@ import io.specmatic.core.WorkflowConfiguration
 import io.specmatic.core.config.HttpsConfiguration
 import io.specmatic.core.config.v3.RefOrValue
 import io.specmatic.core.config.v3.ServerOrigin
+import io.specmatic.core.config.v3.mapValue
+import io.specmatic.core.config.ConfigPathMapper
+import java.io.File
 
 interface ConfigWithCert { val cert: RefOrValue<HttpsConfiguration>? }
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type", visible = true)
 @JsonSubTypes(JsonSubTypes.Type(OpenApiTestConfig::class, name = "test"), JsonSubTypes.Type(OpenApiMockConfig::class, name = "mock"), JsonSubTypes.Type(OpenApiMockConfig::class, name = "stateful-mock"))
-sealed interface OpenApiRunOptions : IRunOptions { val type: RunOptionType? }
+sealed interface OpenApiRunOptions : IRunOptions {
+    val type: RunOptionType?
+    override fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): OpenApiRunOptions
+}
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 data class OpenApiTestConfig(
@@ -29,6 +35,13 @@ data class OpenApiTestConfig(
     override val specs: List<OpenApiRunOptionsSpecifications>? = null
 ) : OpenApiRunOptions, ConfigWithCert {
     override val config: Map<String, Any> = emptyMap()
+
+    override fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): OpenApiTestConfig = copy(
+        cert = cert?.mapValue { it.mapPaths(mapper.child("cert"), configDirectory) },
+        specs = specs?.mapIndexed { index, spec ->
+            spec.mapPaths(mapper = mapper.child("specs").child(index), baseDirectory = configDirectory)
+        }
+    )
 
     @JsonIgnore
     override fun gerServerOrigin(): ServerOrigin? {
@@ -57,6 +70,14 @@ data class OpenApiMockConfig(
     override val specs: List<OpenApiRunOptionsSpecifications>? = null
 ) : OpenApiRunOptions, ConfigWithCert {
     override val config: Map<String, Any> = emptyMap()
+
+    override fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): OpenApiMockConfig = copy(
+        cert = cert?.mapValue { it.mapPaths(mapper.child("cert"), configDirectory) },
+        logsDirPath = logsDirPath?.let { mapper.child("logsDirPath").map(it, configDirectory) },
+        specs = specs?.mapIndexed { index, spec ->
+            spec.mapPaths(mapper = mapper.child("specs").child(index), baseDirectory = configDirectory)
+        }
+    )
 
     @JsonIgnore
     override fun gerServerOrigin(): ServerOrigin? {

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/ProtobufRunOptions.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/ProtobufRunOptions.kt
@@ -3,15 +3,17 @@ package io.specmatic.core.config.v3.components.runOptions
 import com.fasterxml.jackson.annotation.JsonAnyGetter
 import com.fasterxml.jackson.annotation.JsonAnySetter
 import com.fasterxml.jackson.annotation.JsonIgnore
-import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import io.specmatic.core.config.v3.ServerOrigin
+import io.specmatic.core.config.ConfigPathMapper
+import java.io.File
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type", visible = true)
 @JsonSubTypes(JsonSubTypes.Type(ProtobufTestConfig::class, name = "test"), JsonSubTypes.Type(ProtobufMockConfig::class, name = "mock"))
 sealed interface ProtobufRunOptions : IRunOptions {
     val type: RunOptionType?
+    override fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): ProtobufRunOptions
 
     @JsonIgnore
     override fun gerServerOrigin(): ServerOrigin? {
@@ -23,9 +25,15 @@ sealed interface ProtobufRunOptions : IRunOptions {
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 data class ProtobufTestConfig(
     override val type: RunOptionType? = null,
-    override val specs: List<RunOptionsSpecifications>? = null
+    override val specs: List<RunOptionsSpecifications>? = null,
+    @JsonIgnore private val _config: MutableMap<String, Any> = linkedMapOf()
 ) : ProtobufRunOptions {
-    private val _config: MutableMap<String, Any> = linkedMapOf()
+    override fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): ProtobufTestConfig = copy(
+        _config = config.mapImportPaths(mapper, configDirectory).toMutableMap(),
+        specs = specs?.mapIndexed { index, spec ->
+            spec.mapPaths(mapper.child("specs").child(index), configDirectory)
+        },
+    )
 
     init {
         require(type == null || type == RunOptionType.TEST) {
@@ -45,9 +53,15 @@ data class ProtobufTestConfig(
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 data class ProtobufMockConfig(
     override val type: RunOptionType? = null,
-    override val specs: List<RunOptionsSpecifications>? = null
+    override val specs: List<RunOptionsSpecifications>? = null,
+    @JsonIgnore private val _config: MutableMap<String, Any> = linkedMapOf()
 ) : ProtobufRunOptions {
-    private val _config: MutableMap<String, Any> = linkedMapOf()
+    override fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): ProtobufMockConfig = copy(
+        _config = config.mapImportPaths(mapper, configDirectory).toMutableMap(),
+        specs = specs?.mapIndexed { index, spec ->
+            spec.mapPaths(mapper.child("specs").child(index), configDirectory)
+        },
+    )
 
     init {
         require(type == null || type == RunOptionType.MOCK) {
@@ -61,5 +75,14 @@ data class ProtobufMockConfig(
     @JsonAnySetter
     fun put(key: String, value: Any) {
         _config[key] = value
+    }
+}
+
+private fun Map<String, Any>.mapImportPaths(mapper: ConfigPathMapper, base: File): Map<String, Any> = mapValues { (key, value) ->
+    if (key != "importPaths") return@mapValues value
+    if (value !is List<*>) return@mapValues value
+    value.mapIndexed { index, item ->
+        if (item !is String) return@mapIndexed item
+        mapper.child("config").child("importPaths").child(index).map(path = item, baseDirectory = base)
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/RunOptions.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/RunOptions.kt
@@ -6,11 +6,15 @@ import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonIgnore
 import io.specmatic.core.config.SpecmaticSpecConfig
 import io.specmatic.core.config.v3.ServerOrigin
+import io.specmatic.core.config.ConfigPathMapper
+import java.io.File
 import io.specmatic.reporter.model.SpecType
 
 interface IRunOptions {
     val specs: List<IRunOptionSpecification>?
     val config: Map<String, Any>
+
+    fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): IRunOptions
 
     @JsonIgnore
     fun gerServerOrigin(): ServerOrigin?
@@ -38,7 +42,15 @@ data class RunOptions(
     val asyncapi: AsyncApiRunOptions? = null,
     val graphqlsdl: GraphQLSdlRunOptions? = null,
     val protobuf: ProtobufRunOptions? = null,
-)
+) {
+    fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): RunOptions = copy(
+        wsdl = wsdl?.mapPaths(mapper.child("wsdl"), configDirectory),
+        openapi = openapi?.mapPaths(mapper.child("openapi"), configDirectory),
+        asyncapi = asyncapi?.mapPaths(mapper.child("asyncapi"), configDirectory),
+        protobuf = protobuf?.mapPaths(mapper.child("protobuf"), configDirectory),
+        graphqlsdl = graphqlsdl?.mapPaths(mapper.child("graphqlsdl"), configDirectory),
+    )
+}
 
 data class TestRunOptions(
     val openapi: OpenApiTestConfig? = null,
@@ -47,6 +59,14 @@ data class TestRunOptions(
     val graphqlsdl: GraphQLSdlTestConfig? = null,
     val protobuf: ProtobufTestConfig? = null,
 ) {
+    fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): TestRunOptions = copy(
+        wsdl = wsdl?.mapPaths(mapper.child("wsdl"), configDirectory),
+        openapi = openapi?.mapPaths(mapper.child("openapi"), configDirectory),
+        asyncapi = asyncapi?.mapPaths(mapper.child("asyncapi"), configDirectory),
+        protobuf = protobuf?.mapPaths(mapper.child("protobuf"), configDirectory),
+        graphqlsdl = graphqlsdl?.mapPaths(mapper.child("graphqlsdl"), configDirectory),
+    )
+
     @JsonIgnore
     fun hasSpecOverride(specId: String): Boolean {
         return collectOverriddenSpecIds().contains(specId)
@@ -93,6 +113,14 @@ data class MockRunOptions(
     val graphqlsdl: GraphQLSdlMockConfig? = null,
     val protobuf: ProtobufMockConfig? = null,
 ) {
+    fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): MockRunOptions = copy(
+        wsdl = wsdl?.mapPaths(mapper.child("wsdl"), configDirectory),
+        openapi = openapi?.mapPaths(mapper.child("openapi"), configDirectory),
+        protobuf = protobuf?.mapPaths(mapper.child("protobuf"), configDirectory),
+        asyncapi = asyncapi?.mapPaths(mapper.child("asyncapi"), configDirectory),
+        graphqlsdl = graphqlsdl?.mapPaths(mapper.child("graphqlsdl"), configDirectory),
+    )
+
     @JsonIgnore
     fun hasSpecOverride(specId: String): Boolean {
         return collectOverriddenSpecIds().contains(specId)

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/RunOptionsSpecifications.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/RunOptionsSpecifications.kt
@@ -4,8 +4,9 @@ import com.fasterxml.jackson.annotation.JsonAnyGetter
 import com.fasterxml.jackson.annotation.JsonAnySetter
 import com.fasterxml.jackson.annotation.JsonIgnore
 import io.specmatic.core.config.v3.ServerOrigin
+import io.specmatic.core.config.ConfigPathMapper
+import java.io.File
 import io.specmatic.core.config.v3.components.SecuritySchemeConfigurationV3
-import kotlin.String
 
 interface IRunOptionSpecification {
     fun getId(): String?
@@ -23,6 +24,10 @@ interface IRunOptionSpecification {
 }
 
 data class RunOptionsSpecifications(val spec: Value) : IRunOptionSpecification {
+    fun mapPaths(mapper: ConfigPathMapper, baseDirectory: File): RunOptionsSpecifications {
+        return copy(spec = spec.mapPaths(mapper, baseDirectory))
+    }
+
     @JsonIgnore
     override fun getId(): String? {
         return spec.id
@@ -61,6 +66,10 @@ data class RunOptionsSpecifications(val spec: Value) : IRunOptionSpecification {
         @JsonIgnore
         private val _config: MutableMap<String, Any> = linkedMapOf()
     ) {
+        fun mapPaths(mapper: ConfigPathMapper, baseDirectory: File): Value {
+            return copy(overlayFilePath = overlayFilePath?.let { mapper.child("overlayFilePath").map(it, baseDirectory) })
+        }
+
         @get:JsonAnyGetter
         val config: Map<String, Any> get() = _config.toMap()
 
@@ -110,6 +119,10 @@ data class WsdlRunOptionsSpecifications(val spec: Value) : IRunOptionSpecificati
 }
 
 data class OpenApiRunOptionsSpecifications(val spec: Value) : IRunOptionSpecification {
+    fun mapPaths(mapper: ConfigPathMapper, baseDirectory: File): OpenApiRunOptionsSpecifications {
+        return copy(spec = spec.mapPaths(mapper, baseDirectory))
+    }
+
     @JsonIgnore
     override fun getId(): String? {
         return spec.id
@@ -160,4 +173,8 @@ data class OpenApiRunOptionsSpecifications(val spec: Value) : IRunOptionSpecific
         val swaggerUiBaseUrl: String? = null,
         val actuatorUrl: String? = null,
     )
+
+    private fun Value.mapPaths(mapper: ConfigPathMapper, baseDirectory: File): Value {
+        return copy(overlayFilePath = overlayFilePath?.let { mapper.child("overlayFilePath").map(it, baseDirectory) })
+    }
 }

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/WsdlRunOptions.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/WsdlRunOptions.kt
@@ -4,10 +4,16 @@ import com.fasterxml.jackson.annotation.*
 import io.specmatic.core.config.HttpsConfiguration
 import io.specmatic.core.config.v3.RefOrValue
 import io.specmatic.core.config.v3.ServerOrigin
+import io.specmatic.core.config.ConfigPathMapper
+import io.specmatic.core.config.v3.mapValue
+import java.io.File
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type", visible = true)
 @JsonSubTypes(JsonSubTypes.Type(WsdlTestConfig::class, name = "test"), JsonSubTypes.Type(WsdlMockConfig::class, name = "mock"))
-sealed interface WsdlRunOptions : IRunOptions { val type: RunOptionType? }
+sealed interface WsdlRunOptions : IRunOptions {
+    val type: RunOptionType?
+    override fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): WsdlRunOptions
+}
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 data class WsdlTestConfig(
@@ -16,9 +22,12 @@ data class WsdlTestConfig(
     val host: String? = null,
     val port: Int? = null,
     override val cert: RefOrValue<HttpsConfiguration>? = null,
-    override val specs: List<WsdlRunOptionsSpecifications>? = null
+    override val specs: List<WsdlRunOptionsSpecifications>? = null,
+    @JsonIgnore private val _config: MutableMap<String, Any> = linkedMapOf()
 ) : WsdlRunOptions, ConfigWithCert {
-    private val _config: MutableMap<String, Any> = linkedMapOf()
+    override fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): WsdlTestConfig = copy(
+        cert = cert?.mapValue { it.mapPaths(mapper.child("cert"), configDirectory) },
+    )
 
     @JsonIgnore
     override fun gerServerOrigin(): ServerOrigin? {
@@ -49,9 +58,12 @@ data class WsdlMockConfig(
     val host: String? = null,
     val port: Int? = null,
     override val cert: RefOrValue<HttpsConfiguration>? = null,
-    override val specs: List<WsdlRunOptionsSpecifications>? = null
+    override val specs: List<WsdlRunOptionsSpecifications>? = null,
+    @JsonIgnore private val _config: MutableMap<String, Any> = linkedMapOf()
 ) : WsdlRunOptions, ConfigWithCert {
-    private val _config: MutableMap<String, Any> = linkedMapOf()
+    override fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): WsdlMockConfig = copy(
+        cert = cert?.mapValue { it.mapPaths(mapper.child("cert"), configDirectory) },
+    )
 
     @JsonIgnore
     override fun gerServerOrigin(): ServerOrigin? {

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/CommonServiceConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/CommonServiceConfig.kt
@@ -1,7 +1,9 @@
 package io.specmatic.core.config.v3.components.services
 
 import io.specmatic.core.config.v3.Data
+import io.specmatic.core.config.ConfigPathMapper
 import io.specmatic.core.config.v3.RefOrValue
+import io.specmatic.core.config.v3.components.sources.SourceV3
 import io.specmatic.core.config.v3.RefOrValueResolver
 import io.specmatic.core.config.v3.resolveElseThrow
 import java.io.File
@@ -13,6 +15,25 @@ data class CommonServiceConfig<RunOptions : Any, Settings : Any>(
     val data: Data? = null,
     val settings: RefOrValue<Settings>? = null
 ) {
+    fun mapPaths(
+        mapper: ConfigPathMapper,
+        configDirectory: File,
+        sourceReferences: Map<String, SourceV3> = emptyMap()
+    ): CommonServiceConfig<RunOptions, Settings> {
+        val mappedDefinitions = definitions.mapIndexed { index, definition ->
+            definition.mapPaths(
+                configDirectory = configDirectory,
+                sourceReferences = sourceReferences,
+                mapper = mapper.child("definitions").child(index),
+            )
+        }
+
+        return copy(
+            definitions = mappedDefinitions,
+            data = data?.mapPaths(mapper.child("data"), configDirectory),
+        )
+    }
+
     fun withCanonicalizedDefinitionFilesystemSources(
         resolver: RefOrValueResolver,
         workingDirectory: File

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/Definition.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/Definition.kt
@@ -1,9 +1,32 @@
 package io.specmatic.core.config.v3.components.services
 
+import io.specmatic.core.config.ConfigPathMapper
 import io.specmatic.core.config.v3.RefOrValue
+import io.specmatic.core.config.v3.mapValue
 import io.specmatic.core.config.v3.components.sources.SourceV3
+import java.io.File
 
 data class Definition(val definition: Value) {
+    fun mapPaths(
+        mapper: ConfigPathMapper,
+        configDirectory: File,
+        sourceReferences: Map<String, SourceV3> = emptyMap()
+    ): Definition {
+        val mappedSource = definition.source.mapValue {
+            it.mapPaths(mapper.child("source"), configDirectory)
+        }
+
+        val mappedBase = mappedSource.filesystemBase(configDirectory, sourceReferences) ?: return copy(
+            definition = definition.copy(source = mappedSource)
+        )
+
+        return copy(definition = definition.copy(source = mappedSource, specs = mappedBase.let { base ->
+            definition.specs.mapIndexed { index, spec ->
+                spec.mapPaths(mapper.child("specs").child(index), base)
+            }
+        }))
+    }
+
     data class Value(val source: RefOrValue<SourceV3>, val specs: List<SpecificationDefinition>)
 
     companion object {
@@ -12,5 +35,22 @@ data class Definition(val definition: Value) {
             val value = Value(RefOrValue.Value(source), specs = listOf(specificationDefinition))
             return Definition(value)
         }
+    }
+}
+
+private fun RefOrValue<SourceV3>.filesystemBase(
+    configDirectory: File,
+    sourceReferences: Map<String, SourceV3>
+): File? {
+    return when (this) {
+        is RefOrValue.Value -> value.filesystemBase(configDirectory)
+        is RefOrValue.Reference -> sourceReferences[ref.substringAfterLast('/')].filesystemBase(configDirectory)
+    }
+}
+
+private fun SourceV3?.filesystemBase(configDirectory: File): File? {
+    return this?.getFileSystem()?.directory?.let { directory ->
+        val file = File(directory)
+        if (file.isAbsolute) file else configDirectory.resolve(file)
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/MockServiceConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/MockServiceConfig.kt
@@ -6,6 +6,9 @@ import io.specmatic.core.config.HttpsConfiguration
 import io.specmatic.core.config.nonNullElse
 import io.specmatic.core.config.v3.Data
 import io.specmatic.core.config.v3.RefOrValue
+import io.specmatic.core.config.ConfigPathMapper
+import io.specmatic.core.config.v3.mapValueOrReference
+import io.specmatic.core.config.v3.mapValue
 import io.specmatic.core.config.v3.RefOrValueResolver
 import io.specmatic.core.config.v3.ServerOrigin
 import io.specmatic.core.config.v3.SpecmaticConfigV3Resolver
@@ -26,6 +29,18 @@ import kotlin.collections.plus
 
 data class MockServiceConfig(val services: List<Value>, val data: Data? = null, val settings: RefOrValue<MockSettings>? = null) {
     data class Value(val service: RefOrValue<CommonServiceConfig<MockRunOptions, MockSettings>>)
+
+    fun mapPaths(
+        mapper: ConfigPathMapper,
+        configDirectory: File,
+        sourceReferences: Map<String, SourceV3>,
+        resolver: RefOrValueResolver,
+    ): MockServiceConfig = copy(
+        data = data?.mapPaths(mapper.child("data"), configDirectory),
+        services = services.mapIndexed { index, value ->
+            mapService(index, value, configDirectory, mapper, resolver, sourceReferences)
+        },
+    )
 
     @JsonIgnore
     fun getService(specFile: File, resolver: RefOrValueResolver): CommonServiceConfig<MockRunOptions, MockSettings>? {
@@ -230,5 +245,48 @@ data class MockServiceConfig(val services: List<Value>, val data: Data? = null, 
             }
         }
         return listOfNotNull(globalHooks) + serviceHooks
+    }
+
+    private fun mapService(
+        index: Int,
+        value: Value,
+        configDirectory: File,
+        mapper: ConfigPathMapper,
+        resolver: RefOrValueResolver,
+        sourceReferences: Map<String, SourceV3>,
+    ): Value {
+        val serviceMapper = mapper.child("services").child(index).child("service")
+        return value.copy(
+            service = value.service.mapValueOrReference(
+                resolver = resolver,
+                resolve = { ref, refResolver -> ref.resolveElseThrow<MockRunOptions, MockSettings>(refResolver) },
+                transform = { service -> mapService(configDirectory, serviceMapper, sourceReferences, service) },
+                transformReference = { service -> mapService(configDirectory, serviceMapper, sourceReferences, service, mapDefinitions = false) },
+            )
+        )
+    }
+
+    private fun mapService(
+        configDirectory: File,
+        serviceMapper: ConfigPathMapper,
+        sourceReferences: Map<String, SourceV3>,
+        service: CommonServiceConfig<MockRunOptions, MockSettings>,
+        mapDefinitions: Boolean = true,
+    ): CommonServiceConfig<MockRunOptions, MockSettings> {
+        return service.copy(
+            data = service.data?.mapPaths(serviceMapper.child("data"), configDirectory),
+            runOptions = service.runOptions?.mapValue { it.mapPaths(serviceMapper.child("runOptions"), configDirectory) },
+            definitions = if (mapDefinitions) {
+                service.definitions.mapIndexed { definitionIndex, definition ->
+                    definition.mapPaths(
+                        configDirectory = configDirectory,
+                        sourceReferences = sourceReferences,
+                        mapper = serviceMapper.child("definitions").child(definitionIndex),
+                    )
+                }
+            } else {
+                service.definitions
+            },
+        )
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/SpecificationDefinition.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/SpecificationDefinition.kt
@@ -12,14 +12,20 @@ import io.specmatic.core.ResiliencyTestSuite
 import io.specmatic.core.SpecificationSourceEntry
 import io.specmatic.core.config.v3.ServerOrigin
 import io.specmatic.core.config.v3.components.sources.SourceV3
+import io.specmatic.core.config.ConfigPathMapper
 import io.specmatic.core.utilities.Flags
 import java.io.File
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION, defaultImpl = SpecificationDefinition.StringValue::class)
 sealed interface SpecificationDefinition {
-    data class Specification(val id: String? = null, val path: String, val urlPathPrefix: String? = null) {
-        private val _config: MutableMap<String, Any?> = linkedMapOf()
+    fun mapPaths(mapper: ConfigPathMapper, baseDirectory: File): SpecificationDefinition
 
+    data class Specification(
+        val id: String? = null,
+        val path: String,
+        val urlPathPrefix: String? = null,
+        @JsonIgnore private val _config: MutableMap<String, Any?> = linkedMapOf()
+    ) {
         @get:JsonAnyGetter
         val config: Map<String, Any?> get() = _config.toMap()
 
@@ -40,6 +46,10 @@ sealed interface SpecificationDefinition {
             val specFile = source.resolveSpecification(File(spec.path))
             val serverOrigin = getServerOrigin(getSpecificationId(), specFile).let(::getServerOriginWithBasePath)
             return source.toSpecificationSource(specFile, spec.path, serverOrigin, resiliencyTestSuite, examples)
+        }
+
+        override fun mapPaths(mapper: ConfigPathMapper, baseDirectory: File): SpecificationDefinition {
+            return copy(spec = spec.copy(path = mapper.child("spec").child("path").map(spec.path, baseDirectory)))
         }
 
         fun hasNoData(): Boolean = spec.urlPathPrefix == null && spec.config.isEmpty()
@@ -67,6 +77,10 @@ sealed interface SpecificationDefinition {
             val specFile = source.resolveSpecification(File(specification))
             val serverOrigin = getServerOrigin(getSpecificationId(), specFile).let(::getServerOriginWithBasePath)
             return source.toSpecificationSource(specFile, specification, serverOrigin, resiliencyTestSuite, examples)
+        }
+
+        override fun mapPaths(mapper: ConfigPathMapper, baseDirectory: File): SpecificationDefinition {
+            return StringValue(mapper.map(specification, baseDirectory))
         }
 
         companion object {

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/TestServiceConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/TestServiceConfig.kt
@@ -7,6 +7,9 @@ import io.specmatic.core.SpecificationSourceEntry
 import io.specmatic.core.config.nonNullElse
 import io.specmatic.core.config.v3.Data
 import io.specmatic.core.config.v3.RefOrValue
+import io.specmatic.core.config.ConfigPathMapper
+import io.specmatic.core.config.v3.mapValueOrReference
+import io.specmatic.core.config.v3.mapValue
 import io.specmatic.core.config.v3.RefOrValueResolver
 import io.specmatic.core.config.v3.ServerOrigin
 import io.specmatic.core.config.v3.SpecmaticConfigV3Resolver
@@ -23,6 +26,20 @@ import io.specmatic.reporter.model.SpecType
 import java.io.File
 
 data class TestServiceConfig(val service: RefOrValue<CommonServiceConfig<TestRunOptions, TestSettings>>) {
+    fun mapPaths(
+        mapper: ConfigPathMapper,
+        configDirectory: File,
+        sourceReferences: Map<String, SourceV3>,
+        resolver: RefOrValueResolver,
+    ): TestServiceConfig = copy(
+        service = service.mapValueOrReference(
+            resolver = resolver,
+            resolve = { ref, refResolver -> ref.resolveElseThrow<TestRunOptions, TestSettings>(refResolver) },
+            transform = { mapService(configDirectory, mapper.child("service"), sourceReferences, it) },
+            transformReference = { mapService(configDirectory, mapper.child("service"), sourceReferences, it, mapDefinitions = false) },
+        )
+    )
+
     @JsonIgnore
     fun getSpecDefinitionFor(specFile: File, resolver: RefOrValueResolver): SpecificationDefinition? {
         val serviceConfig = service.resolveElseThrow(resolver)
@@ -201,5 +218,30 @@ data class TestServiceConfig(val service: RefOrValue<CommonServiceConfig<TestRun
             val runOptionSpecOverride = specId?.let(runOptions::getMatchingSpecification)
             runOptionSpecOverride?.getServerOrigin("localhost") ?: runOptions.gerServerOrigin()
         }
+    }
+
+    private fun mapService(
+        configDirectory: File,
+        mapper: ConfigPathMapper,
+        sourceReferences: Map<String, SourceV3>,
+        service: CommonServiceConfig<TestRunOptions, TestSettings>,
+        mapDefinitions: Boolean = true,
+    ): CommonServiceConfig<TestRunOptions, TestSettings> {
+        return service.copy(
+            data = service.data?.mapPaths(mapper.child("data"), configDirectory),
+            settings = service.settings?.mapValue { it.mapPaths(mapper.child("settings"), configDirectory) },
+            runOptions = service.runOptions?.mapValue { it.mapPaths(mapper.child("runOptions"), configDirectory) },
+            definitions = if (mapDefinitions) {
+                service.definitions.mapIndexed { index, definition ->
+                    definition.mapPaths(
+                        configDirectory = configDirectory,
+                        sourceReferences = sourceReferences,
+                        mapper = mapper.child("definitions").child(index),
+                    )
+                }
+            } else {
+                service.definitions
+            },
+        )
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/settings/GeneralSettings.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/settings/GeneralSettings.kt
@@ -2,7 +2,9 @@ package io.specmatic.core.config.v3.components.settings
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.specmatic.core.config.LoggingConfiguration
+import io.specmatic.core.config.ConfigPathMapper
 import io.specmatic.core.config.ExampleTemplateStringDeserializer
+import java.io.File
 
 data class GeneralSettings(
     val disableTelemetry: Boolean? = null,
@@ -15,4 +17,8 @@ data class GeneralSettings(
     val specExamplesDirectoryTemplate: String? = null,
     @field:JsonDeserialize(contentUsing = ExampleTemplateStringDeserializer::class)
     val sharedExamplesDirectoryTemplate: List<String>? = null
-)
+) {
+    fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): GeneralSettings = copy(
+        logging = logging?.mapPaths(mapper.child("logging"), configDirectory),
+    )
+}

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/settings/TestSettings.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/settings/TestSettings.kt
@@ -2,6 +2,8 @@ package io.specmatic.core.config.v3.components.settings
 
 import com.fasterxml.jackson.annotation.JsonAlias
 import io.specmatic.core.ResiliencyTestSuite
+import io.specmatic.core.config.ConfigPathMapper
+import java.io.File
 
 data class TestSettings(
     @field:JsonAlias("resiliencyTests")
@@ -14,6 +16,14 @@ data class TestSettings(
     val junitReportDir: String? = null,
     val maxTestCount: Int? = null,
 ) {
+    fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): TestSettings {
+        return copy(
+            junitReportDir = junitReportDir?.let {
+                mapper.child("junitReportDir").map(it, configDirectory)
+            }
+        )
+    }
+
     fun merge(fallback: TestSettings?): TestSettings {
         if (fallback == null) return this
         return TestSettings(

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/sources/GitAuthentication.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/sources/GitAuthentication.kt
@@ -7,12 +7,20 @@ import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.node.ObjectNode
 import io.specmatic.core.Auth
+import io.specmatic.core.config.ConfigPathMapper
+import java.io.File
 
 @JsonDeserialize(using = GitAuthentication.Companion.GitAuthenticationDeserializer::class)
 sealed interface GitAuthentication {
     data class BearerFile(val bearerFile: String) : GitAuthentication
     data class BearerEnv(val bearerEnvironmentVariable: String) : GitAuthentication
     data class PersonalAccessToken(val personalAccessToken: String) : GitAuthentication
+
+    fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): GitAuthentication = when (this) {
+        is BearerEnv -> this
+        is PersonalAccessToken -> this
+        is BearerFile -> copy(bearerFile = mapper.child("bearerFile").map(bearerFile, configDirectory))
+    }
 
     fun toCommonAuth(): Auth {
         return Auth(

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/sources/SourceV3.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/sources/SourceV3.kt
@@ -10,6 +10,7 @@ import io.specmatic.core.SpecificationSourceEntry
 import io.specmatic.core.WorkingDirectory
 import io.specmatic.core.config.v3.ServerOrigin
 import io.specmatic.core.getConfigFilePath
+import io.specmatic.core.config.ConfigPathMapper
 import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.utilities.applyIf
 import io.specmatic.core.utilities.ResolvedWebSource
@@ -37,6 +38,15 @@ data class SourceV3(private val git: Git?, private val fileSystem: FileSystem?, 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("web")
     fun getWeb(): Web? = web
+
+    fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): SourceV3 {
+        return copy(
+            git = git?.copy(auth = git.auth?.mapPaths(mapper.child("git").child("auth"), configDirectory)),
+            fileSystem = fileSystem?.copy(directory = fileSystem.directory?.let {
+                mapper.child("fileSystem").child("directory").map(it, configDirectory)
+            })
+        )
+    }
 
     fun resolveSpecification(specification: File): File {
         if (git != null) return git.resolveSpecification(specification)

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/specmatic/Governance.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/specmatic/Governance.kt
@@ -4,8 +4,14 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.specmatic.core.ReportConfiguration
 import io.specmatic.core.SuccessCriteria
+import io.specmatic.core.config.ConfigPathMapper
+import java.io.File
 
 data class Governance(val report: Report? = null, @field:JsonProperty("successCriteria") val successCriterion: SuccessCriterion? = null) : ReportConfiguration {
+    fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): Governance {
+        return copy(report = report?.mapPaths(mapper.child("report"), configDirectory))
+    }
+
     @JsonIgnore
     override fun getSuccessCriteria(): SuccessCriteria {
         return this.successCriterion?.toSuccessCriteria() ?: SuccessCriteria.default

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/specmatic/License.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/specmatic/License.kt
@@ -1,3 +1,10 @@
 package io.specmatic.core.config.v3.specmatic
 
-data class License(val path: String)
+import io.specmatic.core.config.ConfigPathMapper
+import java.io.File
+
+data class License(val path: String) {
+    fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): License {
+        return copy(path = mapper.map(path, configDirectory))
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/specmatic/Report.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/specmatic/Report.kt
@@ -2,6 +2,8 @@ package io.specmatic.core.config.v3.specmatic
 
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonValue
+import io.specmatic.core.config.ConfigPathMapper
+import java.io.File
 
 enum class ReportFormat(val value: String) {
     HTML("html"),
@@ -21,4 +23,8 @@ enum class ReportFormat(val value: String) {
     }
 }
 
-data class Report(val formats: List<ReportFormat>? = null, val outputDirectory: String? = null)
+data class Report(val formats: List<ReportFormat>? = null, val outputDirectory: String? = null) {
+    fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): Report {
+        return copy(outputDirectory = outputDirectory?.let { mapper.child("outputDirectory").map(it, configDirectory) })
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/config/ConfigPathMappingTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/ConfigPathMappingTest.kt
@@ -1,0 +1,435 @@
+package io.specmatic.core.config
+
+import io.specmatic.core.TestConfiguration
+import io.specmatic.core.StubConfiguration
+import io.specmatic.core.config.v2.SpecExecutionConfig.ConfigValue
+import io.specmatic.core.config.v2.ContractConfig
+import io.specmatic.core.config.v2.SpecExecutionConfig
+import io.specmatic.core.config.v2.SpecmaticConfigV2
+import io.specmatic.core.config.v3.components.Adapter
+import io.specmatic.core.config.v3.components.services.CommonServiceConfig
+import io.specmatic.core.config.v3.components.services.MockServiceConfig
+import io.specmatic.core.config.v3.components.services.TestServiceConfig
+import io.specmatic.core.config.v3.Components
+import io.specmatic.core.config.v3.ContextDependentSettings
+import io.specmatic.core.config.v3.Proxy
+import io.specmatic.core.config.v3.ProxyConfigV3
+import io.specmatic.core.config.v3.RefOrValue
+import io.specmatic.core.config.v3.Specmatic
+import io.specmatic.core.config.v3.SpecmaticConfigV3
+import io.specmatic.core.config.v3.components.Dictionary
+import io.specmatic.core.config.v3.components.ExampleDirectories
+import io.specmatic.core.config.v3.components.Examples
+import io.specmatic.core.config.v3.components.runOptions.ContextDependentRunOptions
+import io.specmatic.core.config.v3.components.runOptions.GraphQLSdlMockConfig
+import io.specmatic.core.config.v3.components.runOptions.GraphQLSdlTestConfig
+import io.specmatic.core.config.v3.components.runOptions.MockRunOptions
+import io.specmatic.core.config.v3.components.runOptions.TestRunOptions
+import io.specmatic.core.config.v3.components.runOptions.WsdlMockConfig
+import io.specmatic.core.config.v3.components.runOptions.WsdlTestConfig
+import io.specmatic.core.config.v3.components.settings.MockSettings
+import io.specmatic.core.config.v3.components.settings.TestSettings
+import io.specmatic.core.config.v3.components.sources.SourceV3
+import io.specmatic.core.config.v3.specmatic.License
+import io.specmatic.core.config.v3.components.services.Definition
+import io.specmatic.core.config.v3.components.services.SpecificationDefinition
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import java.io.File
+
+class ConfigPathMappingTest {
+    private val configDirectory = File("/config")
+    private val mapper = MappingConfigPathMapper { location, path, base ->
+        "${location.joinToString(".")}|${base.path}|$path"
+    }
+
+    @Nested
+    inner class V2 {
+        @Test
+        fun `maps root fields and filesystem execution base`() {
+            val config = SpecmaticConfigV2(
+                version = SpecmaticConfigVersion.VERSION_2,
+                examples = listOf("examples"),
+                test = TestConfiguration(overlayFilePath = "overlay.yaml"),
+                contracts = listOf(
+                    ContractConfig(
+                        contractSource = ContractConfig.FileSystemContractSource("contracts"),
+                        provides = listOf(SpecExecutionConfig.StringValue("api.yaml"))
+                    )
+                )
+            )
+
+            val mapped = config.mapPaths(mapper, configDirectory)
+            assertThat(mapped.examples).isEqualTo(listOf("examples.0|${configDirectory.path}|examples"))
+            assertThat(mapped.test?.overlayFilePath).isEqualTo("test.overlayFilePath|${configDirectory.path}|overlay.yaml")
+            assertThat(mapped.contracts.single().getFilesystemSource()?.directory)
+                .isEqualTo("contracts.0.filesystem.directory|${configDirectory.path}|contracts")
+            assertThat((mapped.contracts.single().provides!!.single() as SpecExecutionConfig.StringValue).value)
+                .isEqualTo("contracts.0.provides.0|${resolvedBase("contracts.0.filesystem.directory", "contracts")}|api.yaml")
+        }
+
+        @Test
+        fun `maps https dictionary and mcp paths`() {
+            val config = SpecmaticConfigV2(
+                version = SpecmaticConfigVersion.VERSION_2,
+                test = TestConfiguration(
+                    https = HttpsConfiguration(
+                        keyStore = KeyStoreConfiguration.FileBasedConfig(file = "test.p12")
+                    )
+                ),
+                stub = StubConfiguration(
+                    dictionary = "stub.json",
+                    https = HttpsConfiguration(
+                        keyStore = KeyStoreConfiguration.DirectoryBasedConfig(directory = "certs")
+                    )
+                ),
+                mcp = McpConfiguration(McpTestConfiguration(baseUrl = "http://mcp", dictionaryFile = "mcp.json"))
+            )
+
+            val mapped = config.mapPaths(mapper, configDirectory)
+            assertThat((mapped.test?.https?.keyStore as KeyStoreConfiguration.FileBasedConfig).file)
+                .isEqualTo("test.https.keyStore.file|${configDirectory.path}|test.p12")
+
+            assertThat(mapped.stub?.getDictionary()).isEqualTo("stub.dictionary|${configDirectory.path}|stub.json")
+            assertThat((mapped.stub?.getHttps()?.keyStore as KeyStoreConfiguration.DirectoryBasedConfig).directory)
+                .isEqualTo("stub.https.keyStore.directory|${configDirectory.path}|certs")
+
+            assertThat(mapped.mcp?.test?.dictionaryFile).isEqualTo("mcp.test.dictionaryFile|${configDirectory.path}|mcp.json")
+        }
+
+        @Test
+        fun `maps only string values in dynamic path lists`() {
+            val execution = ConfigValue(
+                specs = listOf("api.yaml"),
+                specType = "openapi",
+                config = mapOf("examples" to listOf("examples", 42), "unknown" to listOf("untouched"))
+            )
+
+            val mapped = execution.mapPaths(mapper.child("execution"), configDirectory, configDirectory)
+            assertThat(mapped).isEqualTo(
+                ConfigValue(
+                    specs = listOf("execution.specs.0|${configDirectory.path}|api.yaml"),
+                    specType = "openapi",
+                    config = mapOf(
+                        "examples" to listOf("execution.config.examples.0|${configDirectory.path}|examples", 42),
+                        "unknown" to listOf("untouched")
+                    )
+                )
+            )
+        }
+    }
+
+    @Nested
+    inner class V3 {
+        @Test
+        fun `maps components examples dictionary license and proxy paths`() {
+            val config = SpecmaticConfigV3(
+                version = SpecmaticConfigVersion.VERSION_3,
+                components = Components(
+                    dictionaries = mapOf("main" to Dictionary("dictionary.json")),
+                    examples = Examples(
+                        testExamples = listOf(RefOrValue.Value(ExampleDirectories(listOf("examples"))))
+                    )
+                ),
+                proxies = listOf(
+                    Proxy(
+                        ProxyConfigV3(
+                            target = "http://target",
+                            mock = listOf("mock.yaml"),
+                            recordingsDirectory = "recordings"
+                        )
+                    )
+                ),
+                specmatic = Specmatic(license = License("license.txt"))
+            )
+
+            val mapped = config.mapPaths(mapper, configDirectory)
+            assertThat(mapped.components?.dictionaries?.get("main")?.path)
+                .isEqualTo("components.dictionaries.main.path|${configDirectory.path}|dictionary.json")
+            assertThat(mapped.components?.examples?.testExamples?.single()?.getOrNull()?.directories)
+                .isEqualTo(listOf("components.examples.testExamples.0.directories.0|${configDirectory.path}|examples"))
+            assertThat(mapped.proxies?.single()?.proxy?.mock)
+                .isEqualTo(listOf("proxies.0.proxy.mock.0|${configDirectory.path}|mock.yaml"))
+            assertThat(mapped.proxies!!.single().proxy.recordingsDirectory)
+                .isEqualTo("proxies.0.proxy.recordingsDirectory|${configDirectory.path}|recordings")
+            assertThat(mapped.specmatic?.license?.path)
+                .isEqualTo("specmatic.license.path|${configDirectory.path}|license.txt")
+        }
+
+        @Test
+        fun `recalculates definition spec base after source mapping`() {
+            val definition = Definition(
+                Definition.Value(
+                    source = RefOrValue.Value(SourceV3.create(filesystem = SourceV3.FileSystem("specs"))),
+                    specs = listOf(SpecificationDefinition.StringValue("api.yaml"))
+                )
+            )
+
+            val mapped = definition.mapPaths(mapper.child("definition"), configDirectory)
+            assertThat(mapped.definition.source.getOrNull()?.getFileSystem()?.directory)
+                .isEqualTo("definition.source.fileSystem.directory|${configDirectory.path}|specs")
+            assertThat(mapped.definition.specs.single().getSpecificationPath())
+                .isEqualTo("definition.specs.0|${resolvedBase("definition.source.fileSystem.directory", "specs")}|api.yaml")
+        }
+
+        @Test
+        fun `preserves references while mapping inline component values`() {
+            val config = SpecmaticConfigV3(
+                version = SpecmaticConfigVersion.VERSION_3,
+                components = Components(
+                    sources = mapOf("source" to SourceV3.create(filesystem = SourceV3.FileSystem("specs"))),
+                    adapters = mapOf("adapter" to Adapter(mapOf("hook" to "hook.kts"))),
+                    certificates = mapOf("cert" to HttpsConfiguration()),
+                    examples = Examples(
+                        testExamples = listOf(RefOrValue.Reference("#/components/examples/reusable"))
+                    )
+                ),
+                systemUnderTest = TestServiceConfig(
+                    RefOrValue.Value(
+                        CommonServiceConfig(
+                            definitions = listOf(
+                                Definition(
+                                    Definition.Value(
+                                        source = RefOrValue.Reference("#/components/sources/source"),
+                                        specs = listOf(SpecificationDefinition.StringValue("api.yaml"))
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+
+            val mapped = config.mapPaths(mapper, configDirectory)
+            assertThat(mapped.components?.examples?.testExamples)
+                .isEqualTo(listOf(RefOrValue.Reference("#/components/examples/reusable")))
+            assertThat(mapped.systemUnderTest?.service?.getOrNull()?.definitions?.single()?.definition?.source)
+                .isEqualTo(RefOrValue.Reference("#/components/sources/source"))
+            assertThat(mapped.components?.sources?.get("source")?.getFileSystem()?.directory)
+                .isEqualTo("components.sources.source.fileSystem.directory|${configDirectory.path}|specs")
+        }
+
+        @Test
+        fun `maps referenced services and preserves context dependent values`() {
+            val service = CommonServiceConfig(
+                definitions = listOf(
+                    element = Definition(
+                        Definition.Value(
+                            source = RefOrValue.Value(SourceV3.create(filesystem = SourceV3.FileSystem("specs"))),
+                            specs = listOf(SpecificationDefinition.StringValue("api.yaml"))
+                        )
+                    )
+                ),
+                settings = RefOrValue.Value(ContextDependentSettings(mapOf("custom" to "setting"))),
+                runOptions = RefOrValue.Value(ContextDependentRunOptions(mapOf("protobuf" to mapOf("importPaths" to listOf("./proto-imports"))))),
+            )
+
+            val config = SpecmaticConfigV3(
+                version = SpecmaticConfigVersion.VERSION_3,
+                components = Components(services = mapOf("service" to service)),
+                systemUnderTest = TestServiceConfig(RefOrValue.Reference("#/components/services/service"))
+            )
+
+            val mapped = config.mapPaths(mapper, configDirectory)
+            val mappedService = mapped.components!!.services!!["service"]!!
+
+            assertThat(mapped.systemUnderTest?.service)
+                .isEqualTo(RefOrValue.Reference("#/components/services/service"))
+            assertThat(mappedService.definitions.single().definition.source.getOrNull()?.getFileSystem()?.directory)
+                .isEqualTo("components.services.service.definitions.0.source.fileSystem.directory|${configDirectory.path}|specs")
+            assertThat(mappedService.definitions.single().definition.specs.single().getSpecificationPath())
+                .isEqualTo("components.services.service.definitions.0.specs.0|${resolvedBase("components.services.service.definitions.0.source.fileSystem.directory", "specs")}|api.yaml")
+            assertThat(mappedService.runOptions)
+                .isEqualTo(
+                    RefOrValue.Value(
+                        ContextDependentRunOptions(
+                            mapOf("protobuf" to mapOf("importPaths" to listOf("./proto-imports")))
+                        )
+                    )
+                )
+            assertThat(mappedService.settings)
+                .isEqualTo(RefOrValue.Value(ContextDependentSettings(mapOf("custom" to "setting"))))
+        }
+
+        @Test
+        fun `maps ref overlays while preserving the reference`() {
+            val overlay = mapOf(
+                pair = "runOptions" to mapOf("protobuf" to mapOf("importPaths" to listOf("./proto-imports")))
+            )
+
+            val config = SpecmaticConfigV3(
+                version = SpecmaticConfigVersion.VERSION_3,
+                components = Components(services = mapOf("service" to CommonServiceConfig(definitions = emptyList()))),
+                systemUnderTest = TestServiceConfig(RefOrValue.Reference(ref = "#/components/services/service", extra = overlay))
+            )
+
+            val mapped = config.mapPaths(mapper, configDirectory)
+            val mappedExtra = (mapped.systemUnderTest?.service as RefOrValue.Reference).extra
+            val mappedRunOptions = mappedExtra["runOptions"] as Map<*, *>
+            val mappedProtobuf = mappedRunOptions["protobuf"] as Map<*, *>
+            assertThat(mappedProtobuf["importPaths"])
+                .isEqualTo(listOf("systemUnderTest.service.runOptions.protobuf.config.importPaths.0|${configDirectory.path}|./proto-imports"))
+        }
+
+        @Test
+        fun `preserves dynamic WSDL and GraphQL run option config while mapping`() {
+            val configs = listOf(
+                WsdlTestConfig().also { it.put("custom", "test-wsdl") },
+                WsdlMockConfig().also { it.put("custom", "mock-wsdl") },
+                GraphQLSdlTestConfig().also { it.put("custom", "test-graphql") },
+                GraphQLSdlMockConfig().also { it.put("custom", "mock-graphql") },
+            )
+
+            assertThat(configs.map { it.mapPaths(mapper, configDirectory).config })
+                .containsExactly(
+                    mapOf("custom" to "test-wsdl"),
+                    mapOf("custom" to "mock-wsdl"),
+                    mapOf("custom" to "test-graphql"),
+                    mapOf("custom" to "mock-graphql"),
+                )
+        }
+
+        @Test
+        fun `preserves dynamic specification definition config while mapping`() {
+            val specification = SpecificationDefinition.Specification(
+                id = "api",
+                path = "api.yaml"
+            ).also {
+                it.put("custom", "value")
+            }
+
+            val definition = Definition(
+                Definition.Value(
+                    source = RefOrValue.Value(SourceV3.create(filesystem = SourceV3.FileSystem("specs"))),
+                    specs = listOf(SpecificationDefinition.ObjectValue(specification))
+                )
+            )
+
+            val mappedSpecification = (definition.mapPaths(mapper, configDirectory).definition.specs.single() as SpecificationDefinition.ObjectValue).spec
+            assertThat(mappedSpecification.config).containsEntry("custom", "value")
+        }
+    }
+
+    @Nested
+    inner class ServiceDefinitionMapping {
+        @ParameterizedTest
+        @ValueSource(booleans = [false, true])
+        fun `maps test service definitions exactly once`(referenced: Boolean) {
+            val config = testConfig(referenced)
+
+            val mappedLocations = mutableListOf<String>()
+            config.mapPaths(RecordingConfigPathMapper(mappedLocations), configDirectory)
+            val serviceLocation = if (referenced) {
+                "components.services.service"
+            } else {
+                "systemUnderTest.service"
+            }
+
+            assertThat(mappedLocations).containsExactly(
+                "$serviceLocation.definitions.0.source.fileSystem.directory",
+                "$serviceLocation.definitions.0.specs.0",
+            )
+        }
+
+        @ParameterizedTest
+        @ValueSource(booleans = [false, true])
+        fun `maps mock service definitions exactly once`(referenced: Boolean) {
+            val config = mockConfig(referenced)
+
+            val mappedLocations = mutableListOf<String>()
+            config.mapPaths(RecordingConfigPathMapper(mappedLocations), configDirectory)
+            val serviceLocation = if (referenced) {
+                "components.services.service"
+            } else {
+                "dependencies.services.0.service"
+            }
+
+            assertThat(mappedLocations).containsExactly(
+                "$serviceLocation.definitions.0.source.fileSystem.directory",
+                "$serviceLocation.definitions.0.specs.0",
+            )
+        }
+
+        private fun testConfig(referenced: Boolean): SpecmaticConfigV3 {
+            val componentService = componentService()
+            val inlineService = testService()
+            return SpecmaticConfigV3(
+                version = SpecmaticConfigVersion.VERSION_3,
+                components = if (referenced) Components(services = mapOf("service" to componentService)) else null,
+                systemUnderTest = TestServiceConfig(
+                    if (referenced) RefOrValue.Reference("#/components/services/service") else RefOrValue.Value(inlineService)
+                ),
+            )
+        }
+
+        private fun mockConfig(referenced: Boolean): SpecmaticConfigV3 {
+            val componentService = componentService()
+            val inlineService = mockService()
+            return SpecmaticConfigV3(
+                version = SpecmaticConfigVersion.VERSION_3,
+                components = if (referenced) Components(services = mapOf("service" to componentService)) else null,
+                dependencies = MockServiceConfig(
+                    services = listOf(
+                        MockServiceConfig.Value(
+                            if (referenced) RefOrValue.Reference("#/components/services/service") else RefOrValue.Value(inlineService)
+                        )
+                    )
+                ),
+            )
+        }
+
+        private fun testService(): CommonServiceConfig<TestRunOptions, TestSettings> = CommonServiceConfig(definitions = definitions())
+        private fun mockService(): CommonServiceConfig<MockRunOptions, MockSettings> = CommonServiceConfig(definitions = definitions())
+        private fun componentService(): CommonServiceConfig<ContextDependentRunOptions, ContextDependentSettings> = CommonServiceConfig(definitions = definitions(),)
+        private fun definitions() = listOf(
+            element = Definition(
+                Definition.Value(
+                    source = RefOrValue.Value(SourceV3.create(filesystem = SourceV3.FileSystem("specs"))),
+                    specs = listOf(SpecificationDefinition.StringValue("api.yaml")),
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `no-op mapper preserves complete aggregate`() {
+        val config = SpecmaticConfigV3(version = SpecmaticConfigVersion.VERSION_3, components = Components())
+        assertThat(config.mapPaths(NoOpConfigPathMapper, configDirectory)).isEqualTo(config)
+    }
+
+    private fun resolvedBase(location: String, path: String): String {
+        val mappedDirectory = "$location|${configDirectory.path}|$path"
+        return configDirectory.resolve(mappedDirectory).path
+    }
+}
+
+private class MappingConfigPathMapper(
+    private val location: List<String> = emptyList(),
+    private val mapping: (location: List<String>, path: String, baseDirectory: File) -> String
+) : ConfigPathMapper {
+    override fun child(segment: String) = MappingConfigPathMapper(location + segment, mapping)
+    override fun child(index: Int) = MappingConfigPathMapper(location + index.toString(), mapping)
+    override fun map(path: String, baseDirectory: File) = mapping(location, path, baseDirectory)
+}
+
+
+private object NoOpConfigPathMapper : ConfigPathMapper {
+    override fun child(segment: String) = this
+    override fun child(index: Int) = this
+    override fun map(path: String, baseDirectory: File) = path
+}
+
+private class RecordingConfigPathMapper(
+    private val mappedLocations: MutableList<String>,
+    private val location: List<String> = emptyList(),
+) : ConfigPathMapper {
+    override fun child(segment: String) = RecordingConfigPathMapper(mappedLocations, location + segment)
+    override fun child(index: Int) = RecordingConfigPathMapper(mappedLocations, location + index.toString())
+    override fun map(path: String, baseDirectory: File): String {
+        mappedLocations += location.joinToString(".")
+        return path
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/config/SpecmaticConfigAllTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/SpecmaticConfigAllTest.kt
@@ -1018,7 +1018,7 @@ internal class SpecmaticConfigAllTest {
     }
 
     @Test
-    fun `when the source v1 config has a source of filesystem type with no directory it gets converted to v2 with no source` () {
+    fun `when the source v1 config has a source of filesystem type with no directory it gets converted to v2 with cwd filesystem source` () {
         val contractConfigYaml = """
             sources:
               - provides:
@@ -1031,7 +1031,7 @@ internal class SpecmaticConfigAllTest {
 
         val configV2 = SpecmaticConfigV2.loadFrom(dslConfig) as SpecmaticConfigV2
 
-        assertThat(configV2.contracts.first().contractSource).isNull()
+        assertThat(configV2.contracts.first().contractSource).isEqualTo(FileSystemContractSource(directory = "."))
     }
 
     @Test


### PR DESCRIPTION
**What**: Added a `ConfigPathMapper` interface for rewriting paths referenced by Specmatic configuration.

Config V2 and V3 DTOs now accept the mapper and invoke it for each supported path, along with the applicable base directory. The mapper can resolve, normalize, replace, or otherwise transform the path as required.

**Why**:

Configuration paths may need to be updated when files or directories are moved, renamed, or resolved relative to a different base directory.

Keeping this logic outside the DTOs provides a common extension point for path remapping without coupling the configuration models to a specific rename or resolution workflow.

**How**:
* Introduced the `ConfigPathMapper` interface.
* Wired path mapping through the relevant Config V2 DTOs.
* Wired path mapping through the relevant Config V3 DTOs.
* Passed both the configured path and its base directory to the mapper.
* Added unit tests verifying that supported paths are passed to the mapper and rewritten correctly.

**Checklist**:

* [x] Unit Tests
* [x] Build passing locally
* [ ] Sonar Quality Gate
* [ ] Security scans don't report any vulnerabilities
* [ ] Documentation added/updated (N/A)
* [ ] Sample Project added/updated (N/A)
* [ ] Demo video (N/A)
* [ ] Article on Website (N/A)
* [ ] Roadmap updated (N/A)
* [ ] Conference Talk (N/A)