### PR TITLE
Backward compatibility check log message fix for new spec file creation

### DIFF
--- a/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckLogger.kt
+++ b/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckLogger.kt
@@ -32,7 +32,7 @@ internal class BackwardCompatibilityCheckLogger {
     fun logNewFile(processedSpec: ProcessedSpec, baseBranch: String) {
         logVerdictFor(
             processedSpec.specFilePath,
-            "(COMPATIBLE) No spec exists at this path on $baseBranch, so no existing contract consumers are affected."
+            "(COMPATIBLE) No spec exists at this path on $baseBranch, so no existing consumers are affected."
                 .prependIndent(ONE_INDENT)
         )
     }

--- a/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
+++ b/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
@@ -326,7 +326,7 @@ class BackwardCompatibilityCheckCommandV2Test {
             assertThat(stdOut).containsIgnoringWhitespaces(
                 """
                 Verdict for spec $newSpec:
-                  (COMPATIBLE) No spec exists at this path on main, so no existing contract consumers are affected.
+                  (COMPATIBLE) No spec exists at this path on main, so no existing consumers are affected.
                 """.trimIndent()
             ).containsIgnoringWhitespaces(
                 """


### PR DESCRIPTION
A tiny language fix to the backward compatibility check message around why a new spec file creation yields a compatible verdict. It didn't seem right to limit the messaging to "contract consumers". The point is there's no effect on any consumers regardless of whether they are using Specmatic. This fix was to remove the word "contract".
