### PR TITLE
Handle response examples without matching request examples

### DIFF
--- a/application/src/test/kotlin/application/ExamplesCommandTest.kt
+++ b/application/src/test/kotlin/application/ExamplesCommandTest.kt
@@ -450,7 +450,7 @@ paths:
             assertThat(exitCode).isEqualTo(0)
             assertThat(stdOut).containsIgnoringWhitespaces("""
             =============== Inline Example Validation Summary ===============
-            All 1 example(s) are valid.
+            All 2 example(s) are valid.
             =================================================================
             """.trimIndent())
             assertThat(stdOut).containsIgnoringWhitespaces("""
@@ -460,7 +460,7 @@ paths:
             """.trimIndent())
             assertThat(stdOut).containsIgnoringWhitespaces("""
             =============== Overall Validation Summary ===============
-            All 3 example(s) are valid.
+            All 4 example(s) are valid.
             ==========================================================
             """.trimIndent())
         }
@@ -475,7 +475,7 @@ paths:
             assertThat(exitCode).isEqualTo(0)
             assertThat(stdOut).containsIgnoringWhitespaces("""
             =============== Inline Example Validation Summary ===============
-            All 1 example(s) are valid.
+            All 2 example(s) are valid.
             =================================================================
             """.trimIndent())
             assertThat(stdOut).containsIgnoringWhitespaces("""
@@ -485,7 +485,7 @@ paths:
             """.trimIndent())
             assertThat(stdOut).containsIgnoringWhitespaces("""
             =============== Overall Validation Summary ===============
-            All 3 example(s) are valid.
+            All 4 example(s) are valid.
             ==========================================================
             """.trimIndent())
         }
@@ -502,7 +502,7 @@ paths:
             """.trimIndent())
             assertThat(stdOut).containsIgnoringWhitespaces("""
             =============== Inline Example Validation Summary ===============
-            All 1 example(s) are valid.
+            All 2 example(s) are valid.
             =================================================================
             """.trimIndent())
             assertThat(stdOut).containsIgnoringWhitespaces("""
@@ -513,7 +513,7 @@ paths:
             assertThat(stdOut).containsIgnoringWhitespaces("""
             Summary:
             =============== Overall Validation Summary ===============
-            All 1 example(s) are valid.
+            All 2 example(s) are valid.
             ==========================================================
             """.trimIndent())
         }
@@ -593,7 +593,7 @@ paths:
             assertThat(stdOut).containsIgnoringWhitespaces("""
             life cycle hook called for 'Validation'
             spec: 'persons.yaml'
-            implicit example: 'person-example-01,person-example-11'
+            implicit example: 'person-example-01,person-example-11,person-list-example'
             external stub: 'create_person-01.json,create_person-02.json'
             """.trimIndent())
         }
@@ -611,7 +611,7 @@ paths:
             assertThat(stdOut).containsIgnoringWhitespaces("""
             life cycle hook called for 'Validation'
             spec: 'persons.yaml'
-            implicit example: 'person-example-01,person-example-11'
+            implicit example: 'person-example-01,person-example-11,person-list-example'
             external stub: 'create_person-01.json'
             """.trimIndent())
         }
@@ -629,7 +629,7 @@ paths:
             assertThat(stdOut).containsIgnoringWhitespaces("""
             life cycle hook called for 'Validation'
             spec: 'persons.yaml'
-            implicit example: 'person-example-01,person-example-11'
+            implicit example: 'person-example-01,person-example-11,person-list-example'
             external stub: 'create_person-01.json,create_person-02.json'
             """.trimIndent())
         }
@@ -644,13 +644,13 @@ paths:
             assertThat(stdOut).containsIgnoringWhitespaces("""
             life cycle hook called for 'Validation'
             spec: 'persons.yaml'
-            implicit example: 'person-example-01,person-example-11'
+            implicit example: 'person-example-01,person-example-11,person-list-example'
             external stub: 'create_person-01.json,create_person-02.json'
             """.trimIndent())
             assertThat(stdOut).containsIgnoringWhitespaces("""
             life cycle hook called for 'Validation'
             spec: 'spec.yaml'
-            implicit example: 'CreateProduct'
+            implicit example: 'CreateProduct,GetProduct'
             external stub: 'example_1.json,example_3.json'
             """.trimIndent())
         }
@@ -667,13 +667,13 @@ paths:
             assertThat(stdOut).containsIgnoringWhitespaces("""
             life cycle hook called for 'Validation'
             spec: 'persons.yaml'
-            implicit example: 'person-example-01,person-example-11'
+            implicit example: 'person-example-01,person-example-11,person-list-example'
             external stub: 'create_person-01.json,create_person-02.json'
             """.trimIndent())
             assertThat(stdOut).containsIgnoringWhitespaces("""
             life cycle hook called for 'Validation'
             spec: 'spec.yaml'
-            implicit example: 'CreateProduct'
+            implicit example: 'CreateProduct,GetProduct'
             external stub: 'example_1.json,example_3.json'
             """.trimIndent())
         }

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -69,9 +69,21 @@ private val HINT_VALUE_DELIMITERS = charArrayOf(',')
 
 var missingRequestExampleErrorMessageForTest: String = "WARNING: Ignoring response example named %s for test or stub data, because no associated request example named %s was found."
 var missingResponseExampleErrorMessageForTest: String = "WARNING: Ignoring request example named %s for test or stub data, because no associated response example named %s was found."
+private const val MISSING_REQUEST_EXAMPLE_ERROR_MESSAGE = "ERROR: Response example named %s has no associated request example named %s."
 
 internal fun missingRequestExampleErrorMessageForTest(exampleName: String): String =
     missingRequestExampleErrorMessageForTest.format(exampleName, exampleName)
+
+internal fun missingRequestExampleErrorMessage(exampleName: String): String =
+    MISSING_REQUEST_EXAMPLE_ERROR_MESSAGE.format(exampleName, exampleName)
+
+internal fun responseExampleWithoutRequestWarning(
+    exampleName: String,
+    responseStatus: Int,
+    httpMethod: String,
+    openApiPath: String
+): String =
+    "WARNING: Ignoring $responseStatus response example named $exampleName for ${httpMethod.uppercase()} $openApiPath because the operation has no request parameters or body where a matching named request example can be defined."
 
 internal fun missingResponseExampleErrorMessageForTest(exampleName: String): String =
     missingResponseExampleErrorMessageForTest.format(exampleName, exampleName)
@@ -773,6 +785,11 @@ class OpenApiSpecification(
         val unusedRequestExampleNames: Set<String>
     )
 
+    private data class ResponseExampleIdentifier(val status: Int, val name: String) {
+        fun matches(responseExample: HttpResponse, exampleName: String): Boolean =
+            responseExample.status == status && exampleName == name
+    }
+
     private data class NoBodyExampleUpdate(
         val additionalInlineExamples: List<NamedStub>,
         val updatedScenarioInfos: List<ScenarioInfo>
@@ -823,6 +840,11 @@ class OpenApiSpecification(
                         httpResponsePatterns.filter { it.responsePattern.status.toString().startsWith("2") }
                             .minOfOrNull { it.responsePattern.status }
 
+                    val firstAvailable2xxResponseExample = httpResponsePatterns.asSequence()
+                        .filter { it.responsePattern.status.toString().startsWith("2") && it.examples.isNotEmpty() }
+                        .map { ResponseExampleIdentifier(it.responsePattern.status, it.examples.keys.first()) }
+                        .firstOrNull()
+
                     val firstNoBodyResponseStatus =
                         httpResponsePatterns.filter { it.responsePattern.body is NoBodyPattern }
                             .minOfOrNull { it.responsePattern.status }
@@ -842,6 +864,9 @@ class OpenApiSpecification(
                                 requestHeaderPointers = requestHeaderPointers
                             )
                         }
+
+                    val canContainNamedRequestExample =
+                        parameters.isNotEmpty() || httpRequestPatterns.any { it.original != null }
 
                     val httpRequestPatternDataGroupedByContentType = httpRequestPatterns.groupBy {
                         it.requestPattern.headersPattern.contentType
@@ -895,6 +920,10 @@ class OpenApiSpecification(
                                 parameters,
                                 openApiRequest,
                                 first2xxResponseStatus,
+                                firstAvailable2xxResponseExample,
+                                canContainNamedRequestExample,
+                                httpMethod,
+                                openApiPath,
                                 httpRequestPattern.nestedObjectQueryParamsByName(),
                                 httpRequestPattern.httpQueryParamPattern.queryPatterns
                             )
@@ -932,10 +961,17 @@ class OpenApiSpecification(
                     }
 
                     val requestExamples = mergeRequestExamples(httpRequestPatterns)
+
+                    val requestsForResponseExamplesWithoutNamedRequests =
+                        if (canContainNamedRequestExample) emptyList()
+                        else requestsForOperationWithoutNamedRequestExamples(httpRequestPatterns)
+
                     val examples = collateExamplesForExpectations(
                         requestExamples = requestExamples,
                         responseExamplesList = httpResponsePatterns,
                         operationPointer = "${pathScopePointer(openApiPath)}/${httpMethod.lowercase()}",
+                        requestsForResponseExamplesWithoutNamedRequests = requestsForResponseExamplesWithoutNamedRequests,
+                        firstAvailable2xxResponseExample = firstAvailable2xxResponseExample,
                     )
 
                     val requestExampleNames = requestExamples.keys.toSet()
@@ -1116,14 +1152,21 @@ class OpenApiSpecification(
         operationPointer: String,
         requestExamples: Map<String, List<RequestExample>>,
         responseExamplesList: List<ResponsePatternData>,
+        requestsForResponseExamplesWithoutNamedRequests: List<RequestExample>,
+        firstAvailable2xxResponseExample: ResponseExampleIdentifier?,
     ): List<NamedStub> {
         return responseExamplesList.flatMap { responseData ->
-            responseData.examples.filter { (name, response) ->
-                name in requestExamples
-                        && response.status != HttpStatusCode.MethodNotAllowed.value
-                        && response.status != HttpStatusCode.UnsupportedMediaType.value
+            responseData.examples.filterNot { (_, response) ->
+                response.status == HttpStatusCode.MethodNotAllowed.value ||
+                        response.status == HttpStatusCode.UnsupportedMediaType.value
             }.flatMap { (name, response) ->
-                requestExamples.getValue(name).map { requestExample ->
+                val requests = requestExamples[name]
+                    ?: requestsForResponseExamplesWithoutNamedRequests.takeIf {
+                        firstAvailable2xxResponseExample?.matches(response, name) == true
+                    }
+                    ?: emptyList()
+
+                requests.map { requestExample ->
                     NamedStub(
                         name = name,
                         stub = ScenarioStub(request = requestExample.request, response = response, exampleType = ExampleType.INLINE),
@@ -1137,6 +1180,24 @@ class OpenApiSpecification(
             }
         }
     }
+
+    private fun requestsForOperationWithoutNamedRequestExamples(
+        requestPatterns: List<RequestPatternsData>
+    ): List<RequestExample> =
+        requestPatterns.flatMap { requestPatternData ->
+            val requestPattern = requestPatternData.requestPattern
+            val request = HttpRequest(
+                method = requestPattern.method,
+                path = requestPattern.httpPathPattern?.toInternalPath()
+            )
+
+            requestPattern.securitySchemes.map { securityScheme ->
+                RequestExample(
+                    request = securityScheme.addTo(request),
+                    sourcePointer = requestPatternData.sourcePointer,
+                )
+            }
+        }.distinct()
 
     private fun mergeRequestExamples(requestPatterns: List<RequestPatternsData>): Map<String, List<RequestExample>> {
         return requestPatterns
@@ -1258,6 +1319,10 @@ class OpenApiSpecification(
         parameters: List<Parameter>,
         openApiRequest: Pair<String, MediaType>?,
         first2xxResponseStatus: Int?,
+        firstAvailable2xxResponseExample: ResponseExampleIdentifier?,
+        canContainNamedRequestExample: Boolean,
+        httpMethod: String,
+        openApiPath: String,
         nestedObjectQueryParamsByName: Map<String, NestedObjectQueryParam> = emptyMap(),
         effectiveQueryPatterns: Map<String, Pattern> = emptyMap()
     ): List<Row> {
@@ -1278,13 +1343,28 @@ class OpenApiSpecification(
             }.toMap().ifEmpty { mapOf(SPECMATIC_TEST_WITH_NO_REQ_EX to "") }
 
             if (requestExamples.containsKey(SPECMATIC_TEST_WITH_NO_REQ_EX)) {
-                if (strictMode) {
-                    throw ContractException(missingRequestExampleErrorMessageForTest(exampleName))
+                if (strictMode && canContainNamedRequestExample) {
+                    throw ContractException(missingRequestExampleErrorMessage(exampleName))
                 }
-                if (responseExample.status != first2xxResponseStatus) {
+                val shouldUseResponseExample = if (canContainNamedRequestExample)
+                    responseExample.status == first2xxResponseStatus
+                else
+                    firstAvailable2xxResponseExample?.matches(responseExample, exampleName) == true
+
+                if (shouldUseResponseExample.not()) {
                     // TODO: Collect as warning
-                    if (specmaticConfig.getIgnoreInlineExampleWarnings().not())
-                        logger.log(missingRequestExampleErrorMessageForTest(exampleName))
+                    if (specmaticConfig.getIgnoreInlineExampleWarnings().not()) {
+                        val warning = if (canContainNamedRequestExample)
+                            missingRequestExampleErrorMessageForTest(exampleName)
+                        else
+                            responseExampleWithoutRequestWarning(
+                                exampleName,
+                                responseExample.status,
+                                httpMethod,
+                                openApiPath
+                            )
+                        logger.log(warning)
+                    }
                     return@mapNotNull null
                 }
             }

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -85,6 +85,16 @@ internal fun responseExampleWithoutRequestWarning(
 ): String =
     "WARNING: Ignoring $responseStatus response example named $exampleName for ${httpMethod.uppercase()} $openApiPath because the operation has no request parameters or body where a matching named request example can be defined."
 
+internal fun unselected2xxResponseExampleWarning(
+    exampleName: String,
+    responseStatus: Int,
+    httpMethod: String,
+    openApiPath: String,
+    selectedExampleName: String,
+    selectedResponseStatus: Int
+): String =
+    "WARNING: Ignoring $responseStatus response example named $exampleName for ${httpMethod.uppercase()} $openApiPath. Since the operation has no request parameters or body, there is no way to indicate which response should be triggered by the request. The first example named $selectedExampleName from the first 2xx response with examples ($selectedResponseStatus) will be used."
+
 internal fun missingResponseExampleErrorMessageForTest(exampleName: String): String =
     missingResponseExampleErrorMessageForTest.format(exampleName, exampleName)
 
@@ -1354,15 +1364,24 @@ class OpenApiSpecification(
                 if (shouldUseResponseExample.not()) {
                     // TODO: Collect as warning
                     if (specmaticConfig.getIgnoreInlineExampleWarnings().not()) {
-                        val warning = if (canContainNamedRequestExample)
-                            missingRequestExampleErrorMessageForTest(exampleName)
-                        else
-                            responseExampleWithoutRequestWarning(
+                        val warning = when {
+                            canContainNamedRequestExample -> missingRequestExampleErrorMessageForTest(exampleName)
+                            responseExample.status in 200..299 && firstAvailable2xxResponseExample != null ->
+                                unselected2xxResponseExampleWarning(
+                                    exampleName,
+                                    responseExample.status,
+                                    httpMethod,
+                                    openApiPath,
+                                    firstAvailable2xxResponseExample.name,
+                                    firstAvailable2xxResponseExample.status
+                                )
+                            else -> responseExampleWithoutRequestWarning(
                                 exampleName,
                                 responseExample.status,
                                 httpMethod,
                                 openApiPath
                             )
+                        }
                         logger.log(warning)
                     }
                     return@mapNotNull null

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -8419,7 +8419,7 @@ paths:
 
         val exampleName = "SUCCESSFUL_API_CALL"
         assertThat(stdout)
-            .contains("Ignoring response example named $exampleName for test or stub data, because no associated request example named $exampleName was found.")
+            .contains(missingRequestExampleErrorMessageForTest(exampleName))
     }
 
     @Test
@@ -8745,7 +8745,7 @@ components:
     }
 
     @Test
-    fun `missing request example should still pick up valid 2xx response example`() {
+    fun `strict mode should retain only first example from first available 2xx response for tests when operation cannot contain a named request example`() {
         val spec = """
         ---
         openapi: "3.0.1"
@@ -8758,6 +8758,8 @@ components:
               summary: "Get all persons"
               responses:
                 200:
+                  description: "accepted without an example"
+                201:
                   description: "all persons"
                   content:
                     text/plain:
@@ -8766,10 +8768,135 @@ components:
                       examples:
                         SUCCESSFUL_API_CALL:
                           value: "all persons"
+                        ANOTHER_SUCCESSFUL_API_CALL:
+                          value: "another set of persons"
         """.trimIndent()
-        val name =
-            OpenApiSpecification.fromYAML(spec, "").toFeature().scenarios.single().examples.single().rows.single().name
-        assertThat(name).isEqualTo("SUCCESSFUL_API_CALL")
+        val feature = OpenApiSpecification.fromYAML(spec, "", strictMode = true).toFeature()
+        val responseWithoutExamples = feature.scenarios.single { it.status == 200 }
+        val responseWithExamples = feature.scenarios.single { it.status == 201 }
+
+        assertThat(responseWithoutExamples.examples).isEmpty()
+        assertThat(responseWithExamples.examples.single().rows.map { it.name })
+            .containsExactly("SUCCESSFUL_API_CALL")
+    }
+
+    @Test
+    fun `strict mode should warn and ignore non-2xx response example when operation cannot contain a named request example`() {
+        val path = "/health"
+        val spec = """
+            openapi: 3.0.3
+            info:
+              title: Health API
+              version: 1.0.0
+            paths:
+              $path:
+                get:
+                  responses:
+                    '200':
+                      description: Healthy
+                    '503':
+                      description: Service unavailable
+                      content:
+                        application/json:
+                          schema:
+                            type: string
+                          examples:
+                            serviceUnavailable:
+                              value: unavailable
+        """.trimIndent()
+
+        lateinit var feature: Feature
+        val (output, _) = captureStandardOutput {
+            feature = OpenApiSpecification.fromYAML(spec, "", strictMode = true).toFeature()
+        }
+
+        assertThat(output).contains(
+            responseExampleWithoutRequestWarning("serviceUnavailable", 503, "get", path)
+        )
+        assertThat(feature.inlineNamedStubs).isEmpty()
+        assertThat(feature.scenarios.single { it.status == 503 }.examples).isEmpty()
+    }
+
+    @Test
+    fun `strict mode should create inline mock expectation from first 2xx response example when operation cannot contain a named request example`() {
+        val spec = """
+            openapi: 3.0.3
+            info:
+              title: Secured Ping API
+              version: 1.0.0
+            security:
+              - apiKey: []
+            paths:
+              /ping:
+                get:
+                  responses:
+                    '200':
+                      description: Success without an example
+                    '201':
+                      description: Created
+                      content:
+                        text/plain:
+                          schema:
+                            type: string
+                          examples:
+                            PING:
+                              value: success
+                            ANOTHER_PING:
+                              value: another success
+            components:
+              securitySchemes:
+                apiKey:
+                  type: apiKey
+                  in: header
+                  name: X-API-Key
+        """.trimIndent()
+
+        val feature = OpenApiSpecification.fromYAML(spec, "", strictMode = true).toFeature()
+        val inlineStub = feature.inlineNamedStubs.single { it.name == "PING" }.stub
+
+        assertThat(inlineStub.request.method).isEqualTo("GET")
+        assertThat(inlineStub.request.path).isEqualTo("/ping")
+        assertThat(inlineStub.request.headers).containsKey("X-API-Key")
+        assertThat(inlineStub.response.status).isEqualTo(201)
+        assertThat(inlineStub.response.body).isEqualTo(StringValue("success"))
+        assertThat(feature.inlineNamedStubs.map { it.name }).containsExactly("PING")
+        assertThat(feature.loadInlineExamplesAsStub()).hasSize(1)
+    }
+
+    @Test
+    fun `strict mode should error when a parameter could contain the matching named request example`() {
+        val spec = """
+            openapi: 3.0.3
+            info:
+              title: Search API
+              version: 1.0.0
+            paths:
+              /items:
+                get:
+                  parameters:
+                    - name: pageToken
+                      in: query
+                      schema:
+                        type: string
+                  responses:
+                    '200':
+                      description: Items
+                      content:
+                        application/json:
+                          schema:
+                            type: array
+                            items:
+                              type: string
+                          examples:
+                            firstPage:
+                              value: []
+        """.trimIndent()
+
+        val error = assertThrows<ContractException> {
+            OpenApiSpecification.fromYAML(spec, "", strictMode = true).toFeature()
+        }
+
+        assertThat(error.message).isEqualTo(missingRequestExampleErrorMessage("firstPage"))
     }
 
     @Test
@@ -12414,14 +12541,14 @@ paths:
     }
 
     @Test
-    fun `should throw exception when a request example has no matching response example during conversion in strict mode`() {
+    fun `should throw an error when a response example has no matching request example during conversion in strict mode`() {
         val specPath = "src/test/resources/openapi/inline_response_example_without_request.yaml"
         val error = assertThrows<ContractException> {
             OpenApiSpecification.fromYAML(yamlContent= File(specPath).readText(), openApiFilePath = specPath, strictMode = true).toFeature()
         }
 
         assertThat(error.message)
-            .contains(missingRequestExampleErrorMessageForTest("success_response"))
+            .isEqualTo(missingRequestExampleErrorMessage("success_response"))
     }
 
 

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -8781,6 +8781,48 @@ components:
     }
 
     @Test
+    fun `strict mode should select first available 2xx response example in declaration order when operation cannot contain a named request example`() {
+        val spec = """
+            openapi: 3.0.3
+            info:
+              title: Declaration Order API
+              version: 1.0.0
+            paths:
+              /result:
+                get:
+                  responses:
+                    '201':
+                      description: Created
+                      content:
+                        text/plain:
+                          schema:
+                            type: string
+                          examples:
+                            CREATED_FIRST:
+                              value: first created response
+                            CREATED_SECOND:
+                              value: second created response
+                    '200':
+                      description: Success
+                      content:
+                        text/plain:
+                          schema:
+                            type: string
+                          examples:
+                            SUCCESS:
+                              value: successful response
+        """.trimIndent()
+
+        val feature = OpenApiSpecification.fromYAML(spec, "", strictMode = true).toFeature()
+        val firstDeclaredResponse = feature.scenarios.single { it.status == 201 }
+        val laterDeclaredResponse = feature.scenarios.single { it.status == 200 }
+
+        assertThat(firstDeclaredResponse.examples.single().rows.map { it.name })
+            .containsExactly("CREATED_FIRST")
+        assertThat(laterDeclaredResponse.examples).isEmpty()
+    }
+
+    @Test
     fun `strict mode should warn and ignore non-2xx response example when operation cannot contain a named request example`() {
         val path = "/health"
         val spec = """

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -8823,6 +8823,50 @@ components:
     }
 
     @Test
+    fun `strict mode should explain which inline example is selected when ignoring additional 2xx response examples`() {
+        val path = "/customer"
+        val spec = """
+            openapi: 3.0.3
+            info:
+              title: Customer API
+              version: 1.0.0
+            paths:
+              $path:
+                get:
+                  responses:
+                    '201':
+                      description: Created
+                      content:
+                        application/json:
+                          schema:
+                            type: string
+                          examples:
+                            SUCCESS_1:
+                              value: success-1
+                            SUCCESS_2:
+                              value: success-2
+                    '200':
+                      description: Success
+                      content:
+                        application/json:
+                          schema:
+                            type: string
+                          examples:
+                            SUCCESS_3:
+                              value: success-3
+        """.trimIndent()
+
+        val (output, _) = captureStandardOutput {
+            OpenApiSpecification.fromYAML(spec, "", strictMode = true).toFeature()
+        }
+
+        assertThat(output).contains(
+            unselected2xxResponseExampleWarning("SUCCESS_2", 201, "get", path, "SUCCESS_1", 201),
+            unselected2xxResponseExampleWarning("SUCCESS_3", 200, "get", path, "SUCCESS_1", 201)
+        )
+    }
+
+    @Test
     fun `strict mode should warn and ignore non-2xx response example when operation cannot contain a named request example`() {
         val path = "/health"
         val spec = """

--- a/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
@@ -924,6 +924,16 @@ paths:
                 paths:
                   /hello:
                     get:
+                      parameters:
+                        - name: example
+                          in: query
+                          schema:
+                            type: string
+                          examples:
+                            FIRST:
+                              value: first
+                            SECOND:
+                              value: second
                       responses:
                         '200':
                           description: OK


### PR DESCRIPTION
## Summary

- Support strict-mode response examples for operations without request parameters or bodies
- Select the first example from the first available 2xx response
- Add clear warnings and errors for ignored or unmatched examples
- Expand OpenAPI conversion coverage for these cases