### PR TITLE
Update log message for compatibility check

### DIFF
--- a/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckLogger.kt
+++ b/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckLogger.kt
@@ -32,7 +32,7 @@ internal class BackwardCompatibilityCheckLogger {
     fun logNewFile(processedSpec: ProcessedSpec, baseBranch: String) {
         logVerdictFor(
             processedSpec.specFilePath,
-            "(COMPATIBLE) No spec exists at this path on $baseBranch, so no existing contract consumers are affected."
+            "(COMPATIBLE) No spec exists at this path on $baseBranch, so no existing consumers are affected."
                 .prependIndent(ONE_INDENT)
         )
     }


### PR DESCRIPTION
A tiny language fix. It didn't seem right to limit the messaging to "contract consumers" in the messaging around why a new file will affect no consumers. The point is there's no effect on any consumers regardless of whether they are using Specmatic. This fix was to remove the word "contract".

