### PR TITLE
Preserve default response reporting in test coverage

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -835,6 +835,8 @@ data class Scenario(
 
     fun isA4xxScenario(): Boolean = this.httpResponsePattern.status in 400..499
 
+    fun isDefaultResponse(): Boolean = this.httpResponsePattern.status == DEFAULT_RESPONSE_CODE
+
     fun hasExampleRows(): Boolean = examples.any { it.rows.isNotEmpty() }
 
     fun hasExamples(): Boolean = examples.isNotEmpty() && hasExampleRows()

--- a/core/src/main/kotlin/io/specmatic/test/TestResultRecord.kt
+++ b/core/src/main/kotlin/io/specmatic/test/TestResultRecord.kt
@@ -197,8 +197,11 @@ fun openAPIOperationFrom(scenario: Scenario, path: String): OpenAPIOperation {
         path = path,
         method = scenario.soapActionUnescaped ?: scenario.method,
         contentType = scenario.requestContentType,
-        responseCode = scenario.status,
+        responseCode = scenario.openAPIResponseCode(),
         protocol = scenario.protocol,
         responseContentType = scenario.responseContentType,
     )
 }
+
+private fun Scenario.openAPIResponseCode(): Int =
+    if (isDefaultResponse()) DEFAULT_RESPONSE_CODE else status

--- a/core/src/test/kotlin/io/specmatic/test/ScenarioAsTestTest.kt
+++ b/core/src/test/kotlin/io/specmatic/test/ScenarioAsTestTest.kt
@@ -5,6 +5,7 @@ import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
 import io.mockk.verify
+import io.specmatic.core.DEFAULT_RESPONSE_CODE
 import io.specmatic.core.Feature
 import io.specmatic.core.utilities.Decision
 import io.specmatic.core.utilities.Reasoning
@@ -44,6 +45,7 @@ import io.specmatic.core.substitution.SubstitutionImpl
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.license.core.SpecmaticProtocol
 import io.specmatic.mock.ScenarioStub
+import io.specmatic.reporter.model.OpenAPIOperation
 import io.specmatic.reporter.model.SpecType
 import io.specmatic.test.fixtures.OpenAPIFixtureExecutor
 import io.specmatic.test.fixtures.FixtureExecutionMetadata
@@ -476,6 +478,8 @@ class ScenarioAsTestTest {
         assertThat(updatedScenario.statusInDescription).isEqualTo("1000")
         assertThat(scenarioInRecord.statusInDescription).isEqualTo("1000")
         assertThat(updatedScenario.httpResponsePattern.headersPattern.contentType).isEqualTo("application/xml")
+        assertThat(testResultRecord.responseStatus).isEqualTo(400)
+        assertThat((testResultRecord.operations.single() as OpenAPIOperation).responseCode).isEqualTo(DEFAULT_RESPONSE_CODE)
     }
 
     @Test

--- a/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/CoverageReportGeneratorTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/CoverageReportGeneratorTest.kt
@@ -1,5 +1,6 @@
 package io.specmatic.test.reports.coverage
 
+import io.specmatic.core.DEFAULT_RESPONSE_CODE
 import io.specmatic.core.HttpResponse
 import io.specmatic.core.Scenario
 import io.specmatic.core.utilities.Decision
@@ -81,6 +82,37 @@ class CoverageReportGeneratorTest {
         val missingInSpecFromApplicationEndpoint = reportOperations.single { it.operation.path == "/payments" }
         assertThat(missingInSpecFromApplicationEndpoint.coverageStatus).isEqualTo(CoverageStatus.MISSING_IN_SPEC)
         assertThat(missingInSpecFromApplicationEndpoint.specConfig.specification).isEqualTo("specs/openapi.yaml")
+    }
+
+    @Test
+    fun `should cover default response operation when an undeclared status matches it`() {
+        val defaultEndpoint = endpoint("/orders", "GET", null, DEFAULT_RESPONSE_CODE, "text/plain")
+        val defaultOperation = defaultEndpoint.toOpenApiOperation()
+        val defaultResponseRecord = TestResultRecord(
+            path = "/orders",
+            method = "GET",
+            responseStatus = DEFAULT_RESPONSE_CODE,
+            responseContentType = "text/plain",
+            request = null,
+            response = HttpResponse(status = 400, headers = mapOf("Content-Type" to "text/plain")),
+            result = TestResult.Success,
+            specification = "specs/openapi.yaml",
+            specType = SpecType.OPENAPI,
+            actualResponseStatus = 400,
+            actualResponseContentType = "text/plain",
+            operations = setOf(defaultOperation),
+        )
+        val context = CoverageContext(
+            tests = listOf(defaultResponseRecord),
+            allSpecEndpoints = listOf(defaultEndpoint),
+        )
+
+        val reportOperation = reportGenerator.generateReportOperations(context).single()
+
+        assertThat(reportOperation.operation.responseCode).isEqualTo(DEFAULT_RESPONSE_CODE)
+        assertThat(reportOperation.coverageStatus).isEqualTo(CoverageStatus.COVERED)
+        assertThat(reportOperation.metrics?.attempts).isEqualTo(1)
+        assertThat(reportOperation.metrics?.matches).isEqualTo(1)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Preserve the default response code when reporting scenarios with undeclared response statuses.
- Add regression coverage for test results and coverage reports.