### PR TITLE
Fix/bcc verdict for hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ Each release section should stand on its own and describe the behavior shipped i
 ### Added
 - Added support for column level filters in the HTML report
 
+### Changed
+
+- Updated backward-compatibility hook results to distinguish passed, failed, and reason-specific unknown outcomes, so downstream checks can report why consumer impact could not be determined.
+
 
 ## 2.53.0 (2026-08-14)
 ### Added

--- a/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckBaseCommand.kt
+++ b/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckBaseCommand.kt
@@ -347,7 +347,7 @@ abstract class BackwardCompatibilityCheckBaseCommand(
         val unusedExamples: Set<String>,
         val precomputedCompatibilityResult: CompatibilityResult,
         val computedCompatibilityCheckHookResult: Pair<CompatibilityResult, List<OperationUsageResponse>?> = Pair(
-            CompatibilityResult.UNKNOWN, emptyList()
+            CompatibilityResult.UNSPECIFIED, emptyList()
         ),
         val isNewFile: Boolean,
         val reportRecords: List<CtrfBackwardCompatibilityRecord> = emptyList()

--- a/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckHookValidator.kt
+++ b/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckHookValidator.kt
@@ -63,6 +63,6 @@ internal class BackwardCompatibilityCheckHookValidator(
 
     private companion object {
         const val POOL_SIZE = 5
-        val unknownResult = Pair<CompatibilityResult, List<OperationUsageResponse>?>(CompatibilityResult.UNKNOWN, emptyList())
+        val unknownResult = Pair<CompatibilityResult, List<OperationUsageResponse>?>(CompatibilityResult.UNSPECIFIED, emptyList())
     }
 }

--- a/application/src/main/kotlin/application/backwardCompatibility/CompatibilityResult.kt
+++ b/application/src/main/kotlin/application/backwardCompatibility/CompatibilityResult.kt
@@ -1,5 +1,25 @@
 package application.backwardCompatibility
 
-enum class CompatibilityResult {
-    PASSED, FAILED, UNKNOWN
+sealed interface CompatibilityResult {
+    data object Passed : CompatibilityResult
+    data object Failed : CompatibilityResult
+
+    data class Unknown(
+        val reason: UnknownReason,
+    ) : CompatibilityResult
+
+    companion object {
+        val FAILED = Failed
+        val PASSED = Passed
+        val UNSPECIFIED = Unknown(UnknownReason.UNSPECIFIED)
+    }
+
+}
+
+enum class UnknownReason {
+    UNSPECIFIED,
+    INSIGHTS_CHECK_FAILED,
+    UNSUPPORTED_PROTOCOL,
+    LICENSE_UNAVAILABLE,
+    NO_OPERATION_REQUESTS,
 }

--- a/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
+++ b/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
@@ -1748,7 +1748,7 @@ class BackwardCompatibilityCheckCommandV2Test {
 
               --------------------
               Verdict for spec $hookFailedSpecPath:
-                (HOOK: FAILED)
+                (HOOK: Failed)
               --------------------
 
 
@@ -1766,7 +1766,7 @@ class BackwardCompatibilityCheckCommandV2Test {
 
               --------------------
               Verdict for spec $hookPassedSpecPath:
-                (HOOK: PASSED)
+                (HOOK: Passed)
               --------------------
 
 
@@ -2364,7 +2364,8 @@ class MixedResultBackwardCompatibilityCheckHook : BackwardCompatibilityCheckHook
         processedSpec: BackwardCompatibilityCheckBaseCommand.ProcessedSpec,
         strictMode: Boolean,
     ): Pair<CompatibilityResult, String> =
-        processedSpec.computedCompatibilityCheckHookResult.first to "(HOOK: ${processedSpec.computedCompatibilityCheckHookResult.first})"
+        processedSpec.computedCompatibilityCheckHookResult.first to
+            "(HOOK: ${processedSpec.computedCompatibilityCheckHookResult.first})"
 
     companion object {
         const val PASSED_SPEC = "hook-passed.yaml"

--- a/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
+++ b/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
@@ -416,7 +416,7 @@ class BackwardCompatibilityCheckCommandV2Test {
             newer = object : IFeature {},
             unusedExamples = emptySet(),
             precomputedCompatibilityResult = CompatibilityResult.FAILED,
-            computedCompatibilityCheckHookResult = Pair(CompatibilityResult.UNKNOWN, emptyList()),
+            computedCompatibilityCheckHookResult = Pair(CompatibilityResult.UNSPECIFIED, emptyList()),
             isNewFile = false
         )
 
@@ -442,14 +442,14 @@ class BackwardCompatibilityCheckCommandV2Test {
                     remoteUrl: String,
                     relativePath: String
                 ): Pair<CompatibilityResult, List<OperationUsageResponse>> =
-                    Pair(CompatibilityResult.UNKNOWN, emptyList())
+                    Pair(CompatibilityResult.UNSPECIFIED, emptyList())
 
                 override fun logCompletedMessage() {}
                 override fun failedVerdictAndMessage(
                     processedSpec: BackwardCompatibilityCheckBaseCommand.ProcessedSpec,
                     strictMode: Boolean,
                 ): Pair<CompatibilityResult, String> {
-                    return Pair(CompatibilityResult.UNKNOWN, "(HOOK: override)")
+                    return Pair(CompatibilityResult.UNSPECIFIED, "(HOOK: override)")
                 }
 
             }
@@ -2353,7 +2353,7 @@ class MixedResultBackwardCompatibilityCheckHook : BackwardCompatibilityCheckHook
     ): Pair<CompatibilityResult, List<OperationUsageResponse>?> = when (specFilePath) {
         PASSED_SPEC -> CompatibilityResult.PASSED to emptyList()
         FAILED_SPEC -> CompatibilityResult.FAILED to emptyList()
-        else -> CompatibilityResult.UNKNOWN to emptyList()
+        else -> CompatibilityResult.UNSPECIFIED to emptyList()
     }
 
     override fun logStartedMessage(failedSpecs: List<BackwardCompatibilityCheckBaseCommand.ProcessedSpec>) {}

--- a/core/src/main/resources/schemas/external_example.yaml
+++ b/core/src/main/resources/schemas/external_example.yaml
@@ -125,32 +125,6 @@ components:
         multipart-formdata:
           type: array
           items:
-            $ref: "#/components/schemas/MultiPartFormData"
-      required:
-        - path
-        - method
-
-    InlineRequestSchema:
-      type: object
-      additionalProperties: false
-      properties:
-        path:
-          type: string
-        method:
-          type: string
-        query:
-          type: object
-        headers:
-          type: object
-        body:
-          nullable: true
-          allOf:
-            - $ref: "#/components/schemas/AnyValue"
-        form-fields:
-          type: object
-        multipart-formdata:
-          type: array
-          items:
             $ref: "#/components/schemas/InlineMultiPartFormData"
         description:
           type: string

--- a/core/src/main/resources/schemas/external_example.yaml
+++ b/core/src/main/resources/schemas/external_example.yaml
@@ -125,6 +125,32 @@ components:
         multipart-formdata:
           type: array
           items:
+            $ref: "#/components/schemas/MultiPartFormData"
+      required:
+        - path
+        - method
+
+    InlineRequestSchema:
+      type: object
+      additionalProperties: false
+      properties:
+        path:
+          type: string
+        method:
+          type: string
+        query:
+          type: object
+        headers:
+          type: object
+        body:
+          nullable: true
+          allOf:
+            - $ref: "#/components/schemas/AnyValue"
+        form-fields:
+          type: object
+        multipart-formdata:
+          type: array
+          items:
             $ref: "#/components/schemas/InlineMultiPartFormData"
         description:
           type: string

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 group=io.specmatic
 version=2.53.1
 specmaticGradlePluginVersion=0.15.24
-specmaticReporterVersion=0.3.41
+specmaticReporterVersion=0.3.42
 swaggerParserVersion=2.1.35
 kotlin.daemon.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m
 org.gradle.jvmargs=-Xmx3g -XX:MaxMetaspaceSize=768m


### PR DESCRIPTION
**What**:

Introduced a structured `CompatibilityResult` model for backward compatibility checks. Passed and failed results remain compatible through companion constants, while unknown results now carry a specific `UnknownReason`.

Updated Core production code and tests to use the new result structure.

**Why**:

The previous `UNKNOWN` result did not indicate why the compatibility check could not produce a definitive result. This made it difficult for consumers to distinguish cases such as an unavailable license, unsupported protocol, missing operation requests, or an Insights check failure.

**How**:

- Replaced the compatibility result enum with a sealed result model.
- Added `UnknownReason` values for supported unknown-result scenarios.
- Preserved existing `PASSED` and `FAILED` usage through companion constants.
- Updated compatibility report generation and default hook behavior.
- Updated affected Core tests.
