### PR TITLE
Prevent duplicate mock shutdown reports

### DIFF
--- a/application/src/main/kotlin/application/StubCommand.kt
+++ b/application/src/main/kotlin/application/StubCommand.kt
@@ -21,6 +21,9 @@ import io.specmatic.stub.HttpStub
 import io.specmatic.stub.RequestHandler
 import io.specmatic.stub.SpecmaticConfigSource
 import io.specmatic.stub.SpecmaticMockRunner
+import io.specmatic.stub.OneShotClose
+import io.specmatic.stub.ShutdownHookRegistrar
+import io.specmatic.stub.JvmShutdownHookRegistrar
 import io.specmatic.stub.endPointFromHostAndPort
 import io.specmatic.stub.extractHost
 import io.specmatic.stub.extractPort
@@ -33,6 +36,7 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import picocli.CommandLine.*
 import picocli.CommandLine.Model.CommandSpec
+import java.io.Closeable
 import java.io.File
 import java.util.concurrent.TimeoutException
 import kotlin.time.DurationUnit
@@ -52,6 +56,7 @@ class StubCommand(
     private val specmaticConfig: SpecmaticConfig = SpecmaticConfig(),
     private val watchMaker: WatchMaker = WatchMaker(),
     private val httpClientFactory: HttpClientFactory = HttpClientFactory(),
+    private val shutdownHookRegistrar: ShutdownHookRegistrar = JvmShutdownHookRegistrar,
     @field:ArgGroup(exclusive = false, heading = "%nInsights reporting options:%n")
     val insightsReportOptions: InsightsReportOptionsWithConfig = InsightsReportOptionsWithConfig()
 ) : SpecmaticMockRunner {
@@ -153,8 +158,18 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
     var specmaticConfigPath: String? = null
 
     var listeners: List<MockEventListener> = emptyList()
-    var registerShutdownHook: Boolean = true
     var requestHandlers: List<RequestHandler> = emptyList()
+
+    private val serverLifecycleLock = Any()
+    private var shutdownHookRegistration: Closeable? = null
+    private val terminalClose = OneShotClose(serverLifecycleLock) {
+        try {
+            consoleLog(StringLog("Shutting down mock servers"))
+            stopServer()
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+        }
+    }
 
     // used by plugins
     @Suppress("unused")
@@ -246,7 +261,7 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
             startServer()
 
             if (httpStub != null) {
-                if (registerShutdownHook) addShutdownHook()
+                shutdownHookRegistration = shutdownHookRegistrar.register(terminalClose)
 
                 val configuredHotReload = configuredHotReload()
 
@@ -349,35 +364,25 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
     }
 
     private fun restartServer() {
-        consoleLog(StringLog("Stopping servers..."))
-        try {
-            stopServer()
-            consoleLog(StringLog("Stopped."))
-        } catch (e: Throwable) {
-            consoleLog(e,"Error stopping server")
-        }
+        synchronized(serverLifecycleLock) {
+            if (terminalClose.hasStarted) return
+            consoleLog(StringLog("Stopping servers..."))
+            try {
+                stopServer()
+                consoleLog(StringLog("Stopped."))
+            } catch (e: Throwable) {
+                consoleLog(e,"Error stopping server")
+            }
 
-        try { startServer() } catch (e: Throwable) {
-            consoleLog(e, "Error starting server")
+            try { startServer() } catch (e: Throwable) {
+                consoleLog(e, "Error starting server")
+            }
         }
     }
 
     private fun stopServer() {
         httpStub?.close()
         httpStub = null
-    }
-
-    private fun addShutdownHook() {
-        Runtime.getRuntime().addShutdownHook(object : Thread() {
-            override fun run() {
-                try {
-                    consoleLog(StringLog("Shutting down mock servers"))
-                    httpStub?.close()
-                } catch (e: InterruptedException) {
-                    currentThread().interrupt()
-                }
-            }
-        })
     }
 
     private fun logStubLoadingSummary(stubData: List<Pair<Feature, List<ScenarioStub>>>) {
@@ -407,7 +412,9 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
     }
 
     override fun close() {
-        stopServer()
+        shutdownHookRegistration?.close()
+        shutdownHookRegistration = null
+        terminalClose.close()
     }
 
     override suspend fun checkReadiness() {

--- a/application/src/main/kotlin/application/mcp/server/tools/MockServerTool.kt
+++ b/application/src/main/kotlin/application/mcp/server/tools/MockServerTool.kt
@@ -1,8 +1,8 @@
 package application.mcp.server.tools
 
 import application.StubCommand
-import io.specmatic.core.config.Switch
 import io.specmatic.stub.waitUntilConnectable
+import io.specmatic.stub.NoOpShutdownHookRegistrar
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.Serializable
 import picocli.CommandLine
@@ -42,10 +42,8 @@ class MockServerTool {
         val specFile = tempDir.resolve("spec.$specFormat").apply { writeText(openApiSpec) }
 
         return try {
-            val command = StubCommand()
+            val command = StubCommand(shutdownHookRegistrar = NoOpShutdownHookRegistrar)
             val argsList = stubCommandArgs(port, specFile)
-
-            command.registerShutdownHook = false
 
             startInBackground(command, port, argsList)
 

--- a/application/src/test/kotlin/application/StubCommandTest.kt
+++ b/application/src/test/kotlin/application/StubCommandTest.kt
@@ -8,6 +8,7 @@ import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.core.CONTRACT_EXTENSION
 import io.specmatic.core.IncomingMtlsRegistry
 import io.specmatic.core.KeyDataRegistry
+import io.specmatic.core.config.Switch
 import io.specmatic.core.parseGherkinStringToFeature
 import io.specmatic.core.utilities.ContractPathData
 import io.specmatic.core.utilities.Flags
@@ -16,6 +17,7 @@ import io.specmatic.core.utilities.StubServerWatcher
 import io.specmatic.mock.ScenarioStub
 import io.specmatic.stub.HttpStub
 import io.specmatic.stub.SpecmaticConfigSource
+import io.specmatic.stub.ShutdownHookRegistrar
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -28,10 +30,15 @@ import org.junit.jupiter.params.provider.ValueSource
 import picocli.CommandLine
 import java.io.File
 import java.io.FileOutputStream
+import java.io.Closeable
 import java.net.ServerSocket
 import java.nio.file.Path
 import java.security.KeyStore
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeoutException
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.io.use
 
 
@@ -52,13 +59,16 @@ internal class StubCommandTest {
     @MockK
     lateinit var stubLoaderEngine: StubLoaderEngine
 
+    @MockK
+    lateinit var shutdownHookRegistrar: ShutdownHookRegistrar
+
     @InjectMockKs
     lateinit var stubCommand: StubCommand
 
     @BeforeEach
     fun setUp() {
         MockKAnnotations.init(this)
-        stubCommand.registerShutdownHook = false
+        every { shutdownHookRegistrar.register(any()) } returns java.io.Closeable {}
     }
 
     @AfterEach
@@ -85,6 +95,157 @@ internal class StubCommandTest {
         CommandLine(stubCommand).execute("/parameter/path/to/contract.$CONTRACT_EXTENSION")
 
         verify(exactly = 0) { specmaticConfig.contractStubPathData() }
+    }
+
+    @Test
+    fun `terminal close closes the active server only once`() {
+        val closeCount = AtomicInteger(0)
+        stubCommand.httpStub = mockk {
+            every { close() } answers { closeCount.incrementAndGet() }
+        }
+
+        stubCommand.close()
+        stubCommand.close()
+        assertThat(closeCount.get()).isEqualTo(1)
+    }
+
+    @Test
+    fun `terminal close before start does not close a server`() {
+        stubCommand.close()
+        assertThat(stubCommand.httpStub).isNull()
+    }
+
+    @Test
+    fun `standalone shutdown hook and explicit terminal close share one final close`(@TempDir tempDir: File) {
+        val contractPath = tempDir.resolve("contract.$CONTRACT_EXTENSION").canonicalPath
+        File(contractPath).writeText("Feature: A stub")
+
+        val registeredHook = slot<Closeable>()
+        val closeCount = AtomicInteger(0)
+        every { watchMaker.make(listOf(contractPath)) } returns watcher
+        every { specmaticConfig.contractStubPaths() } returns arrayListOf(contractPath)
+        every { stubLoaderEngine.loadStubs(any(), any(), any(), any()) } returns emptyList()
+        every { shutdownHookRegistrar.register(capture(registeredHook)) } returns Closeable {}
+        every {
+            httpStubEngine.runHTTPStub(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+        } returns mockk {
+            every { close() } answers { closeCount.incrementAndGet() }
+        }
+
+        assertThat(CommandLine(stubCommand).execute(contractPath)).isZero()
+        assertThat(registeredHook.isCaptured).isTrue()
+
+        registeredHook.captured.close()
+        stubCommand.close()
+
+        assertThat(closeCount.get()).isEqualTo(1)
+    }
+
+    @Test
+    fun `terminal close remains separate from automatic restart closes`(@TempDir tempDir: File) {
+        val contractPath = tempDir.resolve("contract.$CONTRACT_EXTENSION").canonicalPath
+        File(contractPath).writeText("Feature: A stub")
+
+        val restart = slot<() -> Unit>()
+        val closeCount = AtomicInteger(0)
+        val firstServer = mockk<HttpStub> {
+            every { close() } answers { closeCount.incrementAndGet() }
+        }
+
+        val secondServer = mockk<HttpStub> {
+            every { close() } answers { closeCount.incrementAndGet() }
+        }
+
+        val thirdServer = mockk<HttpStub> {
+            every { close() } answers { closeCount.incrementAndGet() }
+        }
+
+        every { watcher.watchForChanges(capture(restart)) } just Runs
+        every { watchMaker.make(listOf(contractPath)) } returns watcher
+        every { stubLoaderEngine.loadStubs(any(), any(), any(), any()) } returns emptyList()
+        every { httpStubEngine.runHTTPStub(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returnsMany listOf(firstServer, secondServer, thirdServer)
+        stubCommand.hotReload = Switch.enabled
+
+        assertThat(CommandLine(stubCommand).execute(contractPath)).isZero()
+        restart.captured.invoke()
+        restart.captured.invoke()
+
+        stubCommand.close()
+        stubCommand.close()
+        restart.captured.invoke()
+        assertThat(closeCount.get()).isEqualTo(3)
+        verify(exactly = 3) {
+            httpStubEngine.runHTTPStub(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `terminal close waits for an in-progress restart`(@TempDir tempDir: File) {
+        val contractPath = tempDir.resolve("contract.$CONTRACT_EXTENSION").canonicalPath
+        File(contractPath).writeText("Feature: A stub")
+
+        val restart = slot<() -> Unit>()
+        val allowRestartStop = CountDownLatch(1)
+        val restartStopStarted = CountDownLatch(1)
+        val terminalCloseRequested = CountDownLatch(1)
+        val closeCount = AtomicInteger(0)
+        val firstServer = mockk<HttpStub> {
+            every { close() } answers {
+                restartStopStarted.countDown()
+                if (!allowRestartStop.await(5, TimeUnit.SECONDS)) {
+                    throw AssertionError("Timed out waiting to finish the restart stop")
+                }
+
+                closeCount.incrementAndGet()
+            }
+        }
+
+        val secondServer = mockk<HttpStub> {
+            every { close() } answers { closeCount.incrementAndGet() }
+        }
+
+        every { watcher.watchForChanges(capture(restart)) } just Runs
+        every { watchMaker.make(listOf(contractPath)) } returns watcher
+        every { stubLoaderEngine.loadStubs(any(), any(), any(), any()) } returns emptyList()
+        every { shutdownHookRegistrar.register(any()) } returns Closeable { terminalCloseRequested.countDown() }
+        every { httpStubEngine.runHTTPStub(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returnsMany listOf(firstServer, secondServer)
+        stubCommand.hotReload = Switch.enabled
+
+        assertThat(CommandLine(stubCommand).execute(contractPath)).isZero()
+        val executor = Executors.newFixedThreadPool(2)
+        try {
+            val restartFuture = executor.submit { restart.captured.invoke() }
+            assertThat(restartStopStarted.await(5, TimeUnit.SECONDS)).isTrue()
+
+            val closeFuture = executor.submit { stubCommand.close() }
+            assertThat(terminalCloseRequested.await(5, TimeUnit.SECONDS)).isTrue()
+            assertThat(closeCount.get()).isZero()
+
+            allowRestartStop.countDown()
+            restartFuture.get(5, TimeUnit.SECONDS)
+            closeFuture.get(5, TimeUnit.SECONDS)
+            assertThat(closeCount.get()).isEqualTo(2)
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `concurrent terminal close closes the active server only once`() {
+        val closeCount = AtomicInteger(0)
+        stubCommand.httpStub = mockk {
+            every { close() } answers { closeCount.incrementAndGet() }
+        }
+
+        val executor = Executors.newFixedThreadPool(8)
+        try {
+            val closes = (1..8).map { executor.submit { stubCommand.close() } }
+            closes.forEach { it.get(5, TimeUnit.SECONDS) }
+        } finally {
+            executor.shutdownNow()
+        }
+
+        assertThat(closeCount.get()).isEqualTo(1)
     }
 
     @Test

--- a/core/src/main/kotlin/io/specmatic/stub/ShutdownHookRegistrar.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/ShutdownHookRegistrar.kt
@@ -1,0 +1,33 @@
+package io.specmatic.stub
+
+import java.io.Closeable
+import java.util.concurrent.atomic.AtomicBoolean
+
+class OneShotClose(private val lifecycleLock: Any, private val action: () -> Unit) : Closeable {
+    private val closeStarted = AtomicBoolean(false)
+    val hasStarted: Boolean get() = closeStarted.get()
+
+    override fun close() {
+        synchronized(lifecycleLock) {
+            if (closeStarted.compareAndSet(false, true)) action()
+        }
+    }
+}
+
+interface ShutdownHookRegistrar {
+    fun register(closeable: Closeable): Closeable
+}
+
+object JvmShutdownHookRegistrar : ShutdownHookRegistrar {
+    override fun register(closeable: Closeable): Closeable {
+        val hook = Thread { closeable.close() }
+        Runtime.getRuntime().addShutdownHook(hook)
+        return Closeable {
+            runCatching { Runtime.getRuntime().removeShutdownHook(hook) }
+        }
+    }
+}
+
+object NoOpShutdownHookRegistrar : ShutdownHookRegistrar {
+    override fun register(closeable: Closeable): Closeable = Closeable {}
+}


### PR DESCRIPTION
**What**:

Prevent duplicate mock shutdown reports by making shutdown ownership explicit and ensuring terminal cleanup runs only once.

**Why**:

In managed mock execution, both the lifecycle manager and individual mock commands could register shutdown hooks. During JVM shutdown, these hooks may run concurrently and their execution order is unspecified. As a result, both could independently stop the same mock and generate the same shutdown report, causing duplicate submissions.

Server restarts also share cleanup logic with terminal shutdown, making it difficult to distinguish a repeatable restart from final command termination.

**How**:

- Separate repeatable server stop/restart operations from terminal command close.
- Introduce explicit shutdown-hook registration through `ShutdownHookRegistrar`.
- Use a one-shot terminal close guarded by a lifecycle lock to make concurrent shutdown calls safe.
- Assign shutdown-hook ownership to the lifecycle manager for managed mocks.
- Use no-op registration for child mock runners so they do not install competing JVM hooks. Unregister hooks before performing terminal cleanup.
- Add unit tests covering repeated shutdown, concurrent shutdown, and restart scenarios.

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated N/A
- [ ] Sample Project added/updated N/A
- [ ] Demo video N/A
- [ ] Article on Website N/A
- [ ] Roadmap updated N/A
- [ ] Conference Talk N/A