### PR TITLE
refactor: Use canonical optionality for XML attributes

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -2189,9 +2189,9 @@ class OpenApiSpecification(
 
         val requiredAttributeNames = schema.required.orEmpty().toSet()
         val attributePointers = attributeProperties.mapKeys { (name, _) ->
-            if (name in requiredAttributeNames) name else "$name.opt"
+            if (name in requiredAttributeNames) name else withOptionality(name)
         }.mapValues { (propertyName, _) ->
-            "$schemaPointer/properties/${escapeJsonPointer(propertyName.removeSuffix(".opt"))}"
+            "$schemaPointer/properties/${escapeJsonPointer(withoutOptionality(propertyName))}"
         }
 
         return withPointer.copy(
@@ -3100,7 +3100,7 @@ class OpenApiSpecification(
                 val attributes: Map<String, Pattern> = attributeProperties.map { (name, propertySchema) ->
                     val attributeContext = collectorContext.at(name)
                     val attributeName = if(name !in schema.required.orEmpty())
-                        "$name.opt"
+                        withOptionality(name)
                     else
                         name
                     attributeName to toSpecmaticPattern(propertySchema, emptyList(), collectorContext = attributeContext)

--- a/core/src/main/kotlin/io/specmatic/core/pattern/Grammar.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/Grammar.kt
@@ -11,7 +11,6 @@ import io.specmatic.core.value.*
 import java.io.File
 import java.math.BigDecimal
 
-const val XML_ATTR_OPTIONAL_SUFFIX = ".opt"
 const val DEFAULT_OPTIONAL_SUFFIX = "?"
 const val UTF_BYTE_ORDER_MARK = "\uFEFF"
 val TOKEN_REGEX = Regex("""\([^)]+\)|\$(\w+)?\([^()]*\)""")
@@ -20,7 +19,6 @@ private val DOLLAR_METHOD_OR_LOOKUP_PATTERN = Regex("^\\$(\\w+)?\\((.*)\\)$")
 fun withoutOptionality(key: String): String {
     return when {
         key.endsWith(DEFAULT_OPTIONAL_SUFFIX) -> key.removeSuffix(DEFAULT_OPTIONAL_SUFFIX)
-        key.endsWith(XML_ATTR_OPTIONAL_SUFFIX) -> key.removeSuffix(XML_ATTR_OPTIONAL_SUFFIX)
         else -> key
     }
 }
@@ -33,7 +31,7 @@ internal fun withOptionality(key: String): String {
 }
 
 fun isOptional(key: String): Boolean =
-    key.endsWith(DEFAULT_OPTIONAL_SUFFIX) || key.endsWith(XML_ATTR_OPTIONAL_SUFFIX)
+    key.endsWith(DEFAULT_OPTIONAL_SUFFIX)
 
 internal fun containsKey(jsonObject: Map<String, Any?>, key: String) =
     when {

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/message/AttributeElement.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/message/AttributeElement.kt
@@ -4,9 +4,9 @@ import io.specmatic.core.log.logger
 import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.pattern.Pattern
 import io.specmatic.core.pattern.XMLAttributeWildcard
-import io.specmatic.core.pattern.XML_ATTR_OPTIONAL_SUFFIX
 import io.specmatic.core.pattern.XMLProcessContents
 import io.specmatic.core.pattern.withoutOptionality
+import io.specmatic.core.pattern.withOptionality
 import io.specmatic.core.pattern.xmlNamespaceConstraint
 import io.specmatic.core.value.StringValue
 import io.specmatic.core.value.Value
@@ -25,7 +25,7 @@ class AttributeElement(xmlNode: XMLNode, wsdl: WSDL) {
     private val mandatory: Boolean = isMandatory(resolvedAttribute) ?: false
     val nameWithOptionality: String = when (mandatory) {
         true -> name
-        else -> "${name}${XML_ATTR_OPTIONAL_SUFFIX}"
+        else -> withOptionality(name)
     }
 }
 

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/payload/ComplexTypedSOAPPayload.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/payload/ComplexTypedSOAPPayload.kt
@@ -1,11 +1,17 @@
 package io.specmatic.core.wsdl.payload
 
+import io.specmatic.core.pattern.ExactValuePattern
 import io.specmatic.core.pattern.Pattern
 import io.specmatic.core.pattern.TYPE_ATTRIBUTE_NAME
 import io.specmatic.core.pattern.XMLPattern
+import io.specmatic.core.pattern.XMLTypeData
+import io.specmatic.core.value.StringValue
 import io.specmatic.core.value.XMLNode
-import io.specmatic.core.value.toXMLNode
+import io.specmatic.core.value.localName
+import io.specmatic.core.value.namespacePrefix
 import io.specmatic.core.wsdl.parser.message.AttributeElement
+import io.specmatic.core.wsdl.parser.message.attributeNamespaceMap
+import io.specmatic.core.wsdl.parser.message.attributePatternMap
 
 data class ComplexTypedSOAPPayload(
     val nodeName: String,
@@ -14,23 +20,35 @@ data class ComplexTypedSOAPPayload(
     val attributes: List<AttributeElement> = emptyList()
 ) : SOAPPayload {
     override fun toPattern(headers: RequestHeaders): Pattern {
-        return XMLPattern(toEnvelope(headers), isSOAP = true)
+        val bodyPattern = toBodyPattern()
+        val envelope = XMLPattern(toEnvelopeShell(headers), isSOAP = true)
+
+        return envelope.copy(
+            pattern = envelope.pattern.copy(
+                nodes = envelope.pattern.nodes.map { childPattern ->
+                    if (childPattern is XMLPattern && childPattern.pattern.name == "Body") {
+                        childPattern.copy(pattern = childPattern.pattern.copy(nodes = listOf(bodyPattern)))
+                    } else {
+                        childPattern
+                    }
+                }
+            )
+        )
     }
 
-    private fun toEnvelope(headers: RequestHeaders): XMLNode {
-        val xml = buildXmlDataForComplexElement(nodeName, specmaticTypeName, attributes)
-        return soapMessage(toXMLNode(xml), namespaces, headers)
-    }
-}
+    private fun toBodyPattern(): XMLPattern =
+        XMLPattern(
+            XMLTypeData(
+                name = nodeName.localName(),
+                realName = nodeName,
+                attributes = mapOf(TYPE_ATTRIBUTE_NAME to ExactValuePattern(StringValue(specmaticTypeName.trim()))) +
+                    attributePatternMap(attributes),
+                namespaceUri = namespaces[nodeName.namespacePrefix()].takeIf { nodeName.namespacePrefix().isNotBlank() },
+                attributeNamespaceUris = attributeNamespaceMap(attributes)
+            )
+        )
 
-fun buildXmlDataForComplexElement(
-    nodeName: String,
-    specmaticTypeName: String,
-    attributes: List<AttributeElement>
-): String {
-    val attributeString = attributes.joinToString(" ") {
-        "${it.nameWithOptionality}=\"${it.type}\""
+    private fun toEnvelopeShell(headers: RequestHeaders): XMLNode {
+        return soapMessage(XMLNode(nodeName, emptyMap(), emptyList(), namespaces), namespaces, headers)
     }
-
-    return "<${nodeName} $TYPE_ATTRIBUTE_NAME=\"${specmaticTypeName.trim()}\" $attributeString />"
 }

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationParseTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationParseTest.kt
@@ -34,6 +34,7 @@ import io.specmatic.mock.NoMatchingScenario
 import io.specmatic.stub.captureStandardOutput
 import io.specmatic.toViolationReportString
 import io.specmatic.core.value.StringValue
+import io.specmatic.core.value.toXMLNode
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -1523,6 +1524,58 @@ class OpenApiSpecificationParseTest {
         val resNumberPattern = responseInventory.nodes.single() as NumberPattern
         assertThat(resNumberPattern.minimum).isEqualTo(BigDecimal(1))
         assertThat(resNumberPattern.maximum).isEqualTo(BigDecimal(101))
+    }
+
+    @Test
+    fun `XML optional attributes use canonical keys and retain source pointers`() {
+        val spec = """
+            openapi: 3.0.0
+            info:
+              title: XML attributes
+              version: 1.0.0
+            paths:
+              /users:
+                post:
+                  requestBody:
+                    content:
+                      application/xml:
+                        schema:
+                          ${'$'}ref: '#/components/schemas/User'
+                  responses:
+                    '200':
+                      description: OK
+            components:
+              schemas:
+                User:
+                  type: object
+                  xml:
+                    name: user
+                  properties:
+                    id:
+                      type: string
+                      xml:
+                        attribute: true
+                    nickname:
+                      type: integer
+                      xml:
+                        attribute: true
+                  required:
+                    - id
+        """.trimIndent()
+
+        val scenario = OpenApiSpecification.fromYAML(spec, "").toFeature().scenarios.single()
+        val requestPattern = resolvedHop(scenario.httpRequestPattern.body, scenario.resolver) as XMLPattern
+        val userPattern = resolvedHop(DeferredPattern("(User)"), scenario.resolver) as XMLPattern
+
+        assertThat(userPattern.pattern.attributes).containsKeys("id", "nickname?")
+        assertThat(requestPattern.attributePointers)
+            .containsEntry("nickname?", "/components/schemas/User/properties/nickname")
+        assertThat(requestPattern.matches(toXMLNode("""<user id="1"/>"""), scenario.resolver))
+            .isInstanceOf(Result.Success::class.java)
+        assertThat(requestPattern.matches(toXMLNode("""<user id="1" nickname="2"/>"""), scenario.resolver))
+            .isInstanceOf(Result.Success::class.java)
+        assertThat(requestPattern.matches(toXMLNode("""<user id="1" nickname="invalid"/>"""), scenario.resolver))
+            .isInstanceOf(Result.Failure::class.java)
     }
 
     @ParameterizedTest

--- a/core/src/test/kotlin/io/specmatic/core/pattern/XMLPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/XMLPatternTest.kt
@@ -1482,7 +1482,14 @@ internal class XMLPatternTest {
 
         @Test
         fun `optional attribute encompasses non optional`() {
-            val bigger = XMLPattern("""<number val$XML_ATTR_OPTIONAL_SUFFIX="(number)">(number)</number>""")
+            val bigger = XMLPattern(
+                XMLTypeData(
+                    name = "number",
+                    realName = "number",
+                    attributes = mapOf("val?" to DeferredPattern("(number)")),
+                    nodes = listOf(DeferredPattern("(number)")),
+                )
+            )
             val smaller = XMLPattern("""<number val="(number)">(number)</number>""")
             assertThat(bigger.encompasses(smaller, Resolver(), Resolver())).isInstanceOf(Result.Success::class.java)
         }
@@ -1638,8 +1645,17 @@ internal class XMLPatternTest {
         }
 
         @Test
+        fun `optional attribute may be absent and is validated when present`() {
+            val type = optionalNumberAttributePattern()
+
+            toXMLNode("""<number/>""") shouldMatch type
+            toXMLNode("""<number val="10"/>""") shouldMatch type
+            toXMLNode("""<number val="invalid"/>""") shouldNotMatch type
+        }
+
+        @Test
         fun `optional attribute should pick up example value`() {
-            val type = XMLPattern("""<number val$XML_ATTR_OPTIONAL_SUFFIX="(number)"></number>""")
+            val type = optionalNumberAttributePattern()
             val example = Row(listOf("val"), listOf("10"))
 
             val newTypes = type.newBasedOn(example, Resolver()).map { it.value as XMLPattern }.toList()
@@ -1651,7 +1667,7 @@ internal class XMLPatternTest {
 
         @Test
         fun `optional attribute without examples should generate all tests for the attribute and without the attribute`() {
-            val type = XMLPattern("""<number val$XML_ATTR_OPTIONAL_SUFFIX="(number)"></number>""")
+            val type = optionalNumberAttributePattern()
 
             val newTypes = type.newBasedOn(Row(), Resolver()).map { it.value as XMLPattern }.toList()
             assertThat(newTypes.size).isEqualTo(2)
@@ -1670,27 +1686,13 @@ internal class XMLPatternTest {
             assertThat(flags).contains("without")
         }
 
-        @Test
-        fun `sanity test that double optional gets handled right`() {
-            val type =
-                XMLPattern("""<number val$XML_ATTR_OPTIONAL_SUFFIX$XML_ATTR_OPTIONAL_SUFFIX="(number)"></number>""")
-
-            val newTypes = type.newBasedOn(Row(), Resolver()).map { it.value as XMLPattern }.toList()
-            assertThat(newTypes).hasSize(2)
-
-            val flags = mutableListOf<String>()
-
-            for (newType in newTypes) {
-                when {
-                    newType.pattern.attributes.containsKey("val$XML_ATTR_OPTIONAL_SUFFIX") -> flags.add("with")
-                    else -> flags.add("without")
-                }
-            }
-
-            assertThat(flags).hasSize(2)
-            assertThat(flags).contains("with")
-            assertThat(flags).contains("without")
-        }
+        private fun optionalNumberAttributePattern() = XMLPattern(
+            XMLTypeData(
+                name = "number",
+                realName = "number",
+                attributes = mapOf("val?" to DeferredPattern("(number)")),
+            )
+        )
     }
 
     @Nested

--- a/core/src/test/kotlin/io/specmatic/core/wsdl/parser/WSDLWiringCharacterizationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/wsdl/parser/WSDLWiringCharacterizationTest.kt
@@ -489,8 +489,8 @@ class WSDLWiringCharacterizationTest {
         val finalPattern = typeInfo.types.getValue("FinalType") as XMLPattern
 
         assertXmlAttribute(finalPattern, "baseId", "(string)")
-        assertXmlAttribute(finalPattern, "middleId.opt", "(string)")
-        assertXmlAttribute(finalPattern, "finalId.opt", "(string)")
+        assertXmlAttribute(finalPattern, "middleId?", "(string)")
+        assertXmlAttribute(finalPattern, "finalId?", "(string)")
     }
 
     @Test
@@ -502,7 +502,7 @@ class WSDLWiringCharacterizationTest {
         val typeInfo = soapElement.deriveSpecmaticTypes("DerivedType", emptyMap(), emptySet())
         val derivedPattern = typeInfo.types.getValue("DerivedType") as XMLPattern
 
-        assertXmlAttribute(derivedPattern, "traceId.opt", "(string)")
+        assertXmlAttribute(derivedPattern, "traceId?", "(string)")
         assertThat(derivedPattern.pattern.attributeWildcards).hasSize(1)
     }
 
@@ -514,7 +514,7 @@ class WSDLWiringCharacterizationTest {
         val derivedType = wsdl.getComplexTypeNode(derivedElement)
 
         assertThat(derivedType.getAttributes().map { it.nameWithOptionality })
-            .contains("traceId.opt", "localCode.opt")
+            .contains("traceId?", "localCode?")
         assertThat(derivedType.getAttributeWildcards()).hasSize(1)
     }
 
@@ -529,8 +529,8 @@ class WSDLWiringCharacterizationTest {
         val childNames = derivedPattern.pattern.nodes.filterIsInstance<XMLPattern>().map { it.pattern.name }
 
         assertThat(childNames).containsExactly("id")
-        assertXmlAttribute(derivedPattern, "traceId.opt", "(string)")
-        assertXmlAttribute(derivedPattern, "localCode.opt", "(string)")
+        assertXmlAttribute(derivedPattern, "traceId?", "(string)")
+        assertXmlAttribute(derivedPattern, "localCode?", "(string)")
     }
 
     @Test
@@ -540,8 +540,20 @@ class WSDLWiringCharacterizationTest {
 
         val soapElement = wsdl.getSOAPElement(FullyQualifiedName("tns", namespace, "Final"))
         val typeInfo = soapElement.deriveSpecmaticTypes("FinalType", emptyMap(), emptySet())
+        val payloadPattern = soapElement.getSOAPPayload(
+            "Final",
+            "FinalType",
+            wsdl.getNamespaces(typeInfo),
+            typeInfo,
+        ).toPattern(RequestHeaders()) as XMLPattern
+        val bodyPattern = payloadPattern.pattern.nodes
+            .filterIsInstance<XMLPattern>()
+            .single { it.pattern.name == "Body" }
+            .pattern.nodes.single() as XMLPattern
         val requestBody = soapBody(soapElement, wsdl, "Final", "FinalType", typeInfo)
 
+        assertThat(bodyPattern.pattern.attributes.keys)
+            .containsExactlyInAnyOrder(TYPE_ATTRIBUTE_NAME, "baseId", "middleId?", "finalId?")
         assertThat(requestBody)
             .contains("baseId=")
             .contains("middleId=")
@@ -571,7 +583,7 @@ class WSDLWiringCharacterizationTest {
         val typeInfo = soapElement.deriveSpecmaticTypes("CodeType", emptyMap(), emptySet())
         val codePattern = typeInfo.types.getValue("CodeType") as XMLPattern
 
-        assertXmlAttribute(codePattern, "code.opt", "(string)")
+        assertXmlAttribute(codePattern, "code?", "(string)")
     }
 
     @Test
@@ -701,7 +713,7 @@ class WSDLWiringCharacterizationTest {
             toXMLNode("""<tns:LabelledDateTime xmlns:tns="$namespace">not-a-date</tns:LabelledDateTime>"""),
             Resolver(),
         )).isInstanceOf(Result.Failure::class.java)
-        assertXmlAttribute(pattern, "timezone.opt", "(string)")
+        assertXmlAttribute(pattern, "timezone?", "(string)")
         assertThat(pattern.pattern.attributeWildcards).hasSize(1)
     }
 
@@ -759,9 +771,9 @@ class WSDLWiringCharacterizationTest {
             toXMLNode("""<tns:Final xmlns:tns="$namespace">value</tns:Final>"""),
             Resolver(),
         )).isInstanceOf(Result.Success::class.java)
-        assertXmlAttribute(pattern, "baseId.opt", "(string)")
-        assertXmlAttribute(pattern, "middleId.opt", "(string)")
-        assertXmlAttribute(pattern, "finalId.opt", "(string)")
+        assertXmlAttribute(pattern, "baseId?", "(string)")
+        assertXmlAttribute(pattern, "middleId?", "(string)")
+        assertXmlAttribute(pattern, "finalId?", "(string)")
     }
 
     @Test
@@ -812,8 +824,8 @@ class WSDLWiringCharacterizationTest {
         val pattern = concreteRoot(typeInfo.types.getValue("Boolean") as XMLPattern, "Boolean", "tns:Boolean", namespace)
         val sample = toXMLNode("""<tns:Boolean xmlns:tns="$namespace" baseLabel="inherited" source="request">true</tns:Boolean>""")
 
-        assertXmlAttribute(pattern, "baseLabel.opt", "(string)")
-        assertXmlAttribute(pattern, "source.opt", "(string)")
+        assertXmlAttribute(pattern, "baseLabel?", "(string)")
+        assertXmlAttribute(pattern, "source?", "(string)")
         assertThat(pattern.matches(sample, Resolver())).isInstanceOf(Result.Success::class.java)
     }
 
@@ -863,8 +875,8 @@ class WSDLWiringCharacterizationTest {
         val pattern = concreteRoot(typeInfo.types.getValue("Code") as XMLPattern, "Code", "tns:Code", namespace)
         val sample = toXMLNode("""<tns:Code xmlns:tns="$namespace" baseLabel="inherited" code="A1">ABC</tns:Code>""")
 
-        assertXmlAttribute(pattern, "baseLabel.opt", "(string)")
-        assertXmlAttribute(pattern, "code.opt", "(string)")
+        assertXmlAttribute(pattern, "baseLabel?", "(string)")
+        assertXmlAttribute(pattern, "code?", "(string)")
         assertThat(pattern.matches(sample, Resolver())).isInstanceOf(Result.Success::class.java)
         assertThat(pattern.matches(
             toXMLNode("""<tns:Code xmlns:tns="$namespace">a</tns:Code>"""),
@@ -1065,8 +1077,8 @@ class WSDLWiringCharacterizationTest {
         val personPattern = typeInfo.types.getValue("PersonType") as XMLPattern
 
         assertXmlAttribute(personPattern, "traceId", "(string)")
-        assertXmlAttribute(personPattern, "createdBy.opt", "(string)")
-        assertXmlAttribute(personPattern, "requestNumber.opt", "(number)")
+        assertXmlAttribute(personPattern, "createdBy?", "(string)")
+        assertXmlAttribute(personPattern, "requestNumber?", "(number)")
     }
 
     @Test
@@ -1081,8 +1093,8 @@ class WSDLWiringCharacterizationTest {
         val ownerPattern = typeInfo.types.getValue("AccountType_Owner") as XMLPattern
 
         assertXmlAttribute(ownerPattern, "traceId", "(string)")
-        assertXmlAttribute(ownerPattern, "createdBy.opt", "(string)")
-        assertXmlAttribute(ownerPattern, "requestNumber.opt", "(number)")
+        assertXmlAttribute(ownerPattern, "createdBy?", "(string)")
+        assertXmlAttribute(ownerPattern, "requestNumber?", "(number)")
     }
 
     @Test
@@ -1097,7 +1109,7 @@ class WSDLWiringCharacterizationTest {
         val importedPersonPattern = typeInfo.types.getValue("ImportedPersonType") as XMLPattern
 
         assertXmlAttribute(importedPersonPattern, "externalTrace", "(string)")
-        assertXmlAttribute(importedPersonPattern, "externalTenant.opt", "(string)")
+        assertXmlAttribute(importedPersonPattern, "externalTenant?", "(string)")
     }
 
     @Test
@@ -1122,7 +1134,7 @@ class WSDLWiringCharacterizationTest {
         val typeInfo = soapElement.deriveSpecmaticTypes("RecursivePersonType", emptyMap(), emptySet())
         val recursivePersonPattern = typeInfo.types.getValue("RecursivePersonType") as XMLPattern
 
-        assertXmlAttribute(recursivePersonPattern, "safe.opt", "(string)")
+        assertXmlAttribute(recursivePersonPattern, "safe?", "(string)")
     }
 
     @Test
@@ -1137,7 +1149,7 @@ class WSDLWiringCharacterizationTest {
     fun `optional untyped attribute defaults to optional string`() {
         val personPattern = personPatternForAttribute("""<xsd:attribute name="id"/>""")
 
-        assertXmlAttribute(personPattern, "id.opt", "(string)")
+        assertXmlAttribute(personPattern, "id?", "(string)")
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
@@ -3339,44 +3339,6 @@ Then status 200
             assertThat(postResponse.statusCode.value()).isEqualTo(200)
         }
 
-        @Test
-        fun `it should be able to stub out xml with an optional attribute when specifying an attribute value in the stub`() {
-            val gherkin = """Feature: Number
-Scenario: Accept a number
-When POST /number
-And request-body <data number$XML_ATTR_OPTIONAL_SUFFIX="(number)"/>
-Then status 200
-        """.trim()
-
-            val request = HttpRequest("POST", "/number", emptyMap(), parsedValue("""<data number="10"/>"""))
-            val mock = ScenarioStub(request, HttpResponse.OK)
-
-            val postResponse = HttpStub(gherkin, listOf(mock)).use { fake ->
-                RestTemplate().postForEntity<String>(fake.endPoint + "/number", """<data number="10"/>""")
-            }
-
-            assertThat(postResponse.statusCode.value()).isEqualTo(200)
-        }
-
-        @Test
-        fun `it should be able to stub out xml with an optional attribute using no attribute in the stub`() {
-            val gherkin = """Feature: Number
-Scenario: Accept a number
-When POST /number
-And request-body <data number$XML_ATTR_OPTIONAL_SUFFIX="(number)"/>
-Then status 200
-        """.trim()
-
-            val request = HttpRequest("POST", "/number", emptyMap(), parsedValue("""<data/>"""))
-            val mock = ScenarioStub(request, HttpResponse.OK)
-
-            val postResponse = HttpStub(gherkin, listOf(mock)).use { fake ->
-                RestTemplate().postForEntity<String>(fake.endPoint + "/number", """<data/>""")
-            }
-
-            assertThat(postResponse.statusCode.value()).isEqualTo(200)
-        }
-
     }
 
     @Nested


### PR DESCRIPTION
## Summary

- Standardize optional XML attribute keys on `?` across OpenAPI and WSDL parsing.
- Preserve source pointers for optional OpenAPI XML attributes.
- Cleanup code building SOAP body patterns with typed attributes and namespace metadata.