### PR TITLE
Fix security scheme handling in request fixing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ Each release section should stand on its own and describe the behavior shipped i
 
 ## Unreleased
 
+### Changed
+
+- Fixed request fixing to preserve security scheme headers and query parameters and repair invalid security values.
+
 ## 2.53.1 (2026-08-22)
 
 ### Added

--- a/core/src/main/kotlin/io/specmatic/conversions/APIKeyInHeaderSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/APIKeyInHeaderSecurityScheme.kt
@@ -8,6 +8,14 @@ import io.swagger.v3.oas.models.parameters.Parameter
 
 
 data class APIKeyInHeaderSecurityScheme(val name: String, private val apiKey:String?) : OpenAPISecurityScheme {
+    override fun failIfInRequest(httpRequest: HttpRequest, resolver: Resolver): Result {
+        val entry = httpRequest.headers.getCaseInsensitive(name) ?: return Result.Success()
+        return Result.Failure(
+            breadCrumb = BreadCrumb.HEADER.with(entry.key),
+            message = resolver.mismatchMessages.unexpectedKey("header", entry.key)
+        )
+    }
+
     override fun matches(httpRequest: HttpRequest, resolver: Resolver): Result {
         return if (httpRequest.headers.containsKey(name) || resolver.mockMode) Result.Success()
         else Result.Failure(

--- a/core/src/main/kotlin/io/specmatic/conversions/APIKeyInHeaderSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/APIKeyInHeaderSecurityScheme.kt
@@ -17,7 +17,7 @@ data class APIKeyInHeaderSecurityScheme(val name: String, private val apiKey:Str
     }
 
     override fun matches(httpRequest: HttpRequest, resolver: Resolver): Result {
-        return if (httpRequest.headers.containsKey(name) || resolver.mockMode) Result.Success()
+        return if (httpRequest.hasHeader(name) || resolver.mockMode) Result.Success()
         else Result.Failure(
             breadCrumb = BreadCrumb.HEADER.with(name),
             message = resolver.mismatchMessages.expectedKeyWasMissing(apiKeyParamName, name),
@@ -26,7 +26,7 @@ data class APIKeyInHeaderSecurityScheme(val name: String, private val apiKey:Str
     }
 
     override fun removeParam(httpRequest: HttpRequest): HttpRequest {
-        return httpRequest.copy(headers = httpRequest.headers.minus(name))
+        return httpRequest.copy(headers = httpRequest.headers.minusCaseInsensitive(name))
     }
 
     override fun addTo(httpRequest: HttpRequest, resolver: Resolver): HttpRequest {
@@ -40,8 +40,8 @@ data class APIKeyInHeaderSecurityScheme(val name: String, private val apiKey:Str
     }
 
     override fun copyFromTo(originalRequest: HttpRequest, newHttpRequest: HttpRequest): HttpRequest {
-        if (!originalRequest.headers.containsKey(name)) return newHttpRequest
-        return newHttpRequest.addSecurityHeader(name, originalRequest.headers.getValue(name))
+        val headerValue = originalRequest.headers.getCaseInsensitive(name)?.value ?: return newHttpRequest
+        return newHttpRequest.addSecurityHeader(name, headerValue)
     }
 
     override fun isInRow(row: Row): Boolean = row.containsField(name)

--- a/core/src/main/kotlin/io/specmatic/conversions/APIKeyInQueryParamSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/APIKeyInQueryParamSecurityScheme.kt
@@ -54,7 +54,7 @@ data class APIKeyInQueryParamSecurityScheme(val name: String, private val apiKey
     override fun copyFromTo(originalRequest: HttpRequest, newHttpRequest: HttpRequest): HttpRequest {
         if (!originalRequest.queryParams.containsKey(name)) return newHttpRequest
         val apiKeyValue = originalRequest.queryParams.getValues(name).first()
-        return newHttpRequest.copy(queryParams = newHttpRequest.queryParams.plus(name to apiKeyValue))
+        return newHttpRequest.copy(queryParams = newHttpRequest.queryParams.minus(name).plus(name to apiKeyValue))
     }
 
     override fun isInRow(row: Row): Boolean = row.containsField(name)

--- a/core/src/main/kotlin/io/specmatic/conversions/APIKeyInQueryParamSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/APIKeyInQueryParamSecurityScheme.kt
@@ -9,6 +9,14 @@ import io.swagger.v3.oas.models.parameters.QueryParameter
 const val apiKeyParamName = "API-Key"
 
 data class APIKeyInQueryParamSecurityScheme(val name: String, private val apiKey:String?) : OpenAPISecurityScheme {
+    override fun failIfInRequest(httpRequest: HttpRequest, resolver: Resolver): Result {
+        if (!httpRequest.hasQueryParam(name)) return Result.Success()
+        return Result.Failure(
+            breadCrumb = BreadCrumb.QUERY.with(name),
+            message = resolver.mismatchMessages.unexpectedKey("query", name)
+        )
+    }
+
     override fun matches(httpRequest: HttpRequest, resolver: Resolver): Result {
         return if (httpRequest.queryParams.containsKey(name) || resolver.mockMode) Result.Success()
         else Result.Failure(

--- a/core/src/main/kotlin/io/specmatic/conversions/BasicAuthSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/BasicAuthSecurityScheme.kt
@@ -9,6 +9,14 @@ import org.apache.http.HttpHeaders.AUTHORIZATION
 import java.util.Base64
 
 data class BasicAuthSecurityScheme(private val token: String? = null) : OpenAPISecurityScheme {
+    override fun failIfInRequest(httpRequest: HttpRequest, resolver: Resolver): Result {
+        val entry = httpRequest.headers.getCaseInsensitive(AUTHORIZATION) ?: return Result.Success()
+        return Result.Failure(
+            breadCrumb = BreadCrumb.HEADER.with(entry.key),
+            message = resolver.mismatchMessages.unexpectedKey("header", entry.key)
+        )
+    }
+
     override fun matches(httpRequest: HttpRequest, resolver: Resolver): Result {
         val authHeaderValue: String = httpRequest.headers[AUTHORIZATION] ?: return when(resolver.mockMode) {
             true -> Result.Success()

--- a/core/src/main/kotlin/io/specmatic/conversions/BasicAuthSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/BasicAuthSecurityScheme.kt
@@ -18,7 +18,7 @@ data class BasicAuthSecurityScheme(private val token: String? = null) : OpenAPIS
     }
 
     override fun matches(httpRequest: HttpRequest, resolver: Resolver): Result {
-        val authHeaderValue: String = httpRequest.headers[AUTHORIZATION] ?: return when(resolver.mockMode) {
+        val authHeaderValue: String = httpRequest.headers.getCaseInsensitive(AUTHORIZATION)?.value ?: return when(resolver.mockMode) {
             true -> Result.Success()
             else -> Result.Failure(
                 breadCrumb = BreadCrumb.HEADER.with(AUTHORIZATION),
@@ -61,7 +61,7 @@ data class BasicAuthSecurityScheme(private val token: String? = null) : OpenAPIS
     }
 
     override fun removeParam(httpRequest: HttpRequest): HttpRequest {
-        return httpRequest.copy(headers = httpRequest.headers.minus(AUTHORIZATION))
+        return httpRequest.copy(headers = httpRequest.headers.minusCaseInsensitive(AUTHORIZATION))
     }
 
     override fun addTo(httpRequest: HttpRequest, resolver: Resolver): HttpRequest {
@@ -73,8 +73,8 @@ data class BasicAuthSecurityScheme(private val token: String? = null) : OpenAPIS
     }
 
     override fun copyFromTo(originalRequest: HttpRequest, newHttpRequest: HttpRequest): HttpRequest {
-        if (!originalRequest.headers.containsKey(AUTHORIZATION)) return newHttpRequest
-        return newHttpRequest.addSecurityHeader(AUTHORIZATION, originalRequest.headers.getValue(AUTHORIZATION))
+        val authHeaderValue = originalRequest.headers.getCaseInsensitive(AUTHORIZATION)?.value ?: return newHttpRequest
+        return newHttpRequest.addSecurityHeader(AUTHORIZATION, authHeaderValue)
     }
 
     override fun isInRow(row: Row): Boolean = row.containsField(AUTHORIZATION)

--- a/core/src/main/kotlin/io/specmatic/conversions/BearerSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/BearerSecurityScheme.kt
@@ -8,6 +8,14 @@ import io.swagger.v3.oas.models.parameters.Parameter
 import org.apache.http.HttpHeaders.AUTHORIZATION
 
 data class BearerSecurityScheme(private val configuredToken: String? = null) : OpenAPISecurityScheme {
+    override fun failIfInRequest(httpRequest: HttpRequest, resolver: Resolver): Result {
+        val entry = httpRequest.headers.getCaseInsensitive(AUTHORIZATION) ?: return Result.Success()
+        return Result.Failure(
+            breadCrumb = BreadCrumb.HEADER.with(entry.key),
+            message = resolver.mismatchMessages.unexpectedKey("header", entry.key)
+        )
+    }
+
     override fun matches(httpRequest: HttpRequest, resolver: Resolver): Result {
         val authHeaderValue = httpRequest.headers.entries.find {
             it.key.equals(AUTHORIZATION, ignoreCase = true)

--- a/core/src/main/kotlin/io/specmatic/conversions/BearerSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/BearerSecurityScheme.kt
@@ -28,7 +28,7 @@ data class BearerSecurityScheme(private val configuredToken: String? = null) : O
             )
         }
 
-        if (!authHeaderValue.value.lowercase().startsWith("bearer")) {
+        if (!authHeaderValue.value.lowercase().startsWith("bearer ")) {
             return Result.Failure(
                 breadCrumb = BreadCrumb.HEADER.with(AUTHORIZATION),
                 message = "$AUTHORIZATION header must be prefixed with \"Bearer\"",
@@ -66,8 +66,8 @@ data class BearerSecurityScheme(private val configuredToken: String? = null) : O
     }
 
     override fun copyFromTo(originalRequest: HttpRequest, newHttpRequest: HttpRequest): HttpRequest {
-        if (!originalRequest.headers.containsKey(AUTHORIZATION)) return newHttpRequest
-        return newHttpRequest.addSecurityHeader(AUTHORIZATION, originalRequest.headers.getValue(AUTHORIZATION))
+        val authHeaderValue = originalRequest.headers.getCaseInsensitive(AUTHORIZATION)?.value ?: return newHttpRequest
+        return newHttpRequest.addSecurityHeader(AUTHORIZATION, authHeaderValue)
     }
 
     override fun getHeaderKey(): String? {

--- a/core/src/main/kotlin/io/specmatic/conversions/CompositeSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/CompositeSecurityScheme.kt
@@ -8,6 +8,10 @@ import io.specmatic.core.pattern.Row
 import io.swagger.v3.oas.models.parameters.Parameter
 
 data class CompositeSecurityScheme(val schemes: List<OpenAPISecurityScheme>): OpenAPISecurityScheme {
+    override fun failIfInRequest(httpRequest: HttpRequest, resolver: Resolver): Result {
+        return Result.fromResults(results = schemes.map { it.failIfInRequest(httpRequest, resolver) })
+    }
+
     override fun matches(httpRequest: HttpRequest, resolver: Resolver): Result {
         val results = schemes.map { it.matches(httpRequest, resolver) }
         return Result.fromResults(results)

--- a/core/src/main/kotlin/io/specmatic/conversions/CompositeSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/CompositeSecurityScheme.kt
@@ -17,6 +17,12 @@ data class CompositeSecurityScheme(val schemes: List<OpenAPISecurityScheme>): Op
         return Result.fromResults(results)
     }
 
+    override fun fixValue(httpRequest: HttpRequest, resolver: Resolver): HttpRequest {
+        return schemes.fold(httpRequest) { request, scheme ->
+            scheme.fixValue(request, resolver)
+        }
+    }
+
     override fun removeParam(httpRequest: HttpRequest): HttpRequest {
         return schemes.fold(httpRequest) { request, scheme ->
             scheme.removeParam(request)

--- a/core/src/main/kotlin/io/specmatic/conversions/NoSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/NoSecurityScheme.kt
@@ -8,6 +8,10 @@ import io.specmatic.core.pattern.Row
 import io.swagger.v3.oas.models.parameters.Parameter
 
 class NoSecurityScheme : OpenAPISecurityScheme {
+    override fun failIfInRequest(httpRequest: HttpRequest, resolver: Resolver): Result {
+        return Result.Success()
+    }
+
     override fun matches(httpRequest: HttpRequest, resolver: Resolver): Result {
         return Result.Success()
     }

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenAPISecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenAPISecurityScheme.kt
@@ -18,6 +18,7 @@ interface OpenAPISecurityScheme {
     fun isInRequest(request: HttpRequest, complete: Boolean): Boolean
     fun getHeaderKey(): String? = null
     fun collectErrorIfExistsInParameters(parameter: List<ParameterWithContext<Parameter>>)
+    fun failIfInRequest(httpRequest: HttpRequest, resolver: Resolver): Result
 }
 
 fun addToHeaderType(

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenAPISecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenAPISecurityScheme.kt
@@ -19,6 +19,13 @@ interface OpenAPISecurityScheme {
     fun getHeaderKey(): String? = null
     fun collectErrorIfExistsInParameters(parameter: List<ParameterWithContext<Parameter>>)
     fun failIfInRequest(httpRequest: HttpRequest, resolver: Resolver): Result
+    fun fixValue(httpRequest: HttpRequest, resolver: Resolver): HttpRequest {
+        return if (matches(httpRequest, resolver).isSuccess()) {
+            httpRequest
+        } else {
+            addTo(removeParam(httpRequest), resolver)
+        }
+    }
 }
 
 fun addToHeaderType(

--- a/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
@@ -629,6 +629,10 @@ fun Map<String, String>.withoutTransportHeaders(
 
 fun <T> Map<String, T>.getCaseInsensitive(key: String): Map.Entry<String, T>? = this.entries.find { it.key.equals(key, ignoreCase = true) }
 
+fun <T> Map<String, T>.minusCaseInsensitive(key: String): Map<String, T> {
+    return this.filterKeys { !it.equals(key, ignoreCase = true) }
+}
+
 fun <T> Map<String, T>.getCaseInsensitiveCheckOptional(key: String): Map.Entry<String, T>? {
     val mandatoryEntry = this.getCaseInsensitive(withoutOptionality(key))
     if (mandatoryEntry != null) return mandatoryEntry

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
@@ -182,20 +182,8 @@ data class HttpRequestPattern(
 
     private fun matchSecurityScheme(parameters: Triple<HttpRequest, Resolver, List<Failure>>): MatchingResult<Triple<HttpRequest, Resolver, List<Failure>>> {
         val (httpRequest, resolver, failures) = parameters
-        val (modifiedHttpRequest, results) = securitySchemes.fold(
-            initial = Pair(httpRequest, emptyList<SecurityMatch>())
-        ) { (request, results), securityScheme ->
-            securityScheme.removeParam(request) to results.plus(
-                SecurityMatch(
-                    presence = when {
-                        securityScheme.isInRequest(httpRequest, complete = true) -> SchemePresence.FULL
-                        securityScheme.isInRequest(httpRequest, complete = false) -> SchemePresence.PARTIAL
-                        else -> SchemePresence.ABSENT
-                    },
-                    result = securityScheme.matches(httpRequest, resolver).breadCrumb(BreadCrumb.PARAMETERS.value)
-                )
-            )
-        }
+        val modifiedHttpRequest = withoutSecuritySchemes(httpRequest)
+        val results = securityMatches(httpRequest, resolver)
 
         SchemePresence.entries.forEach { presence ->
             val presenceResults = results.filter { it.presence == presence }.map { it.result }
@@ -216,6 +204,25 @@ data class HttpRequestPattern(
 
         return if (completeFailure == null) MatchSuccess(Triple(modifiedHttpRequest, resolver, failures))
         else MatchSuccess(Triple(modifiedHttpRequest, resolver, failures.plus(completeFailure)))
+    }
+
+    private fun securityMatches(httpRequest: HttpRequest, resolver: Resolver): List<SecurityMatch> {
+        return securitySchemes.map { securityScheme ->
+            SecurityMatch(
+                scheme = securityScheme,
+                result = securityScheme.matches(httpRequest, resolver).breadCrumb(BreadCrumb.PARAMETERS.value),
+                presence = when {
+                    securityScheme.isInRequest(httpRequest, complete = true) -> SchemePresence.FULL
+                    securityScheme.isInRequest(httpRequest, complete = false) -> SchemePresence.PARTIAL
+                    else -> SchemePresence.ABSENT
+                },
+            )
+        }
+    }
+
+    private fun selectSecurityMatches(results: List<SecurityMatch>): List<SecurityMatch> {
+        val selectedPresence = SchemePresence.entries.firstOrNull { presence -> results.any { it.presence == presence } } ?: return emptyList()
+        return results.filter { it.presence == selectedPresence }
     }
 
     fun matchesSignature(other: HttpRequestPattern): Boolean =
@@ -1131,13 +1138,26 @@ data class HttpRequestPattern(
     }
 
     fun fixRequest(request: HttpRequest, resolver: Resolver): HttpRequest {
-        return request.copy(
+        val sanitizedRequest = withoutSecuritySchemes(request)
+        val fixedRequest = sanitizedRequest.copy(
             method = method,
-            path = httpPathPattern?.fixValue(request.path, resolver),
-            queryParams = httpQueryParamPattern.fixValue(request.queryParams, resolver),
-            headers = headersPattern.fixValue(request.headers, resolver.disableOverrideUnexpectedKeyCheck().updateLookupPath(BreadCrumb.PARAMETERS.value)),
-            body = body.fixValue(request.body, resolver)
+            body = body.fixValue(sanitizedRequest.body, resolver),
+            path = httpPathPattern?.fixValue(sanitizedRequest.path, resolver),
+            queryParams = httpQueryParamPattern.fixValue(sanitizedRequest.queryParams, resolver),
+            headers = headersPattern.fixValue(sanitizedRequest.headers, resolver.disableOverrideUnexpectedKeyCheck().updateLookupPath(BreadCrumb.PARAMETERS.value)),
         )
+
+        return fixSecuritySchemes(request, fixedRequest, resolver)
+    }
+
+    private fun fixSecuritySchemes(originalRequest: HttpRequest, request: HttpRequest, resolver: Resolver): HttpRequest {
+        val selectedMatches = selectSecurityMatches(securityMatches(originalRequest, resolver))
+        if (selectedMatches.isEmpty()) return request
+
+        return selectedMatches.fold(request) { fixedRequest, securityMatch ->
+            val fixedSecurityRequest = securityMatch.scheme.fixValue(originalRequest, resolver)
+            securityMatch.scheme.copyFromTo(fixedSecurityRequest, fixedRequest)
+        }
     }
 
     fun fillInTheBlanks(request: HttpRequest, resolver: Resolver): HttpRequest {
@@ -1210,7 +1230,7 @@ data class HttpRequestPattern(
 }
 
 private enum class SchemePresence { FULL, PARTIAL, ABSENT }
-private data class SecurityMatch(val presence: SchemePresence, val result: Result)
+private data class SecurityMatch(val scheme: OpenAPISecurityScheme, val presence: SchemePresence, val result: Result)
 
 fun missingParam(missingValue: String): ContractException {
     return ContractException("$missingValue is missing. Can't generate the contract test.")

--- a/core/src/main/kotlin/io/specmatic/core/Substitution.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Substitution.kt
@@ -2,6 +2,7 @@ package io.specmatic.core
 
 import io.specmatic.core.pattern.Pattern
 import io.specmatic.core.pattern.ReturnValue
+import io.specmatic.core.substitution.InterpolatedSubstitution
 import io.specmatic.core.value.Value
 
 interface Substitution {
@@ -9,4 +10,9 @@ interface Substitution {
     fun substitute(value: Value): ReturnValue<Value>
     fun substitute(value: Value, pattern: Pattern, resolver: Resolver = Resolver(), key: String? = null): ReturnValue<Value>
     fun upsertStoreUsing(originalValue: Value, runningValue: Value, resolver: Resolver = Resolver()): Substitution
+
+    companion object {
+        fun isOrContainsLookup(text: String): Boolean = InterpolatedSubstitution.containsLookup(text)
+        fun isOrContainsCapture(text: String): Boolean = InterpolatedSubstitution.containsCapture(text)
+    }
 }

--- a/core/src/main/kotlin/io/specmatic/core/substitution/InterpolatedSubstitution.kt
+++ b/core/src/main/kotlin/io/specmatic/core/substitution/InterpolatedSubstitution.kt
@@ -20,6 +20,10 @@ internal object InterpolatedSubstitution {
         return !value.isMatcherTemplate() && useRegex.containsMatchIn(value)
     }
 
+    fun containsCapture(value: String): Boolean {
+        return !value.isMatcherTemplate() && captureRegex.containsMatchIn(value)
+    }
+
     fun resolve(value: String, resolveToken: (String) -> Value): Value {
         if (value.isMatcherTemplate()) return StringValue(value)
 

--- a/core/src/test/kotlin/io/specmatic/conversions/APIKeyInHeaderSecuritySchemeTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/APIKeyInHeaderSecuritySchemeTest.kt
@@ -7,9 +7,28 @@ import io.specmatic.core.Result
 import io.specmatic.core.StandardRuleViolation
 import io.specmatic.toViolationReportString
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class APIKeyInHeaderSecuritySchemeTest {
+    @Nested
+    inner class FixValueTests {
+        @Test
+        fun `should preserve a present header api key`() {
+            val request = HttpRequest(headers = mapOf("API-KEY" to "original"))
+            val scheme = APIKeyInHeaderSecurityScheme(name = "API-KEY", apiKey = "generated")
+            assertThat(scheme.fixValue(request, Resolver())).isEqualTo(request)
+        }
+
+        @Test
+        fun `should add a missing header api key`() {
+            val scheme = APIKeyInHeaderSecurityScheme(name = "API-KEY", apiKey = "generated")
+            assertThat(scheme.fixValue(HttpRequest(), Resolver())).isEqualTo(
+                HttpRequest().addSecurityHeader("API-KEY", "generated")
+            )
+        }
+    }
+
     @Test
     fun `should result in failure when header api key is present`() {
         val httpRequest = HttpRequest(headers = mapOf("api-key" to "123"))

--- a/core/src/test/kotlin/io/specmatic/conversions/APIKeyInHeaderSecuritySchemeTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/APIKeyInHeaderSecuritySchemeTest.kt
@@ -11,6 +11,25 @@ import org.junit.jupiter.api.Test
 
 class APIKeyInHeaderSecuritySchemeTest {
     @Test
+    fun `should result in failure when header api key is present`() {
+        val httpRequest = HttpRequest(headers = mapOf("api-key" to "123"))
+        val result = APIKeyInHeaderSecurityScheme(name = "API-KEY", apiKey = "123").failIfInRequest(httpRequest, Resolver())
+
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
+        assertThat(result.reportString()).isEqualToNormalizingWhitespace(toViolationReportString(
+            breadCrumb = "HEADER.api-key",
+            details = DefaultMismatchMessages.unexpectedKey("header", "api-key")
+        ))
+    }
+
+    @Test
+    fun `should not result in failure when header api key is absent`() {
+        val httpRequest = HttpRequest(headers = emptyMap())
+        val result = APIKeyInHeaderSecurityScheme(name = "API-KEY", apiKey = "123").failIfInRequest(httpRequest, Resolver())
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+    }
+
+    @Test
     fun `should result in failure when header api key is missing`() {
         val httpRequest = HttpRequest(headers = emptyMap())
         val resolver = Resolver(mockMode = false)

--- a/core/src/test/kotlin/io/specmatic/conversions/APIKeyInQueryParamSecuritySchemeTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/APIKeyInQueryParamSecuritySchemeTest.kt
@@ -12,6 +12,25 @@ import org.junit.jupiter.api.Test
 class APIKeyInQueryParamSecuritySchemeTest {
 
     @Test
+    fun `should result in failure when query api key is present`() {
+        val httpRequest = HttpRequest(queryParametersMap = mapOf("API-KEY" to "123"))
+        val result = APIKeyInQueryParamSecurityScheme(name = "API-KEY", apiKey = "123").failIfInRequest(httpRequest, Resolver())
+
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
+        assertThat(result.reportString()).isEqualToNormalizingWhitespace(toViolationReportString(
+            breadCrumb = "QUERY.API-KEY",
+            details = DefaultMismatchMessages.unexpectedKey("query", "API-KEY")
+        ))
+    }
+
+    @Test
+    fun `should not result in failure when query api key is absent`() {
+        val httpRequest = HttpRequest(queryParametersMap = emptyMap())
+        val result = APIKeyInQueryParamSecurityScheme(name = "API-KEY", apiKey = "123").failIfInRequest(httpRequest, Resolver())
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+    }
+
+    @Test
     fun `should result in failure when query api key is missing`() {
         val httpRequest = HttpRequest(headers = emptyMap())
         val resolver = Resolver(mockMode = false)

--- a/core/src/test/kotlin/io/specmatic/conversions/APIKeyInQueryParamSecuritySchemeTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/APIKeyInQueryParamSecuritySchemeTest.kt
@@ -7,9 +7,27 @@ import io.specmatic.core.StandardRuleViolation
 import io.specmatic.toViolationReportString
 import io.specmatic.core.DefaultMismatchMessages
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class APIKeyInQueryParamSecuritySchemeTest {
+    @Nested
+    inner class FixValueTests {
+        @Test
+        fun `should preserve a present query api key`() {
+            val request = HttpRequest(queryParametersMap = mapOf("apiKey" to "original"))
+            val scheme = APIKeyInQueryParamSecurityScheme(name = "apiKey", apiKey = "generated")
+            assertThat(scheme.fixValue(request, Resolver())).isEqualTo(request)
+        }
+
+        @Test
+        fun `should add a missing query api key`() {
+            val scheme = APIKeyInQueryParamSecurityScheme(name = "apiKey", apiKey = "generated")
+            assertThat(scheme.fixValue(HttpRequest(), Resolver())).isEqualTo(
+                HttpRequest().addSecurityQueryParam("apiKey", "generated")
+            )
+        }
+    }
 
     @Test
     fun `should result in failure when query api key is present`() {

--- a/core/src/test/kotlin/io/specmatic/conversions/BasicAuthSecuritySchemeTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/BasicAuthSecuritySchemeTest.kt
@@ -5,6 +5,7 @@ import io.specmatic.core.Dictionary
 import io.specmatic.core.Result.*
 import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.pattern.Row
+import io.specmatic.toViolationReportString
 import org.apache.http.HttpHeaders.AUTHORIZATION
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.*
@@ -15,6 +16,25 @@ import java.util.*
 
 class BasicAuthSecuritySchemeTest {
     private val basicAuthSecurityScheme = BasicAuthSecurityScheme()
+
+    @Test
+    fun `failIfInRequest should return success when authorization header is missing`() {
+        val httpRequest = HttpRequest(headers = emptyMap())
+        val result = basicAuthSecurityScheme.failIfInRequest(httpRequest, Resolver())
+        assertThat(result).isInstanceOf(Success::class.java)
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = [AUTHORIZATION, "authorization", "AUTHORIZATION"])
+    fun `failIfInRequest should return failure when authorization header is present`(authorizationHeaderName: String) {
+        val httpRequest = HttpRequest(headers = mapOf(authorizationHeaderName to "Basic token"))
+        val result = basicAuthSecurityScheme.failIfInRequest(httpRequest, Resolver())
+        assertThat(result).isInstanceOf(Failure::class.java)
+        assertThat(result.reportString()).isEqualToNormalizingWhitespace(toViolationReportString(
+            breadCrumb = "HEADER.$authorizationHeaderName",
+            details = DefaultMismatchMessages.unexpectedKey("header", authorizationHeaderName)
+        ))
+    }
 
     @Test
     fun `matches should return failure when authorization header is missing`() {

--- a/core/src/test/kotlin/io/specmatic/conversions/BasicAuthSecuritySchemeTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/BasicAuthSecuritySchemeTest.kt
@@ -9,6 +9,7 @@ import io.specmatic.toViolationReportString
 import org.apache.http.HttpHeaders.AUTHORIZATION
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -16,6 +17,26 @@ import java.util.*
 
 class BasicAuthSecuritySchemeTest {
     private val basicAuthSecurityScheme = BasicAuthSecurityScheme()
+
+    @Nested
+    inner class FixValueTests {
+        private val credentials = "dXNlcjpwYXNz"
+        private val scheme = BasicAuthSecurityScheme(credentials)
+
+        @Test
+        fun `should preserve a valid basic authorization value`() {
+            val request = HttpRequest(headers = mapOf(AUTHORIZATION to "Basic $credentials"))
+            assertThat(scheme.fixValue(request, Resolver())).isEqualTo(request)
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = ["Bearer invalid", "Basic not-base64", "Basic dXNlcg=="])
+        fun `should replace an invalid basic authorization value`(invalidValue: String) {
+            assertThat(scheme.fixValue(HttpRequest(headers = mapOf(AUTHORIZATION to invalidValue)), Resolver())).isEqualTo(
+                HttpRequest().addSecurityHeader(AUTHORIZATION, "Basic $credentials")
+            )
+        }
+    }
 
     @Test
     fun `failIfInRequest should return success when authorization header is missing`() {

--- a/core/src/test/kotlin/io/specmatic/conversions/BearerSecuritySchemeTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/BearerSecuritySchemeTest.kt
@@ -7,12 +7,32 @@ import io.specmatic.core.Result
 import io.specmatic.toViolationReportString
 import org.apache.http.HttpHeaders.AUTHORIZATION
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
 class BearerSecuritySchemeTest {
     private val scheme = BearerSecurityScheme()
+
+    @Nested
+    inner class FixValueTests {
+        private val scheme = BearerSecurityScheme("expected-token")
+
+        @Test
+        fun `should preserve a valid bearer authorization value`() {
+            val request = HttpRequest(headers = mapOf(AUTHORIZATION to "Bearer original-token"))
+            assertThat(scheme.fixValue(request, Resolver())).isEqualTo(request)
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = ["Basic invalid", "Bearer", "BearerX invalid"])
+        fun `should replace an invalid bearer authorization value`(invalidValue: String) {
+            assertThat(scheme.fixValue(HttpRequest(headers = mapOf(AUTHORIZATION to invalidValue)), Resolver())).isEqualTo(
+                HttpRequest().addSecurityHeader(AUTHORIZATION, "Bearer expected-token")
+            )
+        }
+    }
 
     @Test
     fun `failIfInRequest should return success when authorization header is missing`() {

--- a/core/src/test/kotlin/io/specmatic/conversions/BearerSecuritySchemeTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/BearerSecuritySchemeTest.kt
@@ -4,6 +4,7 @@ import io.specmatic.core.DefaultMismatchMessages
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.Resolver
 import io.specmatic.core.Result
+import io.specmatic.toViolationReportString
 import org.apache.http.HttpHeaders.AUTHORIZATION
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -12,6 +13,30 @@ import org.junit.jupiter.params.provider.ValueSource
 
 class BearerSecuritySchemeTest {
     private val scheme = BearerSecurityScheme()
+
+    @Test
+    fun `failIfInRequest should return success when authorization header is missing`() {
+        val requestWithoutHeader = HttpRequest(method = "POST", path = "/customer")
+        val result = scheme.failIfInRequest(requestWithoutHeader, Resolver())
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = [AUTHORIZATION, "authorization", "AUTHORIZATION"])
+    fun `failIfInRequest should return failure when authorization header is present`(authorizationHeaderName: String) {
+        val requestWithBearer = HttpRequest(
+            method = "POST",
+            path = "/customer",
+            headers = mapOf(authorizationHeaderName to "Bearer foo")
+        )
+
+        val result = scheme.failIfInRequest(requestWithBearer, Resolver())
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
+        assertThat(result.reportString()).isEqualToNormalizingWhitespace(toViolationReportString(
+            breadCrumb = "HEADER.$authorizationHeaderName",
+            details = DefaultMismatchMessages.unexpectedKey("header", authorizationHeaderName)
+        ))
+    }
 
     @Test
     fun `authentication header starts with Bearer when using Bearer security scheme`() {

--- a/core/src/test/kotlin/io/specmatic/conversions/CompositeSecuritySchemeTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/CompositeSecuritySchemeTest.kt
@@ -8,6 +8,7 @@ import io.specmatic.toViolationReportString
 import io.specmatic.core.DefaultMismatchMessages
 import org.apache.http.HttpHeaders.AUTHORIZATION
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class CompositeSecuritySchemeTest {
@@ -21,6 +22,27 @@ class CompositeSecuritySchemeTest {
         BearerSecurityScheme(configuredToken = "API-SECRET"),
         APIKeyInQueryParamSecurityScheme(name = "apiKey", apiKey = "1234")
     ))
+
+    @Nested
+    inner class FixValueTests {
+        @Test
+        fun `should preserve valid components and fix only invalid components`() {
+            val scheme = CompositeSecurityScheme(listOf(
+                BearerSecurityScheme("expected-token"),
+                APIKeyInQueryParamSecurityScheme("apiKey", "expected-api-key")
+            ))
+
+            val request = HttpRequest(
+                headers = mapOf(AUTHORIZATION to "Basic invalid"),
+                queryParametersMap = mapOf("apiKey" to "original-api-key")
+            )
+
+            assertThat(scheme.fixValue(request, Resolver())).isEqualTo(
+                HttpRequest(queryParametersMap = mapOf("apiKey" to "original-api-key"))
+                    .addSecurityHeader(AUTHORIZATION, "Bearer expected-token")
+            )
+        }
+    }
 
     @Test
     fun `should return success when request does not contain any security scheme`() {

--- a/core/src/test/kotlin/io/specmatic/conversions/CompositeSecuritySchemeTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/CompositeSecuritySchemeTest.kt
@@ -23,6 +23,45 @@ class CompositeSecuritySchemeTest {
     ))
 
     @Test
+    fun `should return success when request does not contain any security scheme`() {
+        val httpRequest = HttpRequest(method = "GET", path = "/")
+        val result = securityScheme.failIfInRequest(httpRequest, Resolver())
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+    }
+
+    @Test
+    fun `should return failure when request contains all security schemes`() {
+        val httpRequest = HttpRequest(
+            method = "GET", path = "/",
+            headers = mapOf(AUTHORIZATION to "Bearer API-SECRET"), queryParametersMap = mapOf("apiKey" to "1234")
+        )
+
+        val result = securityScheme.failIfInRequest(httpRequest, Resolver())
+        assertThat(result).isEqualTo(Result.Failure.fromFailures(listOf(
+            Result.Failure(
+                breadCrumb = "HEADER.$AUTHORIZATION",
+                message = DefaultMismatchMessages.unexpectedKey("header", AUTHORIZATION)
+            ),
+            Result.Failure(
+                breadCrumb = "QUERY.apiKey",
+                message = DefaultMismatchMessages.unexpectedKey("query", "apiKey")
+            )
+        )))
+    }
+
+    @Test
+    fun `should return failure when request contains at-least one security schemes`() {
+        val httpRequest = HttpRequest(method = "GET", path = "/", headers = mapOf(AUTHORIZATION to "Bearer API-SECRET"))
+        val result = securityScheme.failIfInRequest(httpRequest, Resolver())
+        assertThat(result).isEqualTo(Result.Failure.fromFailures(listOf(
+            Result.Failure(
+                breadCrumb = "HEADER.$AUTHORIZATION",
+                message = DefaultMismatchMessages.unexpectedKey("header", AUTHORIZATION)
+            ),
+        )))
+    }
+
+    @Test
     fun `should return success when request matches all security schemes`() {
         val httpRequest = HttpRequest(
             method = "GET", path ="/",

--- a/core/src/test/kotlin/io/specmatic/conversions/NoSecuritySchemeTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/NoSecuritySchemeTest.kt
@@ -1,0 +1,18 @@
+package io.specmatic.conversions
+
+import io.specmatic.core.HttpRequest
+import io.specmatic.core.Resolver
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class NoSecuritySchemeTest {
+    @Nested
+    inner class FixValueTests {
+        @Test
+        fun `should preserve a request without security`() {
+            val request = HttpRequest(headers = mapOf("X-Request-ID" to "original"))
+            assertThat(NoSecurityScheme().fixValue(request, Resolver())).isEqualTo(request)
+        }
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/HttpRequestPatternKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpRequestPatternKtTest.kt
@@ -2,11 +2,15 @@ package io.specmatic.core
 
 import io.specmatic.conversions.*
 import io.specmatic.core.pattern.*
+import io.specmatic.core.value.StringValue
 import org.apache.http.HttpHeaders.AUTHORIZATION
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
 
 internal class HttpRequestPatternKtTest {
     @Test
@@ -59,7 +63,380 @@ internal class HttpRequestPatternKtTest {
         }
     }
 
+    @Nested
+    inner class SecuritySchemeFixRequestTests {
+        @Test
+        fun `should preserve security headers while fixing other headers`() {
+            val requestPattern = HttpRequestPattern(
+                httpPathPattern = buildHttpPathPattern("/"),
+                method = "POST",
+                securitySchemes = listOf(BearerSecurityScheme()),
+                headersPattern = HttpHeadersPattern(pattern = mapOf("X-Request-ID" to ExactValuePattern(StringValue("expected")))),
+            )
+
+            val fixedRequest = requestPattern.fixRequest(
+                resolver = Resolver(),
+                request = HttpRequest(
+                    path = "/",
+                    method = "POST",
+                    headers = mapOf("X-Request-ID" to "invalid", AUTHORIZATION to "Bearer original-token")
+                ),
+            )
+
+            assertThat(fixedRequest).isEqualTo(
+                HttpRequest(
+                    path = "/",
+                    method = "POST",
+                    headers = mapOf("X-Request-ID" to "expected")
+                ).addSecurityHeader(AUTHORIZATION, "Bearer original-token")
+            )
+        }
+
+        @Test
+        fun `should preserve security query parameters while fixing other query parameters`() {
+            val requestPattern = HttpRequestPattern(
+                httpPathPattern = buildHttpPathPattern("/"),
+                method = "GET",
+                httpQueryParamPattern = HttpQueryParamPattern(mapOf("page" to QueryParameterScalarPattern(ExactValuePattern(StringValue("expected"))))),
+                securitySchemes = listOf(APIKeyInQueryParamSecurityScheme("apiKey", null))
+            )
+
+            val fixedRequest = requestPattern.fixRequest(
+                resolver = Resolver(),
+                request = HttpRequest(
+                    path = "/",
+                    method = "GET",
+                    queryParametersMap = mapOf("page" to "invalid", "apiKey" to "original-token")
+                ),
+            )
+
+            assertThat(fixedRequest).isEqualTo(
+                HttpRequest(
+                    path = "/",
+                    method = "GET",
+                    queryParametersMap = mapOf("page" to "expected", "apiKey" to "original-token")
+                )
+            )
+        }
+
+        @Test
+        fun `should fix an invalid security scheme`() {
+            val requestPattern = HttpRequestPattern(
+                method = "GET",
+                httpPathPattern = buildHttpPathPattern("/"),
+                securitySchemes = listOf(BearerSecurityScheme("expected-token"))
+            )
+
+            val fixedRequest = requestPattern.fixRequest(
+                resolver = Resolver(),
+                request = HttpRequest(
+                    path = "/",
+                    method = "GET",
+                    headers = mapOf(AUTHORIZATION to "Basic invalid-token")
+                ),
+            )
+
+            assertThat(fixedRequest).isEqualTo(
+                HttpRequest(method = "GET", path = "/")
+                    .addSecurityHeader(AUTHORIZATION, "Bearer expected-token")
+            )
+        }
+
+        @Test
+        fun `should prefer a full presence scheme over an absent alternative`() {
+            val requestPattern = HttpRequestPattern(
+                method = "GET",
+                httpPathPattern = buildHttpPathPattern("/"),
+                securitySchemes = listOf(
+                    APIKeyInQueryParamSecurityScheme("apiKey", "generated-api-key"),
+                    BearerSecurityScheme("generated-bearer")
+                )
+            )
+
+            val fixedRequest = requestPattern.fixRequest(
+                resolver = Resolver(mockMode = true),
+                request = HttpRequest(
+                    path = "/",
+                    method = "GET",
+                    headers = mapOf(AUTHORIZATION to "Bearer original-token")
+                ),
+            )
+
+            assertThat(fixedRequest).isEqualTo(
+                HttpRequest(method = "GET", path = "/").addSecurityHeader(AUTHORIZATION, "Bearer original-token")
+            )
+        }
+
+        @Test
+        fun `should prefer a full presence scheme over a partial alternative`() {
+            val requestPattern = HttpRequestPattern(
+                httpPathPattern = buildHttpPathPattern("/"),
+                method = "GET",
+                securitySchemes = listOf(
+                    BearerSecurityScheme("generated-bearer"),
+                    CompositeSecurityScheme(
+                        listOf(
+                            BearerSecurityScheme("generated-bearer"),
+                            APIKeyInQueryParamSecurityScheme("apiKey", "generated-api-key")
+                        )
+                    ),
+                )
+            )
+
+            val fixedRequest = requestPattern.fixRequest(
+                resolver = Resolver(mockMode = true),
+                request = HttpRequest(
+                    path = "/",
+                    method = "GET",
+                    headers = mapOf(AUTHORIZATION to "Bearer original-token")
+                ),
+            )
+
+            assertThat(fixedRequest).isEqualTo(
+                HttpRequest(method = "GET", path = "/")
+                    .addSecurityHeader(AUTHORIZATION, "Bearer original-token")
+            )
+        }
+
+        @Test
+        fun `should fix every scheme in the selected presence group`() {
+            val requestPattern = HttpRequestPattern(
+                httpPathPattern = buildHttpPathPattern("/"),
+                method = "GET",
+                securitySchemes = listOf(
+                    APIKeyInQueryParamSecurityScheme("apiKey", "original-api-key"),
+                    CompositeSecurityScheme(
+                        listOf(
+                            BearerSecurityScheme("generated-bearer"),
+                            APIKeyInQueryParamSecurityScheme("apiKey", "original-api-key")
+                        )
+                    ),
+                )
+            )
+
+            val fixedRequest = requestPattern.fixRequest(
+                resolver = Resolver(),
+                request = HttpRequest(
+                    path = "/",
+                    method = "GET",
+                    headers = mapOf(AUTHORIZATION to "Basic invalid-token"),
+                    queryParametersMap = mapOf("apiKey" to "original-api-key")
+                ),
+            )
+
+            assertThat(fixedRequest).isEqualTo(
+                HttpRequest(
+                    path = "/",
+                    method = "GET",
+                    queryParametersMap = mapOf("apiKey" to "original-api-key")
+                ).addSecurityHeader(AUTHORIZATION, "Bearer generated-bearer")
+            )
+        }
+
+        @ParameterizedTest
+        @MethodSource("io.specmatic.core.HttpRequestPatternKtTest#securitySchemesWithExpectedValues")
+        fun `should add absent security schemes outside mock mode`(securityScheme: OpenAPISecurityScheme, expectedRequest: HttpRequest) {
+            val requestPattern = HttpRequestPattern(
+                method = "GET",
+                httpPathPattern = buildHttpPathPattern("/"),
+                securitySchemes = listOf(securityScheme)
+            )
+
+            assertThat(requestPattern.fixRequest(HttpRequest(method = "GET", path = "/"), Resolver())).isEqualTo(expectedRequest)
+        }
+
+        @ParameterizedTest
+        @MethodSource("io.specmatic.core.HttpRequestPatternKtTest#invalidSecuritySchemesInMockMode")
+        fun `should fix invalid present security schemes in mock mode without adding absent components`(securityScheme: OpenAPISecurityScheme, request: HttpRequest, expectedRequest: HttpRequest) {
+            val requestPattern = HttpRequestPattern(
+                method = "GET",
+                httpPathPattern = buildHttpPathPattern("/"),
+                securitySchemes = listOf(securityScheme)
+            )
+
+            assertThat(requestPattern.fixRequest(request, Resolver(mockMode = true))).isEqualTo(expectedRequest)
+        }
+
+        @ParameterizedTest
+        @MethodSource("io.specmatic.core.HttpRequestPatternKtTest#partialCompositeFixCases")
+        fun `should complete a partial composite only outside mock mode`(mockMode: Boolean, expectedRequest: HttpRequest) {
+            val requestPattern = HttpRequestPattern(
+                method = "GET",
+                httpPathPattern = buildHttpPathPattern("/"),
+                securitySchemes = listOf(
+                    APIKeyInQueryParamSecurityScheme("apiKey", "alternative-api-key"),
+                    CompositeSecurityScheme(listOf(
+                        BearerSecurityScheme("generated-bearer"),
+                        APIKeyInQueryParamSecurityScheme("apiKey", "generated-api-key")
+                    )),
+                )
+            )
+
+            val request = HttpRequest(
+                path = "/",
+                method = "GET",
+                headers = mapOf(AUTHORIZATION to "Bearer original-token")
+            )
+
+            assertThat(requestPattern.fixRequest(request, Resolver(mockMode = mockMode))).isEqualTo(expectedRequest)
+        }
+
+        @Test
+        fun `should fix ordinary fields without adding security for a no-security request`() {
+            val requestPattern = HttpRequestPattern(
+                method = "GET",
+                httpPathPattern = buildHttpPathPattern("/"),
+                securitySchemes = listOf(NoSecurityScheme()),
+                headersPattern = HttpHeadersPattern(mapOf("X-Request-ID" to ExactValuePattern(StringValue("expected")))),
+                httpQueryParamPattern = HttpQueryParamPattern(mapOf("page" to QueryParameterScalarPattern(ExactValuePattern(StringValue("expected"))))),
+            )
+
+            val request = HttpRequest(
+                method = "GET",
+                path = "/",
+                headers = mapOf("X-Request-ID" to "invalid"),
+                queryParametersMap = mapOf("page" to "invalid")
+            )
+
+            assertThat(requestPattern.fixRequest(request, Resolver())).isEqualTo(
+                HttpRequest(
+                    method = "GET",
+                    path = "/",
+                    headers = mapOf("X-Request-ID" to "expected"),
+                    queryParametersMap = mapOf("page" to "expected")
+                )
+            )
+        }
+
+        @ParameterizedTest
+        @MethodSource("io.specmatic.core.HttpRequestPatternKtTest#securitySchemesWithCaseInsensitiveHeaders")
+        fun `should preserve security headers regardless of header name case`(securityScheme: OpenAPISecurityScheme, request: HttpRequest, expectedRequest: HttpRequest) {
+            val requestPattern = HttpRequestPattern(
+                method = "GET",
+                httpPathPattern = buildHttpPathPattern("/"),
+                securitySchemes = listOf(securityScheme)
+            )
+
+            assertThat(requestPattern.fixRequest(request, Resolver())).isEqualTo(expectedRequest)
+        }
+
+        @ParameterizedTest
+        @MethodSource("io.specmatic.core.HttpRequestPatternKtTest#securitySchemesWithoutPresence")
+        fun `should not add absent security schemes in mock mode`(securityScheme: OpenAPISecurityScheme) {
+            val requestPattern = HttpRequestPattern(
+                method = "GET",
+                httpPathPattern = buildHttpPathPattern("/"),
+                securitySchemes = listOf(securityScheme)
+            )
+
+            val request = HttpRequest(method = "GET", path = "/")
+            assertThat(requestPattern.fixRequest(request, Resolver(mockMode = true))).isEqualTo(request)
+        }
+    }
+
     companion object {
+        @JvmStatic
+        fun securitySchemesWithExpectedValues(): Stream<Arguments> = Stream.of(
+            Arguments.of(
+                NoSecurityScheme(),
+                HttpRequest(method = "GET", path = "/")
+            ),
+            Arguments.of(
+                APIKeyInHeaderSecurityScheme("API-KEY", "generated-api-key"),
+                HttpRequest(method = "GET", path = "/").addSecurityHeader("API-KEY", "generated-api-key")
+            ),
+            Arguments.of(
+                APIKeyInQueryParamSecurityScheme("apiKey", "generated-api-key"),
+                HttpRequest(method = "GET", path = "/", queryParametersMap = mapOf("apiKey" to "generated-api-key"))
+            ),
+            Arguments.of(
+                BasicAuthSecurityScheme("dXNlcjpwYXNz"),
+                HttpRequest(method = "GET", path = "/").addSecurityHeader(AUTHORIZATION, "Basic dXNlcjpwYXNz")
+            ),
+            Arguments.of(
+                BearerSecurityScheme("generated-bearer"),
+                HttpRequest(method = "GET", path = "/").addSecurityHeader(AUTHORIZATION, "Bearer generated-bearer")
+            ),
+            Arguments.of(
+                CompositeSecurityScheme(listOf(
+                    BearerSecurityScheme("generated-bearer"),
+                    APIKeyInQueryParamSecurityScheme("apiKey", "generated-api-key")
+                )),
+                HttpRequest(method = "GET", path = "/", queryParametersMap = mapOf("apiKey" to "generated-api-key"))
+                    .addSecurityHeader(AUTHORIZATION, "Bearer generated-bearer")
+            )
+        )
+
+        @JvmStatic
+        fun invalidSecuritySchemesInMockMode(): Stream<Arguments> = Stream.of(
+            Arguments.of(
+                BearerSecurityScheme("expected-bearer"),
+                HttpRequest(headers = mapOf(AUTHORIZATION to "Basic invalid")),
+                HttpRequest(method = "GET", path = "/").addSecurityHeader(AUTHORIZATION, "Bearer expected-bearer")
+            ),
+            Arguments.of(
+                BasicAuthSecurityScheme("dXNlcjpwYXNz"),
+                HttpRequest(headers = mapOf(AUTHORIZATION to "Bearer invalid")),
+                HttpRequest(method = "GET", path = "/").addSecurityHeader(AUTHORIZATION, "Basic dXNlcjpwYXNz")
+            ),
+            Arguments.of(
+                CompositeSecurityScheme(listOf(
+                    BearerSecurityScheme("expected-bearer"),
+                    APIKeyInQueryParamSecurityScheme("apiKey", "generated-api-key")
+                )),
+                HttpRequest(headers = mapOf(AUTHORIZATION to "Basic invalid")),
+                HttpRequest(method = "GET", path = "/").addSecurityHeader(AUTHORIZATION, "Bearer expected-bearer")
+            )
+        )
+
+        @JvmStatic
+        fun partialCompositeFixCases(): Stream<Arguments> = Stream.of(
+            Arguments.of(
+                false,
+                HttpRequest(
+                    method = "GET",
+                    path = "/",
+                    queryParametersMap = mapOf("apiKey" to "generated-api-key")
+                ).addSecurityHeader(AUTHORIZATION, "Bearer original-token")
+            ),
+            Arguments.of(
+                true,
+                HttpRequest(method = "GET", path = "/").addSecurityHeader(AUTHORIZATION, "Bearer original-token")
+            )
+        )
+
+        @JvmStatic
+        fun securitySchemesWithCaseInsensitiveHeaders(): Stream<Arguments> = Stream.of(
+            Arguments.of(
+                APIKeyInHeaderSecurityScheme("API-KEY", "ignored"),
+                HttpRequest(headers = mapOf("api-key" to "original-api-key")),
+                HttpRequest(method = "GET", path = "/").addSecurityHeader("API-KEY", "original-api-key")
+            ),
+            Arguments.of(
+                BasicAuthSecurityScheme("dXNlcjpwYXNz"),
+                HttpRequest(headers = mapOf("authorization" to "Basic dXNlcjpwYXNz")),
+                HttpRequest(method = "GET", path = "/").addSecurityHeader(AUTHORIZATION, "Basic dXNlcjpwYXNz")
+            ),
+            Arguments.of(
+                BearerSecurityScheme("ignored"),
+                HttpRequest(headers = mapOf("authorization" to "Bearer original-token")),
+                HttpRequest(method = "GET", path = "/").addSecurityHeader(AUTHORIZATION, "Bearer original-token")
+            )
+        )
+
+        @JvmStatic
+        fun securitySchemesWithoutPresence(): Stream<Arguments> = Stream.of(
+            Arguments.of(NoSecurityScheme()),
+            Arguments.of(APIKeyInHeaderSecurityScheme("API-KEY", "generated-api-key")),
+            Arguments.of(APIKeyInQueryParamSecurityScheme("apiKey", "generated-api-key")),
+            Arguments.of(BasicAuthSecurityScheme("dXNlcjpwYXNz")),
+            Arguments.of(BearerSecurityScheme("generated-bearer")),
+            Arguments.of(CompositeSecurityScheme(listOf(
+                BearerSecurityScheme("generated-bearer"),
+                APIKeyInQueryParamSecurityScheme("apiKey", "generated-api-key")
+            )))
+        )
+
         private fun invalidateSecuritySchemes(request: HttpRequest, scheme: OpenAPISecurityScheme): HttpRequest {
             return when (scheme) {
                 is CompositeSecurityScheme -> scheme.schemes.fold(request) { req, it -> invalidateSecuritySchemes(req, it) }

--- a/core/src/test/kotlin/io/specmatic/core/ScenarioTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ScenarioTest.kt
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
+import org.junit.jupiter.params.provider.ValueSource
 import java.util.function.Consumer
 import java.util.stream.Stream
 import io.specmatic.test.TestExecutionReason
@@ -61,6 +62,48 @@ class ScenarioTest {
         )
 
         assertThat(scenario.toApiOperation()).isSameAs(delegatedOperation)
+    }
+
+    @Nested
+    inner class FixRequestResponseTests {
+        @ParameterizedTest
+        @ValueSource(booleans = [false, true])
+        fun `should use the partial key check without adding absent security`(isPartial: Boolean) {
+            val scenario = Scenario(
+                name = "GET /orders",
+                specType = SpecType.OPENAPI,
+                protocol = SpecmaticProtocol.HTTP,
+                httpResponsePattern = HttpResponsePattern(status = 200),
+                httpRequestPattern = HttpRequestPattern(
+                    method = "GET",
+                    httpPathPattern = buildHttpPathPattern("/orders"),
+                    securitySchemes = listOf(BearerSecurityScheme("generated-bearer")),
+                    headersPattern = HttpHeadersPattern(mapOf("X-Request-ID" to ExactValuePattern(StringValue("expected-request-id")))),
+                    httpQueryParamPattern = HttpQueryParamPattern(mapOf("page" to QueryParameterScalarPattern(ExactValuePattern(StringValue("expected-page"))))),
+                ),
+            )
+
+            val request = HttpRequest(method = "GET", path = "/orders")
+            val response = HttpResponse(status = 200)
+            val (fixedRequest, fixedResponse) = scenario.fixRequestResponse(
+                isPartial = isPartial,
+                httpRequest = request,
+                httpResponse = response,
+                flagsBased = DefaultStrategies,
+            )
+
+            val expectedRequest = if (isPartial) {
+                request
+            } else {
+                request.copy(
+                    headers = mapOf("X-Request-ID" to "expected-request-id"),
+                    queryParams = QueryParameters(mapOf("page" to "expected-page"))
+                )
+            }
+
+            assertThat(fixedRequest).isEqualTo(expectedRequest)
+            assertThat(fixedResponse).isEqualTo(response)
+        }
     }
 
     companion object {

--- a/core/src/test/kotlin/io/specmatic/core/SubstitutionTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/SubstitutionTest.kt
@@ -1,0 +1,39 @@
+package io.specmatic.core
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
+
+class SubstitutionTest {
+    @ParameterizedTest(name = "isOrContainsLookup({0}) = {1}")
+    @MethodSource("lookupCases")
+    fun `detects lookup tokens`(text: String, expected: Boolean) {
+        assertThat(Substitution.isOrContainsLookup(text)).isEqualTo(expected)
+    }
+
+    @ParameterizedTest(name = "isOrContainsCapture({0}) = {1}")
+    @MethodSource("captureCases")
+    fun `detects capture tokens`(text: String, expected: Boolean) {
+        assertThat(Substitution.isOrContainsCapture(text)).isEqualTo(expected)
+    }
+
+    companion object {
+        @JvmStatic
+        fun lookupCases(): Stream<Arguments> = Stream.of(
+            Arguments.of("$(ID)", true),
+            Arguments.of("order-123-suffix", false),
+            Arguments.of("order-$(ID)-suffix", true),
+            Arguments.of($$"$match(contains: $(data.person))", false),
+        )
+
+        @JvmStatic
+        fun captureCases(): Stream<Arguments> = Stream.of(
+            Arguments.of("(ID:number)", true),
+            Arguments.of("order-123-suffix", false),
+            Arguments.of("order-(ID:string)-suffix", true),
+            Arguments.of($$"$match(contains: $(data.person))", false),
+        )
+    }
+}


### PR DESCRIPTION
**What**:

- Fix security scheme handling in `HttpRequestPattern.fixRequest`.
- Preserve valid security parameters and repair invalid values.
- Add reusable substitution lookup and capture checks.

**Why**:

- Security scheme headers and query parameters could be treated as extra request fields or dropped during request fixing.
- Invalid security scheme values were not repaired.

**How**:

- Added security scheme value fixing while preserving full, partial, and absent presence precedence.
- Added case-insensitive security header handling.
- Preserved valid components when fixing composite schemes.
- Added substitution helpers for lookup and capture detection.

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate (N/A)
- [ ] Security scans don't report any vulnerabilities (N/A)
- [ ] Documentation added/updated (N/A)
- [ ] Sample Project added/updated (N/A)
- [ ] Demo video (N/A)
- [ ] Article on Website (N/A)
- [ ] Roadmpap updated (N/A)
- [ ] Conference Talk (N/A)