### PR TITLE
refactor: tidy up internal list handling

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/pattern/JSONArrayPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/JSONArrayPattern.kt
@@ -14,7 +14,7 @@ import java.util.*
 
 data class JSONArrayPattern(override val pattern: List<Pattern> = emptyList(), override val typeAlias: String? = null) : Pattern, SequenceType {
     override val memberList: MemberList
-        get() = MemberList(pattern, null)
+        get() = MemberList(pattern)
 
     constructor(jsonString: String, typeAlias: String?) : this(stringTooPatternArray(jsonString), typeAlias = typeAlias)
 
@@ -82,27 +82,25 @@ data class JSONArrayPattern(override val pattern: List<Pattern> = emptyList(), o
 
         return when (otherPattern) {
             is ExactValuePattern -> otherPattern.fitsWithin(listOf(this), otherResolverWithNullType, thisResolverWithNullType, typeStack)
+            is ListPattern -> Result.Failure("Finite list is not a superset of an infinite list.")
             is SequenceType -> try {
                 val otherMembers = otherPattern.memberList
                 val theseMembers = this.memberList
-
-                validateInfiniteLength(otherMembers, theseMembers).ifSuccess {
-                    val otherEncompassables = otherMembers.getEncompassableList(pattern.size, otherResolverWithNullType)
-                    val encompassables = when {
-                        otherEncompassables.size > pattern.size -> theseMembers.getEncompassableList(otherEncompassables.size, thisResolverWithNullType)
-                        else -> memberList.getEncompassables(thisResolverWithNullType)
-                    }
-
-                    val results = encompassables.zip(otherEncompassables).mapIndexed { index, (bigger, smaller) ->
-                        ResultWithIndex(index, biggerEncompassesSmaller(bigger, smaller, thisResolverWithNullType, otherResolverWithNullType, typeStack))
-                    }
-
-                    results.find {
-                        it.result is Result.Failure
-                    }?.let { result ->
-                        result.result.breadCrumb("[${result.index}]")
-                    } ?: Result.Success()
+                val otherEncompassables = otherMembers.getEncompassableList(pattern.size, otherResolverWithNullType)
+                val encompassables = when {
+                    otherEncompassables.size > pattern.size -> theseMembers.getEncompassableList(otherEncompassables.size, thisResolverWithNullType)
+                    else -> memberList.getEncompassables(thisResolverWithNullType)
                 }
+
+                val results = encompassables.zip(otherEncompassables).mapIndexed { index, (bigger, smaller) ->
+                    ResultWithIndex(index, biggerEncompassesSmaller(bigger, smaller, thisResolverWithNullType, otherResolverWithNullType, typeStack))
+                }
+
+                results.find {
+                    it.result is Result.Failure
+                }?.let { result ->
+                    result.result.breadCrumb("[${result.index}]")
+                } ?: Result.Success()
             } catch (e: ContractException) {
                 Result.Failure(e.report())
             }
@@ -118,11 +116,6 @@ data class JSONArrayPattern(override val pattern: List<Pattern> = emptyList(), o
                 patternAtIndex.patternFrom(indexedValue, resolver, parseValueToType)
             }
         )
-    }
-
-    private fun validateInfiniteLength(otherMembers: MemberList, theseMembers: MemberList): Result = when {
-        otherMembers.isEndless() && !theseMembers.isEndless() -> Result.Failure("Finite list is not a superset of an infinite list.")
-        else -> Result.Success()
     }
 
     override val typeName: String = "json array"

--- a/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/ListPattern.kt
@@ -14,7 +14,7 @@ data class ListPattern(
     val itemsPointer: String? = null
 ) : Pattern, SequenceType, HasDefaultExample, PossibleJsonObjectPatternContainer, XMLChildGenerationPattern {
     override val memberList: MemberList
-        get() = MemberList(emptyList(), pattern)
+        get() = MemberList(listOf(pattern))
 
     override fun fixValue(value: Value, resolver: Resolver): Value {
         if (resolver.matchesPattern(this, value).isSuccess()) return value

--- a/core/src/main/kotlin/io/specmatic/core/pattern/MemberList.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/MemberList.kt
@@ -3,42 +3,21 @@ package io.specmatic.core.pattern
 import io.specmatic.core.Resolver
 import io.specmatic.core.utilities.withNullPattern
 
-data class MemberList(private val finiteList: List<Pattern>, private val rest: Pattern?) {
+data class MemberList(private val members: List<Pattern>) {
     fun getEncompassableList(count: Int, resolver: Resolver): List<Pattern> {
-        if(count > 0 && finiteList.isEmpty() && rest == null)
+        if (count > members.size)
             throw ContractException("The lengths of the expected and actual array patterns don't match.")
 
-        return when {
-            count > finiteList.size -> {
-                when(rest) {
-                    null -> throw ContractException("The lengths of the expected and actual array patterns don't match.")
-                    else -> {
-                        val missingEntryCount = count - finiteList.size
-                        val missingEntries = 0.until(missingEntryCount).map { rest }
-                        val paddedPattern = finiteList.plus(missingEntries)
-
-                        getEncompassableList(paddedPattern, resolver)
-                    }
-                }
-            }
-            else -> {
-                getEncompassableList(finiteList, resolver)
-            }
-        }
+        return resolvePatterns(members, resolver)
     }
 
-    private fun getEncompassableList(pattern: List<Pattern>, resolver: Resolver): List<Pattern> {
+    private fun resolvePatterns(pattern: List<Pattern>, resolver: Resolver): List<Pattern> {
         val resolverWithNullType = withNullPattern(resolver)
         return pattern.map { resolvedHop(it, resolverWithNullType) }
     }
 
-    fun getEncompassables(resolver: Resolver): List<Pattern> {
-        return (rest?.let {
-            finiteList.plus(it)
-        } ?: finiteList).map { resolvedHop(it, resolver) }
-    }
+    fun getEncompassables(resolver: Resolver): List<Pattern> =
+        members.map { resolvedHop(it, resolver) }
 
-    fun isEndless(): Boolean = rest != null
-
-    fun patternList(): List<Pattern> = rest?.let { finiteList.plus(it) } ?: finiteList
+    fun patternList(): List<Pattern> = members
 }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLChoiceGroupPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLChoiceGroupPattern.kt
@@ -22,10 +22,7 @@ data class XMLChoiceGroupPattern(
     override val typeName: String = "xml-choice-group"
 
     override val memberList: MemberList
-        get() = MemberList(
-            choices.firstOrNull() ?: emptyList(),
-            null
-        )
+        get() = MemberList(choices.firstOrNull() ?: emptyList())
 
     override fun matches(sampleData: Value?, resolver: Resolver): Result {
         return when (sampleData) {
@@ -489,7 +486,7 @@ data class XMLSequencePattern(
     override val typeName: String = "xml-sequence"
 
     override val memberList: MemberList
-        get() = MemberList(members, null)
+        get() = MemberList(members)
 
     override fun matches(sampleData: Value?, resolver: Resolver): Result {
         return when (sampleData) {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLPattern.kt
@@ -1591,7 +1591,7 @@ data class XMLPattern(
         }
 
     override val memberList: MemberList
-        get() = MemberList(pattern.nodes, null)
+        get() = MemberList(pattern.nodes)
 
     override val typeName: String = "xml"
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/XMLSubstitutionGroupPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/XMLSubstitutionGroupPattern.kt
@@ -24,7 +24,7 @@ data class XMLSubstitutionGroupPattern(
     override val typeName: String = "xml-substitution-group"
 
     override val memberList: MemberList
-        get() = MemberList(candidates, null)
+        get() = MemberList(candidates)
 
     override fun matches(sampleData: Value?, resolver: Resolver): Result {
         return when (sampleData) {

--- a/core/src/test/kotlin/io/specmatic/core/pattern/JSONArrayPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/JSONArrayPatternTest.kt
@@ -138,7 +138,7 @@ internal class JSONArrayPatternTest {
     fun `should not encompass a pattern with a different number of items`() {
         val bigger = parsedPattern("""["(number)", "(number)"]""")
         val smallerLess = parsedPattern("""["(number)"]""")
-        val smallerMore = parsedPattern("""["(number)"]""")
+        val smallerMore = parsedPattern("""["(number)", "(number)", "(number)"]""")
 
         assertThat(bigger.encompasses(smallerLess, Resolver(), Resolver())).isInstanceOf(Result.Failure::class.java)
         assertThat(bigger.encompasses(smallerMore, Resolver(), Resolver())).isInstanceOf(Result.Failure::class.java)


### PR DESCRIPTION
## What

- Remove the repeating `rest` member from `MemberList`.
- Simplify `MemberList` to represent only a finite collection of patterns.
- Handle `JSONArrayPattern` versus `ListPattern` compatibility explicitly.
- Preserve the existing `ListPattern` projection used by Dictionary depth calculation and legacy XML behavior.
- Correct the array-length test so it covers both shorter and longer arrays.

## Why

`MemberList.rest` supported a positional prefix followed by a repeating tail. After `RestPattern` and the legacy repeating-tail syntax were removed, that state no longer has a producer.

`ListPattern` was the only remaining class populating `rest`, but finite `JSONArrayPattern` compatibility with `ListPattern` was rejected before the repeating-tail padding logic could run. The padding branch was therefore unreachable.

This change closes out that obsolete behavior without redesigning `SequenceType`, `ListPattern`, `JSONArrayPattern`, Dictionary handling, or XML repetition.