### PR TITLE
Honor nullable JSON responses

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/pattern/Grammar.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/Grammar.kt
@@ -407,6 +407,7 @@ fun parsedValue(content: String?): Value {
 fun parsedScalarValue(content: String?): Value {
     val trimmed = content?.trim()?.removePrefix(UTF_BYTE_ORDER_MARK) ?: return NullValue
     return when {
+        trimmed == "null" -> NullValue
         trimmed.toIntOrNull() != null -> NumberValue(trimmed.toInt())
         trimmed.toLongOrNull() != null -> NumberValue(trimmed.toLong())
         trimmed.toDoubleOrNull() != null -> NumberValue(trimmed.toDouble())

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -6825,6 +6825,52 @@ paths:
     }
 
     @Test
+    fun `accept null response for a nullable array`() {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+            openapi: 3.0.1
+            info:
+              title: Pet API
+              version: "1"
+            paths:
+              /pets:
+                get:
+                  responses:
+                    200:
+                      description: Pets
+                      content:
+                        application/json:
+                          schema:
+                            type: array
+                            nullable: true
+                            items:
+                              ${"$"}ref: '#/components/schemas/Pet'
+            components:
+              schemas:
+                Pet:
+                  type: object
+                  required:
+                    - id
+                  properties:
+                    id:
+                      type: integer
+            """.trimIndent(),
+            ""
+        ).toFeature()
+
+        val result = feature.scenarios.single().matchesMock(
+            HttpRequest("GET", "/pets"),
+            HttpResponse(
+                status = 200,
+                body = "null",
+                headers = mapOf(CONTENT_TYPE to "application/json")
+            )
+        )
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+    }
+
+    @Test
     fun `randomized response when stubbing out API with byte array request body`() {
         val specification = OpenApiSpecification.fromYAML(
             """

--- a/core/src/test/kotlin/io/specmatic/core/pattern/GrammarKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/GrammarKtTest.kt
@@ -80,6 +80,31 @@ internal class GrammarKtTest {
         assertThat(parsedScalarValue(inputString)).isEqualTo(StringValue("DATA"))
     }
 
+    @Test
+    fun `null literal parses to null value`() {
+        assertThat(parsedScalarValue("null")).isEqualTo(NullValue)
+    }
+
+    @Test
+    fun `null literal with surrounding whitespace parses to null value`() {
+        assertThat(parsedScalarValue("  null\n")).isEqualTo(NullValue)
+    }
+
+    @ParameterizedTest
+    @MethodSource("bomProvider")
+    fun `null literal with BOM parses to null value`(bom: ByteOrderMark) {
+        val charSet = Charset.forName(bom.charsetName)
+        val inputBytes = bom.bytes + "null".toByteArray(charSet)
+        val inputString = String(inputBytes, charset = charSet)
+
+        assertThat(parsedScalarValue(inputString)).isEqualTo(NullValue)
+    }
+
+    @Test
+    fun `uppercase null literal remains a string value`() {
+        assertThat(parsedScalarValue("NULL")).isEqualTo(StringValue("NULL"))
+    }
+
     @ParameterizedTest
     @MethodSource("bomProvider")
     fun `should be able to parse JsonObject data with BOM`(bom: ByteOrderMark) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Honor JSON `null` values in nullable OpenAPI responses.

<!-- Why are these changes necessary? -->

**Why**:

Top-level JSON `null` responses were treated as strings and rejected by nullable schemas.

<!-- How were these changes implemented? -->

**How**:

Added null scalar handling and focused regression coverage.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)