### PR TITLE
Fix OpenAPI regex matching and generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ Each release section should stand on its own and describe the behavior shipped i
 - When generating notes for downstream repos, this repo is consumed by:
   - `enterprise`, bumped in `enterprise/gradle.properties` via `specmaticVersion`
 
+## Unreleased
+
+### Changed
+
+- Fixed OpenAPI and JSON Schema `pattern` matching to use search semantics, so unanchored expressions can match substrings while explicit `^` and `$` anchors continue to constrain the corresponding boundary.
+- Fixed generated values for anchored patterns with alternatives and length constraints, including empty alternatives and partial anchors, so generated values remain valid for the original pattern. Unsupported regex structures will use the lenient fallback.
+
 ## 2.54.0 (2026-09-03)
 
 ### Added

--- a/core/src/main/kotlin/io/specmatic/core/pattern/Grammar.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/Grammar.kt
@@ -230,7 +230,8 @@ fun parsedPattern(rawContent: String, key: String? = null, typeAlias: String? = 
                         typeAlias = typeAlias,
                         minLength = restrictions["minLength"]?.toIntOrNull(),
                         maxLength = restrictions["maxLength"]?.toIntOrNull(),
-                        regex = restrictions["regex"]
+                        regex = restrictions["regex"],
+                        matchMode = restrictions["matchMode"]?.let(RegexMatchMode::valueOf) ?: RegexMatchMode.SEARCH,
                     )
                 } catch (e: IllegalArgumentException) {
                     throw ContractException(e.message ?: "", exceptionCause = e)

--- a/core/src/main/kotlin/io/specmatic/core/pattern/RegExSpec.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/RegExSpec.kt
@@ -1,6 +1,7 @@
 package io.specmatic.core.pattern
 
 import io.specmatic.core.log.logger
+import io.specmatic.core.pattern.regex.OpenApiRegexAnchorNormalizer
 import io.specmatic.core.pattern.regex.RegexBasedStringGenerator
 import io.specmatic.core.value.StringValue
 import io.specmatic.core.value.Value
@@ -95,8 +96,7 @@ class RegExSpec(
 
     private fun cleanRegex(regex: String): String {
         return regex
-            .removePrefix("^")
-            .removeSuffix("$")
+            .removeOuterAnchors()
             .removePrefix(WORD_BOUNDARY)
             .removeSuffix(WORD_BOUNDARY)
             .replaceRegexLowerBounds()
@@ -104,6 +104,15 @@ class RegExSpec(
             .requote()
             .replaceNonCapturingGroups()
             .replaceUnescapedDot()
+    }
+
+    private fun String.removeOuterAnchors(): String {
+        val result = OpenApiRegexAnchorNormalizer().normalize(this)
+        if (result is OpenApiRegexAnchorNormalizer.Result.Unsupported) {
+            logger.debug("Could not normalize OpenAPI regex anchors: ${result.reason}. Using the original regex: ${result.regex}")
+        }
+
+        return result.regex
     }
 
     private fun String.replaceUnescapedDot(): String {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/RegExSpec.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/RegExSpec.kt
@@ -9,12 +9,15 @@ import io.specmatic.core.value.Value
 internal const val WORD_BOUNDARY = "\\b"
 internal const val DOT_WITHOUT_LINE_TERMINATORS = "[^\n\r\u0085\u2028\u2029]"
 
-class RegExSpec(
-    regex: String?,
-) {
+enum class RegexMatchMode {
+    SEARCH,
+    WHOLE_VALUE,
+}
+
+class RegExSpec(regex: String?, private val matchMode: RegexMatchMode = RegexMatchMode.SEARCH) {
     private val originalRegex = regex
     private val regexGenerator = regex?.let(::cleanRegex)?.let(::RegexBasedStringGenerator)
-    private val regexForRuntimeMatch: Regex? = originalRegex?.let { Regex(it.replaceRegexLowerBounds()) }
+    private val regexForRuntimeMatch = originalRegex?.let { Regex(it.toRuntimeRegex(matchMode)) }
 
     init {
         validateRegex()
@@ -24,7 +27,7 @@ class RegExSpec(
         runCatching {
             if (regexGenerator == null || regexForRuntimeMatch == null) return
             val random = regexGenerator.random()
-            if (!regexForRuntimeMatch.matches(random)) {
+            if (!matchesRuntimeRegex(random)) {
                 logger.log("WARNING: Please check the regex $originalRegex. We generated a random string $random and the regex does not match the string.")
             }
         }.getOrElse { e ->
@@ -78,7 +81,14 @@ class RegExSpec(
         return regexGenerator.generateLongest(maxLen) ?: throw IllegalStateException("No valid string found")
     }
 
-    fun match(sampleData: StringValue) = regexForRuntimeMatch?.containsMatchIn(sampleData.toStringLiteral()) ?: true
+    fun match(sampleData: StringValue) = matchesRuntimeRegex(sampleData.toStringLiteral())
+    private fun matchesRuntimeRegex(value: String): Boolean {
+        return when {
+            regexForRuntimeMatch == null -> true
+            matchMode == RegexMatchMode.SEARCH -> regexForRuntimeMatch.containsMatchIn(value)
+            else -> regexForRuntimeMatch.matches(value)
+        }
+    }
 
     fun generateRandomString(minLength: Int, maxLength: Int? = null): Value {
         return regexGenerator?.let {
@@ -147,6 +157,15 @@ class RegExSpec(
 
         if (pendingEscape) result.append('\\')
         return result.toString()
+    }
+
+    private fun String.toRuntimeRegex(matchMode: RegexMatchMode): String {
+        return replaceRegexLowerBounds().let { regex ->
+            when (matchMode) {
+                RegexMatchMode.WHOLE_VALUE -> regex
+                RegexMatchMode.SEARCH -> regex.replaceEcmaEndAssertions()
+            }
+        }
     }
 
     private fun String.replaceRegexLowerBounds(): String {
@@ -246,6 +265,37 @@ class RegExSpec(
                     result.append(ch)
                     index++
                 }
+            }
+        }
+
+        return result.toString()
+    }
+
+    private fun String.replaceEcmaEndAssertions(): String {
+        val result = StringBuilder(length)
+
+        var escaped = false
+        var insideCharClass = false
+        for (ch in this) {
+            when {
+                escaped -> {
+                    result.append(ch)
+                    escaped = false
+                }
+                ch == '\\' -> {
+                    result.append(ch)
+                    escaped = true
+                }
+                ch == '[' -> {
+                    result.append(ch)
+                    insideCharClass = true
+                }
+                ch == ']' && insideCharClass -> {
+                    result.append(ch)
+                    insideCharClass = false
+                }
+                ch == '$' && !insideCharClass -> result.append("\\z")
+                else -> result.append(ch)
             }
         }
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/RegExSpec.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/RegExSpec.kt
@@ -78,7 +78,7 @@ class RegExSpec(
         return regexGenerator.generateLongest(maxLen) ?: throw IllegalStateException("No valid string found")
     }
 
-    fun match(sampleData: StringValue) = regexForRuntimeMatch?.matches(sampleData.toStringLiteral()) ?: true
+    fun match(sampleData: StringValue) = regexForRuntimeMatch?.containsMatchIn(sampleData.toStringLiteral()) ?: true
 
     fun generateRandomString(minLength: Int, maxLength: Int? = null): Value {
         return regexGenerator?.let {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/RegExSpec.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/RegExSpec.kt
@@ -117,7 +117,7 @@ class RegExSpec(regex: String?, private val matchMode: RegexMatchMode = RegexMat
     }
 
     private fun String.removeOuterAnchors(): String {
-        val result = OpenApiRegexAnchorNormalizer().normalize(this)
+        val result = OpenApiRegexAnchorNormalizer(allowUnanchoredSides = matchMode == RegexMatchMode.SEARCH).normalize(this)
         if (result is OpenApiRegexAnchorNormalizer.Result.Unsupported) {
             logger.debug("Could not normalize OpenAPI regex anchors: ${result.reason}. Using the original regex: ${result.regex}")
         }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/StringPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/StringPattern.kt
@@ -23,8 +23,9 @@ data class StringPattern (
     val regex: String? = null,
     private val downsampledMin: Boolean = false,
     private val downsampledMax: Boolean = false,
+    private val matchMode: RegexMatchMode = RegexMatchMode.SEARCH,
 ) : Pattern, ScalarType, HasDefaultExample {
-    internal val regExSpec = RegExSpec(regex)
+    internal val regExSpec = RegExSpec(regex, matchMode)
     private val effectiveMinLength = minLength ?: 0
 
     init {

--- a/core/src/main/kotlin/io/specmatic/core/pattern/regex/OpenApiRegexAnchorNormalizer.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/regex/OpenApiRegexAnchorNormalizer.kt
@@ -1,0 +1,229 @@
+package io.specmatic.core.pattern.regex
+
+import java.util.ArrayDeque
+
+internal class OpenApiRegexAnchorNormalizer {
+    sealed interface Result {
+        val regex: String
+        data class Unchanged(override val regex: String) : Result
+        data class Normalized(override val regex: String) : Result
+        data class Unsupported(override val regex: String, val reason: String) : Result
+    }
+
+    fun normalize(regex: String): Result {
+        if (!regex.containsAnchorAssertion()) return Result.Unchanged(regex)
+        return when (val result = normalizeExpression(regex, Boundaries())) {
+            is Normalization.Success -> Result.Normalized(result.regex)
+            is Normalization.Unsupported -> Result.Unsupported(regex, result.reason)
+        }
+    }
+
+    private fun normalizeExpression(expression: String, inheritedBoundaries: Boundaries): Normalization {
+        val structure = when (val result = scan(expression)) {
+            is ScanResult.Success -> result.structure
+            is ScanResult.Invalid -> return Normalization.Unsupported(result.reason)
+        }
+
+        val alternatives = structure.splitTopLevelAlternatives(expression)
+        val normalized = mutableListOf<String>()
+        for (alternative in alternatives) {
+            when (val result = normalizeAlternative(alternative, inheritedBoundaries)) {
+                is Normalization.Success -> normalized += result.regex
+                is Normalization.Unsupported -> return result
+            }
+        }
+
+        return Normalization.Success(normalized.joinToString("|"))
+    }
+
+    private fun normalizeAlternative(alternative: String, inheritedBoundaries: Boundaries): Normalization {
+        val boundaryAnchors = extractBoundaryAnchors(alternative)
+        val boundaries = inheritedBoundaries.merge(boundaryAnchors.boundaries)
+        val body = boundaryAnchors.body
+
+        return when (val group = unwrapWholeGroup(body)) {
+            is WholeGroup.Found -> {
+                when (val result = normalizeExpression(group.body, boundaries)) {
+                    is Normalization.Success -> Normalization.Success("${group.prefix}${result.regex})")
+                    is Normalization.Unsupported -> result
+                }
+            }
+
+            is WholeGroup.Unsupported -> {
+                if (body.containsAnchorAssertion()) {
+                    Normalization.Unsupported(group.reason)
+                } else {
+                    Normalization.Success(applyBoundaries(body, boundaries))
+                }
+            }
+
+            WholeGroup.NotFound -> {
+                if (body.containsAnchorAssertion()) {
+                    Normalization.Unsupported("Anchor assertion occurs in a position that cannot be normalized safely: $alternative")
+                } else {
+                    Normalization.Success(applyBoundaries(body, boundaries))
+                }
+            }
+        }
+    }
+
+    private fun applyBoundaries(body: String, boundaries: Boundaries): String {
+        if (body.isEmpty()) {
+            return if (boundaries.start && boundaries.end) EMPTY_STRING else ANY_STRING
+        }
+
+        return buildString {
+            if (!boundaries.start) append(ANY_STRING)
+            append(body)
+            if (!boundaries.end) append(ANY_STRING)
+        }
+    }
+
+    private fun extractBoundaryAnchors(value: String): BoundaryAnchors {
+        var start = 0
+        while (start < value.length && value[start] == '^') {
+            start++
+        }
+
+        var end = value.length
+        while (end > start && value[end - 1] == '$' && !value.isEscaped(end - 1)) {
+            end--
+        }
+
+        return BoundaryAnchors(
+            body = value.substring(start, end),
+            boundaries = Boundaries(start = start > 0, end = end < value.length),
+        )
+    }
+
+    private fun Structure.splitTopLevelAlternatives(value: String): List<String> {
+        if (topLevelAlternations.isEmpty()) return listOf(value)
+
+        val alternatives = mutableListOf<String>()
+        var start = 0
+        for (separator in topLevelAlternations) {
+            alternatives += value.substring(start, separator)
+            start = separator + 1
+        }
+
+        alternatives += value.substring(start)
+        return alternatives
+    }
+
+    private fun unwrapWholeGroup(value: String): WholeGroup {
+        if (!value.startsWith("(") || !value.endsWith(")")) {
+            return WholeGroup.NotFound
+        }
+
+        val structure = when (val result = scan(value)) {
+            is ScanResult.Success -> result.structure
+            is ScanResult.Invalid -> return WholeGroup.Unsupported(result.reason)
+        }
+
+        if (structure.groupEnds[0] != value.lastIndex) {
+            return WholeGroup.NotFound
+        }
+
+        val prefixLength = when {
+            value.startsWith("(?:") -> 3
+            value.startsWith("(?") -> return WholeGroup.Unsupported("Anchor normalization does not support this (?...) group construct")
+            else -> 1
+        }
+
+        return WholeGroup.Found(
+            prefix = value.substring(0, prefixLength),
+            body = value.substring(prefixLength, value.lastIndex),
+        )
+    }
+
+    private fun String.containsAnchorAssertion(): Boolean {
+        var escaped = false
+        var insideCharClass = false
+        for (ch in this) {
+            when {
+                escaped -> escaped = false
+                ch == '\\' -> escaped = true
+                insideCharClass -> if (ch == ']') insideCharClass = false
+                ch == '[' -> insideCharClass = true
+                ch == '^' || ch == '$' -> return true
+            }
+        }
+
+        return false
+    }
+
+    private fun String.isEscaped(index: Int): Boolean {
+        var backslashes = 0
+        var current = index - 1
+        while (current >= 0 && this[current] == '\\') {
+            backslashes++
+            current--
+        }
+
+        return backslashes % 2 != 0
+    }
+
+    private fun scan(value: String): ScanResult {
+        val groupStarts = ArrayDeque<Int>()
+        val groupEnds = mutableMapOf<Int, Int>()
+        val topLevelAlternations = mutableListOf<Int>()
+
+        var escaped = false
+        var insideCharClass = false
+        for (index in value.indices) {
+            val ch = value[index]
+            when {
+                escaped -> escaped = false
+                ch == '\\' -> escaped = true
+                insideCharClass -> if (ch == ']') insideCharClass = false
+                ch == '[' -> insideCharClass = true
+                ch == '(' -> groupStarts.addLast(index)
+                ch == ')' -> {
+                    if (groupStarts.isEmpty()) return ScanResult.Invalid("Unexpected ')' at index $index")
+                    groupEnds[groupStarts.removeLast()] = index
+                }
+                ch == '|' && groupStarts.isEmpty() -> topLevelAlternations += index
+            }
+        }
+
+        return when {
+            escaped -> ScanResult.Invalid("Regex ends with an incomplete escape sequence")
+            insideCharClass -> ScanResult.Invalid("Regex contains an unclosed character class")
+            groupStarts.isNotEmpty() -> ScanResult.Invalid("Regex contains an unclosed group")
+            else -> ScanResult.Success(Structure(topLevelAlternations = topLevelAlternations, groupEnds = groupEnds))
+        }
+    }
+
+    private data class Boundaries(val start: Boolean = false, val end: Boolean = false) {
+        fun merge(other: Boundaries): Boundaries = Boundaries(
+            end = end || other.end,
+            start = start || other.start,
+        )
+    }
+
+    private data class BoundaryAnchors(val body: String, val boundaries: Boundaries)
+    private data class Structure(val topLevelAlternations: List<Int>, val groupEnds: Map<Int, Int>)
+
+    private sealed interface Normalization {
+        data class Success(val regex: String) : Normalization
+        data class Unsupported(val reason: String) : Normalization
+    }
+
+    private sealed interface ScanResult {
+        data class Invalid(val reason: String) : ScanResult
+        data class Success(val structure: Structure) : ScanResult
+    }
+
+    private sealed interface WholeGroup {
+        data object NotFound : WholeGroup
+        data class Unsupported(val reason: String) : WholeGroup
+        data class Found(val prefix: String, val body: String) : WholeGroup
+    }
+
+    private companion object {
+        // dk.brics uses () for the empty string and matches the complete input.
+        // .* therefore represents the unconstrained side of an OpenAPI pattern match.
+        const val ANY_STRING = ".*"
+        const val EMPTY_STRING = "()"
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/core/pattern/regex/OpenApiRegexAnchorNormalizer.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/regex/OpenApiRegexAnchorNormalizer.kt
@@ -2,7 +2,7 @@ package io.specmatic.core.pattern.regex
 
 import java.util.ArrayDeque
 
-internal class OpenApiRegexAnchorNormalizer {
+internal class OpenApiRegexAnchorNormalizer(private val allowUnanchoredSides: Boolean = true) {
     sealed interface Result {
         val regex: String
         data class Unchanged(override val regex: String) : Result
@@ -68,6 +68,10 @@ internal class OpenApiRegexAnchorNormalizer {
     }
 
     private fun applyBoundaries(body: String, boundaries: Boundaries): String {
+        if (!allowUnanchoredSides) {
+            return body.ifEmpty { EMPTY_STRING }
+        }
+
         if (body.isEmpty()) {
             return if (boundaries.start && boundaries.end) EMPTY_STRING else ANY_STRING
         }

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/message/SimpleElement.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/message/SimpleElement.kt
@@ -3,6 +3,7 @@ package io.specmatic.core.wsdl.parser.message
 import io.specmatic.core.log.logger
 import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.pattern.Pattern
+import io.specmatic.core.pattern.RegexMatchMode
 import io.specmatic.core.pattern.WSDLTypeDerivationMethod
 import io.specmatic.core.pattern.XMLPattern
 import io.specmatic.core.value.FullyQualifiedName
@@ -257,7 +258,8 @@ private fun constrainedStringValue(restrictions: StringRestrictions): StringValu
     val restrictionClauses = listOfNotNull(
         restrictions.minLength?.let { "minLength $it" },
         restrictions.maxLength?.let { "maxLength $it" },
-        restrictions.regex?.let { "regex $it" }
+        restrictions.regex?.let { "regex $it" },
+        restrictions.regex?.let { "matchMode ${RegexMatchMode.WHOLE_VALUE.name}" }
     )
 
     val token = if (restrictionClauses.isEmpty()) {

--- a/core/src/test/kotlin/io/specmatic/core/pattern/RegExSpecTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/RegExSpecTest.kt
@@ -2,15 +2,100 @@ package io.specmatic.core.pattern
 
 import dk.brics.automaton.RegExp
 import io.specmatic.core.value.StringValue
+import java.util.stream.Stream
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.MethodSource
 import org.junit.jupiter.params.provider.ValueSource
 
 class RegExSpecTest {
+    data class RuntimeMatchCase(val regex: String, val matchingInputs: List<String>, val nonMatchingInputs: List<String> = emptyList()) {
+        override fun toString(): String = "regex=/$regex/"
+    }
+
+    @Nested
+    inner class UnanchoredPatterns {
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("io.specmatic.core.pattern.RegExSpecTest#unanchoredPatternCases")
+        fun `match anywhere in the input`(case: RuntimeMatchCase) = assertRuntimeMatches(case)
+    }
+
+    @Nested
+    inner class StartAnchoredPatterns {
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("io.specmatic.core.pattern.RegExSpecTest#startAnchoredPatternCases")
+        fun `match from the beginning while allowing a suffix`(case: RuntimeMatchCase) = assertRuntimeMatches(case)
+    }
+
+    @Nested
+    inner class EndAnchoredPatterns {
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("io.specmatic.core.pattern.RegExSpecTest#endAnchoredPatternCases")
+        fun `match through the end while allowing a prefix`(case: RuntimeMatchCase) = assertRuntimeMatches(case)
+    }
+
+    @Nested
+    inner class FullyAnchoredPatterns {
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("io.specmatic.core.pattern.RegExSpecTest#fullyAnchoredPatternCases")
+        fun `retain both explicit boundaries`(case: RuntimeMatchCase) = assertRuntimeMatches(case)
+    }
+
+    @Nested
+    inner class AlternationPatterns {
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("io.specmatic.core.pattern.RegExSpecTest#alternationPatternCases")
+        fun `retain anchor semantics independently across alternatives`(case: RuntimeMatchCase) = assertRuntimeMatches(case)
+    }
+
+    @Nested
+    inner class EscapedAnchorPatterns {
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("io.specmatic.core.pattern.RegExSpecTest#escapedAnchorPatternCases")
+        fun `treat escaped anchors as literal characters`(case: RuntimeMatchCase) = assertRuntimeMatches(case)
+    }
+
+    @Nested
+    inner class CharacterClassPatterns {
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("io.specmatic.core.pattern.RegExSpecTest#characterClassPatternCases")
+        fun `treat anchors inside character classes as characters`(case: RuntimeMatchCase) = assertRuntimeMatches(case)
+    }
+
+    @Nested
+    inner class NestedWholeGroups {
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("io.specmatic.core.pattern.RegExSpecTest#nestedWholeGroupCases")
+        fun `apply boundaries around nested whole groups`(case: RuntimeMatchCase) = assertRuntimeMatches(case)
+    }
+
+    @Nested
+    inner class EmptyAlternatives {
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("io.specmatic.core.pattern.RegExSpecTest#emptyAlternativeCases")
+        fun `match empty alternatives only when the original regex allows them`(case: RuntimeMatchCase) = assertRuntimeMatches(case)
+    }
+
+    private fun assertRuntimeMatches(case: RuntimeMatchCase) {
+        val regex = RegExSpec(case.regex)
+        case.matchingInputs.forEach { input ->
+            assertThat(regex.match(StringValue(input)))
+                .withFailMessage("Expected /${case.regex}/ to match $input")
+                .isTrue
+        }
+
+        case.nonMatchingInputs.forEach { input ->
+            assertThat(regex.match(StringValue(input)))
+                .withFailMessage("Expected /${case.regex}/ not to match $input")
+                .isFalse
+        }
+    }
+
     @Test
     fun `should not allow construction with invalid regex`() {
         val invalidRegex = "/^a{10}\$/"
@@ -233,5 +318,124 @@ class RegExSpecTest {
         assertThat(generatedString).allSatisfy {
             assertThat(it).matches(regex)
         }
+    }
+
+    companion object {
+        @JvmStatic
+        fun unanchoredPatternCases(): Stream<RuntimeMatchCase> = Stream.of(
+            RuntimeMatchCase(
+                regex = "ABC",
+                matchingInputs = listOf("ABC", "ABCxx", "xxABC", "xxABCxx"),
+                nonMatchingInputs = listOf("ABX"),
+            ),
+            RuntimeMatchCase(regex = "", matchingInputs = listOf("", "anything")),
+        )
+
+        @JvmStatic
+        fun startAnchoredPatternCases(): Stream<RuntimeMatchCase> = Stream.of(
+            RuntimeMatchCase(
+                regex = "^ABC",
+                matchingInputs = listOf("ABC", "ABCxx"),
+                nonMatchingInputs = listOf("xxABC", "xxABCxx"),
+            ),
+            RuntimeMatchCase(
+                regex = "^[A-Z]{3}",
+                matchingInputs = listOf("ABC", "ABCxxxx", "ABC-anything"),
+                nonMatchingInputs = listOf("xxABC"),
+            ),
+        )
+
+        @JvmStatic
+        fun endAnchoredPatternCases(): Stream<RuntimeMatchCase> = Stream.of(
+            RuntimeMatchCase(
+                regex = """ABC$""",
+                matchingInputs = listOf("ABC", "xxABC"),
+                nonMatchingInputs = listOf("ABCxx", "xxABCxx"),
+            ),
+            RuntimeMatchCase(
+                regex = """[A-Z]{3}$""",
+                matchingInputs = listOf("ABC", "xxxxABC"),
+                nonMatchingInputs = listOf("ABCxxxx"),
+            ),
+        )
+
+        @JvmStatic
+        fun fullyAnchoredPatternCases(): Stream<RuntimeMatchCase> = Stream.of(
+            RuntimeMatchCase(
+                regex = """^ABC$""",
+                matchingInputs = listOf("ABC"),
+                nonMatchingInputs = listOf("xxABCxx", "ABCxx", "xxABC"),
+            ),
+            RuntimeMatchCase(
+                regex = """^[A-Z]{3}$""",
+                matchingInputs = listOf("ABC"),
+                nonMatchingInputs = listOf("ABc", "ABCD", "xxABC"),
+            ),
+        )
+
+        @JvmStatic
+        fun alternationPatternCases(): Stream<RuntimeMatchCase> = Stream.of(
+            RuntimeMatchCase(
+                regex = "foo|bar",
+                matchingInputs = listOf("foo", "xxfoo", "barxx"),
+                nonMatchingInputs = listOf("baz"),
+            ),
+            RuntimeMatchCase(
+                regex = """^ABC$|XYZ""",
+                matchingInputs = listOf("ABC", "xxXYZxx"),
+                nonMatchingInputs = listOf("xxABCxx", "ABCxx"),
+            ),
+            RuntimeMatchCase(
+                regex = """^ABC|XYZ$""",
+                matchingInputs = listOf("ABC", "ABCxx", "XYZ", "xxXYZ"),
+                nonMatchingInputs = listOf("xxABC", "XYZxx"),
+            ),
+        )
+
+        @JvmStatic
+        fun escapedAnchorPatternCases(): Stream<RuntimeMatchCase> = Stream.of(
+            RuntimeMatchCase(
+                regex = """\^foo\$""",
+                matchingInputs = listOf("^foo$", $$"xx^foo$xx"),
+                nonMatchingInputs = listOf("foo", $$"xxfoo$xx"),
+            ),
+        )
+
+        @JvmStatic
+        fun characterClassPatternCases(): Stream<RuntimeMatchCase> = Stream.of(
+            RuntimeMatchCase(
+                regex = """[a^$]+""",
+                matchingInputs = listOf("a", "^", "$", $$"x^$a"),
+                nonMatchingInputs = listOf("xyz"),
+            ),
+            RuntimeMatchCase(
+                regex = """[^$]+""",
+                matchingInputs = listOf("abc"),
+                nonMatchingInputs = listOf("$"),
+            ),
+        )
+
+        @JvmStatic
+        fun nestedWholeGroupCases(): Stream<RuntimeMatchCase> = Stream.of(
+            RuntimeMatchCase(
+                regex = """^((foo|bar))$""",
+                matchingInputs = listOf("foo", "bar"),
+                nonMatchingInputs = listOf("foobar", "xxfoo"),
+            ),
+        )
+
+        @JvmStatic
+        fun emptyAlternativeCases(): Stream<RuntimeMatchCase> = Stream.of(
+            RuntimeMatchCase(
+                regex = """^$|^[A-Za-z0-9._\-]{1,64}$""",
+                matchingInputs = listOf("", "abc", "a_b.c-1"),
+                nonMatchingInputs = listOf("a!"),
+            ),
+            RuntimeMatchCase(
+                regex = """^(foo|)$""",
+                matchingInputs = listOf("", "foo"),
+                nonMatchingInputs = listOf("bar", "foobar"),
+            ),
+        )
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/pattern/RegExSpecTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/RegExSpecTest.kt
@@ -198,6 +198,19 @@ class RegExSpecTest {
         assertThat(regExSpec.match(StringValue("a\nb"))).isFalse()
     }
 
+    @ParameterizedTest
+    @CsvSource(
+        delimiter = ';',
+        value = [
+            "^foo; foo",
+            "foo$; foo",
+            "^foo|bar$; foo|bar",
+        ],
+    )
+    fun `whole-value generation does not add unanchored sides`(regex: String, expectedRegex: String) {
+        assertThat(RegExSpec(regex, RegexMatchMode.WHOLE_VALUE).toString()).isEqualTo(expectedRegex)
+    }
+
     @Test
     fun `generation for unescaped dot must not accept line terminators that match rejects`() {
         val cleaned = RegExSpec(".").toString()

--- a/core/src/test/kotlin/io/specmatic/core/pattern/StringPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/StringPatternTest.kt
@@ -12,6 +12,7 @@ import io.specmatic.toViolationReportString
 import org.apache.commons.lang3.RandomStringUtils
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -20,6 +21,20 @@ import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.ValueSource
 
 internal class StringPatternTest {
+    @Nested
+    inner class PartialAnchoringWithLengthConstraints {
+        @ParameterizedTest
+        @ValueSource(strings = ["^[A-Z]{3}", "[A-Z]{3}$"])
+        fun `generates values at minimum regular and maximum lengths that satisfy the original pattern`(regex: String) {
+            val pattern = StringPattern(regex = regex, minLength = 3, maxLength = 20)
+            listOf(3, 10, 20).forEach { requestedLength ->
+                val generated = pattern.regExSpec.generateRandomString(requestedLength, requestedLength)
+                assertThat(generated.toStringLiteral()).hasSize(requestedLength)
+                assertThat(pattern.matches(generated, Resolver()).isSuccess()).isTrue
+            }
+        }
+    }
+
     @Test
     fun `should fail to match null values gracefully`() {
         NullValue shouldNotMatch StringPattern()

--- a/core/src/test/kotlin/io/specmatic/core/pattern/StringPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/StringPatternTest.kt
@@ -26,7 +26,11 @@ internal class StringPatternTest {
         @ParameterizedTest
         @ValueSource(strings = ["^[A-Z]{3}", "[A-Z]{3}$"])
         fun `generates values at minimum regular and maximum lengths that satisfy the original pattern`(regex: String) {
-            val pattern = StringPattern(regex = regex, minLength = 3, maxLength = 20)
+            val pattern = StringPattern(
+                regex = regex,
+                minLength = 3,
+                maxLength = 20,
+            )
             listOf(3, 10, 20).forEach { requestedLength ->
                 val generated = pattern.regExSpec.generateRandomString(requestedLength, requestedLength)
                 assertThat(generated.toStringLiteral()).hasSize(requestedLength)

--- a/core/src/test/kotlin/io/specmatic/core/pattern/StringPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/StringPatternTest.kt
@@ -39,6 +39,53 @@ internal class StringPatternTest {
         }
     }
 
+    @Nested
+    inner class WholeValueRegexWithLengthConstraints {
+        @ParameterizedTest
+        @CsvSource(
+            delimiter = ';',
+            value = [
+                "^foo; 3; 3",
+                "foo$; 3; 3",
+                "^foo|bar$; 3; 3",
+                "^[A-Z]{3,5}$; 4; 4",
+            ],
+        )
+        fun `generated values match the whole-value regex within length constraints`(regex: String, minLength: Int, maxLength: Int) {
+            val pattern = StringPattern(
+                regex = regex,
+                minLength = minLength,
+                maxLength = maxLength,
+                matchMode = RegexMatchMode.WHOLE_VALUE,
+            )
+
+            repeat(10) {
+                val generated = pattern.generate(Resolver())
+                assertThat(generated.toStringLiteral()).hasSizeBetween(minLength, maxLength)
+                assertThat(pattern.matches(generated, Resolver()).isSuccess())
+                    .withFailMessage("$generated does not match the whole-value regex $regex")
+                    .isTrue
+            }
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = ["^[A-Z]{3,20}", "[A-Z]{3,20}$"])
+        fun `generates values at minimum regular and maximum lengths that satisfy the whole-value regex`(regex: String) {
+            val pattern = StringPattern(
+                regex = regex,
+                minLength = 3,
+                maxLength = 20,
+                matchMode = RegexMatchMode.WHOLE_VALUE,
+            )
+
+            listOf(3, 10, 20).forEach { requestedLength ->
+                val generated = pattern.regExSpec.generateRandomString(requestedLength, requestedLength)
+                assertThat(generated.toStringLiteral()).hasSize(requestedLength)
+                assertThat(pattern.matches(generated, Resolver()).isSuccess()).isTrue
+            }
+        }
+    }
+
     @Test
     fun `should fail to match null values gracefully`() {
         NullValue shouldNotMatch StringPattern()

--- a/core/src/test/kotlin/io/specmatic/core/pattern/regex/OpenApiRegexAnchorNormalizerTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/regex/OpenApiRegexAnchorNormalizerTest.kt
@@ -1,0 +1,263 @@
+package io.specmatic.core.pattern.regex
+
+import dk.brics.automaton.RegExp
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.MethodSource
+import org.junit.jupiter.params.provider.ValueSource
+
+internal class OpenApiRegexAnchorNormalizerTest {
+    private val normalizer = OpenApiRegexAnchorNormalizer()
+
+    @Nested
+    inner class FullyAnchoredPatterns {
+        @ParameterizedTest
+        @CsvSource(
+            delimiter = '→',
+            value = [
+                "^foo$→foo",
+                "^$→()",
+                "^^foo$$→foo",
+                "^^$$→()",
+                "^[A-Za-z0-9._\\-]{0,64}$→[A-Za-z0-9._\\-]{0,64}",
+                "^foo\\$$→foo\\$",
+                "^foo\\^bar$→foo\\^bar",
+                "^[a^$]+$→[a^$]+",
+                "^[^$]+$→[^$]+",
+                "^foo\\|bar$→foo\\|bar",
+            ],
+        )
+        fun `normalizes fully anchored patterns`(regex: String, expected: String) {
+            assertThat(normalizer.normalize(regex)).isEqualTo(OpenApiRegexAnchorNormalizer.Result.Normalized(expected))
+        }
+    }
+
+    @Nested
+    inner class PartiallyAnchoredPatterns {
+        @ParameterizedTest
+        @CsvSource(
+            delimiter = '→',
+            value = [
+                "^foo→foo.*",
+                "foo$→.*foo",
+                "^[a-z0-9]{6,10}→[a-z0-9]{6,10}.*",
+                "[a-z0-9]{6,10}$→.*[a-z0-9]{6,10}",
+                "^foo\\$→foo\\$.*",
+                "\\^foo$→.*\\^foo",
+                "^→.*",
+                "$→.*",
+                "^^→.*",
+                "$$→.*",
+            ],
+        )
+        fun `adds an arbitrary suffix or prefix for a missing boundary`(regex: String, expected: String) {
+            assertThat(normalizer.normalize(regex)).isEqualTo(OpenApiRegexAnchorNormalizer.Result.Normalized(expected))
+        }
+    }
+
+    @Nested
+    inner class Alternatives {
+        @ParameterizedTest
+        @CsvSource(
+            delimiter = '→',
+            value = [
+                "^$|^[A-Za-z0-9._\\-]{1,64}$→()|[A-Za-z0-9._\\-]{1,64}",
+                "^foo$|^bar$→foo|bar",
+                "^foo|bar$→foo.*|.*bar",
+                "^foo$|bar→foo|.*bar.*",
+                "foo|^bar$→.*foo.*|bar",
+                "^foo|bar→foo.*|.*bar.*",
+                "foo|bar$→.*foo.*|.*bar",
+                "|^foo$→.*|foo",
+                "^foo$|→foo|.*",
+                "^$|$→()|.*",
+                "^|foo$→.*|.*foo",
+            ],
+        )
+        fun `normalizes each top level alternative independently`(regex: String, expected: String) {
+            assertThat(normalizer.normalize(regex)).isEqualTo(OpenApiRegexAnchorNormalizer.Result.Normalized(expected))
+        }
+    }
+
+    @Nested
+    inner class WholeExpressionGroups {
+        @ParameterizedTest
+        @CsvSource(
+            delimiter = '→',
+            value = [
+                "(^foo$|^bar$)→(foo|bar)",
+                "(?:^foo$|^bar$)→(?:foo|bar)",
+                "^(foo|bar)$→(foo|bar)",
+                "^(?:foo|bar)$→(?:foo|bar)",
+                "^(^foo$|bar)$→(foo|bar)",
+                "^(foo$|bar$)→(foo|bar)",
+                "(^foo|^bar)$→(foo|bar)",
+                "^(foo|bar)→(foo.*|bar.*)",
+                "(foo|bar)$→(.*foo|.*bar)",
+                "^(foo|bar$)→(foo.*|bar)",
+                "(^foo|bar)$→(foo|.*bar)",
+                "(foo$|bar$)→(.*foo|.*bar)",
+                "(^foo|^bar)→(foo.*|bar.*)",
+                "(foo|^bar$)→(.*foo.*|bar)",
+                "^((^foo$|bar))$→((foo|bar))",
+                "^(|foo)$→(()|foo)",
+                "^(foo|)$→(foo|())",
+                "^(foo||bar)$→(foo|()|bar)",
+                "^(|foo)→(.*|foo.*)",
+                "(|foo)$→(.*|.*foo)",
+            ],
+        )
+        fun `propagates inherited boundaries through whole expression groups`(regex: String, expected: String) {
+            assertThat(normalizer.normalize(regex)).isEqualTo(OpenApiRegexAnchorNormalizer.Result.Normalized(expected))
+        }
+    }
+
+    @Nested
+    inner class LiteralAnchorCharacters {
+        @ParameterizedTest
+        @ValueSource(
+            strings = [
+                "",
+                "foo",
+                "foo|bar",
+                "\\^foo\\$",
+                "[a^$]",
+                "[^$]",
+                "[\\^$]",
+                "foo\\|bar",
+                "(foo|bar)",
+            ],
+        )
+        fun `leaves patterns without anchor assertions unchanged`(regex: String) {
+            assertThat(normalizer.normalize(regex)).isEqualTo(OpenApiRegexAnchorNormalizer.Result.Unchanged(regex))
+        }
+    }
+
+    @Nested
+    inner class UnsupportedAnchorPositions {
+        @ParameterizedTest
+        @ValueSource(
+            strings = [
+                "foo^bar",
+                $$"foo$bar",
+                "^foo^bar$",
+                "x(^foo$|bar)y",
+                "(^foo$|bar)+",
+                "^x(^foo$|bar)$",
+                "foo(?=^bar$)",
+            ],
+        )
+        fun `falls back when an anchor occurs inside a non whole expression position`(regex: String) {
+            assertThat(normalizer.normalize(regex)).isEqualTo(
+                    OpenApiRegexAnchorNormalizer.Result.Unsupported(
+                        regex = regex,
+                        reason = "Anchor assertion occurs in a position that cannot be normalized safely: $regex",
+                    ),
+                )
+        }
+
+        @ParameterizedTest
+        @ValueSource(
+            strings = [
+                "(?=^foo$)",
+                "(?!^foo$)",
+                "^(?=^foo$)$",
+            ],
+        )
+        fun `falls back for unsupported whole group constructs containing anchors`(regex: String) {
+            assertThat(normalizer.normalize(regex)).isEqualTo(
+                    OpenApiRegexAnchorNormalizer.Result.Unsupported(
+                        regex = regex,
+                        reason = "Anchor normalization does not support this (?...) group construct",
+                    ),
+                )
+        }
+    }
+
+    @Nested
+    inner class MalformedPatterns {
+        @ParameterizedTest
+        @CsvSource(
+            delimiter = '→',
+            value = [
+                "^(foo$→Regex contains an unclosed group",
+                "^foo[bar$→Regex contains an unclosed character class",
+                "^foo$\\→Regex ends with an incomplete escape sequence",
+                "^foo$)→Unexpected ')' at index 5",
+            ],
+        )
+        fun `falls back with the structural parsing reason`(regex: String, reason: String) {
+            assertThat(normalizer.normalize(regex)).isEqualTo(
+                    OpenApiRegexAnchorNormalizer.Result.Unsupported(
+                        regex = regex,
+                        reason = reason,
+                    ),
+                )
+        }
+
+        @ParameterizedTest
+        @ValueSource(
+            strings = [
+                "(foo",
+                "foo[bar",
+                "foo\\",
+            ],
+        )
+        fun `does not validate malformed patterns that contain no anchor assertions`(regex: String) {
+            assertThat(normalizer.normalize(regex)).isEqualTo(OpenApiRegexAnchorNormalizer.Result.Unchanged(regex))
+        }
+    }
+
+    @Nested
+    inner class AutomatonSemantics {
+        @Test
+        fun `reported old and new patterns produce equivalent automata`() {
+            val oldPattern = "^$|^[A-Za-z0-9._\\-]{1,64}$"
+            val newPattern = "^[A-Za-z0-9._\\-]{0,64}$"
+
+            val oldAutomaton = RegExp(normalizer.normalize(oldPattern).regex, 0).toAutomaton()
+            val newAutomaton = RegExp(normalizer.normalize(newPattern).regex, 0).toAutomaton()
+
+            assertThat(oldAutomaton).isEqualTo(newAutomaton)
+        }
+
+        @ParameterizedTest(name = "{0}: /{1}/ against \"{2}\" => {3}")
+        @MethodSource("io.specmatic.core.pattern.regex.OpenApiRegexAnchorNormalizerTest#boundarySemanticsCases")
+        fun `regex boundary semantics`(description: String, pattern: String, input: String, expected: Boolean) {
+            val regex = normalizer.normalize(pattern).regex
+            val automaton = RegExp(regex, 0).toAutomaton()
+            assertThat(automaton.run(input)).isEqualTo(expected)
+        }
+    }
+
+    companion object {
+        @JvmStatic
+        fun boundarySemanticsCases() = listOf(
+            // Start anchored pattern
+            Arguments.of("start anchored", "^[a-z0-9]{6,10}", "abcdef", true),
+            Arguments.of("start anchored", "^[a-z0-9]{6,10}", "abcdefXYZ", true),
+            Arguments.of("start anchored", "^[a-z0-9]{6,10}", "abcdef-whatever", true),
+            Arguments.of("start anchored", "^[a-z0-9]{6,10}", "XYZabcdef", false),
+            Arguments.of("start anchored", "^[a-z0-9]{6,10}", "abcde", false),
+
+            // End anchored pattern
+            Arguments.of("end anchored", "[a-z0-9]{6,10}$", "abcdef", true),
+            Arguments.of("end anchored", "[a-z0-9]{6,10}$", "XYZabcdef", true),
+            Arguments.of("end anchored", "[a-z0-9]{6,10}$", "--abcdef", true),
+            Arguments.of("end anchored", "[a-z0-9]{6,10}$", "abcdefXYZ", false),
+            Arguments.of("end anchored", "[a-z0-9]{6,10}$", "abcde", false),
+
+            // Mixed alternatives
+            Arguments.of("mixed alternatives", "^foo|bar$", "foo", true),
+            Arguments.of("mixed alternatives", "^foo|bar$", "foobar", true),
+            Arguments.of("mixed alternatives", "^foo|bar$", "xxfoo", false),
+            Arguments.of("mixed alternatives", "^foo|bar$", "bar", true),
+            Arguments.of("mixed alternatives", "^foo|bar$", "xxbar", true),
+            Arguments.of("mixed alternatives", "^foo|bar$", "barxx", false),
+        )
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/pattern/regex/OpenApiRegexAnchorNormalizerTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/regex/OpenApiRegexAnchorNormalizerTest.kt
@@ -12,6 +12,7 @@ import org.junit.jupiter.params.provider.ValueSource
 
 internal class OpenApiRegexAnchorNormalizerTest {
     private val normalizer = OpenApiRegexAnchorNormalizer()
+    private val wholeValueNormalizer = OpenApiRegexAnchorNormalizer(allowUnanchoredSides = false)
 
     @Nested
     inner class FullyAnchoredPatterns {
@@ -56,6 +57,104 @@ internal class OpenApiRegexAnchorNormalizerTest {
         )
         fun `adds an arbitrary suffix or prefix for a missing boundary`(regex: String, expected: String) {
             assertThat(normalizer.normalize(regex)).isEqualTo(OpenApiRegexAnchorNormalizer.Result.Normalized(expected))
+        }
+    }
+
+    @Nested
+    inner class WholeValuePatterns {
+        @ParameterizedTest
+        @CsvSource(
+            delimiter = '→',
+            value = [
+                "^foo$→foo",
+                "^$→()",
+                "^^foo$$→foo",
+                "^^$$→()",
+                "^[A-Za-z0-9._\\-]{0,64}$→[A-Za-z0-9._\\-]{0,64}",
+                "^foo\\$$→foo\\$",
+                "^foo\\^bar$→foo\\^bar",
+                "^[a^$]+$→[a^$]+",
+                "^[^$]+$→[^$]+",
+                "^foo\\|bar$→foo\\|bar",
+            ],
+        )
+        fun `removes fully anchored boundaries`(regex: String, expected: String) {
+            assertThat(wholeValueNormalizer.normalize(regex))
+                .isEqualTo(OpenApiRegexAnchorNormalizer.Result.Normalized(expected))
+        }
+
+        @ParameterizedTest
+        @CsvSource(
+            delimiter = '→',
+            value = [
+                "^foo→foo",
+                "foo$→foo",
+                "^[a-z0-9]{6,10}→[a-z0-9]{6,10}",
+                "[a-z0-9]{6,10}$→[a-z0-9]{6,10}",
+                "^foo\\$→foo\\$",
+                "\\^foo$→\\^foo",
+                "^→()",
+                "$→()",
+                "^^→()",
+                "$$→()",
+            ],
+        )
+        fun `removes partial anchors without adding unanchored sides`(regex: String, expected: String) {
+            assertThat(wholeValueNormalizer.normalize(regex))
+                .isEqualTo(OpenApiRegexAnchorNormalizer.Result.Normalized(expected))
+        }
+
+        @ParameterizedTest
+        @CsvSource(
+            delimiter = '→',
+            value = [
+                "^$|^[A-Za-z0-9._\\-]{1,64}$→()|[A-Za-z0-9._\\-]{1,64}",
+                "^foo$|^bar$→foo|bar",
+                "^foo|bar$→foo|bar",
+                "^foo$|bar→foo|bar",
+                "foo|^bar$→foo|bar",
+                "^foo|bar→foo|bar",
+                "foo|bar$→foo|bar",
+                "|^foo$→()|foo",
+                "^foo$|→foo|()",
+                "^$|$→()|()",
+                "^|foo$→()|foo",
+            ],
+        )
+        fun `normalizes alternatives without adding unanchored sides`(regex: String, expected: String) {
+            assertThat(wholeValueNormalizer.normalize(regex))
+                .isEqualTo(OpenApiRegexAnchorNormalizer.Result.Normalized(expected))
+        }
+
+        @ParameterizedTest
+        @CsvSource(
+            delimiter = '→',
+            value = [
+                "(^foo$|^bar$)→(foo|bar)",
+                "(?:^foo$|^bar$)→(?:foo|bar)",
+                "^(foo|bar)$→(foo|bar)",
+                "^(?:foo|bar)$→(?:foo|bar)",
+                "^(^foo$|bar)$→(foo|bar)",
+                "^(foo$|bar$)→(foo|bar)",
+                "(^foo|^bar)$→(foo|bar)",
+                "^(foo|bar)→(foo|bar)",
+                "(foo|bar)$→(foo|bar)",
+                "^(foo|bar$)→(foo|bar)",
+                "(^foo|bar)$→(foo|bar)",
+                "(foo$|bar$)→(foo|bar)",
+                "(^foo|^bar)→(foo|bar)",
+                "(foo|^bar$)→(foo|bar)",
+                "^((^foo$|bar))$→((foo|bar))",
+                "^(|foo)$→(()|foo)",
+                "^(foo|)$→(foo|())",
+                "^(foo||bar)$→(foo|()|bar)",
+                "^(|foo)→(()|foo)",
+                "(|foo)$→(()|foo)",
+            ],
+        )
+        fun `normalizes whole expression groups without adding unanchored sides`(regex: String, expected: String) {
+            assertThat(wholeValueNormalizer.normalize(regex))
+                .isEqualTo(OpenApiRegexAnchorNormalizer.Result.Normalized(expected))
         }
     }
 


### PR DESCRIPTION
## What

- Handle `^` and `$` anchors safely for top-level alternatives.
- Preserve lenient fallback for unsupported regex structures.
- Keep escaped anchors and anchors inside character classes as literals.
- Normalize whole-expression groups while propagating anchor context safely.
- Handle empty anchored alternatives using the `dk.brics` empty expression.
- Fix OpenAPI and JSON Schema `pattern` matching to use search semantics.
- Preserve partial-anchor generation with length constraints:
  - `^[A-Z]{3}` grows safely on the right.
  - `[A-Z]{3}$` grows safely on the left.

## Why

Regex anchor preprocessing could change the meaning of valid OpenAPI patterns.

For example, these patterns describe the same set of values:

```regex
^$|^[A-Za-z0-9._\-]{1,64}$
```

and:

```regex
^[A-Za-z0-9._\-]{0,64}$
```

They must normalize consistently:

```regex
()|[A-Za-z0-9._\-]{1,64}
```

and:

```regex
[A-Za-z0-9._\-]{0,64}
```

OpenAPI `pattern` constraints use search semantics rather than implicit full-string matching. Therefore, an unanchored pattern such as `ABC` must match values like `xxABCxx`.

Partial anchors are also important when `StringPattern` applies length constraints. Given:

```text
pattern = ^[A-Z]{3}
minLength = 3
maxLength = 20
```

generated values at lengths 3, 10, and 20 must still begin with three uppercase letters. The mirror case:

```text
pattern = [A-Z]{3}$
```

must grow on the left so the generated values still end with three uppercase letters.

## How

- Use search-based runtime matching for OpenAPI `pattern` constraints.
- Scan regex structure to distinguish real assertions from escaped anchors and
  character-class contents.
- Normalize top-level alternatives independently.
- Propagate anchor context only through whole-expression groups.
- Use `()` for empty generated alternatives.
- Preserve the existing unconstrained-side generation behavior where `.*` is
  required for length-aware example generation.
- Return the original regex with a reason when a structure cannot be handled
  safely, preventing partial normalization.

## Tests

- Added runtime matching coverage for unanchored, start-anchored, end-anchored,
  fully anchored, and alternative patterns.
- Added cases for escaped anchors and anchors inside character classes.
- Added nested whole-group and empty-alternative coverage.
- Added malformed and unsupported-anchor fallback coverage.
- Added `StringPattern` integration coverage for partial anchors with
  `minLength = 3`, `maxLength = 20`, and generated lengths 3, 10, and 20.

## Checklist

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated
- [ ] Sample Project added/updated (share link) N/A
- [ ] Demo video (share link) N/A
- [ ] Article on Website (share link) N/A
- [ ] Roadmap updated (share link) N/A
- [ ] Conference Talk (share link) N/A