### PR TITLE
fix: fix bcc mcp tool in case of docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ Each release section should stand on its own and describe the behavior shipped i
 - When generating notes for downstream repos, this repo is consumed by:
   - `enterprise`, bumped in `enterprise/gradle.properties` via `specmaticVersion`
 
+## Unreleased 
+- Updated the MCP backward compatibility tool to correctly handle Docker-based executions. When the required files are not available inside the Docker container, the tool returns the appropriate Docker backward compatibility command for the user to run.
+
 ## 2.51.1 (2026-07-31)
 
 ### Changed

--- a/application/src/main/kotlin/application/mcp/server/DefaultSpecmaticMcpToolProvider.kt
+++ b/application/src/main/kotlin/application/mcp/server/DefaultSpecmaticMcpToolProvider.kt
@@ -70,7 +70,7 @@ class DefaultSpecmaticMcpToolProvider(
     fun getBCCTool(): McpServerFeatures.SyncToolSpecification {
         return tool(
             name = "backward_compatibility_check",
-            description = "Check for breaking changes in OpenAPI specifications",
+            description = "Check for breaking changes in OpenAPI specifications. If the execution fails then it should return a fallback docker command and should not keeping on trying the bcc mcp tool again and again.",
             inputSchema = toolSchema(
                 properties = mapOf(
                     "targetPath" to stringProperty("File or folder path to analyze"),

--- a/application/src/main/kotlin/application/mcp/server/DefaultSpecmaticMcpToolProvider.kt
+++ b/application/src/main/kotlin/application/mcp/server/DefaultSpecmaticMcpToolProvider.kt
@@ -70,7 +70,7 @@ class DefaultSpecmaticMcpToolProvider(
     fun getBCCTool(): McpServerFeatures.SyncToolSpecification {
         return tool(
             name = "backward_compatibility_check",
-            description = "Check for breaking changes in OpenAPI specifications. If the execution fails then it should return a fallback docker command and should not keeping on trying the bcc mcp tool again and again.",
+            description = "Check for breaking changes in OpenAPI specifications. Call at most once. Do not retry — failures are environmental, not transient. On failure, returns a fallback docker command for the user to run locally. This is the final answer, not an error. Do not attempt the check via shell, other tools, or code execution. Just relay the command to the user.",
             inputSchema = toolSchema(
                 properties = mapOf(
                     "targetPath" to stringProperty("File or folder path to analyze"),

--- a/application/src/main/kotlin/application/mcp/server/tools/BackwardCompatibilityTool.kt
+++ b/application/src/main/kotlin/application/mcp/server/tools/BackwardCompatibilityTool.kt
@@ -2,7 +2,9 @@ package application.mcp.server.tools
 
 import application.backwardCompatibility.BackwardCompatibilityCheckCommandV2
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 import picocli.CommandLine
+import java.io.File
 
 @Serializable
 data class BackwardCompatArgs(
@@ -11,14 +13,30 @@ data class BackwardCompatArgs(
     val repoDir: String? = null
 )
 
+@Serializable
+data class BackwardCompatibilityFallbackResponse(
+    val action: String = "display_only",
+    val title: String = "Specmatic Backward Compatibility Check",
+    val status: String = "FALLBACK",
+    val message: String,
+    val dockerCommand: String,
+    val suggestion: String
+)
+
 class BackwardCompatibilityTool {
 
     internal fun runBackwardCompatibilityCheck(args: BackwardCompatArgs): String {
+        if(args.repoDir != null) {
+            val repoDirFile = File(args.repoDir)
+            if (!repoDirFile.exists() || !repoDirFile.isDirectory) {
+                return getReturnMessage(args)
+            }
+        }
         val command = BackwardCompatibilityCheckCommandV2()
         val argsList = mutableListOf<String>()
         args.targetPath?.let { argsList.add("--target-path"); argsList.add(it) }
         args.baseBranch?.let { argsList.add("--base-branch"); argsList.add(it) }
-        args.repoDir?.let { argsList.add("--repo-dir"); argsList.add(it) }
+        args.repoDir?.let { argsList.add("--repo-dir"); argsList.add(args.repoDir) }
 
         val (exitCode, stdout, stderr) = captureStandardStreams {
             CommandLine(command).execute(*argsList.toTypedArray())
@@ -52,5 +70,34 @@ class BackwardCompatibilityTool {
                 append("\n```\n")
             }
         }
+    }
+
+    internal fun getReturnMessage(args: BackwardCompatArgs): String {
+        val command = mutableListOf(
+            "docker",
+            "run",
+            "--rm",
+            "-i",
+            "-v",
+            "${args.repoDir}:/usr/src/app",
+            "specmatic/specmatic",
+            "backward-compatibility-check"
+        )
+
+        args.targetPath?.takeIf { it.isNotBlank() }?.let {
+            command += listOf("--target-path", it)
+        }
+
+        args.baseBranch?.takeIf { it.isNotBlank() }?.let {
+            command += listOf("--base-branch", it)
+        }
+
+        return Json.encodeToString(
+            BackwardCompatibilityFallbackResponse(
+                message = "The specified repository directory `${args.repoDir}` does not exist or is not available from the current container filesystem.",
+                dockerCommand = command.joinToString(" "),
+                suggestion = "Use the docker command below or retry from the CLI variant."
+            )
+        )
     }
 }

--- a/application/src/main/kotlin/application/mcp/server/tools/BackwardCompatibilityTool.kt
+++ b/application/src/main/kotlin/application/mcp/server/tools/BackwardCompatibilityTool.kt
@@ -15,9 +15,7 @@ data class BackwardCompatArgs(
 
 @Serializable
 data class BackwardCompatibilityFallbackResponse(
-    val action: String = "display_only",
     val title: String = "Specmatic Backward Compatibility Check",
-    val status: String = "FALLBACK",
     val message: String,
     val dockerCommand: String,
     val suggestion: String
@@ -29,7 +27,7 @@ class BackwardCompatibilityTool {
         if(args.repoDir != null) {
             val repoDirFile = File(args.repoDir)
             if (!repoDirFile.exists() || !repoDirFile.isDirectory) {
-                return getReturnMessage(args)
+                return getFallbackResponse(args)
             }
         }
         val command = BackwardCompatibilityCheckCommandV2()
@@ -72,7 +70,7 @@ class BackwardCompatibilityTool {
         }
     }
 
-    internal fun getReturnMessage(args: BackwardCompatArgs): String {
+    internal fun getFallbackResponse(args: BackwardCompatArgs): String {
         val command = mutableListOf(
             "docker",
             "run",
@@ -96,7 +94,7 @@ class BackwardCompatibilityTool {
             BackwardCompatibilityFallbackResponse(
                 message = "The specified repository directory `${args.repoDir}` does not exist or is not available from the current container filesystem.",
                 dockerCommand = command.joinToString(" "),
-                suggestion = "Use the docker command below or retry from the CLI variant."
+                suggestion = "Use the docker command"
             )
         )
     }

--- a/application/src/main/kotlin/application/mcp/server/tools/BackwardCompatibilityTool.kt
+++ b/application/src/main/kotlin/application/mcp/server/tools/BackwardCompatibilityTool.kt
@@ -24,17 +24,12 @@ data class BackwardCompatibilityFallbackResponse(
 class BackwardCompatibilityTool {
 
     internal fun runBackwardCompatibilityCheck(args: BackwardCompatArgs): String {
-        if(args.repoDir != null) {
-            val repoDirFile = File(args.repoDir)
-            if (!repoDirFile.exists() || !repoDirFile.isDirectory) {
-                return getFallbackResponse(args)
-            }
-        }
+        if(isInvalidRepoDir(args)) return getFallbackResponse(args)
         val command = BackwardCompatibilityCheckCommandV2()
         val argsList = mutableListOf<String>()
         args.targetPath?.let { argsList.add("--target-path"); argsList.add(it) }
         args.baseBranch?.let { argsList.add("--base-branch"); argsList.add(it) }
-        args.repoDir?.let { argsList.add("--repo-dir"); argsList.add(args.repoDir) }
+        args.repoDir?.let { argsList.add("--repo-dir"); argsList.add(it) }
 
         val (exitCode, stdout, stderr) = captureStandardStreams {
             CommandLine(command).execute(*argsList.toTypedArray())
@@ -97,5 +92,13 @@ class BackwardCompatibilityTool {
                 suggestion = "Use the docker command"
             )
         )
+    }
+
+    internal fun isInvalidRepoDir(args: BackwardCompatArgs): Boolean {
+        if(args.repoDir != null) {
+            val repoDirFile = File(args.repoDir)
+            return !repoDirFile.exists() || !repoDirFile.isDirectory
+        }
+        return true
     }
 }

--- a/application/src/test/kotlin/application/mcp/server/tools/BackwardCompatibilityToolTest.kt
+++ b/application/src/test/kotlin/application/mcp/server/tools/BackwardCompatibilityToolTest.kt
@@ -6,7 +6,9 @@ import io.mockk.unmockkAll
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 import picocli.CommandLine
+import java.io.File
 
 class BackwardCompatibilityToolTest {
 
@@ -18,7 +20,7 @@ class BackwardCompatibilityToolTest {
     }
 
     @Test
-    fun `runBackwardCompatibilityCheck should format results correctly for a successful check`() {
+    fun `runBackwardCompatibilityCheck should format results correctly for a successful check`(@TempDir tempDir: File) {
         var capturedArgs: List<String> = emptyList()
 
         mockkConstructor(CommandLine::class)
@@ -37,7 +39,7 @@ class BackwardCompatibilityToolTest {
         val args = BackwardCompatArgs(
             targetPath = "spec.yaml",
             baseBranch = "main",
-            repoDir = "repo"
+            repoDir = tempDir.path
         )
 
         val result = tool.runBackwardCompatibilityCheck(args)
@@ -45,7 +47,7 @@ class BackwardCompatibilityToolTest {
         assertThat(capturedArgs).containsExactly(
             "--target-path", "spec.yaml",
             "--base-branch", "main",
-            "--repo-dir", "repo"
+            "--repo-dir", tempDir.path
         )
         assertThat(result).contains("## Specmatic Backward Compatibility Check")
         assertThat(result).contains("File: `spec.yaml`")
@@ -55,17 +57,36 @@ class BackwardCompatibilityToolTest {
     }
 
     @Test
-    fun `runBackwardCompatibilityCheck should format results correctly for a failed check`() {
+    fun `runBackwardCompatibilityCheck should format results correctly for a failed check`(@TempDir tempDir: File) {
         mockkConstructor(CommandLine::class)
         every { anyConstructed<CommandLine>().execute(*anyVararg()) } returns 1
 
         val args = BackwardCompatArgs(
-            targetPath = "spec.yaml"
+            targetPath = "spec.yaml",
+            repoDir = tempDir.path
         )
 
         val result = tool.runBackwardCompatibilityCheck(args)
 
         assertThat(result).contains("## Specmatic Backward Compatibility Check")
         assertThat(result).contains("Status: BREAKING CHANGES DETECTED OR CHECK FAILED")
+    }
+
+    @Test
+    fun `isInvalidRepoDir should return true when repoDir is null`() {
+        val args = BackwardCompatArgs(targetPath = "spec.yaml")
+        assertThat(tool.isInvalidRepoDir(args)).isTrue()
+    }
+
+    @Test
+    fun `isInvalidRepoDir should return false when repoDir exists`(@TempDir tempDir: File) {
+        val args = BackwardCompatArgs(repoDir = tempDir.path)
+        assertThat(tool.isInvalidRepoDir(args)).isFalse()
+    }
+
+    @Test
+    fun `isInvalidRepoDir should return true when repoDir does not exist`() {
+        val args = BackwardCompatArgs(repoDir = "non_existent_dir_12345")
+        assertThat(tool.isInvalidRepoDir(args)).isTrue()
     }
 }


### PR DESCRIPTION
Reason to change: 
BCC mcp tool was failing when use with docker. This PR ensures that the failure is handled by returning a docker bcc command as response by MCP as fallback.