### PR TITLE
Add OpenID Connect security scheme support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Each release section should stand on its own and describe the behavior shipped i
   - `enterprise`, bumped in `enterprise/gradle.properties` via `specmaticVersion`
 
 ## Unreleased 
+- Added support for OpenAPI `openIdConnect` security schemes.
 - Updated the MCP backward compatibility tool to correctly handle Docker-based executions. When the required files are not available inside the Docker container, the tool returns the appropriate Docker backward compatibility command for the user to run.
 
 ## 2.51.1 (2026-07-31)

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -2588,7 +2588,7 @@ class OpenApiSpecification(
             return toBearerSecurityScheme(securitySchemeConfiguration, schemeName)
         }
 
-        if (securityScheme.type == SecurityScheme.Type.OAUTH2) {
+        if (securityScheme.type == SecurityScheme.Type.OAUTH2 || securityScheme.type == SecurityScheme.Type.OPENIDCONNECT) {
             return toBearerSecurityScheme(securitySchemeConfiguration, schemeName)
         }
 
@@ -2603,7 +2603,7 @@ class OpenApiSpecification(
         }
 
         collectorContext.record(
-            message = "Specmatic only supports oauth2, bearer, and api key authentication (header, query) security schemes at the moment, ignoring this scheme",
+            message = "Specmatic only supports oauth2, openIdConnect, bearer, basic, and api key authentication (header, query) security schemes at the moment, ignoring this scheme",
             ruleViolation = OpenApiLintViolations.UNSUPPORTED_FEATURE
         )
         return null

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfigV1V2Common.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfigV1V2Common.kt
@@ -1823,6 +1823,7 @@ data class OpenAPISecurityConfiguration(
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 @JsonSubTypes(
     JsonSubTypes.Type(value = OAuth2SecuritySchemeConfiguration::class, name = "oauth2"),
+    JsonSubTypes.Type(value = OpenIdConnectSecuritySchemeConfiguration::class, name = "openIdConnect"),
     JsonSubTypes.Type(value = BasicAuthSecuritySchemeConfiguration::class, name = "basicAuth"),
     JsonSubTypes.Type(value = BearerSecuritySchemeConfiguration::class, name = "bearer"),
     JsonSubTypes.Type(value = APIKeySecuritySchemeConfiguration::class, name = "apiKey")
@@ -1838,6 +1839,12 @@ interface SecuritySchemeWithOAuthToken {
 @JsonTypeName("oauth2")
 data class OAuth2SecuritySchemeConfiguration(
     override val type: String = "oauth2",
+    override val token: String = ""
+) : SecuritySchemeConfiguration(), SecuritySchemeWithOAuthToken
+
+@JsonTypeName("openIdConnect")
+data class OpenIdConnectSecuritySchemeConfiguration(
+    override val type: String = "openIdConnect",
     override val token: String = ""
 ) : SecuritySchemeConfiguration(), SecuritySchemeWithOAuthToken
 

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/SecuritySchemes.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/SecuritySchemes.kt
@@ -3,6 +3,7 @@ package io.specmatic.core.config.v3.components
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonValue
 import io.specmatic.core.OAuth2SecuritySchemeConfiguration
+import io.specmatic.core.OpenIdConnectSecuritySchemeConfiguration
 import io.specmatic.core.BasicAuthSecuritySchemeConfiguration
 import io.specmatic.core.BearerSecuritySchemeConfiguration
 import io.specmatic.core.APIKeySecuritySchemeConfiguration
@@ -10,6 +11,7 @@ import io.specmatic.core.SecuritySchemeConfiguration
 
 enum class SecuritySchemeType(private val value: String) {
     OAUTH2("oauth2"),
+    OPEN_ID_CONNECT("openIdConnect"),
     BASIC_AUTH("basicAuth"),
     BEARER("bearer"),
     API_KEY("apiKey");
@@ -29,6 +31,7 @@ data class SecuritySchemeConfigurationV3(val type: SecuritySchemeType, val token
     fun toSecuritySchemeConfiguration(): SecuritySchemeConfiguration {
         return when(type) {
             SecuritySchemeType.OAUTH2 -> OAuth2SecuritySchemeConfiguration(token = token)
+            SecuritySchemeType.OPEN_ID_CONNECT -> OpenIdConnectSecuritySchemeConfiguration(token = token)
             SecuritySchemeType.BASIC_AUTH -> BasicAuthSecuritySchemeConfiguration(token = token)
             SecuritySchemeType.BEARER -> BearerSecuritySchemeConfiguration(token = token)
             SecuritySchemeType.API_KEY -> APIKeySecuritySchemeConfiguration(value = token)

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/upgrade/SystemUnderTestMapper.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/upgrade/SystemUnderTestMapper.kt
@@ -4,6 +4,7 @@ import io.specmatic.core.APIKeySecuritySchemeConfiguration
 import io.specmatic.core.BasicAuthSecuritySchemeConfiguration
 import io.specmatic.core.BearerSecuritySchemeConfiguration
 import io.specmatic.core.OAuth2SecuritySchemeConfiguration
+import io.specmatic.core.OpenIdConnectSecuritySchemeConfiguration
 import io.specmatic.core.SecurityConfiguration
 import io.specmatic.core.SecuritySchemeConfiguration
 import io.specmatic.core.config.OpenAPITestConfig as LegacyOpenAPITestConfig
@@ -114,6 +115,8 @@ class SystemUnderTestMapper {
         return when (this) {
             is OAuth2SecuritySchemeConfiguration ->
                 SecuritySchemeConfigurationV3(SecuritySchemeType.OAUTH2, token)
+            is OpenIdConnectSecuritySchemeConfiguration ->
+                SecuritySchemeConfigurationV3(SecuritySchemeType.OPEN_ID_CONNECT, token)
             is BasicAuthSecuritySchemeConfiguration ->
                 SecuritySchemeConfigurationV3(SecuritySchemeType.BASIC_AUTH, token)
             is BearerSecuritySchemeConfiguration ->

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiIntegrationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiIntegrationTest.kt
@@ -819,7 +819,7 @@ Feature: Authenticated
         }
 
         @Test
-        fun `should throw not supported error when a security scheme other than oauth2 bearer or api key is defined`() {
+        fun `should throw not supported error when an unsupported security scheme is defined`() {
             assertThrows<ContractException> {
                 parseGherkinStringToFeature(
                     """
@@ -829,7 +829,7 @@ Background:
   Given openapi openapi/unsupported-authentication.yaml
         """.trimIndent(), sourceSpecPath
                 )
-            }.also { assertThat(exceptionCauseMessage(it)).contains("Specmatic only supports oauth2, bearer, and api key authentication (header, query) security schemes at the moment") }
+            }.also { assertThat(exceptionCauseMessage(it)).contains("Specmatic only supports oauth2, openIdConnect, bearer, basic, and api key authentication (header, query) security schemes at the moment") }
         }
 
         @Test
@@ -843,7 +843,7 @@ Background:
   Given openapi openapi/apiKeyAuthCookie.yaml
         """.trimIndent(), sourceSpecPath
                 )
-            }.also { assertThat(exceptionCauseMessage(it)).contains("Specmatic only supports oauth2, bearer, and api key authentication (header, query) security schemes at the moment") }
+            }.also { assertThat(exceptionCauseMessage(it)).contains("Specmatic only supports oauth2, openIdConnect, bearer, basic, and api key authentication (header, query) security schemes at the moment") }
         }
 
         @Test

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenIdConnectSecuritySchemeTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenIdConnectSecuritySchemeTest.kt
@@ -1,0 +1,107 @@
+package io.specmatic.conversions
+
+import com.google.common.net.HttpHeaders
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.specmatic.core.HttpRequest
+import io.specmatic.core.HttpResponse
+import io.specmatic.core.OpenAPISecurityConfiguration
+import io.specmatic.core.OpenIdConnectSecuritySchemeConfiguration
+import io.specmatic.core.Result
+import io.specmatic.core.SecurityConfiguration
+import io.specmatic.core.config.v3.components.SecuritySchemeConfigurationV3
+import io.specmatic.core.config.v3.components.SecuritySchemeType
+import io.specmatic.core.utilities.yamlMapper
+import io.specmatic.test.TestExecutor
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class OpenIdConnectSecuritySchemeTest {
+    @Test
+    fun `generates authorization header using configured OIDC token`() {
+        val feature = OpenApiSpecification.fromYAML(
+            oidcProtectedApi,
+            "",
+            securityConfiguration = SecurityConfiguration(
+                OpenAPI = OpenAPISecurityConfiguration(
+                    securitySchemes = mapOf(
+                        "oidc" to OpenIdConnectSecuritySchemeConfiguration(token = "configured-token")
+                    )
+                )
+            )
+        ).toFeature()
+
+        val result = feature.generateContractTests().single().runTest(object : TestExecutor {
+            override fun execute(request: HttpRequest): HttpResponse {
+                assertThat(request.headers).containsEntry(HttpHeaders.AUTHORIZATION, "Bearer configured-token")
+                return HttpResponse(status = 200)
+            }
+        }).result
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+    }
+
+    @Test
+    fun `generates authorization header using token named after OIDC scheme`() {
+        try {
+            System.setProperty("oidc", "environment-token")
+            val feature = OpenApiSpecification.fromYAML(oidcProtectedApi, "").toFeature()
+
+            val result = feature.generateContractTests().single().runTest(object : TestExecutor {
+                override fun execute(request: HttpRequest): HttpResponse {
+                    assertThat(request.headers).containsEntry(HttpHeaders.AUTHORIZATION, "Bearer environment-token")
+                    return HttpResponse(status = 200)
+                }
+            }).result
+
+            assertThat(result).isInstanceOf(Result.Success::class.java)
+        } finally {
+            System.clearProperty("oidc")
+        }
+    }
+
+    @Test
+    fun `deserializes OIDC security configuration in legacy config`() {
+        val configuration = yamlMapper.readValue<SecurityConfiguration>(
+            """
+            OpenAPI:
+              securitySchemes:
+                oidc:
+                  type: openIdConnect
+                  token: jwt-token
+            """.trimIndent()
+        )
+
+        assertThat(configuration.getOpenAPISecurityScheme("oidc"))
+            .isEqualTo(OpenIdConnectSecuritySchemeConfiguration(token = "jwt-token"))
+    }
+
+    @Test
+    fun `maps OIDC v3 security configuration to bearer-token configuration`() {
+        val configuration = SecuritySchemeConfigurationV3(
+            type = SecuritySchemeType.OPEN_ID_CONNECT,
+            token = "jwt-token"
+        ).toSecuritySchemeConfiguration()
+
+        assertThat(configuration).isEqualTo(OpenIdConnectSecuritySchemeConfiguration(token = "jwt-token"))
+    }
+
+    private val oidcProtectedApi = """
+        openapi: 3.0.3
+        info:
+          title: OIDC protected API
+          version: 1.0.0
+        paths:
+          /products:
+            get:
+              security:
+                - oidc: []
+              responses:
+                '200':
+                  description: Products
+        components:
+          securitySchemes:
+            oidc:
+              type: openIdConnect
+              openIdConnectUrl: https://issuer.example/.well-known/openid-configuration
+    """.trimIndent()
+}

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3UpgradeTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3UpgradeTest.kt
@@ -1242,6 +1242,9 @@ class SpecmaticConfigV3UpgradeTest {
                           bearerAuth:
                             type: bearer
                             token: bearer-token
+                          oidcAuth:
+                            type: openIdConnect
+                            token: oidc-token
                     """.trimIndent(),
                     beforeV2 = """
                     version: 2
@@ -1259,6 +1262,9 @@ class SpecmaticConfigV3UpgradeTest {
                           bearerAuth:
                             type: bearer
                             token: bearer-token
+                          oidcAuth:
+                            type: openIdConnect
+                            token: oidc-token
                     """.trimIndent(),
                     afterV3 = """
                     version: 3
@@ -1285,6 +1291,9 @@ class SpecmaticConfigV3UpgradeTest {
                                     bearerAuth:
                                       type: bearer
                                       token: bearer-token
+                                    oidcAuth:
+                                      type: openIdConnect
+                                      token: oidc-token
                     """.trimIndent()
                 ),
                 LegacyPairCase(

--- a/core/src/test/resources/openapi/unsupported-authentication.yaml
+++ b/core/src/test/resources/openapi/unsupported-authentication.yaml
@@ -42,6 +42,6 @@ paths:
 
 components:
   securitySchemes:
-    basicAuth:
-      type: openIdConnect
-      scheme: basic
+    digestAuth:
+      type: http
+      scheme: digest


### PR DESCRIPTION
## Summary

- Support OpenID Connect security schemes as bearer-token authentication.
- Add legacy and v3 configuration support, including upgrade mapping.
- Add coverage for token resolution, deserialization, conversion, and unsupported schemes.

## Enterprise tracking

- Related to specmatic/enterprise#542.