### PR TITLE
Add external mock handler extensibility via SPI

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -5,6 +5,7 @@ import io.specmatic.core.azure.AzureAPI
 import io.specmatic.core.config.BackwardCompatibilityConfig
 import io.specmatic.core.config.LoggingConfiguration
 import io.specmatic.core.config.McpConfiguration
+import io.specmatic.core.config.MockMode
 import io.specmatic.core.config.SpecmaticConfigVersion
 import io.specmatic.core.config.SpecmaticGlobalSettings
 import io.specmatic.core.config.SpecmaticSpecConfig
@@ -12,7 +13,6 @@ import io.specmatic.core.config.Switch
 import io.specmatic.core.utilities.ContractSource
 import io.specmatic.core.utilities.ContractSourceEntry
 import io.specmatic.core.utilities.FileAssociation
-import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.Value
 import io.specmatic.reporter.ctrf.model.CtrfSpecConfig
 import io.specmatic.reporter.model.SpecType
@@ -76,6 +76,9 @@ internal fun SpecmaticConfig.mostSpecificMatchingBaseUrl(requestUrl: URI, candid
 }
 
 interface SpecmaticConfig {
+    @JsonIgnore
+    fun getMockMode(specFile: File): MockMode = MockMode.MOCK
+
     @JsonIgnore
     fun getLogConfigurationOrDefault(): LoggingConfiguration
 

--- a/core/src/main/kotlin/io/specmatic/core/config/MockMode.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/MockMode.kt
@@ -1,0 +1,6 @@
+package io.specmatic.core.config
+
+enum class MockMode {
+    MOCK,
+    STATEFUL_MOCK;
+}

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3Impl.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3Impl.kt
@@ -54,6 +54,7 @@ import io.specmatic.core.config.BackwardCompatibilityConfig
 import io.specmatic.core.config.HttpsConfiguration
 import io.specmatic.core.config.LoggingConfiguration
 import io.specmatic.core.config.McpConfiguration
+import io.specmatic.core.config.MockMode
 import io.specmatic.core.config.SpecmaticConfigVersion
 import io.specmatic.core.config.SpecmaticGlobalSettings
 import io.specmatic.core.config.SpecmaticSpecConfig
@@ -67,6 +68,7 @@ import io.specmatic.core.config.v3.components.runOptions.OpenApiMockConfig
 import io.specmatic.core.config.v3.components.runOptions.OpenApiRunOptionsSpecifications
 import io.specmatic.core.config.v3.components.runOptions.OpenApiTestConfig
 import io.specmatic.core.config.v3.components.runOptions.ProtobufRunOptions
+import io.specmatic.core.config.v3.components.runOptions.RunOptionType
 import io.specmatic.core.config.v3.components.services.MockServiceConfig
 import io.specmatic.core.config.v3.components.services.TestServiceConfig
 import io.specmatic.core.config.v3.components.settings.MockSettings
@@ -528,6 +530,11 @@ data class SpecmaticConfigV3Impl(val file: File? = null, val specmaticConfig: Sp
     override fun getStubFilter(specFile: File): String? {
         val runOpts = getMockRunOptions(specFile, SpecType.OPENAPI) as? OpenApiMockConfig ?: return null
         return runOpts.filter
+    }
+
+    override fun getMockMode(specFile: File): MockMode {
+        val runOpts = getMockRunOptions(specFile, SpecType.OPENAPI) as? OpenApiMockConfig
+        return if (runOpts?.type == RunOptionType.STATEFUL_MOCK) MockMode.STATEFUL_MOCK else MockMode.MOCK
     }
 
     override fun getStubHttpsConfiguration(): CertRegistry {

--- a/core/src/main/kotlin/io/specmatic/stub/DefaultHttpStubHandler.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/DefaultHttpStubHandler.kt
@@ -1,0 +1,70 @@
+package io.specmatic.stub
+
+import io.specmatic.core.Feature
+import io.specmatic.core.HttpRequest
+import io.specmatic.core.Result
+import io.specmatic.mock.ScenarioStub
+
+internal class DefaultHttpStubHandler(private val context: HttpStubHandlerContext) : HttpStubHandler.Default {
+    private val specmaticConfig = context.specmaticConfigSource.load().config
+    private val httpExpectations = HttpExpectations(
+        strictMode = context.strictMode,
+        specmaticConfig = specmaticConfig,
+        specToBaseUrlMap = context.specToBaseUrlMap,
+        static = staticHttpStubData(context.rawHttpStubs),
+        transient = context.rawHttpStubs.filter { it.stubToken != null }.reversed().toMutableList(),
+    )
+
+    override val stubCount: Int
+        get() = httpExpectations.stubCount
+
+    override val transientStubCount: Int
+        get() = httpExpectations.transientStubCount
+
+    override fun serveStubResponse(
+        baseUrl: String,
+        urlPath: String,
+        defaultBaseUrl: String,
+        features: List<Feature>,
+        httpRequest: HttpRequest,
+    ): StubbedResponseResult {
+        return getHttpResponse(
+            features = features,
+            httpRequest = httpRequest,
+            strictMode = context.strictMode,
+            specmaticConfig = specmaticConfig,
+            httpClientFactory = context.httpClientFactory,
+            passThroughTargetBase = context.passThroughTargetBase,
+            httpExpectations = httpExpectations.associatedTo(baseUrl, defaultBaseUrl, urlPath),
+        )
+    }
+
+    override fun addExpectation(stub: ScenarioStub, expectations: List<HttpStubData>) {
+        val results = expectations.map {
+            Pair(Result.Success(), it.copy(scenarioStub = stub))
+        }
+
+        if (stub.stubToken != null) {
+            results.forEach { httpExpectations.addDynamicTransient(it, stub) }
+        } else {
+            results.forEach { httpExpectations.addDynamic(it, stub) }
+        }
+    }
+
+    override fun utilizeMock(mock: HttpStubData) {
+        httpExpectations.utilizeMock(mock)
+    }
+
+    override fun removeWithToken(token: String?) {
+        httpExpectations.removeWithToken(token)
+    }
+
+    private fun staticHttpStubData(rawHttpStubs: List<HttpStubData>): MutableList<HttpStubData> {
+        val staticStubs = rawHttpStubs.filter { it.stubToken == null }
+        val stubsFromSpecificationExamples: List<HttpStubData> = context.features
+            .flatMap { it.loadInlineExamplesAsStub() }
+            .mapNotNull { returnValue -> returnValue.withDefault(null) { it } }
+
+        return staticStubs.plus(stubsFromSpecificationExamples).toMutableList()
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -65,7 +65,6 @@ import io.specmatic.core.utilities.URIValidationResult
 import io.specmatic.core.utilities.capitalizeFirstChar
 import io.specmatic.core.utilities.exceptionCauseMessage
 import io.specmatic.core.utilities.exitWithMessage
-import io.specmatic.core.utilities.toMap
 import io.specmatic.core.utilities.validateTestOrStubUri
 import io.specmatic.core.value.EmptyString
 import io.specmatic.core.value.BinaryValue
@@ -133,7 +132,7 @@ private const val SWAGGER_SPEC_NOT_AVAILABLE_MESSAGE = "No OpenAPI specification
 
 class HttpStub(
     private val features: List<Feature>,
-    rawHttpStubs: List<HttpStubData> = emptyList(),
+    private val rawHttpStubs: List<HttpStubData> = emptyList(),
     val host: String = "127.0.0.1",
     private val port: Int = 9000,
     private val log: (event: LogMessage) -> Unit = dontPrintToConsole,
@@ -235,12 +234,15 @@ class HttpStub(
         }
     )
 
-    private val httpExpectations: HttpExpectations = HttpExpectations(
+    private val httpStubHandlers = HttpStubHandlers(
+        features = features,
         strictMode = strictMode,
+        rawHttpStubs = rawHttpStubs,
+        specToBaseUrlMap = specToBaseUrlMap,
+        httpClientFactory = httpClientFactory,
         specmaticConfig = specmaticConfigInstance,
-        static = staticHttpStubData(rawHttpStubs),
-        transient = rawHttpStubs.filter { it.stubToken != null }.reversed().toMutableList(),
-        specToBaseUrlMap = specToBaseUrlMap
+        passThroughTargetBase = passThroughTargetBase,
+        specmaticConfigPath = loadedSpecmaticConfig.path,
     )
 
     private val firstMockedOpenApiSpec: MockedOpenApiSpec? by lazy {
@@ -265,22 +267,6 @@ class HttpStub(
         requestHandlers.add(requestHandler)
     }
 
-    private fun staticHttpStubData(rawHttpStubs: List<HttpStubData>): MutableList<HttpStubData> {
-        val staticStubs = rawHttpStubs.filter { it.stubToken == null }
-
-        val stubsFromSpecificationExamples: List<HttpStubData> = features.map {
-            it.loadInlineExamplesAsStub()
-        }.flatten().mapNotNull {
-            it.realise(
-                hasValue = { stubData, _ -> stubData },
-                orFailure = { null },
-                orException = { null }
-            )
-        }
-
-        return staticStubs.plus(stubsFromSpecificationExamples).toMutableList()
-    }
-
     private val _logs: MutableList<StubEndpoint> = Collections.synchronizedList(ArrayList())
     private val _allEndpoints: List<StubEndpoint> = extractAllEndpoints()
 
@@ -290,12 +276,12 @@ class HttpStub(
 
     val stubCount: Int
         get() {
-            return httpExpectations.stubCount
+            return httpStubHandlers.stubCount
         }
 
     val transientStubCount: Int
         get() {
-            return httpExpectations.transientStubCount
+            return httpStubHandlers.transientStubCount
         }
 
     val endPoint = endPointFromHostAndPort(host, port, keyDataRegistry.hasAny())
@@ -845,19 +831,22 @@ class HttpStub(
         val url = "$baseUrl$urlPath"
         val stubBaseUrlPath = specmaticConfigInstance.stubBaseUrlPathAssociatedTo(url, defaultBaseUrl)
 
-        return getHttpResponse(
-            httpRequest = httpRequest.trimBaseUrlPath(stubBaseUrlPath),
-            features = featuresAssociatedTo(baseUrl, features, specToBaseUrlMap, urlPath),
-            httpExpectations.associatedTo(baseUrl, defaultBaseUrl, urlPath),
-            strictMode = strictMode,
-            passThroughTargetBase = passThroughTargetBase,
-            httpClientFactory = httpClientFactory,
-            specmaticConfig = specmaticConfigInstance,
+        val trimmedRequest = httpRequest.trimBaseUrlPath(stubBaseUrlPath)
+        val candidateFeatures = featuresAssociatedTo(baseUrl, features, specToBaseUrlMap, urlPath)
+        val (handler, features) = httpStubHandlers.handlerForRequest(candidateFeatures, trimmedRequest)
+
+        return handler.serveStubResponse(
+            baseUrl = baseUrl,
+            urlPath = urlPath,
+            features = features,
+            httpRequest = trimmedRequest,
+            defaultBaseUrl = defaultBaseUrl,
         ).also {
-            if (it is FoundStubbedResponse) {
-                it.response.mock?.let { mock -> httpExpectations.utilizeMock(mock) }
-            }
             it.log(_logs, httpRequest)
+            if (it is FoundStubbedResponse) {
+                val mock = it.response.mock ?: return@also
+                httpStubHandlers.utilize(handler, mock)
+            }
         }
     }
 
@@ -886,7 +875,7 @@ class HttpStub(
     private fun handleFlushTransientStubsRequest(httpRequest: HttpRequest): HttpStubResponse {
         val token = httpRequest.path?.removePrefix("/_specmatic/$TRANSIENT_MOCK/")
 
-        httpExpectations.removeWithToken(token)
+        httpStubHandlers.removeWithToken(token)
 
         return HttpStubResponse(HttpResponse.OK)
     }
@@ -1117,47 +1106,28 @@ class HttpStub(
     }
 
     fun setExpectation(stub: ScenarioStub): List<HttpStubData> {
-        val results = features.asSequence().map { feature -> setExpectation(stub, feature) }
-
-        val result: Pair<Pair<Result.Success, List<HttpStubData>>?, NoMatchingScenario?>? =
-            results.find { it.first != null }
-        val firstResult: Pair<Result.Success, List<HttpStubData>>? = result?.first
-
-        when (firstResult) {
-            null -> {
-                val failures = results
-                    .flatMap {
-                        it.second?.results?.withoutFluff()?.results ?: emptyList()
-                    }
-                    .filterIsInstance<Result.Failure>()
-                    .distinctBy { failure -> failure.toReport().toText() }
-                    .toList()
-
-                val failureResults = Results(failures).withoutFluff()
-                throw NoMatchingScenario(
-                    failureResults,
-                    cachedMessage = failureResults.report(stub.requestElsePartialRequest())
-                )
-            }
-
-            else -> {
-                val stubData = firstResult.second.map { it.copy(scenarioStub = stub) }
-                val resultWithRequestBodyRegex = stubData.map { Pair(firstResult.first, it) }
-
-                if (stub.stubToken != null) {
-                    resultWithRequestBodyRegex.forEach {
-                        httpExpectations.addDynamicTransient(it, stub)
-                    }
-
-                } else {
-                    resultWithRequestBodyRegex.forEach {
-                        httpExpectations.addDynamic(it, stub)
-                    }
-                }
-            }
+        val results = features.asSequence().map { feature -> feature to setExpectation(stub, feature) }
+        val matchingResult = results.firstNotNullOfOrNull { (feature, result) ->
+            result.first?.let { expectation -> feature to expectation }
         }
 
-        return firstResult.second
+        if (matchingResult == null) {
+            val failures = results
+                .flatMap { (_, result) -> result.second?.results?.withoutFluff()?.results ?: emptyList() }
+                .filterIsInstance<Result.Failure>()
+                .distinctBy { failure -> failure.toReport().toText() }
+                .toList()
+
+            val failureResults = Results(failures).withoutFluff()
+            throw NoMatchingScenario(
+                results = failureResults,
+                cachedMessage = failureResults.report(stub.requestElsePartialRequest())
+            )
+        }
+
+        val (matchingFeature, expectation) = matchingResult
+        httpStubHandlers.addExpectation(matchingFeature, stub, expectation.second)
+        return expectation.second
     }
 
     private fun parseRegex(regex: String?): Regex? {

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStubHandler.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStubHandler.kt
@@ -1,0 +1,41 @@
+package io.specmatic.stub
+
+import io.specmatic.core.Feature
+import io.specmatic.core.HttpRequest
+import io.specmatic.mock.ScenarioStub
+import java.util.ServiceLoader
+
+data class HttpStubHandlerContext(
+    val strictMode: Boolean,
+    val features: List<Feature>,
+    val passThroughTargetBase: String,
+    val rawHttpStubs: List<HttpStubData>,
+    val httpClientFactory: HttpClientFactory,
+    val specToBaseUrlMap: Map<String, String>,
+    val specmaticConfigSource: SpecmaticConfigSource,
+)
+
+interface HttpStubHandlerFactory {
+    fun stateful(context: HttpStubHandlerContext): HttpStubHandler.Stateful?
+}
+
+interface HttpStubHandler {
+    fun addExpectation(stub: ScenarioStub, expectations: List<HttpStubData>)
+    fun serveStubResponse(baseUrl: String, urlPath: String, defaultBaseUrl: String, features: List<Feature>, httpRequest: HttpRequest): StubbedResponseResult
+
+    interface Default : HttpStubHandler {
+        val stubCount: Int
+        val transientStubCount: Int
+        fun utilizeMock(mock: HttpStubData)
+        fun removeWithToken(token: String?)
+    }
+
+    interface Stateful : HttpStubHandler {
+        companion object {
+            fun create(context: HttpStubHandlerContext): Stateful? {
+                val services = ServiceLoader.load(HttpStubHandlerFactory::class.java).toList()
+                return services.firstNotNullOfOrNull { it.stateful(context) }
+            }
+        }
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStubHandlers.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStubHandlers.kt
@@ -1,0 +1,118 @@
+package io.specmatic.stub
+
+import io.specmatic.core.Feature
+import io.specmatic.core.HttpRequest
+import io.specmatic.core.SpecmaticConfig
+import io.specmatic.core.config.MockMode
+import io.specmatic.core.pattern.ContractException
+import io.specmatic.mock.ScenarioStub
+import java.io.File
+
+data class HandlerSelection(val handler: HttpStubHandler, val features: List<Feature>)
+class HttpStubHandlers(
+    specmaticConfigPath: String?,
+    private val strictMode: Boolean,
+    private val features: List<Feature>,
+    private val passThroughTargetBase: String,
+    private val rawHttpStubs: List<HttpStubData>,
+    private val specmaticConfig: SpecmaticConfig,
+    private val httpClientFactory: HttpClientFactory,
+    private val specToBaseUrlMap: Map<String, String>,
+) {
+    private val specmaticConfigSource = SpecmaticConfigSource.fromConfigObject(specmaticConfig, specmaticConfigPath)
+    private val mockModeByFeature = features.associate { feature ->
+        feature.path to specmaticConfig.getMockMode(File(feature.path))
+    }
+
+    private val statefulMockHandler: HttpStubHandler.Stateful? = createStatefulMockHandler()
+    private val mockHandler: HttpStubHandler.Default = createStatelessMockHandler()
+
+    val stubCount: Int
+        get() = mockHandler.stubCount
+
+    val transientStubCount: Int
+        get() = mockHandler.transientStubCount
+
+    fun handlerForRequest(candidateFeatures: List<Feature>, httpRequest: HttpRequest): HandlerSelection {
+        val mode = modeForRequest(candidateFeatures, httpRequest)
+        return HandlerSelection(
+            handler = handlerFor(mode),
+            features = featuresForMode(candidateFeatures, mode)
+        )
+    }
+
+    fun addExpectation(feature: Feature, stub: ScenarioStub, expectations: List<HttpStubData>) {
+        val handler = handlerFor(modeForFeature(feature))
+        handler.addExpectation(stub, expectations)
+    }
+
+    fun removeWithToken(token: String?) {
+        mockHandler.removeWithToken(token)
+    }
+
+    fun utilize(handler: HttpStubHandler, mock: HttpStubData) {
+        if (handler !is HttpStubHandler.Default) return
+        handler.utilizeMock(mock)
+    }
+
+    private fun featuresForMode(candidateFeatures: List<Feature>, mode: MockMode): List<Feature> {
+        if (statefulMockHandler == null) return candidateFeatures
+        return candidateFeatures.filter { modeForFeature(it) == mode }
+    }
+
+    private fun handlerFor(mode: MockMode): HttpStubHandler {
+        return when (mode) {
+            MockMode.MOCK -> mockHandler
+            MockMode.STATEFUL_MOCK -> statefulMockHandler ?: mockHandler
+        }
+    }
+
+    private fun modeForRequest(candidateFeatures: List<Feature>, httpRequest: HttpRequest): MockMode {
+        if (statefulMockHandler == null) return MockMode.MOCK
+        val matchingFeature = candidateFeatures.firstOrNull { feature -> featureMatchesRequest(feature, httpRequest) }
+        return modeForFeature(matchingFeature ?: candidateFeatures.firstOrNull())
+    }
+
+    private fun createStatefulMockHandler(): HttpStubHandler.Stateful? {
+        if (features.none { modeForFeature(it) == MockMode.STATEFUL_MOCK }) return null
+        return HttpStubHandler.Stateful.create(contextFor(MockMode.STATEFUL_MOCK))
+            ?: throw ContractException("Stateful mocking is not supported in Specmatic Open Source")
+    }
+
+    private fun createStatelessMockHandler(): HttpStubHandler.Default {
+        val context = contextFor(MockMode.MOCK, includeAllModes = statefulMockHandler == null)
+        return DefaultHttpStubHandler(context)
+    }
+
+    private fun contextFor(mode: MockMode, includeAllModes: Boolean = false): HttpStubHandlerContext {
+        return HttpStubHandlerContext(
+            strictMode = strictMode,
+            specToBaseUrlMap = specToBaseUrlMap,
+            httpClientFactory = httpClientFactory,
+            passThroughTargetBase = passThroughTargetBase,
+            specmaticConfigSource = specmaticConfigSource,
+            features = if (includeAllModes) features else features.filter { modeForFeature(it) == mode },
+            rawHttpStubs = if (includeAllModes) rawHttpStubs else rawHttpStubs.filter { modeForRawHttpStub(it) == mode },
+        )
+    }
+
+    private fun modeForFeature(feature: Feature?): MockMode {
+        val feature = feature ?: return MockMode.MOCK
+        return mockModeByFeature[feature.path] ?: MockMode.MOCK
+    }
+
+    private fun modeForRawHttpStub(stubData: HttpStubData): MockMode {
+        return mockModeByFeature[stubData.contractPath] ?: MockMode.MOCK
+    }
+
+    companion object {
+        fun featureMatchesRequest(feature: Feature, httpRequest: HttpRequest): Boolean {
+            if (feature.identifierMatchingScenario(httpRequest) != null) return true
+            val expectedStatus = httpRequest.expectedResponseCode()
+            return feature.scenarios
+                .asSequence()
+                .filter { scenario -> scenario.status in setOf(405, 415) && (expectedStatus == null || scenario.status == expectedStatus) }
+                .any { scenario -> scenario.requestBelongsToScenarioForExpectedStatus(httpRequest, expectedStatus ?: scenario.status) }
+        }
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStubHandlers.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStubHandlers.kt
@@ -80,19 +80,19 @@ class HttpStubHandlers(
     }
 
     private fun createStatelessMockHandler(): HttpStubHandler.Default {
-        val context = contextFor(MockMode.MOCK, includeAllModes = statefulMockHandler == null)
+        val context = contextFor(MockMode.MOCK, skipModeFilter = statefulMockHandler == null)
         return DefaultHttpStubHandler(context)
     }
 
-    private fun contextFor(mode: MockMode, includeAllModes: Boolean = false): HttpStubHandlerContext {
+    private fun contextFor(mode: MockMode, skipModeFilter: Boolean = false): HttpStubHandlerContext {
         return HttpStubHandlerContext(
             strictMode = strictMode,
             specToBaseUrlMap = specToBaseUrlMap,
             httpClientFactory = httpClientFactory,
             passThroughTargetBase = passThroughTargetBase,
             specmaticConfigSource = specmaticConfigSource,
-            features = if (includeAllModes) features else features.filter { modeForFeature(it) == mode },
-            rawHttpStubs = if (includeAllModes) rawHttpStubs else rawHttpStubs.filter { modeForRawHttpStub(it) == mode },
+            features = if (skipModeFilter) features else features.filter { modeForFeature(it) == mode },
+            rawHttpStubs = if (skipModeFilter) rawHttpStubs else rawHttpStubs.filter { modeForRawHttpStub(it) == mode },
         )
     }
 

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubHandlerTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubHandlerTest.kt
@@ -1,0 +1,483 @@
+package io.specmatic.stub
+
+import io.specmatic.conversions.OpenApiSpecification
+import io.specmatic.core.Feature
+import io.specmatic.core.HttpRequest
+import io.specmatic.core.HttpResponse
+import io.specmatic.core.SpecmaticConfig
+import io.specmatic.core.SpecmaticConfigV1V2Common
+import io.specmatic.core.config.MockMode
+import io.specmatic.core.config.toSpecmaticConfig
+import io.specmatic.core.pattern.ContractException
+import io.specmatic.core.pattern.parsedJSONArray
+import io.specmatic.core.pattern.parsedJSONObject
+import io.specmatic.core.value.StringValue
+import io.specmatic.mock.ScenarioStub
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.io.File
+import java.net.ServerSocket
+import java.net.URL
+import java.util.Collections
+import java.util.ServiceLoader
+import java.util.stream.Stream
+
+class HttpStubHandlerTest {
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    inner class MockModeResolution {
+        @TempDir
+        lateinit var tempDir: File
+
+        @ParameterizedTest(name = "type={0} resolves to {1}")
+        @MethodSource("mockModes")
+        fun `should resolve the mock mode from the OpenAPI mock type`(type: String?, expectedMode: MockMode) {
+            val specFile = resourceFile("config/mock_mode_api.yaml")
+            val openApiRunOptions = type?.let { "type: $it" } ?: "{}"
+
+            val configFile = tempDir.resolve("specmatic.yaml").apply {
+                writeText("""
+                version: 3
+                dependencies:
+                  services:
+                    - service:
+                        definitions:
+                          - definition:
+                              source:
+                                filesystem:
+                                  directory: ${specFile.parentFile.canonicalPath}
+                              specs:
+                                - ${specFile.name}
+                        runOptions:
+                          openapi:
+                            $openApiRunOptions
+                """.trimIndent())
+            }
+
+            assertThat(configFile.toSpecmaticConfig().getMockMode(specFile)).isEqualTo(expectedMode)
+        }
+
+        @Test
+        fun `should default non-v3 configurations to ordinary mocking`() {
+            assertThat(SpecmaticConfigV1V2Common().getMockMode(File("api.yaml")))
+                .isEqualTo(MockMode.MOCK)
+        }
+
+        fun mockModes(): Stream<Arguments> = Stream.of(
+            Arguments.of(null, MockMode.MOCK),
+            Arguments.of("mock", MockMode.MOCK),
+            Arguments.of("stateful-mock", MockMode.STATEFUL_MOCK),
+        )
+    }
+
+    @Nested
+    inner class ServiceLoaderIntegration {
+        @Test
+        fun `should discover the core test handler factory through ServiceLoader`() {
+            val factories = ServiceLoader.load(HttpStubHandlerFactory::class.java).map { it::class.java }.toList()
+            assertThat(factories).containsExactly(HttpStubTestHandlerFactory::class.java)
+        }
+
+        @Test
+        fun `should create a stateful handler`() {
+            val factory = ServiceLoader.load(HttpStubHandlerFactory::class.java).single()
+            assertThat(factory.stateful(emptyContext())).isNotNull()
+        }
+
+        @Test
+        fun `should delegate a stateful request to the ServiceLoader handler`() {
+            val feature = handlerFeature()
+            HttpStub(
+                port = availablePort(),
+                features = listOf(feature),
+                specmaticConfigSource = SpecmaticConfigSource.fromConfigObject(configWithMode { MockMode.STATEFUL_MOCK }),
+            ).use { stub ->
+                val response = stub.client.execute(HttpRequest(method = "GET", path = "/spi"))
+                assertThat(response.status).isEqualTo(200)
+                assertThat(response.body).isEqualTo(StringValue("served by SPI"))
+                assertThat(response.getHeader("X-Test-SPI")).isEqualTo("true")
+                assertThat(response.getHeader("X-Test-SPI-Features")).isEqualTo("1")
+                assertThat(response.getHeader("X-Test-SPI-Raw-Stubs")).isEqualTo("0")
+                assertThat(stub.stubCount).isZero()
+                assertThat(stub.transientStubCount).isZero()
+            }
+        }
+    }
+
+    @Nested
+    inner class Fallback {
+        @Test
+        fun `should use the default handler when the provider declines ordinary mock mode`() {
+            val feature = handlerFeature()
+            val expectedResponse = HttpResponse(status = 200, body = StringValue("hello"))
+            val scenarioStub = ScenarioStub(request = HttpRequest(method = "GET", path = "/hello"), response = expectedResponse)
+
+            HttpStub(
+                port = availablePort(),
+                features = listOf(feature),
+                rawHttpStubs = contractInfoToHttpExpectations(listOf(feature to listOf(scenarioStub))),
+                specmaticConfigSource = SpecmaticConfigSource.fromConfigObject(configWithMode { MockMode.MOCK }),
+            ).use { stub ->
+                val response = stub.client.execute(scenarioStub.request)
+                assertThat(response.status).isEqualTo(expectedResponse.status)
+                assertThat(response.body).isEqualTo(expectedResponse.body)
+                assertThat(stub.stubCount).isEqualTo(2)
+                assertThat(stub.transientStubCount).isZero()
+            }
+        }
+
+        @Test
+        fun `should fail when no stateful mock provider is available`() {
+            val feature = handlerFeature()
+            val expectedResponse = HttpResponse(status = 200, body = StringValue("hello"))
+            val scenarioStub = ScenarioStub(request = HttpRequest(method = "GET", path = "/hello"), response = expectedResponse)
+
+            assertThatThrownBy {
+                withoutHttpStubHandlerServices {
+                    HttpStub(
+                        port = availablePort(),
+                        features = listOf(feature),
+                        rawHttpStubs = contractInfoToHttpExpectations(listOf(feature to listOf(scenarioStub))),
+                        specmaticConfigSource = SpecmaticConfigSource.fromConfigObject(configWithMode { MockMode.STATEFUL_MOCK }),
+                    ).use { }
+                }
+            }.isInstanceOf(ContractException::class.java)
+                .hasMessage("Stateful mocking is not supported in Specmatic Open Source")
+        }
+    }
+
+    @Nested
+    inner class DefaultHandlerBehavior {
+        @Test
+        fun `should preserve inline example matching after extracting the default handler`() {
+            HttpStub(features = listOf(handlerFeature()), port = availablePort()).use { stub ->
+                val response = stub.client.execute(
+                    request = HttpRequest(
+                        method = "POST",
+                        path = "/example",
+                        headers = mapOf("Content-Type" to "application/json"),
+                        body = parsedJSONObject("""{"id":1}"""),
+                    )
+                )
+
+                assertThat(response.status).isEqualTo(200)
+                assertThat(response.body).isEqualTo(StringValue("served from OpenAPI example"))
+            }
+        }
+
+        @Test
+        fun `should preserve transient precedence and flushing after extracting the default handler`() {
+            val feature = handlerFeature()
+            val staticStub = ScenarioStub(
+                request = HttpRequest(method = "GET", path = "/hello"),
+                response = HttpResponse(status = 200, body = StringValue("static")),
+            )
+
+            val transientStub = staticStub.copy(
+                stubToken = "transient-token",
+                response = HttpResponse(status = 200, body = StringValue("transient")),
+            )
+
+            HttpStub(
+                port = availablePort(),
+                features = listOf(feature),
+                rawHttpStubs = contractInfoToHttpExpectations(listOf(feature to listOf(staticStub))),
+            ).use { stub ->
+                stub.setExpectation(transientStub)
+                assertThat(stub.stubCount).isEqualTo(2)
+                assertThat(stub.transientStubCount).isEqualTo(1)
+                assertThat(stub.client.execute(transientStub.request).body)
+                    .isEqualTo(StringValue("transient"))
+
+                val flushResponse = stub.client.execute(HttpRequest(method = "DELETE", path = "/_specmatic/http-stub/transient-token"))
+                assertThat(flushResponse.status).isEqualTo(200)
+                assertThat(stub.transientStubCount).isZero()
+                assertThat(stub.client.execute(staticStub.request).body)
+                    .isEqualTo(StringValue("static"))
+            }
+        }
+
+        @Test
+        fun `should preserve persistent dynamic precedence after extracting the default handler`() {
+            val feature = handlerFeature()
+            val staticStub = ScenarioStub(
+                request = HttpRequest(method = "GET", path = "/hello"),
+                response = HttpResponse(status = 200, body = StringValue("static")),
+            )
+
+            HttpStub(
+                port = availablePort(),
+                features = listOf(feature),
+                rawHttpStubs = contractInfoToHttpExpectations(listOf(feature to listOf(staticStub))),
+            ).use { stub ->
+                val dynamicStub = staticStub.copy(response = HttpResponse(status = 200, body = StringValue("dynamic")))
+                stub.setExpectation(dynamicStub)
+
+                assertThat(stub.stubCount).isEqualTo(2)
+                assertThat(stub.transientStubCount).isZero()
+                assertThat(stub.client.execute(dynamicStub.request).body)
+                    .isEqualTo(StringValue("dynamic"))
+
+                stub.client.execute(HttpRequest(method = "DELETE", path = "/_specmatic/http-stub/any-token"))
+                assertThat(stub.client.execute(staticStub.request).body)
+                    .isEqualTo(StringValue("dynamic"))
+            }
+        }
+    }
+
+    @Nested
+    inner class DynamicExpectationIntegration {
+        @Test
+        fun `should route dynamic expectations to the selected ServiceLoader handler`() {
+            val feature = handlerFeature()
+            val expectation = ScenarioStub(
+                stubToken = "persistent-token",
+                request = HttpRequest(method = "GET", path = "/dynamic"),
+                response = HttpResponse(status = 201, body = StringValue("dynamic response")),
+            )
+
+            HttpStub(
+                port = availablePort(),
+                features = listOf(feature),
+                specmaticConfigSource = SpecmaticConfigSource.fromConfigObject(configWithMode { MockMode.STATEFUL_MOCK }),
+            ).use { stub ->
+                stub.setExpectation(expectation)
+                assertThat(stub.stubCount).isZero()
+                assertThat(stub.transientStubCount).isZero()
+
+                val responseBeforeFlush = stub.client.execute(expectation.request)
+                assertThat(responseBeforeFlush.status).isEqualTo(expectation.response.status)
+                assertThat(responseBeforeFlush.body).isEqualTo(expectation.response.body)
+
+                val flushResponse = stub.client.execute(HttpRequest(method = "DELETE", path = "/_specmatic/http-stub/persistent-token"))
+                assertThat(flushResponse.status).isEqualTo(200)
+                assertThat(stub.transientStubCount).isZero()
+
+                val responseAfterFlush = stub.client.execute(expectation.request)
+                assertThat(responseAfterFlush.status).isEqualTo(expectation.response.status)
+                assertThat(responseAfterFlush.body).isEqualTo(expectation.response.body)
+            }
+        }
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    inner class ModeRouting {
+        @ParameterizedTest(name = "stateful feature first={0}")
+        @MethodSource("featureOrderings")
+        fun `should use feature order to select the mode handler`(statefulFeatureFirst: Boolean) {
+            val fixtures = sharedFixtures()
+            val orderedFeatures = if (statefulFeatureFirst) {
+                listOf(fixtures.statefulFeature, fixtures.ordinaryFeature)
+            } else {
+                listOf(fixtures.ordinaryFeature, fixtures.statefulFeature)
+            }
+
+            HttpStub(
+                port = availablePort(),
+                features = orderedFeatures,
+                rawHttpStubs = fixtures.rawHttpStubs,
+                specmaticConfigSource = SpecmaticConfigSource.fromConfigObject(fixtures.config),
+            ).use { stub ->
+                val response = stub.client.execute(HttpRequest(method = "GET", path = "/shared"))
+                assertThat(response.status).isEqualTo(200)
+                assertThat(response.body).isEqualTo(
+                    if (statefulFeatureFirst) StringValue("served by SPI") else StringValue("ordinary")
+                )
+
+                assertThat(response.getHeader("X-Test-SPI")).isEqualTo(
+                    if (statefulFeatureFirst) "true" else null
+                )
+
+                assertThat(response.getHeader("X-Test-SPI-Features")).isEqualTo(
+                    if (statefulFeatureFirst) "1" else null
+                )
+
+                assertThat(response.getHeader("X-Test-SPI-Raw-Stubs")).isEqualTo(
+                    if (statefulFeatureFirst) "1" else null
+                )
+
+                assertThat(stub.stubCount).isEqualTo(1)
+                assertThat(stub.transientStubCount).isZero()
+            }
+        }
+
+        fun featureOrderings(): Stream<Arguments> = Stream.of(
+            Arguments.of(true),
+            Arguments.of(false),
+        )
+
+        private fun sharedFixtures(): SharedFixtures {
+            val statefulSpec = resourceFile("http_stub_handler/shared_stateful.yaml")
+            val ordinarySpec = resourceFile("http_stub_handler/shared_ordinary.yaml")
+            val statefulFeature = openApiFeature(statefulSpec)
+            val ordinaryFeature = openApiFeature(ordinarySpec)
+
+            val statefulStub = ScenarioStub(
+                request = HttpRequest(method = "GET", path = "/shared"),
+                response = HttpResponse(status = 200, body = parsedJSONArray("""[{"id":1}]""")),
+            )
+
+            val ordinaryStub = ScenarioStub(
+                request = HttpRequest(method = "GET", path = "/shared"),
+                response = HttpResponse(status = 200, body = StringValue("ordinary")),
+            )
+
+            val config = object : SpecmaticConfig by SpecmaticConfigV1V2Common() {
+                override fun getMockMode(specFile: File): MockMode = when (specFile.canonicalFile) {
+                    ordinarySpec.canonicalFile -> MockMode.MOCK
+                    statefulSpec.canonicalFile -> MockMode.STATEFUL_MOCK
+                    else -> MockMode.MOCK
+                }
+            }
+
+            return SharedFixtures(
+                config = config,
+                statefulFeature = statefulFeature,
+                ordinaryFeature = ordinaryFeature,
+                rawHttpStubs = contractInfoToHttpExpectations(
+                    listOf(
+                        statefulFeature to listOf(statefulStub),
+                        ordinaryFeature to listOf(ordinaryStub)
+                    )
+                ),
+            )
+        }
+    }
+
+    @Nested
+    inner class InvalidRequestRouting {
+        @ParameterizedTest(name = "invalid response status={0}, storage={1}")
+        @CsvSource("405,static", "415,static", "405,dynamic", "415,dynamic")
+        fun `should route invalid request examples to their owning ordinary feature`(status: Int, storage: String) {
+            val statefulSpec = resourceFile("http_stub_handler/invalid_stateful.yaml")
+            val ordinarySpec = resourceFile("http_stub_handler/invalid_ordinary.yaml")
+            val statefulFeature = openApiFeature(statefulSpec)
+            val ordinaryFeature = openApiFeature(ordinarySpec)
+
+            val expectedBody = if (status == 405) {
+                parsedJSONObject("""{"error":"method not allowed"}""")
+            } else {
+                parsedJSONObject("""{"error":"unsupported media type"}""")
+            }
+
+            val scenarioStub = if (status == 405) {
+                ScenarioStub(
+                    request = HttpRequest(
+                        method = "PATCH",
+                        path = "/orders",
+                        body = parsedJSONObject("""{"data":"found"}"""),
+                        headers = mapOf("Content-Type" to "application/json"),
+                    ),
+                    response = HttpResponse(status = status, body = expectedBody),
+                )
+            } else {
+                ScenarioStub(
+                    request = HttpRequest(
+                        method = "POST",
+                        path = "/orders",
+                        body = StringValue("request sent here"),
+                        headers = mapOf("Content-Type" to "text/plain"),
+                    ),
+                    response = HttpResponse(status = status, body = expectedBody),
+                )
+            }
+
+            val config = object : SpecmaticConfig by SpecmaticConfigV1V2Common() {
+                override fun getMockMode(specFile: File): MockMode {
+                    return if (specFile.canonicalFile == statefulSpec.canonicalFile) {
+                        MockMode.STATEFUL_MOCK
+                    } else {
+                        MockMode.MOCK
+                    }
+                }
+            }
+
+            HttpStub(
+                port = availablePort(),
+                features = listOf(statefulFeature, ordinaryFeature),
+                specmaticConfigSource = SpecmaticConfigSource.fromConfigObject(config),
+                rawHttpStubs = if (storage == "static") contractInfoToHttpExpectations(listOf(ordinaryFeature to listOf(scenarioStub))) else emptyList(),
+            ).use { stub ->
+                if (storage != "static") {
+                    stub.setExpectation(scenarioStub.copy(stubToken = if (storage in setOf("transient", "flushed")) "token" else null))
+                }
+
+                val response = stub.client.execute(scenarioStub.request)
+                assertThat(response.status).isEqualTo(status)
+                assertThat(response.body).isEqualTo(expectedBody)
+                assertThat(response.getHeader("X-Test-SPI")).isNull()
+                assertThat(stub.stubCount).isEqualTo(if (storage == "static") 1 else 0)
+                assertThat(stub.transientStubCount).isZero()
+            }
+        }
+    }
+
+    private fun handlerFeature(): Feature {
+        return openApiFeature(resourceFile("http_stub_handler/handler.yaml"))
+    }
+
+    private fun openApiFeature(specFile: File): Feature {
+        return OpenApiSpecification.fromFile(specFile.canonicalPath).toFeature()
+    }
+
+    private fun resourceFile(path: String): File {
+        return File("src/test/resources/$path").canonicalFile
+    }
+
+    private fun configWithMode(mode: (File) -> MockMode): SpecmaticConfig {
+        return object : SpecmaticConfig by SpecmaticConfigV1V2Common() {
+            override fun getMockMode(specFile: File): MockMode = mode(specFile)
+        }
+    }
+
+    private fun emptyContext(): HttpStubHandlerContext {
+        return HttpStubHandlerContext(
+            strictMode = false,
+            features = emptyList(),
+            passThroughTargetBase = "",
+            rawHttpStubs = emptyList(),
+            specToBaseUrlMap = emptyMap(),
+            httpClientFactory = HttpClientFactory(),
+            specmaticConfigSource = SpecmaticConfigSource.None,
+        )
+    }
+
+    private fun withoutHttpStubHandlerServices(block: () -> Unit) {
+        val currentThread = Thread.currentThread()
+        val originalClassLoader = currentThread.contextClassLoader
+        val serviceName = "META-INF/services/${HttpStubHandlerFactory::class.java.name}"
+        currentThread.contextClassLoader = object : ClassLoader(originalClassLoader) {
+            override fun getResources(name: String): java.util.Enumeration<URL> {
+                return if (name == serviceName) {
+                    Collections.emptyEnumeration()
+                } else {
+                    super.getResources(name)
+                }
+            }
+        }
+
+        try {
+            block()
+        } finally {
+            currentThread.contextClassLoader = originalClassLoader
+        }
+    }
+
+    private fun availablePort(): Int = ServerSocket(0).use { it.localPort }
+
+    private data class SharedFixtures(
+        val config: SpecmaticConfig,
+        val statefulFeature: Feature,
+        val ordinaryFeature: Feature,
+        val rawHttpStubs: List<HttpStubData>,
+    )
+}

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubTestHandlerFactory.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubTestHandlerFactory.kt
@@ -1,0 +1,51 @@
+package io.specmatic.stub
+
+import io.specmatic.core.Feature
+import io.specmatic.core.HttpRequest
+import io.specmatic.core.HttpResponse
+import io.specmatic.core.value.StringValue
+import io.specmatic.mock.ScenarioStub
+
+@Suppress("unused")
+class HttpStubTestHandlerFactory : HttpStubHandlerFactory {
+    override fun stateful(context: HttpStubHandlerContext): HttpStubHandler.Stateful {
+        return HttpStubStatefulTestHandler(context)
+    }
+}
+
+private class HttpStubStatefulTestHandler(private val context: HttpStubHandlerContext) : HttpStubHandler.Stateful {
+    private val dynamicExpectations = mutableListOf<ScenarioStub>()
+
+    override fun serveStubResponse(
+        baseUrl: String,
+        urlPath: String,
+        defaultBaseUrl: String,
+        features: List<Feature>,
+        httpRequest: HttpRequest,
+    ): StubbedResponseResult {
+        val response = dynamicExpectations
+            .firstOrNull { it.request.method == httpRequest.method && it.request.path == httpRequest.path }
+            ?.response
+            ?: HttpResponse(
+                status = 200,
+                headers = mapOf(
+                    "X-Test-SPI" to "true",
+                    "X-Test-SPI-Features" to features.size.toString(),
+                    "X-Test-SPI-Raw-Stubs" to context.rawHttpStubs.size.toString(),
+                ),
+                body = StringValue("served by SPI"),
+            )
+
+        return FoundStubbedResponse(
+            HttpStubResponse(
+                response = response,
+                feature = features.firstOrNull(),
+                contractPath = features.firstOrNull()?.path.orEmpty(),
+            )
+        )
+    }
+
+    override fun addExpectation(stub: ScenarioStub, expectations: List<HttpStubData>) {
+        dynamicExpectations.add(stub)
+    }
+}

--- a/core/src/test/resources/META-INF/services/io.specmatic.stub.HttpStubHandlerFactory
+++ b/core/src/test/resources/META-INF/services/io.specmatic.stub.HttpStubHandlerFactory
@@ -1,0 +1,1 @@
+io.specmatic.stub.HttpStubTestHandlerFactory

--- a/core/src/test/resources/config/mock_mode_api.yaml
+++ b/core/src/test/resources/config/mock_mode_api.yaml
@@ -1,0 +1,5 @@
+openapi: 3.0.3
+info:
+  title: Mock mode API
+  version: 1.0.0
+paths: {}

--- a/core/src/test/resources/http_stub_handler/handler.yaml
+++ b/core/src/test/resources/http_stub_handler/handler.yaml
@@ -1,0 +1,57 @@
+openapi: 3.0.3
+info:
+  title: Http stub handler API
+  version: 1.0.0
+paths:
+  /spi:
+    get:
+      responses:
+        '200':
+          description: SPI response
+          content:
+            text/plain:
+              schema:
+                type: string
+  /dynamic:
+    get:
+      responses:
+        '201':
+          description: Dynamic response
+          content:
+            text/plain:
+              schema:
+                type: string
+  /hello:
+    get:
+      responses:
+        '200':
+          description: Greeting response
+          content:
+            text/plain:
+              schema:
+                type: string
+  /example:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [id]
+              properties:
+                id:
+                  type: integer
+            examples:
+              example:
+                value:
+                  id: 1
+      responses:
+        '200':
+          description: Inline example response
+          content:
+            text/plain:
+              schema:
+                type: string
+              examples:
+                example:
+                  value: served from OpenAPI example

--- a/core/src/test/resources/http_stub_handler/invalid_ordinary.yaml
+++ b/core/src/test/resources/http_stub_handler/invalid_ordinary.yaml
@@ -1,0 +1,32 @@
+openapi: 3.0.3
+info:
+  title: Ordinary API
+  version: 1.0.0
+paths:
+  /orders:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+        '415':
+          description: Unsupported media type
+          content:
+            application/json:
+              schema:
+                type: object
+        '405':
+          description: Method not allowed
+          content:
+            application/json:
+              schema:
+                type: object

--- a/core/src/test/resources/http_stub_handler/invalid_stateful.yaml
+++ b/core/src/test/resources/http_stub_handler/invalid_stateful.yaml
@@ -1,0 +1,20 @@
+openapi: 3.0.3
+info:
+  title: Stateful API
+  version: 1.0.0
+paths:
+  /orders:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object

--- a/core/src/test/resources/http_stub_handler/shared_ordinary.yaml
+++ b/core/src/test/resources/http_stub_handler/shared_ordinary.yaml
@@ -1,0 +1,14 @@
+openapi: 3.0.3
+info:
+  title: Ordinary API
+  version: 1.0.0
+paths:
+  /shared:
+    get:
+      responses:
+        '200':
+          description: Shared text
+          content:
+            text/plain:
+              schema:
+                type: string

--- a/core/src/test/resources/http_stub_handler/shared_stateful.yaml
+++ b/core/src/test/resources/http_stub_handler/shared_stateful.yaml
@@ -1,0 +1,20 @@
+openapi: 3.0.3
+info:
+  title: Stateful API
+  version: 1.0.0
+paths:
+  /shared:
+    get:
+      responses:
+        '200':
+          description: Shared collection
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required: [id]
+                  properties:
+                    id:
+                      type: integer


### PR DESCRIPTION
**What**:
- Add per-spec mock mode resolution.
- Extract the existing `HttpExpectations` behavior into the default handler.
- Load mock mode handlers through `ServiceLoader`, with the core handler as fallback.
- Add an SPI for externally provided mock handlers and OpenAPI-backed routing coverage.

**Why**:

This change introduces an extension point for external mock implementations, such as stateful mocks.
> There is technically no behavioral change to core `HttpStub` usage: standard mocks continue using the existing matching, expectation, transient stub, token removal, and hook behavior through the default handler.

**How**:

- Resolve mock mode independently for each specification.
- Route requests and expectations to an external handler only when that mode is provided.
- Preserve the existing implementation as the default core handler.
- Add regression coverage for SPI loading and routing.

**Checklist**:

- [x] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated — N/A
- [ ] Sample Project added/updated — N/A
- [ ] Demo video — N/A
- [ ] Article on Website — N/A
- [ ] Roadmap updated — N/A
- [ ] Conference Talk — N/A