### PR TITLE
Restore BCC performance benchmark boundary

### DIFF
--- a/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityPerfTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityPerfTest.kt
@@ -1,7 +1,6 @@
 package io.specmatic.core
 
 import io.specmatic.conversions.OpenApiSpecification
-import io.specmatic.reporter.commands.InsightsReportOptions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertTimeoutPreemptively
@@ -18,8 +17,7 @@ class TestBackwardCompatibilityPerfTest {
 
         var results: Results? = null
         assertTimeoutPreemptively(ofSeconds(5)) {
-            val timeTaken = measureTimeMillis { results = testBackwardCompatibility(oldFeature, newFeature,
-                InsightsReportOptions()) }
+            val timeTaken = measureTimeMillis { results = backwardCompatibilityRecords(oldFeature, newFeature).first }
             System.err.println("Backward compatibility check took ${timeTaken}ms")
         }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Restore the backward compatibility performance test's calculation-only benchmark boundary.

<!-- Why are these changes necessary? -->

**Why**:

Report generation and filesystem output caused CI timeouts unrelated to backward compatibility calculation performance.

<!-- How were these changes implemented? -->

**How**:

Keep calculation performance coverage separate from the existing report functional coverage.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)

<!-- feel free to add additional comments -->
