### PR TITLE
feat: wire CLI metadata into report generation

### DIFF
--- a/application/src/main/kotlin/application/CompareCommand.kt
+++ b/application/src/main/kotlin/application/CompareCommand.kt
@@ -5,6 +5,9 @@ import io.specmatic.core.log.logger
 import io.specmatic.core.log.logException
 import io.specmatic.core.pattern.ContractException
 import io.specmatic.license.core.cli.Category
+import io.specmatic.reporter.commands.GitReportDefaultValueProvider
+import io.specmatic.reporter.commands.InsightsReportOptions
+import picocli.CommandLine.ArgGroup
 import picocli.CommandLine.Command
 import picocli.CommandLine.Option
 import picocli.CommandLine.Parameters
@@ -18,7 +21,9 @@ import kotlin.system.exitProcess
 Checks if two contracts are equivalent.
 DEPRECATED: This command will be removed in the next major release. Use 'backward-compatibility-check' command instead.
 """
-        ])
+        ],
+        defaultValueProvider = GitReportDefaultValueProvider::class
+)
 @Category("Specmatic core")
 class CompareCommand : Callable<Unit> {
     @Parameters(index = "0", description = ["Older contract file path"])
@@ -30,7 +35,11 @@ class CompareCommand : Callable<Unit> {
     @Option(names = ["--mirror"], required = false)
     var mirror: Boolean = false
 
+    @field:ArgGroup(exclusive = false, heading = "%nInsights reporting options:%n")
+    val insightsReportOptions = InsightsReportOptions()
+
     override fun call() {
+        insightsReportOptions.validate()
         if(!olderContractFilePath.isContractFile()) {
             logger.log(invalidContractExtensionMessage(olderContractFilePath))
             exitProcess(1)
@@ -47,7 +56,7 @@ class CompareCommand : Callable<Unit> {
 
             if(mirror)
                 logger.log("Comparing older with newer...")
-            val report = backwardCompatible(olderContract, newerContract)
+            val report = backwardCompatible(olderContract, newerContract, insightsReportOptions)
             println(report.message())
 
             if(!mirror)
@@ -55,7 +64,7 @@ class CompareCommand : Callable<Unit> {
 
             logger.newLine()
             logger.log("Comparing newer with older...")
-            val mirrorReport = backwardCompatible(newerContract, olderContract)
+            val mirrorReport = backwardCompatible(newerContract, olderContract, insightsReportOptions)
             println(mirrorReport.message())
         }
 
@@ -63,9 +72,9 @@ class CompareCommand : Callable<Unit> {
     }
 }
 
-fun backwardCompatible(olderContract: Feature, newerContract: Feature): CompatibilityReport =
+fun backwardCompatible(olderContract: Feature, newerContract: Feature, insightsReportOptions: InsightsReportOptions): CompatibilityReport =
         try {
-            testBackwardCompatibility(olderContract, newerContract).let { results ->
+            testBackwardCompatibility(olderContract, newerContract, insightsReportOptions).let { results ->
                 when {
                     results.failureCount > 0 -> {
                         IncompatibleReport(results)

--- a/application/src/main/kotlin/application/HTTPStubEngine.kt
+++ b/application/src/main/kotlin/application/HTTPStubEngine.kt
@@ -12,6 +12,7 @@ import io.specmatic.stub.RequestHandler
 import io.specmatic.stub.SpecmaticConfigSource
 import io.specmatic.stub.contractInfoToHttpExpectations
 import io.specmatic.stub.listener.MockEventListener
+import io.specmatic.reporter.commands.InsightsReportOptions
 
 class HTTPStubEngine {
     fun runHTTPStub(
@@ -28,7 +29,8 @@ class HTTPStubEngine {
         gracefulRestartTimeoutInMs: Long,
         specToBaseUrlMap: Map<String, String?>,
         listeners: List<MockEventListener> = emptyList(),
-        requestHandlers: List<RequestHandler> = emptyList()
+        requestHandlers: List<RequestHandler> = emptyList(),
+        insightsReportOptions: InsightsReportOptions? = null,
     ): HttpStub {
         return HttpStub(
             features = stubs.map { it.first },
@@ -46,7 +48,8 @@ class HTTPStubEngine {
             timeoutMillis = gracefulRestartTimeoutInMs,
             specToStubBaseUrlMap = specToBaseUrlMap,
             listeners = listeners,
-            requestHandlers = requestHandlers.toMutableList()
+            requestHandlers = requestHandlers.toMutableList(),
+            insightsReportOptions = insightsReportOptions,
         ).also {
             it.printStartupMessage()
         }

--- a/application/src/main/kotlin/application/HTTPStubEngine.kt
+++ b/application/src/main/kotlin/application/HTTPStubEngine.kt
@@ -30,7 +30,7 @@ class HTTPStubEngine {
         specToBaseUrlMap: Map<String, String?>,
         listeners: List<MockEventListener> = emptyList(),
         requestHandlers: List<RequestHandler> = emptyList(),
-        insightsReportOptions: InsightsReportOptions? = null,
+        insightsReportOptions: InsightsReportOptions,
     ): HttpStub {
         return HttpStub(
             features = stubs.map { it.first },

--- a/application/src/main/kotlin/application/SpecmaticApplication.kt
+++ b/application/src/main/kotlin/application/SpecmaticApplication.kt
@@ -6,6 +6,7 @@ import io.specmatic.core.utilities.UncaughtExceptionHandler
 import io.specmatic.license.core.Executor
 import io.specmatic.license.core.LicenseResolver
 import io.specmatic.license.core.util.LicenseConfig
+import io.specmatic.reporter.ReportTracker
 import io.specmatic.specmatic.executable.JULForwarder
 import picocli.CommandLine
 
@@ -27,6 +28,7 @@ open class SpecmaticApplication {
             }
             setupPicoCli()
             setupLogging()
+            ReportTracker.initialize()
 
             Thread.setDefaultUncaughtExceptionHandler(UncaughtExceptionHandler())
 

--- a/application/src/main/kotlin/application/StubCommand.kt
+++ b/application/src/main/kotlin/application/StubCommand.kt
@@ -250,7 +250,6 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
             startServer()
 
             if (httpStub != null) {
-                ReportTracker.instance
                 if (registerShutdownHook) addShutdownHook()
 
                 val configuredHotReload = configuredHotReload()

--- a/application/src/main/kotlin/application/StubCommand.kt
+++ b/application/src/main/kotlin/application/StubCommand.kt
@@ -13,6 +13,9 @@ import io.specmatic.core.loadSpecmaticConfigOrNull
 import io.specmatic.core.toIncomingMtlsRegistryForStub
 import io.specmatic.core.utilities.Flags.Companion.SPECMATIC_BASE_URL
 import io.specmatic.license.core.cli.Category
+import io.specmatic.reporter.commands.GitReportDefaultValueProvider
+import io.specmatic.reporter.commands.InsightsReportOptions
+import io.specmatic.reporter.ReportTracker
 import io.specmatic.mock.ScenarioStub
 import io.specmatic.stub.HttpClientFactory
 import io.specmatic.stub.HttpStub
@@ -40,7 +43,8 @@ import kotlin.time.toDuration
     name = "mock",
     aliases = ["virtualize", "stub"],
     mixinStandardHelpOptions = true,
-    description = ["Start a mock server with contract"]
+    description = ["Start a mock server with contract"],
+    defaultValueProvider = GitReportDefaultValueProvider::class,
 )
 @Category("Specmatic core")
 class StubCommand(
@@ -145,6 +149,9 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
     @Option(names = ["--lenient"], description = ["Parse the OpenAPI Specification with leniency"], required = false)
     var lenientMode: Boolean? = null
 
+    @field:ArgGroup(exclusive = false, heading = "%nInsights reporting options:%n")
+    val insightsReportOptions = InsightsReportOptions()
+
     private var contractSources: List<ContractPathData> = emptyList()
 
     var specmaticConfigPath: String? = null
@@ -193,6 +200,7 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
     }
 
     override fun call(): Int {
+        insightsReportOptions.validate()
         configureLogging(
             LoggingFromOpts(
                 debug = verbose,
@@ -242,6 +250,7 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
             startServer()
 
             if (httpStub != null) {
+                ReportTracker.instance
                 if (registerShutdownHook) addShutdownHook()
 
                 val configuredHotReload = configuredHotReload()
@@ -322,7 +331,8 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
             gracefulRestartTimeoutInMs = configuredGracefulTimeout(),
             specToBaseUrlMap = contractSources.specToBaseUrlMap(),
             listeners = listeners,
-            requestHandlers = requestHandlers
+            requestHandlers = requestHandlers,
+            insightsReportOptions = insightsReportOptions,
         )
 
         LogTail.storeSnapshot()

--- a/application/src/main/kotlin/application/TestCommand.kt
+++ b/application/src/main/kotlin/application/TestCommand.kt
@@ -11,6 +11,8 @@ import io.specmatic.core.utilities.exitWithMessage
 import io.specmatic.core.utilities.newXMLBuilder
 import io.specmatic.core.utilities.xmlToString
 import io.specmatic.license.core.cli.Category
+import io.specmatic.reporter.commands.GitReportDefaultValueProvider
+import io.specmatic.reporter.commands.InsightsReportOptions
 import io.specmatic.test.ContractTestSettings
 import io.specmatic.test.DeprecatedArguments
 import io.specmatic.test.SpecmaticJUnitSupport
@@ -40,7 +42,12 @@ private const val SYSTEM_OUT_TESTCASE_TAG = "system-out"
 
 private const val DISPLAY_NAME_PREFIX_IN_SYSTEM_OUT_TAG_TEXT = "display-name: "
 
-@Command(name = "test", mixinStandardHelpOptions = true, description = ["Run contract tests"])
+@Command(
+    name = "test",
+    mixinStandardHelpOptions = true,
+    description = ["Run contract tests"],
+    defaultValueProvider = GitReportDefaultValueProvider::class,
+)
 @Category("Specmatic core")
 class TestCommand(private val junitLauncher: Launcher = LauncherFactory.create()) : Callable<Int> {
     @CommandLine.Parameters(arity = "0..*", description = ["Contract file paths"])
@@ -119,6 +126,9 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
     @Option(names = ["--lenient"], description = ["Parse the OpenAPI Specification with leniency"], required = false)
     var lenientMode: Boolean = false
 
+    @field:CommandLine.ArgGroup(exclusive = false, heading = "%nInsights reporting options:%n")
+    val insightsReportOptions = InsightsReportOptions()
+
     @Spec
     lateinit var commandSpec: CommandSpec
 
@@ -132,6 +142,7 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
         configureLogging(
             LoggingFromOpts(debug = verboseMode),
             LoggingConfigSource.FromConfig(specmaticConfig.getLogConfigurationOrDefault()))
+        insightsReportOptions.validate()
         setParallelism(specmaticConfig)
         setTestThreadLocalSettings()
 
@@ -227,6 +238,7 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
             configFile = configFileName.takeIf(::isNotNullOrBlank),
             timeoutInMilliSeconds = timeoutInMs ?: timeout?.times(1000),
             contractPaths = contractPaths?.joinToString(separator = ",").takeIf(::isNotNullOrBlank),
+            insightsReportOptions = insightsReportOptions,
         )
 
         SpecmaticJUnitSupport.settingsStaging.set(settings)

--- a/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckBaseCommand.kt
+++ b/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckBaseCommand.kt
@@ -59,6 +59,7 @@ abstract class BackwardCompatibilityCheckBaseCommand(
 
     final override fun call(): Int {
         configureLogging(LoggingConfiguration.Companion.LoggingFromOpts(debug = options.debugLog))
+        options.insightsReportOptions.validate()
         addShutdownHook()
 
         val specsToCheck = getSpecsToCheck()
@@ -198,7 +199,8 @@ abstract class BackwardCompatibilityCheckBaseCommand(
             generateBackwardCompatibilityReport(
                 specsValidatedByHook.flatMap { it.reportRecords },
                 reportStartTime,
-                System.currentTimeMillis()
+                System.currentTimeMillis(),
+                options.insightsReportOptions,
             )
 
             return CompatibilityReport(results)

--- a/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckOptions.kt
+++ b/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckOptions.kt
@@ -1,8 +1,13 @@
 package application.backwardCompatibility
 
+import io.specmatic.reporter.commands.InsightsReportOptions
+import picocli.CommandLine.Mixin
 import picocli.CommandLine.Option
 
 class BackwardCompatibilityCheckOptions {
+    @field:Mixin
+    val insightsReportOptions = InsightsReportOptions()
+
     @Option(
         names = ["--base-branch"],
         description = ["Base branch to compare the changes against", "Default value is the local origin HEAD of the current branch"],

--- a/application/src/test/kotlin/application/HTTPStubEngineTest.kt
+++ b/application/src/test/kotlin/application/HTTPStubEngineTest.kt
@@ -7,6 +7,7 @@ import io.specmatic.core.IncomingMtlsRegistry
 import io.specmatic.core.KeyDataRegistry
 import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.WorkingDirectory
+import io.specmatic.reporter.commands.InsightsReportOptions
 import io.specmatic.stub.HttpClientFactory
 import io.specmatic.stub.SpecmaticConfigSource
 import org.assertj.core.api.Assertions.assertThat
@@ -28,6 +29,7 @@ class HTTPStubEngineTest {
                 gracefulRestartTimeoutInMs = 0,
                 specToBaseUrlMap = specToBaseUrlMap,
                 specmaticConfigSource = SpecmaticConfigSource.fromConfigObject(SpecmaticConfig()),
+                insightsReportOptions = InsightsReportOptions()
             ).close()
         }
 

--- a/application/src/test/kotlin/application/StubCommandTest.kt
+++ b/application/src/test/kotlin/application/StubCommandTest.kt
@@ -132,6 +132,7 @@ internal class StubCommandTest {
                     gracefulRestartTimeoutInMs = any(),
                     specToBaseUrlMap = any(),
                     specmaticConfigSource = any(),
+                    insightsReportOptions = any(),
                 )
             }.returns(
                 mockk {
@@ -158,6 +159,7 @@ internal class StubCommandTest {
                     gracefulRestartTimeoutInMs = any(),
                     specToBaseUrlMap = any(),
                     specmaticConfigSource = any(),
+                    insightsReportOptions = any(),
                 )
             }
         } finally {
@@ -179,7 +181,7 @@ internal class StubCommandTest {
         every { specmaticConfig.contractStubPaths() }.returns(arrayListOf("/config/path/to/contract.$extension"))
         every { specmaticConfig.contractStubPathData() } returns emptyList()
         every { stubLoaderEngine.loadStubs(any(), any(), any(), any()) } returns emptyList()
-        every { httpStubEngine.runHTTPStub(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } answers {
+        every { httpStubEngine.runHTTPStub(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } answers {
             mockk<HttpStub> { every { close() } returns Unit }
         }
 
@@ -262,6 +264,7 @@ internal class StubCommandTest {
                     gracefulRestartTimeoutInMs = any(),
                     specToBaseUrlMap = any(),
                     specmaticConfigSource = any(),
+                    insightsReportOptions = any(),
                 )
             }.returns(
                 mockk {
@@ -291,6 +294,7 @@ internal class StubCommandTest {
                     gracefulRestartTimeoutInMs = any(),
                     specToBaseUrlMap = any(),
                     specmaticConfigSource = any(),
+                    insightsReportOptions = any(),
                 )
             }
         } finally {
@@ -404,6 +408,7 @@ internal class StubCommandTest {
                 any(),
                 any(),
                 any(),
+                any(),
                 any()
             )
         } returns mockk { every { close() } returns Unit }
@@ -479,7 +484,7 @@ internal class StubCommandTest {
         assertThat(output).contains("FATAL: No examples found for the given filters")
         assertThat(output).contains("METHOD='POST'")
         verify(exactly = 0) {
-            httpStubEngine.runHTTPStub(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+            httpStubEngine.runHTTPStub(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
         }
     }
 
@@ -490,7 +495,7 @@ internal class StubCommandTest {
         every { specmaticConfig.contractStubPaths() } returns emptyList()
         every { specmaticConfig.contractStubPathData() } returns emptyList()
         every {
-            httpStubEngine.runHTTPStub(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+            httpStubEngine.runHTTPStub(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
         } returns mockk { every { close() } returns Unit }
 
         try {
@@ -547,6 +552,8 @@ internal class StubCommandTest {
                 any(),
                 any(),
                 capture(timeoutSlot),
+                any(),
+                any(),
                 any(),
                 any()
             )
@@ -609,6 +616,8 @@ internal class StubCommandTest {
                 any(),
                 capture(timeoutSlot),
                 any(),
+                any(),
+                any(),
                 any()
             )
         } returns mockk { every { close() } returns Unit }
@@ -662,6 +671,7 @@ internal class StubCommandTest {
                 any(),
                 any(),
                 any(),
+                any(),
                 any()
             )
         } returns mockk<HttpStub> { every { close() } returns Unit }
@@ -702,6 +712,8 @@ internal class StubCommandTest {
                 any(),
                 capture(timeoutSlot),
                 any(),
+                any(),
+                any(),
                 any()
             )
         } answers {
@@ -739,6 +751,8 @@ internal class StubCommandTest {
                 any(),
                 capture(hostSlot),
                 capture(portSlot),
+                any(),
+                any(),
                 any(),
                 any(),
                 any(),
@@ -790,6 +804,8 @@ internal class StubCommandTest {
                 any(),
                 any(),
                 any(),
+                any(),
+                any(),
                 any()
             )
         } returns mockk { every { close() } returns Unit }
@@ -818,6 +834,8 @@ internal class StubCommandTest {
                 any(),
                 any(),
                 capture(keyDataSlot),
+                any(),
+                any(),
                 any(),
                 any(),
                 any(),
@@ -866,6 +884,8 @@ internal class StubCommandTest {
                 any(),
                 any(),
                 any(),
+                any(),
+                any(),
                 any()
             )
         } returns mockk { every { close() } returns Unit }
@@ -900,6 +920,8 @@ internal class StubCommandTest {
                 any(),
                 any(),
                 capture(incomingMtlsSlot),
+                any(),
+                any(),
                 any(),
                 any(),
                 any(),
@@ -953,6 +975,8 @@ internal class StubCommandTest {
                 any(),
                 any(),
                 capture(timeoutSlot),
+                any(),
+                any(),
                 any(),
                 any()
             )

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -213,5 +213,7 @@ subprojects {
         maxHeapSize = "1g"
         jvmArgs("-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/heap-dump-${project.name}.hprof")
         forkEvery = 100
+
+        environment = System.getenv().filterKeys { it != "CI" && !it.startsWith("GITHUB_") }
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/TestBackwardCompatibility.kt
+++ b/core/src/main/kotlin/io/specmatic/core/TestBackwardCompatibility.kt
@@ -7,6 +7,7 @@ import io.specmatic.core.value.NullValue
 import io.specmatic.core.value.Value
 import io.specmatic.reporter.ctrf.model.CtrfBackwardCompatibilityRecord
 import io.specmatic.reporter.ctrf.model.CtrfReport
+import io.specmatic.reporter.commands.InsightsReportOptions
 
 private const val BCC_REPORT_DIR_SUFFIX = "backward_compatibility"
 
@@ -37,7 +38,12 @@ fun List<CtrfBackwardCompatibilityRecord>.toBackwardCompatibilityStatuses(): Res
         }
 }
 
-fun generateBackwardCompatibilityReport(records: List<CtrfBackwardCompatibilityRecord>, startTime: Long, endTime: Long): CtrfReport? {
+fun generateBackwardCompatibilityReport(
+    records: List<CtrfBackwardCompatibilityRecord>,
+    startTime: Long,
+    endTime: Long,
+    insightsReportOptions: InsightsReportOptions? = null,
+): CtrfReport? {
     if (records.isEmpty()) return null
     val reportOperations = BccReportGenerator().generateReportOperations(records)
     val reportDir = loadSpecmaticConfigOrDefault(getConfigFileName()).getReportDirPath(BCC_REPORT_DIR_SUFFIX).toFile()
@@ -47,6 +53,7 @@ fun generateBackwardCompatibilityReport(records: List<CtrfBackwardCompatibilityR
         reportDir = reportDir,
         coverageReportOperations = reportOperations,
         specConfigs = reportOperations.map { it.specConfig }.distinct(),
+        insightsReportOptions = insightsReportOptions,
     )
 }
 

--- a/core/src/main/kotlin/io/specmatic/core/TestBackwardCompatibility.kt
+++ b/core/src/main/kotlin/io/specmatic/core/TestBackwardCompatibility.kt
@@ -11,17 +11,17 @@ import io.specmatic.reporter.commands.InsightsReportOptions
 
 private const val BCC_REPORT_DIR_SUFFIX = "backward_compatibility"
 
-fun testBackwardCompatibility(older: Feature, newer: Feature): Results {
-    return testBackwardCompatibilityWithReport(older, newer).first
+fun testBackwardCompatibility(older: Feature, newer: Feature, insightsReportOptions: InsightsReportOptions): Results {
+    return testBackwardCompatibilityWithReport(older, newer, insightsReportOptions).first
 }
 
-internal fun testBackwardCompatibilityWithReport(older: Feature, newer: Feature): Pair<Results, CtrfReport?> {
+internal fun testBackwardCompatibilityWithReport(older: Feature, newer: Feature, insightsReportOptions: InsightsReportOptions): Pair<Results, CtrfReport?> {
     val startTime = System.currentTimeMillis()
     val records = OpenApiBackwardCompatibilityChecker(older, newer).run()
     val endTime = System.currentTimeMillis()
 
     val result = records.toBackwardCompatibilityStatuses().copy(addSourceLocation = true)
-    val report = generateBackwardCompatibilityReport(records, startTime, endTime)
+    val report = generateBackwardCompatibilityReport(records, startTime, endTime, insightsReportOptions)
     return Pair(result, report)
 }
 
@@ -42,7 +42,7 @@ fun generateBackwardCompatibilityReport(
     records: List<CtrfBackwardCompatibilityRecord>,
     startTime: Long,
     endTime: Long,
-    insightsReportOptions: InsightsReportOptions? = null,
+    insightsReportOptions: InsightsReportOptions,
 ): CtrfReport? {
     if (records.isEmpty()) return null
     val reportOperations = BccReportGenerator().generateReportOperations(records)

--- a/core/src/main/kotlin/io/specmatic/core/report/ReportGenerator.kt
+++ b/core/src/main/kotlin/io/specmatic/core/report/ReportGenerator.kt
@@ -3,6 +3,9 @@ package io.specmatic.core.report
 import io.specmatic.core.config.toResolvedSpecmaticConfigMap
 import io.specmatic.core.getConfigFilePath
 import io.specmatic.core.log.consoleLog
+import io.specmatic.reporter.ReportTracker
+import io.specmatic.reporter.RawReportType
+import io.specmatic.reporter.commands.InsightsReportOptions
 import io.specmatic.reporter.ctrf.CoverageReportSpecification
 import io.specmatic.reporter.ctrf.CtrfReportGenerator
 import io.specmatic.reporter.ctrf.model.BaseBccReportOperation
@@ -22,6 +25,8 @@ object ReportGenerator {
         absoluteCoverage: Int? = null,
         reportDir: File,
         toolName: String = "Specmatic ${VersionInfo.describe()}",
+        reportType: RawReportType,
+        insightsReportOptions: InsightsReportOptions,
     ) {
         if (isCoverageReportSpecificationsValid(coverageReportSpecifications).not()) return
 
@@ -41,6 +46,7 @@ object ReportGenerator {
             toolName = toolName
         )
 
+        ReportTracker.instance.send(report, reportType, insightsReportOptions)
         ReportProvider.generateCtrfReport(report, reportDir)
         ReportProvider.generateHtmlReport(report, reportDir, specmaticConfigAsMap())
     }
@@ -52,6 +58,7 @@ object ReportGenerator {
         specConfigs: List<CtrfSpecConfig>,
         toolName: String = "Specmatic ${VersionInfo.describe()}",
         coverageReportOperations: List<BaseBccReportOperation>,
+        insightsReportOptions: InsightsReportOptions? = null,
     ): CtrfReport? {
         if (isCtrfSpecConfigsValid(specConfigs).not()) return null
         val totalChecksRan = coverageReportOperations.asSequence().flatMap { it.tests.asSequence() }.map { it.id }.distinct().count()
@@ -70,6 +77,7 @@ object ReportGenerator {
             extra = extra,
         )
 
+        ReportTracker.instance.send(report, RawReportType.BCC, insightsReportOptions)
         ReportProvider.generateCtrfReport(report, reportDir)
         ReportProvider.generateHtmlReport(report, reportDir, specmaticConfigAsMap())
         return report

--- a/core/src/main/kotlin/io/specmatic/core/report/ReportGenerator.kt
+++ b/core/src/main/kotlin/io/specmatic/core/report/ReportGenerator.kt
@@ -58,7 +58,7 @@ object ReportGenerator {
         specConfigs: List<CtrfSpecConfig>,
         toolName: String = "Specmatic ${VersionInfo.describe()}",
         coverageReportOperations: List<BaseBccReportOperation>,
-        insightsReportOptions: InsightsReportOptions? = null,
+        insightsReportOptions: InsightsReportOptions,
     ): CtrfReport? {
         if (isCtrfSpecConfigsValid(specConfigs).not()) return null
         val totalChecksRan = coverageReportOperations.asSequence().flatMap { it.tests.asSequence() }.map { it.id }.distinct().count()

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -55,6 +55,8 @@ import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.pattern.parsedJSON
 import io.specmatic.core.pattern.parsedValue
 import io.specmatic.core.report.ReportGenerator
+import io.specmatic.reporter.RawReportType
+import io.specmatic.reporter.commands.InsightsReportOptions
 import io.specmatic.core.route.modules.HealthCheckModule.Companion.configureHealthCheckModule
 import io.specmatic.core.route.modules.HealthCheckModule.Companion.isHealthCheckRequest
 import io.specmatic.core.urlDecodePathSegments
@@ -149,7 +151,8 @@ class HttpStub(
     },
     private val listeners: List<MockEventListener> = emptyList(),
     private val startTime: Instant = Instant.now(),
-    var requestHandlers: MutableList<RequestHandler> = mutableListOf()
+    var requestHandlers: MutableList<RequestHandler> = mutableListOf(),
+    private val insightsReportOptions: InsightsReportOptions = InsightsReportOptions.sniff().also { it.validate() },
 ) : ContractStub {
     private val incomingMtlsSslContextsByPort: MutableMap<Int, SslContext> = mutableMapOf()
     private val mtlsEnabledByPort: MutableMap<Int, Boolean> = mutableMapOf()
@@ -1186,7 +1189,9 @@ class HttpStub(
                 endTime = Instant.now().toEpochMilli(),
                 coverage = mockUsageReport.coverage,
                 absoluteCoverage = mockUsageReport.absoluteCoverage,
-                reportDir = File("${specmaticConfigInstance.getReportDirPath()}/stub")
+                reportDir = File("${specmaticConfigInstance.getReportDirPath()}/stub"),
+                reportType = RawReportType.MOCK,
+                insightsReportOptions = insightsReportOptions,
             )
         }
     }

--- a/core/src/test/kotlin/integration_tests/InterpolatedPathsE2ETest.kt
+++ b/core/src/test/kotlin/integration_tests/InterpolatedPathsE2ETest.kt
@@ -12,6 +12,7 @@ import io.specmatic.core.testBackwardCompatibility
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.StringValue
 import io.specmatic.mock.ScenarioStub
+import io.specmatic.reporter.commands.InsightsReportOptions
 import io.specmatic.reporter.model.TestResult
 import io.specmatic.stub.HttpStub
 import io.specmatic.stub.listener.MockEvent
@@ -221,7 +222,7 @@ class InterpolatedPathsE2ETest {
         }
 
         assertThat(newFeatureWithIncompatiblePathType.path).isEqualToIgnoringWhitespace(specFile.path)
-        val compatibility = testBackwardCompatibility(oldFeature, newFeatureWithIncompatiblePathType)
+        val compatibility = testBackwardCompatibility(oldFeature, newFeatureWithIncompatiblePathType, InsightsReportOptions())
 
         assertThat(compatibility.success()).isFalse()
         assertThat(compatibility.report()).isEqualToNormalizingWhitespace(
@@ -268,8 +269,8 @@ API: GET /example/(id1:string),(id2:number)/status -> 404
         val openApi30Feature = loadFeature("3.0.3")
         val openApi31Feature = loadFeature("3.1.0")
 
-        val oldToNew = testBackwardCompatibility(openApi30Feature, openApi31Feature)
-        val newToOld = testBackwardCompatibility(openApi31Feature, openApi30Feature)
+        val oldToNew = testBackwardCompatibility(openApi30Feature, openApi31Feature, InsightsReportOptions())
+        val newToOld = testBackwardCompatibility(openApi31Feature, openApi30Feature, InsightsReportOptions())
 
         assertThat(Result.fromResults(oldToNew.results)).isInstanceOf(Result.Success::class.java)
         assertThat(Result.fromResults(newToOld.results)).isInstanceOf(Result.Success::class.java)

--- a/core/src/test/kotlin/integration_tests/OpenApi31Test.kt
+++ b/core/src/test/kotlin/integration_tests/OpenApi31Test.kt
@@ -29,6 +29,7 @@ import io.specmatic.core.utilities.Flags.Companion.SCHEMA_EXAMPLE_DEFAULT
 import io.specmatic.core.value.NullValue
 import io.specmatic.core.value.NumberValue
 import io.specmatic.core.value.StringValue
+import io.specmatic.reporter.commands.InsightsReportOptions
 import io.specmatic.stub.HttpStub
 import io.specmatic.stub.SpecmaticConfigSource
 import org.assertj.core.api.Assertions.assertThat
@@ -261,12 +262,12 @@ class OpenApi31Test {
         val openApi30Feature = ScenarioFilter(filterClauses = backwardCompatibilityFilter).filter(openApi30Specification.toFeature())
         val openApi31Feature = ScenarioFilter(filterClauses = backwardCompatibilityFilter).filter(openApi31Specification.toFeature())
 
-        val openApi30To31 = testBackwardCompatibility(openApi30Feature, openApi31Feature)
+        val openApi30To31 = testBackwardCompatibility(openApi30Feature, openApi31Feature, InsightsReportOptions())
         assertThat(Result.fromResults(openApi30To31.results))
             .withFailMessage { Result.fromResults(openApi30To31.results).reportString() }
             .isInstanceOf(Result.Success::class.java)
 
-        val openApi31To30 = testBackwardCompatibility(openApi31Feature, openApi30Feature)
+        val openApi31To30 = testBackwardCompatibility(openApi31Feature, openApi30Feature, InsightsReportOptions())
         assertThat(Result.fromResults(openApi31To30.results))
             .withFailMessage { Result.fromResults(openApi31To30.results).reportString() }
             .isInstanceOf(Result.Success::class.java)

--- a/core/src/test/kotlin/io/specmatic/TestUtilities.kt
+++ b/core/src/test/kotlin/io/specmatic/TestUtilities.kt
@@ -6,10 +6,10 @@ import io.specmatic.core.utilities.ContractSourceEntry
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.Value
 import io.specmatic.mock.ScenarioStub
+import io.specmatic.reporter.commands.InsightsReportOptions
 import io.specmatic.stub.HttpExpectations
 import io.specmatic.stub.HttpStubData
 import io.specmatic.stub.HttpStubResponse
-import io.specmatic.stub.ThreadSafeListOfStubs
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertFalse
 import java.io.File
@@ -61,26 +61,26 @@ infix fun Value.shouldNotMatch(pattern: Pattern) {
 
 fun emptyPattern() = DeferredPattern("(empty)")
 
-infix fun String.backwardCompatibleWith(oldContractGherkin: String) {
-    val results = testBackwardCompatibility(oldContractGherkin)
+fun String.backwardCompatibleWith(oldContractGherkin: String, insightsReportOptions: InsightsReportOptions) {
+    val results = testBackwardCompatibility(oldContractGherkin, insightsReportOptions)
     assertThat(results.success()).isTrue()
     assertThat(results.failureCount).isZero()
 
     stubsFrom(oldContractGherkin).workWith(this)
 }
 
-infix fun String.notBackwardCompatibleWith(oldContractGherkin: String) {
-    val results = testBackwardCompatibility(oldContractGherkin)
+fun String.notBackwardCompatibleWith(oldContractGherkin: String, insightsReportOptions: InsightsReportOptions) {
+    val results = testBackwardCompatibility(oldContractGherkin, insightsReportOptions)
     assertThat(results.success()).isFalse()
     assertThat(results.failureCount).isPositive()
 
     stubsFrom(oldContractGherkin).breakOn(this)
 }
 
-fun String.testBackwardCompatibility(oldContractGherkin: String): Results {
+fun String.testBackwardCompatibility(oldContractGherkin: String, insightsReportOptions: InsightsReportOptions): Results {
     val oldFeature = parseGherkinStringToFeature(oldContractGherkin)
     val newFeature = parseGherkinStringToFeature(this)
-    return testBackwardCompatibility(oldFeature, newFeature)
+    return testBackwardCompatibility(oldFeature, newFeature, insightsReportOptions)
 }
 
 fun stubResponse(httpRequest: HttpRequest, features: List<Feature>, threadSafeStubs: List<HttpStubData>, strictMode: Boolean): HttpStubResponse {

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiKtTest.kt
@@ -21,6 +21,7 @@ import io.specmatic.core.StandardRuleViolation
 import io.specmatic.toViolationReportString
 import io.specmatic.jsonBody
 import io.specmatic.license.core.SpecmaticProtocol
+import io.specmatic.reporter.commands.InsightsReportOptions
 import io.specmatic.reporter.model.SpecType
 import io.specmatic.stub.HttpStub
 import io.specmatic.stub.SpecificationAndRequestMismatchMessages
@@ -866,7 +867,7 @@ Background:
         """.trimIndent(), sourceSpecPath
         )
 
-        val result = testBackwardCompatibility(feature, feature)
+        val result = testBackwardCompatibility(feature, feature, InsightsReportOptions())
         assertThat(result.success()).isTrue()
     }
 
@@ -881,7 +882,7 @@ Background:
         """.trimIndent(), sourceSpecPath
         )
 
-        val result = testBackwardCompatibility(feature, feature)
+        val result = testBackwardCompatibility(feature, feature, InsightsReportOptions())
         assertThat(result.success()).isTrue()
 
         val resp = HttpStub(feature).use {
@@ -910,7 +911,7 @@ Background:
         """.trimIndent(), sourceSpecPath
         )
 
-        val result = testBackwardCompatibility(feature, feature)
+        val result = testBackwardCompatibility(feature, feature, InsightsReportOptions())
         assertThat(result.success()).isTrue()
 
         val resp = HttpStub(feature).use {
@@ -940,7 +941,7 @@ Background:
         """.trimIndent(), sourceSpecPath
         )
 
-        val result = testBackwardCompatibility(feature, feature)
+        val result = testBackwardCompatibility(feature, feature, InsightsReportOptions())
         assertThat(result.success()).isTrue()
 
         val resp = HttpStub(feature).use {
@@ -970,7 +971,7 @@ Background:
         """.trimIndent(), sourceSpecPath
         )
 
-        val result = testBackwardCompatibility(feature, feature)
+        val result = testBackwardCompatibility(feature, feature, InsightsReportOptions())
         assertThat(result.success()).isTrue()
 
         val resp = HttpStub(feature).use {

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -28,6 +28,7 @@ import io.specmatic.license.core.SpecmaticProtocol
 import io.specmatic.toViolationReportString
 import io.specmatic.mock.NoMatchingScenario
 import io.specmatic.mock.ScenarioStub
+import io.specmatic.reporter.commands.InsightsReportOptions
 import io.specmatic.reporter.model.SpecType
 import io.specmatic.stub.HttpStub
 import io.specmatic.stub.HttpStubData
@@ -7727,7 +7728,7 @@ paths:
             """.trimIndent(), ""
         ).toFeature()
 
-        val result = testBackwardCompatibility(oldSpec, newSpec)
+        val result = testBackwardCompatibility(oldSpec, newSpec, InsightsReportOptions())
 
         assertThat(result.success()).isFalse()
 

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiXmlOneOfBackwardCompatibilityTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiXmlOneOfBackwardCompatibilityTest.kt
@@ -1,6 +1,7 @@
 package io.specmatic.conversions
 
 import io.specmatic.core.testBackwardCompatibility
+import io.specmatic.reporter.commands.InsightsReportOptions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -16,7 +17,7 @@ class OpenApiXmlOneOfBackwardCompatibilityTest {
             ""
         ).toFeature()
 
-        val result = testBackwardCompatibility(oldFeature, newFeature)
+        val result = testBackwardCompatibility(oldFeature, newFeature, InsightsReportOptions())
 
         assertThat(result.success()).withFailMessage(result.report()).isTrue()
     }
@@ -32,7 +33,7 @@ class OpenApiXmlOneOfBackwardCompatibilityTest {
             ""
         ).toFeature()
 
-        val result = testBackwardCompatibility(oldFeature, newFeature)
+        val result = testBackwardCompatibility(oldFeature, newFeature, InsightsReportOptions())
 
         assertThat(result.success()).isFalse()
         assertThat(result.report()).contains("parcel")
@@ -73,7 +74,7 @@ ${variants.toComponentsYaml(12)}
             buildString {
                 appendLine("${indentation}schema:")
                 append(nestedIndentation)
-                append("${"$"}ref: '#/components/schemas/")
+                append($$"$ref: '#/components/schemas/")
                 append(variant.componentName)
                 append("'")
             }

--- a/core/src/test/kotlin/io/specmatic/core/FeatureKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FeatureKtTest.kt
@@ -6,13 +6,12 @@ import io.specmatic.core.pattern.*
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.NumberValue
 import io.specmatic.core.value.StringValue
-import io.specmatic.osAgnosticPath
 import io.mockk.every
 import io.mockk.mockk
 import io.specmatic.core.utilities.OpenApiPath
 import io.specmatic.license.core.SpecmaticProtocol
+import io.specmatic.reporter.commands.InsightsReportOptions
 import io.specmatic.reporter.model.SpecType
-import io.specmatic.stub.captureStandardOutput
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -186,7 +185,7 @@ class FeatureKtTest {
               Then status 200
         """.trimIndent())
 
-        val patterns = behaviour.scenarios.single().httpRequestPattern.multiPartFormDataPattern.map { it as MultiPartContentPattern }
+        val patterns = behaviour.scenarios.single().httpRequestPattern.multiPartFormDataPattern
 
         val resolver = Resolver(newPatterns = behaviour.scenarios.single().patterns)
 
@@ -802,9 +801,9 @@ paths:
     fun `should parse equivalent json and yaml representation of an API`() {
         val yamlSpec = parseContractFileToFeature("src/test/resources/openapi/jsonAndYamlEquivalence/openapi.yaml")
         val jsonSpec = parseContractFileToFeature("src/test/resources/openapi/jsonAndYamlEquivalence/openapi.json")
-        val yamlToJson = testBackwardCompatibility(yamlSpec, jsonSpec)
+        val yamlToJson = testBackwardCompatibility(yamlSpec, jsonSpec, InsightsReportOptions())
         assertThat(yamlToJson.success()).withFailMessage(yamlToJson.report()).isTrue
-        val jsonToYAml = testBackwardCompatibility(jsonSpec, yamlSpec)
+        val jsonToYAml = testBackwardCompatibility(jsonSpec, yamlSpec, InsightsReportOptions())
         assertThat(jsonToYAml.success()).withFailMessage(jsonToYAml.report()).isTrue
     }
 

--- a/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
@@ -11,6 +11,7 @@ import io.specmatic.core.log.Verbose
 import io.specmatic.core.log.logger
 import io.specmatic.core.pattern.ContractException
 import io.specmatic.reporter.api.client.OBJECT_MAPPER
+import io.specmatic.reporter.commands.InsightsReportOptions
 import io.specmatic.reporter.ctrf.model.CtrfReport
 import io.specmatic.stub.captureStandardOutput
 import io.specmatic.toViolationReportString
@@ -44,7 +45,7 @@ internal class TestBackwardCompatibilityKtTest {
         val older = OpenApiSpecification.fromYAML(oldSpec, "old.yaml").toFeature()
         val newer = OpenApiSpecification.fromYAML(newSpec, "new.yaml").toFeature()
 
-        val results = testBackwardCompatibility(older, newer)
+        val results = testBackwardCompatibility(older, newer, InsightsReportOptions())
 
         assertThat(results.success()).isFalse
         assertThat(results.distinctReport().normalizeBlankLines()).isEqualToNormalizingNewlines(
@@ -347,7 +348,7 @@ Then status 200"""
         val olderContract = parseGherkinStringToFeature(oldContract)
         val newerContract = parseGherkinStringToFeature(newContract)
 
-        val result: Results = testBackwardCompatibility(olderContract, newerContract)
+        val result: Results = testBackwardCompatibility(olderContract, newerContract, InsightsReportOptions())
 
         println(result.report())
 
@@ -389,7 +390,7 @@ Then status 200
         val olderContract = parseGherkinStringToFeature(gherkin1)
         val newerContract = parseGherkinStringToFeature(gherkin2)
 
-        val result: Results = testBackwardCompatibility(olderContract, newerContract)
+        val result: Results = testBackwardCompatibility(olderContract, newerContract, InsightsReportOptions())
 
         println(result.report())
 
@@ -439,7 +440,7 @@ And response-body (Value)
         val olderContract = parseGherkinStringToFeature(gherkin1)
         val newerContract = parseGherkinStringToFeature(gherkin2)
 
-        val result: Results = testBackwardCompatibility(olderContract, newerContract)
+        val result: Results = testBackwardCompatibility(olderContract, newerContract, InsightsReportOptions())
 
         println(result.report())
 
@@ -489,7 +490,7 @@ Feature: New contract
         val olderContract = parseGherkinStringToFeature(gherkin1)
         val newerContract = parseGherkinStringToFeature(gherkin2)
 
-        val result: Results = testBackwardCompatibility(olderContract, newerContract)
+        val result: Results = testBackwardCompatibility(olderContract, newerContract, InsightsReportOptions())
 
         println(result.report())
 
@@ -539,7 +540,7 @@ Feature: New contract
         val olderContract = parseGherkinStringToFeature(gherkin1)
         val newerContract = parseGherkinStringToFeature(gherkin2)
 
-        val result: Results = testBackwardCompatibility(olderContract, newerContract)
+        val result: Results = testBackwardCompatibility(olderContract, newerContract, InsightsReportOptions())
 
         println(result.report())
 
@@ -589,7 +590,7 @@ Feature: New contract
         val olderContract = parseGherkinStringToFeature(gherkin1)
         val newerContract = parseGherkinStringToFeature(gherkin2)
 
-        val result: Results = testBackwardCompatibility(olderContract, newerContract)
+        val result: Results = testBackwardCompatibility(olderContract, newerContract, InsightsReportOptions())
 
         println(result.report())
 
@@ -643,7 +644,7 @@ Feature: Old contract
         val olderContract = parseGherkinStringToFeature(gherkin1)
         val newerContract = parseGherkinStringToFeature(gherkin2)
 
-        val result: Results = testBackwardCompatibility(olderContract, newerContract)
+        val result: Results = testBackwardCompatibility(olderContract, newerContract, InsightsReportOptions())
 
         println(result.report())
 
@@ -697,7 +698,7 @@ Feature: Old contract
         val olderContract = parseGherkinStringToFeature(gherkin1)
         val newerContract = parseGherkinStringToFeature(gherkin2)
 
-        val result: Results = testBackwardCompatibility(olderContract, newerContract)
+        val result: Results = testBackwardCompatibility(olderContract, newerContract, InsightsReportOptions())
 
         println(result.report())
 
@@ -762,7 +763,7 @@ Feature: Old contract
         val olderContract = parseGherkinStringToFeature(gherkin1)
         val newerContract = parseGherkinStringToFeature(gherkin2)
 
-        val result: Results = testBackwardCompatibility(olderContract, newerContract)
+        val result: Results = testBackwardCompatibility(olderContract, newerContract, InsightsReportOptions())
 
         println(result.report())
 
@@ -814,7 +815,7 @@ Feature: New contract
         val olderContract = parseGherkinStringToFeature(gherkin1)
         val newerContract = parseGherkinStringToFeature(gherkin2)
 
-        val result: Results = testBackwardCompatibility(olderContract, newerContract)
+        val result: Results = testBackwardCompatibility(olderContract, newerContract, InsightsReportOptions())
 
         println(result.report())
 
@@ -870,7 +871,7 @@ Feature: New contract
         val olderContract = parseGherkinStringToFeature(gherkin1)
         val newerContract = parseGherkinStringToFeature(gherkin2)
 
-        val result: Results = testBackwardCompatibility(olderContract, newerContract)
+        val result: Results = testBackwardCompatibility(olderContract, newerContract, InsightsReportOptions())
 
         println(result.report())
 
@@ -920,7 +921,7 @@ Then status 200
         val olderContract = parseGherkinStringToFeature(gherkin1)
         val newerContract = parseGherkinStringToFeature(gherkin2)
 
-        val result: Results = testBackwardCompatibility(olderContract, newerContract)
+        val result: Results = testBackwardCompatibility(olderContract, newerContract, InsightsReportOptions())
 
         println(result.report())
 
@@ -940,7 +941,7 @@ Then status 200
 
         val contract = parseGherkinStringToFeature(gherkin)
 
-        val results: Results = testBackwardCompatibility(contract, contract)
+        val results: Results = testBackwardCompatibility(contract, contract, InsightsReportOptions())
 
         if (results.failureCount > 0)
             println(results.report())
@@ -963,7 +964,7 @@ Then status 200
 
         val contract = parseGherkinStringToFeature(gherkin)
 
-        val results: Results = testBackwardCompatibility(contract, contract)
+        val results: Results = testBackwardCompatibility(contract, contract, InsightsReportOptions())
 
         if (results.failureCount > 0)
             println(results.report())
@@ -984,7 +985,7 @@ And response-body (number?)
 
         val contract = parseGherkinStringToFeature(gherkin)
 
-        val results: Results = testBackwardCompatibility(contract, contract)
+        val results: Results = testBackwardCompatibility(contract, contract, InsightsReportOptions())
 
         if (results.failureCount > 0)
             println(results.report())
@@ -1007,7 +1008,7 @@ And response-body (Number)
 
         val contract = parseGherkinStringToFeature(gherkin)
 
-        val results: Results = testBackwardCompatibility(contract, contract)
+        val results: Results = testBackwardCompatibility(contract, contract, InsightsReportOptions())
 
         if (results.failureCount > 0)
             println(results.report())
@@ -1031,7 +1032,7 @@ And response-body
 """.trim()
         )
 
-        val results: Results = testBackwardCompatibility(behaviour, behaviour)
+        val results: Results = testBackwardCompatibility(behaviour, behaviour, InsightsReportOptions())
 
         println(results.report())
         assertThat(results.success()).withFailMessage(results.report()).isTrue
@@ -1053,7 +1054,7 @@ And response-body
 """.trim()
         )
 
-        val results: Results = testBackwardCompatibility(behaviour, behaviour)
+        val results: Results = testBackwardCompatibility(behaviour, behaviour, InsightsReportOptions())
 
         println(results.report())
         assertThat(results.success()).withFailMessage(results.report()).isTrue
@@ -1075,7 +1076,7 @@ And response-body
 """.trim()
         )
 
-        val results: Results = testBackwardCompatibility(behaviour, behaviour)
+        val results: Results = testBackwardCompatibility(behaviour, behaviour, InsightsReportOptions())
 
         println(results.report())
         assertThat(results.success()).isTrue
@@ -1111,7 +1112,7 @@ And response-body
 """.trim()
         )
 
-        val results: Results = testBackwardCompatibility(older, newer)
+        val results: Results = testBackwardCompatibility(older, newer, InsightsReportOptions())
 
         println(results.report())
         assertBackwardCompatibilityFailure(
@@ -1144,7 +1145,7 @@ And response-body (number)
 
         val contract = parseGherkinStringToFeature(gherkin)
 
-        val results: Results = testBackwardCompatibility(contract, contract)
+        val results: Results = testBackwardCompatibility(contract, contract, InsightsReportOptions())
 
         if (results.failureCount > 0)
             println(results.report())
@@ -1168,7 +1169,7 @@ And response-body (number)
 
         val contract = parseGherkinStringToFeature(gherkin)
 
-        val results: Results = testBackwardCompatibility(contract, contract)
+        val results: Results = testBackwardCompatibility(contract, contract, InsightsReportOptions())
 
         if (results.failureCount > 0)
             println(results.report())
@@ -1203,7 +1204,7 @@ And response-body (number)
     """.trim()
 
         val results: Results =
-            testBackwardCompatibility(parseGherkinStringToFeature(gherkin1), parseGherkinStringToFeature(gherkin2))
+            testBackwardCompatibility(parseGherkinStringToFeature(gherkin1), parseGherkinStringToFeature(gherkin2), InsightsReportOptions())
 
         if (results.failureCount > 0)
             println(results.report())
@@ -1248,7 +1249,7 @@ Then status 200
     """.trim()
 
         val results: Results =
-            testBackwardCompatibility(parseGherkinStringToFeature(gherkin1), parseGherkinStringToFeature(gherkin2))
+            testBackwardCompatibility(parseGherkinStringToFeature(gherkin1), parseGherkinStringToFeature(gherkin2), InsightsReportOptions())
 
         // The breaking WIP scenario is retained as an ignorable failure: it does not break the
         // check, but it is still visible (so it shows up in console output) rather than dropped.
@@ -1267,7 +1268,7 @@ Then status 200
         val older = OpenApiSpecification.fromYAML(oldSpec, "old.yaml").toFeature()
         val newer = OpenApiSpecification.fromYAML(newSpec, "new.yaml").toFeature()
 
-        val results = testBackwardCompatibility(older, newer)
+        val results = testBackwardCompatibility(older, newer, InsightsReportOptions())
 
         assertThat(results.success()).isFalse
         assertThat(results.distinctReport().normalizeBlankLines()).isEqualToNormalizingNewlines(
@@ -1327,7 +1328,7 @@ Then status 200
             """.trimIndent()
 
         val feature = parseGherkinStringToFeature(gherkin)
-        val results = testBackwardCompatibility(feature, feature)
+        val results = testBackwardCompatibility(feature, feature, InsightsReportOptions())
 
         if (results.failureCount > 0)
             println(results.report())
@@ -1391,7 +1392,7 @@ Then status 200
                             type: number
             """.trimIndent().openAPIToContract("new.yaml")
 
-        val result: Results = testBackwardCompatibility(olderContract, newerContract)
+        val result: Results = testBackwardCompatibility(olderContract, newerContract, InsightsReportOptions())
 
         assertThat(result.report()).doesNotContain("data?")
     }
@@ -1458,14 +1459,14 @@ Then status 200
 
         @Test
         fun `new should be should be backward compatible with old`() {
-            val results: Results = testBackwardCompatibility(specWithStringInResponse, specWithEnumInResponse)
+            val results: Results = testBackwardCompatibility(specWithStringInResponse, specWithEnumInResponse, InsightsReportOptions())
 
             assertThat(results.success()).withFailMessage(results.report()).isTrue
         }
 
         @Test
         fun `old should be backward incompatible with new`() {
-            val results: Results = testBackwardCompatibility(specWithEnumInResponse, specWithStringInResponse)
+            val results: Results = testBackwardCompatibility(specWithEnumInResponse, specWithStringInResponse, InsightsReportOptions())
 
             println(results.report())
 
@@ -1551,7 +1552,7 @@ paths:
 """.trimIndent(), "new.yaml"
         ).toFeature()
 
-        val result: Results = testBackwardCompatibility(oldContract, newContract)
+        val result: Results = testBackwardCompatibility(oldContract, newContract, InsightsReportOptions())
 
         assertThat(result.report()).isEqualToNormalizingWhitespace(
             """
@@ -1647,7 +1648,7 @@ paths:
 """.trimIndent(), ""
         ).toFeature()
 
-        val result: Results = testBackwardCompatibility(oldContract, newContract)
+        val result: Results = testBackwardCompatibility(oldContract, newContract, InsightsReportOptions())
 
         assertBackwardCompatibilityFailure(
             result,
@@ -1730,7 +1731,7 @@ paths:
 """.trimIndent(), ""
         ).toFeature()
 
-        val result: Results = testBackwardCompatibility(oldContract, newContract)
+        val result: Results = testBackwardCompatibility(oldContract, newContract, InsightsReportOptions())
 
         val report: String = result.report()
         println(report)
@@ -1793,7 +1794,7 @@ paths:
 """.trimIndent(), "new.yaml"
         ).toFeature()
 
-        val result: Results = testBackwardCompatibility(oldContract, newContract)
+        val result: Results = testBackwardCompatibility(oldContract, newContract, InsightsReportOptions())
 
         assertThat(result.distinctReport()).isEqualTo("""
             In scenario "POST /ping. Response: ok"
@@ -1893,7 +1894,7 @@ paths:
 """.trimIndent(), "new.yaml"
         ).toFeature()
 
-        val result: Results = testBackwardCompatibility(oldContract, newContract)
+        val result: Results = testBackwardCompatibility(oldContract, newContract, InsightsReportOptions())
 
         assertThat(result.distinctReport()).isEqualToIgnoringWhitespace("""
             In scenario "POST /ping. Response: common"
@@ -2009,7 +2010,7 @@ paths:
 """.trimIndent(), "new.yaml"
         ).toFeature()
 
-        val result: Results = testBackwardCompatibility(oldContract, newContract)
+        val result: Results = testBackwardCompatibility(oldContract, newContract, InsightsReportOptions())
 
         val reportText: String = result.report()
         println(reportText)
@@ -2086,7 +2087,7 @@ paths:
 """.trimIndent(), ""
         ).toFeature()
 
-        val result: Results = testBackwardCompatibility(contract, contract)
+        val result: Results = testBackwardCompatibility(contract, contract, InsightsReportOptions())
 
         assertThat(result.success()).isTrue
     }
@@ -2163,7 +2164,7 @@ paths:
 """.trimIndent(), ""
         ).toFeature()
 
-        val result: Results = testBackwardCompatibility(oldContract, newContract)
+        val result: Results = testBackwardCompatibility(oldContract, newContract, InsightsReportOptions())
 
         private val reportText: String = result.report().also { println(it) }
 
@@ -2250,7 +2251,7 @@ paths:
 """.trimIndent(), ""
         ).toFeature()
 
-        val result = testBackwardCompatibility(oldContract, newContract)
+        val result = testBackwardCompatibility(oldContract, newContract, InsightsReportOptions())
         val reportText = result.report()
 
         assertThat(reportText).contains("POST /data")
@@ -2347,7 +2348,7 @@ paths:
 """.trimIndent(), ""
         ).toFeature()
 
-        val result = testBackwardCompatibility(oldContract, newContract)
+        val result = testBackwardCompatibility(oldContract, newContract, InsightsReportOptions())
         val reportText = result.report()
 
         println(reportText)
@@ -2478,7 +2479,7 @@ paths:
 """.trimIndent(), ""
         ).toFeature()
 
-        val result = testBackwardCompatibility(oldContract, newContract)
+        val result = testBackwardCompatibility(oldContract, newContract, InsightsReportOptions())
         val reportText = result.report().also { println(it) }
 
         assertThat(reportText).contains("API: POST /data -> 200")
@@ -2553,7 +2554,7 @@ paths:
 """.trimIndent(), "new.yaml"
         ).toFeature()
 
-        val result = testBackwardCompatibility(oldContract, newContract)
+        val result = testBackwardCompatibility(oldContract, newContract, InsightsReportOptions())
         assertBackwardCompatibilityFailure(
             result,
             """
@@ -2636,7 +2637,7 @@ paths:
 """.trimIndent(), ""
         ).toFeature()
 
-        val result = testBackwardCompatibility(oldContract, newContract)
+        val result = testBackwardCompatibility(oldContract, newContract, InsightsReportOptions())
         assertThat(result.success()).isTrue()
     }
 
@@ -2709,7 +2710,7 @@ paths:
 """.trimIndent(), "new.yaml"
         ).toFeature()
 
-        val result = testBackwardCompatibility(oldContract, newContract)
+        val result = testBackwardCompatibility(oldContract, newContract, InsightsReportOptions())
         assertBackwardCompatibilityFailure(
             result,
             """
@@ -2760,7 +2761,7 @@ paths:
         """.trimIndent()
         )
 
-        val result = testBackwardCompatibility(older, newer)
+        val result = testBackwardCompatibility(older, newer, InsightsReportOptions())
         assertThat(result.success()).withFailMessage(result.report()).isTrue
     }
 
@@ -2813,7 +2814,7 @@ paths:
 """.trimIndent(), ""
         ).toFeature()
 
-        val results = testBackwardCompatibility(oldContract, newContract)
+        val results = testBackwardCompatibility(oldContract, newContract, InsightsReportOptions())
         assertBackwardCompatibilityFailure(
             results,
             """
@@ -2885,7 +2886,7 @@ paths:
                         type: string
             """.trimIndent().openAPIToContract("new.yaml")
 
-        val results: Results = testBackwardCompatibility(olderContract, newerContract)
+        val results: Results = testBackwardCompatibility(olderContract, newerContract, InsightsReportOptions())
 
         assertThat(results.success()).isTrue
     }
@@ -2944,7 +2945,7 @@ paths:
                         type: string
             """.trimIndent().openAPIToContract("new.yaml")
 
-        val results: Results = testBackwardCompatibility(olderContract, newerContract)
+        val results: Results = testBackwardCompatibility(olderContract, newerContract, InsightsReportOptions())
 
         assertBackwardCompatibilityFailure(
             results,
@@ -3021,7 +3022,7 @@ paths:
                         type: string
             """.trimIndent().openAPIToContract("new.yaml")
 
-        val results: Results = testBackwardCompatibility(olderContract, newerContract)
+        val results: Results = testBackwardCompatibility(olderContract, newerContract, InsightsReportOptions())
 
         assertThat(results.success()).isTrue
     }
@@ -3084,7 +3085,7 @@ paths:
                         type: string
             """.trimIndent().openAPIToContract("new.yaml")
 
-        val results: Results = testBackwardCompatibility(olderContract, newerContract)
+        val results: Results = testBackwardCompatibility(olderContract, newerContract, InsightsReportOptions())
         println(results.report())
         assertThat(results.report())
             .containsIgnoringWhitespaces("""
@@ -3158,7 +3159,7 @@ paths:
                         type: string
             """.trimIndent().openAPIToContract("new.yaml")
 
-        val results: Results = testBackwardCompatibility(olderContract, newerContract)
+        val results: Results = testBackwardCompatibility(olderContract, newerContract, InsightsReportOptions())
         assertThat(results.success()).isTrue
     }
 
@@ -3218,7 +3219,7 @@ paths:
                         type: string
             """.trimIndent().openAPIToContract("new.yaml")
 
-        val results: Results = testBackwardCompatibility(olderContract, newerContract)
+        val results: Results = testBackwardCompatibility(olderContract, newerContract, InsightsReportOptions())
         assertThat(results.report())
             .containsIgnoringWhitespaces("""
             In scenario "get products. Response: OK"
@@ -3300,7 +3301,7 @@ paths:
                                     type: string
         """.trimIndent().openAPIToContract("new.yaml")
 
-        val results: Results = testBackwardCompatibility(olderContract, newerContract)
+        val results: Results = testBackwardCompatibility(olderContract, newerContract, InsightsReportOptions())
         assertBackwardCompatibilityFailure(
             results,
             """
@@ -3382,7 +3383,7 @@ paths:
                           # No content key, indicating no body
         """.trimIndent().openAPIToContract("new.yaml")
 
-        val results: Results = testBackwardCompatibility(olderContract, newerContract)
+        val results: Results = testBackwardCompatibility(olderContract, newerContract, InsightsReportOptions())
         println(results.report())
         assertBackwardCompatibilityFailure(
             results,
@@ -3448,7 +3449,7 @@ paths:
                           description: Created
         """.trimIndent().openAPIToContract("new.yaml")
 
-        val results: Results = testBackwardCompatibility(olderContract, newerContract)
+        val results: Results = testBackwardCompatibility(olderContract, newerContract, InsightsReportOptions())
         println(results.report())
         assertBackwardCompatibilityFailure(
             results,
@@ -3484,7 +3485,7 @@ paths:
 
             logger = Verbose()
             val (stdout, _) = captureStandardOutput {
-                testBackwardCompatibility(feature, feature)
+                testBackwardCompatibility(feature, feature, InsightsReportOptions())
             }
 
         assertThat(stdout).contains("[Compatibility Check] Executing 1 scenarios for POST /products against 1 operations")
@@ -3511,7 +3512,7 @@ paths:
 
         val groupedFeature = feature.copy(scenarios = listOf(feature.scenarios.first(), feature.scenarios.first().copy()))
         val (stdout, _) = captureStandardOutput {
-            testBackwardCompatibility(groupedFeature, groupedFeature)
+            testBackwardCompatibility(groupedFeature, groupedFeature, InsightsReportOptions())
         }
 
         assertThat(stdout).contains("[Compatibility Check] Executing 1 scenarios for GET /products against 2 operations")
@@ -3536,7 +3537,7 @@ paths:
 
         val groupedFeature = feature.copy(scenarios = List(1001) { feature.scenarios.first().copy() })
         val (stdout, _) = captureStandardOutput {
-            testBackwardCompatibility(groupedFeature, groupedFeature)
+            testBackwardCompatibility(groupedFeature, groupedFeature, InsightsReportOptions())
         }
 
         assertThat(stdout).contains("[Compatibility Check] Executing 1 scenarios for GET /products against 1001 operations")
@@ -3567,7 +3568,7 @@ paths:
 
         val groupedFeature = feature.copy(scenarios = List(1000) { feature.scenarios.first().copy() }.plus(feature.scenarios.last()))
         val (stdout, _) = captureStandardOutput {
-            testBackwardCompatibility(groupedFeature, groupedFeature)
+            testBackwardCompatibility(groupedFeature, groupedFeature, InsightsReportOptions())
         }
 
         assertThat(stdout).contains("[Compatibility Check] Executing 1 scenarios for GET /products against 1001 operations")
@@ -3592,7 +3593,7 @@ paths:
 
         val groupedFeature = feature.copy(scenarios = listOf(feature.scenarios.first(), feature.scenarios.first().copy()))
         val (stdout, _) = captureStandardOutput {
-            testBackwardCompatibility(groupedFeature, groupedFeature)
+            testBackwardCompatibility(groupedFeature, groupedFeature, InsightsReportOptions())
         }
 
         assertThat(stdout).contains("[Compatibility Check] Executing 1 scenarios for GET /products against 2 operations")
@@ -3638,7 +3639,7 @@ paths:
         """.trimIndent().openAPIToContract("new.yaml")
 
         val (stdout, _) = captureStandardOutput {
-            testBackwardCompatibility(olderContract, newerContract)
+            testBackwardCompatibility(olderContract, newerContract, InsightsReportOptions())
         }
 
         assertThat(stdout).contains("[Compatibility Check] Executing 1 scenarios for GET /products against 1 operations")
@@ -3696,7 +3697,7 @@ paths:
                           description: Created
         """.trimIndent().openAPIToContract("new.yaml")
 
-        val results: Results = testBackwardCompatibility(olderContract, newerContract)
+        val results: Results = testBackwardCompatibility(olderContract, newerContract, InsightsReportOptions())
         println(results.report())
         assertBackwardCompatibilityFailure(
             results,
@@ -3753,7 +3754,7 @@ paths:
                   description: Created
         """.trimIndent().openAPIToContract("new.yaml")
 
-        val results: Results = testBackwardCompatibility(olderContract, newerContract)
+        val results: Results = testBackwardCompatibility(olderContract, newerContract, InsightsReportOptions())
         assertBackwardCompatibilityFailure(
             results,
             """
@@ -3823,7 +3824,7 @@ paths:
                   description: Created
         """.trimIndent().openAPIToContract("new.yaml")
 
-        val results: Results = testBackwardCompatibility(olderContract, newerContract)
+        val results: Results = testBackwardCompatibility(olderContract, newerContract, InsightsReportOptions())
         assertBackwardCompatibilityFailure(
             results = results,
             expectedReport = """
@@ -3927,7 +3928,7 @@ paths:
                   description: Created
         """.trimIndent().openAPIToContract("new.yaml")
 
-        val results: Results = testBackwardCompatibility(olderContract, newerContract)
+        val results: Results = testBackwardCompatibility(olderContract, newerContract, InsightsReportOptions())
         assertBackwardCompatibilityFailure(
             results = results,
             expectedReport = """
@@ -4003,7 +4004,7 @@ paths:
                   description: Created
         """.trimIndent().openAPIToContract("new.yaml")
 
-        val results: Results = testBackwardCompatibility(olderContract, newerContract)
+        val results: Results = testBackwardCompatibility(olderContract, newerContract, InsightsReportOptions())
         assertBackwardCompatibilityFailure(
             results = results,
             expectedReport = """
@@ -4076,7 +4077,7 @@ paths:
         val olderContract = OpenApiSpecification.fromYAML(oldSpec, "").toFeature()
         val newerContract = OpenApiSpecification.fromYAML(newSpec, "").toFeature()
 
-        val result: Results = testBackwardCompatibility(olderContract, newerContract)
+        val result: Results = testBackwardCompatibility(olderContract, newerContract, InsightsReportOptions())
 
         assertThat(result.success()).isTrue
     }
@@ -4142,7 +4143,7 @@ paths:
         val olderContract = OpenApiSpecification.fromYAML(oldSpec, "").toFeature()
         val newerContract = OpenApiSpecification.fromYAML(newSpec, "").toFeature()
 
-        val result: Results = testBackwardCompatibility(olderContract, newerContract)
+        val result: Results = testBackwardCompatibility(olderContract, newerContract, InsightsReportOptions())
 
         assertThat(result.success()).isTrue
     }
@@ -4204,7 +4205,7 @@ paths:
         val olderContract = OpenApiSpecification.fromYAML(oldSpec, "").toFeature()
         val newerContract = OpenApiSpecification.fromYAML(newSpec, "").toFeature()
 
-        val result: Results = testBackwardCompatibility(olderContract, newerContract)
+        val result: Results = testBackwardCompatibility(olderContract, newerContract, InsightsReportOptions())
 
         assertThat(result.success()).withFailMessage(result.report()).isTrue
     }
@@ -4266,7 +4267,7 @@ paths:
         val olderContract = OpenApiSpecification.fromYAML(oldSpec, "old.yaml").toFeature()
         val newerContract = OpenApiSpecification.fromYAML(newSpec, "new.yaml").toFeature()
 
-        val result: Results = testBackwardCompatibility(olderContract, newerContract)
+        val result: Results = testBackwardCompatibility(olderContract, newerContract, InsightsReportOptions())
 
         assertThat(result.success()).withFailMessage(result.report()).isFalse
         assertThat(result.report())
@@ -4825,7 +4826,7 @@ paths:
         val reportDir = tempDir.resolve("reports/backward_compatibility").canonicalFile
 
         using(CONFIG_FILE_PATH to configFile.canonicalPath) {
-            val (result, report) = testBackwardCompatibilityWithReport(olderContract, newerContract)
+            val (result, report) = testBackwardCompatibilityWithReport(olderContract, newerContract, InsightsReportOptions())
             assertThat(report).withFailMessage("Expected CTRF Report to be generated").isNotNull
             assertThat(result.success()).isFalse
 
@@ -4885,7 +4886,7 @@ paths:
         }
 
         using(CONFIG_FILE_PATH to configFile.canonicalPath) {
-            val report = generateBackwardCompatibilityReport(emptyList(), 0L, 1L)
+            val report = generateBackwardCompatibilityReport(emptyList(), 0L, 1L, InsightsReportOptions())
 
             assertThat(report).isNull()
             assertThat(tempDir.resolve("reports")).doesNotExist()
@@ -5563,7 +5564,7 @@ paths:
             val newFeature = OpenApiSpecification.fromYAML(newSpec, "new.yaml").toFeature()
 
             return using(CONFIG_FILE_PATH to configFile.canonicalPath) {
-                testBackwardCompatibilityWithReport(oldFeature, newFeature)
+                testBackwardCompatibilityWithReport(oldFeature, newFeature, InsightsReportOptions())
             }
         }
 
@@ -6397,7 +6398,7 @@ paths:
             val newFeature = OpenApiSpecification.fromYAML(newSpec, "new.yaml").toFeature()
 
             return using(CONFIG_FILE_PATH to configFile.canonicalPath) {
-                val (_, report) = testBackwardCompatibilityWithReport(oldFeature, newFeature)
+                val (_, report) = testBackwardCompatibilityWithReport(oldFeature, newFeature, InsightsReportOptions())
                 val json = OBJECT_MAPPER.valueToTree<JsonNode>(report)
                 json.path("results").path("summary").path("extra").path("executionDetails").first().path("operations")
             }

--- a/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityPerfTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityPerfTest.kt
@@ -1,6 +1,7 @@
 package io.specmatic.core
 
 import io.specmatic.conversions.OpenApiSpecification
+import io.specmatic.reporter.commands.InsightsReportOptions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertTimeoutPreemptively
@@ -17,7 +18,8 @@ class TestBackwardCompatibilityPerfTest {
 
         var results: Results? = null
         assertTimeoutPreemptively(ofSeconds(5)) {
-            val timeTaken = measureTimeMillis { results = testBackwardCompatibility(oldFeature, newFeature) }
+            val timeTaken = measureTimeMillis { results = testBackwardCompatibility(oldFeature, newFeature,
+                InsightsReportOptions()) }
             System.err.println("Backward compatibility check took ${timeTaken}ms")
         }
 

--- a/core/src/test/kotlin/io/specmatic/core/pattern/CsvPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/CsvPatternTest.kt
@@ -6,8 +6,8 @@ import io.specmatic.core.*
 import io.specmatic.core.Result.Failure
 import io.specmatic.core.Result.Success
 import io.specmatic.core.value.StringValue
-import io.specmatic.core.value.Value
 import io.specmatic.mock.ScenarioStub
+import io.specmatic.reporter.commands.InsightsReportOptions
 import io.specmatic.stub.HttpStub
 import io.specmatic.test.TestExecutor
 import org.assertj.core.api.Assertions.assertThat
@@ -146,7 +146,7 @@ paths:
 
     @Test
     fun `old and new are backward compatible when the csv type has not changed`() {
-        val result = testBackwardCompatibility(contract, contract)
+        val result = testBackwardCompatibility(contract, contract, InsightsReportOptions())
 
         assertThat(result.success()).isTrue()
     }
@@ -183,7 +183,7 @@ paths:
         """.trimIndent(), ""
         ).toFeature()
 
-        val result = testBackwardCompatibility(contract, newContract)
+        val result = testBackwardCompatibility(contract, newContract, InsightsReportOptions())
 
         assertThat(result.success()).isFalse()
     }
@@ -216,7 +216,7 @@ paths:
                 type: string
         """.trimIndent(), "").toFeature()
 
-        val result = testBackwardCompatibility(contract, newContract)
+        val result = testBackwardCompatibility(contract, newContract, InsightsReportOptions())
 
         assertThat(result.success()).isFalse()
     }

--- a/core/src/test/kotlin/io/specmatic/core/pattern/DictionaryPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/DictionaryPatternTest.kt
@@ -7,6 +7,7 @@ import io.specmatic.core.Resolver
 import io.specmatic.core.testBackwardCompatibility
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.StringValue
+import io.specmatic.reporter.commands.InsightsReportOptions
 import io.specmatic.shouldMatch
 import io.specmatic.shouldNotMatch
 
@@ -83,7 +84,7 @@ Feature: Recursive test
 """.trim()
 
         val feature = parseGherkinStringToFeature(gherkin)
-        val result = testBackwardCompatibility(feature, feature)
+        val result = testBackwardCompatibility(feature, feature, InsightsReportOptions())
 
         println(result.report())
 
@@ -106,7 +107,7 @@ Feature: Recursive test
 """.trim()
 
         val feature = parseGherkinStringToFeature(gherkin)
-        val result = testBackwardCompatibility(feature, feature)
+        val result = testBackwardCompatibility(feature, feature, InsightsReportOptions())
 
         println(result.report())
 

--- a/core/src/test/kotlin/io/specmatic/core/pattern/JSONArrayPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/JSONArrayPatternTest.kt
@@ -4,6 +4,7 @@ import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.core.*
 import io.specmatic.core.value.*
 import io.specmatic.mock.ScenarioStub
+import io.specmatic.reporter.commands.InsightsReportOptions
 import io.specmatic.shouldMatch
 import io.specmatic.shouldNotMatch
 import io.specmatic.stub.HttpStub
@@ -165,7 +166,7 @@ Feature: Recursive test
 """.trim()
 
         val feature = parseGherkinStringToFeature(gherkin)
-        val result = testBackwardCompatibility(feature, feature)
+        val result = testBackwardCompatibility(feature, feature, InsightsReportOptions())
         println(result.report())
         assertThat(result.success()).isTrue()
     }
@@ -185,7 +186,7 @@ Feature: Recursive test
 """.trim()
 
         val feature = parseGherkinStringToFeature(gherkin)
-        val result = testBackwardCompatibility(feature, feature)
+        val result = testBackwardCompatibility(feature, feature, InsightsReportOptions())
         println(result.report())
         assertThat(result.success()).isTrue()
     }
@@ -205,7 +206,7 @@ Feature: Recursive test
 """.trim()
 
         val feature = parseGherkinStringToFeature(gherkin)
-        val result = testBackwardCompatibility(feature, feature)
+        val result = testBackwardCompatibility(feature, feature, InsightsReportOptions())
         println(result.report())
         assertThat(result.success()).isTrue()
     }

--- a/core/src/test/kotlin/io/specmatic/core/pattern/ListPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/ListPatternTest.kt
@@ -5,6 +5,7 @@ import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.core.*
 import io.specmatic.core.substitution.SubstitutionImpl
 import io.specmatic.core.value.*
+import io.specmatic.reporter.commands.InsightsReportOptions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
@@ -128,7 +129,7 @@ Feature: Recursive test
 """.trim()
 
         val feature = parseGherkinStringToFeature(gherkin)
-        val result = testBackwardCompatibility(feature, feature)
+        val result = testBackwardCompatibility(feature, feature, InsightsReportOptions())
         println(result.report())
         assertThat(result.success()).isTrue()
     }

--- a/core/src/test/kotlin/io/specmatic/core/pattern/TabularPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/TabularPatternTest.kt
@@ -13,6 +13,7 @@ import io.specmatic.stub.HttpStub
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.cucumber.messages.types.Scenario
 import io.specmatic.conversions.unwrapFeature
+import io.specmatic.reporter.commands.InsightsReportOptions
 import io.specmatic.trimmedLinesString
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -353,7 +354,7 @@ Feature: Recursive test
 """.trim()
 
         val feature = parseGherkinStringToFeature(gherkin)
-        val result = testBackwardCompatibility(feature, feature)
+        val result = testBackwardCompatibility(feature, feature, InsightsReportOptions())
         assertThat(result.success()).isTrue()
     }
 

--- a/core/src/test/kotlin/io/specmatic/core/wsdl/WSDLParserContractBlackBoxTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/wsdl/WSDLParserContractBlackBoxTest.kt
@@ -8,9 +8,8 @@ import io.specmatic.core.SPECMATIC_RESULT_HEADER
 import io.specmatic.core.parseContractFileToFeature
 import io.specmatic.core.pattern.parsedValue
 import io.specmatic.core.testBackwardCompatibility
-import io.specmatic.core.value.toXMLNode
-import io.specmatic.core.wsdl.parser.WSDL
 import io.specmatic.core.wsdl.payload.emptySoapMessage
+import io.specmatic.reporter.commands.InsightsReportOptions
 import io.specmatic.stub.HttpStub
 import io.specmatic.stub.RequestContext
 import io.specmatic.test.TestExecutor
@@ -259,9 +258,9 @@ class WSDLParserContractBlackBoxTest {
             operation = "requestChoiceBcc",
         )
 
-        assertThat(testBackwardCompatibility(oldFeature, oldFeature).success()).isTrue()
-        assertThat(testBackwardCompatibility(oldFeature, featureWithAddedBranch).success()).isTrue()
-        assertThat(testBackwardCompatibility(oldFeature, featureWithRemovedBranch).success()).isFalse()
+        assertThat(testBackwardCompatibility(oldFeature, oldFeature, InsightsReportOptions()).success()).isTrue()
+        assertThat(testBackwardCompatibility(oldFeature, featureWithAddedBranch, InsightsReportOptions()).success()).isTrue()
+        assertThat(testBackwardCompatibility(oldFeature, featureWithRemovedBranch, InsightsReportOptions()).success()).isFalse()
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/rules/JSONBackwardCompatibilityModel.kt
+++ b/core/src/test/kotlin/io/specmatic/rules/JSONBackwardCompatibilityModel.kt
@@ -2,6 +2,7 @@ package io.specmatic.rules
 
 import io.specmatic.backwardCompatibleWith
 import io.specmatic.notBackwardCompatibleWith
+import io.specmatic.reporter.commands.InsightsReportOptions
 import org.junit.jupiter.api.Test
 
 class JSONBackwardCompatibilityModel {
@@ -35,7 +36,7 @@ Feature: User API
     And response-body (Status)
 """.trimIndent()
 
-        newContract notBackwardCompatibleWith oldContract
+        newContract.notBackwardCompatibleWith(oldContract, InsightsReportOptions())
     }
 
     @Test
@@ -55,7 +56,7 @@ Feature: User API
     And response-body (Status)
 """.trimIndent()
 
-        newContract backwardCompatibleWith oldContract
+        newContract.backwardCompatibleWith(oldContract, InsightsReportOptions())
     }
 
     @Test
@@ -74,7 +75,7 @@ Feature: User API
     And response-body (Status)
 """.trimIndent()
 
-        newContract backwardCompatibleWith oldContract
+        newContract.backwardCompatibleWith(oldContract, InsightsReportOptions())
     }
 
     @Test
@@ -107,7 +108,7 @@ Feature: User API
     And response-body (Status)
 """.trimIndent()
 
-        newContract backwardCompatibleWith oldContract
+        newContract.backwardCompatibleWith(oldContract, InsightsReportOptions())
     }
 
     @Test
@@ -140,7 +141,7 @@ Feature: User API
     And response-body (Status)
 """.trimIndent()
 
-        newContract notBackwardCompatibleWith oldContract
+        newContract.notBackwardCompatibleWith(oldContract, InsightsReportOptions())
     }
 
     @Test
@@ -159,6 +160,6 @@ Feature: User API
     And response-body (Status)
 """.trimIndent()
 
-        newContract backwardCompatibleWith oldContract
+        newContract.backwardCompatibleWith(oldContract, InsightsReportOptions())
     }
 }

--- a/junit5-support/src/main/kotlin/io/specmatic/test/ContractTestSettings.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/ContractTestSettings.kt
@@ -41,7 +41,7 @@ data class ContractTestSettings(
     val previousRunCoverageMetrics: Map<OpenAPIOperation, CtrfOperationMetrics> = emptyMap(),
     val timeoutInMilliSeconds: Long? = null,
     val otherArguments: DeprecatedArguments? = null,
-    val insightsReportOptions: InsightsReportOptions? = null,
+    val insightsReportOptions: InsightsReportOptions = InsightsReportOptions.sniff().also { it.validate() }
 ) {
     val host: String? = otherArguments?.host
     val port: String? = otherArguments?.port
@@ -140,7 +140,7 @@ data class ContractTestSettings(
         contractPaths = contractTestSettings?.contractPaths,
         timeoutInMilliSeconds = contractTestSettings?.timeoutInMilliSeconds,
         filter = contractTestSettings?.filter,
-        insightsReportOptions = contractTestSettings?.insightsReportOptions,
+        insightsReportOptions = contractTestSettings?.insightsReportOptions ?: InsightsReportOptions.sniff().also { it.validate() },
         otherArguments = DeprecatedArguments(
             host = contractTestSettings?.otherArguments?.host,
             port = contractTestSettings?.otherArguments?.port,

--- a/junit5-support/src/main/kotlin/io/specmatic/test/ContractTestSettings.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/ContractTestSettings.kt
@@ -8,6 +8,7 @@ import io.specmatic.core.loadSpecmaticConfigOrDefault
 import io.specmatic.core.loadSpecmaticConfigOrNull
 import io.specmatic.core.orDefault
 import io.specmatic.core.utilities.Flags
+import io.specmatic.reporter.commands.InsightsReportOptions
 import io.specmatic.reporter.ctrf.model.CtrfOperationMetrics
 import io.specmatic.reporter.model.OpenAPIOperation
 import io.specmatic.reporter.model.SpecType
@@ -40,6 +41,7 @@ data class ContractTestSettings(
     val previousRunCoverageMetrics: Map<OpenAPIOperation, CtrfOperationMetrics> = emptyMap(),
     val timeoutInMilliSeconds: Long? = null,
     val otherArguments: DeprecatedArguments? = null,
+    val insightsReportOptions: InsightsReportOptions? = null,
 ) {
     val host: String? = otherArguments?.host
     val port: String? = otherArguments?.port
@@ -138,6 +140,7 @@ data class ContractTestSettings(
         contractPaths = contractTestSettings?.contractPaths,
         timeoutInMilliSeconds = contractTestSettings?.timeoutInMilliSeconds,
         filter = contractTestSettings?.filter,
+        insightsReportOptions = contractTestSettings?.insightsReportOptions,
         otherArguments = DeprecatedArguments(
             host = contractTestSettings?.otherArguments?.host,
             port = contractTestSettings?.otherArguments?.port,

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -10,8 +10,8 @@ import io.specmatic.core.log.logger
 import io.specmatic.core.log.setLoggerUsing
 import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.report.ReportGenerator
+import io.specmatic.reporter.RawReportType
 import io.specmatic.core.utilities.*
-import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.license.core.*
 import io.specmatic.license.core.util.LicenseConfig
 import io.specmatic.reporter.internal.dto.coverage.CoverageStatus
@@ -143,6 +143,8 @@ open class SpecmaticJUnitSupport {
             coverage = coverageReport.totalCoveragePercentage,
             actuatorEnabled = coverageReport.actuatorEnabled,
             absoluteCoverage = coverageReport.absoluteCoveragePercentage,
+            reportType = RawReportType.TEST,
+            insightsReportOptions = settings.insightsReportOptions,
         )
     }
 


### PR DESCRIPTION
This pull request introduces support for insights reporting options across the main Specmatic CLI commands (`stub`, `test`, and backward compatibility checks), enabling users to configure and validate reporting-related settings directly via command-line arguments. The changes also ensure that these options are properly integrated into the application's execution flow and tested accordingly.
