### PR TITLE
Fix substitutions in nullable array responses

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
@@ -50,7 +50,11 @@ data class AnyPattern(
         } else null
     }
 
-    private fun selectPattern(value: Value, resolver: Resolver): Pattern {
+    private fun selectPattern(
+        value: Value,
+        resolver: Resolver,
+        updatedPatterns: List<Pattern> = getUpdatedPattern(resolver),
+    ): Pattern {
         val discriminatorValue = extractDiscriminatorValue(value)
         if (discriminatorValue != null) {
             val discriminatorBasedPattern = getDiscriminatorPattern(discriminatorValue, resolver)
@@ -59,7 +63,7 @@ data class AnyPattern(
             }
         }
 
-        val patternMatches = getUpdatedPattern(resolver).sortedBy(::isEmpty).map { pattern ->
+        val patternMatches = updatedPatterns.sortedBy(::isEmpty).map { pattern ->
             AnyPatternMatch(pattern, pattern.matches(value, resolver))
         }
         val bestMatch = patternMatches.minBy { (it.result as? Failure)?.failureCount() ?: 0 }
@@ -155,16 +159,32 @@ data class AnyPattern(
     }
 
     override fun resolveSubstitutions(substitution: Substitution, value: Value, resolver: Resolver, key: String?): ReturnValue<Value> {
-        return evaluateWithUpdatedResolver(resolver) { pattern, updatedResolver ->
+        val updatedPatterns = getUpdatedPattern(resolver)
+        val patternsToEvaluate = selectPatternsForSubstitution(substitution, value, resolver, updatedPatterns)
+
+        return evaluateWithUpdatedResolver(resolver, updatedPatterns, patternsToEvaluate) { pattern, updatedResolver ->
             pattern.resolveSubstitutions(substitution, value, updatedResolver, key)
         }
     }
 
+    private fun selectPatternsForSubstitution(
+        substitution: Substitution,
+        value: Value,
+        resolver: Resolver,
+        updatedPatterns: List<Pattern>,
+    ): List<Pattern> {
+        if (updatedPatterns.isEmpty()) return emptyList()
+
+        val valueForSelection = (substitution.substitute(value) as? HasValue)?.value ?: value
+        return listOf(selectPattern(valueForSelection, resolver, updatedPatterns))
+    }
+
     private inline fun evaluateWithUpdatedResolver(
         resolver: Resolver,
+        updatedPatterns: List<Pattern> = getUpdatedPattern(resolver),
+        patternsToEvaluate: List<Pattern> = updatedPatterns,
         crossinline evaluate: (Pattern, Resolver) -> ReturnValue<Value>
     ): ReturnValue<Value> {
-        val updatedPatterns = getUpdatedPattern(resolver)
         val newPatterns = updatedPatterns
             .filter { it.typeAlias != null && it !is DeferredPattern }
             .associateBy { it.typeAlias.orEmpty() }
@@ -173,7 +193,7 @@ data class AnyPattern(
             .copy(newPatterns = resolver.newPatterns.plus(newPatterns))
             .updateLookupPath(this.typeAlias)
 
-        val result = updatedPatterns.firstSuccessOrFailures(
+        val result = patternsToEvaluate.firstSuccessOrFailures(
             evaluate = { evaluate(it, updatedResolver) },
             isSuccess = { it is HasValue },
             toFailure = { it as ReturnFailure }

--- a/core/src/test/kotlin/integration_tests/StubSubstitutionTest.kt
+++ b/core/src/test/kotlin/integration_tests/StubSubstitutionTest.kt
@@ -43,6 +43,20 @@ import java.io.File
 
 class StubSubstitutionTest {
     @Test
+    fun `stub example resolves substitution in nullable response array`() {
+        val spec = osAgnosticPath("src/test/resources/openapi/substitutions/nullable_array_response.yaml")
+
+        createStubFromContracts(listOf(spec), timeoutMillis = 0).use { stub ->
+            val response = stub.client.execute(
+                HttpRequest("POST", "/echo", body = parsedJSONObject("""{"id":"ECHO-ME"}"""))
+            )
+
+            assertThat(response.status).isEqualTo(200)
+            assertThat(response.body).isEqualTo(parsedJSON("""[{"id":"ECHO-ME"}]"""))
+        }
+    }
+
+    @Test
     fun `stub example with substitution in response body`() {
         val specWithSubstitution = osAgnosticPath("src/test/resources/openapi/substitutions/spec_with_substitution_in_response_body.yaml")
 

--- a/core/src/test/kotlin/io/specmatic/core/pattern/AnyPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/AnyPatternTest.kt
@@ -6,6 +6,7 @@ import io.specmatic.core.substitution.SubstitutionImpl
 import io.specmatic.core.utilities.withNullPattern
 import io.specmatic.core.value.*
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Named
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Nested
@@ -13,8 +14,36 @@ import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
 
 internal class AnyPatternTest {
+    companion object {
+        @JvmStatic
+        fun jsonObjectAlternativeCases(): Stream<Arguments> = Stream.of(
+            Arguments.of(
+                Named.of(
+                    "alternatives with distinct keys",
+                    JSONObjectPattern(mapOf("string" to StringPattern())),
+                )
+            ),
+            Arguments.of(
+                Named.of(
+                    "first alternative containing all keys from the second",
+                    JSONObjectPattern(mapOf("string" to StringPattern(), "number" to NumberPattern())),
+                )
+            ),
+            Arguments.of(
+                Named.of(
+                    "first alternative containing all keys from the second",
+                    JSONObjectPattern(mapOf("string" to StringPattern(), "number" to StringPattern())),
+                )
+            ),
+        )
+    }
+
     @Test
     fun `should be able to generate for a discriminator value when it's nested inside another AnyPattern`() {
         val discriminator = Discriminator(
@@ -1301,6 +1330,22 @@ internal class AnyPatternTest {
             val resolvedValue = pattern.resolveSubstitutions(substitution, StringValue("$(id)"), Resolver()).value
 
             assertThat(resolvedValue).isEqualTo(StringValue("second"))
+        }
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("io.specmatic.core.pattern.AnyPatternTest#jsonObjectAlternativeCases")
+        fun `should select correct alternative between two json objects`(stringAlternative: JSONObjectPattern) {
+            val numberAlternative = JSONObjectPattern(mapOf("number" to NumberPattern()))
+
+            val pattern = AnyPattern(
+                listOf(stringAlternative, numberAlternative),
+                extensions = emptyMap(),
+            )
+            val substitution = SubstitutionImpl.empty()
+
+            val resolvedValue = pattern.resolveSubstitutions(substitution, JSONObjectValue(mapOf("number" to StringValue("$(id)"))), Resolver()).value
+
+            assertThat(numberAlternative.matches(resolvedValue, Resolver())).isInstanceOf(Result.Success::class.java)
         }
 
         @Test

--- a/core/src/test/kotlin/io/specmatic/core/pattern/AnyPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/AnyPatternTest.kt
@@ -1199,6 +1199,126 @@ internal class AnyPatternTest {
 
     @Nested
     inner class ResolveSubstitutionsTests {
+        private fun substitution(variableName: String, pattern: Pattern, value: Value): Substitution =
+            SubstitutionImpl.empty().upsertStoreUsing(
+                StringValue("($variableName:${pattern.typeName})"),
+                value,
+                Resolver(),
+            )
+
+        @Test
+        fun `should resolve nested substitutions in nullable arrays`() {
+            val itemPattern = JSONObjectPattern(mapOf("id" to StringPattern()))
+            val pattern = ListPattern(itemPattern).toNullable(null)
+            val value = parsedJSONArray("""[{"id":"$(id)"}]""")
+            val substitution = substitution("id", StringPattern(), StringValue("ECHO-ME"))
+
+            val resolvedValue = pattern.resolveSubstitutions(substitution, value, Resolver()).value
+
+            assertThat(resolvedValue).isEqualTo(parsedJSONArray("""[{"id":"ECHO-ME"}]"""))
+        }
+
+        @Test
+        fun `should resolve nested substitutions in nullable objects`() {
+            val pattern = JSONObjectPattern(mapOf("id" to StringPattern())).toNullable(null)
+            val value = parsedJSONObject("""{"id":"$(id)"}""")
+            val substitution = substitution("id", StringPattern(), StringValue("ECHO-ME"))
+
+            val resolvedValue = pattern.resolveSubstitutions(substitution, value, Resolver()).value
+
+            assertThat(resolvedValue).isEqualTo(parsedJSONObject("""{"id":"ECHO-ME"}"""))
+        }
+
+        @Test
+        fun `should select nullable scalar branch using typed captured value`() {
+            val numberPattern = NumberPattern()
+            val pattern = numberPattern.toNullable(null)
+            val substitution = substitution("id", numberPattern, NumberValue(10))
+
+            val resolvedValue = pattern.resolveSubstitutions(substitution, StringValue("$(id)"), Resolver()).value
+
+            assertThat(resolvedValue).isEqualTo(NumberValue(10))
+        }
+
+        @Test
+        fun `should resolve substitution in nullable string`() {
+            val stringPattern = StringPattern()
+            val pattern = stringPattern.toNullable(null)
+            val substitution = substitution("id", stringPattern, StringValue("ECHO-ME"))
+
+            val resolvedValue = pattern.resolveSubstitutions(substitution, StringValue("$(id)"), Resolver()).value
+
+            assertThat(resolvedValue).isEqualTo(StringValue("ECHO-ME"))
+        }
+
+        @Test
+        fun `should select scalar oneOf alternative using typed captured value regardless of order`() {
+            val numberPattern = NumberPattern()
+            val substitution = substitution("id", numberPattern, NumberValue(10))
+            val patterns = listOf(
+                AnyPattern(listOf(StringPattern(), numberPattern), extensions = emptyMap()),
+                AnyPattern(listOf(numberPattern, StringPattern()), extensions = emptyMap()),
+            )
+
+            assertThat(patterns.map { it.resolveSubstitutions(substitution, StringValue("$(id)"), Resolver()).value })
+                .containsExactly(NumberValue(10), NumberValue(10))
+        }
+
+        @Test
+        fun `should select scalar anyOf alternative using typed captured value regardless of order`() {
+            val numberPattern = NumberPattern()
+            val substitution = substitution("id", numberPattern, NumberValue(10))
+            val patterns = listOf(
+                AnyOfPattern(listOf(StringPattern(), numberPattern), extensions = emptyMap()),
+                AnyOfPattern(listOf(numberPattern, StringPattern()), extensions = emptyMap()),
+            )
+
+            assertThat(patterns.map { it.resolveSubstitutions(substitution, StringValue("$(id)"), Resolver()).value })
+                .containsExactly(NumberValue(10), NumberValue(10))
+        }
+
+        @Test
+        fun `should select string alternative for interpolated substitutions regardless of order`() {
+            val stringPattern = StringPattern()
+            val substitution = substitution("id", stringPattern, StringValue("ECHO-ME"))
+            val patterns = listOf(
+                AnyPattern(listOf(NumberPattern(), stringPattern), extensions = emptyMap()),
+                AnyPattern(listOf(stringPattern, NumberPattern()), extensions = emptyMap()),
+            )
+
+            assertThat(patterns.map { it.resolveSubstitutions(substitution, StringValue("id-$(id)"), Resolver()).value })
+                .containsExactly(StringValue("id-ECHO-ME"), StringValue("id-ECHO-ME"))
+        }
+
+        @Test
+        fun `should select same-type constrained alternative using captured value`() {
+            val pattern = AnyPattern(
+                listOf(ExactValuePattern(StringValue("first")), ExactValuePattern(StringValue("second"))),
+                extensions = emptyMap(),
+            )
+            val substitution = substitution("id", StringPattern(), StringValue("second"))
+
+            val resolvedValue = pattern.resolveSubstitutions(substitution, StringValue("$(id)"), Resolver()).value
+
+            assertThat(resolvedValue).isEqualTo(StringValue("second"))
+        }
+
+        @Test
+        fun `should use selected branch lenient fallback when lookup is missing`() {
+            val pattern = AnyPattern(
+                listOf(NumberPattern(example = "10"), StringPattern(example = "fallback")),
+                extensions = emptyMap(),
+            )
+
+            val resolvedValue = pattern.resolveSubstitutions(
+                SubstitutionImpl.empty(),
+                StringValue("$(missing)"),
+                Resolver(),
+            ).value
+
+            assertThat(resolvedValue).isInstanceOf(NumberValue::class.java)
+        }
+
         @Test
         fun `should use dictionary backed generation with discriminator`() {
             val pattern = AnyPattern(

--- a/core/src/test/kotlin/io/specmatic/core/pattern/EnumPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/EnumPatternTest.kt
@@ -479,6 +479,24 @@ class EnumPatternTest {
     }
 
     @Test
+    fun `resolveSubstitutions should preserve typed captured value for nullable multi-type enum`() {
+        val pattern = EnumPattern(
+            values = listOf(StringValue("active"), NumberValue(10), NullValue),
+            nullable = true,
+            multiType = true,
+        )
+        val substitution = SubstitutionImpl.empty().upsertStoreUsing(
+            StringValue("(status:number)"),
+            NumberValue(10),
+            Resolver(),
+        )
+
+        val result = pattern.resolveSubstitutions(substitution, StringValue("$(status)"), Resolver())
+
+        assertThat(result.value).isEqualTo(NumberValue(10))
+    }
+
+    @Test
     fun `resolveSubstitutions should not fail when substituted value not in enum`() {
         val enumValues = listOf(StringValue("active"), StringValue("inactive"))
         val pattern = EnumPattern(enumValues)

--- a/core/src/test/resources/openapi/substitutions/nullable_array_response.yaml
+++ b/core/src/test/resources/openapi/substitutions/nullable_array_response.yaml
@@ -1,0 +1,33 @@
+openapi: 3.0.0
+info:
+  title: Nullable response array substitution
+  version: 1.0.0
+paths:
+  /echo:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - id
+              properties:
+                id:
+                  type: string
+      responses:
+        '200':
+          description: Echoed id
+          content:
+            application/json:
+              schema:
+                type: array
+                nullable: true
+                items:
+                  type: object
+                  required:
+                    - id
+                  properties:
+                    id:
+                      type: string

--- a/core/src/test/resources/openapi/substitutions/nullable_array_response_examples/echo.json
+++ b/core/src/test/resources/openapi/substitutions/nullable_array_response_examples/echo.json
@@ -1,0 +1,17 @@
+{
+  "http-request": {
+    "method": "POST",
+    "path": "/echo",
+    "body": {
+      "id": "(id_1:string)"
+    }
+  },
+  "http-response": {
+    "status": 200,
+    "body": [
+      {
+        "id": "$(id_1)"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Select the appropriate typed branch before resolving substitutions.
- Preserve typed captured values for nullable and multi-type patterns.
- Add coverage for nullable arrays, objects, scalars, enums, and alternatives.