### PR TITLE
Restrict OpenAPI Default Responses to Undeclared Statuses

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -1574,8 +1574,14 @@ class OpenApiSpecification(
         return value.toIntOrNull() != null
     }
 
+    private fun String.toSpecmaticResponseStatus(): Int {
+        return if (this == "default") DEFAULT_RESPONSE_CODE else toInt()
+    }
+
     private fun toHttpResponsePatterns(responses: ApiResponses?, collectorContext: CollectorContext, openApiPath: String, httpMethod: String): List<ResponsePatternData> {
         val responsesContext = collectorContext.at("responses")
+        val explicitlyDefinedStatuses = responses.orEmpty().keys.mapNotNull { it.toIntOrNull() }.toSet()
+
         return responses.orEmpty().map { (status, response) ->
             logger.debug("Processing response payload with status $status")
             val statusContext = responsesContext.at(status)
@@ -1600,6 +1606,7 @@ class OpenApiSpecification(
                     responseBasePointer = responseBasePointer,
                     responseUseSitePointer = responseUseSitePointer,
                     responseHeaderPointers = responseHeaderPointers,
+                    explicitlyDefinedStatuses = explicitlyDefinedStatuses,
                 )
             }
         }.flatten()
@@ -1679,6 +1686,7 @@ class OpenApiSpecification(
         collectorContext: CollectorContext,
         responseBasePointer: String,
         responseUseSitePointer: String,
+        explicitlyDefinedStatuses: Set<Int>,
         responseHeaderPointers: Map<String, String> = emptyMap(),
     ): List<ResponsePatternData> {
         val headerExamples =
@@ -1698,7 +1706,8 @@ class OpenApiSpecification(
                         parameterPointers = responseHeaderPointers
                     ),
                     body = NoBodyPattern,
-                    status = status.toIntOrNull() ?: DEFAULT_RESPONSE_CODE,
+                    status = status.toSpecmaticResponseStatus(),
+                    explicitlyDefinedStatuses = explicitlyDefinedStatuses,
                 )
 
             val examples =
@@ -1743,7 +1752,8 @@ class OpenApiSpecification(
                     preferEscapedSoapAction = preferEscapedSoapAction,
                     parameterPointers = responseHeaderPointers
                 ),
-                status = if (status == "default") 1000 else status.toInt(),
+                status = status.toSpecmaticResponseStatus(),
+                explicitlyDefinedStatuses = explicitlyDefinedStatuses,
                 body = when (contentType) {
                     "application/xml" -> {
                         val rawXmlBody = toXMLPattern(mediaType, mediaTypeContext)

--- a/core/src/main/kotlin/io/specmatic/core/BadRequestOrDefault.kt
+++ b/core/src/main/kotlin/io/specmatic/core/BadRequestOrDefault.kt
@@ -18,7 +18,7 @@ class BadRequestOrDefault(val badRequestResponses: Map<Int, List<Scenario>> = em
 
     fun supportsStatus(status: String): Boolean {
         val statusInt = status.toIntOrNull() ?: return false
-        return badRequestResponses.containsKey(statusInt) || defaultResponses.isNotEmpty()
+        return badRequestResponses.containsKey(statusInt) || defaultResponses.any { it.httpResponsePattern.matchesStatus(statusInt) }
     }
 
     fun supportsResponseContentType(contentType: String): Boolean {
@@ -31,11 +31,12 @@ class BadRequestOrDefault(val badRequestResponses: Map<Int, List<Scenario>> = em
     private fun findBestMatchingScenario(httpResponse: HttpResponse): BestEffortMatch? {
         val sameStatus = badRequestResponses[httpResponse.status].orEmpty()
         val otherStatuses = badRequestResponses.filterKeys { it != httpResponse.status }.values.flatten()
+        val matchingDefaultResponses = defaultResponses.filter { it.httpResponsePattern.matchesStatus(httpResponse.status) }
 
         val sameStatusAndContentType = matchByContentType(sameStatus, httpResponse)
         if (sameStatusAndContentType != null) return BestEffortMatch(sameStatusAndContentType)
 
-        val defaultAndContentType = matchByContentType(defaultResponses, httpResponse)
+        val defaultAndContentType = matchByContentType(matchingDefaultResponses, httpResponse)
         if (defaultAndContentType != null) return BestEffortMatch(defaultAndContentType, fromDefault = true)
 
         val sameStatusFirst = sameStatus.firstOrNull()
@@ -44,7 +45,7 @@ class BadRequestOrDefault(val badRequestResponses: Map<Int, List<Scenario>> = em
         val otherStatusAndContentType = matchByContentType(otherStatuses, httpResponse)
         if (otherStatusAndContentType != null) return BestEffortMatch(otherStatusAndContentType)
 
-        val defaultFirst = defaultResponses.firstOrNull()
+        val defaultFirst = matchingDefaultResponses.firstOrNull()
         if (defaultFirst != null) return BestEffortMatch(defaultFirst, fromDefault = true)
 
         val otherStatusFirst = otherStatuses.firstOrNull()

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -1010,7 +1010,7 @@ data class Feature(
         val badRequestResponses = matchingScenarios.filter {
             it.httpResponsePattern.status in 400..499
         }
-        val defaultResponses = matchingScenarios.filter { it.httpResponsePattern.status == DEFAULT_RESPONSE_CODE }
+        val defaultResponses = matchingScenarios.filter { it.isDefaultResponse() }
 
         if (badRequestResponses.isEmpty() && defaultResponses.isEmpty()) return null
         return BadRequestOrDefault(

--- a/core/src/main/kotlin/io/specmatic/core/HttpResponsePattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpResponsePattern.kt
@@ -222,7 +222,7 @@ data class HttpResponsePattern(
 
     fun fixResponse(response: HttpResponse, resolver: Resolver): HttpResponse {
         return response.copy(
-            status = status,
+            status = response.status.takeIf(::matchesStatus) ?: status,
             headers = headersPattern.fixValue(response.headers, resolver.disableOverrideUnexpectedKeyCheck().updateLookupPath(BreadCrumb.RESPONSE.value)),
             body = body.fixValue(response.body, resolver)
         )

--- a/core/src/main/kotlin/io/specmatic/core/HttpResponsePattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpResponsePattern.kt
@@ -14,7 +14,8 @@ const val STATUS_BREAD_CRUMB = "STATUS"
 data class HttpResponsePattern(
     val headersPattern: HttpHeadersPattern = HttpHeadersPattern(),
     val status: Int = 0,
-    val body: Pattern = EmptyStringPattern
+    val body: Pattern = EmptyStringPattern,
+    val explicitlyDefinedStatuses: Set<Int> = emptySet()
 ) {
     constructor(response: HttpResponse) : this(HttpHeadersPattern(response.headers.mapValues { stringToPattern(it.value, it.key) }), response.status, response.body.exactMatchElseType())
 
@@ -68,10 +69,20 @@ data class HttpResponsePattern(
 
     fun matchesMock(response: HttpResponse, resolver: Resolver) = matchesResponse(response, resolver)
 
-    private fun matchStatus(parameters: Pair<HttpResponse, Resolver>): MatchingResult<Pair<HttpResponse, Resolver>> {
-        if(status == DEFAULT_RESPONSE_CODE) return MatchSuccess(parameters)
+    fun withStatus(status: Int): HttpResponsePattern = copy(status = status)
 
+    // explicitlyDefinedStatuses is ambient operation-level context used only while matching a default response.
+    // It is not part of this response pattern's own contract and must not affect structural comparisons.
+    fun withoutExplicitlyDefinedStatuses(): HttpResponsePattern = copy(explicitlyDefinedStatuses = emptySet())
+
+    fun matchesStatus(responseStatus: Int): Boolean {
+        return responseStatus == status ||
+            status == DEFAULT_RESPONSE_CODE && responseStatus !in explicitlyDefinedStatuses
+    }
+
+    private fun matchStatus(parameters: Pair<HttpResponse, Resolver>): MatchingResult<Pair<HttpResponse, Resolver>> {
         val (response, resolver) = parameters
+        if (matchesStatus(response.status)) return MatchSuccess(parameters)
         return when (response.status) {
             status -> MatchSuccess(parameters)
             else -> MatchFailure(mismatchFailure(

--- a/core/src/main/kotlin/io/specmatic/core/HttpResponsePattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpResponsePattern.kt
@@ -83,15 +83,12 @@ data class HttpResponsePattern(
     private fun matchStatus(parameters: Pair<HttpResponse, Resolver>): MatchingResult<Pair<HttpResponse, Resolver>> {
         val (response, resolver) = parameters
         if (matchesStatus(response.status)) return MatchSuccess(parameters)
-        return when (response.status) {
-            status -> MatchSuccess(parameters)
-            else -> MatchFailure(mismatchFailure(
-                expected = "status $status",
-                actual = "status ${response.status}",
-                ruleViolation = OpenApiRuleViolation.STATUS_MISMATCH,
-                mismatchMessages = resolver.mismatchMessages
-            ).copy(breadCrumb = "RESPONSE.STATUS", failureReason = FailureReason.StatusMismatch))
-        }
+        return MatchFailure(mismatchFailure(
+            expected = "status $status",
+            actual = "status ${response.status}",
+            ruleViolation = OpenApiRuleViolation.STATUS_MISMATCH,
+            mismatchMessages = resolver.mismatchMessages
+        ).copy(breadCrumb = "RESPONSE.STATUS", failureReason = FailureReason.StatusMismatch))
     }
 
     private fun matchHeaders(parameters: Pair<HttpResponse, Resolver>): MatchingResult<Triple<HttpResponse, Resolver, List<Result.Failure>>> {

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -195,8 +195,7 @@ data class Scenario(
         httpRequestPattern.requestMatchesIdentityForResponseStatus(responseStatus, httpRequest, resolver)
 
     fun matchesStatusAndContentType(httpResponse: HttpResponse): Boolean {
-        if (this.status !in setOf(DEFAULT_RESPONSE_CODE, httpResponse.status)) return false
-        return matchesContentType(httpResponse)
+        return httpResponsePattern.matchesStatus(httpResponse.status) && matchesContentType(httpResponse)
     }
 
     fun matchesContentType(httpResponse: HttpResponse): Boolean {
@@ -344,7 +343,7 @@ data class Scenario(
         httpRequest: HttpRequest, httpResponse: HttpResponse, mismatchMessages: MismatchMessages,
         flagsBased: FlagsBased, isPartial: Boolean = false, disableOverrideKeyCheck: Boolean = true
     ): Result {
-        if (httpResponsePattern.status == DEFAULT_RESPONSE_CODE || httpResponse.status != httpResponsePattern.status) {
+        if (!httpResponsePattern.matchesStatus(httpResponse.status)) {
             return Result.Failure(
                 message = "",
                 breadCrumb = "STATUS",
@@ -699,7 +698,7 @@ data class Scenario(
             if (requestMatchResult is Result.Failure)
                 requestMatchResult.updateScenario(this)
 
-            if (requestMatchResult is Result.Failure && response.status != httpResponsePattern.status)
+            if (requestMatchResult is Result.Failure && !httpResponsePattern.matchesStatus(response.status))
                 return Result.Failure(
                     cause = requestMatchResult,
                     failureReason = FailureReason.RequestMismatchButStatusAlsoWrong

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -14,7 +14,6 @@ import io.specmatic.core.utilities.Reasoning
 import io.specmatic.core.utilities.capitalizeFirstChar
 import io.specmatic.core.utilities.nullOrExceptionString
 import io.specmatic.core.value.JSONObjectValue
-import io.specmatic.core.value.Value
 import io.specmatic.license.core.SpecmaticProtocol
 import io.specmatic.mock.ScenarioStub
 import io.specmatic.reporter.internal.dto.operation.APIOperation
@@ -407,10 +406,16 @@ data class Scenario(
         }
 
         return try {
-            httpResponsePattern.matchesResponse(httpResponse, resolver).updateScenario(this)
+            updatedDefaultResponsePatternForExample(resolver).matchesResponse(httpResponse, resolver).updateScenario(this)
         } catch (exception: Throwable) {
             Result.Failure("Exception: ${exception.message}")
         }
+    }
+
+    private fun updatedDefaultResponsePatternForExample(resolver: Resolver): HttpResponsePattern {
+        if (resolver.mockMode || !isDefaultResponse()) return httpResponsePattern
+        val exampleResponseStatus = exampleRow?.responseExample?.status?.takeIf { it != 0 } ?: return httpResponsePattern
+        return httpResponsePattern.withStatus(exampleResponseStatus)
     }
 
     fun matches(httpRequest: HttpRequest, resolver: Resolver): Result {

--- a/core/src/main/kotlin/io/specmatic/core/ScenarioFingerprint.kt
+++ b/core/src/main/kotlin/io/specmatic/core/ScenarioFingerprint.kt
@@ -26,7 +26,9 @@ data class ScenarioFingerprint(
             httpRequestPattern = scenario.httpRequestPattern.let { request ->
                 request.copy(httpPathPattern = request.httpPathPattern?.withoutOtherPathPatterns())
             },
-            httpResponsePattern = scenario.httpResponsePattern,
+            // Drop the operation-level status context so adding another response status does not
+            // mark existing response scenarios as changed.
+            httpResponsePattern = scenario.httpResponsePattern.withoutExplicitlyDefinedStatuses(),
         )
 
         fun keyOf(scenario: Scenario): Key = Key(

--- a/core/src/main/kotlin/io/specmatic/core/log/HttpLogMessage.kt
+++ b/core/src/main/kotlin/io/specmatic/core/log/HttpLogMessage.kt
@@ -178,7 +178,7 @@ data class HttpLogMessage(
         return when {
             result != null -> result.testResult()
             this.matchedAnExample -> TestResult.Success
-            response?.status == scenario.status -> TestResult.Success
+            response?.let { scenario.httpResponsePattern.matchesStatus(it.status) } == true -> TestResult.Success
             else -> TestResult.Failed
         }
     }
@@ -189,7 +189,7 @@ data class HttpLogMessage(
         return when {
             this.isInlineExample -> "Request Matched Inline Example: ${this.resolvedExampleName}"
             this.isExternalExample -> "Request Matched External Example: ${this.resolvedExampleName}"
-            scenario != null && response?.status == scenario.status -> "Request Matched Contract ${scenario.defaultAPIDescription}"
+            scenario != null && response?.let { scenario.httpResponsePattern.matchesStatus(it.status) } == true -> "Request Matched Contract ${scenario.defaultAPIDescription}"
             this.exception != null -> "Invalid Request\n${exception?.let(::exceptionCauseMessage)}"
             else -> response?.body?.toStringLiteral() ?: "Request Didn't Match Contract"
         }

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -560,6 +560,7 @@ class HttpStub(
             testType = STUB_TEST_TYPE,
             actualResponseStatus = httpResponse.status,
             actualResponseContentType = httpResponse.normalizedContentType(),
+            matchesResponseIdentifiers = httpLogMessage.scenario?.matchesStatusAndContentType(httpResponse) ?: false,
             operations = setOf(
                 OpenAPIOperation(
                     path = path,

--- a/core/src/test/kotlin/HttpLogMessageTest.kt
+++ b/core/src/test/kotlin/HttpLogMessageTest.kt
@@ -1,3 +1,4 @@
+import io.specmatic.core.DEFAULT_RESPONSE_CODE
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpResponse
 import io.specmatic.core.parseContractFileToFeature
@@ -6,6 +7,7 @@ import io.specmatic.core.log.HttpLogMessage
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.NumberValue
 import io.specmatic.core.value.StringValue
+import io.specmatic.reporter.model.TestResult
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
@@ -124,5 +126,25 @@ internal class HttpLogMessageTest {
         )
 
         assertThat(message.toDetails()).isEqualTo("Request Matched External Example: examples/example.json")
+    }
+
+    @ParameterizedTest
+    @CsvSource("200, false", "400, true")
+    fun `toResult and toDetails should use the default response status only for undeclared statuses`(responseStatus: Int, expectedMatch: Boolean) {
+        val defaultScenario = parseContractFileToFeature(File("src/test/resources/openapi/default_response_status_selection/api.yaml"))
+            .scenarios
+            .single { it.status == DEFAULT_RESPONSE_CODE }
+
+        val message = HttpLogMessage(
+            scenario = defaultScenario,
+            response = HttpResponse(status = responseStatus),
+            request = HttpRequest("GET", "/items?kind=fallback"),
+        )
+
+        assertThat(message.toResult()).isEqualTo(if (expectedMatch) TestResult.Success else TestResult.Failed)
+        assertThat(message.toDetails()).isEqualTo(
+            if (expectedMatch) "Request Matched Contract ${defaultScenario.defaultAPIDescription}"
+            else ""
+        )
     }
 }

--- a/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
+++ b/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
@@ -47,6 +47,7 @@ private val XML_ONEOF_CONTRACT = XML_ONEOF_RESOURCE_DIR.resolve("api.yaml")
 private val XML_ONEOF_CONTRACT_WITH_INLINE_EXAMPLES = XML_ONEOF_RESOURCE_DIR.resolve("api_with_inline_examples.yaml")
 private val XML_ONEOF_EXTERNAL_EXAMPLES_DIR = XML_ONEOF_RESOURCE_DIR.resolve("api_examples")
 private val XML_ONEOF_INVALID_INVOICE_EXAMPLE = XML_ONEOF_RESOURCE_DIR.resolve("invalid_examples/invoice.json")
+private val DEFAULT_RESPONSE_STATUS_SELECTION_SPEC = File("src/test/resources/openapi/default_response_status_selection/api.yaml")
 
 class LoadTestsFromExternalisedFiles {
     @TempDir
@@ -55,6 +56,68 @@ class LoadTestsFromExternalisedFiles {
     @BeforeEach
     fun setup() {
         unmockkAll()
+    }
+
+    @Nested
+    inner class DefaultResponseStatusSelection {
+        @Test
+        fun `external examples are loaded, generated tests execute, and mock responses retain their statuses`() {
+            val feature = OpenApiSpecification.fromFile(DEFAULT_RESPONSE_STATUS_SELECTION_SPEC.canonicalPath)
+                .toFeature()
+                .loadExternalisedExamples()
+
+            val scenariosByStatus = feature.scenarios.associateBy { it.status }
+            assertThat(scenariosByStatus.keys).isEqualTo(setOf(200, DEFAULT_RESPONSE_CODE))
+            assertThat(scenariosByStatus.getValue(200).examples.flatMap { it.rows }.map { it.name })
+                .isEqualTo(listOf("explicit"))
+            assertThat(scenariosByStatus.getValue(DEFAULT_RESPONSE_CODE).examples.flatMap { it.rows }.map { it.name })
+                .isEqualTo(listOf("fallback"))
+
+            feature.validateExamplesOrException()
+            val generatedResults = feature.enableGenerativeTesting().executeTests(object : TestExecutor {
+                override fun execute(request: HttpRequest): HttpResponse {
+                    return if (request.headers["Specmatic-Response-Code"] == "200") {
+                        HttpResponse(
+                            status = 200,
+                            body = parsedJSONObject("""{"id": 2}"""),
+                            headers = mapOf(CONTENT_TYPE to "application/json")
+                        )
+                    } else {
+                        HttpResponse(
+                            status = 400,
+                            headers = mapOf(CONTENT_TYPE to "application/json"),
+                            body = parsedJSONObject("""{"message": "unavailable"}"""),
+                        )
+                    }
+                }
+            })
+
+            assertThat(generatedResults.failureCount).withFailMessage(generatedResults.report()).isEqualTo(0)
+            assertThat(generatedResults.successCount).isEqualTo(3)
+
+            val externalExamples = ExampleModule(SpecmaticConfig()).getExamplesFor(DEFAULT_RESPONSE_STATUS_SELECTION_SPEC)
+            HttpStub(feature = feature, port = freePort(), strictMode = true, scenarioStubs = externalExamples.map { it.scenarioStub }).use { stub ->
+                val responses = listOf("explicit", "fallback").map { kind ->
+                    stub.client.execute(
+                        request = HttpRequest(
+                            method = "GET",
+                            path = "/items",
+                            queryParams = QueryParameters(mapOf("kind" to kind))
+                        )
+                    )
+                }
+
+                assertThat(responses.map { it.status }).isEqualTo(listOf(200, 400))
+                assertThat(responses.map { it.body }).isEqualTo(
+                    listOf(
+                        parsedJSONObject("""{"id": 1}"""),
+                        parsedJSONObject("""{"message": "unavailable"}""")
+                    )
+                )
+                assertThat(stub.ctrfTestResultRecords().map { it.matchesResponseIdentifiers })
+                    .containsExactly(true, true)
+            }
+        }
     }
 
     @Test

--- a/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
+++ b/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
@@ -33,6 +33,7 @@ import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.EnumSource
 import java.io.File
 import java.math.BigDecimal
@@ -117,6 +118,24 @@ class LoadTestsFromExternalisedFiles {
                 assertThat(stub.ctrfTestResultRecords().map { it.matchesResponseIdentifiers })
                     .containsExactly(true, true)
             }
+        }
+
+        @ParameterizedTest
+        @CsvSource("400, 0, 1", "401, 1, 0")
+        fun `default response external example should require its response status`(actualStatus: Int, expectedFailureCount: Int, expectedSuccessCount: Int) {
+            val feature = OpenApiSpecification.fromFile(DEFAULT_RESPONSE_STATUS_SELECTION_SPEC.canonicalPath)
+                .toFeature()
+                .loadExternalisedExamples()
+
+            val defaultScenario = feature.scenarios.single { it.status == DEFAULT_RESPONSE_CODE }
+            val exampleResponse = requireNotNull(defaultScenario.examples.single().rows.single().responseExample)
+            val defaultFeature = feature.copy(scenarios = listOf(defaultScenario))
+            val results = defaultFeature.executeTests(object : TestExecutor {
+                override fun execute(request: HttpRequest): HttpResponse = exampleResponse.copy(status = actualStatus)
+            })
+
+            assertThat(results.failureCount).withFailMessage(results.report()).isEqualTo(expectedFailureCount)
+            assertThat(results.successCount).isEqualTo(expectedSuccessCount)
         }
     }
 

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationParseTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationParseTest.kt
@@ -3,6 +3,7 @@ package io.specmatic.conversions
 import integration_tests.OpenApiVersion
 import io.specmatic.core.Feature
 import io.specmatic.core.CONTENT_TYPE
+import io.specmatic.core.DEFAULT_RESPONSE_CODE
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpResponse
 import io.specmatic.core.IssueSeverity
@@ -57,6 +58,32 @@ import java.math.BigDecimal
 import java.util.stream.Stream
 
 class OpenApiSpecificationParseTest {
+    @Nested
+    inner class ResponseStatusPatterns {
+        @ParameterizedTest
+        @ValueSource(strings = ["3.0.0", "3.1.0"])
+        fun `response patterns retain all explicitly defined statuses for an operation`(openApiVersion: String) {
+            val specification = loadFixture("openapi/default_response_status_selection/status_patterns.yaml")
+                .replace("openapi: 3.0.0", "openapi: $openApiVersion")
+
+            val feature = OpenApiSpecification.fromYAML(specification, "").toFeature()
+            val scenariosByStatus = feature.scenarios.associateBy { it.httpResponsePattern.status }
+            assertThat(scenariosByStatus.keys).isEqualTo(setOf(200, 201, DEFAULT_RESPONSE_CODE))
+            assertThat(scenariosByStatus.mapValues { it.value.httpResponsePattern.explicitlyDefinedStatuses })
+                .isEqualTo(
+                    mapOf(
+                        200 to setOf(200, 201),
+                        201 to setOf(200, 201),
+                        DEFAULT_RESPONSE_CODE to setOf(200, 201),
+                    )
+                )
+
+            val badRequestOrDefault = feature.getBadRequestsOrDefault(scenariosByStatus.getValue(200))!!
+            assertThat(badRequestOrDefault.supportsStatus("200")).isFalse()
+            assertThat(badRequestOrDefault.supportsStatus("202")).isTrue()
+        }
+    }
+
     @Test
     fun `unsupported enum type preserves null string fallback`() {
         val specification = """

--- a/core/src/test/kotlin/io/specmatic/core/BadRequestOrDefaultTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/BadRequestOrDefaultTest.kt
@@ -5,6 +5,8 @@ import io.specmatic.reporter.model.SpecType
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 
 class BadRequestOrDefaultTest {
     @Nested
@@ -25,6 +27,22 @@ class BadRequestOrDefaultTest {
         fun `should return false when status absent and no default response exists`() {
             val badRequestOrDefault = BadRequestOrDefault(badRequestResponses = mapOf(401 to listOf(scenario(status = 401, contentType = "application/json"))))
             assertThat(badRequestOrDefault.supportsStatus("400")).isFalse()
+        }
+
+        @ParameterizedTest
+        @CsvSource("400, false", "401, true")
+        fun `default response should only support undeclared statuses`(status: String, expected: Boolean) {
+            val badRequestOrDefault = BadRequestOrDefault(
+                defaultResponses = listOf(
+                    scenario(
+                        status = DEFAULT_RESPONSE_CODE,
+                        contentType = "application/json",
+                        explicitlyDefinedStatuses = setOf(400),
+                    )
+                )
+            )
+
+            assertThat(badRequestOrDefault.supportsStatus(status)).isEqualTo(expected)
         }
     }
 
@@ -84,6 +102,16 @@ class BadRequestOrDefaultTest {
             assertThat(result).isInstanceOf(Result.Success::class.java)
             assertThat((result as Result.Success).partialSuccessMessage)
                 .isEqualTo("The response matched the default response, but the contract should declare a 499 response.")
+        }
+
+        @Test
+        fun `should not select default response for an explicitly defined status`() {
+            val defaultScenario = scenario(status = DEFAULT_RESPONSE_CODE, contentType = "application/json", explicitlyDefinedStatuses = setOf(400))
+            val badRequestOrDefault = BadRequestOrDefault(defaultResponses = listOf(defaultScenario))
+            val result = badRequestOrDefault.matches(httpResponse(status = 400, contentType = "application/json"), Resolver())
+            assertThat(result).isInstanceOf(Result.Failure::class.java)
+            assertThat((result as Result.Failure).message)
+                .isEqualTo("No matching or default response found for status 400.")
         }
 
         @Test
@@ -261,13 +289,22 @@ class BadRequestOrDefaultTest {
         }
     }
 
-    private fun scenario(status: Int, contentType: String, name: String = "scenario-$status") =
+    private fun scenario(
+        status: Int,
+        contentType: String,
+        name: String = "scenario-$status",
+        explicitlyDefinedStatuses: Set<Int> = emptySet()
+    ) =
         Scenario(
             name = name,
             specType = SpecType.OPENAPI,
             protocol = SpecmaticProtocol.HTTP,
             httpRequestPattern = HttpRequestPattern(),
-            httpResponsePattern = HttpResponsePattern(status = status, headersPattern = HttpHeadersPattern(contentType = contentType)),
+            httpResponsePattern = HttpResponsePattern(
+                status = status,
+                explicitlyDefinedStatuses = explicitlyDefinedStatuses,
+                headersPattern = HttpHeadersPattern(contentType = contentType),
+            ),
         )
 
     private fun httpResponse(status: Int, contentType: String): HttpResponse {

--- a/core/src/test/kotlin/io/specmatic/core/HttpResponsePatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpResponsePatternTest.kt
@@ -9,6 +9,8 @@ import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.StringValue
 import io.specmatic.core.value.XMLNode
 import org.junit.jupiter.api.Nested
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 
 internal class HttpResponsePatternTest {
     @Test
@@ -229,6 +231,25 @@ internal class HttpResponsePatternTest {
 
         assertThat(result).isInstanceOf(Result.Failure::class.java)
         assertThat(result.reportString()).contains(">> RESPONSE.STATUS")
+    }
+
+    @Nested
+    inner class DefaultStatusMatching {
+        @ParameterizedTest
+        @CsvSource("200, false", "201, true")
+        fun `default response should match only statuses not explicitly defined`(responseStatus: Int, expected: Boolean) {
+            val pattern = HttpResponsePattern(status = DEFAULT_RESPONSE_CODE, explicitlyDefinedStatuses = setOf(200))
+            assertThat(pattern.matchesStatus(responseStatus)).isEqualTo(expected)
+        }
+
+        @Test
+        fun `default response should not match an explicitly defined status`() {
+            val pattern = HttpResponsePattern(status = DEFAULT_RESPONSE_CODE, explicitlyDefinedStatuses = setOf(200))
+            assertThat(pattern.matchesStatusAndContentType(HttpResponse(status = 200), Resolver()))
+                .isInstanceOf(Result.Failure::class.java)
+            assertThat(pattern.matchesStatusAndContentType(HttpResponse(status = 201), Resolver()))
+                .isInstanceOf(Result.Success::class.java)
+        }
     }
 
     @Nested

--- a/core/src/test/kotlin/io/specmatic/core/HttpResponsePatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpResponsePatternTest.kt
@@ -235,6 +235,14 @@ internal class HttpResponsePatternTest {
 
     @Nested
     inner class DefaultStatusMatching {
+        @Test
+        fun `withStatus should return a copy with only the status changed`() {
+            val pattern = HttpResponsePattern(status = DEFAULT_RESPONSE_CODE, body = StringPattern(), explicitlyDefinedStatuses = setOf(200))
+            val updatedPattern = pattern.withStatus(400)
+            assertThat(updatedPattern).isEqualTo(pattern.copy(status = 400))
+            assertThat(pattern.status).isEqualTo(DEFAULT_RESPONSE_CODE)
+        }
+
         @ParameterizedTest
         @CsvSource("200, false", "201, true")
         fun `default response should match only statuses not explicitly defined`(responseStatus: Int, expected: Boolean) {

--- a/core/src/test/kotlin/io/specmatic/core/HttpResponsePatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpResponsePatternTest.kt
@@ -258,6 +258,14 @@ internal class HttpResponsePatternTest {
             assertThat(pattern.matchesStatusAndContentType(HttpResponse(status = 201), Resolver()))
                 .isInstanceOf(Result.Success::class.java)
         }
+
+        @ParameterizedTest
+        @CsvSource("201, 201", "200, 1000")
+        fun `fixResponse should preserve a response status only when the default pattern matches`(responseStatus: Int, expectedStatus: Int) {
+            val pattern = HttpResponsePattern(status = DEFAULT_RESPONSE_CODE, explicitlyDefinedStatuses = setOf(200))
+            val fixedResponse = pattern.fixResponse(HttpResponse(status = responseStatus), Resolver())
+            assertThat(fixedResponse.status).isEqualTo(expectedStatus)
+        }
     }
 
     @Nested

--- a/core/src/test/kotlin/io/specmatic/core/ScenarioFingerprintTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ScenarioFingerprintTest.kt
@@ -76,7 +76,8 @@ class ScenarioFingerprintTest {
                 httpPathPattern = scenario.httpRequestPattern.httpPathPattern?.withoutOtherPathPatterns()
             )
         )
-        assertThat(fingerprint.httpResponsePattern).isEqualTo(scenario.httpResponsePattern)
+        assertThat(fingerprint.httpResponsePattern)
+            .isEqualTo(scenario.httpResponsePattern.withoutExplicitlyDefinedStatuses())
     }
 
     @Test
@@ -142,6 +143,34 @@ class ScenarioFingerprintTest {
 
         assertThat(ScenarioFingerprint.from(original))
             .isNotEqualTo(ScenarioFingerprint.from(differentStatus))
+    }
+
+    @Test
+    fun `fingerprint ignores statuses explicitly defined for the whole operation`() {
+        val oldSpec = """
+            openapi: 3.0.0
+            info:
+              title: Orders API
+              version: 1.0.0
+            paths:
+              /orders:
+                get:
+                  responses:
+                    '200':
+                      description: ok
+        """.trimIndent()
+
+        val newSpec = oldSpec.applyJsonPatch("""
+            - op: add
+              path: /paths/~1orders/get/responses/201
+              value:
+                description: created
+        """.trimIndent())
+
+        val oldResponse = scenariosFrom(oldSpec).single()
+        val newResponse = scenariosFrom(newSpec).single { it.status == 200 }
+        assertThat(ScenarioFingerprint.from(oldResponse))
+            .isEqualTo(ScenarioFingerprint.from(newResponse))
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/core/ScenarioTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ScenarioTest.kt
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.MethodSource
 import org.junit.jupiter.params.provider.ValueSource
 import java.util.function.Consumer
@@ -37,6 +38,42 @@ import io.specmatic.test.TestSkipReason
 import org.assertj.core.api.Assertions.assertThat
 
 class ScenarioTest {
+
+    @Nested
+    inner class ResponseStatusMatching {
+        @ParameterizedTest
+        @CsvSource("200, false", "201, true")
+        fun `scenario status matching should respect explicitly defined statuses`(responseStatus: Int, expected: Boolean) {
+            val scenario = scenarioWithResponseStatus(status = DEFAULT_RESPONSE_CODE, explicitlyDefinedStatuses = setOf(200))
+            assertThat(scenario.matchesStatusAndContentType(HttpResponse(status = responseStatus))).isEqualTo(expected)
+        }
+
+        @ParameterizedTest
+        @CsvSource("200, false", "201, true")
+        fun `full request response matching should respect explicitly defined statuses`(responseStatus: Int, expected: Boolean) {
+            val scenario = scenarioWithResponseStatus(status = DEFAULT_RESPONSE_CODE, explicitlyDefinedStatuses = setOf(200))
+            val result = scenario.matches(
+                flagsBased = DefaultStrategies,
+                mismatchMessages = DefaultMismatchMessages,
+                httpResponse = HttpResponse(status = responseStatus),
+                httpRequest = HttpRequest(method = "GET", path = "/items"),
+            )
+
+            assertThat(result).isInstanceOf(if (expected) Result.Success::class.java else Result.Failure::class.java)
+        }
+
+        @ParameterizedTest
+        @CsvSource("200, RequestMismatchButStatusAlsoWrong", "201, null")
+        fun `mock matching should use the centralized status predicate when request also mismatches`(responseStatus: Int, expectedFailureReason: String) {
+            val scenario = scenarioWithResponseStatus(status = DEFAULT_RESPONSE_CODE, explicitlyDefinedStatuses = setOf(200))
+            val result = scenario.matchesMock(
+                request = HttpRequest(method = "GET", path = "/other-items"),
+                response = HttpResponse(status = responseStatus),
+            ) as Result.Failure
+
+            assertThat(result.failureReason?.name).isEqualTo(expectedFailureReason.takeUnless { it == "null" })
+        }
+    }
 
     @Test
     fun `operation is derived through the scenario operation provider`() {
@@ -104,6 +141,23 @@ class ScenarioTest {
             assertThat(fixedRequest).isEqualTo(expectedRequest)
             assertThat(fixedResponse).isEqualTo(response)
         }
+    }
+
+    @Suppress("SameParameterValue")
+    private fun scenarioWithResponseStatus(status: Int, explicitlyDefinedStatuses: Set<Int>): Scenario {
+        return Scenario(
+            name = "GET /items",
+            httpRequestPattern = HttpRequestPattern(
+                method = "GET",
+                httpPathPattern = buildHttpPathPattern("/items"),
+            ),
+            httpResponsePattern = HttpResponsePattern(
+                status = status,
+                explicitlyDefinedStatuses = explicitlyDefinedStatuses,
+            ),
+            protocol = SpecmaticProtocol.HTTP,
+            specType = SpecType.OPENAPI,
+        )
     }
 
     companion object {

--- a/core/src/test/kotlin/io/specmatic/core/ScenarioTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ScenarioTest.kt
@@ -42,6 +42,33 @@ class ScenarioTest {
     @Nested
     inner class ResponseStatusMatching {
         @ParameterizedTest
+        @CsvSource("400, true", "401, false")
+        fun `default response should match the status from its response example`(responseStatus: Int, expected: Boolean) {
+            val scenario = scenarioWithResponseStatus(
+                status = DEFAULT_RESPONSE_CODE,
+                explicitlyDefinedStatuses = emptySet(),
+            ).copy(exampleRow = Row(responseExample = HttpResponse(status = 400)))
+
+            val result = scenario.matches(HttpResponse(status = responseStatus))
+            assertThat(result.isSuccess()).isEqualTo(expected)
+        }
+
+        @Test
+        fun `mock matching should retain default response status matching when an example exists`() {
+            val scenario = scenarioWithResponseStatus(
+                status = DEFAULT_RESPONSE_CODE,
+                explicitlyDefinedStatuses = emptySet(),
+            ).copy(exampleRow = Row(responseExample = HttpResponse(status = 400)))
+
+            val result = scenario.matchesMock(
+                request = HttpRequest(method = "GET", path = "/items"),
+                response = HttpResponse(status = 401),
+            )
+
+            assertThat(result).isInstanceOf(Result.Success::class.java)
+        }
+
+        @ParameterizedTest
         @CsvSource("200, false", "201, true")
         fun `scenario status matching should respect explicitly defined statuses`(responseStatus: Int, expected: Boolean) {
             val scenario = scenarioWithResponseStatus(status = DEFAULT_RESPONSE_CODE, explicitlyDefinedStatuses = setOf(200))

--- a/core/src/test/kotlin/io/specmatic/test/ScenarioAsTestTest.kt
+++ b/core/src/test/kotlin/io/specmatic/test/ScenarioAsTestTest.kt
@@ -6,6 +6,7 @@ import io.mockk.mockkObject
 import io.mockk.unmockkObject
 import io.mockk.verify
 import io.specmatic.core.DEFAULT_RESPONSE_CODE
+import io.specmatic.core.FailureReason
 import io.specmatic.core.Feature
 import io.specmatic.core.utilities.Decision
 import io.specmatic.core.utilities.Reasoning
@@ -59,12 +60,48 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.ValueSource
 import java.net.ServerSocket
 import java.net.URLClassLoader
 import java.nio.file.Files
 
 class ScenarioAsTestTest {
+
+    @Nested
+    inner class DefaultResponseExampleStatus {
+        @ParameterizedTest
+        @CsvSource("400, true", "401, false")
+        fun `default response example should require its response status`(actualStatus: Int, expectedSuccess: Boolean) {
+            val testScenario = scenario(
+                exampleRow = Row(responseExample = HttpResponse(status = 400)),
+                status = DEFAULT_RESPONSE_CODE,
+            )
+
+            val result = scenarioAsTest(testScenario)
+                .runTest(fixedResponseExecutor(status = actualStatus, body = "anything"))
+                .result
+
+            assertThat(result.isSuccess()).isEqualTo(expectedSuccess)
+            if (!expectedSuccess) {
+                assertThat((result as Result.Failure).failureReason).isEqualTo(FailureReason.StatusMismatch)
+            }
+        }
+
+        @Test
+        fun `negative tests should continue to use default response fallback matching`() {
+            val negativeScenario = negativeScenario(
+                expectedResponses = mapOf(400 to listOf(expectationScenario(status = 400, contentType = "text/plain"))),
+                defaultResponses = listOf(expectationScenario(status = DEFAULT_RESPONSE_CODE, contentType = "application/xml")),
+            )
+
+            val result = scenarioAsTest(negativeScenario)
+                .runTest(fixedResponseExecutor(status = 401, body = "response", headers = mapOf("Content-Type" to "application/xml")))
+                .result
+
+            assertThat(result).isInstanceOf(Result.Success::class.java)
+        }
+    }
 
     @Nested
     inner class FixtureExecutorTest {

--- a/core/src/test/resources/openapi/default_response_status_selection/api.yaml
+++ b/core/src/test/resources/openapi/default_response_status_selection/api.yaml
@@ -1,0 +1,34 @@
+openapi: 3.0.0
+info:
+  title: Response status selection
+  version: 1.0.0
+paths:
+  /items:
+    get:
+      parameters:
+        - name: kind
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [id]
+                properties:
+                  id:
+                    type: integer
+        default:
+          description: Other response
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [message]
+                properties:
+                  message:
+                    type: string

--- a/core/src/test/resources/openapi/default_response_status_selection/api_examples/explicit.json
+++ b/core/src/test/resources/openapi/default_response_status_selection/api_examples/explicit.json
@@ -1,0 +1,11 @@
+{
+  "http-request": {
+    "method": "GET",
+    "path": "/items",
+    "query": { "kind": "explicit" }
+  },
+  "http-response": {
+    "status": 200,
+    "body": { "id": 1 }
+  }
+}

--- a/core/src/test/resources/openapi/default_response_status_selection/api_examples/fallback.json
+++ b/core/src/test/resources/openapi/default_response_status_selection/api_examples/fallback.json
@@ -1,0 +1,11 @@
+{
+  "http-request": {
+    "method": "GET",
+    "path": "/items",
+    "query": { "kind": "fallback" }
+  },
+  "http-response": {
+    "status": 400,
+    "body": { "message": "unavailable" }
+  }
+}

--- a/core/src/test/resources/openapi/default_response_status_selection/status_patterns.yaml
+++ b/core/src/test/resources/openapi/default_response_status_selection/status_patterns.yaml
@@ -1,0 +1,22 @@
+openapi: 3.0.0
+info:
+  title: Response status matching
+  version: 1.0.0
+paths:
+  /items:
+    get:
+      responses:
+        '200':
+          description: OK
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: string
+        default:
+          description: Other response
+          content:
+            application/json:
+              schema:
+                type: string


### PR DESCRIPTION
**What**:

- Store explicitly defined statuses on response patterns.
- Prevent default responses from matching explicitly defined statuses.
- Fix example loading and validation for default response statuses.
- Require positive tests generated from default-response examples to match the example’s response status.

**Why**:

OpenAPI `default` responses were treated as matching every status, including statuses explicitly declared by the same operation. This caused incorrect response selection, example validation, and contract-test results.

**How**:

- Capture numeric response statuses at the operation level during OpenAPI parsing.
- Centralize status matching in `HttpResponsePattern`.
- Apply the matcher across scenario, mock, and fallback response selection.
- Match default-response example statuses through the normal `Scenario.matches` contract-test path.
- Preserve wildcard behavior for negative flows, mock matching, and scenario-less reporting records.
- Add resource-backed specifications and external examples for end-to-end coverage.

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (N/A)
- [ ] Sample Project added/updated (N/A)
- [ ] Demo video (N/A)
- [ ] Article on Website (N/A)
- [ ] Roadmap updated (N/A)
- [ ] Conference Talk (N/A)