### PR TITLE
Handle 429 responses in non-4xx contract tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Each release section should stand on its own and describe the behavior shipped i
 
 ## Unreleased 
 - Updated the MCP backward compatibility tool to correctly handle Docker-based executions. When the required files are not available inside the Docker container, the tool returns the appropriate Docker backward compatibility command for the user to run.
+- Contract tests now retry documented `429 Too Many Requests` responses according to `Retry-After`, while preserving every request and response attempt for reporting integrations such as Studio.
 
 ## 2.51.1 (2026-07-31)
 

--- a/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
@@ -38,6 +38,11 @@ import kotlin.jvm.java
 private const val BEFORE_FIXTURE_DISCRIMINATOR_KEY = "before"
 private const val AFTER_FIXTURE_DISCRIMINATOR_KEY = "after"
 
+private data class ResponsesAfterHandling(
+    val responseForResult: HttpResponse,
+    val responseToValidate: HttpResponse,
+)
+
 data class ScenarioAsTest(
     override val scenario: Scenario,
     private val feature: Feature,
@@ -275,12 +280,18 @@ data class ScenarioAsTest(
                 )
             }
 
-            val responseToCheckAndStore = when (responseHandler) {
-                null -> response
+            val (responseForResult, responseToValidate) = when (responseHandler) {
+                null -> ResponsesAfterHandling(
+                    responseForResult = response,
+                    responseToValidate = response,
+                )
                 else -> {
                     val client = if (testExecutor is LegacyHttpClient) testExecutor.copy() else testExecutor
                     when (val handlerResult = responseHandler.handle(request, response, scenario, client)) {
-                        is ResponseHandlingResult.Continue -> handlerResult.response
+                        is ResponseHandlingResult.Continue -> ResponsesAfterHandling(
+                            responseForResult = handlerResult.recordedResponseOverride ?: response,
+                            responseToValidate = handlerResult.response,
+                        )
                         is ResponseHandlingResult.Stop -> {
                             val bindingResponse = handlerResult.response ?: response
                             return ContractTestExecutionResult(
@@ -295,21 +306,21 @@ data class ScenarioAsTest(
             }
 
             val result = validators.asSequence().mapNotNull {
-                it.postValidate(testScenario, originalScenario, request, responseToCheckAndStore)
+                it.postValidate(testScenario, originalScenario, request, responseToValidate)
             }.firstOrNull() ?: Result.Success()
 
             if(result !is Result.Failure) {
                 val updatedSubstitution = updateSubstitutionWithResponse(
                     substitution = requestSubstitution,
                     scenario = testScenario,
-                    httpResponse = response
+                    httpResponse = responseForResult
                 )
 
                 val substitution = when (updatedSubstitution) {
                     !is ReturnFailure -> updatedSubstitution.value
                     else -> return ContractTestExecutionResult(
                         request = request,
-                        response = response,
+                        response = responseForResult,
                         beforeFixtureExecutionResult = beforeFixtureExecutionResult.fixtureExecutionResults,
                         result = updatedSubstitution.toFailure(),
                     )
@@ -328,7 +339,7 @@ data class ScenarioAsTest(
                 return ContractTestExecutionResult(
                     result = contractTestResult,
                     request = request,
-                    response = response,
+                    response = responseForResult,
                     beforeFixtureExecutionResult = beforeFixtureExecutionResult.fixtureExecutionResults,
                     afterFixtureExecutionResult = afterFixtureExecutionResult.fixtureExecutionResults
                 )
@@ -337,7 +348,7 @@ data class ScenarioAsTest(
             return ContractTestExecutionResult(
                 result = result,
                 request = request,
-                response = response,
+                response = responseForResult,
                 beforeFixtureExecutionResult = beforeFixtureExecutionResult.fixtureExecutionResults
             )
         } catch (exception: Throwable) {

--- a/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
@@ -39,8 +39,8 @@ private const val BEFORE_FIXTURE_DISCRIMINATOR_KEY = "before"
 private const val AFTER_FIXTURE_DISCRIMINATOR_KEY = "after"
 
 private data class ResponsesAfterHandling(
-    val responseForResult: HttpResponse,
-    val responseToValidate: HttpResponse,
+    val responseForTestResult: HttpResponse,
+    val terminalResponse: HttpResponse,
 )
 
 data class ScenarioAsTest(
@@ -233,7 +233,7 @@ data class ScenarioAsTest(
             }
 
             testExecutor.preExecuteScenario(testScenario, request)
-            val response = testExecutor.execute(request)
+            val immediateResponse = testExecutor.execute(request)
 
             val responseBodyFromExample = testScenario.responseBodyFromExample()
 
@@ -241,7 +241,7 @@ data class ScenarioAsTest(
                 matcherEngine?.let {
                     val matchesResult = it.matchResponseValue(
                         responseBodyFromExample,
-                        response.body,
+                        immediateResponse.body,
                         testScenario.resolver,
                         testScenario.exampleRow?.scenarioStub?.data ?: JSONObjectValue()
                     )
@@ -249,7 +249,7 @@ data class ScenarioAsTest(
                         return ContractTestExecutionResult(
                             result = matchesResult.breadCrumb("RESPONSE.BODY"),
                             request = request,
-                            response = response,
+                            response = immediateResponse,
                             beforeFixtureExecutionResult = beforeFixtureExecutionResult.fixtureExecutionResults
                         )
                     }
@@ -257,43 +257,43 @@ data class ScenarioAsTest(
             }
 
             //TODO: Review - Do we need workflow anymore
-            workflow.extractDataFrom(response, originalScenario)
-            val validatorResult = validators.asSequence().mapNotNull { it.validate(scenario, response) }.firstOrNull()
+            workflow.extractDataFrom(immediateResponse, originalScenario)
+            val validatorResult = validators.asSequence().mapNotNull { it.validate(scenario, immediateResponse) }.firstOrNull()
 
             if (validatorResult is Result.Failure) {
                 return ContractTestExecutionResult(
                     result = validatorResult,
                     request = request,
-                    response = response,
+                    response = immediateResponse,
                     beforeFixtureExecutionResult = beforeFixtureExecutionResult.fixtureExecutionResults
                 )
             }
 
-            val testResult = validatorResult ?: testResult(request, response, testScenario, flagsBased)
-            val responseHandler = response.getResponseHandlerIfExists()
+            val testResult = validatorResult ?: testResult(request, immediateResponse, testScenario, flagsBased)
+            val responseHandler = immediateResponse.getResponseHandlerIfExists()
             if (testResult is Result.Failure && responseHandler == null) {
                 return ContractTestExecutionResult(
                     result = testResult,
                     request = request,
-                    response = response,
+                    response = immediateResponse,
                     beforeFixtureExecutionResult = beforeFixtureExecutionResult.fixtureExecutionResults
                 )
             }
 
-            val (responseForResult, responseToValidate) = when (responseHandler) {
+            val (responseForTestResult, terminalResponse) = when (responseHandler) {
                 null -> ResponsesAfterHandling(
-                    responseForResult = response,
-                    responseToValidate = response,
+                    responseForTestResult = immediateResponse,
+                    terminalResponse = immediateResponse,
                 )
                 else -> {
                     val client = if (testExecutor is LegacyHttpClient) testExecutor.copy() else testExecutor
-                    when (val handlerResult = responseHandler.handle(request, response, scenario, client)) {
+                    when (val handlerResult = responseHandler.handle(request, immediateResponse, scenario, client)) {
                         is ResponseHandlingResult.Continue -> ResponsesAfterHandling(
-                            responseForResult = handlerResult.recordedResponseOverride ?: response,
-                            responseToValidate = handlerResult.response,
+                            responseForTestResult = handlerResult.responseForTestResultOverride ?: immediateResponse,
+                            terminalResponse = handlerResult.terminalResponse,
                         )
                         is ResponseHandlingResult.Stop -> {
-                            val bindingResponse = handlerResult.response ?: response
+                            val bindingResponse = handlerResult.response ?: immediateResponse
                             return ContractTestExecutionResult(
                                 result = handlerResult.result,
                                 request = request,
@@ -306,21 +306,21 @@ data class ScenarioAsTest(
             }
 
             val result = validators.asSequence().mapNotNull {
-                it.postValidate(testScenario, originalScenario, request, responseToValidate)
+                it.postValidate(testScenario, originalScenario, request, terminalResponse)
             }.firstOrNull() ?: Result.Success()
 
             if(result !is Result.Failure) {
                 val updatedSubstitution = updateSubstitutionWithResponse(
                     substitution = requestSubstitution,
                     scenario = testScenario,
-                    httpResponse = responseForResult
+                    httpResponse = responseForTestResult
                 )
 
                 val substitution = when (updatedSubstitution) {
                     !is ReturnFailure -> updatedSubstitution.value
                     else -> return ContractTestExecutionResult(
                         request = request,
-                        response = responseForResult,
+                        response = responseForTestResult,
                         beforeFixtureExecutionResult = beforeFixtureExecutionResult.fixtureExecutionResults,
                         result = updatedSubstitution.toFailure(),
                     )
@@ -339,7 +339,7 @@ data class ScenarioAsTest(
                 return ContractTestExecutionResult(
                     result = contractTestResult,
                     request = request,
-                    response = responseForResult,
+                    response = responseForTestResult,
                     beforeFixtureExecutionResult = beforeFixtureExecutionResult.fixtureExecutionResults,
                     afterFixtureExecutionResult = afterFixtureExecutionResult.fixtureExecutionResults
                 )
@@ -348,7 +348,7 @@ data class ScenarioAsTest(
             return ContractTestExecutionResult(
                 result = result,
                 request = request,
-                response = responseForResult,
+                response = responseForTestResult,
                 beforeFixtureExecutionResult = beforeFixtureExecutionResult.fixtureExecutionResults
             )
         } catch (exception: Throwable) {

--- a/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
@@ -235,51 +235,7 @@ data class ScenarioAsTest(
             testExecutor.preExecuteScenario(testScenario, request)
             val immediateResponse = testExecutor.execute(request)
 
-            val responseBodyFromExample = testScenario.responseBodyFromExample()
-
-            if(testScenario.isNegative.not() && responseBodyFromExample != null) {
-                matcherEngine?.let {
-                    val matchesResult = it.matchResponseValue(
-                        responseBodyFromExample,
-                        immediateResponse.body,
-                        testScenario.resolver,
-                        testScenario.exampleRow?.scenarioStub?.data ?: JSONObjectValue()
-                    )
-                    if(matchesResult is Result.Failure) {
-                        return ContractTestExecutionResult(
-                            result = matchesResult.breadCrumb("RESPONSE.BODY"),
-                            request = request,
-                            response = immediateResponse,
-                            beforeFixtureExecutionResult = beforeFixtureExecutionResult.fixtureExecutionResults
-                        )
-                    }
-                }
-            }
-
-            //TODO: Review - Do we need workflow anymore
-            workflow.extractDataFrom(immediateResponse, originalScenario)
-            val validatorResult = validators.asSequence().mapNotNull { it.validate(scenario, immediateResponse) }.firstOrNull()
-
-            if (validatorResult is Result.Failure) {
-                return ContractTestExecutionResult(
-                    result = validatorResult,
-                    request = request,
-                    response = immediateResponse,
-                    beforeFixtureExecutionResult = beforeFixtureExecutionResult.fixtureExecutionResults
-                )
-            }
-
-            val testResult = validatorResult ?: testResult(request, immediateResponse, testScenario, flagsBased)
             val responseHandler = immediateResponse.getResponseHandlerIfExists()
-            if (testResult is Result.Failure && responseHandler == null) {
-                return ContractTestExecutionResult(
-                    result = testResult,
-                    request = request,
-                    response = immediateResponse,
-                    beforeFixtureExecutionResult = beforeFixtureExecutionResult.fixtureExecutionResults
-                )
-            }
-
             val (responseForTestResult, terminalResponse) = when (responseHandler) {
                 null -> ResponsesAfterHandling(
                     responseForTestResult = immediateResponse,
@@ -290,7 +246,7 @@ data class ScenarioAsTest(
                     when (val handlerResult = responseHandler.handle(request, immediateResponse, scenario, client)) {
                         is ResponseHandlingResult.Continue -> ResponsesAfterHandling(
                             responseForTestResult = handlerResult.responseForTestResultOverride ?: immediateResponse,
-                            terminalResponse = handlerResult.terminalResponse,
+                            terminalResponse = handlerResult.response,
                         )
                         is ResponseHandlingResult.Stop -> {
                             val bindingResponse = handlerResult.response ?: immediateResponse
@@ -303,6 +259,50 @@ data class ScenarioAsTest(
                         }
                     }
                 }
+            }
+
+            val responseBodyFromExample = testScenario.responseBodyFromExample()
+
+            if(testScenario.isNegative.not() && responseBodyFromExample != null) {
+                matcherEngine?.let {
+                    val matchesResult = it.matchResponseValue(
+                        responseBodyFromExample,
+                        responseForTestResult.body,
+                        testScenario.resolver,
+                        testScenario.exampleRow?.scenarioStub?.data ?: JSONObjectValue()
+                    )
+                    if(matchesResult is Result.Failure) {
+                        return ContractTestExecutionResult(
+                            result = matchesResult.breadCrumb("RESPONSE.BODY"),
+                            request = request,
+                            response = responseForTestResult,
+                            beforeFixtureExecutionResult = beforeFixtureExecutionResult.fixtureExecutionResults
+                        )
+                    }
+                }
+            }
+
+            //TODO: Review - Do we need workflow anymore
+            workflow.extractDataFrom(responseForTestResult, originalScenario)
+            val validatorResult = validators.asSequence().mapNotNull { it.validate(scenario, responseForTestResult) }.firstOrNull()
+
+            if (validatorResult is Result.Failure) {
+                return ContractTestExecutionResult(
+                    result = validatorResult,
+                    request = request,
+                    response = responseForTestResult,
+                    beforeFixtureExecutionResult = beforeFixtureExecutionResult.fixtureExecutionResults
+                )
+            }
+
+            val testResult = validatorResult ?: testResult(request, responseForTestResult, testScenario, flagsBased)
+            if (testResult is Result.Failure) {
+                return ContractTestExecutionResult(
+                    result = testResult,
+                    request = request,
+                    response = responseForTestResult,
+                    beforeFixtureExecutionResult = beforeFixtureExecutionResult.fixtureExecutionResults
+                )
             }
 
             val result = validators.asSequence().mapNotNull {

--- a/core/src/main/kotlin/io/specmatic/test/handlers/ResponseHandler.kt
+++ b/core/src/main/kotlin/io/specmatic/test/handlers/ResponseHandler.kt
@@ -7,7 +7,10 @@ import io.specmatic.core.Scenario
 import io.specmatic.test.TestExecutor
 
 sealed interface ResponseHandlingResult {
-    data class Continue(val response: HttpResponse) : ResponseHandlingResult
+    data class Continue(
+        val response: HttpResponse,
+        val recordedResponseOverride: HttpResponse? = null,
+    ) : ResponseHandlingResult
     data class Stop(val result: Result, val response: HttpResponse? = null) : ResponseHandlingResult
 }
 

--- a/core/src/main/kotlin/io/specmatic/test/handlers/ResponseHandler.kt
+++ b/core/src/main/kotlin/io/specmatic/test/handlers/ResponseHandler.kt
@@ -8,9 +8,11 @@ import io.specmatic.test.TestExecutor
 
 sealed interface ResponseHandlingResult {
     data class Continue(
-        val terminalResponse: HttpResponse,
-        val responseForTestResultOverride: HttpResponse? = null,
-    ) : ResponseHandlingResult
+        val response: HttpResponse,
+        val responseForTestResultOverride: HttpResponse?,
+    ) : ResponseHandlingResult {
+        constructor(response: HttpResponse) : this(response, null)
+    }
     data class Stop(val result: Result, val response: HttpResponse? = null) : ResponseHandlingResult
 }
 

--- a/core/src/main/kotlin/io/specmatic/test/handlers/ResponseHandler.kt
+++ b/core/src/main/kotlin/io/specmatic/test/handlers/ResponseHandler.kt
@@ -8,8 +8,8 @@ import io.specmatic.test.TestExecutor
 
 sealed interface ResponseHandlingResult {
     data class Continue(
-        val response: HttpResponse,
-        val recordedResponseOverride: HttpResponse? = null,
+        val terminalResponse: HttpResponse,
+        val responseForTestResultOverride: HttpResponse? = null,
     ) : ResponseHandlingResult
     data class Stop(val result: Result, val response: HttpResponse? = null) : ResponseHandlingResult
 }

--- a/core/src/main/kotlin/io/specmatic/test/handlers/TooManyRequestsHandler.kt
+++ b/core/src/main/kotlin/io/specmatic/test/handlers/TooManyRequestsHandler.kt
@@ -15,6 +15,7 @@ import io.specmatic.test.MonitorRequestGeneratorStrategy
 import io.specmatic.test.MonitorResult
 import io.specmatic.test.ResponseMonitor
 import io.specmatic.test.TestExecutor
+import io.specmatic.test.normalizedContentType
 import io.specmatic.test.utils.DelayStrategy
 import io.specmatic.test.utils.RetryHandler
 import io.specmatic.test.utils.RetryResult
@@ -31,7 +32,7 @@ class TooManyRequestsHandler(
     }
 
     override fun handle(request: HttpRequest, response: HttpResponse, testScenario: Scenario, testExecutor: TestExecutor): ResponseHandlingResult {
-        val processingScenario = getProcessingScenario()
+        val processingScenario = getProcessingScenario(response)
             ?: return ResponseHandlingResult.Stop(Result.Failure("No tooManyRequests scenario found for ${originalScenario.defaultAPIDescription}"))
 
         val processingScenarioResult = processingScenario.matches(response)
@@ -85,7 +86,7 @@ class TooManyRequestsHandler(
 
         return when (val monitorResult = responseMonitor.waitForResponse(testExecutor)) {
             is MonitorResult.Success -> ResponseHandlingResult.Continue(
-                terminalResponse = monitorResult.response,
+                response = monitorResult.response,
                 responseForTestResultOverride = monitorResult.response.takeUnless {
                     testScenario.status == HttpStatusCode.TooManyRequests.value
                 },
@@ -118,11 +119,18 @@ class TooManyRequestsHandler(
         )
     }
 
-    private fun getProcessingScenario(): Scenario? {
+    private fun getProcessingScenario(response: HttpResponse): Scenario? {
         return feature.scenarioAssociatedTo(
             path = originalScenario.path,
             method = originalScenario.method,
             responseStatusCode = HttpStatusCode.TooManyRequests.value,
+            reqContentType = originalScenario.requestContentType,
+            resContentType = response.normalizedContentType(),
+        ) ?: feature.scenarioAssociatedTo(
+            path = originalScenario.path,
+            method = originalScenario.method,
+            responseStatusCode = HttpStatusCode.TooManyRequests.value,
+            reqContentType = originalScenario.requestContentType,
         )
     }
 }

--- a/core/src/main/kotlin/io/specmatic/test/handlers/TooManyRequestsHandler.kt
+++ b/core/src/main/kotlin/io/specmatic/test/handlers/TooManyRequestsHandler.kt
@@ -23,12 +23,12 @@ class TooManyRequestsHandler(
     private val feature: Feature,
     private val originalScenario: Scenario,
     private val retryHandler: RetryHandler<MonitorResult, HttpResponse> = RetryHandler(DelayStrategy.RespectRetryAfter())
-): ResponseHandler {
+) : ResponseHandler {
     override fun canHandle(response: HttpResponse, scenario: Scenario): Boolean {
-        val isTooManyRequestsPossible= feature.isResponseStatusPossible(scenario, HttpStatusCode.TooManyRequests.value)
-        return scenario.status == HttpStatusCode.TooManyRequests.value
-                && response.status == HttpStatusCode.TooManyRequests.value
-                && isTooManyRequestsPossible
+        val isTooManyRequestsPossible = feature.isResponseStatusPossible(scenario, HttpStatusCode.TooManyRequests.value)
+
+        return response.status == HttpStatusCode.TooManyRequests.value &&
+                isTooManyRequestsPossible
     }
 
     override fun handle(request: HttpRequest, response: HttpResponse, testScenario: Scenario, testExecutor: TestExecutor): ResponseHandlingResult {
@@ -44,11 +44,31 @@ class TooManyRequestsHandler(
         }
 
         val matchingScenarios = findMatchingScenarios(testScenario)
+        var lastRetryResponse: HttpResponse? = null
         val responseMonitor = ResponseMonitor(
             requestGeneratorStrategy = MonitorRequestGeneratorStrategy.ReuseRequest(testScenario, request),
             initialDelayContext = response,
             retryHandler = retryHandler,
             onResponse = { response ->
+                lastRetryResponse = response
+
+                if (response.status == HttpStatusCode.TooManyRequests.value) {
+                    val retryResponseResult = processingScenario.matches(response)
+                    if (retryResponseResult is Result.Failure) {
+                        return@ResponseMonitor RetryResult.Stop(
+                            MonitorResult.Failure(
+                                failure = Result.Failure(
+                                    message = "Response doesn't match processing scenario",
+                                    cause = retryResponseResult,
+                                ).updateScenario(processingScenario),
+                                response = response,
+                            )
+                        )
+                    }
+
+                    return@ResponseMonitor RetryResult.Continue(response)
+                }
+
                 val matchResult = matchingScenarios.findMatching(response)
                 if (matchResult is ReturnFailure) {
                     logger.debug("Response didn't match any valid scenarios")
@@ -58,25 +78,33 @@ class TooManyRequestsHandler(
 
                 matchResult.realise(
                     hasValue = { _, _ -> RetryResult.Stop(MonitorResult.Success(response)) },
-                    orException = { e -> retryResultOnMatchFailure(e, response) },
-                    orFailure = { f -> retryResultOnMatchFailure(f, response) },
+                    orException = { e -> RetryResult.Stop(MonitorResult.Failure(e.toFailure(), response)) },
+                    orFailure = { f -> RetryResult.Stop(MonitorResult.Failure(f.toFailure(), response)) },
                 )
             },
         )
 
         return when (val monitorResult = responseMonitor.waitForResponse(testExecutor)) {
-            is MonitorResult.Success -> ResponseHandlingResult.Continue(monitorResult.response)
-            is MonitorResult.Failure -> ResponseHandlingResult.Stop(monitorResult.failure.updateScenario(testScenario), monitorResult.response)
+            is MonitorResult.Success -> ResponseHandlingResult.Continue(
+                response = monitorResult.response,
+                recordedResponseOverride = monitorResult.response.takeUnless {
+                    testScenario.status == HttpStatusCode.TooManyRequests.value
+                },
+            )
+            is MonitorResult.Failure -> ResponseHandlingResult.Stop(
+                monitorResult.failure.updateScenario(testScenario),
+                monitorResult.response ?: lastRetryResponse,
+            )
         }
     }
 
-    private fun findMatchingScenarios(testScenarios: Scenario): List<Scenario> {
-        return if (testScenarios.status == HttpStatusCode.TooManyRequests.value) {
+    private fun findMatchingScenarios(testScenario: Scenario): List<Scenario> {
+        return if (testScenario.status == HttpStatusCode.TooManyRequests.value) {
             feature.scenarios.filter {
-                it.path == testScenarios.path && it.method == testScenarios.method && it.isA2xxScenario()
+                it.path == testScenario.path && it.method == testScenario.method && it.isA2xxScenario()
             }
         } else {
-            listOf(originalScenario)
+            listOf(testScenario)
         }
     }
 
@@ -87,16 +115,8 @@ class TooManyRequestsHandler(
 
         return results.firstOrNull { it.isSuccess() }?.let(::HasValue) ?: HasFailure(
             failure = Result.fromFailures(results.filterIsInstance<Result.Failure>().toList()) as Result.Failure,
-            message = "Invalid 2xx response received on retry",
+            message = "Invalid response received on retry",
         )
-    }
-
-    private fun retryResultOnMatchFailure(result: ReturnFailure, response: HttpResponse): RetryResult<MonitorResult, HttpResponse> {
-        return if (response.status in 200..299) {
-            RetryResult.Stop(MonitorResult.Failure(failure = result.toFailure()))
-        } else {
-            RetryResult.Continue(response)
-        }
     }
 
     private fun getProcessingScenario(): Scenario? {

--- a/core/src/main/kotlin/io/specmatic/test/handlers/TooManyRequestsHandler.kt
+++ b/core/src/main/kotlin/io/specmatic/test/handlers/TooManyRequestsHandler.kt
@@ -86,8 +86,8 @@ class TooManyRequestsHandler(
 
         return when (val monitorResult = responseMonitor.waitForResponse(testExecutor)) {
             is MonitorResult.Success -> ResponseHandlingResult.Continue(
-                response = monitorResult.response,
-                recordedResponseOverride = monitorResult.response.takeUnless {
+                terminalResponse = monitorResult.response,
+                responseForTestResultOverride = monitorResult.response.takeUnless {
                     testScenario.status == HttpStatusCode.TooManyRequests.value
                 },
             )

--- a/core/src/main/kotlin/io/specmatic/test/handlers/TooManyRequestsHandler.kt
+++ b/core/src/main/kotlin/io/specmatic/test/handlers/TooManyRequestsHandler.kt
@@ -25,10 +25,9 @@ class TooManyRequestsHandler(
     private val retryHandler: RetryHandler<MonitorResult, HttpResponse> = RetryHandler(DelayStrategy.RespectRetryAfter())
 ) : ResponseHandler {
     override fun canHandle(response: HttpResponse, scenario: Scenario): Boolean {
-        val isTooManyRequestsPossible = feature.isResponseStatusPossible(scenario, HttpStatusCode.TooManyRequests.value)
+        if (response.status != HttpStatusCode.TooManyRequests.value) return false
 
-        return response.status == HttpStatusCode.TooManyRequests.value &&
-                isTooManyRequestsPossible
+        return feature.isResponseStatusPossible(scenario, HttpStatusCode.TooManyRequests.value)
     }
 
     override fun handle(request: HttpRequest, response: HttpResponse, testScenario: Scenario, testExecutor: TestExecutor): ResponseHandlingResult {

--- a/core/src/test/kotlin/io/specmatic/core/RunContractTestsUsingScenario.kt
+++ b/core/src/test/kotlin/io/specmatic/core/RunContractTestsUsingScenario.kt
@@ -791,7 +791,7 @@ paths:
     }
 
     @Test
-    fun `should fail a test if a tooManyRequests response was returned for a 201 test`() {
+    fun `should retry a documented tooManyRequests response returned for a 201 test`() {
         val postScenario = Scenario(ScenarioInfo(
             httpRequestPattern = HttpRequestPattern(
                 httpPathPattern = buildHttpPathPattern("/(id:string)"), method = "POST",
@@ -820,15 +820,68 @@ paths:
             protocol = SpecmaticProtocol.HTTP,
             specType = SpecType.OPENAPI
         )
-        val (result) = contractTest.runTest(object : TestExecutor {
+        val executionResult = contractTest.runTest(object : TestExecutor {
+            var executionCount = 0
+
             override fun execute(request: HttpRequest): HttpResponse {
-                return HttpResponse(429, headers = mapOf(HttpHeaders.RetryAfter to "0"))
+                executionCount++
+                return if (executionCount == 1) {
+                    HttpResponse(429, headers = mapOf(HttpHeaders.RetryAfter to "0"))
+                } else {
+                    HttpResponse(201)
+                }
             }
         })
 
-        println(result.reportString())
-        assertThat(result).isInstanceOf(Result.Failure::class.java)
-        assertThat(result.reportString()).contains("expected status 201 but response contained status 429")
+        assertThat(executionResult.result).isInstanceOf(Result.Success::class.java)
+        assertThat(executionResult.response).isEqualTo(HttpResponse(201))
+    }
+
+    @Test
+    fun `should retry a documented tooManyRequests response returned for a 403 test`() {
+        val forbiddenScenario = Scenario(ScenarioInfo(
+            httpRequestPattern = HttpRequestPattern(
+                httpPathPattern = buildHttpPathPattern("/(id:string)"), method = "POST",
+                body = JSONObjectPattern(mapOf("age" to NumberPattern()))
+            ),
+            httpResponsePattern = HttpResponsePattern(status = HttpStatusCode.Forbidden.value),
+            protocol = SpecmaticProtocol.HTTP,
+            specType = SpecType.OPENAPI
+        ))
+        val tooManyRequestsScenario = Scenario(ScenarioInfo(
+            httpRequestPattern = HttpRequestPattern(
+                httpPathPattern = buildHttpPathPattern("/(id:string)"), method = "POST",
+                body = JSONObjectPattern(mapOf("age" to NumberPattern()))
+            ),
+            httpResponsePattern = HttpResponsePattern(status = HttpStatusCode.TooManyRequests.value),
+            protocol = SpecmaticProtocol.HTTP,
+            specType = SpecType.OPENAPI
+        ))
+
+        val feature = Feature(name = "", scenarios = listOf(forbiddenScenario, tooManyRequestsScenario), protocol = SpecmaticProtocol.HTTP)
+        val contractTest = ScenarioAsTest(
+            forbiddenScenario,
+            feature,
+            feature.flagsBased,
+            originalScenario = forbiddenScenario,
+            protocol = SpecmaticProtocol.HTTP,
+            specType = SpecType.OPENAPI
+        )
+        val executionResult = contractTest.runTest(object : TestExecutor {
+            var executionCount = 0
+
+            override fun execute(request: HttpRequest): HttpResponse {
+                executionCount++
+                return if (executionCount == 1) {
+                    HttpResponse(429, headers = mapOf(HttpHeaders.RetryAfter to "0"))
+                } else {
+                    HttpResponse(HttpStatusCode.Forbidden.value)
+                }
+            }
+        })
+
+        assertThat(executionResult.result).isInstanceOf(Result.Success::class.java)
+        assertThat(executionResult.response).isEqualTo(HttpResponse(HttpStatusCode.Forbidden.value))
     }
 
     @Test
@@ -861,7 +914,7 @@ paths:
         val feature = Feature(name = "", scenarios = listOf(postScenario, acceptedScenario, tooManyRequestsScenario), protocol = SpecmaticProtocol.HTTP)
         val contractTest = ScenarioAsTest(tooManyRequestsScenario, feature, feature.flagsBased, originalScenario = tooManyRequestsScenario,
             protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI)
-        val (result) = contractTest.runTest(object : TestExecutor {
+        val executionResult = contractTest.runTest(object : TestExecutor {
             var retryCount: Int = 0
 
             override fun execute(request: HttpRequest): HttpResponse {
@@ -870,7 +923,8 @@ paths:
             }
         })
 
-        assertThat(result).isInstanceOf(Result.Success::class.java)
+        assertThat(executionResult.result).isInstanceOf(Result.Success::class.java)
+        assertThat(executionResult.response).isEqualTo(HttpResponse(429, headers = mapOf(HttpHeaders.RetryAfter to "0")))
     }
 
     @ParameterizedTest

--- a/core/src/test/kotlin/io/specmatic/test/AcceptedResponseHandlerTest.kt
+++ b/core/src/test/kotlin/io/specmatic/test/AcceptedResponseHandlerTest.kt
@@ -188,7 +188,7 @@ class AcceptedResponseHandlerTest {
         )
 
         assertThat(result).isInstanceOf(ResponseHandlingResult.Continue::class.java); result as ResponseHandlingResult.Continue
-        assertThat(result.terminalResponse).isEqualTo(HttpResponse(
+        assertThat(result.response).isEqualTo(HttpResponse(
             status = 201,
             headers = mapOf("Content-Type" to "application/json"),
             body = parsedJSONObject("""{"name": "John", "age": 20}"""),
@@ -260,7 +260,7 @@ class AcceptedResponseHandlerTest {
 
         assertThat(result).isInstanceOf(ResponseHandlingResult.Continue::class.java); result as ResponseHandlingResult.Continue
         assertThat(count).isEqualTo(1)
-        assertThat(result.terminalResponse).isEqualTo(HttpResponse(
+        assertThat(result.response).isEqualTo(HttpResponse(
             status = 201,
             headers = mapOf("Content-Type" to "application/json"),
             body = parsedJSONObject("""{"name": "John", "age": 20}"""),
@@ -457,11 +457,11 @@ class AcceptedResponseHandlerTest {
         )
 
         assertThat(result).isInstanceOf(ResponseHandlingResult.Continue::class.java); result as ResponseHandlingResult.Continue
-        assertThat(result.terminalResponse.status).isEqualTo(201)
-        assertThat(result.terminalResponse.headers).isEqualTo(mapOf(
+        assertThat(result.response.status).isEqualTo(201)
+        assertThat(result.response.headers).isEqualTo(mapOf(
             "Content-Type" to "application/json",
             "X-Extra" to "Extra-Value",
         ))
-        assertThat(result.terminalResponse.body).isEqualTo(response.jsonObject["body"])
+        assertThat(result.response.body).isEqualTo(response.jsonObject["body"])
     }
 }

--- a/core/src/test/kotlin/io/specmatic/test/AcceptedResponseHandlerTest.kt
+++ b/core/src/test/kotlin/io/specmatic/test/AcceptedResponseHandlerTest.kt
@@ -188,7 +188,7 @@ class AcceptedResponseHandlerTest {
         )
 
         assertThat(result).isInstanceOf(ResponseHandlingResult.Continue::class.java); result as ResponseHandlingResult.Continue
-        assertThat(result.response).isEqualTo(HttpResponse(
+        assertThat(result.terminalResponse).isEqualTo(HttpResponse(
             status = 201,
             headers = mapOf("Content-Type" to "application/json"),
             body = parsedJSONObject("""{"name": "John", "age": 20}"""),
@@ -260,7 +260,7 @@ class AcceptedResponseHandlerTest {
 
         assertThat(result).isInstanceOf(ResponseHandlingResult.Continue::class.java); result as ResponseHandlingResult.Continue
         assertThat(count).isEqualTo(1)
-        assertThat(result.response).isEqualTo(HttpResponse(
+        assertThat(result.terminalResponse).isEqualTo(HttpResponse(
             status = 201,
             headers = mapOf("Content-Type" to "application/json"),
             body = parsedJSONObject("""{"name": "John", "age": 20}"""),
@@ -457,11 +457,11 @@ class AcceptedResponseHandlerTest {
         )
 
         assertThat(result).isInstanceOf(ResponseHandlingResult.Continue::class.java); result as ResponseHandlingResult.Continue
-        assertThat(result.response.status).isEqualTo(201)
-        assertThat(result.response.headers).isEqualTo(mapOf(
+        assertThat(result.terminalResponse.status).isEqualTo(201)
+        assertThat(result.terminalResponse.headers).isEqualTo(mapOf(
             "Content-Type" to "application/json",
             "X-Extra" to "Extra-Value",
         ))
-        assertThat(result.response.body).isEqualTo(response.jsonObject["body"])
+        assertThat(result.terminalResponse.body).isEqualTo(response.jsonObject["body"])
     }
 }

--- a/core/src/test/kotlin/io/specmatic/test/ScenarioAsTestTest.kt
+++ b/core/src/test/kotlin/io/specmatic/test/ScenarioAsTestTest.kt
@@ -19,6 +19,9 @@ import io.specmatic.core.Result
 import io.specmatic.core.Scenario
 import io.specmatic.core.ScenarioInfo
 import io.specmatic.core.Substitution
+import io.specmatic.core.Workflow
+import io.specmatic.core.WorkflowConfiguration
+import io.specmatic.core.WorkflowIDOperation
 import io.specmatic.core.HttpQueryParamPattern
 import io.specmatic.core.matchers.MatcherEngine
 import io.specmatic.core.pattern.ExactValuePattern
@@ -527,6 +530,78 @@ class ScenarioAsTestTest {
     }
 
     @Test
+    fun `runTest should pass the terminal response to the response example matcher after a documented 429`() {
+        val matcherEngine = mockk<MatcherEngine>()
+        mockkObject(MatcherEngine.Companion)
+        every { MatcherEngine.load() } returns matcherEngine
+        every { matcherEngine.matchResponseValue(any(), any(), any(), any()) } returns Result.Success()
+
+        val terminalBody = parsedJSONObject("""{"id": "terminal"}""")
+        val testScenario = scenarioWithDocumentedRateLimit().copy(
+            exampleRow = Row(
+                scenarioStub = ScenarioStub(
+                    response = HttpResponse(status = 200, body = terminalBody),
+                ),
+            ),
+        )
+        val rateLimitScenario = documentedRateLimitScenario()
+
+        try {
+            val executionResult = scenarioAsTest(
+                scenario = testScenario,
+                scenarios = listOf(testScenario, rateLimitScenario),
+            ).runTest(rateLimitedExecutor(terminalBody))
+
+            assertThat(executionResult.result).isInstanceOf(Result.Success::class.java)
+            verify(exactly = 1) { matcherEngine.matchResponseValue(terminalBody, terminalBody, any(), any()) }
+        } finally {
+            unmockkObject(MatcherEngine.Companion)
+        }
+    }
+
+    @Test
+    fun `runTest should extract workflow data from the test result response after a documented 429`() {
+        val testScenario = scenarioWithDocumentedRateLimit()
+        val rateLimitScenario = documentedRateLimitScenario()
+        val workflow = Workflow(
+            workflow = WorkflowConfiguration(
+                ids = mapOf(testScenario.defaultAPIDescription to WorkflowIDOperation(extract = "BODY.id")),
+            ),
+        )
+        val terminalBody = parsedJSONObject("""{"id": "terminal"}""")
+
+        val executionResult = scenarioAsTest(
+            scenario = testScenario,
+            scenarios = listOf(testScenario, rateLimitScenario),
+            workflow = workflow,
+        ).runTest(rateLimitedExecutor(terminalBody))
+
+        assertThat(executionResult.result).isInstanceOf(Result.Success::class.java)
+        assertThat(workflow.id).isEqualTo(StringValue("terminal"))
+    }
+
+    @Test
+    fun `runTest should pass the test result response to first-phase validators after a documented 429`() {
+        val testScenario = scenarioWithDocumentedRateLimit()
+        val rateLimitScenario = documentedRateLimitScenario()
+        val validatedStatuses = mutableListOf<Int>()
+        val validator = object : ResponseValidator {
+            override fun validate(scenario: Scenario, httpResponse: HttpResponse): Result? {
+                validatedStatuses.add(httpResponse.status)
+                return if (httpResponse.status == 429) Result.Failure("intermediate response") else null
+            }
+        }
+
+        val executionResult = scenarioAsTest(
+            scenario = testScenario,
+            scenarios = listOf(testScenario, rateLimitScenario),
+        ).plusValidator(validator).runTest(rateLimitedExecutor(parsedJSONObject("""{"id": "terminal"}""")))
+
+        assertThat(executionResult.result).isInstanceOf(Result.Success::class.java)
+        assertThat(validatedStatuses).containsExactly(200)
+    }
+
+    @Test
     fun `runTest should report positive response example matcher failures under response body`() {
         val matcherEngine = mockk<MatcherEngine>()
         mockkObject(MatcherEngine.Companion)
@@ -705,7 +780,8 @@ class ScenarioAsTestTest {
         scenario: Scenario,
         scenarios: List<Scenario> = listOf(scenario),
         originalScenario: Scenario = scenario,
-        substitution: Substitution = SubstitutionImpl.empty()
+        substitution: Substitution = SubstitutionImpl.empty(),
+        workflow: Workflow = Workflow(),
     ): ScenarioAsTest {
         val feature = Feature(name = "feature", scenarios = scenarios, protocol = SpecmaticProtocol.HTTP)
         return ScenarioAsTest(
@@ -715,8 +791,51 @@ class ScenarioAsTestTest {
             originalScenario = originalScenario,
             protocol = SpecmaticProtocol.HTTP,
             specType = SpecType.OPENAPI,
-            substitution = substitution
+            substitution = substitution,
+            workflow = workflow,
         )
+    }
+
+    private fun scenarioWithDocumentedRateLimit(): Scenario {
+        return Scenario(
+            ScenarioInfo(
+                specType = SpecType.OPENAPI,
+                protocol = SpecmaticProtocol.HTTP,
+                httpRequestPattern = HttpRequestPattern(httpPathPattern = buildHttpPathPattern("/resource"), method = "GET"),
+                httpResponsePattern = HttpResponsePattern(
+                    status = 200,
+                    body = JSONObjectPattern(mapOf("id" to StringPattern())),
+                ),
+            )
+        )
+    }
+
+    private fun documentedRateLimitScenario(): Scenario {
+        return scenarioWithDocumentedRateLimit().copy(
+            httpResponsePattern = HttpResponsePattern(
+                status = 429,
+                body = JSONObjectPattern(mapOf("error" to StringPattern())),
+            ),
+        )
+    }
+
+    private fun rateLimitedExecutor(terminalBody: Value): TestExecutor {
+        return object : TestExecutor {
+            private var executionCount = 0
+
+            override fun execute(request: HttpRequest): HttpResponse {
+                executionCount++
+                return if (executionCount == 1) {
+                    HttpResponse(
+                        status = 429,
+                        headers = mapOf("Retry-After" to "0"),
+                        body = parsedJSONObject("""{"error": "rate limited"}"""),
+                    )
+                } else {
+                    HttpResponse(status = 200, body = terminalBody)
+                }
+            }
+        }
     }
 
     private fun fixedResponseExecutor(status: Int = 200, body: String, headers: Map<String, String> = emptyMap()): TestExecutor {

--- a/core/src/test/kotlin/io/specmatic/test/handlers/ResponseHandlerTest.kt
+++ b/core/src/test/kotlin/io/specmatic/test/handlers/ResponseHandlerTest.kt
@@ -1,0 +1,18 @@
+package io.specmatic.test.handlers
+
+import io.specmatic.core.HttpResponse
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ResponseHandlerTest {
+    @Test
+    fun `Continue should preserve its one-argument JVM constructor and response property`() {
+        val constructor = ResponseHandlingResult.Continue::class.java.getConstructor(HttpResponse::class.java)
+        val response = HttpResponse(status = 200)
+
+        val result = constructor.newInstance(response)
+
+        assertThat(result.response).isSameAs(response)
+        assertThat(result.responseForTestResultOverride).isNull()
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/test/handlers/ResponseHandlerTest.kt
+++ b/core/src/test/kotlin/io/specmatic/test/handlers/ResponseHandlerTest.kt
@@ -6,11 +6,10 @@ import org.junit.jupiter.api.Test
 
 class ResponseHandlerTest {
     @Test
-    fun `Continue should preserve its one-argument JVM constructor and response property`() {
-        val constructor = ResponseHandlingResult.Continue::class.java.getConstructor(HttpResponse::class.java)
+    fun `Continue should preserve its one-argument constructor and response property`() {
         val response = HttpResponse(status = 200)
 
-        val result = constructor.newInstance(response)
+        val result = ResponseHandlingResult.Continue(response)
 
         assertThat(result.response).isSameAs(response)
         assertThat(result.responseForTestResultOverride).isNull()

--- a/core/src/test/kotlin/io/specmatic/test/handlers/TooManyRequestsHandlerTest.kt
+++ b/core/src/test/kotlin/io/specmatic/test/handlers/TooManyRequestsHandlerTest.kt
@@ -2,10 +2,13 @@ package io.specmatic.test.handlers
 
 import io.ktor.http.*
 import io.specmatic.core.*
+import io.specmatic.core.pattern.ExactValuePattern
 import io.specmatic.core.pattern.JSONObjectPattern
 import io.specmatic.core.pattern.NumberPattern
+import io.specmatic.core.pattern.StringPattern
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.NumberValue
+import io.specmatic.core.value.StringValue
 import io.specmatic.license.core.SpecmaticProtocol
 import io.specmatic.reporter.model.SpecType
 import io.specmatic.toViolationReportString
@@ -43,6 +46,33 @@ class TooManyRequestsHandlerTest {
         private val throwAwayExecutor = object : TestExecutor {
             override fun execute(request: HttpRequest): HttpResponse { throw AssertionError() }
         }
+    }
+
+    @Test
+    fun `should handle documented too-many-requests responses for a 2xx test`() {
+        val feature = Feature(name = "", scenarios = listOf(postScenario, tooManyRequestsScenario), protocol = SpecmaticProtocol.HTTP)
+        val handler = TooManyRequestsHandler(feature, postScenario)
+
+        assertThat(handler.canHandle(HttpResponse(status = 429), postScenario)).isTrue()
+    }
+
+    @Test
+    fun `should handle documented too-many-requests responses for a non-2xx test`() {
+        val forbiddenScenario = postScenario.copy(
+            httpResponsePattern = HttpResponsePattern(status = HttpStatusCode.Forbidden.value)
+        )
+        val feature = Feature(name = "", scenarios = listOf(forbiddenScenario, tooManyRequestsScenario), protocol = SpecmaticProtocol.HTTP)
+        val handler = TooManyRequestsHandler(feature, forbiddenScenario)
+
+        assertThat(handler.canHandle(HttpResponse(status = 429), forbiddenScenario)).isTrue()
+    }
+
+    @Test
+    fun `should not handle too-many-requests responses when they are undocumented`() {
+        val feature = Feature(name = "", scenarios = listOf(postScenario), protocol = SpecmaticProtocol.HTTP)
+        val handler = TooManyRequestsHandler(feature, postScenario)
+
+        assertThat(handler.canHandle(HttpResponse(status = 429), postScenario)).isFalse()
     }
 
     @Test
@@ -116,11 +146,12 @@ class TooManyRequestsHandlerTest {
 
         assertThat(result).isInstanceOf(ResponseHandlingResult.Continue::class.java); result as ResponseHandlingResult.Continue
         assertThat(result.response).isEqualTo(HttpResponse(status = 201))
+        assertThat(result.recordedResponseOverride).isEqualTo(HttpResponse(status = 201))
         assertThat(sleepDurations).containsExactly(5.seconds.inWholeMilliseconds)
     }
 
     @Test
-    fun `should retry for specified times while following the next retry-after delay from response`() {
+    fun `should retry repeated valid too-many-requests responses using each retry-after delay`() {
         val feature = Feature(name = "", scenarios = listOf(postScenario, tooManyRequestsScenario), protocol = SpecmaticProtocol.HTTP)
         val sleepSequence = sequenceOf(1, 2, 3, 4, 5)
         val sleepDurations = mutableListOf<Long>()
@@ -145,7 +176,7 @@ class TooManyRequestsHandlerTest {
                 override fun execute(request: HttpRequest): HttpResponse {
                     assertThat(request).isEqualTo(initialRequest)
                     return if (iterator.hasNext()) {
-                        HttpResponse(status = 402, headers = mapOf(HttpHeaders.RetryAfter to iterator.next().toString()))
+                        HttpResponse(status = 429, headers = mapOf(HttpHeaders.RetryAfter to iterator.next().toString()))
                     } else {
                         HttpResponse(status = 201)
                     }
@@ -155,7 +186,103 @@ class TooManyRequestsHandlerTest {
 
         assertThat(result).isInstanceOf(ResponseHandlingResult.Continue::class.java); result as ResponseHandlingResult.Continue
         assertThat(result.response).isEqualTo(HttpResponse(status = 201))
+        assertThat(result.recordedResponseOverride).isEqualTo(HttpResponse(status = 201))
         assertThat(sleepDurations).isEqualTo(sleepSequence.map { it.seconds.inWholeMilliseconds }.toList())
+    }
+
+    @Test
+    fun `should fail immediately when a later too-many-requests response violates its contract`() {
+        val tooManyRequestsWithRequiredHeader = tooManyRequestsScenario.copy(
+            httpResponsePattern = HttpResponsePattern(
+                status = HttpStatusCode.TooManyRequests.value,
+                headersPattern = HttpHeadersPattern(pattern = mapOf(HttpHeaders.RetryAfter to NumberPattern())),
+            )
+        )
+        val feature = Feature(name = "", scenarios = listOf(postScenario, tooManyRequestsWithRequiredHeader), protocol = SpecmaticProtocol.HTTP)
+        var executions = 0
+        val handler = TooManyRequestsHandler(
+            feature,
+            postScenario,
+            RetryHandler(
+                maxAttempts = 3,
+                delayStrategy = DelayStrategy.RespectRetryAfter(),
+                sleeper = object : Sleeper {
+                    override fun sleep(milliSeconds: Long) = Unit
+                },
+            ),
+        )
+
+        val invalidRetryResponse = HttpResponse(status = 429)
+        val result = handler.handle(
+            HttpRequest("POST", "/ABC", body = JSONObjectValue(mapOf("age" to NumberValue(10)))),
+            HttpResponse(status = 429, headers = mapOf(HttpHeaders.RetryAfter to "0")),
+            postScenario,
+            object : TestExecutor {
+                override fun execute(request: HttpRequest): HttpResponse {
+                    executions++
+                    return invalidRetryResponse
+                }
+            },
+        )
+
+        assertThat(result).isInstanceOf(ResponseHandlingResult.Stop::class.java); result as ResponseHandlingResult.Stop
+        assertThat(result.response).isEqualTo(invalidRetryResponse)
+        assertThat(result.result.reportString()).contains("Response doesn't match processing scenario")
+        assertThat(executions).isEqualTo(1)
+    }
+
+    @Test
+    fun `should fail immediately when a retry returns an unexpected non-429 response`() {
+        val feature = Feature(name = "", scenarios = listOf(postScenario, tooManyRequestsScenario), protocol = SpecmaticProtocol.HTTP)
+        var executions = 0
+        val unexpectedResponse = HttpResponse(status = 500)
+        val handler = TooManyRequestsHandler(feature, postScenario)
+
+        val result = handler.handle(
+            HttpRequest("POST", "/ABC", body = JSONObjectValue(mapOf("age" to NumberValue(10)))),
+            HttpResponse(status = 429, headers = mapOf(HttpHeaders.RetryAfter to "0")),
+            postScenario,
+            object : TestExecutor {
+                override fun execute(request: HttpRequest): HttpResponse {
+                    executions++
+                    return unexpectedResponse
+                }
+            },
+        )
+
+        assertThat(result).isInstanceOf(ResponseHandlingResult.Stop::class.java); result as ResponseHandlingResult.Stop
+        assertThat(result.response).isEqualTo(unexpectedResponse)
+        assertThat(result.result.reportString()).contains("Invalid response received on retry")
+        assertThat(executions).isEqualTo(1)
+    }
+
+    @Test
+    fun `should validate the terminal response against the generated test scenario`() {
+        val originalScenario = postScenario.copy(
+            httpResponsePattern = HttpResponsePattern(status = 201, body = StringPattern())
+        )
+        val generatedTestScenario = originalScenario.copy(
+            httpResponsePattern = HttpResponsePattern(
+                status = 201,
+                body = ExactValuePattern(StringValue("expected")),
+            )
+        )
+        val feature = Feature(name = "", scenarios = listOf(originalScenario, tooManyRequestsScenario), protocol = SpecmaticProtocol.HTTP)
+        val terminalResponse = HttpResponse(status = 201, body = "different")
+        val handler = TooManyRequestsHandler(feature, originalScenario)
+
+        val result = handler.handle(
+            HttpRequest("POST", "/ABC", body = JSONObjectValue(mapOf("age" to NumberValue(10)))),
+            HttpResponse(status = 429, headers = mapOf(HttpHeaders.RetryAfter to "0")),
+            generatedTestScenario,
+            object : TestExecutor {
+                override fun execute(request: HttpRequest): HttpResponse = terminalResponse
+            },
+        )
+
+        assertThat(result).isInstanceOf(ResponseHandlingResult.Stop::class.java); result as ResponseHandlingResult.Stop
+        assertThat(result.response).isEqualTo(terminalResponse)
+        assertThat(result.result.reportString()).contains("Invalid response received on retry")
     }
 
     @Test
@@ -226,7 +353,7 @@ class TooManyRequestsHandlerTest {
         ${
             toViolationReportString(
                 breadCrumb = "RESPONSE.STATUS",
-                details = "Invalid 2xx response received on retry\n${DefaultMismatchMessages.mismatchMessage("status 201", "status 202")}",
+                details = "Invalid response received on retry\n${DefaultMismatchMessages.mismatchMessage("status 201", "status 202")}",
                 OpenApiRuleViolation.STATUS_MISMATCH
             )
         }
@@ -254,6 +381,7 @@ class TooManyRequestsHandlerTest {
 
         assertThat(result).isInstanceOf(ResponseHandlingResult.Continue::class.java); result as ResponseHandlingResult.Continue
         assertThat(result.response).isEqualTo(HttpResponse(status = 202))
+        assertThat(result.recordedResponseOverride).isNull()
     }
 
     @Test
@@ -274,8 +402,14 @@ class TooManyRequestsHandlerTest {
             HttpResponse(status = 429),
             postScenario,
             object : TestExecutor {
+                var retryCount = 0
+
                 override fun execute(request: HttpRequest): HttpResponse {
-                    return HttpResponse(status = 429)
+                    retryCount++
+                    return HttpResponse(
+                        status = 429,
+                        headers = mapOf(HttpHeaders.RetryAfter to retryCount.toString()),
+                    )
                 }
             },
         )
@@ -286,5 +420,8 @@ class TooManyRequestsHandlerTest {
         API: POST /(id:string) -> 201
         Max retries of 5 exceeded with POST /ABC
         """.trimIndent())
+        assertThat(result.response).isEqualTo(
+            HttpResponse(status = 429, headers = mapOf(HttpHeaders.RetryAfter to "5"))
+        )
     }
 }

--- a/core/src/test/kotlin/io/specmatic/test/handlers/TooManyRequestsHandlerTest.kt
+++ b/core/src/test/kotlin/io/specmatic/test/handlers/TooManyRequestsHandlerTest.kt
@@ -145,8 +145,8 @@ class TooManyRequestsHandlerTest {
         )
 
         assertThat(result).isInstanceOf(ResponseHandlingResult.Continue::class.java); result as ResponseHandlingResult.Continue
-        assertThat(result.response).isEqualTo(HttpResponse(status = 201))
-        assertThat(result.recordedResponseOverride).isEqualTo(HttpResponse(status = 201))
+        assertThat(result.terminalResponse).isEqualTo(HttpResponse(status = 201))
+        assertThat(result.responseForTestResultOverride).isEqualTo(HttpResponse(status = 201))
         assertThat(sleepDurations).containsExactly(5.seconds.inWholeMilliseconds)
     }
 
@@ -185,8 +185,8 @@ class TooManyRequestsHandlerTest {
         )
 
         assertThat(result).isInstanceOf(ResponseHandlingResult.Continue::class.java); result as ResponseHandlingResult.Continue
-        assertThat(result.response).isEqualTo(HttpResponse(status = 201))
-        assertThat(result.recordedResponseOverride).isEqualTo(HttpResponse(status = 201))
+        assertThat(result.terminalResponse).isEqualTo(HttpResponse(status = 201))
+        assertThat(result.responseForTestResultOverride).isEqualTo(HttpResponse(status = 201))
         assertThat(sleepDurations).isEqualTo(sleepSequence.map { it.seconds.inWholeMilliseconds }.toList())
     }
 
@@ -316,7 +316,7 @@ class TooManyRequestsHandlerTest {
         )
 
         assertThat(result).isInstanceOf(ResponseHandlingResult.Continue::class.java); result as ResponseHandlingResult.Continue
-        assertThat(result.response).isEqualTo(HttpResponse(status = 201))
+        assertThat(result.terminalResponse).isEqualTo(HttpResponse(status = 201))
         assertThat(sleepDurations.single()).isBetween(expectedDelay - tolerance, expectedDelay + tolerance)
     }
 
@@ -380,8 +380,8 @@ class TooManyRequestsHandlerTest {
         )
 
         assertThat(result).isInstanceOf(ResponseHandlingResult.Continue::class.java); result as ResponseHandlingResult.Continue
-        assertThat(result.response).isEqualTo(HttpResponse(status = 202))
-        assertThat(result.recordedResponseOverride).isNull()
+        assertThat(result.terminalResponse).isEqualTo(HttpResponse(status = 202))
+        assertThat(result.responseForTestResultOverride).isNull()
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/test/handlers/TooManyRequestsHandlerTest.kt
+++ b/core/src/test/kotlin/io/specmatic/test/handlers/TooManyRequestsHandlerTest.kt
@@ -76,6 +76,60 @@ class TooManyRequestsHandlerTest {
     }
 
     @Test
+    fun `should validate too-many-requests response against the matching request and response content types`() {
+        val jsonPostScenario = postScenario.copy(
+            httpRequestPattern = postScenario.httpRequestPattern.copy(
+                headersPattern = HttpHeadersPattern(contentType = ContentType.Application.Json.toString()),
+            ),
+        )
+        val xmlTooManyRequestsScenario = tooManyRequestsScenario.copy(
+            httpRequestPattern = tooManyRequestsScenario.httpRequestPattern.copy(
+                headersPattern = HttpHeadersPattern(contentType = ContentType.Application.Xml.toString()),
+            ),
+            httpResponsePattern = HttpResponsePattern(
+                status = HttpStatusCode.TooManyRequests.value,
+                headersPattern = HttpHeadersPattern(contentType = ContentType.Application.Xml.toString()),
+                body = ExactValuePattern(StringValue("xml rate limit")),
+            ),
+        )
+        val jsonTooManyRequestsScenario = tooManyRequestsScenario.copy(
+            httpRequestPattern = tooManyRequestsScenario.httpRequestPattern.copy(
+                headersPattern = HttpHeadersPattern(contentType = ContentType.Application.Json.toString()),
+            ),
+            httpResponsePattern = HttpResponsePattern(
+                status = HttpStatusCode.TooManyRequests.value,
+                headersPattern = HttpHeadersPattern(contentType = ContentType.Application.Json.toString()),
+                body = ExactValuePattern(StringValue("json rate limit")),
+            ),
+        )
+        val feature = Feature(
+            name = "",
+            scenarios = listOf(jsonPostScenario, xmlTooManyRequestsScenario, jsonTooManyRequestsScenario),
+            protocol = SpecmaticProtocol.HTTP,
+        )
+
+        val result = TooManyRequestsHandler(feature, jsonPostScenario).handle(
+            request = HttpRequest(
+                method = "POST",
+                path = "/ABC",
+                headers = mapOf(HttpHeaders.ContentType to ContentType.Application.Json.toString()),
+                body = JSONObjectValue(mapOf("age" to NumberValue(10))),
+            ),
+            response = HttpResponse(
+                status = HttpStatusCode.TooManyRequests.value,
+                headers = mapOf(HttpHeaders.ContentType to ContentType.Application.Json.toString()),
+                body = StringValue("json rate limit"),
+            ),
+            testScenario = jsonPostScenario,
+            testExecutor = object : TestExecutor {
+                override fun execute(request: HttpRequest): HttpResponse = HttpResponse(status = 201)
+            },
+        )
+
+        assertThat(result).isInstanceOf(ResponseHandlingResult.Continue::class.java)
+    }
+
+    @Test
     fun `should retry failure if too-many-requests response is not possible`() {
         val feature = Feature(name = "", scenarios = listOf(postScenario), protocol = SpecmaticProtocol.HTTP)
         val handler = TooManyRequestsHandler(feature, postScenario)
@@ -145,7 +199,7 @@ class TooManyRequestsHandlerTest {
         )
 
         assertThat(result).isInstanceOf(ResponseHandlingResult.Continue::class.java); result as ResponseHandlingResult.Continue
-        assertThat(result.terminalResponse).isEqualTo(HttpResponse(status = 201))
+        assertThat(result.response).isEqualTo(HttpResponse(status = 201))
         assertThat(result.responseForTestResultOverride).isEqualTo(HttpResponse(status = 201))
         assertThat(sleepDurations).containsExactly(5.seconds.inWholeMilliseconds)
     }
@@ -185,7 +239,7 @@ class TooManyRequestsHandlerTest {
         )
 
         assertThat(result).isInstanceOf(ResponseHandlingResult.Continue::class.java); result as ResponseHandlingResult.Continue
-        assertThat(result.terminalResponse).isEqualTo(HttpResponse(status = 201))
+        assertThat(result.response).isEqualTo(HttpResponse(status = 201))
         assertThat(result.responseForTestResultOverride).isEqualTo(HttpResponse(status = 201))
         assertThat(sleepDurations).isEqualTo(sleepSequence.map { it.seconds.inWholeMilliseconds }.toList())
     }
@@ -316,7 +370,7 @@ class TooManyRequestsHandlerTest {
         )
 
         assertThat(result).isInstanceOf(ResponseHandlingResult.Continue::class.java); result as ResponseHandlingResult.Continue
-        assertThat(result.terminalResponse).isEqualTo(HttpResponse(status = 201))
+        assertThat(result.response).isEqualTo(HttpResponse(status = 201))
         assertThat(sleepDurations.single()).isBetween(expectedDelay - tolerance, expectedDelay + tolerance)
     }
 
@@ -380,7 +434,7 @@ class TooManyRequestsHandlerTest {
         )
 
         assertThat(result).isInstanceOf(ResponseHandlingResult.Continue::class.java); result as ResponseHandlingResult.Continue
-        assertThat(result.terminalResponse).isEqualTo(HttpResponse(status = 202))
+        assertThat(result.response).isEqualTo(HttpResponse(status = 202))
         assertThat(result.responseForTestResultOverride).isNull()
     }
 

--- a/junit5-support/src/test/kotlin/io/specmatic/test/reports/TestHooksTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/reports/TestHooksTest.kt
@@ -56,42 +56,17 @@ class TestHooksTest {
 
     @Test
     fun `onTestResult should report retries for special handling cases like 429`(@TempDir tempDir: File) {
-        val specYaml = """
-        openapi: 3.0.0
-        info:
-          title: TestHooks special case reporting
-          version: 1.0.0
-        paths:
-          /products:
-            get:
-              parameters:
-                - in: header
-                  name: X-Header
-                  required: true
-                  schema:
-                    type: integer
-                  examples:
-                    TOO_MANY_REQUESTS:
-                      value: 0
-              responses:
-                '200':
-                  description: OK
-                '429':
-                  description: Bad request
-                  headers:
-                    X-Retry-After:
-                      schema:
-                        type: integer
-                      examples:
-                        TOO_MANY_REQUESTS:
-                          value: 0
-        """.trimIndent()
-
-        ContractTestScope.from(specYaml, tempDir).execute(v3Config(tempDir)) { server ->
+        ContractTestScope.from(rateLimitSpecYaml(), tempDir).execute(v3Config(tempDir)) { server ->
             server.on("/products", "GET") {
                 header("X-Header", "0")
                 respond(HttpResponse(status = 429, headers = mapOf(HttpHeaders.RetryAfter to "0")))
-                times(3)
+                times(2)
+            }
+
+            server.on("/products", "GET") {
+                header("X-Header", "(number)")
+                respond(HttpResponse(status = 429, headers = mapOf(HttpHeaders.RetryAfter to "0")))
+                times(1)
             }
 
             server.on("/products", "GET") {
@@ -100,14 +75,67 @@ class TestHooksTest {
             }
         }.verify { listener ->
             assertThat(listener.testResults).hasSize(listener.dynamicTests.size).hasSize(2)
+            assertThat(listener.testResults.filter { it.scenario.status == 200 }).hasSize(1).allSatisfy { record ->
+                assertThat(record.testRecord.result).isEqualTo(TestResult.Success)
+                assertThat(record.request).hasSize(record.response.size).hasSize(2)
+                assertThat(record.response.mapNotNull { it?.status }).containsExactly(429, 200)
+            }
             assertThat(listener.testResults.filter { it.scenario.status == 429 }).hasSize(1).allSatisfy { record ->
                 assertThat(record.testRecord.result).isEqualTo(TestResult.Success)
+                assertThat(record.request).hasSize(record.response.size).hasSize(3)
+                assertThat(record.response.mapNotNull { it?.status }).containsExactly(429, 429, 200)
+            }
+        }
+    }
+
+    @Test
+    fun `onTestResult should report every too-many-requests response when retries are exhausted`(@TempDir tempDir: File) {
+        ContractTestScope.from(rateLimitSpecYaml(), tempDir).execute(v3Config(tempDir)) { server ->
+            server.on("/products", "GET") {
+                header("X-Header", "(number)")
+                respond(HttpResponse(status = 429, headers = mapOf(HttpHeaders.RetryAfter to "0")))
+            }
+        }.verify { listener ->
+            assertThat(listener.testResults).hasSize(listener.dynamicTests.size).hasSize(2)
+            assertThat(listener.testResults.filter { it.scenario.status == 200 }).hasSize(1).allSatisfy { record ->
+                assertThat(record.testRecord.result).isEqualTo(TestResult.Failed)
                 assertThat(record.request).hasSize(record.response.size).hasSize(4)
-                assertThat(record.response.mapNotNull { it?.status }).containsExactly(429, 429, 429, 200)
+                assertThat(record.response.mapNotNull { it?.status }).containsExactly(429, 429, 429, 429)
             }
         }
     }
 }
+
+private fun rateLimitSpecYaml() = """
+    openapi: 3.0.0
+    info:
+      title: TestHooks special case reporting
+      version: 1.0.0
+    paths:
+      /products:
+        get:
+          parameters:
+            - in: header
+              name: X-Header
+              required: true
+              schema:
+                type: integer
+              examples:
+                TOO_MANY_REQUESTS:
+                  value: 0
+          responses:
+            '200':
+              description: OK
+            '429':
+              description: Bad request
+              headers:
+                X-Retry-After:
+                  schema:
+                    type: integer
+                  examples:
+                    TOO_MANY_REQUESTS:
+                      value: 0
+""".trimIndent()
 
 private fun v3Config(tempDir: File) =
     tempDir.resolve("specmatic.yaml").apply {


### PR DESCRIPTION
## Summary

- Handle `429 Too Many Requests` responses before evaluating final expected statuses.
- Preserve retry attempts and response reporting across contract tests and test hooks.
- Add coverage for response handling, scenario execution, and generated reports.