### PR TITLE
fix: main schema should override any member schema having the same property name from main schema during allOf parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ Each release section should stand on its own and describe the behavior shipped i
 - When generating notes for downstream repos, this repo is consumed by:
   - `enterprise`, bumped in `enterprise/gradle.properties` via `specmaticVersion`
 
+## Unreleased
+
+### Changed
+
+- Fixed OpenAPI `allOf` conversion so a main-schema property overrides a matching member property without generating both optional and required keys.
+
 ## 2.51.0 (2026-07-25)
 
 ## Added

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -3016,28 +3016,18 @@ class OpenApiSpecification(
         propertiesEntry: Map<String, Pattern>,
         propertiesAcc: Map<String, Pattern>
     ): Map<String, Pattern> {
-        val updatedPropertiesAcc: Map<String, Pattern> =
-            propertiesEntry.entries.fold(propertiesAcc) { acc, propertyEntry ->
-                val existingPropertyValue = acc[propertyEntry.key.withOptionalSuffix()]
-                    ?: acc[propertyEntry.key.withoutOptionalSuffix()]
+        return propertiesEntry.entries.fold(propertiesAcc) { acc, propertyEntry ->
+            val existingPropertyValue = acc[propertyEntry.key.withOptionalSuffix()]
+                ?: acc[propertyEntry.key.withoutOptionalSuffix()]
+            val newPropertyValue = existingPropertyValue?.let {
+                restrictivePatternBetween(it, propertyEntry.value)
+            } ?: propertyEntry.value
+            val keyWithoutOptionality = withoutOptionality(propertyEntry.key)
 
-                val newPropertyValue = if (existingPropertyValue != null)
-                    restrictivePatternBetween(existingPropertyValue, propertyEntry.value)
-                else propertyEntry.value
-
-                when (val keyWithoutOptionality = withoutOptionality(propertyEntry.key)) {
-                    in acc ->
-                        acc.plus(propertyEntry.key to newPropertyValue)
-
-                    propertyEntry.key ->
-                        acc.minus("$keyWithoutOptionality?").plus(propertyEntry.key to newPropertyValue)
-
-                    else ->
-                        acc.plus(propertyEntry.key to newPropertyValue)
-                }
-            }
-
-        return updatedPropertiesAcc
+            acc.minus(keyWithoutOptionality)
+                .minus("$keyWithoutOptionality?")
+                .plus(propertyEntry.key to newPropertyValue)
+        }
     }
 
     private fun restrictivePatternBetween(pattern1: Pattern, pattern2: Pattern): Pattern {

--- a/core/src/test/kotlin/integration_tests/YamlToPatternTests.kt
+++ b/core/src/test/kotlin/integration_tests/YamlToPatternTests.kt
@@ -1016,8 +1016,9 @@ class YamlToPatternTests {
 
         @JvmStatic
         fun allOfScenarios(): Stream<Arguments> {
-            return listOf(
-                multiVersionCase("allOf merge objects", OpenApiVersion.OAS30, OpenApiVersion.OAS31) {
+            return (
+                listOf(
+                    multiVersionCase("allOf merge objects", OpenApiVersion.OAS30, OpenApiVersion.OAS31) {
                     schema {
                         put("allOf", listOf(
                             mapOf(
@@ -1059,6 +1060,31 @@ class YamlToPatternTests {
                         assertFailure(pattern.match(mapOf("name" to "Alice")))
                     }
                 },
+                ) + listOf(false, true).flatMap { memberRequired ->
+                    listOf(false, true).map { mainRequired ->
+                        multiVersionCase(
+                            "allOf main schema ${if (mainRequired) "required" else "optional"} property overrides ${if (memberRequired) "required" else "optional"} member property",
+                            OpenApiVersion.OAS30,
+                            OpenApiVersion.OAS31,
+                        ) {
+                            schema {
+                                put("type", "object")
+                                put("allOf", listOf(buildMap {
+                                    put("type", "object")
+                                    put("properties", mapOf("common" to mapOf("type" to "string")))
+                                    if (memberRequired) put("required", listOf("common"))
+                                }))
+                                put("properties", mapOf("common" to mapOf("type" to "string")))
+                                if (mainRequired) put("required", listOf("common"))
+                            }
+                            validate { pattern ->
+                                val objectPattern = pattern as JSONObjectPattern
+                                val key = if (mainRequired) "common" else "common?"
+                                assertThat(objectPattern.pattern).containsOnlyKeys(key)
+                            }
+                        }
+                    }
+                }
             ).flatten().stream()
         }
 


### PR DESCRIPTION
- Fixed OpenAPI `allOf` conversion producing duplicate keys for same property: required `field` + optional `field?`.
- Main-schema properties now override matching `allOf` member properties, including optionality and pattern.
- Preserved top-level `required` behavior for properties defined only in member schemas.
- Added regression test.