### PR TITLE
Select the most specific matching stub base URL

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -67,6 +67,14 @@ data class SpecificationSourceEntry(
     )
 }
 
+internal fun SpecmaticConfig.mostSpecificMatchingBaseUrl(requestUrl: URI, candidates: Collection<URI>): URI? {
+    return candidates.filter { candidate ->
+        isSameBaseIgnoringHost(requestUrl, candidate)
+    }.maxByOrNull { candidate ->
+        candidate.path.length
+    }
+}
+
 interface SpecmaticConfig {
     @JsonIgnore
     fun getLogConfigurationOrDefault(): LoggingConfiguration
@@ -130,9 +138,7 @@ interface SpecmaticConfig {
     @JsonIgnore
     fun stubBaseUrlPathAssociatedTo(url: String, defaultBaseUrl: String): String {
         val parsedUrl = URI(url)
-        return stubBaseUrls(defaultBaseUrl).map(::URI).firstOrNull { stubBaseUrl ->
-            isSameBaseIgnoringHost(parsedUrl, stubBaseUrl)
-        }?.path.orEmpty()
+        return this.mostSpecificMatchingBaseUrl(parsedUrl, stubBaseUrls(defaultBaseUrl).map(::URI))?.path.orEmpty()
     }
 
     @JsonIgnore

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfigV1V2Common.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfigV1V2Common.kt
@@ -44,7 +44,6 @@ import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.Value
 import io.specmatic.reporter.ctrf.model.CtrfSpecConfig
 import io.specmatic.reporter.model.SpecType
-import io.specmatic.stub.isSameBaseIgnoringHost
 import io.specmatic.test.TestResultRecord.Companion.CONTRACT_TEST_TEST_TYPE
 import java.io.File
 import java.net.URI
@@ -680,9 +679,7 @@ data class SpecmaticConfigV1V2Common(
     @JsonIgnore
     override fun stubBaseUrlPathAssociatedTo(url: String, defaultBaseUrl: String): String {
         val parsedUrl = URI(url)
-        return stubBaseUrls(defaultBaseUrl).map(::URI).firstOrNull { stubBaseUrl ->
-            isSameBaseIgnoringHost(parsedUrl, stubBaseUrl)
-        }?.path.orEmpty()
+        return this.mostSpecificMatchingBaseUrl(parsedUrl, stubBaseUrls(defaultBaseUrl).map(::URI))?.path.orEmpty()
     }
 
     @JsonIgnore

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -43,6 +43,7 @@ import io.specmatic.core.WorkingDirectory
 import io.specmatic.core.examples.server.ExampleMismatchMessages
 import io.specmatic.core.invalidRequestStatuses
 import io.specmatic.core.listOfExcludedHeaders
+import io.specmatic.core.mostSpecificMatchingBaseUrl
 import io.specmatic.core.log.HttpLogMessage
 import io.specmatic.core.log.LogMessage
 import io.specmatic.core.log.LogTail
@@ -865,8 +866,16 @@ class HttpStub(
         urlPath: String
     ): List<Feature> {
         val parsedBaseUrl = URI(baseUrl + urlPath)
-        val specsForGivenBaseUrl = specToBaseUrlMap.mapValues { URI(it.value) }.filterValues { stubBaseUrl ->
+        val specToParsedBaseUrlMap = specToBaseUrlMap.mapValues { URI(it.value) }
+        val matchingSpecs = specToParsedBaseUrlMap.filterValues { stubBaseUrl ->
             isSameBaseIgnoringHost(parsedBaseUrl, stubBaseUrl)
+        }
+        val selectedBaseUrl = specmaticConfigInstance.mostSpecificMatchingBaseUrl(
+            parsedBaseUrl,
+            matchingSpecs.values
+        ) ?: return emptyList()
+        val specsForGivenBaseUrl = matchingSpecs.filterValues { stubBaseUrl ->
+            selectedBaseUrl.path == stubBaseUrl.path
         }
 
         return features.filter { feature -> feature.path in specsForGivenBaseUrl }.distinctBy { feature -> feature.path }

--- a/core/src/main/kotlin/io/specmatic/stub/ThreadSafeListOfStubs.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/ThreadSafeListOfStubs.kt
@@ -5,6 +5,7 @@ import io.specmatic.core.RequestScore.Companion.orEmpty
 import io.specmatic.core.Result
 import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.invalidRequestStatuses
+import io.specmatic.core.mostSpecificMatchingBaseUrl
 import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.pattern.IgnoreUnexpectedKeys
 import io.specmatic.mock.ScenarioStub
@@ -27,9 +28,10 @@ class ThreadSafeListOfStubs(
         val resolvedUrls = setOf(baseUrl, defaultBaseUrl).map { it.plus(urlPath) }.map(::URI)
 
         return resolvedUrls.firstNotNullOfOrNull { resolvedUrl ->
-            baseUrlToListOfStubsMap.entries.firstOrNull { (stubBaseUrl, _) ->
-                isSameBaseIgnoringHost(resolvedUrl, stubBaseUrl)
-            }?.value
+            specmaticConfig.mostSpecificMatchingBaseUrl(
+                resolvedUrl,
+                baseUrlToListOfStubsMap.keys
+            )?.let(baseUrlToListOfStubsMap::get)
         } ?: emptyStubs()
     }
 

--- a/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigKtTest.kt
@@ -40,6 +40,27 @@ import java.util.stream.Stream
 
 internal class SpecmaticConfigKtTest {
     @Test
+    fun `should use the longest matching stub baseUrl path while retaining partial prefix matching`() {
+        val config = SpecmaticConfigV1V2Common(
+            sources = listOf(
+                Source(
+                    stub = listOf(
+                        SpecExecutionConfig.ObjectValue.FullUrl(baseUrl = "http://localhost:8080", specs = listOf("root.yaml")),
+                        SpecExecutionConfig.ObjectValue.FullUrl(baseUrl = "http://localhost:8080/api", specs = listOf("nested.yaml"))
+                    )
+                )
+            )
+        )
+
+        val baseUrlPath = config.stubBaseUrlPathAssociatedTo(
+            "http://localhost:8080/apiary/widgets",
+            "http://localhost:8080"
+        )
+
+        assertThat(baseUrlPath).isEqualTo("/api")
+    }
+
+    @Test
     fun `getStubHooks should return global hook associations for v1 v2 config`() {
         val hooks = mapOf("preSpecmaticRequestProcessor" to "./hooks/decode_request.sh")
         val config = SpecmaticConfigV1V2Common(version = SpecmaticConfigVersion.VERSION_2, hooks = hooks)

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3ImplTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3ImplTest.kt
@@ -31,6 +31,44 @@ class SpecmaticConfigV3ImplTest {
     @TempDir
     lateinit var tempDir: File
 
+    @Test
+    fun `should use the longest matching stub baseUrl path`() {
+        val config = v3Config(
+            """
+            version: 3
+            dependencies:
+              services:
+                - service:
+                    definitions:
+                      - definition:
+                          source:
+                            filesystem:
+                              directory: ./synthetic-specs
+                          specs:
+                            - spec:
+                                id: root
+                                path: root.yaml
+                            - spec:
+                                id: nested
+                                path: nested.yaml
+                    runOptions:
+                      openapi:
+                        baseUrl: http://localhost:8080
+                        specs:
+                          - spec:
+                              id: nested
+                              baseUrl: http://localhost:8080/api
+            """.trimIndent()
+        )
+
+        val baseUrlPath = config.stubBaseUrlPathAssociatedTo(
+            "http://localhost:8080/api/widgets",
+            "http://localhost:8080"
+        )
+
+        assertThat(baseUrlPath).isEqualTo("/api")
+    }
+
     @ParameterizedTest
     @MethodSource("loadSourcesTestCases")
     fun `should return similar values between v2 and v3 loadSources`(testCase: TestCase) = testCase.run(tempDir)

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
@@ -53,33 +53,41 @@ private const val STUB_SHUTDOWN_TIMEOUT = 0L
 internal class HttpStubTest {
     @Test
     fun `should route root and nested synthetic features on the same port`() {
-        val rootFeature = parseGherkinStringToFeature(
+        val rootFeature = OpenApiSpecification.fromYAML(
             """
-            Feature: Root service
-
-              Scenario: Get root resource
-                When GET /root-resource
-                Then status 200
-            """.trimIndent(),
-            "root.spec"
-        )
-        val nestedFeature = parseGherkinStringToFeature(
+            openapi: 3.0.3
+            info:
+              title: Root service
+              version: 1.0.0
+            paths:
+              /root-resource:
+                get:
+                  responses:
+                    "200":
+                      description: Root resource
+            """.trimIndent(), "root.yaml"
+        ).toFeature()
+        val nestedFeature = OpenApiSpecification.fromYAML(
             """
-            Feature: Nested service
-
-              Scenario: Get account
-                When GET /accounts
-                Then status 200
-            """.trimIndent(),
-            "nested.spec"
-        )
+            openapi: 3.0.3
+            info:
+              title: Nested service
+              version: 1.0.0
+            paths:
+              /accounts:
+                get:
+                  responses:
+                    "200":
+                      description: Account
+            """.trimIndent(), "nested.yaml"
+        ).toFeature()
         val port = ServerSocket(0).use { it.localPort }
         val config = SpecmaticConfigV1V2Common(
             sources = listOf(
                 Source(
                     stub = listOf(
-                        SpecExecutionConfig.ObjectValue.FullUrl(baseUrl = "http://localhost:$port", specs = listOf("root.spec")),
-                        SpecExecutionConfig.ObjectValue.FullUrl(baseUrl = "http://localhost:$port/services/nested", specs = listOf("nested.spec"))
+                        SpecExecutionConfig.ObjectValue.FullUrl(baseUrl = "http://localhost:$port", specs = listOf("root.yaml")),
+                        SpecExecutionConfig.ObjectValue.FullUrl(baseUrl = "http://localhost:$port/services/nested", specs = listOf("nested.yaml"))
                     )
                 )
             )

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
@@ -4,6 +4,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.core.*
+import io.specmatic.core.config.v2.SpecExecutionConfig
 import io.specmatic.core.log.*
 import io.specmatic.core.pattern.*
 import io.specmatic.core.utilities.*
@@ -50,6 +51,56 @@ import kotlin.time.measureTime
 private const val STUB_SHUTDOWN_TIMEOUT = 0L
 
 internal class HttpStubTest {
+    @Test
+    fun `should route root and nested synthetic features on the same port`() {
+        val rootFeature = parseGherkinStringToFeature(
+            """
+            Feature: Root service
+
+              Scenario: Get root resource
+                When GET /root-resource
+                Then status 200
+            """.trimIndent(),
+            "root.spec"
+        )
+        val nestedFeature = parseGherkinStringToFeature(
+            """
+            Feature: Nested service
+
+              Scenario: Get account
+                When GET /accounts
+                Then status 200
+            """.trimIndent(),
+            "nested.spec"
+        )
+        val port = ServerSocket(0).use { it.localPort }
+        val config = SpecmaticConfigV1V2Common(
+            sources = listOf(
+                Source(
+                    stub = listOf(
+                        SpecExecutionConfig.ObjectValue.FullUrl(baseUrl = "http://localhost:$port", specs = listOf("root.spec")),
+                        SpecExecutionConfig.ObjectValue.FullUrl(baseUrl = "http://localhost:$port/services/nested", specs = listOf("nested.spec"))
+                    )
+                )
+            )
+        )
+
+        HttpStub(
+            features = listOf(rootFeature, nestedFeature),
+            port = port,
+            specmaticConfigSource = SpecmaticConfigSource.fromConfigObject(config),
+            specToStubBaseUrlMap = mapOf(
+                rootFeature.path to "http://localhost:$port",
+                nestedFeature.path to "http://localhost:$port/services/nested"
+            )
+        ).use { stub ->
+            val client = LegacyHttpClient(stub.endPoint)
+
+            assertThat(client.execute(HttpRequest(method = "GET", path = "/root-resource")).status).isEqualTo(200)
+            assertThat(client.execute(HttpRequest(method = "GET", path = "/services/nested/accounts")).status).isEqualTo(200)
+        }
+    }
+
     @Test
     fun `randomly generated HTTP response includes an HTTP header indicating that it was randomly generated`() {
         val gherkin = """
@@ -4065,6 +4116,48 @@ Then status 200
                     )
 
                     assertThat(result).isEqualTo(listOf(feature1, feature2))
+                }
+            }
+
+            @Test
+            fun `should return features from the most specific matching baseUrl`() {
+                val specToStubBaseUrlMap = linkedMapOf(
+                    "root.yaml" to "http://localhost:8080",
+                    "nested-first.yaml" to "http://localhost:8080/api",
+                    "nested-second.yaml" to "http://stub-host:8080/api"
+                )
+                val rootFeature = mockk<Feature> {
+                    every { path } returns "root.yaml"
+                    every { specification } returns "root.yaml"
+                    every { loadInlineExamplesAsStub() } returns emptyList()
+                    every { scenarios } returns emptyList()
+                    every { protocol } returns SpecmaticProtocol.HTTP
+                }
+                val nestedFirstFeature = mockk<Feature> {
+                    every { path } returns "nested-first.yaml"
+                    every { specification } returns "nested-first.yaml"
+                    every { loadInlineExamplesAsStub() } returns emptyList()
+                    every { scenarios } returns emptyList()
+                    every { protocol } returns SpecmaticProtocol.HTTP
+                }
+                val nestedSecondFeature = mockk<Feature> {
+                    every { path } returns "nested-second.yaml"
+                    every { specification } returns "nested-second.yaml"
+                    every { loadInlineExamplesAsStub() } returns emptyList()
+                    every { scenarios } returns emptyList()
+                    every { protocol } returns SpecmaticProtocol.HTTP
+                }
+                val features = listOf(rootFeature, nestedFirstFeature, nestedSecondFeature)
+
+                HttpStub(features = features, port = ServerSocket(0).use { it.localPort }).use { stub ->
+                    val result = stub.featuresAssociatedTo(
+                        "http://localhost:8080",
+                        features,
+                        specToStubBaseUrlMap,
+                        urlPath = "/api/widgets"
+                    )
+
+                    assertThat(result).isEqualTo(listOf(nestedFirstFeature, nestedSecondFeature))
                 }
             }
 

--- a/core/src/test/kotlin/io/specmatic/stub/ThreadSafeListOfStubsTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/ThreadSafeListOfStubsTest.kt
@@ -431,6 +431,28 @@ class ThreadSafeListOfStubsTest {
         }
 
         @Test
+        fun `should return stubs from the most specific matching baseUrl`() {
+            val specToBaseUrlMap = linkedMapOf(
+                "root-first.yaml" to "http://localhost:8080",
+                "root-second.yaml" to "http://localhost:8080",
+                "nested.yaml" to "http://localhost:8080/api"
+            )
+            val httpStubs = mutableListOf(
+                mockk<HttpStubData> { every { contractPath } returns "root-first.yaml" },
+                mockk<HttpStubData> { every { contractPath } returns "root-second.yaml" },
+                mockk<HttpStubData> { every { contractPath } returns "nested.yaml" }
+            )
+
+            val result = ThreadSafeListOfStubs(httpStubs, specToBaseUrlMap).stubAssociatedTo(
+                baseUrl = "http://localhost:8080",
+                defaultBaseUrl = "http://localhost:9090",
+                urlPath = "/api/widgets"
+            )
+
+            assertThat(result.size).isEqualTo(1)
+        }
+
+        @Test
         fun `should return an empty list if no stubs exist`() {
             val specToBaseUrlMap = mapOf("spec1.yaml" to "http://localhost:8080")
             val httpStubs = mutableListOf<HttpStubData>()


### PR DESCRIPTION
## Summary

- Route requests to the longest matching stub base URL path.
- Preserve partial prefix matching and support multiple specifications sharing a port.
- Add coverage for v1/v2, v3, HTTP stub, and thread-safe stub selection.

## Testing

Not run (not requested)