### PR TITLE
fix: group BCC Insights options

### DIFF
--- a/application/src/main/kotlin/application/StubCommand.kt
+++ b/application/src/main/kotlin/application/StubCommand.kt
@@ -52,7 +52,9 @@ class StubCommand(
     private val stubLoaderEngine: StubLoaderEngine = StubLoaderEngine(),
     private val specmaticConfig: SpecmaticConfig = SpecmaticConfig(),
     private val watchMaker: WatchMaker = WatchMaker(),
-    private val httpClientFactory: HttpClientFactory = HttpClientFactory()
+    private val httpClientFactory: HttpClientFactory = HttpClientFactory(),
+    @field:ArgGroup(exclusive = false, heading = "%nInsights reporting options:%n")
+    val insightsReportOptions: InsightsReportOptions = InsightsReportOptions()
 ) : SpecmaticMockRunner {
     var httpStub: HttpStub? = null
 
@@ -149,8 +151,6 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
     @Option(names = ["--lenient"], description = ["Parse the OpenAPI Specification with leniency"], required = false)
     var lenientMode: Boolean? = null
 
-    @field:ArgGroup(exclusive = false, heading = "%nInsights reporting options:%n")
-    val insightsReportOptions = InsightsReportOptions()
 
     private var contractSources: List<ContractPathData> = emptyList()
 

--- a/application/src/main/kotlin/application/TestCommand.kt
+++ b/application/src/main/kotlin/application/TestCommand.kt
@@ -28,6 +28,7 @@ import org.w3c.dom.Node
 import org.w3c.dom.NodeList
 import org.xml.sax.InputSource
 import picocli.CommandLine
+import picocli.CommandLine.ArgGroup
 import picocli.CommandLine.Command
 import picocli.CommandLine.Model.CommandSpec
 import picocli.CommandLine.Option
@@ -49,7 +50,11 @@ private const val DISPLAY_NAME_PREFIX_IN_SYSTEM_OUT_TAG_TEXT = "display-name: "
     defaultValueProvider = GitReportDefaultValueProvider::class,
 )
 @Category("Specmatic core")
-class TestCommand(private val junitLauncher: Launcher = LauncherFactory.create()) : Callable<Int> {
+class TestCommand(
+    private val junitLauncher: Launcher = LauncherFactory.create(),
+    @field:ArgGroup(exclusive = false, heading = "%nInsights reporting options:%n")
+    val insightsReportOptions: InsightsReportOptions = InsightsReportOptions()
+) : Callable<Int> {
     @CommandLine.Parameters(arity = "0..*", description = ["Contract file paths"])
     var contractPaths: List<String>? = null
 
@@ -125,9 +130,6 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
 
     @Option(names = ["--lenient"], description = ["Parse the OpenAPI Specification with leniency"], required = false)
     var lenientMode: Boolean = false
-
-    @field:CommandLine.ArgGroup(exclusive = false, heading = "%nInsights reporting options:%n")
-    val insightsReportOptions = InsightsReportOptions()
 
     @Spec
     lateinit var commandSpec: CommandSpec

--- a/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckCommandV2.kt
+++ b/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckCommandV2.kt
@@ -8,6 +8,7 @@ import io.specmatic.core.log.logger
 import io.specmatic.core.utilities.exceptionCauseMessage
 import io.specmatic.license.core.cli.Category
 import io.specmatic.loader.OpenApiSpecCompatibilityChecker
+import io.specmatic.reporter.commands.GitReportDefaultValueProvider
 import io.specmatic.stub.isOpenAPI
 import picocli.CommandLine.Command
 import java.io.File
@@ -20,7 +21,8 @@ import kotlin.io.path.pathString
 @Command(
     name = "backward-compatibility-check",
     mixinStandardHelpOptions = true,
-    description = ["Checks backward compatibility of OpenAPI specifications"]
+    description = ["Checks backward compatibility of OpenAPI specifications"],
+    defaultValueProvider = GitReportDefaultValueProvider::class,
 )
 @Category("Specmatic core")
 class BackwardCompatibilityCheckCommandV2(options: BackwardCompatibilityCheckOptions = BackwardCompatibilityCheckOptions()): BackwardCompatibilityCheckBaseCommand(options) {

--- a/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckOptions.kt
+++ b/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckOptions.kt
@@ -1,11 +1,11 @@
 package application.backwardCompatibility
 
 import io.specmatic.reporter.commands.InsightsReportOptions
-import picocli.CommandLine.Mixin
+import picocli.CommandLine.ArgGroup
 import picocli.CommandLine.Option
 
 class BackwardCompatibilityCheckOptions {
-    @field:Mixin
+    @field:ArgGroup(exclusive = false, heading = "%nInsights reporting options:%n")
     val insightsReportOptions = InsightsReportOptions()
 
     @Option(

--- a/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
+++ b/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
@@ -2215,6 +2215,23 @@ class BackwardCompatibilityCheckCommandV2Test {
         remoteDir.deleteRecursively()
     }
 
+    @Test
+    fun `should infer Insights repository metadata`() {
+        val previous = System.getProperty("specmatic.repo.name")
+        try {
+            System.setProperty("specmatic.repo.name", "orders")
+            val command = BackwardCompatibilityCheckCommandV2()
+
+            val commandLine = picocli.CommandLine(command)
+            commandLine.parseArgs()
+
+            assertThat(command.options.insightsReportOptions.repoName).isEqualTo("orders")
+            assertThat(commandLine.usageMessage).contains("Insights reporting options:")
+        } finally {
+            if (previous == null) System.clearProperty("specmatic.repo.name") else System.setProperty("specmatic.repo.name", previous)
+        }
+    }
+
     private fun File.referTo(schemaFileName: String) {
         val specContent = """
            openapi: 3.1.0  # OpenAPI version specified here


### PR DESCRIPTION
This pull request enhances the `BackwardCompatibilityCheckCommandV2` command to better support Insights reporting options and to automatically infer repository metadata from environment properties. It also improves the user experience by grouping related command-line options and providing clearer usage messages.

**Enhancements to command-line options and metadata inference:**

* Added `GitReportDefaultValueProvider` as the `defaultValueProvider` for `BackwardCompatibilityCheckCommandV2`, enabling automatic inference of default values such as repository metadata from environment properties.
* Changed `insightsReportOptions` in `BackwardCompatibilityCheckOptions` from a `@Mixin` to an `@ArgGroup`, grouping Insights reporting options under a dedicated heading in the CLI help output for better usability.

**Testing improvements:**

* Added a test to verify that the Insights repository name is correctly inferred from the `specmatic.repo.name` system property and that the CLI usage message includes the Insights reporting options section.