### PR TITLE
Fix form-data body pattern and content encoding conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ Each release section should stand on its own and describe the behavior shipped i
 ### Changed
 
 - Fixed loading of OpenAPI examples referenced through internal or external references, with consistent handling of scalar, structured, array, null, and Specmatic values.
+- Fixed OpenAPI `multipart/form-data` and `application/x-www-form-urlencoded` examples so their requests use multipart parts or form fields instead of a generic request body, allowing inline and external examples to match request patterns during test generation and mocking.
+- Fixed multipart mock request parsing to preserve each part's `Content-Encoding`, so multipart examples declaring an encoding can match the incoming request.
 - Fixed request examples for operations with an empty response body so path parameter examples are retained when a request body is present.
 - Synchronized the bundled multipart-form-data example schemas with the supported example structure.
 

--- a/core/src/main/kotlin/io/specmatic/conversions/ExampleRequestBuilder.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/ExampleRequestBuilder.kt
@@ -60,6 +60,7 @@ class ExampleRequestBuilder(
                     method = httpMethod,
                     path = httpPathPattern.toInternalPath(),
                     headers = mapOf(CONTENT_TYPE to contentType),
+                    body = NoBodyValue,
                     formFields = formFields
                 )
 
@@ -88,6 +89,7 @@ class ExampleRequestBuilder(
                     multiPartFormData = multiPartFormData,
                     path = httpPathPattern.toInternalPath(),
                     headers = mapOf(CONTENT_TYPE to contentType),
+                    body = NoBodyValue,
                 )
 
                 securitySchemes.map { securityScheme ->

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -1953,6 +1953,7 @@ class OpenApiSpecification(
                     val schemaPointer = "$requestBodyBasePointer/content/${escapeJsonPointer(contentType)}/schema"
                     Pair(
                         requestPattern.copy(
+                            body = NoBodyPattern,
                             multiPartFormDataPattern = parts,
                             multiPartPointers = formContentPointers(mediaType.schema, schemaPointer),
                             headersPattern = headersPatternWithContentType(requestPattern, contentType)
@@ -1975,6 +1976,7 @@ class OpenApiSpecification(
                     val schemaPointer = "$requestBodyBasePointer/content/${escapeJsonPointer(contentType)}/schema"
                     Pair(
                         requestPattern.copy(
+                            body = NoBodyPattern,
                             formFieldsPattern = toFormFields(mediaType, mediaTypeContext),
                             formFieldPointers = formContentPointers(mediaType.schema, schemaPointer),
                             headersPattern = headersPatternWithContentType(requestPattern, contentType)

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -1320,6 +1320,7 @@ private suspend fun bodyFromCall(call: ApplicationCall): Triple<Value, Map<Strin
                             },
                             boundary = boundary,
                             specifiedContentType = it.contentType?.let { contentType -> "${contentType.contentType}/${contentType.contentSubtype}" },
+                            contentEncoding = it.headers[HttpHeaders.ContentEncoding],
                             filename = it.originalFileName,
                         )
                     }
@@ -1329,7 +1330,8 @@ private suspend fun bodyFromCall(call: ApplicationCall): Triple<Value, Map<Strin
                             it.name ?: "",
                             StringValue(it.value),
                             boundary,
-                            specifiedContentType = it.contentType?.let { contentType -> "${contentType.contentType}/${contentType.contentSubtype}" }
+                            specifiedContentType = it.contentType?.let { contentType -> "${contentType.contentType}/${contentType.contentSubtype}" },
+                            contentEncoding = it.headers[HttpHeaders.ContentEncoding]
                         )
                     }
 
@@ -1339,6 +1341,7 @@ private suspend fun bodyFromCall(call: ApplicationCall): Triple<Value, Map<Strin
                             content = it.provider().asStream().use { input -> BinaryValue(input.readBytes()) },
                             boundary = boundary,
                             specifiedContentType = it.contentType?.let { contentType -> "${contentType.contentType}/${contentType.contentSubtype}" },
+                            contentEncoding = it.headers[HttpHeaders.ContentEncoding],
                         )
                     }
 

--- a/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
+++ b/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
@@ -6,6 +6,7 @@ import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.core.*
+import io.specmatic.core.examples.module.ExampleModule
 import io.specmatic.core.examples.source.CombinedSource
 import io.specmatic.core.examples.source.DirectoryExampleSource
 import io.specmatic.core.examples.source.PreLoadedExampleObjects
@@ -21,6 +22,7 @@ import io.specmatic.core.utilities.Flags.Companion.EXTENSIBLE_SCHEMA
 import io.specmatic.core.utilities.Flags.Companion.IGNORE_INLINE_EXAMPLES
 import io.specmatic.core.value.*
 import io.specmatic.mock.ScenarioStub
+import io.specmatic.stub.HttpStub
 import io.specmatic.test.TestExecutor
 import io.specmatic.test.FixtureExecutionDetails
 import io.specmatic.test.fixtures.FixtureExecutionMetadata
@@ -30,8 +32,11 @@ import io.specmatic.test.interceptor.InterceptResult
 import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import java.io.File
 import java.math.BigDecimal
+import java.net.ServerSocket
 import java.net.URLClassLoader
 import java.nio.file.Files
 
@@ -486,6 +491,65 @@ class LoadTestsFromExternalisedFiles {
 
         assertThat(idsSeen).contains("123", "456")
         assertThat(results.testCount).isEqualTo(3)
+    }
+
+    @Nested
+    inner class FormDataExampleMatrix {
+        @ParameterizedTest(name = "{0}")
+        @EnumSource(FormDataKind::class)
+        fun `two inline and two external examples are all executed`(kind: FormDataKind) {
+            val feature = OpenApiSpecification.fromFile(kind.specificationPath)
+                .toFeature()
+                .loadExternalisedExamples()
+
+            feature.validateExamplesOrException()
+            assertThat(feature.scenarios.single().examples.flatMap { it.rows }.map { it.name })
+                .containsExactlyInAnyOrderElementsOf(kind.expectedExamples.map { it.name })
+
+            val requests = mutableListOf<HttpRequest>()
+            val results = feature.executeTests(object : TestExecutor {
+                override fun execute(request: HttpRequest): HttpResponse {
+                    requests += request
+                    return HttpResponse(
+                        status = 200,
+                        body = StringValue("ok"),
+                        headers = mapOf(CONTENT_TYPE to "text/plain"),
+                    )
+                }
+            })
+
+            assertThat(results.results).hasOnlyElementsOfTypes(Result.Success::class.java).hasSize(kind.expectedExamples.size)
+            assertThat(requests).containsExactlyInAnyOrderElementsOf(kind.expectedExamples.map { it.request(kind.contentType) })
+        }
+
+        @ParameterizedTest(name = "{0}")
+        @EnumSource(FormDataKind::class)
+        fun `inline and external examples can be used as mock expectations`(kind: FormDataKind) {
+            val feature = OpenApiSpecification.fromFile(kind.specificationPath).toFeature()
+            feature.loadExternalisedExamples().validateExamplesOrException()
+            val externalExamples = ExampleModule(SpecmaticConfig()).getExamplesFor(File(kind.specificationPath))
+
+            assertThat(externalExamples.map { it.file.nameWithoutExtension })
+                .containsExactlyInAnyOrder("external", "external-secondary")
+
+            HttpStub(
+                feature = feature,
+                port = freePort(),
+                strictMode = true,
+                scenarioStubs = externalExamples.map { it.scenarioStub },
+            ).use { stub ->
+                assertThat(stub.stubCount).isEqualTo(kind.expectedExamples.size)
+
+                val responses = kind.expectedExamples.map { expectedExample ->
+                    stub.client.execute(expectedExample.request(kind.contentType))
+                }
+
+                assertThat(responses.map { it.status }).containsExactlyElementsOf(List(kind.expectedExamples.size) { 200 })
+                assertThat(responses.map { it.body }).containsExactlyElementsOf(
+                    List(kind.expectedExamples.size) { StringValue("ok") }
+                )
+            }
+        }
     }
 
     @Test
@@ -1549,8 +1613,141 @@ class LoadTestsFromExternalisedFiles {
             }
         }
     }
+
+    internal data class ExpectedFormDataExample(
+        val name: String,
+        val trace: String,
+        val fields: Map<String, String>? = null,
+        val multipart: List<MultiPartContentValue>? = null,
+    ) {
+        fun request(contentType: String): HttpRequest {
+            val request = HttpRequest(
+                path = "/data",
+                method = "POST",
+                body = NoBodyValue,
+                queryParametersMap = mapOf("trace" to trace),
+                headers = mapOf(CONTENT_TYPE to contentType, "Specmatic-Response-Code" to "200"),
+            )
+
+            return when {
+                fields != null -> request.copy(formFields = fields)
+                multipart != null -> request.copy(multiPartFormData = multipart)
+                else -> error("Expected form data example $name has no form data")
+            }
+        }
+    }
+
+    enum class FormDataKind(val contentType: String, val specificationPath: String) {
+        FORM_FIELDS(
+            contentType = "application/x-www-form-urlencoded",
+            specificationPath = "src/test/resources/openapi/form_data_examples/form_fields.yaml",
+        ),
+        MULTIPART(
+            contentType = "multipart/form-data",
+            specificationPath = "src/test/resources/openapi/form_data_examples/multipart.yaml",
+        );
+
+        internal val expectedExamples: List<ExpectedFormDataExample> get() = when (this) {
+            FORM_FIELDS -> listOf(
+                ExpectedFormDataExample(
+                    name = "inline",
+                    trace = "inline-trace",
+                    fields = mapOf("data" to "inline", "mode" to "alpha"),
+                ),
+                ExpectedFormDataExample(
+                    name = "inline-secondary",
+                    trace = "inline-secondary-trace",
+                    fields = mapOf("data" to "inline-secondary", "mode" to "beta"),
+                ),
+                ExpectedFormDataExample(
+                    name = "external",
+                    trace = "external-trace",
+                    fields = mapOf("data" to "external", "mode" to "gamma"),
+                ),
+                ExpectedFormDataExample(
+                    name = "external-secondary",
+                    trace = "external-secondary-trace",
+                    fields = mapOf("data" to "external-secondary", "mode" to "delta"),
+                ),
+            )
+            MULTIPART -> listOf(
+                ExpectedFormDataExample(
+                    name = "inline",
+                    trace = "inline-trace",
+                    multipart = listOf(
+                        MultiPartContentValue(
+                            name = "data",
+                            content = StringValue("inline"),
+                            specifiedContentType = "text/plain",
+                        ),
+                        MultiPartContentValue(
+                            name = "document",
+                            specifiedContentType = "application/octet-stream",
+                            filename = "src/test/resources/openapi/form_data_examples/multipart_files/inline-document.txt",
+                            content = BinaryValue(File("src/test/resources/openapi/form_data_examples/multipart_files/inline-document.txt").readBytes()),
+                        ),
+                    ),
+                ),
+                ExpectedFormDataExample(
+                    name = "inline-secondary",
+                    trace = "inline-secondary-trace",
+                    multipart = listOf(
+                        MultiPartContentValue(
+                            name = "data",
+                            specifiedContentType = "text/plain",
+                            content = StringValue("inline-secondary"),
+                        ),
+                        MultiPartContentValue(
+                            name = "document",
+                            specifiedContentType = "application/octet-stream",
+                            filename = "src/test/resources/openapi/form_data_examples/multipart_files/inline-secondary-document.txt",
+                            content = BinaryValue(File("src/test/resources/openapi/form_data_examples/multipart_files/inline-secondary-document.txt").readBytes()),
+                        ),
+                    ),
+                ),
+                ExpectedFormDataExample(
+                    name = "external",
+                    trace = "external-trace",
+                    multipart = listOf(
+                        MultiPartContentValue(
+                            name = "data",
+                            contentEncoding = "identity",
+                            content = StringValue("external"),
+                            specifiedContentType = "text/plain",
+                        ),
+                        MultiPartContentValue(
+                            name = "document",
+                            contentEncoding = "identity",
+                            specifiedContentType = "application/octet-stream",
+                            content = StringValue("external-document"),
+                        ),
+                    ),
+                ),
+                ExpectedFormDataExample(
+                    name = "external-secondary",
+                    trace = "external-secondary-trace",
+                    multipart = listOf(
+                        MultiPartContentValue(
+                            name = "data",
+                            contentEncoding = "identity",
+                            specifiedContentType = "text/plain",
+                            content = StringValue("external-secondary"),
+                        ),
+                        MultiPartContentValue(
+                            name = "document",
+                            contentEncoding = "identity",
+                            specifiedContentType = "application/octet-stream",
+                            filename = "src/test/resources/openapi/form_data_examples/multipart_files/external-document.txt",
+                            content = BinaryValue(File("src/test/resources/openapi/form_data_examples/multipart_files/external-document.txt").readBytes()),
+                        ),
+                    ),
+                ),
+            )
+        }
+    }
 }
 
+private fun freePort(): Int = ServerSocket(0).use { it.localPort }
 private fun <T> withServiceLoaderEntries(entries: Map<Class<*>, String>, block: () -> T): T {
     val previousContextClassLoader = Thread.currentThread().contextClassLoader
     val tempDir = Files.createTempDirectory("specmatic-service-loader-test")

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationParseTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationParseTest.kt
@@ -2,9 +2,13 @@ package io.specmatic.conversions
 
 import integration_tests.OpenApiVersion
 import io.specmatic.core.Feature
+import io.specmatic.core.CONTENT_TYPE
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpResponse
 import io.specmatic.core.IssueSeverity
+import io.specmatic.core.MultiPartContentValue
+import io.specmatic.core.NoBodyPattern
+import io.specmatic.core.NoBodyValue
 import io.specmatic.core.NestedQuerySchema
 import io.specmatic.core.ObjectQueryRoot
 import io.specmatic.core.ObjectQuerySyntax
@@ -2819,10 +2823,31 @@ $parameters
                             selected: { value: ok }
             """.trimIndent()
 
-            val inlineStub = OpenApiSpecification.fromYAML(contractString, "")
-                .toFeature()
-                .inlineNamedStubs
+            val feature = OpenApiSpecification.fromYAML(contractString, "").toFeature()
+            val inlineStub = feature.inlineNamedStubs
                 .single { it.name == "selected" }
+
+            assertThat(feature.scenarios.single().httpRequestPattern.body).isEqualTo(NoBodyPattern)
+            assertThat(inlineStub.stub.request).isEqualTo(
+                HttpRequest(
+                    method = "POST",
+                    path = "/documents",
+                    headers = mapOf(CONTENT_TYPE to "multipart/form-data"),
+                    body = NoBodyValue,
+                    multiPartFormData = listOf(
+                        MultiPartContentValue(
+                            name = "metadata",
+                            content = JSONObjectValue(mapOf("id" to NumberValue(7))),
+                            specifiedContentType = "application/json",
+                        ),
+                        MultiPartContentValue(
+                            name = "document",
+                            content = StringValue("encoded-content"),
+                            specifiedContentType = "application/octet-stream",
+                        ),
+                    ),
+                )
+            )
 
             val parts = inlineStub.stub.request.multiPartFormData.associateBy { it.name }
             assertThat(parts.getValue("document").filename).isNull()
@@ -2908,6 +2933,49 @@ $parameters
             ).toFeature()
 
             assertThat(feature.inlineNamedStubs).isEmpty()
+        }
+    }
+
+    @Nested
+    inner class FormUrlEncodedExamples {
+        @Test
+        fun `inline form-urlencoded example has a bodyless request and bodyless request pattern`() {
+            val feature = OpenApiSpecification.fromYAML(
+                """
+                openapi: 3.0.3
+                info: { title: test, version: '1.0' }
+                paths:
+                  /token:
+                    post:
+                      requestBody:
+                        content:
+                          application/x-www-form-urlencoded:
+                            schema:
+                              type: object
+                              required: [client_id]
+                              properties:
+                                client_id: { type: string }
+                            examples:
+                              selected:
+                                value:
+                                  client_id: client-123
+                      responses:
+                        '200':
+                          description: OK
+                """.trimIndent(),
+                "",
+            ).toFeature()
+
+            assertThat(feature.scenarios.single().httpRequestPattern.body).isEqualTo(NoBodyPattern)
+            assertThat(feature.inlineNamedStubs.single { it.name == "selected" }.stub.request).isEqualTo(
+                HttpRequest(
+                    method = "POST",
+                    path = "/token",
+                    headers = mapOf(CONTENT_TYPE to "application/x-www-form-urlencoded"),
+                    body = NoBodyValue,
+                    formFields = mapOf("client_id" to "client-123"),
+                )
+            )
         }
     }
 

--- a/core/src/test/kotlin/io/specmatic/core/FormUrlEncodedExampleTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FormUrlEncodedExampleTest.kt
@@ -8,6 +8,7 @@ import io.specmatic.core.examples.module.ExampleValidationModule
 import io.specmatic.core.pattern.parsedJSONObject
 import io.specmatic.mock.ScenarioStub
 import io.specmatic.stub.HttpStub
+import io.specmatic.stub.SPECMATIC_RESPONSE_CODE_HEADER
 import io.specmatic.test.TestExecutor
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -120,8 +121,18 @@ internal class FormUrlEncodedExampleTest {
     private fun assertContractTestUsesFormFields(feature: Feature) {
         val results = feature.executeTests(object : TestExecutor {
             override fun execute(request: HttpRequest): HttpResponse {
-                assertThat(request.path).isEqualTo("/token")
-                assertThat(request.formFields).isEqualTo(VALID_FORM_FIELDS)
+                assertThat(request).isEqualTo(
+                    HttpRequest(
+                        method = "POST",
+                        path = "/token",
+                        headers = mapOf(
+                            CONTENT_TYPE to FORM_URLENCODED,
+                            SPECMATIC_RESPONSE_CODE_HEADER to "200",
+                        ),
+                        body = NoBodyValue,
+                        formFields = VALID_FORM_FIELDS,
+                    )
+                )
 
                 return tokenResponse()
             }

--- a/core/src/test/kotlin/io/specmatic/core/MultipartContractTestGenerationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/MultipartContractTestGenerationTest.kt
@@ -111,6 +111,7 @@ internal class MultipartContractTestGenerationTest {
 
         assertThat(results).allSatisfy { assertThat(it.isSuccess()).isTrue() }
         assertThat(requests).hasSize(1)
+        assertThat(requests.single().body).isEqualTo(NoBodyValue)
         return requests.single()
     }
 

--- a/core/src/test/kotlin/io/specmatic/stub/MultipartFilenameHttpStubTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/MultipartFilenameHttpStubTest.kt
@@ -1,5 +1,12 @@
 package io.specmatic.stub
 
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.call
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.netty.Netty
+import io.ktor.server.response.respond
+import io.ktor.server.routing.post
+import io.ktor.server.routing.routing
 import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpResponse
@@ -8,6 +15,7 @@ import io.specmatic.core.SPECMATIC_TYPE_HEADER
 import io.specmatic.core.pattern.parsedJSONObject
 import io.specmatic.core.value.StringValue
 import io.specmatic.mock.ScenarioStub
+import io.specmatic.test.HttpClient
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -153,6 +161,57 @@ internal class MultipartFilenameHttpStubTest {
                 assertThat(response.headers[SPECMATIC_TYPE_HEADER]).isEqualTo("random")
             }
         }
+
+        @Test
+        fun `multipart content encoding is preserved when matching a mock expectation`() {
+            val request = request(filename = null, contentEncoding = "identity")
+
+            val example = ScenarioStub(request, HttpResponse.ok("example response"))
+            HttpStub(feature(), listOf(example), port = availablePort(), strictMode = true).use { stub ->
+                val response = stub.client.execute(request)
+                assertThat(response.status).isEqualTo(200)
+                assertThat(response.body.toStringLiteral()).isEqualTo("example response")
+            }
+        }
+
+        @Test
+        fun `ktor request conversion preserves multipart content encoding`() {
+            val port = availablePort()
+            val server = embeddedServer(Netty, port = port) {
+                routing {
+                    post("/data") {
+                        val convertedRequest = ktorHttpRequestToHttpRequest(call)
+                        val convertedPart = convertedRequest.multiPartFormData.single()
+
+                        assertThat(convertedRequest.method).isEqualTo("POST")
+                        assertThat(convertedRequest.path).isEqualTo("/data")
+                        assertThat(convertedPart.toJSONObject()).isEqualTo(
+                            MultiPartContentValue(
+                                name = "data",
+                                contentEncoding = "identity",
+                                content = StringValue("hello"),
+                                specifiedContentType = "text/plain",
+                            ).toJSONObject(),
+                        )
+
+                        call.respond(HttpStatusCode.OK)
+                    }
+                }
+            }
+
+            server.start(wait = false)
+            try {
+                HttpClient("http://localhost:$port").use { client ->
+                    val response = client.execute(
+                        request(filename = null, contentEncoding = "identity"),
+                    )
+
+                    assertThat(response.status).isEqualTo(200)
+                }
+            } finally {
+                server.stop()
+            }
+        }
     }
 
     private fun example(filename: String?) =
@@ -161,7 +220,7 @@ internal class MultipartFilenameHttpStubTest {
             response = HttpResponse.ok("example response"),
         )
 
-    private fun request(filename: String?): HttpRequest =
+    private fun request(filename: String?, contentEncoding: String? = null): HttpRequest =
         HttpRequest(
             method = "POST",
             path = "/data",
@@ -170,6 +229,7 @@ internal class MultipartFilenameHttpStubTest {
                     name = "data",
                     content = StringValue("hello"),
                     specifiedContentType = "text/plain",
+                    contentEncoding = contentEncoding,
                     filename = filename,
                 ),
             ),

--- a/core/src/test/resources/openapi/form_data_examples/form_fields.yaml
+++ b/core/src/test/resources/openapi/form_data_examples/form_fields.yaml
@@ -1,0 +1,52 @@
+openapi: 3.0.3
+info:
+  title: Form data examples
+  version: "1.0"
+paths:
+  /data:
+    post:
+      parameters:
+        - name: trace
+          in: query
+          required: true
+          schema:
+            type: string
+          examples:
+            inline:
+              value: inline-trace
+            inline-secondary:
+              value: inline-secondary-trace
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required: [data, mode]
+              properties:
+                data: { type: string }
+                mode: { type: string }
+            examples:
+              inline:
+                value:
+                  data: inline
+                  mode: alpha
+              inline-secondary:
+                $ref: '#/components/examples/InlineSecondary'
+      responses:
+        '200':
+          description: OK
+          content:
+            text/plain:
+              schema: { type: string }
+              examples:
+                inline:
+                  value: ok
+                inline-secondary:
+                  value: ok
+components:
+  examples:
+    InlineSecondary:
+      value:
+        data: inline-secondary
+        mode: beta

--- a/core/src/test/resources/openapi/form_data_examples/form_fields_examples/external-secondary.json
+++ b/core/src/test/resources/openapi/form_data_examples/form_fields_examples/external-secondary.json
@@ -1,0 +1,23 @@
+{
+  "http-request": {
+    "method": "POST",
+    "path": "/data",
+    "headers": {
+      "Content-Type": "application/x-www-form-urlencoded"
+    },
+    "query": {
+      "trace": "external-secondary-trace"
+    },
+    "form-fields": {
+      "data": "external-secondary",
+      "mode": "delta"
+    }
+  },
+  "http-response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "text/plain"
+    },
+    "body": "ok"
+  }
+}

--- a/core/src/test/resources/openapi/form_data_examples/form_fields_examples/external.json
+++ b/core/src/test/resources/openapi/form_data_examples/form_fields_examples/external.json
@@ -1,0 +1,23 @@
+{
+  "http-request": {
+    "method": "POST",
+    "path": "/data",
+    "headers": {
+      "Content-Type": "application/x-www-form-urlencoded"
+    },
+    "query": {
+      "trace": "external-trace"
+    },
+    "form-fields": {
+      "data": "external",
+      "mode": "gamma"
+    }
+  },
+  "http-response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "text/plain"
+    },
+    "body": "ok"
+  }
+}

--- a/core/src/test/resources/openapi/form_data_examples/multipart.yaml
+++ b/core/src/test/resources/openapi/form_data_examples/multipart.yaml
@@ -1,0 +1,56 @@
+openapi: 3.0.3
+info:
+  title: Form data examples
+  version: "1.0"
+paths:
+  /data:
+    post:
+      parameters:
+        - name: trace
+          in: query
+          required: true
+          schema:
+            type: string
+          examples:
+            inline:
+              value: inline-trace
+            inline-secondary:
+              value: inline-secondary-trace
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [data, document]
+              properties:
+                data: { type: string }
+                document:
+                  type: string
+                  format: binary
+            examples:
+              inline:
+                value:
+                  data: inline
+                  document:
+                    externalValue: src/test/resources/openapi/form_data_examples/multipart_files/inline-document.txt
+              inline-secondary:
+                $ref: '#/components/examples/InlineSecondary'
+      responses:
+        '200':
+          description: OK
+          content:
+            text/plain:
+              schema: { type: string }
+              examples:
+                inline:
+                  value: ok
+                inline-secondary:
+                  value: ok
+components:
+  examples:
+    InlineSecondary:
+      value:
+        data: inline-secondary
+        document:
+          externalValue: src/test/resources/openapi/form_data_examples/multipart_files/inline-secondary-document.txt

--- a/core/src/test/resources/openapi/form_data_examples/multipart_examples/external-secondary.json
+++ b/core/src/test/resources/openapi/form_data_examples/multipart_examples/external-secondary.json
@@ -1,0 +1,33 @@
+{
+  "http-request": {
+    "method": "POST",
+    "path": "/data",
+    "headers": {
+      "Content-Type": "multipart/form-data"
+    },
+    "query": {
+      "trace": "external-secondary-trace"
+    },
+    "multipart-formdata": [
+      {
+        "name": "data",
+        "content": "external-secondary",
+        "contentType": "text/plain",
+        "contentEncoding": "identity"
+      },
+      {
+        "name": "document",
+        "filename": "@src/test/resources/openapi/form_data_examples/multipart_files/external-document.txt",
+        "contentType": "application/octet-stream",
+        "contentEncoding": "identity"
+      }
+    ]
+  },
+  "http-response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "text/plain"
+    },
+    "body": "ok"
+  }
+}

--- a/core/src/test/resources/openapi/form_data_examples/multipart_examples/external.json
+++ b/core/src/test/resources/openapi/form_data_examples/multipart_examples/external.json
@@ -1,0 +1,33 @@
+{
+  "http-request": {
+    "method": "POST",
+    "path": "/data",
+    "headers": {
+      "Content-Type": "multipart/form-data"
+    },
+    "query": {
+      "trace": "external-trace"
+    },
+    "multipart-formdata": [
+      {
+        "name": "data",
+        "content": "external",
+        "contentType": "text/plain",
+        "contentEncoding": "identity"
+      },
+      {
+        "name": "document",
+        "content": "external-document",
+        "contentType": "application/octet-stream",
+        "contentEncoding": "identity"
+      }
+    ]
+  },
+  "http-response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "text/plain"
+    },
+    "body": "ok"
+  }
+}

--- a/core/src/test/resources/openapi/form_data_examples/multipart_files/external-document.txt
+++ b/core/src/test/resources/openapi/form_data_examples/multipart_files/external-document.txt
@@ -1,0 +1,1 @@
+external-document-file

--- a/core/src/test/resources/openapi/form_data_examples/multipart_files/inline-document.txt
+++ b/core/src/test/resources/openapi/form_data_examples/multipart_files/inline-document.txt
@@ -1,0 +1,1 @@
+inline-document

--- a/core/src/test/resources/openapi/form_data_examples/multipart_files/inline-secondary-document.txt
+++ b/core/src/test/resources/openapi/form_data_examples/multipart_files/inline-secondary-document.txt
@@ -1,0 +1,1 @@
+inline-secondary-document


### PR DESCRIPTION
**What**

Fixed request example generation and multipart mock request parsing for:

- `application/x-www-form-urlencoded`
- `multipart/form-data`

Generated form-data examples now use `NoBodyValue`, and corresponding request patterns use `NoBodyPattern`. Multipart request parsing now preserves each part’s `Content-Encoding`.

**Why**

Form data is represented through `formFields` or `multiPartFormData`, not through the generic HTTP body.

Previously, generated examples used `NoBodyValue` while the corresponding request pattern used `EmptyStringPattern`, causing matching and `fillInTheBlanks` to fail.

Additionally, multipart examples declaring `contentEncoding` could not match mock requests because Ktor multipart parsing dropped the per-part `Content-Encoding` header.

**How**

- Updated OpenAPI request pattern generation for form-urlencoded and multipart content to use `NoBodyPattern`.
- Updated form-field and multipart example request generation to use `NoBodyValue`.
- Preserved per-part `Content-Encoding` when converting incoming Ktor multipart requests.
- Added focused assertions for:
  - Generated request bodies and request patterns.
  - Multipart mock matching with `contentEncoding`.
  - Direct `ktorHttpRequestToHttpRequest` conversion.

**Checklist**

- [x] Unit Tests
- [ ] Build passing locally — focused tests pass; full suite not run locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities — not run locally
- [ ] Documentation added/updated — N/A
- [ ] Sample Project added/updated — N/A
- [ ] Demo video — N/A
- [ ] Article on Website — N/A
- [ ] Roadmap updated — N/A
- [ ] Conference Talk — N/A