### PR TITLE
Include config in raw reports

### DIFF
--- a/application/src/main/kotlin/application/StubCommand.kt
+++ b/application/src/main/kotlin/application/StubCommand.kt
@@ -14,8 +14,7 @@ import io.specmatic.core.toIncomingMtlsRegistryForStub
 import io.specmatic.core.utilities.Flags.Companion.SPECMATIC_BASE_URL
 import io.specmatic.license.core.cli.Category
 import io.specmatic.reporter.commands.GitReportDefaultValueProvider
-import io.specmatic.reporter.commands.InsightsReportOptions
-import io.specmatic.reporter.ReportTracker
+import io.specmatic.reporter.commands.InsightsReportOptionsWithConfig
 import io.specmatic.mock.ScenarioStub
 import io.specmatic.stub.HttpClientFactory
 import io.specmatic.stub.HttpStub
@@ -54,7 +53,7 @@ class StubCommand(
     private val watchMaker: WatchMaker = WatchMaker(),
     private val httpClientFactory: HttpClientFactory = HttpClientFactory(),
     @field:ArgGroup(exclusive = false, heading = "%nInsights reporting options:%n")
-    val insightsReportOptions: InsightsReportOptions = InsightsReportOptions()
+    val insightsReportOptions: InsightsReportOptionsWithConfig = InsightsReportOptionsWithConfig()
 ) : SpecmaticMockRunner {
     var httpStub: HttpStub? = null
 
@@ -111,9 +110,6 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
     @Option(names = ["--debug"], description = ["Debug logs"])
     var verbose: Boolean? = null
 
-    @Option(names = ["--config"], description = ["Configuration file name ($APPLICATION_NAME_LOWER_CASE.json by default)"])
-    var configFileName: String? = null
-
     @Option(names = ["--textLog"], description = ["Directory in which to write a text log"])
     var textLogDir: File? = null
 
@@ -165,9 +161,9 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
     fun ctrfTestResultRecords() = (httpStub as? HttpStub)?.ctrfTestResultRecords().orEmpty()
 
     private val specmaticConfigurationSource: SpecmaticConfigSource by lazy(LazyThreadSafetyMode.NONE) {
-        if (configFileName != null) Configuration.configFilePath = configFileName as String
+        insightsReportOptions.configPath?.let { Configuration.configFilePath = it }
         val specmaticConfigPath = File(Configuration.configFilePath).canonicalPath
-        val configFromFile = loadSpecmaticConfigOrNull(specmaticConfigPath, explicitlySpecifiedByUser = configFileName != null)
+        val configFromFile = loadSpecmaticConfigOrNull(specmaticConfigPath, explicitlySpecifiedByUser = insightsReportOptions.configPath != null)
         val config = configFromFile.orDefault()
         val pathFromWhichConfigWasLoaded = if (configFromFile != null) {
             specmaticConfigPath

--- a/application/src/main/kotlin/application/TestCommand.kt
+++ b/application/src/main/kotlin/application/TestCommand.kt
@@ -12,7 +12,7 @@ import io.specmatic.core.utilities.newXMLBuilder
 import io.specmatic.core.utilities.xmlToString
 import io.specmatic.license.core.cli.Category
 import io.specmatic.reporter.commands.GitReportDefaultValueProvider
-import io.specmatic.reporter.commands.InsightsReportOptions
+import io.specmatic.reporter.commands.InsightsReportOptionsWithConfig
 import io.specmatic.test.ContractTestSettings
 import io.specmatic.test.DeprecatedArguments
 import io.specmatic.test.SpecmaticJUnitSupport
@@ -53,7 +53,7 @@ private const val DISPLAY_NAME_PREFIX_IN_SYSTEM_OUT_TAG_TEXT = "display-name: "
 class TestCommand(
     private val junitLauncher: Launcher = LauncherFactory.create(),
     @field:ArgGroup(exclusive = false, heading = "%nInsights reporting options:%n")
-    val insightsReportOptions: InsightsReportOptions = InsightsReportOptions()
+    val insightsReportOptions: InsightsReportOptionsWithConfig = InsightsReportOptionsWithConfig()
 ) : Callable<Int> {
     @CommandLine.Parameters(arity = "0..*", description = ["Contract file paths"])
     var contractPaths: List<String>? = null
@@ -102,9 +102,6 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
     @Option(names = ["--junitReportDir"], description = ["Create junit xml reports in this directory"])
     var junitReportDirName: String? = null
 
-    @Option(names = ["--config"], description = ["Configuration file name ($APPLICATION_NAME_LOWER_CASE.json by default)"])
-    var configFileName: String? = null
-
     @Option(names = ["--debug"], description = ["Debug logs"])
     var verboseMode: Boolean? = null
 
@@ -135,9 +132,9 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
     lateinit var commandSpec: CommandSpec
 
     private val specmaticConfig: SpecmaticConfig by lazy(LazyThreadSafetyMode.NONE) {
-        configFileName?.let { Configuration.configFilePath = it }
-        val resolvedConfigPath = configFileName ?: Configuration.configFilePath
-        loadSpecmaticConfigOrNull(resolvedConfigPath, explicitlySpecifiedByUser = configFileName != null).orDefault()
+        insightsReportOptions.configPath?.let { Configuration.configFilePath = it }
+        val resolvedConfigPath = insightsReportOptions.configPath ?: Configuration.configFilePath
+        loadSpecmaticConfigOrNull(resolvedConfigPath, explicitlySpecifiedByUser = insightsReportOptions.configPath != null).orDefault()
     }
 
     override fun call(): Int = try {
@@ -237,7 +234,7 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
             reportBaseDirectory = resolvedJunitReportDir(),
             filter = filter.takeIf(::isNotNullOrBlank),
             testBaseURL = testBaseURL.takeIf(::isNotNullOrBlank),
-            configFile = configFileName.takeIf(::isNotNullOrBlank),
+            configFile = insightsReportOptions.configPath.takeIf(::isNotNullOrBlank),
             timeoutInMilliSeconds = timeoutInMs ?: timeout?.times(1000),
             contractPaths = contractPaths?.joinToString(separator = ",").takeIf(::isNotNullOrBlank),
             insightsReportOptions = insightsReportOptions,

--- a/application/src/test/kotlin/application/StubCommandTest.kt
+++ b/application/src/test/kotlin/application/StubCommandTest.kt
@@ -88,6 +88,13 @@ internal class StubCommandTest {
     }
 
     @Test
+    fun `stores config path in insights report options`() {
+        CommandLine(stubCommand).parseArgs("--config", "specmatic.yaml")
+
+        assertThat(stubCommand.insightsReportOptions.configPath).isEqualTo("specmatic.yaml")
+    }
+
+    @Test
     fun `should attempt to start a HTTP stub`(@TempDir tempDir: File) {
         val contractPath = osAgnosticPath("${tempDir.path}/contract.$CONTRACT_EXTENSION")
         val contract = """

--- a/core/src/main/kotlin/io/specmatic/core/report/ReportGenerator.kt
+++ b/core/src/main/kotlin/io/specmatic/core/report/ReportGenerator.kt
@@ -1,8 +1,11 @@
 package io.specmatic.core.report
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.specmatic.core.config.toResolvedSpecmaticConfigMap
 import io.specmatic.core.getConfigFilePath
+import io.specmatic.core.loadSpecmaticConfigOrNull
 import io.specmatic.core.log.consoleLog
+import io.specmatic.reporter.ReportConfig
 import io.specmatic.reporter.ReportTracker
 import io.specmatic.reporter.RawReportType
 import io.specmatic.reporter.commands.InsightsReportOptions
@@ -46,7 +49,7 @@ object ReportGenerator {
             toolName = toolName
         )
 
-        ReportTracker.instance.send(report, reportType, insightsReportOptions)
+        ReportTracker.instance.send(report, reportType, insightsReportOptions, rawReportConfig())
         ReportProvider.generateCtrfReport(report, reportDir)
         ReportProvider.generateHtmlReport(report, reportDir, specmaticConfigAsMap())
     }
@@ -77,7 +80,7 @@ object ReportGenerator {
             extra = extra,
         )
 
-        ReportTracker.instance.send(report, RawReportType.BCC, insightsReportOptions)
+        ReportTracker.instance.send(report, RawReportType.BCC, insightsReportOptions, rawReportConfig())
         ReportProvider.generateCtrfReport(report, reportDir)
         ReportProvider.generateHtmlReport(report, reportDir, specmaticConfigAsMap())
         return report
@@ -89,6 +92,12 @@ object ReportGenerator {
         } catch(_: Throwable) {
             emptyMap()
         }
+    }
+
+    internal fun rawReportConfig(): ReportConfig {
+        val configPath = getConfigFilePath()
+        val config = loadSpecmaticConfigOrNull(configPath) ?: return ReportConfig()
+        return ReportConfig(configPath, ObjectMapper().writeValueAsString(config))
     }
 
     private fun isCoverageReportSpecificationsValid(

--- a/core/src/test/kotlin/io/specmatic/core/report/ReportGeneratorTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/report/ReportGeneratorTest.kt
@@ -1,5 +1,6 @@
 package io.specmatic.core.report
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.specmatic.core.utilities.Flags.Companion.CONFIG_FILE_PATH
 import io.specmatic.core.utilities.Flags.Companion.using
 import org.assertj.core.api.Assertions.assertThat
@@ -12,6 +13,18 @@ import java.io.File
 import java.util.stream.Stream
 
 class ReportGeneratorTest {
+    @Test
+    fun `raw report config returns loaded config as JSON`(@TempDir tempDir: File) {
+        val configFile = tempDir.resolve("specmatic.yaml").apply { writeText("version: 2") }
+
+        val config = using(CONFIG_FILE_PATH to configFile.canonicalPath) {
+            ReportGenerator.rawReportConfig()
+        }
+
+        assertThat(config.path).isEqualTo(configFile.canonicalPath)
+        assertThat(ObjectMapper().readTree(config.json)["version"].asInt()).isEqualTo(2)
+    }
+
     @Test
     fun `specmaticConfigAsMap returns empty map when config file is empty`(@TempDir tempDir: File) {
         val configFile = tempDir.resolve("specmatic.yaml").apply { writeText("") }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 group=io.specmatic
 version=2.53.2
 specmaticGradlePluginVersion=0.15.24
-specmaticReporterVersion=0.3.43
+specmaticReporterVersion=0.3.44
 swaggerParserVersion=2.1.35
 kotlin.daemon.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m
 org.gradle.jvmargs=-Xmx3g -XX:MaxMetaspaceSize=768m


### PR DESCRIPTION
Adds the active Specmatic config to raw report submission metadata and keeps the test/mock CLI config option within Insights reporting options.