### PR TITLE
fix: Preserve null literals outside JSON bodies

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/pattern/Grammar.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/Grammar.kt
@@ -380,8 +380,9 @@ fun parsedJSONArray(content: String, mismatchMessages: MismatchMessages = Defaul
 }
 
 fun parsedJsonValue(content: String?): Value {
-    return content?.trim()?.removePrefix(UTF_BYTE_ORDER_MARK)?.let {
+    return content?.trim()?.removePrefix(UTF_BYTE_ORDER_MARK)?.trim()?.let {
         when {
+            it == "null" -> NullValue
             it.startsWith("{") -> JSONObjectValue(jsonStringToValueMap(it))
             it.startsWith("[") -> JSONArrayValue(jsonStringToValueArray(it))
             else -> parsedScalarValue(it)
@@ -407,7 +408,6 @@ fun parsedValue(content: String?): Value {
 fun parsedScalarValue(content: String?): Value {
     val trimmed = content?.trim()?.removePrefix(UTF_BYTE_ORDER_MARK) ?: return NullValue
     return when {
-        trimmed == "null" -> NullValue
         trimmed.toIntOrNull() != null -> NumberValue(trimmed.toInt())
         trimmed.toLongOrNull() != null -> NumberValue(trimmed.toLong())
         trimmed.toDoubleOrNull() != null -> NumberValue(trimmed.toDouble())

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationParseTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationParseTest.kt
@@ -47,6 +47,33 @@ import java.math.BigDecimal
 import java.util.stream.Stream
 
 class OpenApiSpecificationParseTest {
+    @Test
+    fun `unsupported enum type preserves null string fallback`() {
+        val specification = """
+            openapi: 3.1.0
+            info:
+              title: Null enum
+              version: "1"
+            paths:
+              /state:
+                get:
+                  responses:
+                    "200":
+                      description: state
+                      content:
+                        application/json:
+                          schema:
+                            type: mystery
+                            enum: ["null"]
+        """.trimIndent()
+
+        val feature = OpenApiSpecification.fromYAML(specification, "").toFeature()
+        val scenario = feature.scenarios.single()
+
+        assertThat(scenario.httpResponsePattern.body.matches(StringValue("null"), scenario.resolver))
+            .isInstanceOf(Result.Success::class.java)
+    }
+
     @ParameterizedTest
     @ValueSource(strings = ["3.0.0", "3.1.0"])
     fun `should parse openapi paths with multi parameters per segment using a separator`(openApiVersion: String) {

--- a/core/src/test/kotlin/io/specmatic/core/HttpPathPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpPathPatternTest.kt
@@ -863,6 +863,16 @@ internal class HttpPathPatternTest {
         }
 
         @Test
+        fun `should preserve null literal from a path example row`() {
+            val pathPattern = buildHttpPathPattern("/items/(id:string)")
+            val generatedPathSegments = pathPattern.readFrom(Row(mapOf("id" to "null")), Resolver()).single()
+
+            val path = generatedPathSegments.joinToString("") { it.generate(Resolver()).toStringLiteral() }
+
+            assertThat(path).isEqualTo("/items/null")
+        }
+
+        @Test
         fun `should generate negative interpolated path params with annotations`() {
             val pathPattern = buildHttpPathPattern("/product/product-(id:number)/order/order-(orderId:number)/latest")
             val negatives = pathPattern.negativeBasedOn(Row(mapOf("id" to "10", "orderId" to "20")), Resolver()).toList()

--- a/core/src/test/kotlin/io/specmatic/core/HttpResponseTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpResponseTest.kt
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
+import org.junit.jupiter.params.provider.ValueSource
 import java.io.File
 import java.util.stream.Stream
 
@@ -139,6 +140,18 @@ internal class HttpResponseTest {
 
     @Nested
     inner class AdjustResponseForContentTypeTests {
+
+        @ParameterizedTest
+        @ValueSource(strings = ["application/json", "application/problem+json"])
+        fun `should parse null literal for json content types`(contentType: String) {
+            val response = HttpResponse(
+                status = 200,
+                headers = mapOf("Content-Type" to contentType),
+                body = StringValue("null"),
+            )
+
+            assertThat(response.adjustPayloadForContentType().body).isEqualTo(NullValue)
+        }
 
         @ParameterizedTest
         @MethodSource("io.specmatic.core.HttpResponseTest#xmlContentTypeScenarios")

--- a/core/src/test/kotlin/io/specmatic/core/QueryParametersTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/QueryParametersTest.kt
@@ -1,9 +1,17 @@
 package io.specmatic.core
 
+import io.specmatic.core.value.StringValue
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class QueryParametersTest {
+
+    @Test
+    fun `should preserve null literal as a string value`() {
+        val queryParameters = QueryParameters(mapOf("q" to "null"))
+
+        assertThat(queryParameters.asValueMap()).containsEntry("q", StringValue("null"))
+    }
 
     @Test
     fun `should return map with value as json array for numeric array query parameters`() {

--- a/core/src/test/kotlin/io/specmatic/core/pattern/GrammarKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/GrammarKtTest.kt
@@ -21,6 +21,14 @@ internal class GrammarKtTest {
         }
 
         @JvmStatic
+        fun quotedJsonScalarProvider(): List<String> = listOf(
+            "\"null\"",
+            "\"123\"",
+            "\"true\"",
+            "\"line\\nquote\\\"slash\\\\\"",
+        )
+
+        @JvmStatic
         fun contentToFormatProvider(): Stream<Arguments> {
             val expectedValue = JSONObjectValue(mapOf("hello" to StringValue("world")))
             val expectedXmlValue = XMLNode("hello", "hello", emptyMap(), listOf(StringValue("world")), "", emptyMap())
@@ -29,6 +37,7 @@ internal class GrammarKtTest {
                 Arguments.of("hello: world", "yaml", expectedValue),
                 Arguments.of("hello: world", "yml", expectedValue),
                 Arguments.of("<hello>world</hello>", "xml", expectedXmlValue),
+                Arguments.of("null", "txt", StringValue("null")),
             )
         }
     }
@@ -81,23 +90,44 @@ internal class GrammarKtTest {
     }
 
     @Test
-    fun `null literal parses to null value`() {
-        assertThat(parsedScalarValue("null")).isEqualTo(NullValue)
+    fun `null literal remains a scalar string value`() {
+        assertThat(parsedScalarValue("null")).isEqualTo(StringValue("null"))
     }
 
     @Test
-    fun `null literal with surrounding whitespace parses to null value`() {
-        assertThat(parsedScalarValue("  null\n")).isEqualTo(NullValue)
+    fun `null literal with surrounding whitespace remains a scalar string value`() {
+        assertThat(parsedScalarValue("  null\n")).isEqualTo(StringValue("null"))
     }
 
     @ParameterizedTest
     @MethodSource("bomProvider")
-    fun `null literal with BOM parses to null value`(bom: ByteOrderMark) {
+    fun `null literal with BOM remains a scalar string value`(bom: ByteOrderMark) {
         val charSet = Charset.forName(bom.charsetName)
         val inputBytes = bom.bytes + "null".toByteArray(charSet)
         val inputString = String(inputBytes, charset = charSet)
 
-        assertThat(parsedScalarValue(inputString)).isEqualTo(NullValue)
+        assertThat(parsedScalarValue(inputString)).isEqualTo(StringValue("null"))
+    }
+
+    @Test
+    fun `json null literal parses to null value`() {
+        assertThat(parsedJsonValue("  null\n")).isEqualTo(NullValue)
+    }
+
+    @ParameterizedTest
+    @MethodSource("bomProvider")
+    fun `json null literal with BOM parses to null value`(bom: ByteOrderMark) {
+        val charSet = Charset.forName(bom.charsetName)
+        val inputBytes = bom.bytes + "  null\n".toByteArray(charSet)
+        val inputString = String(inputBytes, charset = charSet)
+
+        assertThat(parsedJsonValue(inputString)).isEqualTo(NullValue)
+    }
+
+    @ParameterizedTest
+    @MethodSource("quotedJsonScalarProvider")
+    fun `quoted json scalar preserves its wire representation`(input: String) {
+        assertThat(parsedJsonValue(input)).isEqualTo(StringValue(input))
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/core/utilities/OpenApiYamlFromExampleDirTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/utilities/OpenApiYamlFromExampleDirTest.kt
@@ -441,6 +441,28 @@ class OpenApiYamlFromExampleDirTest {
     }
 
     @Test
+    fun `infers null literals in query parameters and headers as strings`() {
+        val request = HttpRequest(
+            method = "GET",
+            path = "/search",
+            headers = mapOf("X-Mode" to "null"),
+            queryParams = QueryParameters(mapOf("q" to "null")),
+        )
+        val response = HttpResponse(
+            status = 200,
+            headers = mapOf("X-State" to "null"),
+            body = StringValue("ok"),
+        )
+
+        val openApi = openApiFromTraffic("Search", listOf(namedStub("search", request, response)))!!
+        val operation = openApi.paths["/search"]!!.get
+
+        assertThat(operation.parameters.single { it.`in` == "query" && it.name == "q" }.schema.type).isEqualTo("string")
+        assertThat(operation.parameters.single { it.`in` == "header" && it.name == "X-Mode" }.schema.type).isEqualTo("string")
+        assertThat(operation.responses["200"]!!.headers["X-State"]!!.schema.type).isEqualTo("string")
+    }
+
+    @Test
     fun `infers header optionality and preserves optional query parameters across recordings`() {
         val firstRequest = HttpRequest(
             method = "GET",


### PR DESCRIPTION
## Summary

- Preserve `null` as a string in scalar, query, header, and path values
- Parse JSON `null` as `NullValue`
- Add regression coverage for parsing and OpenAPI inference
