### PR TITLE
Support retries for undocumented 429 responses

### DIFF
--- a/core/src/main/kotlin/io/specmatic/test/handlers/TooManyRequestsHandler.kt
+++ b/core/src/main/kotlin/io/specmatic/test/handlers/TooManyRequestsHandler.kt
@@ -26,21 +26,13 @@ class TooManyRequestsHandler(
     private val retryHandler: RetryHandler<MonitorResult, HttpResponse> = RetryHandler(DelayStrategy.RespectRetryAfter())
 ) : ResponseHandler {
     override fun canHandle(response: HttpResponse, scenario: Scenario): Boolean {
-        if (response.status != HttpStatusCode.TooManyRequests.value) return false
-
-        return feature.isResponseStatusPossible(scenario, HttpStatusCode.TooManyRequests.value)
+        return response.status == HttpStatusCode.TooManyRequests.value
     }
 
     override fun handle(request: HttpRequest, response: HttpResponse, testScenario: Scenario, testExecutor: TestExecutor): ResponseHandlingResult {
         val processingScenario = getProcessingScenario(response)
-            ?: return ResponseHandlingResult.Stop(Result.Failure("No tooManyRequests scenario found for ${originalScenario.defaultAPIDescription}"))
-
-        val processingScenarioResult = processingScenario.matches(response)
-        if (processingScenarioResult is Result.Failure) {
-            return ResponseHandlingResult.Stop(Result.Failure(
-                message = "Response doesn't match processing scenario",
-                cause = processingScenarioResult,
-            ).updateScenario(processingScenario))
+        validateDocumentedTooManyRequestsResponse(response, processingScenario)?.let {
+            return ResponseHandlingResult.Stop(it)
         }
 
         val matchingScenarios = findMatchingScenarios(testScenario)
@@ -53,14 +45,11 @@ class TooManyRequestsHandler(
                 lastRetryResponse = response
 
                 if (response.status == HttpStatusCode.TooManyRequests.value) {
-                    val retryResponseResult = processingScenario.matches(response)
-                    if (retryResponseResult is Result.Failure) {
+                    val retryResponseFailure = validateDocumentedTooManyRequestsResponse(response, processingScenario)
+                    if (retryResponseFailure != null) {
                         return@ResponseMonitor RetryResult.Stop(
                             MonitorResult.Failure(
-                                failure = Result.Failure(
-                                    message = "Response doesn't match processing scenario",
-                                    cause = retryResponseResult,
-                                ).updateScenario(processingScenario),
+                                failure = retryResponseFailure,
                                 response = response,
                             )
                         )
@@ -96,6 +85,19 @@ class TooManyRequestsHandler(
                 monitorResult.response ?: lastRetryResponse,
             )
         }
+    }
+
+    private fun validateDocumentedTooManyRequestsResponse(
+        response: HttpResponse,
+        processingScenario: Scenario?,
+    ): Result.Failure? {
+        val result = processingScenario?.matches(response) ?: return null
+        if (result !is Result.Failure) return null
+
+        return Result.Failure(
+            message = "Response doesn't match processing scenario",
+            cause = result,
+        ).updateScenario(processingScenario)
     }
 
     private fun findMatchingScenarios(testScenario: Scenario): List<Scenario> {

--- a/core/src/main/kotlin/io/specmatic/test/utils/DelayStrategy.kt
+++ b/core/src/main/kotlin/io/specmatic/test/utils/DelayStrategy.kt
@@ -28,11 +28,14 @@ sealed interface DelayStrategy<T> {
 
         private fun extractRetryAfter(response: HttpResponse?): Long? {
             val retryAfter = response?.headers?.getCaseInsensitive(HttpHeaders.RetryAfter)?.value ?: return null
-            retryAfter.toLongOrNull()?.let { seconds -> return seconds * 1000 }
+            retryAfter.toLongOrNull()?.takeIf { it >= 0 }?.let { seconds -> return seconds * 1000 }
             return runCatching {
-                val target = Instant.parse(retryAfter)
+                val target = runCatching { retryAfter.fromHttpToGmtDate().timestamp }.getOrElse {
+                    // Retain support for ISO-8601 values accepted by earlier versions, even though HTTP specifies HTTP-date.
+                    Instant.parse(retryAfter).toEpochMilli()
+                }
                 val now = Instant.now()
-                val delayMillis = target.toEpochMilli() - now.toEpochMilli()
+                val delayMillis = target - now.toEpochMilli()
                 delayMillis.coerceAtLeast(0)
             }.getOrNull()
         }

--- a/core/src/test/kotlin/io/specmatic/core/RunContractTestsUsingScenario.kt
+++ b/core/src/test/kotlin/io/specmatic/core/RunContractTestsUsingScenario.kt
@@ -838,6 +838,44 @@ paths:
     }
 
     @Test
+    fun `should retry an undocumented tooManyRequests response returned for a 200 test`() {
+        val successScenario = Scenario(ScenarioInfo(
+            httpRequestPattern = HttpRequestPattern(
+                httpPathPattern = buildHttpPathPattern("/(id:string)"), method = "POST",
+                body = JSONObjectPattern(mapOf("age" to NumberPattern()))
+            ),
+            httpResponsePattern = HttpResponsePattern(status = 200),
+            protocol = SpecmaticProtocol.HTTP,
+            specType = SpecType.OPENAPI
+        ))
+        val feature = Feature(name = "", scenarios = listOf(successScenario), protocol = SpecmaticProtocol.HTTP)
+        val contractTest = ScenarioAsTest(
+            successScenario,
+            feature,
+            feature.flagsBased,
+            originalScenario = successScenario,
+            protocol = SpecmaticProtocol.HTTP,
+            specType = SpecType.OPENAPI
+        )
+        var executionCount = 0
+
+        val executionResult = contractTest.runTest(object : TestExecutor {
+            override fun execute(request: HttpRequest): HttpResponse {
+                executionCount++
+                return if (executionCount == 1) {
+                    HttpResponse(429, headers = mapOf(HttpHeaders.RetryAfter to "0"))
+                } else {
+                    HttpResponse(200)
+                }
+            }
+        })
+
+        assertThat(executionResult.result).isInstanceOf(Result.Success::class.java)
+        assertThat(executionResult.response).isEqualTo(HttpResponse(200))
+        assertThat(executionCount).isEqualTo(2)
+    }
+
+    @Test
     fun `should retry a documented tooManyRequests response returned for a 403 test`() {
         val forbiddenScenario = Scenario(ScenarioInfo(
             httpRequestPattern = HttpRequestPattern(

--- a/core/src/test/kotlin/io/specmatic/test/handlers/TooManyRequestsHandlerTest.kt
+++ b/core/src/test/kotlin/io/specmatic/test/handlers/TooManyRequestsHandlerTest.kt
@@ -68,11 +68,11 @@ class TooManyRequestsHandlerTest {
     }
 
     @Test
-    fun `should not handle too-many-requests responses when they are undocumented`() {
+    fun `should handle too-many-requests responses when they are undocumented`() {
         val feature = Feature(name = "", scenarios = listOf(postScenario), protocol = SpecmaticProtocol.HTTP)
         val handler = TooManyRequestsHandler(feature, postScenario)
 
-        assertThat(handler.canHandle(HttpResponse(status = 429), postScenario)).isFalse()
+        assertThat(handler.canHandle(HttpResponse(status = 429), postScenario)).isTrue()
     }
 
     @Test
@@ -130,20 +130,44 @@ class TooManyRequestsHandlerTest {
     }
 
     @Test
-    fun `should retry failure if too-many-requests response is not possible`() {
+    fun `should retry too-many-requests response without validating it when it is undocumented`() {
         val feature = Feature(name = "", scenarios = listOf(postScenario), protocol = SpecmaticProtocol.HTTP)
         val handler = TooManyRequestsHandler(feature, postScenario)
         val result = handler.handle(
-            HttpRequest(),
-            HttpResponse(status = 429),
+            HttpRequest("POST", "/ABC", body = JSONObjectValue(mapOf("age" to NumberValue(10)))),
+            HttpResponse(status = 429, headers = mapOf(HttpHeaders.RetryAfter to "0")),
             postScenario,
-            throwAwayExecutor,
+            object : TestExecutor {
+                override fun execute(request: HttpRequest): HttpResponse = HttpResponse(status = 201)
+            },
         )
 
-        assertThat(result).isInstanceOf(ResponseHandlingResult.Stop::class.java); result as ResponseHandlingResult.Stop
-        assertThat(result.result.reportString()).isEqualToNormalizingWhitespace("""
-        No tooManyRequests scenario found for POST /(id:string) -> 201
-        """.trimIndent())
+        assertThat(result).isInstanceOf(ResponseHandlingResult.Continue::class.java); result as ResponseHandlingResult.Continue
+        assertThat(result.response).isEqualTo(HttpResponse(status = 201))
+    }
+
+    @Test
+    fun `should not validate undocumented too-many-requests response against default response`() {
+        val defaultScenario = tooManyRequestsScenario.copy(
+            httpResponsePattern = HttpResponsePattern(
+                status = DEFAULT_RESPONSE_CODE,
+                body = ExactValuePattern(StringValue("default error")),
+            ),
+        )
+        val feature = Feature(name = "", scenarios = listOf(postScenario, defaultScenario), protocol = SpecmaticProtocol.HTTP)
+        val handler = TooManyRequestsHandler(feature, postScenario)
+
+        val result = handler.handle(
+            HttpRequest("POST", "/ABC", body = JSONObjectValue(mapOf("age" to NumberValue(10)))),
+            HttpResponse(status = 429, body = StringValue("rate limited")),
+            postScenario,
+            object : TestExecutor {
+                override fun execute(request: HttpRequest): HttpResponse = HttpResponse(status = 201)
+            },
+        )
+
+        assertThat(result).isInstanceOf(ResponseHandlingResult.Continue::class.java); result as ResponseHandlingResult.Continue
+        assertThat(result.response).isEqualTo(HttpResponse(status = 201))
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/test/utils/DelayStrategyTest.kt
+++ b/core/src/test/kotlin/io/specmatic/test/utils/DelayStrategyTest.kt
@@ -1,0 +1,47 @@
+package io.specmatic.test.utils
+
+import io.ktor.http.HttpHeaders
+import io.ktor.http.fromHttpToGmtDate
+import io.ktor.http.toHttpDate
+import io.ktor.util.date.GMTDate
+import io.specmatic.core.HttpResponse
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import kotlin.time.Duration.Companion.seconds
+
+class DelayStrategyTest {
+    private val strategy = DelayStrategy.RespectRetryAfter()
+
+    @Test
+    fun `should calculate delay from standards compliant HTTP date`() {
+        val retryAfter = GMTDate(Instant.now().plusSeconds(10).toEpochMilli()).toHttpDate()
+        val targetTime = retryAfter.fromHttpToGmtDate().timestamp
+        val earliestExpectedDelay = targetTime - Instant.now().toEpochMilli()
+
+        val delay = strategy.getInitialDelay(contextFor(retryAfter))
+
+        assertThat(delay).isBetween(earliestExpectedDelay - 1.seconds.inWholeMilliseconds, earliestExpectedDelay)
+    }
+
+    @Test
+    fun `should continue calculating delay from ISO 8601 date`() {
+        val retryAfter = Instant.now().plusSeconds(10).toString()
+
+        val delay = strategy.getInitialDelay(contextFor(retryAfter))
+
+        assertThat(delay).isBetween(9.seconds.inWholeMilliseconds, 10.seconds.inWholeMilliseconds)
+    }
+
+    @Test
+    fun `should use fallback delay for negative delay seconds`() {
+        val delay = strategy.calculateDelay(contextFor("-1"))
+
+        assertThat(delay).isEqualTo(1.seconds.inWholeMilliseconds)
+    }
+
+    private fun contextFor(retryAfter: String) = DelayStrategyContext(
+        value = HttpResponse(headers = mapOf(HttpHeaders.RetryAfter to retryAfter)),
+        attempt = 0,
+    )
+}


### PR DESCRIPTION
## Summary
- Retry documented and undocumented `429 Too Many Requests` responses.
- Parse standards-compliant HTTP-date `Retry-After` values while preserving ISO-8601 compatibility.
- Add coverage for undocumented responses and retry-delay handling.