### PR TITLE
Submit raw reports to Insights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Each release section should stand on its own and describe the behavior shipped i
 ### Added
 
 - Added support for loading OpenAPI `multipart/form-data` request examples, including multipart content and external file references for mock.
+- Test, mock, and backward-compatibility commands now submit their generated CTRF reports to Insights as raw reports, preserving the report type and passing CI, build, and repository metadata separately from the report payload. Local runs can infer Git repository metadata, while CI submissions require an explicit build ID.
 
 ### Changed
 

--- a/application/src/main/kotlin/application/StubCommand.kt
+++ b/application/src/main/kotlin/application/StubCommand.kt
@@ -13,6 +13,9 @@ import io.specmatic.core.loadSpecmaticConfigOrNull
 import io.specmatic.core.toIncomingMtlsRegistryForStub
 import io.specmatic.core.utilities.Flags.Companion.SPECMATIC_BASE_URL
 import io.specmatic.license.core.cli.Category
+import io.specmatic.reporter.commands.GitReportDefaultValueProvider
+import io.specmatic.reporter.commands.InsightsReportOptions
+import io.specmatic.reporter.RawReportType
 import io.specmatic.mock.ScenarioStub
 import io.specmatic.stub.HttpClientFactory
 import io.specmatic.stub.HttpStub
@@ -26,6 +29,7 @@ import io.specmatic.stub.isSupportedAPISpecification
 import io.specmatic.stub.listener.MockEventListener
 import io.specmatic.stub.waitForNotNull
 import io.specmatic.stub.waitUntilConnectable
+import io.specmatic.test.sendRawReportToInsights
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -40,7 +44,8 @@ import kotlin.time.toDuration
     name = "mock",
     aliases = ["virtualize", "stub"],
     mixinStandardHelpOptions = true,
-    description = ["Start a mock server with contract"]
+    description = ["Start a mock server with contract"],
+    defaultValueProvider = GitReportDefaultValueProvider::class,
 )
 @Category("Specmatic core")
 class StubCommand(
@@ -145,6 +150,12 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
     @Option(names = ["--lenient"], description = ["Parse the OpenAPI Specification with leniency"], required = false)
     var lenientMode: Boolean? = null
 
+    @field:ArgGroup(
+        exclusive = false,
+        heading = "%nInsights reporting options:%n",
+    )
+    val insightsReportOptions = InsightsReportOptions()
+
     private var contractSources: List<ContractPathData> = emptyList()
 
     var specmaticConfigPath: String? = null
@@ -193,6 +204,7 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
     }
 
     override fun call(): Int {
+        insightsReportOptions.validate()
         configureLogging(
             LoggingFromOpts(
                 debug = verbose,
@@ -346,7 +358,7 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
     private fun restartServer() {
         consoleLog(StringLog("Stopping servers..."))
         try {
-            stopServer()
+            sendReportToInsights(stopServer())
             consoleLog(StringLog("Stopped."))
         } catch (e: Throwable) {
             consoleLog(e,"Error stopping server")
@@ -357,9 +369,11 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
         }
     }
 
-    private fun stopServer() {
-        httpStub?.close()
+    @Synchronized
+    private fun stopServer(): File? {
+        val report = httpStub?.also { it.close() }?.getReport()
         httpStub = null
+        return report
     }
 
     private fun addShutdownHook() {
@@ -367,9 +381,9 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
             override fun run() {
                 try {
                     consoleLog(StringLog("Shutting down mock servers"))
-                    httpStub?.close()
-                } catch (e: InterruptedException) {
-                    currentThread().interrupt()
+                    sendReportToInsights(stopServer())
+                } catch (e: Throwable) {
+                    logger.debug("Could not generate the mock report during shutdown: ${e.message}")
                 }
             }
         })
@@ -402,7 +416,11 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
     }
 
     override fun close() {
-        stopServer()
+        sendReportToInsights(stopServer())
+    }
+
+    private fun sendReportToInsights(report: File?) {
+        sendRawReportToInsights(report, RawReportType.MOCK, insightsReportOptions)
     }
 
     override suspend fun checkReadiness() {

--- a/application/src/main/kotlin/application/TestCommand.kt
+++ b/application/src/main/kotlin/application/TestCommand.kt
@@ -11,6 +11,8 @@ import io.specmatic.core.utilities.exitWithMessage
 import io.specmatic.core.utilities.newXMLBuilder
 import io.specmatic.core.utilities.xmlToString
 import io.specmatic.license.core.cli.Category
+import io.specmatic.reporter.commands.InsightsReportOptions
+import io.specmatic.reporter.commands.GitReportDefaultValueProvider
 import io.specmatic.test.ContractTestSettings
 import io.specmatic.test.DeprecatedArguments
 import io.specmatic.test.SpecmaticJUnitSupport
@@ -40,7 +42,12 @@ private const val SYSTEM_OUT_TESTCASE_TAG = "system-out"
 
 private const val DISPLAY_NAME_PREFIX_IN_SYSTEM_OUT_TAG_TEXT = "display-name: "
 
-@Command(name = "test", mixinStandardHelpOptions = true, description = ["Run contract tests"])
+@Command(
+    name = "test",
+    mixinStandardHelpOptions = true,
+    description = ["Run contract tests"],
+    defaultValueProvider = GitReportDefaultValueProvider::class,
+)
 @Category("Specmatic core")
 class TestCommand(private val junitLauncher: Launcher = LauncherFactory.create()) : Callable<Int> {
     @CommandLine.Parameters(arity = "0..*", description = ["Contract file paths"])
@@ -119,6 +126,12 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
     @Option(names = ["--lenient"], description = ["Parse the OpenAPI Specification with leniency"], required = false)
     var lenientMode: Boolean = false
 
+    @field:CommandLine.ArgGroup(
+        exclusive = false,
+        heading = "%nInsights reporting options:%n",
+    )
+    val insightsReportOptions = InsightsReportOptions()
+
     @Spec
     lateinit var commandSpec: CommandSpec
 
@@ -132,6 +145,7 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
         configureLogging(
             LoggingFromOpts(debug = verboseMode),
             LoggingConfigSource.FromConfig(specmaticConfig.getLogConfigurationOrDefault()))
+        insightsReportOptions.validate()
         setParallelism(specmaticConfig)
         setTestThreadLocalSettings()
 
@@ -158,7 +172,9 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
             }
         }
 
-        ContractExecutionListener.exitCode()
+        val exitCode = ContractExecutionListener.exitCode()
+        SpecmaticJUnitSupport.sendGeneratedCtrfReportToInsights(insightsReportOptions)
+        exitCode
     }
     catch (e: Throwable) {
         logger.log(e)
@@ -227,6 +243,7 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
             configFile = configFileName.takeIf(::isNotNullOrBlank),
             timeoutInMilliSeconds = timeoutInMs ?: timeout?.times(1000),
             contractPaths = contractPaths?.joinToString(separator = ",").takeIf(::isNotNullOrBlank),
+            insightsReportOptions = insightsReportOptions,
         )
 
         SpecmaticJUnitSupport.settingsStaging.set(settings)

--- a/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckBaseCommand.kt
+++ b/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckBaseCommand.kt
@@ -5,7 +5,7 @@ import io.specmatic.core.IFeature
 import io.specmatic.core.Results
 import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.config.LoggingConfiguration
-import io.specmatic.core.generateBackwardCompatibilityReport
+import io.specmatic.core.generateBackwardCompatibilityReportWithFile
 import io.specmatic.core.git.GitCommand
 import io.specmatic.core.git.SystemGit
 import io.specmatic.core.loadSpecmaticConfigIfAvailableElseDefault
@@ -42,6 +42,7 @@ abstract class BackwardCompatibilityCheckBaseCommand(
     private val backwardCompatibilityLogger = BackwardCompatibilityCheckLogger()
 
     private var areLocalChangesStashed = false
+    protected var bccReport: File? = null
 
     abstract fun checkBackwardCompatibility(oldFeature: IFeature, newFeature: IFeature): BackwardCompatibilityCheckResult
     abstract fun File.isValidFileFormat(): Boolean
@@ -56,10 +57,13 @@ abstract class BackwardCompatibilityCheckBaseCommand(
     open fun regexForMatchingReferred(schemaFileName: String): String = ""
     open fun areExamplesValid(feature: IFeature, which: String): Boolean = true
     open fun getUnusedExamples(feature: IFeature): Set<String> = emptySet()
+    protected open fun sendReportsToInsights() {}
 
     final override fun call(): Int {
         configureLogging(LoggingConfiguration.Companion.LoggingFromOpts(debug = options.debugLog))
+        options.insightsReportOptions.validate()
         addShutdownHook()
+        bccReport = null
 
         val specsToCheck = getSpecsToCheck()
         if (specsToCheck.isEmpty()) {
@@ -77,6 +81,7 @@ abstract class BackwardCompatibilityCheckBaseCommand(
         }
 
         logger.log(result.report)
+        sendReportsToInsights()
         return result.exitCode
     }
 
@@ -195,11 +200,11 @@ abstract class BackwardCompatibilityCheckBaseCommand(
             // THIRD PASS: do the actual logging and produce final CompatibilityResult list
             val results = specsValidatedByHook.mapIndexed(::logCompatibilityResultAndReturn)
 
-            generateBackwardCompatibilityReport(
+            bccReport = generateBackwardCompatibilityReportWithFile(
                 specsValidatedByHook.flatMap { it.reportRecords },
                 reportStartTime,
                 System.currentTimeMillis()
-            )
+            )?.second
 
             return CompatibilityReport(results)
         } finally {

--- a/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckCommandV2.kt
+++ b/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckCommandV2.kt
@@ -4,10 +4,13 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.core.*
+import io.specmatic.core.git.SystemGit
 import io.specmatic.core.log.logger
 import io.specmatic.core.utilities.exceptionCauseMessage
 import io.specmatic.license.core.cli.Category
 import io.specmatic.loader.OpenApiSpecCompatibilityChecker
+import io.specmatic.reporter.RawReportType
+import io.specmatic.test.sendRawReportToInsights
 import io.specmatic.stub.isOpenAPI
 import picocli.CommandLine.Command
 import java.io.File
@@ -20,7 +23,7 @@ import kotlin.io.path.pathString
 @Command(
     name = "backward-compatibility-check",
     mixinStandardHelpOptions = true,
-    description = ["Checks backward compatibility of OpenAPI specifications"]
+    description = ["Checks backward compatibility of OpenAPI specifications"],
 )
 @Category("Specmatic core")
 class BackwardCompatibilityCheckCommandV2(options: BackwardCompatibilityCheckOptions = BackwardCompatibilityCheckOptions()): BackwardCompatibilityCheckBaseCommand(options) {
@@ -29,6 +32,10 @@ class BackwardCompatibilityCheckCommandV2(options: BackwardCompatibilityCheckOpt
     override fun checkBackwardCompatibility(oldFeature: IFeature, newFeature: IFeature): BackwardCompatibilityCheckResult {
         val (results, records) = backwardCompatibilityRecords(oldFeature as Feature, newFeature as Feature, effectiveRepoDir)
         return BackwardCompatibilityCheckResult(results, records)
+    }
+
+    override fun sendReportsToInsights() {
+        sendRawReportToInsights(bccReport, RawReportType.BCC, options.insightsReportOptions, SystemGit(effectiveRepoDir))
     }
 
     companion object {

--- a/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckOptions.kt
+++ b/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckOptions.kt
@@ -1,8 +1,33 @@
 package application.backwardCompatibility
 
+import io.specmatic.reporter.commands.InsightsReportOptions
+import picocli.CommandLine.Mixin
 import picocli.CommandLine.Option
 
 class BackwardCompatibilityCheckOptions {
+    @field:Mixin
+    val insightsReportOptions = InsightsReportOptions()
+
+    var branchName: String?
+        get() = insightsReportOptions.branchName
+        set(value) { insightsReportOptions.branchName = value }
+
+    var repoName: String?
+        get() = insightsReportOptions.repoName
+        set(value) { insightsReportOptions.repoName = value }
+
+    var repoId: String?
+        get() = insightsReportOptions.repoId
+        set(value) { insightsReportOptions.repoId = value }
+
+    var repoUrl: String?
+        get() = insightsReportOptions.repoUrl
+        set(value) { insightsReportOptions.repoUrl = value }
+
+    var token: String?
+        get() = insightsReportOptions.token
+        set(value) { insightsReportOptions.token = value }
+
     @Option(
         names = ["--base-branch"],
         description = ["Base branch to compare the changes against", "Default value is the local origin HEAD of the current branch"],

--- a/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
+++ b/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
@@ -7,7 +7,10 @@ import application.backwardCompatibility.CompatibilityResult
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.mockk.every
+import io.mockk.mockkObject
 import io.mockk.spyk
+import io.mockk.unmockkObject
+import io.mockk.verify
 import io.specmatic.core.IFeature
 import io.specmatic.core.Results
 import io.specmatic.core.git.SystemGit
@@ -18,6 +21,8 @@ import io.specmatic.license.core.LicensedProduct
 import io.specmatic.license.core.SpecmaticFeature
 import io.specmatic.license.core.SpecmaticProtocol
 import io.specmatic.reporter.backwardcompat.dto.OperationUsageResponse
+import io.specmatic.reporter.RawReportSender
+import io.specmatic.reporter.RawReportType
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.entry
 import org.junit.jupiter.api.AfterEach
@@ -30,6 +35,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
+import picocli.CommandLine
 import java.io.File
 import java.net.URLClassLoader
 import java.nio.file.Files
@@ -37,6 +43,45 @@ import java.nio.file.Paths
 
 class BackwardCompatibilityCheckCommandV2Test {
     private val objectMapper = ObjectMapper()
+
+    @Test
+    fun `accepts Insights reporting options`() {
+        val command = BackwardCompatibilityCheckCommandV2()
+
+        CommandLine(command).parseArgs(
+            "--ci", "--build-id", "42", "--repo-id", "repo-id", "--repo-name", "repo-name",
+            "--repo-url", "https://example.com/repo.git", "--branch-name", "main",
+        )
+
+        assertThat(command.options.insightsReportOptions.repoName).isEqualTo("repo-name")
+        assertThat(command.options.insightsReportOptions.buildId).isEqualTo("42")
+    }
+
+    @Test
+    fun `sends the generated BCC report with Insights metadata`() {
+        val report = tempDir.resolve("ctrf-report.json").apply { writeText("{}") }
+        val command = BackwardCompatibilityCheckCommandV2().apply {
+            options.repoDir = tempDir.canonicalPath
+            options.insightsReportOptions.apply {
+                repoId = "repo-id"
+                repoName = "repo-name"
+                repoUrl = "https://example.com/repo.git"
+                branchName = "main"
+                token = "token"
+            }
+        }
+        BackwardCompatibilityCheckBaseCommand::class.java.getDeclaredField("bccReport").apply { isAccessible = true }.set(command, report)
+        mockkObject(RawReportSender)
+        every { RawReportSender.send(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns true
+
+        try {
+            command.javaClass.getDeclaredMethod("sendReportsToInsights").apply { isAccessible = true }.invoke(command)
+
+            verify { RawReportSender.send(report, RawReportType.BCC, false, null, "repo-id", "repo-name", "https://example.com/repo.git", "main", "token") }
+        } finally {
+            unmockkObject(RawReportSender)
+        }
+    }
 
     companion object {
         @JvmStatic

--- a/application/src/test/kotlin/application/RawReportSubmissionTest.kt
+++ b/application/src/test/kotlin/application/RawReportSubmissionTest.kt
@@ -1,0 +1,54 @@
+package application
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
+import io.specmatic.core.git.SystemGit
+import io.specmatic.reporter.RawReportSender
+import io.specmatic.reporter.RawReportType
+import io.specmatic.reporter.commands.InsightsReportOptions
+import io.specmatic.test.sendRawReportToInsights
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class RawReportSubmissionTest {
+    @Test
+    fun `forwards all Insights report options to the sender`(@TempDir tempDir: File) {
+        val report = tempDir.resolve("ctrf-report.json").apply { writeText("{}") }
+        val options = InsightsReportOptions().apply {
+            ci = true
+            buildId = "build-42"
+            repoId = "repo-id"
+            repoName = "repo-name"
+            repoUrl = "https://example.com/repo.git"
+            branchName = "main"
+            token = "token"
+        }
+        val git = mockk<SystemGit>()
+        mockkObject(RawReportSender)
+        every { RawReportSender.send(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns true
+
+        try {
+            sendRawReportToInsights(report, RawReportType.TEST, options, git)
+
+            verify(exactly = 1) {
+                RawReportSender.send(
+                    reportFile = report,
+                    reportType = RawReportType.TEST,
+                    ci = true,
+                    buildId = "build-42",
+                    repoId = "repo-id",
+                    repoName = "repo-name",
+                    repoUrl = "https://example.com/repo.git",
+                    branchName = "main",
+                    token = "token",
+                )
+            }
+        } finally {
+            unmockkObject(RawReportSender)
+        }
+    }
+}

--- a/application/src/test/kotlin/application/StubCommandTest.kt
+++ b/application/src/test/kotlin/application/StubCommandTest.kt
@@ -14,6 +14,8 @@ import io.specmatic.core.utilities.Flags
 import io.specmatic.core.utilities.Flags.Companion.CONFIG_FILE_PATH
 import io.specmatic.core.utilities.StubServerWatcher
 import io.specmatic.mock.ScenarioStub
+import io.specmatic.reporter.RawReportSender
+import io.specmatic.reporter.RawReportType
 import io.specmatic.stub.HttpStub
 import io.specmatic.stub.SpecmaticConfigSource
 import kotlinx.coroutines.runBlocking
@@ -61,10 +63,56 @@ internal class StubCommandTest {
         stubCommand.registerShutdownHook = false
     }
 
+    @Test
+    fun `accepts Insights reporting options`() {
+        CommandLine(stubCommand).parseArgs(
+            "--ci", "--build-id", "42", "--repo-id", "repo-id", "--repo-name", "repo-name",
+            "--repo-url", "https://example.com/repo.git", "--branch-name", "main",
+        )
+
+        assertThat(stubCommand.insightsReportOptions.repoName).isEqualTo("repo-name")
+        assertThat(stubCommand.insightsReportOptions.buildId).isEqualTo("42")
+    }
+
+    @Test
+    fun `sends reports from each completed mock lifecycle`(@TempDir tempDir: Path) {
+        val report = tempDir.resolve("reports/stub/ctrf/ctrf-report.json").toFile()
+        val restartedReport = tempDir.resolve("reports/stub/ctrf/ctrf-report-after-restart.json").toFile()
+        stubCommand.configFileName = tempDir.resolve("specmatic.yaml").toFile().apply {
+            writeText("version: 2\nreportDirPath: ${tempDir.resolve("reports")}")
+        }.path
+        stubCommand.httpStub = mockk {
+            every { close() } answers {
+                report.parentFile.mkdirs()
+                report.writeText("{}")
+            }
+            every { getReport() } returns report
+        }
+        mockkObject(RawReportSender)
+        every {
+            RawReportSender.send(any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+        } returns true
+
+        try {
+            stubCommand.close()
+            stubCommand.httpStub = mockk {
+                every { close() } answers { restartedReport.parentFile.mkdirs(); restartedReport.writeText("{}") }
+                every { getReport() } returns restartedReport
+            }
+            stubCommand.close()
+
+            verify(exactly = 1) { RawReportSender.send(report, RawReportType.MOCK, any(), any(), any(), any(), any(), any(), any(), any()) }
+            verify(exactly = 1) { RawReportSender.send(restartedReport, RawReportType.MOCK, any(), any(), any(), any(), any(), any(), any(), any()) }
+        } finally {
+            unmockkObject(RawReportSender)
+        }
+    }
+
     @AfterEach
     fun cleanUp() {
         clearAllMocks()
         System.clearProperty(Flags.SPECMATIC_BASE_URL)
+        System.clearProperty(CONFIG_FILE_PATH)
         stubCommand.contractPaths = arrayListOf()
         stubCommand.specmaticConfigPath = null
     }

--- a/application/src/test/kotlin/application/TestCommandTest.kt
+++ b/application/src/test/kotlin/application/TestCommandTest.kt
@@ -29,6 +29,7 @@ import picocli.CommandLine
 import java.io.File
 import java.io.StringReader
 import java.util.*
+import java.util.concurrent.atomic.AtomicReference
 import java.util.stream.Stream
 
 
@@ -45,6 +46,13 @@ internal class TestCommandTest {
     fun `clean up test command`() {
         testCommand.contractPaths = arrayListOf()
         testCommand.junitReportDirName = null
+        testCommand.insightsReportOptions.ci = false
+        testCommand.insightsReportOptions.repoId = null
+        testCommand.insightsReportOptions.repoName = null
+        testCommand.insightsReportOptions.repoUrl = null
+        testCommand.insightsReportOptions.branchName = null
+        testCommand.insightsReportOptions.token = null
+        testCommand.insightsReportOptions.buildId = null
     }
 
     @Test
@@ -73,6 +81,27 @@ internal class TestCommandTest {
 
         assertThat(exitCode).isEqualTo(1)
         assertThat(output).contains("does not exist").contains("missing.$CONTRACT_EXTENSION")
+    }
+
+    @Test
+    fun `requires a CI build ID when ci is enabled`() {
+        val (output, exitCode) = captureStandardOutput(redirectStdErrToStdout = true) {
+            CommandLine(testCommand, factory).execute("--ci")
+        }
+
+        assertThat(exitCode).isEqualTo(1)
+        assertThat(output).contains("--build-id is required when --ci is specified")
+    }
+
+    @Test
+    fun `passes Insights options to the JUnit runner`() {
+        CommandLine(testCommand, factory).parseArgs("--token", "token", "--repo-id", "repo-id")
+        TestCommand::class.java.getDeclaredMethod("setTestThreadLocalSettings").apply { isAccessible = true }.invoke(testCommand)
+
+        val settings = AtomicReference<ContractTestSettings?>()
+        Thread { settings.set(SpecmaticJUnitSupport.settingsStaging.get()) }.apply { start(); join() }
+
+        assertThat(settings.get()?.insightsReportOptions).isSameAs(testCommand.insightsReportOptions)
     }
 
     @Test

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,12 @@ allprojects {
     repositories {
         mavenLocal()
         mavenCentral()
+
+        maven {
+            name = "specmaticSnapshots"
+            url = uri("https://repo.specmatic.io/snapshots")
+        }
+
         maven {
             name = "sonatypeCentralSnapshots"
             url = uri("https://central.sonatype.com/repository/maven-snapshots/")

--- a/core/src/main/kotlin/io/specmatic/core/TestBackwardCompatibility.kt
+++ b/core/src/main/kotlin/io/specmatic/core/TestBackwardCompatibility.kt
@@ -7,6 +7,7 @@ import io.specmatic.core.value.NullValue
 import io.specmatic.core.value.Value
 import io.specmatic.reporter.ctrf.model.CtrfBackwardCompatibilityRecord
 import io.specmatic.reporter.ctrf.model.CtrfReport
+import java.io.File
 
 private const val BCC_REPORT_DIR_SUFFIX = "backward_compatibility"
 
@@ -37,7 +38,10 @@ fun List<CtrfBackwardCompatibilityRecord>.toBackwardCompatibilityStatuses(): Res
         }
 }
 
-fun generateBackwardCompatibilityReport(records: List<CtrfBackwardCompatibilityRecord>, startTime: Long, endTime: Long): CtrfReport? {
+fun generateBackwardCompatibilityReport(records: List<CtrfBackwardCompatibilityRecord>, startTime: Long, endTime: Long): CtrfReport? =
+    generateBackwardCompatibilityReportWithFile(records, startTime, endTime)?.first
+
+fun generateBackwardCompatibilityReportWithFile(records: List<CtrfBackwardCompatibilityRecord>, startTime: Long, endTime: Long): Pair<CtrfReport, File?>? {
     if (records.isEmpty()) return null
     val reportOperations = BccReportGenerator().generateReportOperations(records)
     val reportDir = loadSpecmaticConfigOrDefault(getConfigFileName()).getReportDirPath(BCC_REPORT_DIR_SUFFIX).toFile()

--- a/core/src/main/kotlin/io/specmatic/core/report/ReportGenerator.kt
+++ b/core/src/main/kotlin/io/specmatic/core/report/ReportGenerator.kt
@@ -22,9 +22,9 @@ object ReportGenerator {
         absoluteCoverage: Int? = null,
         reportDir: File,
         toolName: String = "Specmatic ${VersionInfo.describe()}",
-    ) {
-        if (isCoverageReportSpecificationsValid(coverageReportSpecifications).not()) return
-
+        generateEmptyReport: Boolean = false,
+    ): File? {
+        if (!generateEmptyReport && isCoverageReportSpecificationsValid(coverageReportSpecifications).not()) return null
         val extra = buildMap<String, Any> {
             coverage?.let { put("apiCoverage", "$coverage%") }
             actuatorEnabled?.let { put("actuatorEnabled", it) }
@@ -41,8 +41,9 @@ object ReportGenerator {
             toolName = toolName
         )
 
-        ReportProvider.generateCtrfReport(report, reportDir)
+        val reportFile = ReportProvider.generateCtrfReport(report, reportDir)
         ReportProvider.generateHtmlReport(report, reportDir, specmaticConfigAsMap())
+        return reportFile
     }
 
     fun generateReportBcc(
@@ -52,7 +53,7 @@ object ReportGenerator {
         specConfigs: List<CtrfSpecConfig>,
         toolName: String = "Specmatic ${VersionInfo.describe()}",
         coverageReportOperations: List<BaseBccReportOperation>,
-    ): CtrfReport? {
+    ): Pair<CtrfReport, File?>? {
         if (isCtrfSpecConfigsValid(specConfigs).not()) return null
         val totalChecksRan = coverageReportOperations.asSequence().flatMap { it.tests.asSequence() }.map { it.id }.distinct().count()
         val extra = buildMap<String, Any> {
@@ -70,9 +71,9 @@ object ReportGenerator {
             extra = extra,
         )
 
-        ReportProvider.generateCtrfReport(report, reportDir)
+        val reportFile = ReportProvider.generateCtrfReport(report, reportDir)
         ReportProvider.generateHtmlReport(report, reportDir, specmaticConfigAsMap())
-        return report
+        return report to reportFile
     }
 
     internal fun specmaticConfigAsMap(): Map<String, Any> {

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -224,6 +224,9 @@ class HttpStub(
     private val prettyPrint = specmaticConfigInstance.getPrettyPrint()
 
     private val ctrfTestResultRecords = mutableListOf<TestResultRecord>()
+    private var generatedCtrfReport: File? = null
+
+    fun getReport(): File? = generatedCtrfReport
 
     val specToBaseUrlMap: Map<String, String> = getValidatedBaseUrlsOrExit(
         features.associate {
@@ -1168,19 +1171,19 @@ class HttpStub(
 
     override fun close() {
         val protocols = features.map { it.protocol }.distinct()
-        if (SpecmaticProtocol.HTTP in protocols) generateReports()
+        if (SpecmaticProtocol.HTTP in protocols) generateReport()
         logger.debug("Stopping the server with grace period of $timeoutMillis and force timeout of $forceTimeoutMillis")
         server.stop(gracePeriodMillis = timeoutMillis, timeoutMillis = max(timeoutMillis, forceTimeoutMillis))
     }
 
-    private fun generateReports() {
+    fun generateReport(): File? {
         synchronized(ctrfTestResultRecords) {
             val mockUsage = OpenApiMockUsage()
             mockUsage.addEndpoints(_allEndpoints)
             ctrfTestResultRecords.forEach(mockUsage::addTestResultRecord)
             val mockUsageReport = mockUsage.generate()
 
-            ReportGenerator.generateReport(
+            generatedCtrfReport = ReportGenerator.generateReport(
                 coverageReportSpecifications = mockUsage.coverageReportSpecifications(mockUsageReport.coverageReportOperations),
                 startTime = startTime.toEpochMilli(),
                 endTime = Instant.now().toEpochMilli(),
@@ -1188,6 +1191,7 @@ class HttpStub(
                 absoluteCoverage = mockUsageReport.absoluteCoverage,
                 reportDir = File("${specmaticConfigInstance.getReportDirPath()}/stub")
             )
+            return generatedCtrfReport
         }
     }
 

--- a/core/src/main/kotlin/io/specmatic/stub/SpecmaticMockRunner.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/SpecmaticMockRunner.kt
@@ -11,12 +11,15 @@ import java.net.InetSocketAddress
 import java.net.Socket
 import java.util.concurrent.Callable
 import java.util.concurrent.TimeoutException
+import java.io.File
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.TimeSource
 
 interface SpecmaticMockRunner: Callable<Int>, Closeable {
     suspend fun checkReadiness()
+
+    fun getReport(): File? = null
 
     companion object {
         val WILDCARDS = setOf("0.0.0.0", "::", "[::]")

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,3 +5,4 @@ specmaticReporterVersion=0.3.43
 swaggerParserVersion=2.1.35
 kotlin.daemon.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m
 org.gradle.jvmargs=-Xmx3g -XX:MaxMetaspaceSize=768m
+org.gradle.parallel=false

--- a/junit5-support/build.gradle.kts
+++ b/junit5-support/build.gradle.kts
@@ -29,4 +29,5 @@ dependencies {
     implementation("org.junit.platform:junit-platform-reporting:1.14.4")
 
     implementation("org.fusesource.jansi:jansi:2.4.3")
+    testImplementation("io.mockk:mockk-jvm:1.14.11")
 }

--- a/junit5-support/src/main/kotlin/io/specmatic/test/ContractTestSettings.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/ContractTestSettings.kt
@@ -11,6 +11,7 @@ import io.specmatic.core.utilities.Flags
 import io.specmatic.reporter.ctrf.model.CtrfOperationMetrics
 import io.specmatic.reporter.model.OpenAPIOperation
 import io.specmatic.reporter.model.SpecType
+import io.specmatic.reporter.commands.InsightsReportOptions
 import io.specmatic.test.SpecmaticJUnitSupport.Companion.TEST_BASE_URL
 import io.specmatic.test.reports.TestReportListener
 import java.io.File
@@ -39,6 +40,7 @@ data class ContractTestSettings(
     val lenientMode: Boolean? = null,
     val previousRunCoverageMetrics: Map<OpenAPIOperation, CtrfOperationMetrics> = emptyMap(),
     val timeoutInMilliSeconds: Long? = null,
+    val insightsReportOptions: InsightsReportOptions = InsightsReportOptions(),
     val otherArguments: DeprecatedArguments? = null,
 ) {
     val host: String? = otherArguments?.host
@@ -137,6 +139,7 @@ data class ContractTestSettings(
         testBaseURL = contractTestSettings?.testBaseURL,
         contractPaths = contractTestSettings?.contractPaths,
         timeoutInMilliSeconds = contractTestSettings?.timeoutInMilliSeconds,
+        insightsReportOptions = contractTestSettings?.insightsReportOptions ?: InsightsReportOptions(),
         filter = contractTestSettings?.filter,
         otherArguments = DeprecatedArguments(
             host = contractTestSettings?.otherArguments?.host,

--- a/junit5-support/src/main/kotlin/io/specmatic/test/RawReportSubmission.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/RawReportSubmission.kt
@@ -1,0 +1,31 @@
+package io.specmatic.test
+
+import io.specmatic.core.git.SystemGit
+import io.specmatic.core.log.logger
+import io.specmatic.reporter.RawReportSender
+import io.specmatic.reporter.RawReportType
+import io.specmatic.reporter.commands.InsightsReportOptions
+import java.io.File
+
+fun sendRawReportToInsights(
+    report: File?,
+    reportType: RawReportType,
+    options: InsightsReportOptions,
+    git: SystemGit = SystemGit(),
+) {
+    if (report == null) return
+    runCatching {
+        val repoUrl = options.repoUrl ?: git.getRemoteUrl()
+        RawReportSender.send(
+            reportFile = report,
+            reportType = reportType,
+            ci = options.ci,
+            buildId = options.buildId,
+            repoId = options.repoId,
+            repoName = options.repoName ?: repoUrl.substringAfterLast('/').removeSuffix(".git"),
+            repoUrl = repoUrl,
+            branchName = options.branchName ?: git.currentBranch(),
+            token = options.token,
+        )
+    }.onFailure { logger.debug("Could not send the ${reportType.wireValue} report to Insights: ${it.message}") }
+}

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -2,6 +2,8 @@ package io.specmatic.test
 
 import io.specmatic.conversions.convertPathParameterStyle
 import io.specmatic.core.*
+import io.specmatic.reporter.RawReportType
+import io.specmatic.reporter.commands.InsightsReportOptions
 import io.specmatic.core.filters.ScenarioMetadataFilter
 import io.specmatic.core.filters.ScenarioMetadataFilter.Companion.filterUsingDecisions
 import io.specmatic.core.log.LogMessage
@@ -69,7 +71,17 @@ open class SpecmaticJUnitSupport {
     init { setLoggerUsing(specmaticConfig.getLogConfigurationOrDefault()) }
 
     companion object {
-        val settingsStaging = ThreadLocal<ContractTestSettings?>()
+        private val generatedCtrfReport = AtomicReference<File?>(null)
+        private val submittedCtrfReport = AtomicReference<String?>(null)
+
+        fun getReport(): File? = generatedCtrfReport.get()
+        fun sendGeneratedCtrfReportToInsights(options: InsightsReportOptions) {
+            val report = getReport() ?: return
+            val reportPath = report.canonicalPath
+            if (!submittedCtrfReport.compareAndSet(null, reportPath)) return
+            sendRawReportToInsights(report, RawReportType.TEST, options)
+        }
+        val settingsStaging = InheritableThreadLocal<ContractTestSettings?>()
 
         const val HOST = "host"
         const val PORT = "port"
@@ -128,14 +140,14 @@ open class SpecmaticJUnitSupport {
 
     private fun getConfigFileWithAbsolutePath() = File(settings.configFile.orEmpty()).canonicalPath
 
-    fun generateCtrfReport() {
+    fun generateCtrfReport(): File? {
         val start = startTime?.toEpochMilli() ?: 0L
         val reportDirPath = specmaticConfig.getReportDirPath()
         val end = startTime?.let { Instant.now().toEpochMilli() } ?: 0L
         val coverageReport = openApiCoverage.generateWithoutHooks()
 
         consoleLog("Generating CTRF report using coverage report specifications...")
-        ReportGenerator.generateReport(
+        val report = ReportGenerator.generateReport(
             endTime = end,
             startTime = start,
             reportDir = File("$reportDirPath/test"),
@@ -143,7 +155,10 @@ open class SpecmaticJUnitSupport {
             coverage = coverageReport.totalCoveragePercentage,
             actuatorEnabled = coverageReport.actuatorEnabled,
             absoluteCoverage = coverageReport.absoluteCoveragePercentage,
+            generateEmptyReport = true,
         )
+        generatedCtrfReport.set(report)
+        return report
     }
 
     @AfterAll
@@ -161,6 +176,7 @@ open class SpecmaticJUnitSupport {
         } finally {
             report.onProcessingComplete()
             this.generateCtrfReport()
+            sendGeneratedCtrfReportToInsights(settings.insightsReportOptions)
             threads.distinct().let {
                 if (it.size > 1) {
                     logger.newLine()
@@ -188,6 +204,8 @@ open class SpecmaticJUnitSupport {
 
     @TestFactory
     fun contractTest(): Stream<DynamicTest> {
+        generatedCtrfReport.set(null)
+        submittedCtrfReport.set(null)
         LicenseResolver.setCurrentExecutorIfNotSet(Executor.PROGRAMMATIC)
 
         settings = ContractTestSettings(settings, specmaticConfig)

--- a/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
@@ -1,6 +1,7 @@
 package io.specmatic.test
 
 import io.specmatic.core.HttpResponse
+import io.specmatic.core.report.ReportGenerator
 import io.specmatic.core.Result
 import io.specmatic.core.ResiliencyTestSuite
 import io.specmatic.core.Scenario
@@ -32,6 +33,9 @@ import io.specmatic.reporter.ctrf.model.CtrfOperationMetrics
 import io.specmatic.reporter.model.OpenAPIOperation
 import io.specmatic.reporter.model.SpecType
 import io.specmatic.reporter.model.TestResult
+import io.specmatic.reporter.RawReportSender
+import io.specmatic.reporter.RawReportType
+import io.specmatic.reporter.commands.InsightsReportOptions
 import io.specmatic.test.SpecmaticJUnitSupport.Companion.HOST
 import io.specmatic.test.SpecmaticJUnitSupport.Companion.PORT
 import io.specmatic.test.SpecmaticJUnitSupport.Companion.PROTOCOL
@@ -54,6 +58,10 @@ import org.junit.platform.launcher.TestExecutionListener
 import org.opentest4j.TestAbortedException
 import io.specmatic.core.pattern.parsedJsonValue
 import io.specmatic.test.utils.MockHttpServer
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.PrintStream
@@ -994,6 +1002,30 @@ paths:
             assertThat(listener.onTestsCompleteCalls).isEqualTo(1)
             assertThat(listener.onEndCalls).isEqualTo(1)
         } finally {
+            SpecmaticJUnitSupport.settingsStaging.remove()
+        }
+    }
+
+    @Test
+    fun `report sends CTRF output when programmatic Insights options are supplied`(@TempDir tempDir: File) {
+        val report = tempDir.resolve("ctrf-report.json").apply { writeText("{}") }
+        val options = InsightsReportOptions().apply {
+            repoName = "repo-name"
+            repoUrl = "https://example.com/repo.git"
+            branchName = "main"
+            token = "token"
+        }
+        SpecmaticJUnitSupport.settingsStaging.set(ContractTestSettings(insightsReportOptions = options))
+        mockkObject(ReportGenerator, RawReportSender)
+        every { ReportGenerator.generateReport(any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns report
+        every { RawReportSender.send(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns true
+
+        try {
+            SpecmaticJUnitSupport().report()
+
+            verify { RawReportSender.send(report, RawReportType.TEST, false, null, null, "repo-name", "https://example.com/repo.git", "main", "token") }
+        } finally {
+            unmockkObject(ReportGenerator, RawReportSender)
             SpecmaticJUnitSupport.settingsStaging.remove()
         }
     }


### PR DESCRIPTION
## What changed
- Test, mock, and backward-compatibility commands submit generated CTRF reports as raw Insights reports.
- CI and repository metadata flow through shared reporting options; local runs derive Git metadata.
- Generated report files are returned through report lifecycle helpers, avoiding fixed report-path discovery.

## Validation
- `./gradlew :specmatic-executable:test --tests application.TestCommandTest --tests application.StubCommandTest --tests application.BackwardCompatibilityCheckCommandV2Test`