### PR TITLE
Select OpenAPI example responses by status

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/BadRequestOrDefault.kt
+++ b/core/src/main/kotlin/io/specmatic/core/BadRequestOrDefault.kt
@@ -32,14 +32,12 @@ class BadRequestOrDefault(val badRequestResponses: Map<Int, List<Scenario>> = em
         val sameStatus = badRequestResponses[httpResponse.status].orEmpty()
         val otherStatuses = badRequestResponses.filterKeys { it != httpResponse.status }.values.flatten()
 
-        val sameStatusAndContentType = matchByContentType(sameStatus, httpResponse)
-        if (sameStatusAndContentType != null) return BestEffortMatch(sameStatusAndContentType)
+        if (sameStatus.isNotEmpty()) {
+            return BestEffortMatch(matchByContentType(sameStatus, httpResponse) ?: sameStatus.first())
+        }
 
         val defaultAndContentType = matchByContentType(defaultResponses, httpResponse)
         if (defaultAndContentType != null) return BestEffortMatch(defaultAndContentType, fromDefault = true)
-
-        val sameStatusFirst = sameStatus.firstOrNull()
-        if (sameStatusFirst != null) return BestEffortMatch(sameStatusFirst)
 
         val otherStatusAndContentType = matchByContentType(otherStatuses, httpResponse)
         if (otherStatusAndContentType != null) return BestEffortMatch(otherStatusAndContentType)

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -803,11 +803,14 @@ data class Feature(
         onSuccess: (Scenario) -> T
     ): ScenarioMatchResult<T> {
         val failures = mutableListOf<Result>()
-        val filteredScenarios = getMatchingAndSortedScenarios(
+        val requestMatchingScenarios = getMatchingAndSortedScenarios(
             request,
             scenarios,
             responseStatus
         )
+        val filteredScenarios = responseStatus?.let {
+            scenariosEligibleForResponseStatus(request, it, requestMatchingScenarios)
+        } ?: requestMatchingScenarios
 
         for (scenario in filteredScenarios) {
             try {
@@ -821,6 +824,25 @@ data class Feature(
         }
 
         return EarlyResult.Failures(failures.filterIsInstance<Result.Failure>())
+    }
+
+    private fun scenariosEligibleForResponseStatus(
+        request: HttpRequest,
+        responseStatus: Int,
+        candidateScenarios: List<Scenario> = scenarios
+    ): List<Scenario> {
+        val operationScenarios = candidateScenarios.filter { it.matchesPathStructureAndMethod(request) }
+        if (operationScenarios.isEmpty()) return candidateScenarios
+
+        val explicitlyDeclaredResponseStatuses = operationScenarios.asSequence()
+            .map { it.status }
+            .filter { it != DEFAULT_RESPONSE_CODE }
+            .toSet()
+
+        return candidateScenarios.filter { scenario ->
+            scenario !in operationScenarios ||
+                    scenario.ownsResponseStatus(responseStatus, explicitlyDeclaredResponseStatuses)
+        }
     }
 
     private fun Decision<ReturnValue<Scenario>, Scenario>.normalizeAcceptHeader(): Decision<ReturnValue<Scenario>, Scenario> {
@@ -1150,6 +1172,7 @@ data class Feature(
         val request = scenarioStub.requestElsePartialRequest()
         val result = matchRequestScenariosWithEarlySuccess(
             request = request,
+            responseStatus = scenarioStub.responseStatus(),
             match = { scenario -> scenario.matchesPartial(scenarioStub.partial, mismatchMessages) },
             onSuccess = { scenario ->
                 val requestTypeWithAncestors = scenario.httpRequestPattern.copy(headersPattern = scenario.httpRequestPattern.headersPattern.copy(ancestorHeaders = scenario.httpRequestPattern.headersPattern.pattern))
@@ -2279,11 +2302,18 @@ data class Feature(
 
     private fun useExamples(externalisedJSONExamples: Map<OpenApiSpecification.OperationIdentifier, List<Row>>): Feature {
         val scenariosWithExamples: List<Scenario> = scenarios.map {
-            it.useExamples(externalisedJSONExamples)
+            it.useExamples(externalisedJSONExamples, explicitlyDeclaredResponseStatusesFor(it))
         }
 
         return this.copy(scenarios = scenariosWithExamples)
     }
+
+    private fun explicitlyDeclaredResponseStatusesFor(scenario: Scenario): Set<Int> =
+        scenarios.asSequence()
+            .filter { it.method == scenario.method && it.path == scenario.path }
+            .map { it.status }
+            .filter { it != DEFAULT_RESPONSE_CODE }
+            .toSet()
 
     fun filterExamples(examples: List<ScenarioStub>, filter: String): FeatureAndExamples {
         if (filter.isBlank()) return FeatureAndExamples(this, externalExamples = examples)

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -199,6 +199,10 @@ data class Scenario(
         return matchesContentType(httpResponse)
     }
 
+    internal fun ownsResponseStatus(responseStatus: Int, explicitlyDeclaredResponseStatuses: Set<Int>): Boolean =
+        status == responseStatus ||
+                (status == DEFAULT_RESPONSE_CODE && responseStatus !in explicitlyDeclaredResponseStatuses)
+
     fun matchesContentType(httpResponse: HttpResponse): Boolean {
         val result = this.httpResponsePattern.matchesContentType(httpResponse, resolver)
         return result.isSuccess()
@@ -880,8 +884,18 @@ data class Scenario(
         )
     }
 
-    fun useExamples(rawExternalisedExamples: Map<OpenApiSpecification.OperationIdentifier, List<Row>>): Scenario {
-        val matchingRawExternalisedExamples: Map<OpenApiSpecification.OperationIdentifier, List<Row>> = matchingRows(rawExternalisedExamples)
+    fun useExamples(rawExternalisedExamples: Map<OpenApiSpecification.OperationIdentifier, List<Row>>): Scenario =
+        useExamples(
+            rawExternalisedExamples,
+            setOf(status).filter { it != DEFAULT_RESPONSE_CODE }.toSet()
+        )
+
+    internal fun useExamples(
+        rawExternalisedExamples: Map<OpenApiSpecification.OperationIdentifier, List<Row>>,
+        explicitlyDeclaredResponseStatuses: Set<Int>
+    ): Scenario {
+        val matchingRawExternalisedExamples: Map<OpenApiSpecification.OperationIdentifier, List<Row>> =
+            matchingRows(rawExternalisedExamples, explicitlyDeclaredResponseStatuses)
 
         val externalisedExamples: List<Examples> = matchingRawExternalisedExamples.map { (operationId, rows) ->
             if(rows.isEmpty())
@@ -897,7 +911,10 @@ data class Scenario(
         return this.copy(examples = inlineExamplesThatAreNotOverridden(externalisedExamples) + externalisedExamples)
     }
 
-    private fun matchingRows(externalisedJSONExamples: Map<OpenApiSpecification.OperationIdentifier, List<Row>>): Map<OpenApiSpecification.OperationIdentifier, List<Row>> {
+    private fun matchingRows(
+        externalisedJSONExamples: Map<OpenApiSpecification.OperationIdentifier, List<Row>>,
+        explicitlyDeclaredResponseStatuses: Set<Int>
+    ): Map<OpenApiSpecification.OperationIdentifier, List<Row>> {
         val patternMatchingResolver = resolver.copy(mockMode = true)
 
         return externalisedJSONExamples.mapValues { (operationId, rows) ->
@@ -905,8 +922,13 @@ data class Scenario(
                 return@mapValues emptyList()
 
             rows.filter { row ->
-                requestBelongsToScenario(row, operationId, patternMatchingResolver)
-                        && responseBelongsToScenario(row, operationId, patternMatchingResolver)
+                requestBelongsToScenario(row, operationId, patternMatchingResolver) &&
+                        responseBelongsToScenario(
+                            row,
+                            operationId,
+                            patternMatchingResolver,
+                            explicitlyDeclaredResponseStatuses
+                        )
             }
         }.filterValues { it.isNotEmpty() }
     }
@@ -942,10 +964,16 @@ data class Scenario(
     private fun requestContentTypeForReporting(): String? =
         requestContentTypeForReport ?: httpRequestPattern.headersPattern.contentType
 
-    private fun responseBelongsToScenario(row: Row, operationId: OpenApiSpecification.OperationIdentifier, patternMatchingResolver: Resolver): Boolean {
+    private fun responseBelongsToScenario(
+        row: Row,
+        operationId: OpenApiSpecification.OperationIdentifier,
+        patternMatchingResolver: Resolver,
+        explicitlyDeclaredResponseStatuses: Set<Int>
+    ): Boolean {
         return row.responseExample?.let { response ->
-            httpResponsePattern.matchesStatusAndContentType(response, patternMatchingResolver).isSuccess()
-        } ?: matchesResponseOperationIdentifier(operationId)
+            ownsResponseStatus(response.status, explicitlyDeclaredResponseStatuses) &&
+                    httpResponsePattern.matchesStatusAndContentType(response, patternMatchingResolver).isSuccess()
+        } ?: matchesResponseOperationIdentifier(operationId, explicitlyDeclaredResponseStatuses)
     }
 
     private fun matchesRequestOperationIdentifier(operationId: OpenApiSpecification.OperationIdentifier, patternMatchingResolver: Resolver): Boolean {
@@ -954,8 +982,12 @@ data class Scenario(
                 && matchesRequestContentType(operationId)
     }
 
-    private fun matchesResponseOperationIdentifier(operationId: OpenApiSpecification.OperationIdentifier): Boolean {
-        return operationId.responseStatus == status && matchesResponseContentType(operationId)
+    private fun matchesResponseOperationIdentifier(
+        operationId: OpenApiSpecification.OperationIdentifier,
+        explicitlyDeclaredResponseStatuses: Set<Int>
+    ): Boolean {
+        return ownsResponseStatus(operationId.responseStatus, explicitlyDeclaredResponseStatuses) &&
+                matchesResponseContentType(operationId)
     }
 
     private fun matchesResponseContentType(operationId: OpenApiSpecification.OperationIdentifier): Boolean {

--- a/core/src/test/kotlin/io/specmatic/core/BadRequestOrDefaultTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/BadRequestOrDefaultTest.kt
@@ -174,9 +174,10 @@ class BadRequestOrDefaultTest {
         }
 
         @Test
-        fun `should choose default and content type when same status content type does not match`() {
+        fun `should choose explicit same status before validating content type`() {
+            val explicitScenario = scenario(status = 400, contentType = "text/plain", name = "same-status")
             val badRequestOrDefault = BadRequestOrDefault(
-                badRequestResponses = mapOf(400 to listOf(scenario(status = 400, contentType = "text/plain", name = "same-status"))),
+                badRequestResponses = mapOf(400 to listOf(explicitScenario)),
                 defaultResponses = listOf(scenario(status = DEFAULT_RESPONSE_CODE, contentType = "application/json", name = "default"))
             )
 
@@ -185,7 +186,8 @@ class BadRequestOrDefaultTest {
                 scenario(status = 201, contentType = "application/xml", name = "input")
             )
 
-            assertThat(updated.statusInDescription).isEqualTo(DEFAULT_RESPONSE_CODE.toString())
+            assertThat(updated.statusInDescription).isEqualTo("400")
+            assertThat(updated.httpResponsePattern).isEqualTo(explicitScenario.httpResponsePattern)
         }
 
         @Test

--- a/core/src/test/kotlin/io/specmatic/core/examples/module/ResponseStatusSelectionTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/examples/module/ResponseStatusSelectionTest.kt
@@ -1,0 +1,286 @@
+package io.specmatic.core.examples.module
+
+import io.specmatic.core.DEFAULT_RESPONSE_CODE
+import io.specmatic.core.ExampleType
+import io.specmatic.core.Feature
+import io.specmatic.core.HttpHeadersPattern
+import io.specmatic.core.HttpRequest
+import io.specmatic.core.HttpRequestPattern
+import io.specmatic.core.HttpResponse
+import io.specmatic.core.HttpResponsePattern
+import io.specmatic.core.Result
+import io.specmatic.core.Scenario
+import io.specmatic.core.ScenarioInfo
+import io.specmatic.core.SpecmaticConfig
+import io.specmatic.core.buildHttpPathPattern
+import io.specmatic.core.examples.source.PreLoadedExampleObjects
+import io.specmatic.core.pattern.JSONObjectPattern
+import io.specmatic.core.pattern.Pattern
+import io.specmatic.core.pattern.StringPattern
+import io.specmatic.core.value.StringValue
+import io.specmatic.conversions.OpenApiSpecification
+import io.specmatic.license.core.SpecmaticProtocol
+import io.specmatic.mock.NoMatchingScenario
+import io.specmatic.mock.ScenarioStub
+import io.specmatic.reporter.model.SpecType
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+class ResponseStatusSelectionTest {
+    private val request = HttpRequest(method = "GET", path = "/products")
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `example validation does not fall through to default when the concrete status is declared`(defaultFirst: Boolean) {
+        val feature = featureWithExplicitAndDefault(defaultFirst)
+        val example = ScenarioStub(
+            request = request,
+            response = HttpResponse(
+                status = 200,
+                headers = mapOf("Content-Type" to "text/plain"),
+                body = StringValue("accepted only by default")
+            )
+        )
+
+        val result = ExampleValidationModule(specmaticConfig = SpecmaticConfig())
+            .validateExample(feature, example)
+
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `example validation rejects explicit status content type mismatch when default has the same content type`(defaultFirst: Boolean) {
+        val feature = featureWithExplicitAndDefault(defaultFirst, defaultContentType = "application/json")
+        val example = ScenarioStub(
+            request = request,
+            response = HttpResponse(
+                status = 200,
+                headers = mapOf("Content-Type" to "text/plain"),
+                body = StringValue("does not match either response representation")
+            )
+        )
+
+        val result = ExampleValidationModule(specmaticConfig = SpecmaticConfig())
+            .validateExample(feature, example)
+
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `mock expectation does not fall through to default when the concrete status is declared`(defaultFirst: Boolean) {
+        val feature = featureWithExplicitAndDefault(defaultFirst)
+        val expectation = HttpResponse(
+            status = 200,
+            headers = mapOf("Content-Type" to "text/plain"),
+            body = StringValue("accepted only by default")
+        )
+
+        assertThatThrownBy { feature.matchingStub(request, expectation) }
+            .isInstanceOf(NoMatchingScenario::class.java)
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `mock expectation does not fall through to default after explicit response body mismatch`(defaultFirst: Boolean) {
+        val feature = featureWithExplicitAndDefault(defaultFirst, defaultContentType = "application/json")
+        val expectation = HttpResponse(
+            status = 200,
+            headers = mapOf("Content-Type" to "application/json"),
+            body = StringValue("accepted only by default")
+        )
+
+        assertThatThrownBy { feature.matchingStub(request, expectation) }
+            .isInstanceOf(NoMatchingScenario::class.java)
+    }
+
+    @Test
+    fun `partial mock expectation does not fall through to default when the concrete status is declared`() {
+        val feature = featureWithExplicitAndDefault(defaultFirst = true)
+        val partialExpectation = ScenarioStub(
+            partial = ScenarioStub(
+                request = request,
+                response = HttpResponse(
+                    status = 200,
+                    headers = mapOf("Content-Type" to "text/plain"),
+                    body = StringValue("accepted only by default")
+                )
+            )
+        )
+
+        assertThatThrownBy { feature.matchingStub(partialExpectation) }
+            .isInstanceOf(NoMatchingScenario::class.java)
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `inline example is validated only against its declared response status`(defaultFirst: Boolean) {
+        val feature = OpenApiSpecification.fromYAML(openApiWithInvalidInlineExample(defaultFirst), "").toFeature()
+
+        val validationResults = ExampleValidationModule(specmaticConfig = SpecmaticConfig())
+            .validateInlineExamples(feature, feature.inlineNamedStubs)
+
+        assertThat(validationResults).hasSize(1)
+        assertThat(validationResults.values.single()).isInstanceOf(Result.Failure::class.java)
+    }
+
+    @Test
+    fun `mock expectation uses default for an undeclared concrete status and preserves that status`() {
+        val feature = Feature(
+            scenarios = listOf(defaultScenario()),
+            name = "default response",
+            protocol = SpecmaticProtocol.HTTP
+        )
+        val expectation = HttpResponse(
+            status = 500,
+            headers = mapOf("Content-Type" to "text/plain"),
+            body = StringValue("default response")
+        )
+
+        val stub = feature.matchingStub(request, expectation)
+
+        assertThat(stub.scenario?.status).isEqualTo(DEFAULT_RESPONSE_CODE)
+        assertThat(stub.response.status).isEqualTo(500)
+    }
+
+    @Test
+    fun `external example with undeclared status is associated only with default response`() {
+        val explicit = explicitScenario(status = 200)
+        val default = defaultScenario()
+        val loadedFeature = Feature(
+            scenarios = listOf(explicit, default),
+            name = "external examples",
+            protocol = SpecmaticProtocol.HTTP
+        ).loadExternalisedExamplesAndListUnloadableExamples(externalExample(status = 500)).first
+
+        assertThat(loadedFeature.scenarios.single { it.status == 200 }.externalExampleRows()).isEmpty()
+        assertThat(loadedFeature.scenarios.single { it.status == DEFAULT_RESPONSE_CODE }.externalExampleRows()).hasSize(1)
+        assertThat(loadedFeature.scenarios.single { it.status == DEFAULT_RESPONSE_CODE }.externalExampleRows().single().responseExample?.status).isEqualTo(500)
+    }
+
+    @Test
+    fun `external example with declared status is associated only with explicit response`() {
+        val explicit = explicitScenario(status = 500, contentType = "text/plain", body = StringPattern())
+        val default = defaultScenario()
+        val loadedFeature = Feature(
+            scenarios = listOf(default, explicit),
+            name = "external examples",
+            protocol = SpecmaticProtocol.HTTP
+        ).loadExternalisedExamplesAndListUnloadableExamples(externalExample(status = 500)).first
+
+        assertThat(loadedFeature.scenarios.single { it.status == 500 }.externalExampleRows()).hasSize(1)
+        assertThat(loadedFeature.scenarios.single { it.status == DEFAULT_RESPONSE_CODE }.externalExampleRows()).isEmpty()
+    }
+
+    private fun featureWithExplicitAndDefault(
+        defaultFirst: Boolean,
+        defaultContentType: String = "text/plain"
+    ): Feature {
+        val explicit = explicitScenario(
+            status = 200,
+            contentType = "application/json",
+            body = JSONObjectPattern(mapOf("name" to StringPattern()))
+        )
+        val default = defaultScenario(defaultContentType)
+        return Feature(
+            scenarios = if (defaultFirst) listOf(default, explicit) else listOf(explicit, default),
+            name = "response selection",
+            protocol = SpecmaticProtocol.HTTP
+        )
+    }
+
+    private fun explicitScenario(
+        status: Int,
+        contentType: String = "application/json",
+        body: Pattern = JSONObjectPattern(mapOf("name" to StringPattern()))
+    ): Scenario = responseScenario(status, contentType, body)
+
+    private fun defaultScenario(contentType: String = "text/plain"): Scenario = responseScenario(
+        status = DEFAULT_RESPONSE_CODE,
+        contentType = contentType,
+        body = StringPattern()
+    )
+
+    private fun responseScenario(
+        status: Int,
+        contentType: String,
+        body: Pattern
+    ): Scenario = Scenario(
+        ScenarioInfo(
+            scenarioName = "GET products -> $status",
+            httpRequestPattern = HttpRequestPattern(method = "GET", httpPathPattern = buildHttpPathPattern("/products")),
+            httpResponsePattern = HttpResponsePattern(
+                status = status,
+                headersPattern = HttpHeadersPattern(contentType = contentType),
+                body = body
+            ),
+            protocol = SpecmaticProtocol.HTTP,
+            specType = SpecType.OPENAPI
+        )
+    )
+
+    private fun externalExample(status: Int): PreLoadedExampleObjects {
+        val examples = PreLoadedExampleObjects.transform(
+            specmaticConfig = SpecmaticConfig(),
+            examples = listOf(
+                ScenarioStub(
+                    request = request,
+                    response = HttpResponse(
+                        status = status,
+                        headers = mapOf("Content-Type" to "text/plain"),
+                        body = StringValue("default response")
+                    ),
+                    exampleType = ExampleType.EXTERNAL
+                )
+            )
+        )
+        return PreLoadedExampleObjects(examples = examples)
+    }
+
+    private fun openApiWithInvalidInlineExample(defaultFirst: Boolean): String {
+        val explicitResponse = """
+            '200':
+              description: explicit response
+              content:
+                application/json:
+                  schema:
+                    type: object
+                    required: [name]
+                    properties:
+                      name:
+                        type: string
+                  examples:
+                    invalid-explicit-example:
+                      value: accepted only by default
+        """.trimIndent()
+        val defaultResponse = """
+            default:
+              description: default response
+              content:
+                application/json:
+                  schema:
+                    type: string
+        """.trimIndent()
+        val responses = if (defaultFirst) "$defaultResponse\n$explicitResponse" else "$explicitResponse\n$defaultResponse"
+
+        val header = """
+            openapi: 3.0.0
+            info:
+              title: Response selection
+              version: 1.0.0
+            paths:
+              /products:
+                get:
+                  responses:
+        """.trimIndent()
+        return "$header\n${responses.prependIndent("        ")}"
+    }
+
+    private fun Scenario.externalExampleRows() = examples
+        .flatMap { it.rows }
+        .filter { it.exampleType == ExampleType.EXTERNAL }
+}

--- a/core/src/test/kotlin/io/specmatic/test/ScenarioAsTestTest.kt
+++ b/core/src/test/kotlin/io/specmatic/test/ScenarioAsTestTest.kt
@@ -466,7 +466,7 @@ class ScenarioAsTestTest {
     }
 
     @Test
-    fun `runTest should choose default response with matching content type when same-status content type does not match`() {
+    fun `runTest should choose explicit response before validating content type`() {
         val negativeScenario = negativeScenario(
             expectedResponses = mapOf(400 to listOf(expectationScenario(status = 400, contentType = "text/plain"))),
             defaultResponses = listOf(expectationScenario(status = 1000, contentType = "application/xml"))
@@ -478,11 +478,12 @@ class ScenarioAsTestTest {
         val testResultRecord = scenarioAsTest(negativeScenario).testResultRecord(executionResult)
         val scenarioInRecord = testResultRecord.scenarioResult?.scenario as Scenario
 
-        assertThat(updatedScenario.statusInDescription).isEqualTo("1000")
-        assertThat(scenarioInRecord.statusInDescription).isEqualTo("1000")
-        assertThat(updatedScenario.httpResponsePattern.headersPattern.contentType).isEqualTo("application/xml")
+        assertThat(executionResult.result).isInstanceOf(Result.Failure::class.java)
+        assertThat(updatedScenario.statusInDescription).isEqualTo("400")
+        assertThat(scenarioInRecord.statusInDescription).isEqualTo("400")
+        assertThat(updatedScenario.httpResponsePattern.headersPattern.contentType).isEqualTo("text/plain")
         assertThat(testResultRecord.responseStatus).isEqualTo(400)
-        assertThat((testResultRecord.operations.single() as OpenAPIOperation).responseCode).isEqualTo(DEFAULT_RESPONSE_CODE)
+        assertThat((testResultRecord.operations.single() as OpenAPIOperation).responseCode).isEqualTo(400)
     }
 
     @Test


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
OpenAPI examples and mock expectations now select the eligible response definition by concrete HTTP status before validation.

<!-- Why are these changes necessary? -->

**Why**:
An explicit response must own its status, while `default` must apply only to undeclared statuses.

<!-- How were these changes implemented? -->

**How**:
Applied the status-selection rule consistently to mock expectations, external example association, and contract-test response matching, with focused regression coverage.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)

<!-- feel free to add additional comments -->