### PR TITLE
Fix example module discovery and stable IDs for inline examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Each release section should stand on its own and describe the behavior shipped i
 ### Changed
 
 - Fixed OpenAPI `allOf` conversion so a main-schema property overrides a matching member property without generating both optional and required keys.
+- Example files are now discovered recursively in configured example directories, including nested directories for `examples` command and `studio`.
 - Fixed multi-spec stubs to route requests to the most specific matching base-URL path.
 
 ## 2.51.0 (2026-07-25)

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -759,7 +759,13 @@ class OpenApiSpecification(
         })
     }
 
-    data class RequestPatternsData(val requestPattern: HttpRequestPattern, val examples: Map<String, List<HttpRequest>>, val original: Pair<String, MediaType>? = null)
+    private data class RequestExample(val request: HttpRequest, val sourcePointer: String)
+    private data class RequestPatternsData(
+        val requestPattern: HttpRequestPattern,
+        val examples: Map<String, List<HttpRequest>>,
+        val original: Pair<String, MediaType>? = null,
+        val sourcePointer: String,
+    )
 
     private data class ParsedOperation(
         val scenarioInfos: List<ScenarioInfo>,
@@ -925,11 +931,12 @@ class OpenApiSpecification(
                         )
                     }
 
-                    val responseExamplesList = httpResponsePatterns.map { it.examples }
-
-                    val requestExamples = mergeRequestExamples(httpRequestPatterns.map { it.examples })
-
-                    val examples = collateExamplesForExpectations(requestExamples, responseExamplesList)
+                    val requestExamples = mergeRequestExamples(httpRequestPatterns)
+                    val examples = collateExamplesForExpectations(
+                        requestExamples = requestExamples,
+                        responseExamplesList = httpResponsePatterns,
+                        operationPointer = "${pathScopePointer(openApiPath)}/${httpMethod.lowercase()}",
+                    )
 
                     val requestExampleNames = requestExamples.keys.toSet()
 
@@ -950,7 +957,8 @@ class OpenApiSpecification(
                                 unusedRequestExampleNames,
                                 scenarioInfos,
                                 parameters,
-                                firstNoBodyResponseStatus
+                                firstNoBodyResponseStatus,
+                                "${pathScopePointer(openApiPath)}/${httpMethod.lowercase()}",
                             )
 
                         else -> NoBodyExampleUpdate(additionalInlineExamples = emptyList(), updatedScenarioInfos = scenarioInfos)
@@ -1011,11 +1019,12 @@ class OpenApiSpecification(
 
     private fun getUpdatedScenarioInfosWithNoBodyResponseExamples(
         responseThatReturnsNoValues: ResponsePatternData,
-        requestExamples: Map<String, List<HttpRequest>>,
+        requestExamples: Map<String, List<RequestExample>>,
         unusedRequestExampleNames: Set<String>,
         scenarioInfos: List<ScenarioInfo>,
         parameters: List<Parameter>,
         firstNoBodyResponseStatus: Int?,
+        operationPointer: String,
     ): NoBodyExampleUpdate {
         val emptyResponse = HttpResponse(
             status = responseThatReturnsNoValues.responsePattern.status,
@@ -1026,8 +1035,16 @@ class OpenApiSpecification(
             requestExamples
                 .filterKeys { it in unusedRequestExampleNames }
                 .flatMap { (exampleName, examples) ->
-                    examples.map { request ->
-                        NamedStub(exampleName, ScenarioStub(request = request, response = emptyResponse, exampleType = ExampleType.INLINE))
+                    examples.map { requestExample ->
+                        NamedStub(
+                            name = exampleName,
+                            stub = ScenarioStub(request = requestExample.request, response = emptyResponse, exampleType = ExampleType.INLINE),
+                            source = NamedStubSource(
+                                operationPointer = operationPointer,
+                                requestVariantPointer = requestExample.sourcePointer,
+                                responseVariantPointer = responseThatReturnsNoValues.sourcePointer,
+                            ),
+                        )
                     }
                 }
 
@@ -1060,12 +1077,13 @@ class OpenApiSpecification(
     }
 
     private fun getRowsFromRequestExample(
-        requestExample: Map<String, List<HttpRequest>>,
+        requestExample: Map<String, List<RequestExample>>,
         parameters: List<Parameter>,
         scenarioInfo: ScenarioInfo
     ): List<Row> {
         return requestExample.flatMap { (key, requests) ->
-            requests.map { request ->
+            requests.map { requestExample ->
+                val request = requestExample.request
                 val paramExamples = (request.headers + request.queryParams.asMap()).toList()
                 val pathParameterExamples = try {
                     serializedParameterExamples(
@@ -1095,26 +1113,41 @@ class OpenApiSpecification(
     }
 
     private fun collateExamplesForExpectations(
-        requestExamples: Map<String, List<HttpRequest>>,
-        responseExamplesList: List<Map<String, HttpResponse>>
+        operationPointer: String,
+        requestExamples: Map<String, List<RequestExample>>,
+        responseExamplesList: List<ResponsePatternData>,
     ): List<NamedStub> {
-        return responseExamplesList.flatMap { responseExamples ->
-            responseExamples.filter { (key, responseExample) ->
-                key in requestExamples
-                        && responseExample.status != HttpStatusCode.MethodNotAllowed.value
-                        && responseExample.status != HttpStatusCode.UnsupportedMediaType.value
-            }.map { (key, responseExample) ->
-                requestExamples.getValue(key).map { request ->
-                    NamedStub(key, ScenarioStub(request = request, response = responseExample, exampleType = ExampleType.INLINE))
+        return responseExamplesList.flatMap { responseData ->
+            responseData.examples.filter { (name, response) ->
+                name in requestExamples
+                        && response.status != HttpStatusCode.MethodNotAllowed.value
+                        && response.status != HttpStatusCode.UnsupportedMediaType.value
+            }.flatMap { (name, response) ->
+                requestExamples.getValue(name).map { requestExample ->
+                    NamedStub(
+                        name = name,
+                        stub = ScenarioStub(request = requestExample.request, response = response, exampleType = ExampleType.INLINE),
+                        source = NamedStubSource(
+                            operationPointer = operationPointer,
+                            requestVariantPointer = requestExample.sourcePointer,
+                            responseVariantPointer = responseData.sourcePointer,
+                        ),
+                    )
                 }
             }
-        }.flatten()
+        }
     }
 
-    private fun mergeRequestExamples(examplesList: List<Map<String, List<HttpRequest>>>): Map<String, List<HttpRequest>> {
-        return examplesList
-            .flatMap { it.entries }
-            .groupBy(keySelector = { it.key }, valueTransform = { it.value })
+    private fun mergeRequestExamples(requestPatterns: List<RequestPatternsData>): Map<String, List<RequestExample>> {
+        return requestPatterns
+            .flatMap { requestPattern ->
+                requestPattern.examples.map { (name, requests) ->
+                    name to requests.map { request ->
+                        RequestExample(request = request, sourcePointer = requestPattern.sourcePointer)
+                    }
+                }
+            }
+            .groupBy(keySelector = { it.first }, valueTransform = { it.second })
             .mapValues { (_, groupedRequests) -> groupedRequests.flatten() }
     }
 
@@ -1392,7 +1425,15 @@ class OpenApiSpecification(
             val responseHeaderPointers = buildResponseHeaderPointers(resolvedResponse, responseBasePointer)
 
             attempt(breadCrumb = status) {
-                openAPIResponseToSpecmatic(resolvedResponse, finalizedStatus, headersMap, responseContext, responseBasePointer, responseHeaderPointers)
+                openAPIResponseToSpecmatic(
+                    response = resolvedResponse,
+                    status = finalizedStatus,
+                    headersMap = headersMap,
+                    collectorContext = responseContext,
+                    responseBasePointer = responseBasePointer,
+                    responseUseSitePointer = responseUseSitePointer,
+                    responseHeaderPointers = responseHeaderPointers,
+                )
             }
         }.flatten()
     }
@@ -1422,7 +1463,8 @@ class OpenApiSpecification(
         val response: ApiResponse,
         val mediaType: MediaType,
         val responsePattern: HttpResponsePattern,
-        val examples: Map<String, HttpResponse>
+        val examples: Map<String, HttpResponse>,
+        val sourcePointer: String,
     )
 
     private fun resolveResponseHeader(header: Header, collectorContext: CollectorContext): Pair<Header, CollectorContext> {
@@ -1463,7 +1505,15 @@ class OpenApiSpecification(
         )
     }
 
-    private fun openAPIResponseToSpecmatic(response: ApiResponse, status: String, headersMap: Map<String, Pair<Pattern, CollectorContext>>, collectorContext: CollectorContext, responseBasePointer: String, responseHeaderPointers: Map<String, String> = emptyMap()): List<ResponsePatternData> {
+    private fun openAPIResponseToSpecmatic(
+        response: ApiResponse,
+        status: String,
+        headersMap: Map<String, Pair<Pattern, CollectorContext>>,
+        collectorContext: CollectorContext,
+        responseBasePointer: String,
+        responseUseSitePointer: String,
+        responseHeaderPointers: Map<String, String> = emptyMap(),
+    ): List<ResponsePatternData> {
         val headerExamples =
             if (specmaticConfig.getIgnoreInlineExamples())
                 emptyMap()
@@ -1496,7 +1546,15 @@ class OpenApiSpecification(
                         )
                 }.toMap()
 
-            return listOf(ResponsePatternData(response, MediaType(), responsePattern, examples))
+            return listOf(
+                ResponsePatternData(
+                    response = response,
+                    examples = examples,
+                    mediaType = MediaType(),
+                    responsePattern = responsePattern,
+                    sourcePointer = responseUseSitePointer,
+                )
+            )
         }
 
         val contentTypeHeader = headersMap.entries.find { it.key.lowercase() in listOf("content-type", "content-type?") }?.value
@@ -1564,7 +1622,13 @@ class OpenApiSpecification(
                     }.toMap()
                 }
 
-            ResponsePatternData(response, mediaType, responsePattern, examples)
+            ResponsePatternData(
+                response = response,
+                examples = examples,
+                mediaType = mediaType,
+                responsePattern = responsePattern,
+                sourcePointer = "$responseUseSitePointer/content/${escapeJsonPointer(contentType)}",
+            )
         }
     }
 
@@ -1667,13 +1731,19 @@ class OpenApiSpecification(
 
         val (requestBody, requestBodyContext) = resolveRequestBody(operation, collectorContext) ?: return listOf(
             RequestPatternsData(
-                requestPattern.copy(body = NoBodyPattern),
-                exampleRequestBuilder.examplesBasedOnParameters
+                requestPattern = requestPattern.copy(body = NoBodyPattern),
+                examples = exampleRequestBuilder.examplesBasedOnParameters,
+                sourcePointer = "${pathScopePointer(openApiPath)}/${httpMethod.lowercase()}"
             )
         )
 
         if (requestBody.content == null || requestBody.content.isEmpty()) {
-            val patternData = RequestPatternsData(requestPattern.copy(body = NoBodyPattern), exampleRequestBuilder.examplesBasedOnParameters)
+            val patternData = RequestPatternsData(
+                requestPattern = requestPattern.copy(body = NoBodyPattern),
+                examples = exampleRequestBuilder.examplesBasedOnParameters,
+                sourcePointer = "${pathScopePointer(openApiPath)}/${httpMethod.lowercase()}"
+            )
+
             return listOf(patternData)
         }
 
@@ -1796,7 +1866,14 @@ class OpenApiSpecification(
                         ), allExamples
                     )
                 }
-            }.let { RequestPatternsData(it.first, it.second, Pair(contentType, mediaType)) }
+            }.let {
+                RequestPatternsData(
+                    examples = it.second,
+                    requestPattern = it.first,
+                    original = Pair(contentType, mediaType),
+                    sourcePointer = "${pathScopePointer(openApiPath)}/${httpMethod.lowercase()}/requestBody/content/${escapeJsonPointer(contentType)}",
+                )
+            }
         }
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/ExampleStore.kt
+++ b/core/src/main/kotlin/io/specmatic/core/ExampleStore.kt
@@ -10,7 +10,8 @@ data class ExampleData(
     val example: ScenarioStub,
     val name: String,
     val type: ExampleType,
-    val tags: Set<ExampleTag>
+    val tags: Set<ExampleTag>,
+    val source: NamedStubSource? = null
 )
 
 data class ExampleStore(val examples: List<ExampleData>, val size: Int = examples.size) {
@@ -22,7 +23,8 @@ data class ExampleStore(val examples: List<ExampleData>, val size: Int = example
                         name = namedStub.name,
                         example = namedStub.stub.withType(type),
                         type = type,
-                        tags = namedStub.stub.getTags()
+                        tags = namedStub.stub.getTags(),
+                        source = namedStub.source
                     )
                 }
             )

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -199,7 +199,7 @@ data class Feature(
         get() = exampleStore.examples
             .asSequence()
             .filter { it.type == ExampleType.INLINE }
-            .map { NamedStub(name = it.name, stub = it.example) }
+            .map { data -> NamedStub(data.name, data.example, data.source) }
             .toList()
 
     @Deprecated(

--- a/core/src/main/kotlin/io/specmatic/core/NamedStub.kt
+++ b/core/src/main/kotlin/io/specmatic/core/NamedStub.kt
@@ -3,8 +3,16 @@ package io.specmatic.core
 import io.specmatic.license.core.SpecmaticProtocol
 import io.specmatic.mock.ScenarioStub
 
-data class NamedStub(val name: String, val shortName: String, val stub: ScenarioStub) {
+data class NamedStubSource(val operationPointer: String, val requestVariantPointer: String, val responseVariantPointer: String)
+data class NamedStub(
+    val name: String,
+    val shortName: String,
+    val stub: ScenarioStub,
+    val source: NamedStubSource? = null,
+) {
     constructor(name: String, stub: ScenarioStub) : this(name, name, stub)
+    constructor(name: String, stub: ScenarioStub, source: NamedStubSource?) : this(name, name, stub, source)
+
     val protocol: SpecmaticProtocol
         get() = stub.protocol
 }

--- a/core/src/main/kotlin/io/specmatic/core/examples/module/ExampleModule.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/module/ExampleModule.kt
@@ -8,22 +8,44 @@ import io.specmatic.core.log.consoleDebug
 import io.specmatic.core.log.logger
 import io.specmatic.core.utilities.exceptionCauseMessage
 import io.specmatic.core.value.NullValue
+import io.specmatic.mock.PARTIAL
 import java.io.File
 import kotlin.system.exitProcess
 
+data class ScenarioExampleMatch<T>(val example: T, val result: Result)
 class ExampleModule(private val specmaticConfig: SpecmaticConfig) {
     fun getExistingExampleFiles(feature: Feature, scenario: Scenario, examples: List<ExampleFromFile>): List<Pair<ExampleFromFile, Result>> {
+        val results = matchExamplesForScenario(
+            feature = feature,
+            scenario = scenario,
+            examples = examples,
+            requestOf = { it.request },
+            responseOf = { it.response },
+            isPartial = { it.isPartial() }
+        )
+
+        return results.map { it.example to it.result }
+    }
+
+    fun <T> matchExamplesForScenario(
+        feature: Feature,
+        examples: List<T>,
+        scenario: Scenario,
+        isPartial: (T) -> Boolean,
+        requestOf: (T) -> HttpRequest,
+        responseOf: (T) -> HttpResponse,
+    ): List<ScenarioExampleMatch<T>> {
         return examples.mapNotNull { example ->
             val matchResult = scenario.matches(
-                httpRequest = example.request,
-                httpResponse = example.response,
+                httpRequest = requestOf(example),
+                httpResponse = responseOf(example),
                 mismatchMessages = ExampleMismatchMessages,
                 flagsBased = feature.flagsBased,
-                isPartial = example.isPartial()
+                isPartial = isPartial(example),
             )
 
             when (matchResult) {
-                is Result.Success -> example to matchResult
+                is Result.Success -> ScenarioExampleMatch(example, matchResult)
                 is Result.Failure -> {
                     val isFailureRelatedToScenario = matchResult.getFailureBreadCrumbs("").none { breadCrumb ->
                         breadCrumb.contains(BreadCrumb.PATH.value)
@@ -33,7 +55,10 @@ class ExampleModule(private val specmaticConfig: SpecmaticConfig) {
                                 || breadCrumb.contains(BreadCrumb.RESPONSE.plus(BreadCrumb.HEADER).with(CONTENT_TYPE))
                     } || matchResult.hasReason(FailureReason.URLPathParamMismatchButSameStructure)
                             || matchResult.hasReason(FailureReason.UndeclaredRequestVariantMismatch)
-                    if (isFailureRelatedToScenario) { example to example.breadCrumbIfPartial(matchResult) } else null
+
+                    if (!isFailureRelatedToScenario) return@mapNotNull null
+                    if (!isPartial(example)) return@mapNotNull ScenarioExampleMatch(example, matchResult)
+                    ScenarioExampleMatch(example, matchResult.breadCrumb(PARTIAL))
                 }
             }
         }
@@ -46,6 +71,12 @@ class ExampleModule(private val specmaticConfig: SpecmaticConfig) {
         return listOf(implicitExamplesDir, testDirs, stubDirs).flatten().distinctBy { it.normalizedPath() }
     }
 
+    fun getCandidateExampleFiles(contractFile: File): List<File> {
+        return getExamplesDirPaths(contractFile)
+            .filter { it.isDirectory }
+            .flatMap { it.jsonFilesRecursively() }
+    }
+
     fun getExamplesFor(contractFile: File, strictMode: Boolean = true): List<ExampleFromFile> {
         return getExamplesDirPaths(contractFile)
             .filter { it.isDirectory }
@@ -54,7 +85,7 @@ class ExampleModule(private val specmaticConfig: SpecmaticConfig) {
     }
 
     fun getExamplesFromDir(dir: File, strictMode: Boolean = true): List<ExampleFromFile> {
-        return getExamplesFromFiles(dir.listFiles().orEmpty().filter { it.extension == "json" }, strictMode)
+        return getExamplesFromFiles(dir.jsonFilesRecursively(), strictMode)
     }
 
     fun getExamplesFromFiles(files: List<File>, strictMode: Boolean = true): List<ExampleFromFile> {
@@ -116,7 +147,7 @@ class ExampleModule(private val specmaticConfig: SpecmaticConfig) {
     }
 
     private fun getSchemaExamples(dir: File): List<SchemaExample> {
-        return dir.listFiles().orEmpty().filter { it.extension == "json" }.mapNotNull {
+        return dir.jsonFilesRecursively().mapNotNull {
             SchemaExample.fromFile(it).realise(
                 hasValue = { example, _ -> example },
                 orException = { err -> consoleDebug(exceptionCauseMessage(err.t)); null },
@@ -127,6 +158,10 @@ class ExampleModule(private val specmaticConfig: SpecmaticConfig) {
 
     private fun File.normalizedPath(): String {
         return runCatching { canonicalPath }.getOrElse { absolutePath }
+    }
+
+    private fun File.jsonFilesRecursively(): List<File> {
+        return walk().filter { it.isFile && it.extension == "json" }.toList()
     }
 
     private fun firstCommonByNormalizedPath(first: List<File>, second: List<File>): File? {

--- a/core/src/main/kotlin/io/specmatic/core/examples/module/ExampleModule.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/module/ExampleModule.kt
@@ -89,13 +89,15 @@ class ExampleModule(private val specmaticConfig: SpecmaticConfig) {
     }
 
     fun getExamplesFromFiles(files: List<File>, strictMode: Boolean = true): List<ExampleFromFile> {
-        return files.mapNotNull {
-            ExampleFromFile.fromFile(it, strictMode).realise(
-                hasValue = { example, _ -> example },
-                orException = { err -> consoleDebug(exceptionCauseMessage(err.t)); null },
-                orFailure = { null }
-            )
-        }
+        return files.mapNotNull { exampleFromFile(it, strictMode) }
+    }
+
+    fun exampleFromFile(file: File, strictMode: Boolean = true): ExampleFromFile? {
+        return ExampleFromFile.fromFile(file, strictMode).realise(
+            orFailure = { null },
+            hasValue = { example, _ -> example },
+            orException = { err -> consoleDebug(exceptionCauseMessage(err.t)); null },
+        )
     }
 
     fun getSchemaExamplesFor(contractFile: File): List<SchemaExample> {

--- a/core/src/main/kotlin/io/specmatic/core/examples/module/ExampleValidationModule.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/module/ExampleValidationModule.kt
@@ -54,7 +54,7 @@ class ExampleValidationModule(private val lenientMode: Boolean = false, private 
             logger.debug("Validating $name")
 
             exampleList.mapNotNull { example ->
-                val results = validateExample(updatedFeature, example)
+                val results = validateExampleReturningResults(updatedFeature, example)
                 if (!results.hasResults()) return@mapNotNull null else results.toResultIfAny()
             }.let {
                 Result.fromResults(it)
@@ -85,8 +85,8 @@ class ExampleValidationModule(private val lenientMode: Boolean = false, private 
     fun validateExample(contractFile: File, exampleFile: File): ValidationResult {
         val feature = parseContractFileToFeature(contractFile, specmaticConfig = specmaticConfig, lenientMode = lenientMode)
         return ValidationResult(
-            validateExample(feature, exampleFile),
-            callLifecycleHook(feature, ExampleModule(specmaticConfig).getExamplesFromFiles(listOf(exampleFile)))
+            exampleValidationResult = validateExample(feature, exampleFile),
+            hookValidationResult = callLifecycleHook(feature, ExampleModule(specmaticConfig).getExamplesFromFiles(listOf(exampleFile)))
         )
     }
 
@@ -98,11 +98,29 @@ class ExampleValidationModule(private val lenientMode: Boolean = false, private 
         )
     }
 
-    fun validateExample(feature: Feature, scenarioStub: ScenarioStub): Results {
+    fun validateExampleReturningResults(feature: Feature, scenarioStub: ScenarioStub): Results {
+        LicenseResolver.utilize(
+            product = LicensedProduct.OPEN_SOURCE,
+            feature = SpecmaticFeature.EXAMPLES_VALIDATED,
+            protocol = listOf(feature.protocol)
+        )
+
         return feature.matchResultFlagBased(scenarioStub, ExampleMismatchMessages)
     }
 
-    private fun validateExample(feature: Feature, example: ExampleFromFile): Result {
+    fun validateExample(feature: Feature, scenarioStub: ScenarioStub): Result {
+        val result = validateExampleReturningResults(feature, scenarioStub).toResultIfAnyWithCauses()
+        val scenarioResultWithBreadCrumb = scenarioStub.breadCrumbIfPartial(result)
+        return Result.fromResults(listOf(scenarioStub.validationErrors, scenarioResultWithBreadCrumb))
+    }
+
+    fun validateExample(feature: Feature, example: ExampleFromFile): Result {
+        LicenseResolver.utilize(
+            product = LicensedProduct.OPEN_SOURCE,
+            feature = SpecmaticFeature.EXAMPLES_VALIDATED,
+            protocol = listOf(feature.protocol)
+        )
+
         val scenarioResult = feature.matchResultFlagBased(
             request = example.request,
             response = example.response,
@@ -115,6 +133,12 @@ class ExampleValidationModule(private val lenientMode: Boolean = false, private 
     }
 
     private fun validateExample(feature: Feature, schemaExample: SchemaExample): Result {
+        LicenseResolver.utilize(
+            product = LicensedProduct.OPEN_SOURCE,
+            feature = SpecmaticFeature.EXAMPLES_VALIDATED,
+            protocol = listOf(feature.protocol)
+        )
+
         if (schemaExample.value is NullValue) {
             return Result.Success()
         }
@@ -129,12 +153,6 @@ class ExampleValidationModule(private val lenientMode: Boolean = false, private 
     }
 
     fun validateExample(feature: Feature, exampleFile: File, strictMode: Boolean = false): Result {
-        LicenseResolver.utilize(
-            product = LicensedProduct.OPEN_SOURCE,
-            feature = SpecmaticFeature.EXAMPLES_VALIDATED,
-            protocol = listOf(feature.protocol)
-        )
-
         return ExampleFromFile.fromFile(exampleFile, strictMode = strictMode).realise(
             hasValue = { example, _ -> validateExample(feature, example) },
             orFailure = { validateSchemaExample(feature, exampleFile) },
@@ -156,6 +174,14 @@ class ExampleValidationModule(private val lenientMode: Boolean = false, private 
             ExamplesUsedFor.Validation,
             listOf(Pair(feature, scenarioStubs))
         )
+    }
+}
+
+internal fun ScenarioStub.breadCrumbIfPartial(result: Result): Result {
+    return if (isPartial()) {
+        result.breadCrumb(PARTIAL)
+    } else {
+        result
     }
 }
 

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationParseTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationParseTest.kt
@@ -1,6 +1,7 @@
 package io.specmatic.conversions
 
 import integration_tests.OpenApiVersion
+import io.specmatic.core.Feature
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpResponse
 import io.specmatic.core.IssueSeverity
@@ -23,7 +24,6 @@ import io.specmatic.core.pattern.DeferredPattern
 import io.specmatic.core.pattern.JSONObjectPattern
 import io.specmatic.core.pattern.NumberPattern
 import io.specmatic.core.pattern.NullPattern
-import io.specmatic.core.pattern.Pattern
 import io.specmatic.core.pattern.QueryParameterScalarPattern
 import io.specmatic.core.pattern.StringPattern
 import io.specmatic.core.pattern.XMLPattern
@@ -33,9 +33,9 @@ import io.specmatic.core.utilities.yamlMapper
 import io.specmatic.mock.NoMatchingScenario
 import io.specmatic.stub.captureStandardOutput
 import io.specmatic.toViolationReportString
-import io.specmatic.core.value.StringValue
 import io.specmatic.core.value.toXMLNode
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.io.TempDir
@@ -2067,6 +2067,179 @@ $parameters
                     '200':
                       description: OK
         """.trimIndent()
+    }
+
+
+    @Nested
+    inner class InlineExampleSourceMetadata {
+        @Test
+        fun `retains logical request and response variant pointers`() {
+            val source = parse("""
+            paths:
+              /orders:
+                post:
+                  requestBody:
+                    content:
+                      application/json:
+                        schema:
+                          type: object
+                        examples:
+                          sample:
+                            value:
+                              id: order-1
+                  responses:
+                    '200':
+                      description: OK
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                          examples:
+                            sample:
+                              value:
+                                accepted: true
+            """).inlineNamedStubs.single().source
+
+            assertThat(source).isNotNull
+            assertThat(source!!.operationPointer).isEqualTo("/paths/~1orders/post")
+            assertThat(source.requestVariantPointer).isEqualTo("/paths/~1orders/post/requestBody/content/application~1json")
+            assertThat(source.responseVariantPointer).isEqualTo("/paths/~1orders/post/responses/200/content/application~1json")
+        }
+
+        @Test
+        fun `parameter only example uses the operation and no body request variant`() {
+            val source = parse("""
+            paths:
+              /orders/{id}:
+                get:
+                  parameters:
+                    - name: id
+                      in: path
+                      required: true
+                      schema:
+                        type: string
+                      examples:
+                        sample:
+                          value: order-1
+                  responses:
+                    '204':
+                      description: No content
+            """).inlineNamedStubs.single().source
+
+            assertThat(source).isNotNull
+            assertThat(source!!.operationPointer).isEqualTo("/paths/~1orders~1{id}/get")
+            assertThat(source.requestVariantPointer).isEqualTo("/paths/~1orders~1{id}/get")
+            assertThat(source.responseVariantPointer).isEqualTo("/paths/~1orders~1{id}/get/responses/204")
+        }
+
+        @Test
+        fun `request only example keeps real request and no body response variants`() {
+            val source = parse("""
+            paths:
+              /orders:
+                post:
+                  requestBody:
+                    content:
+                      application/json:
+                        schema:
+                          type: object
+                        examples:
+                          sample:
+                            value:
+                              id: order-1
+                  responses:
+                    '204':
+                      description: No content
+            """).inlineNamedStubs.single().source
+
+            assertThat(source).isNotNull
+            assertThat(source!!.responseVariantPointer).isEqualTo("/paths/~1orders/post/responses/204")
+            assertThat(source.requestVariantPointer).isEqualTo("/paths/~1orders/post/requestBody/content/application~1json")
+        }
+
+        @Test
+        fun `distinguishes the same name by response variant`() {
+            val sources = parse("""
+            paths:
+              /orders:
+                get:
+                  parameters:
+                    - name: trace
+                      in: query
+                      schema:
+                        type: string
+                      examples:
+                        sample:
+                          value: trace-1
+                  responses:
+                    '200':
+                      description: OK
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                          examples:
+                            sample:
+                              value:
+                                state: accepted
+                    '400':
+                      description: Bad request
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                          examples:
+                            sample:
+                              value:
+                                state: rejected
+            """).inlineNamedStubs.map { it.source!! }
+
+            assertThat(sources).hasSize(2)
+            assertThat(sources.map { it.operationPointer }).containsOnly("/paths/~1orders/get")
+            assertThat(sources.map { it.responseVariantPointer }).containsExactlyInAnyOrder(
+                "/paths/~1orders/get/responses/200/content/application~1json",
+                "/paths/~1orders/get/responses/400/content/application~1json",
+            )
+        }
+
+        @Test
+        fun `payload changes do not change source metadata`() {
+            fun source(requestId: String, accepted: Boolean) = parse("""
+            paths:
+              /orders:
+                post:
+                  requestBody:
+                    content:
+                      application/json:
+                        schema:
+                          type: object
+                        examples:
+                          sample:
+                            value:
+                              id: $requestId
+                  responses:
+                    '200':
+                      description: OK
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                          examples:
+                            sample:
+                              value:
+                                accepted: $accepted
+            """).inlineNamedStubs.single().source
+            assertThat(source("order-1", true)).isEqualTo(source("order-2", false))
+        }
+
+        private fun parse(paths: String): Feature {
+            return OpenApiSpecification.fromYAML("""
+            openapi: 3.0.0
+            info:
+              title: Inline example source metadata
+              version: 1.0.0
+            """.trimIndent() + "\n" + paths.trimIndent(), "inline-example-source.yaml").toFeature()
+        }
     }
 
     @Suppress("SameParameterValue")

--- a/core/src/test/kotlin/io/specmatic/core/examples/module/ExampleModuleTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/examples/module/ExampleModuleTest.kt
@@ -1,8 +1,10 @@
 package io.specmatic.core.examples.module
 
+import io.specmatic.conversions.ExampleFromFile
 import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpResponse
+import io.specmatic.core.Result
 import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.CONTENT_TYPE
 import io.specmatic.core.config.SpecmaticConfigVersion
@@ -30,6 +32,79 @@ import java.util.UUID
 
 class ExampleModuleTest {
     private val exampleModule = ExampleModule(SpecmaticConfig())
+
+    @Test
+    fun `generic matcher returns original example and excludes structural mismatch`() {
+        data class Candidate(val request: HttpRequest, val response: HttpResponse)
+        val feature = OpenApiSpecification.fromYAML("""
+        openapi: 3.0.3
+        info: { title: Sample, version: 1.0.0 }
+        paths:
+          /hello:
+            get:
+              responses:
+                '200': { description: ok }
+        """.trimIndent(), "api.yaml").toFeature()
+
+        val scenario = feature.scenarios.single()
+        val matching = Candidate(HttpRequest("GET", "/hello"), HttpResponse(status = 200))
+        val wrongMethod = Candidate(HttpRequest("POST", "/hello"), HttpResponse(status = 200))
+        val matches = exampleModule.matchExamplesForScenario(
+            feature = feature,
+            scenario = scenario,
+            isPartial = { false },
+            requestOf = { it.request },
+            responseOf = { it.response },
+            examples = listOf(matching, wrongMethod),
+        )
+
+        assertThat(matches).hasSize(1)
+        assertThat(matches.single().example).isSameAs(matching)
+        assertThat(matches.single().result).isInstanceOf(Result.Success::class.java)
+    }
+
+    @Test
+    fun `get existing examples returns structural result without external validation errors`() {
+        val feature = OpenApiSpecification.fromYAML("""
+        openapi: 3.0.3
+        info: { title: Sample, version: 1.0.0 }
+        paths:
+          /hello:
+            get:
+              responses:
+                '200':
+                  description: ok
+                  content:
+                    application/json:
+                      schema:
+                        type: object
+                        required: [message]
+                        properties:
+                          message: { type: string }
+        """.trimIndent(), "api.yaml").toFeature()
+
+        val example = ExampleFromFile(
+            ScenarioStub(
+                strictMode = false,
+                response = HttpResponse(status = 200),
+                request = HttpRequest("GET", "/hello"),
+                validationErrors = Result.Failure("validation error"),
+            )
+        )
+
+        val scenario = feature.scenarios.single()
+        val structuralResult = exampleModule.matchExamplesForScenario(
+            feature = feature,
+            scenario = scenario,
+            examples = listOf(example),
+            requestOf = { it.request },
+            responseOf = { it.response },
+            isPartial = { it.isPartial() },
+        ).single().result
+
+        val result = exampleModule.getExistingExampleFiles(feature, scenario, listOf(example)).single().second
+        assertThat(result).isEqualTo(structuralResult)
+    }
 
     @Test
     fun `get existing examples should be able to pick mutated and partial examples properly`(@TempDir tempDir: File) {
@@ -631,9 +706,11 @@ class ExampleModuleTest {
         val contractFile = tempDir.resolve("api.yaml")
         val configuredDir = tempDir.resolve("configured_examples").apply { mkdirs() }
         val implicitDir = tempDir.resolve("api_examples").apply { mkdirs() }
+        val nestedConfiguredDir = configuredDir.resolve("nested").apply { mkdirs() }
 
         val configuredExample = ScenarioStub(request = HttpRequest("GET", "/orders/10"),response = HttpResponse(status = 200)).toJSON().toStringLiteral()
         configuredDir.resolve("configured.json").writeText(configuredExample)
+        nestedConfiguredDir.resolve("nested-configured.json").writeText(configuredExample)
 
         val implicitExample = ScenarioStub(request = HttpRequest("POST", "/orders"),response = HttpResponse(status = 201)).toJSON().toStringLiteral()
         implicitDir.resolve("implicit.json").writeText(implicitExample)
@@ -646,7 +723,7 @@ class ExampleModuleTest {
         val module = ExampleModule(specmaticConfig)
         val loadedExamples = module.getExamplesFor(contractFile).map { it.file.name }
 
-        assertThat(loadedExamples).containsExactlyInAnyOrder("configured.json", "implicit.json")
+        assertThat(loadedExamples).containsExactlyInAnyOrder("configured.json", "nested-configured.json", "implicit.json")
     }
 
     @Test
@@ -654,8 +731,10 @@ class ExampleModuleTest {
         val contractFile = tempDir.resolve("api.yaml")
         val configuredDir = tempDir.resolve("configured_examples").apply { mkdirs() }
         val implicitDir = tempDir.resolve("api_examples").apply { mkdirs() }
+        val nestedConfiguredDir = configuredDir.resolve("nested").apply { mkdirs() }
 
         configuredDir.resolve("resource.order.example.json").writeText("""{"id": 10}""")
+        nestedConfiguredDir.resolve("resource.nested.example.json").writeText("""{"id": 30}""")
         implicitDir.resolve("resource.customer.example.json").writeText("""{"id": 20}""")
 
         val specmaticConfig = mockk<SpecmaticConfig>(relaxed = true).apply {
@@ -667,7 +746,7 @@ class ExampleModuleTest {
         val schemaExamples = module.getSchemaExamplesFor(contractFile)
 
         assertThat(schemaExamples.map { it.file.name })
-            .containsExactlyInAnyOrder("resource.order.example.json", "resource.customer.example.json")
+            .containsExactlyInAnyOrder("resource.order.example.json", "resource.nested.example.json", "resource.customer.example.json")
     }
 
     @Test
@@ -830,5 +909,43 @@ class ExampleModuleTest {
         val dir = module.getFirstExampleDir(contractFile)
         assertThat(dir.path).isEqualTo(File(missingDir).path)
         assertThat(dir.exists()).isFalse()
+    }
+
+    @Test
+    fun `getCandidateExampleFiles should return all JSON files in example directories`(@TempDir tempDir: File) {
+        val contractFile = tempDir.resolve("api.yaml")
+        val testDir = tempDir.resolve("test_examples").apply { mkdirs() }
+        val stubDir = tempDir.resolve("stub_examples").apply { mkdirs() }
+
+        // Create implicit examples
+        tempDir.resolve("api_examples").apply { mkdirs() }.resolve("implicit1.json").writeText("{}")
+        tempDir.resolve("api_examples").apply { mkdirs() }.resolve("implicit2.json").writeText("{}")
+
+        // Create test examples
+        tempDir.resolve("test_examples").resolve("test1.json").writeText("{}")
+        tempDir.resolve("test_examples").resolve("test2.json").writeText("{}")
+        tempDir.resolve("test_examples").resolve("nested").apply { mkdirs() }.resolve("nested-test.json").writeText("{}")
+        tempDir.resolve("test_examples").resolve("test.txt").writeText("not json")
+
+        // Create stub examples
+        tempDir.resolve("stub_examples").resolve("stub1.json").writeText("{}")
+        tempDir.resolve("stub_examples").resolve("stub2.json").writeText("{}")
+
+        val specmaticConfig = mockk<SpecmaticConfig>(relaxed = true).apply {
+            every { getTestExampleDirs(contractFile) } returns listOf(testDir.path)
+            every { getStubExampleDirs(contractFile) } returns listOf(stubDir.path)
+        }
+
+        val module = ExampleModule(specmaticConfig)
+        val files = module.getCandidateExampleFiles(contractFile)
+        assertThat(files.map { it.name }).hasSize(7).containsExactlyInAnyOrder(
+            "implicit1.json",
+            "implicit2.json",
+            "test1.json",
+            "test2.json",
+            "nested-test.json",
+            "stub1.json",
+            "stub2.json"
+        )
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/examples/module/ExampleValidationModuleTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/examples/module/ExampleValidationModuleTest.kt
@@ -71,7 +71,7 @@ class ExampleValidationModuleTest {
             )
         )
 
-        val result = exampleValidationModule.validateExample(Feature(listOf(scenario), name= "", protocol = SpecmaticProtocol.HTTP), example)
+        val result = exampleValidationModule.validateExampleReturningResults(Feature(listOf(scenario), name= "", protocol = SpecmaticProtocol.HTTP), example)
         assertThat(result.toResultIfAny()).isInstanceOf(Result.Success::class.java)
     }
 
@@ -108,7 +108,7 @@ class ExampleValidationModuleTest {
             )
         )
 
-        val result = exampleValidationModule.validateExample(Feature(listOf(scenario), name= "", protocol = SpecmaticProtocol.HTTP), example)
+        val result = exampleValidationModule.validateExampleReturningResults(Feature(listOf(scenario), name= "", protocol = SpecmaticProtocol.HTTP), example)
         assertThat(result.report()).isEqualToNormalizingWhitespace("""
         In scenario ""
         API: POST /add -> 200
@@ -175,7 +175,7 @@ class ExampleValidationModuleTest {
         )
         val feature = Feature(listOf(scenario), name = "", protocol = SpecmaticProtocol.HTTP)
         val example = ScenarioStub(request = HttpRequest(method = "GET", path = "/test/abc/name/123"), response = HttpResponse.OK)
-        val result = exampleValidationModule.validateExample(feature, example).toResultIfAny()
+        val result = exampleValidationModule.validateExampleReturningResults(feature, example).toResultIfAny()
 
         assertThat(result).isInstanceOf(Result.Failure::class.java)
         assertThat(result.reportString()).isEqualToNormalizingWhitespace("""
@@ -200,7 +200,7 @@ class ExampleValidationModuleTest {
         )
         val feature = Feature(listOf(scenario), name = "", protocol = SpecmaticProtocol.HTTP)
         val example = ScenarioStub(request = HttpRequest(method = "GET", path = "/test/abc/name/123"), response = HttpResponse(status = 400))
-        val result = exampleValidationModule.validateExample(feature, example)
+        val result = exampleValidationModule.validateExampleReturningResults(feature, example)
 
         assertThat(result.toResultIfAny()).isInstanceOf(Result.Success::class.java)
     }


### PR DESCRIPTION
What: 
- Extract generic scenario example matching, and add Recursively load JSON examples
- Add stable logical source metadata to OpenAPI named inline examples.

Why: 
- Nested example directories were not discovered. Generic matching enables reuse across example types.
- Inline examples need collision-safe, stable identities that do not depend on generated scenarios, request or response values, or resolved component locations.

How: 
- Added recursive File.walk() JSON discovery and generic matching callbacks.
- Added `NamedStubSource` with operation, request variant, and response variant use-site pointers

**Checklist**:
- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)