### PR TITLE
Fix ref-based path parameter change tracking

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityChecker.kt
+++ b/core/src/main/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityChecker.kt
@@ -15,9 +15,9 @@ class OpenApiBackwardCompatibilityChecker(
 ) {
     private val newScenariosByMethodAndReqContentType = newFeature.scenarios.groupBy { it.method to it.requestContentType }
     private val oldChangeTrackingScenariosByPathAndMethod = oldFeature.scenariosForChangeTracking()
-        .groupBy { it.path to it.method }
+        .groupBy { it.openApiPath to it.method }
     private val newChangeTrackingScenariosByPathAndMethod = newFeature.scenariosForChangeTracking()
-        .groupBy { it.path to it.method }
+        .groupBy { it.openApiPath to it.method }
 
     fun run(): List<OpenApiBackwardCompatibilityCheckRecord> {
         val requestFamilies = groupScenariosByPathAndMethod(oldFeature)
@@ -32,7 +32,7 @@ class OpenApiBackwardCompatibilityChecker(
     }
 
     private fun operationChangeStatus(requestFamily: RequestFamily): (Scenario) -> ChangeStatus {
-        val operationIdentifier = requestFamily.path to requestFamily.method
+        val operationIdentifier = requestFamily.openApiPath to requestFamily.method
         val oldScenariosForOperation = oldChangeTrackingScenariosByPathAndMethod[operationIdentifier].orEmpty()
         val newScenariosForOperation = newChangeTrackingScenariosByPathAndMethod[operationIdentifier].orEmpty()
         return ScenarioFingerprint.changeStatusBetween(oldScenariosForOperation, newScenariosForOperation)
@@ -239,7 +239,7 @@ private data class RequestFamily(val scenarios: List<Scenario>) {
     private val groupedByRequestIdentifiers = scenarios.groupBy { Triple(it.path, it.method, it.requestContentType) }
     private val groupedByResponseIdentifiers = scenarios.groupBy { Pair(it.status, it.responseContentType) }
 
-    val path: String get() = representativeScenario.path
+    val openApiPath: String get() = representativeScenario.openApiPath
     val method: String get() = representativeScenario.method
 
     fun oneScenarioPerReqIdentifiers(): List<Scenario> {

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -123,6 +123,11 @@ data class Scenario(
             return httpRequestPattern.httpPathPattern?.toInternalPath() ?: ""
         }
 
+    val openApiPath: String
+        get() {
+            return httpRequestPattern.httpPathPattern?.toOpenApiPath() ?: ""
+        }
+
     val status: Int
         get() {
             return if (isNegative && !isA4xxScenario()) 400 else httpResponsePattern.status

--- a/core/src/main/kotlin/io/specmatic/core/ScenarioFingerprint.kt
+++ b/core/src/main/kotlin/io/specmatic/core/ScenarioFingerprint.kt
@@ -30,7 +30,7 @@ data class ScenarioFingerprint(
         )
 
         fun keyOf(scenario: Scenario): Key = Key(
-            path = scenario.path,
+            path = scenario.openApiPath,
             method = scenario.method,
             requestContentType = scenario.requestContentType,
             status = scenario.status,
@@ -41,8 +41,8 @@ data class ScenarioFingerprint(
             oldScenarios: Collection<Scenario>,
             newScenarios: Collection<Scenario>,
         ): (Scenario) -> ChangeStatus {
-            val oldByKey = oldScenarios.associate { keyOf(it) to from(it) }
-            val newByKey = newScenarios.associate { keyOf(it) to from(it) }
+            val oldByKey = oldScenarios.groupBy(::keyOf).mapValues { (_, scenarios) -> scenarios.map(::from).toSet() }
+            val newByKey = newScenarios.groupBy(::keyOf).mapValues { (_, scenarios) -> scenarios.map(::from).toSet() }
             val statusByKey = (oldByKey.keys + newByKey.keys).associateWith { key ->
                 if (oldByKey[key] == newByKey[key]) ChangeStatus.UNCHANGED else ChangeStatus.CHANGED
             }

--- a/core/src/test/kotlin/io/specmatic/core/ScenarioFingerprintTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ScenarioFingerprintTest.kt
@@ -80,6 +80,36 @@ class ScenarioFingerprintTest {
     }
 
     @Test
+    fun `openApiPath preserves the OpenAPI template when the internal path contains a ref alias`() {
+        val spec = $$"""
+        openapi: 3.0.0
+        info:
+          title: Orders API
+          version: 1.0.0
+        paths:
+          /orders/{id}:
+            get:
+              parameters:
+                - name: id
+                  in: path
+                  required: true
+                  schema:
+                    $ref: '#/components/schemas/OrderId'
+              responses:
+                '200':
+                  description: ok
+        components:
+          schemas:
+            OrderId:
+              type: integer
+        """.trimIndent()
+
+        val scenario = OpenApiSpecification.fromYAML(spec, "test.yaml").toFeature().scenarios.single()
+        assertThat(scenario.path).isEqualTo("/orders/(id:OrderId)")
+        assertThat(scenario.openApiPath).isEqualTo("/orders/{id}")
+    }
+
+    @Test
     fun `fingerprints of structurally identical scenarios are equal`() {
         val first = singleScenarioFrom(baseSpec)
         val second = singleScenarioFrom(baseSpec)
@@ -161,6 +191,13 @@ class ScenarioFingerprintTest {
     }
 
     @Test
+    fun `changeStatusBetween stays UNCHANGED when an inline schema becomes an equivalent ref`() {
+        val old = scenariosFrom(baseSpec)
+        val new = scenariosFrom(componentRefSpec)
+        assertThat(aggregateChangeStatus(old, new)).isEqualTo(ChangeStatus.UNCHANGED)
+    }
+
+    @Test
     fun `changeStatusBetween returns UNCHANGED when an unused component schema changes`() {
         val specWithUnusedComponent = componentRefSpec.applyJsonPatch("""
             - op: add
@@ -205,6 +242,80 @@ class ScenarioFingerprintTest {
         val new = scenariosFrom(baseSpec)
 
         assertThat(aggregateChangeStatus(old, new)).isEqualTo(ChangeStatus.CHANGED)
+    }
+
+    @Test
+    fun `changeStatusBetween compares all scenarios sharing a canonical operation key`() {
+        val pathParameterSpec = """
+        openapi: 3.0.0
+        info:
+          title: Orders API
+          version: 1.0.0
+        paths:
+          /orders/{id}:
+            get:
+              parameters:
+                - name: id
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+              responses:
+                '200':
+                  description: ok
+        """.trimIndent()
+
+        val original = singleScenarioFrom(pathParameterSpec)
+        val variant = original.copy(
+            httpRequestPattern = original.httpRequestPattern.copy(
+                httpPathPattern = HttpPathPattern.from("/orders/(id:number)")
+            )
+        )
+
+        val statusFor = ScenarioFingerprint.changeStatusBetween(
+            oldScenarios = listOf(variant, original),
+            newScenarios = listOf(original),
+        )
+
+        assertThat(statusFor(original)).isEqualTo(ChangeStatus.CHANGED)
+        assertThat(statusFor(variant)).isEqualTo(ChangeStatus.CHANGED)
+    }
+
+    @Test
+    fun `changeStatusBetween is independent of scenario order for multiple internal path variants`() {
+        val pathParameterSpec = """
+        openapi: 3.0.0
+        info:
+          title: Orders API
+          version: 1.0.0
+        paths:
+          /orders/{id}:
+            get:
+              parameters:
+                - name: id
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+              responses:
+                '200':
+                  description: ok
+        """.trimIndent()
+
+        val original = singleScenarioFrom(pathParameterSpec)
+        val variant = original.copy(
+            httpRequestPattern = original.httpRequestPattern.copy(
+                httpPathPattern = HttpPathPattern.from("/orders/(id:number)")
+            )
+        )
+
+        val statusFor = ScenarioFingerprint.changeStatusBetween(
+            oldScenarios = listOf(variant, original),
+            newScenarios = listOf(original, variant),
+        )
+
+        assertThat(statusFor(original)).isEqualTo(ChangeStatus.UNCHANGED)
+        assertThat(statusFor(variant)).isEqualTo(ChangeStatus.UNCHANGED)
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
@@ -6036,6 +6036,333 @@ paths:
             return if (qualifiers.contains("changed")) "CHANGED" else "UNCHANGED"
         }
 
+        @Test
+        fun `a schema ref used by a path parameter keeps the operation change status stable`(@TempDir tempDir: File) {
+            val referencedPathParameterSpec = $$"""
+            openapi: 3.0.0
+            info:
+              title: Orders API
+              version: 1.0.0
+            paths:
+              /orders/{id}:
+                get:
+                  parameters:
+                    - name: id
+                      in: path
+                      required: true
+                      schema:
+                        $ref: '#/components/schemas/OrderId'
+                  responses:
+                    '200':
+                      description: ok
+            components:
+              schemas:
+                OrderId:
+                  type: integer
+            """.trimIndent()
+
+            val unchangedOperations = runBccAndGetOperations(
+                oldSpec = referencedPathParameterSpec,
+                newSpec = referencedPathParameterSpec,
+                tempDir = tempDir.resolve("unchanged").apply { mkdirs() },
+            )
+
+            assertThat(unchangedOperations.changeStatusFor(method = "GET", path = "/orders/{id}")).isEqualTo("UNCHANGED")
+            val changedSpec = referencedPathParameterSpec.applyJsonPatch("""
+            - op: replace
+              path: /components/schemas/OrderId/type
+              value: string
+            """.trimIndent())
+
+            val changedOperations = runBccAndGetOperations(
+                newSpec = changedSpec,
+                oldSpec = referencedPathParameterSpec,
+                tempDir = tempDir.resolve("changed").apply { mkdirs() },
+            )
+
+            assertThat(changedOperations.changeStatusFor(method = "GET", path = "/orders/{id}")).isEqualTo("CHANGED")
+        }
+
+        @Test
+        fun `a path parameter ref changed to an equivalent inline schema stays unchanged`(@TempDir tempDir: File) {
+            val refSpec = $$"""
+            openapi: 3.0.0
+            info:
+              title: Orders API
+              version: 1.0.0
+            paths:
+              /orders/{id}:
+                get:
+                  parameters:
+                    - name: id
+                      in: path
+                      required: true
+                      schema:
+                        $ref: '#/components/schemas/OrderId'
+                  responses:
+                    '200':
+                      description: ok
+            components:
+              schemas:
+                OrderId:
+                  type: integer
+            """.trimIndent()
+
+            val inlineSpec = refSpec.applyJsonPatch("""
+            - op: replace
+              path: /paths/~1orders~1{id}/get/parameters/0/schema
+              value:
+                type: integer
+            """.trimIndent())
+
+            val operations = runBccAndGetOperations(
+                oldSpec = refSpec,
+                newSpec = inlineSpec,
+                tempDir = tempDir.apply { mkdirs() },
+            )
+
+            assertThat(operations.changeStatusFor(method = "GET", path = "/orders/{id}")).isEqualTo("UNCHANGED")
+        }
+
+        @Test
+        fun `an inline path parameter changed to an equivalent schema ref stays unchanged`(@TempDir tempDir: File) {
+            val inlineSpec = """
+            openapi: 3.0.0
+            info:
+              title: Orders API
+              version: 1.0.0
+            paths:
+              /orders/{id}:
+                get:
+                  parameters:
+                    - name: id
+                      in: path
+                      required: true
+                      schema:
+                        type: integer
+                  responses:
+                    '200':
+                      description: ok
+            """.trimIndent()
+
+            val refSpec = inlineSpec.applyJsonPatch($$"""
+            - op: add
+              path: /components
+              value:
+                schemas:
+                  OrderId:
+                    type: integer
+            - op: replace
+              path: /paths/~1orders~1{id}/get/parameters/0/schema
+              value:
+                $ref: '#/components/schemas/OrderId'
+            """.trimIndent())
+
+            val operations = runBccAndGetOperations(
+                oldSpec = inlineSpec,
+                newSpec = refSpec,
+                tempDir = tempDir.apply { mkdirs() },
+            )
+
+            assertThat(operations.changeStatusFor(method = "GET", path = "/orders/{id}")).isEqualTo("UNCHANGED")
+        }
+
+        @Test
+        fun `an inline path parameter changed to a ref with a different schema is changed`(@TempDir tempDir: File) {
+            val inlineSpec = """
+            openapi: 3.0.0
+            info:
+              title: Orders API
+              version: 1.0.0
+            paths:
+              /orders/{id}:
+                get:
+                  parameters:
+                    - name: id
+                      in: path
+                      required: true
+                      schema:
+                        type: integer
+                  responses:
+                    '200':
+                      description: ok
+            """.trimIndent()
+
+            val refSpec = inlineSpec.applyJsonPatch($$"""
+            - op: add
+              path: /components
+              value:
+                schemas:
+                  OrderId:
+                    type: string
+            - op: replace
+              path: /paths/~1orders~1{id}/get/parameters/0/schema
+              value:
+                $ref: '#/components/schemas/OrderId'
+            """.trimIndent())
+
+            val operations = runBccAndGetOperations(
+                oldSpec = inlineSpec,
+                newSpec = refSpec,
+                tempDir = tempDir.apply { mkdirs() },
+            )
+
+            assertThat(operations.changeStatusFor(method = "GET", path = "/orders/{id}")).isEqualTo("CHANGED")
+        }
+
+        @Test
+        fun `an inline path parameter changed to an equivalent whole parameter ref stays unchanged`(@TempDir tempDir: File) {
+            val inlineSpec = """
+            openapi: 3.0.0
+            info:
+              title: Orders API
+              version: 1.0.0
+            paths:
+              /orders/{id}:
+                get:
+                  parameters:
+                    - name: id
+                      in: path
+                      required: true
+                      schema:
+                        type: integer
+                  responses:
+                    '200':
+                      description: ok
+            """.trimIndent()
+
+            val refSpec = inlineSpec.applyJsonPatch($$"""
+            - op: add
+              path: /components
+              value:
+                parameters:
+                  OrderId:
+                    name: id
+                    in: path
+                    required: true
+                    schema:
+                      type: integer
+            - op: replace
+              path: /paths/~1orders~1{id}/get/parameters/0
+              value:
+                $ref: '#/components/parameters/OrderId'
+            """.trimIndent())
+
+            val operations = runBccAndGetOperations(
+                oldSpec = inlineSpec,
+                newSpec = refSpec,
+                tempDir = tempDir.apply { mkdirs() },
+            )
+
+            assertThat(operations.changeStatusFor(method = "GET", path = "/orders/{id}")).isEqualTo("UNCHANGED")
+        }
+
+        @Test
+        fun `a whole path parameter ref changed to an equivalent inline parameter stays unchanged`(@TempDir tempDir: File) {
+            val refSpec = $$"""
+            openapi: 3.0.0
+            info:
+              title: Orders API
+              version: 1.0.0
+            paths:
+              /orders/{id}:
+                get:
+                  parameters:
+                    - $ref: '#/components/parameters/OrderId'
+                  responses:
+                    '200':
+                      description: ok
+            components:
+              parameters:
+                OrderId:
+                  name: id
+                  in: path
+                  required: true
+                  schema:
+                    type: integer
+            """.trimIndent()
+
+            val inlineSpec = refSpec.applyJsonPatch("""
+            - op: replace
+              path: /paths/~1orders~1{id}/get/parameters/0
+              value:
+                name: id
+                in: path
+                required: true
+                schema:
+                  type: integer
+            """.trimIndent())
+
+            val operations = runBccAndGetOperations(
+                oldSpec = refSpec,
+                newSpec = inlineSpec,
+                tempDir = tempDir.apply { mkdirs() },
+            )
+
+            assertThat(operations.changeStatusFor(method = "GET", path = "/orders/{id}")).isEqualTo("UNCHANGED")
+        }
+
+        @Test
+        fun `multiple referenced path parameters use one stable OpenAPI operation identity`(@TempDir tempDir: File) {
+            val spec = $$"""
+            openapi: 3.0.0
+            info:
+              title: Orders API
+              version: 1.0.0
+            paths:
+              /orders/{orderId}/items/{itemId}:
+                get:
+                  parameters:
+                    - $ref: '#/components/parameters/OrderId'
+                    - $ref: '#/components/parameters/ItemId'
+                  responses:
+                    '200':
+                      description: ok
+            components:
+              parameters:
+                OrderId:
+                  name: orderId
+                  in: path
+                  required: true
+                  schema:
+                    type: integer
+                ItemId:
+                  name: itemId
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+            """.trimIndent()
+
+            val changedSpec = spec.applyJsonPatch("""
+            - op: replace
+              path: /components/parameters/ItemId/schema/type
+              value: integer
+            """.trimIndent())
+
+            val unchangedOperations = runBccAndGetOperations(
+                oldSpec = spec,
+                newSpec = spec,
+                tempDir = tempDir.resolve("unchanged").apply { mkdirs() },
+            )
+
+            assertThat(unchangedOperations.changeStatusFor(
+                method = "GET",
+                path = "/orders/{orderId}/items/{itemId}",
+            )).isEqualTo("UNCHANGED")
+
+            val changedOperations = runBccAndGetOperations(
+                oldSpec = spec,
+                newSpec = changedSpec,
+                tempDir = tempDir.resolve("changed").apply { mkdirs() },
+            )
+
+            assertThat(changedOperations.changeStatusFor(
+                method = "GET",
+                path = "/orders/{orderId}/items/{itemId}",
+            )).isEqualTo("CHANGED")
+        }
+
         // TODO(product): decide whether new-only operations should surface as CHANGED in the BCC report.
         // Today OpenApiBackwardCompatibilityChecker iterates over old scenarios only, so an operation
         // present in the new spec but absent in the old spec produces no record and is not reported.


### PR DESCRIPTION
**What**:

Fix change tracking for path parameters defined through `$ref`.

For example:
```yaml
/orders/{id}:
  parameters:
    - name: id
      in: path
      required: true
      schema:
        $ref: '#/components/schemas/OrderId'
```

The normal scenario could contain `/orders/(id:OrderId)`,  while the change-tracking scenario resolves the ref and contains `/orders/(id:integer)`. 

> This caused the unchanged operation to be reported as changed.

**Why**:
Referenced and inline path parameter schemas should identify the same OpenAPI
operation. Real schema changes must still be reported as changed.

**How**:
- Use the canonical `/orders/{id}` path for operation identity.
- Retain internal paths for request coverage grouping.
- Compare complete fingerprint sets for duplicate operation keys.
- Add regression tests for inline, schema-ref, and whole-parameter-ref transitions.

**Checklist**:
- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
