### PR TITLE
Clarify backward compatibility logging for new specs

### DIFF
--- a/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckBaseCommand.kt
+++ b/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckBaseCommand.kt
@@ -211,7 +211,7 @@ abstract class BackwardCompatibilityCheckBaseCommand(
         backwardCompatibilityLogger.logCheckStart(index, processedSpec)
 
         if (processedSpec.isNewFile) {
-            backwardCompatibilityLogger.logNewFile(processedSpec)
+            backwardCompatibilityLogger.logNewFile(processedSpec, effectiveBaseBranch)
             return CompatibilityResult.PASSED
         }
 

--- a/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckLogger.kt
+++ b/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckLogger.kt
@@ -29,8 +29,12 @@ internal class BackwardCompatibilityCheckLogger {
         logger.log("${index.inc()}. Running the check for ${processedSpec.specFilePath}:")
     }
 
-    fun logNewFile(processedSpec: ProcessedSpec) {
-        logger.log("${ONE_INDENT}${processedSpec.specFilePath} is a new file.$newLine")
+    fun logNewFile(processedSpec: ProcessedSpec, baseBranch: String) {
+        logVerdictFor(
+            processedSpec.specFilePath,
+            "(COMPATIBLE) The spec is a new file and is considered backward compatible because no corresponding spec exists at this path on $baseBranch"
+                .prependIndent(ONE_INDENT)
+        )
     }
 
     private fun Set<String>.printSummary(message: String) {

--- a/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckLogger.kt
+++ b/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckLogger.kt
@@ -32,7 +32,7 @@ internal class BackwardCompatibilityCheckLogger {
     fun logNewFile(processedSpec: ProcessedSpec, baseBranch: String) {
         logVerdictFor(
             processedSpec.specFilePath,
-            "(COMPATIBLE) The spec is a new file and is considered backward compatible because no corresponding spec exists at this path on $baseBranch"
+            "(COMPATIBLE) No spec exists at this path on $baseBranch, so no existing contract consumers are affected."
                 .prependIndent(ONE_INDENT)
         )
     }

--- a/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
+++ b/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
@@ -326,7 +326,7 @@ class BackwardCompatibilityCheckCommandV2Test {
             assertThat(stdOut).containsIgnoringWhitespaces(
                 """
                 Verdict for spec $newSpec:
-                  (COMPATIBLE) The spec is a new file and is considered backward compatible because no corresponding spec exists at this path on main
+                  (COMPATIBLE) No spec exists at this path on main, so no existing contract consumers are affected.
                 """.trimIndent()
             ).containsIgnoringWhitespaces(
                 """

--- a/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
+++ b/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
@@ -300,6 +300,43 @@ class BackwardCompatibilityCheckCommandV2Test {
     }
 
     @Nested
+    inner class NewFileTests {
+        @Test
+        fun `should report a committed new spec as compatible because there is no corresponding spec on the base branch`() {
+            tempDir.resolve("baseline.txt").writeText("baseline")
+            commitAndPush(tempDir, "Initial commit")
+            ProcessBuilder("git", "checkout", "-b", "feature")
+                .directory(tempDir)
+                .inheritIO()
+                .start()
+                .waitFor()
+
+            val newSpec = tempDir.resolve("customer_orders_v2.yaml").canonicalFile
+            File("src/test/resources/specifications/spec_with_examples/api.yaml").copyTo(newSpec)
+            commit(tempDir, "Add v2 spec")
+
+            val (stdOut, exitCode) = captureStandardOutput {
+                BackwardCompatibilityCheckCommandV2().apply {
+                    options.repoDir = tempDir.canonicalPath
+                    options.baseBranch = "main"
+                }.call()
+            }
+
+            assertThat(exitCode).isEqualTo(0)
+            assertThat(stdOut).containsIgnoringWhitespaces(
+                """
+                Verdict for spec $newSpec:
+                  (COMPATIBLE) The spec is a new file and is considered backward compatible because no corresponding spec exists at this path on main
+                """.trimIndent()
+            ).containsIgnoringWhitespaces(
+                """
+                Files checked: 1 (Passed: 1, Failed: 0)
+                """.trimIndent()
+            )
+        }
+    }
+
+    @Nested
     inner class SystemGitTestsSpecificToBackwardCompatibility {
         @Test
         fun `getFilesChangedInCurrentBranch returns the uncommitted, unstaged changed file`() {


### PR DESCRIPTION
## Summary
- Report newly added specs as compatible when no matching spec exists on the base branch.
- Include the base branch in the compatibility verdict message.