### PR TITLE
Add CLI command to validate Specmatic configuration

### DIFF
--- a/application/src/main/kotlin/application/ConfigCommand.kt
+++ b/application/src/main/kotlin/application/ConfigCommand.kt
@@ -11,17 +11,19 @@ import io.specmatic.core.config.SpecmaticConfigVersion.Companion.getLatestVersio
 import io.specmatic.core.config.SpecmaticConfigVersion.Companion.isValidVersion
 import io.specmatic.core.config.getVersion
 import io.specmatic.core.config.toSpecmaticConfig
+import io.specmatic.core.config.validation.ConfigValidationOutput
+import io.specmatic.core.config.validation.ConfigValidationResult
+import io.specmatic.core.config.validation.ConfigValidationSeverity
+import io.specmatic.core.config.validation.ConfigSchemaOutputFormat
+import io.specmatic.core.config.validation.SpecmaticConfigValidator
 import io.specmatic.core.getConfigFilePath
 import io.specmatic.core.log.logger
 import io.specmatic.core.utilities.exitWithMessage
 import io.specmatic.license.core.cli.Category
-import picocli.CommandLine.Command
-import picocli.CommandLine.Option
+import kotlinx.serialization.json.Json
+import picocli.CommandLine.*
 import java.io.File
 import java.util.concurrent.Callable
-import kotlin.reflect.KClass
-import kotlin.reflect.full.memberProperties
-import kotlin.reflect.jvm.isAccessible
 import kotlin.system.exitProcess
 
 private const val SUCCESS_EXIT_CODE = 0
@@ -33,7 +35,8 @@ private const val SPECMATIC_CONFIGURATION = "Specmatic Configuration"
     mixinStandardHelpOptions = true,
     description = ["Manage and configure $SPECMATIC_CONFIGURATION."],
     subcommands = [
-        ConfigCommand.Upgrade::class
+        ConfigCommand.Upgrade::class,
+        ConfigCommand.Validate::class,
     ]
 )
 @Category("Specmatic core")
@@ -124,5 +127,118 @@ class ConfigCommand : Callable<Int> {
             }
             return configFile
         }
+    }
+
+    @Command(
+        name = "validate",
+        mixinStandardHelpOptions = true,
+        description = ["Validate $SPECMATIC_CONFIGURATION against its schema and semantic rules."],
+    )
+    class Validate : Callable<Int> {
+        private val validator = SpecmaticConfigValidator()
+        private val renderer = ConfigValidationTextRenderer()
+        @Option(
+            names = ["--input"],
+            description = ["Path to the $SPECMATIC_CONFIGURATION file. Defaults to the normal config path."],
+        )
+        var inputFile: File? = null
+
+        @Option(
+            names = ["--format"],
+            defaultValue = "text",
+            description = ["Output format: text or json."],
+            converter = [OutputFormatConverter::class],
+        )
+        var format: OutputFormat = OutputFormat.TEXT
+
+        @Option(
+            names = ["--schema-output"],
+            converter = [SchemaOutputFormatConverter::class],
+            description = ["Schema validation output: list or hierarchical. Defaults to list for text and hierarchical for JSON."],
+        )
+        var schemaOutput: ConfigSchemaOutputFormat? = null
+
+        override fun call(): Int {
+            val configFile = inputFile ?: File(getConfigFilePath())
+            val content = try {
+                configFile.readText()
+            } catch (e: Exception) {
+                val result = unreadableFile(configFile, e)
+                print(result, configFile, "")
+                return 1
+            }
+
+            val result = validator.validate(content, configFile.toPath(), schemaOutput ?: defaultSchemaOutput())
+            print(result, configFile, content)
+            return if (result is ConfigValidationResult.Valid) 0 else 1
+        }
+
+        private fun print(result: ConfigValidationResult, configFile: File, content: String) {
+            when (format) {
+                OutputFormat.JSON -> println(serializeOutputs(result))
+                OutputFormat.TEXT -> println(renderer.render(configFile.name, content, result))
+            }
+        }
+
+        private fun serializeOutputs(result: ConfigValidationResult): String {
+            return json.encodeToString(
+                value = when (result) {
+                    is ConfigValidationResult.Invalid -> result.output
+                    is ConfigValidationResult.Valid -> listOf(validOutput())
+                }
+            )
+        }
+
+        private fun validOutput() = ConfigValidationOutput(
+            valid = true,
+            keywordLocation = "",
+            instanceLocation = "",
+            severity = ConfigValidationSeverity.INFO,
+        )
+
+        private fun defaultSchemaOutput(): ConfigSchemaOutputFormat = when (format) {
+            OutputFormat.TEXT -> ConfigSchemaOutputFormat.LIST
+            OutputFormat.JSON -> ConfigSchemaOutputFormat.HIERARCHICAL
+        }
+
+        private fun unreadableFile(file: File, exception: Exception): ConfigValidationResult.Invalid {
+            val message = exception.message?.takeIf { it.isNotBlank() } ?: "The file could not be read."
+            return ConfigValidationResult.Invalid(
+                version = null,
+                output = listOf(
+                    element = ConfigValidationOutput(
+                        valid = false,
+                        keywordLocation = "",
+                        instanceLocation = "",
+                        error = "Could not read ${file.path}: $message",
+                    )
+                ),
+            )
+        }
+
+        private companion object {
+            val json = Json { prettyPrint = true; prettyPrintIndent = "  "; encodeDefaults = true }
+        }
+    }
+
+    class OutputFormatConverter : ITypeConverter<OutputFormat> {
+        override fun convert(value: String): OutputFormat = when (value.lowercase()) {
+            "text" -> OutputFormat.TEXT
+            "json" -> OutputFormat.JSON
+            else -> throw IllegalArgumentException("expected text or json")
+        }
+    }
+
+    class SchemaOutputFormatConverter : ITypeConverter<ConfigSchemaOutputFormat> {
+        override fun convert(value: String): ConfigSchemaOutputFormat = when (value.lowercase()) {
+            "list" -> ConfigSchemaOutputFormat.LIST
+            "hierarchical", "hierarchy" -> ConfigSchemaOutputFormat.HIERARCHICAL
+            else -> throw IllegalArgumentException("expected list or hierarchical")
+        }
+    }
+
+    enum class OutputFormat {
+        TEXT,
+        JSON,
     }
 }

--- a/application/src/main/kotlin/application/ConfigValidationTextRenderer.kt
+++ b/application/src/main/kotlin/application/ConfigValidationTextRenderer.kt
@@ -1,0 +1,155 @@
+package application
+
+import io.specmatic.core.config.validation.ConfigValidationOutput
+import io.specmatic.core.config.validation.ConfigValidationResult
+import io.specmatic.core.config.validation.ConfigValidationSeverity
+import org.yaml.snakeyaml.Yaml
+import org.yaml.snakeyaml.error.Mark
+import org.yaml.snakeyaml.nodes.Node
+import org.yaml.snakeyaml.nodes.AnchorNode
+import org.yaml.snakeyaml.nodes.ScalarNode
+import org.yaml.snakeyaml.nodes.MappingNode
+import org.yaml.snakeyaml.nodes.SequenceNode
+
+class ConfigValidationTextRenderer {
+    fun render(fileName: String, source: String, result: ConfigValidationResult): String {
+        return when (result) {
+            is ConfigValidationResult.Valid -> "Configuration is valid: $fileName"
+            is ConfigValidationResult.Invalid -> renderInvalid(fileName, source, result.output)
+        }
+    }
+
+    private fun renderInvalid(fileName: String, source: String, outputs: List<ConfigValidationOutput>): String {
+        val root = runCatching { Yaml().compose(source.reader()) }.getOrNull()
+        return buildList {
+            add("Configuration is invalid: $fileName")
+            add("")
+            outputs.forEachIndexed { index, output ->
+                if (index > 0) add(DIAGNOSTIC_SEPARATOR)
+                add(renderDiagnostic(fileName, root, output))
+            }
+            add("")
+            add(summary(outputs))
+        }.joinToString("\n").trimEnd()
+    }
+
+    private fun renderDiagnostic(fileName: String, root: Node?, output: ConfigValidationOutput, depth: Int = 0): String {
+        val mark = root?.locate(output.instanceLocation)?.markFor(output)
+        val message = output.error ?: "Configuration validation failed."
+        val indentation = "  ".repeat(depth)
+        val location = if (mark == null) {
+            "$fileName:${output.instanceLocation.ifBlank { "/" }}"
+        } else {
+            "$fileName:${mark.line + 1}:${mark.column + 1}\n${snippet(mark)}"
+        }
+
+        val current = buildList {
+            add(location)
+            if (mark != null) add("")
+            add(message)
+            help(output)?.let(::add)
+        }.joinToString("\n").indent(indentation)
+
+        return buildList {
+            add(current)
+            if (output.details.isNotEmpty()) {
+                add("")
+                add("${indentation}Validation details:")
+                output.details.forEach { detail ->
+                    add(renderDiagnostic(fileName, root, detail, depth + 1))
+                }
+            }
+        }.joinToString("\n")
+    }
+
+    private fun String.indent(indentation: String): String = lines().joinToString("\n") {
+        if (it.isBlank()) it else indentation + it
+    }
+
+    private fun snippet(mark: Mark): String {
+        val lines = mark._snippet.trimEnd().lines()
+        val lineNumber = mark.line + 1
+        val gutter = lineNumber.toString()
+
+        return lines.mapIndexed { index, line ->
+            if (index == 0) "$gutter | $line" else "${" ".repeat(gutter.length)} | $line"
+        }.joinToString("\n")
+    }
+
+    private fun help(output: ConfigValidationOutput): String? {
+        val metadata = output.metadata ?: return null
+        if (output.severity == ConfigValidationSeverity.WARNING) {
+            return metadata.deprecationMessage?.let { "Deprecated: $it" }
+        }
+
+        return listOfNotNull(
+            metadata.title?.takeIf { it.isNotBlank() && it != output.error },
+            metadata.description?.takeIf { it.isNotBlank() && it != output.error },
+        ).joinToString(" — ").ifBlank { null }
+    }
+
+    private fun summary(outputs: List<ConfigValidationOutput>): String {
+        val errors = outputs.count { it.severity == ConfigValidationSeverity.ERROR }
+        val warnings = outputs.count { it.severity == ConfigValidationSeverity.WARNING }
+        return listOfNotNull(
+            "$errors error${if (errors == 1) "" else "s"}".takeIf { errors > 0 },
+            "$warnings warning${if (warnings == 1) "" else "s"}".takeIf { warnings > 0 },
+        ).joinToString(", ")
+    }
+
+    private fun Node.locate(pointer: String): LocatedNode? {
+        var current = unwrap()
+        var located = LocatedNode(current)
+        if (pointer.isBlank()) return located
+
+        pointer.removePrefix("/").split("/").map(::unescape).forEach { segment ->
+            located = when (current) {
+                is MappingNode -> {
+                    val entry = current.value.firstOrNull { (it.keyNode as? ScalarNode)?.value == segment } ?: return null
+                    current = entry.valueNode.unwrap()
+                    LocatedNode(current, entry.keyNode)
+                }
+
+                is SequenceNode -> {
+                    current = current.value.getOrNull(segment.toIntOrNull() ?: return null)?.unwrap() ?: return null
+                    LocatedNode(current)
+                }
+
+                else -> return null
+            }
+        }
+
+        return located
+    }
+
+    private fun Node.unwrap(): Node {
+        return if (this is AnchorNode) realNode.unwrap() else this
+    }
+
+    private fun unescape(value: String): String {
+        return value.replace("~1", "/").replace("~0", "~")
+    }
+
+    companion object {
+        private const val DIAGNOSTIC_SEPARATOR = "--------------------------------"
+    }
+}
+
+private data class LocatedNode(val value: Node, val key: Node? = null) {
+    fun markFor(output: ConfigValidationOutput): Mark {
+        return if (key != null && isPropertyDiagnostic(output)) key.startMark else value.startMark
+    }
+
+    private fun isPropertyDiagnostic(output: ConfigValidationOutput): Boolean {
+        val keyword = output.metadata?.keyword ?: output.keywordLocation.substringAfterLast('/')
+        return output.metadata?.deprecated == true || keyword in PROPERTY_KEYWORDS
+    }
+
+    private companion object {
+        val PROPERTY_KEYWORDS = setOf(
+            "additionalProperties",
+            "unevaluatedProperties",
+            "propertyNames",
+        )
+    }
+}

--- a/application/src/main/kotlin/application/ExamplesCommand.kt
+++ b/application/src/main/kotlin/application/ExamplesCommand.kt
@@ -112,8 +112,8 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
             }
         }
 
-        private val specmaticConfig = loadSpecmaticConfigIfAvailableElseDefault()
-        private val exampleValidationModule = ExampleValidationModule(lenientMode = lenientMode, specmaticConfig = specmaticConfig)
+        private val specmaticConfig by lazy { loadSpecmaticConfigIfAvailableElseDefault() }
+        private val exampleValidationModule by lazy { ExampleValidationModule(lenientMode = lenientMode, specmaticConfig = specmaticConfig) }
 
         override fun call(): Int {
             configureLogger(this.verbose)

--- a/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckBaseCommand.kt
+++ b/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckBaseCommand.kt
@@ -29,8 +29,8 @@ abstract class BackwardCompatibilityCheckBaseCommand(
     @field:picocli.CommandLine.Mixin
     val options: BackwardCompatibilityCheckOptions = BackwardCompatibilityCheckOptions()
 ): Callable<Int> {
-    protected val specmaticConfig: SpecmaticConfig = loadSpecmaticConfigIfAvailableElseDefault()
-    protected val backwardCompConfig = specmaticConfig.getBackwardCompatibilityConfig()
+    protected val specmaticConfig: SpecmaticConfig by lazy { loadSpecmaticConfigIfAvailableElseDefault() }
+    protected val backwardCompConfig by lazy { specmaticConfig.getBackwardCompatibilityConfig() }
     protected val effectiveRepoDir: String by lazy { options.repoDir ?: backwardCompConfig?.repoDirectory ?: "." }
     protected val gitCommand: GitCommand by lazy { SystemGit(workingDirectory = Paths.get(effectiveRepoDir).absolutePathString()) }
     protected val effectiveBaseBranch: String by lazy { options.baseBranch ?: backwardCompConfig?.baseBranch ?: gitCommand.currentRemoteBranch() }

--- a/application/src/main/kotlin/application/mcp/McpTestCommand.kt
+++ b/application/src/main/kotlin/application/mcp/McpTestCommand.kt
@@ -68,8 +68,8 @@ open class McpTestCommand : Callable<Int> {
     )
     var verbose: Boolean? = null
 
-    private val specmaticConfig = loadSpecmaticConfigIfAvailableElseDefault()
-    private val mcpConfig = specmaticConfig.getMcpConfiguration()
+    private val specmaticConfig by lazy { loadSpecmaticConfigIfAvailableElseDefault() }
+    private val mcpConfig by lazy { specmaticConfig.getMcpConfiguration() }
 
     override fun call(): Int {
         McpBaseCommand.configureLogger(verbose)
@@ -103,14 +103,16 @@ open class McpTestCommand : Callable<Int> {
     ): McpAutoTest = McpAutoTest(baseUrl, transport, enableResiliency, dictionaryFile, bearerToken, filterTools, skipTools)
 
     private fun effectiveTransport(): McpTransport {
+        val config = mcpConfig
         if (transportKind != null) return transportKind as McpTransport
-        if (mcpConfig?.test?.transportKind != null) return mcpConfig.test.transportKind as McpTransport
+        if (config?.test?.transportKind != null) return config.test.transportKind as McpTransport
         throw ContractException("Please provide transportKind through CLI arguments or Specmatic Config")
     }
 
     private fun effectiveBaseUrl(): String {
+        val config = mcpConfig
         if (baseUrl != null) return baseUrl as String
-        if (mcpConfig?.test?.baseUrl != null) return mcpConfig.test.baseUrl
+        if (config?.test?.baseUrl != null) return config.test.baseUrl
         throw ContractException("Please provide baseUrl through CLI arguments or Specmatic Config")
     }
 

--- a/application/src/main/kotlin/application/validate/ValidateCommand.kt
+++ b/application/src/main/kotlin/application/validate/ValidateCommand.kt
@@ -29,15 +29,19 @@ class ValidateCommandOptions {
 class ValidateCommand(
     private val validator: Validator<out Any?> = OpenApiValidator(),
     specCompatibilityChecker: SpecCompatibilityChecker = OpenApiSpecCompatibilityChecker(),
-    specmaticConfig: io.specmatic.core.SpecmaticConfig = loadSpecmaticConfigIfAvailableElseDefault(),
+    specmaticConfig: io.specmatic.core.SpecmaticConfig? = null,
     configBackedSpecificationLoader: ConfigBackedSpecificationLoader? = null,
     private val currentDirectoryProvider: () -> File = { File(".").canonicalFile },
     @field:CommandLine.Mixin val validateOptions: ValidateCommandOptions = ValidateCommandOptions()
 ) : Callable<Int> {
-    private val recursiveSpecificationAndExampleClassifier =
-        RecursiveSpecificationAndExampleClassifier(specmaticConfig, specCompatibilityChecker, setOf(".specmatic"))
-    private val effectiveConfigBackedSpecificationLoader =
-        configBackedSpecificationLoader ?: ConfigBackedSpecificationLoader(specmaticConfig, recursiveSpecificationAndExampleClassifier)
+    private val effectiveSpecmaticConfig by lazy { specmaticConfig ?: loadSpecmaticConfigIfAvailableElseDefault() }
+    private val recursiveSpecificationAndExampleClassifier by lazy {
+        RecursiveSpecificationAndExampleClassifier(effectiveSpecmaticConfig, specCompatibilityChecker, setOf(".specmatic"))
+    }
+
+    private val effectiveConfigBackedSpecificationLoader by lazy {
+        configBackedSpecificationLoader ?: ConfigBackedSpecificationLoader(effectiveSpecmaticConfig, recursiveSpecificationAndExampleClassifier)
+    }
 
     override fun call(): Int {
         configureLogging(LoggingConfiguration.Companion.LoggingFromOpts(debug = validateOptions.debug))

--- a/application/src/test/kotlin/application/ConfigCommandValidateTest.kt
+++ b/application/src/test/kotlin/application/ConfigCommandValidateTest.kt
@@ -155,7 +155,7 @@ class ConfigCommandValidateTest {
             assertThat(output).contains(
                 "Configuration is invalid: missing.yaml",
                 "missing.yaml:/",
-                "Could not read ${missingFile.path}: ${missingFile.path} (",
+                "Could not read ${missingFile.path}: ${missingFile.path}",
             )
         }
 

--- a/application/src/test/kotlin/application/ConfigCommandValidateTest.kt
+++ b/application/src/test/kotlin/application/ConfigCommandValidateTest.kt
@@ -1,0 +1,358 @@
+package application
+
+import io.specmatic.core.config.validation.ConfigValidationMetadata
+import io.specmatic.core.config.validation.ConfigValidationOutput
+import io.specmatic.core.config.validation.ConfigValidationResult
+import io.specmatic.core.config.validation.ConfigValidationSeverity
+import io.specmatic.core.utilities.Flags
+import io.specmatic.core.utilities.Flags.Companion.CONFIG_FILE_PATH
+import io.specmatic.core.utilities.SystemExit
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import picocli.CommandLine
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.PrintStream
+
+class ConfigCommandValidateTest {
+    @Nested
+    inner class Registration {
+        @Test
+        fun `registers validate alongside upgrade`() {
+            assertThat(CommandLine(ConfigCommand()).subcommands.keys)
+                .containsExactlyInAnyOrder("upgrade", "validate")
+        }
+    }
+
+    @Nested
+    inner class CommandExecution {
+        @Test
+        fun `validates the default configuration path`(@TempDir tempDir: File) {
+            val configFile = tempDir.resolve("specmatic.yaml").apply { writeText("version: 3\n") }
+            val (output, exitCode) = Flags.using(CONFIG_FILE_PATH to configFile.path) {
+                captureOutput { CommandLine(ConfigCommand()).execute("validate") }
+            }
+
+            assertThat(exitCode).isZero()
+            assertThat(output).isEqualTo("Configuration is valid: specmatic.yaml")
+        }
+
+        @Test
+        fun `validates an explicit input and returns a text diagnostic`(@TempDir tempDir: File) {
+            val configFile = tempDir.resolve("custom.yaml").apply {
+                writeText("version: 2\nreport: invalid\n")
+            }
+
+            val (output, exitCode) = captureOutput {
+                CommandLine(ConfigCommand()).execute("validate", "--input", configFile.path)
+            }
+
+            assertThat(exitCode).withFailMessage(output).isEqualTo(1)
+            assertThat(output).isEqualTo("""
+            Configuration is invalid: custom.yaml
+
+            custom.yaml:2:9
+            2 |     report: invalid
+              |             ^
+
+            string found, object expected
+            Reporting configuration — Report types and API-coverage thresholds.
+
+            1 error
+            """.trimIndent())
+        }
+
+        @Test
+        fun `serializes the backend result directly as json`(@TempDir tempDir: File) {
+            val configFile = tempDir.resolve("invalid.yaml").apply {
+                writeText("version: 2\nreport: invalid\n")
+            }
+
+            val (output, exitCode) = captureOutput {
+                CommandLine(ConfigCommand()).execute(
+                    "validate", "--input", configFile.path, "--format", "json",
+                )
+            }
+
+            assertThat(exitCode).isEqualTo(1)
+            assertThat(output).isEqualTo($$"""
+            [
+              {
+                "valid": false,
+                "error": "string found, object expected",
+                "keywordLocation": "/properties/report/$ref",
+                "instanceLocation": "/report",
+                "absoluteKeywordLocation": "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ReportConfigurationDetails",
+                "severity": "ERROR",
+                "metadata": {
+                  "title": "Reporting configuration",
+                  "keyword": "$ref",
+                  "description": "Report types and API-coverage thresholds.",
+                  "deprecated": null,
+                  "deprecationMessage": null
+                }
+              }
+            ]""".trimIndent())
+        }
+
+        @Test
+        fun `serializes a valid result as one valid output`(@TempDir tempDir: File) {
+            val configFile = tempDir.resolve("valid.yaml").apply {
+                writeText("version: 3\n")
+            }
+
+            val (output, exitCode) = captureOutput {
+                CommandLine(ConfigCommand()).execute(
+                    "validate", "--input", configFile.path, "--format", "json",
+                )
+            }
+
+            assertThat(exitCode).isZero()
+            assertThat(output).isEqualTo("""
+            [
+              {
+                "valid": true,
+                "error": null,
+                "keywordLocation": "",
+                "instanceLocation": "",
+                "absoluteKeywordLocation": null,
+                "severity": "INFO",
+                "metadata": null
+              }
+            ]""".trimIndent())
+        }
+
+        @Test
+        fun `renders a valid result without an error severity in text output`(@TempDir tempDir: File) {
+            val configFile = tempDir.resolve("valid.yaml").apply {
+                writeText("version: 3\n")
+            }
+
+            val (output, exitCode) = captureOutput {
+                CommandLine(ConfigCommand()).execute(
+                    "validate", "--input", configFile.path,
+                )
+            }
+
+            assertThat(exitCode).isZero()
+            assertThat(output).isEqualTo("Configuration is valid: valid.yaml")
+        }
+
+        @Test
+        fun `reports an unreadable input without a stack trace`(@TempDir tempDir: File) {
+            val missingFile = tempDir.resolve("missing.yaml")
+            val (output, exitCode) = captureOutput {
+                CommandLine(ConfigCommand()).execute(
+                    "validate", "--input", missingFile.path,
+                )
+            }
+
+            assertThat(exitCode).isEqualTo(1)
+            assertThat(output).endsWith("1 error")
+            assertThat(output).doesNotContain("Exception")
+            assertThat(output).contains(
+                "Configuration is invalid: missing.yaml",
+                "missing.yaml:/",
+                "Could not read ${missingFile.path}: ${missingFile.path} (",
+            )
+        }
+
+        @Test
+        fun `explicit input is validated even when the default configuration is broken`(@TempDir tempDir: File) {
+            val defaultFile = tempDir.resolve("default.yaml").apply { writeText("version: [") }
+            val explicitFile = tempDir.resolve("explicit.yaml").apply { writeText("version: 3\n") }
+            val (output, exitCode) = Flags.using(CONFIG_FILE_PATH to defaultFile.path) {
+                captureOutput {
+                    try {
+                        SystemExit.throwOnExit {
+                            SpecmaticApplication.main(arrayOf("config", "validate", "--input", explicitFile.path))
+                        }
+                        -1
+                    } catch (exception: io.specmatic.core.utilities.SystemExitException) {
+                        exception.code
+                    }
+                }
+            }
+
+            assertThat(exitCode).isZero()
+            assertThat(output.lineSequence().last()).isEqualTo("Configuration is valid: explicit.yaml")
+        }
+    }
+
+    @Nested
+    inner class TextRenderer {
+        private val renderer = ConfigValidationTextRenderer()
+
+        @Test
+        fun `renders multiple issues with metadata and severity`() {
+            val source = """
+            version: 3
+            logPrefix: specmatic
+            banana: true
+            """.trimIndent()
+
+            val outputs = listOf(
+                ConfigValidationOutput(
+                    valid = false,
+                    error = "Deprecated property.",
+                    instanceLocation = "/logPrefix",
+                    keywordLocation = "/properties/logPrefix",
+                    severity = ConfigValidationSeverity.WARNING,
+                    metadata = ConfigValidationMetadata(
+                        deprecated = true,
+                        title = "Log prefix",
+                        deprecationMessage = "use 'logFilePrefix' instead.",
+                    ),
+                ),
+                ConfigValidationOutput(
+                    valid = false,
+                    instanceLocation = "/banana",
+                    error = "Unknown property 'banana'.",
+                    keywordLocation = "/additionalProperties",
+                    severity = ConfigValidationSeverity.ERROR,
+                ),
+            )
+
+            assertThat(renderer.render("specmatic.yaml", source, ConfigValidationResult.Invalid(null, outputs))).isEqualTo("""
+            Configuration is invalid: specmatic.yaml
+
+            specmatic.yaml:2:1
+            2 |     logPrefix: specmatic
+              |     ^
+
+            Deprecated property.
+            Deprecated: use 'logFilePrefix' instead.
+            --------------------------------
+            specmatic.yaml:3:1
+            3 |     banana: true
+              |     ^
+
+            Unknown property 'banana'.
+
+            1 error, 1 warning
+            """.trimIndent())
+        }
+
+        @Test
+        fun `supports flat schema output when requested`(@TempDir tempDir: File) {
+            val configFile = tempDir.resolve("invalid.yaml").apply {
+                writeText("version: 2\nreport: invalid\n")
+            }
+
+            val (output, exitCode) = captureOutput {
+                CommandLine(ConfigCommand()).execute(
+                    "validate", "--input", configFile.path, "--format", "json", "--schema-output", "list",
+                )
+            }
+
+            assertThat(exitCode).isEqualTo(1)
+            assertThat(output).isEqualTo($$"""
+            [
+              {
+                "valid": false,
+                "error": "string found, object expected",
+                "keywordLocation": "/properties/report/$ref",
+                "instanceLocation": "/report",
+                "absoluteKeywordLocation": "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ReportConfigurationDetails",
+                "severity": "ERROR",
+                "metadata": {
+                  "title": "Reporting configuration",
+                  "keyword": "$ref",
+                  "description": "Report types and API-coverage thresholds.",
+                  "deprecated": null,
+                  "deprecationMessage": null
+                }
+              }
+            ]""".trimIndent())
+        }
+
+        @Test
+        fun `falls back to the instance location when source location is unavailable`() {
+            val output = ConfigValidationOutput(
+                valid = false,
+                keywordLocation = "/required",
+                instanceLocation = "/components",
+                error = "Configuration has an invalid structure.",
+            )
+
+            assertThat(renderer.render("specmatic.json", "", ConfigValidationResult.Invalid(null, listOf(output)))).isEqualTo("""
+            Configuration is invalid: specmatic.json
+
+            specmatic.json:/components
+            Configuration has an invalid structure.
+
+            1 error
+            """.trimIndent())
+        }
+
+        @Test
+        fun `renders nested validation details without flattening the hierarchy`() {
+            val source = "version: 2\nreport: invalid\n"
+            val output = ConfigValidationOutput(
+                valid = false,
+                keywordLocation = "/oneOf",
+                instanceLocation = "/report",
+                error = "Value does not match any supported report shape.",
+                details = listOf(
+                    element = ConfigValidationOutput(
+                        valid = false,
+                        keywordLocation = "/oneOf/0",
+                        instanceLocation = "/report",
+                        error = "string found, object expected",
+                        details = listOf(
+                            element = ConfigValidationOutput(
+                                valid = false,
+                                instanceLocation = "/report",
+                                keywordLocation = "/oneOf/0/type",
+                                error = "report must be an object",
+                            ),
+                        ),
+                    ),
+                ),
+            )
+
+            assertThat(renderer.render("config.yaml", source, ConfigValidationResult.Invalid(null, listOf(output)))).isEqualTo("""
+            Configuration is invalid: config.yaml
+
+            config.yaml:2:9
+            2 |     report: invalid
+              |             ^
+
+            Value does not match any supported report shape.
+
+            Validation details:
+              config.yaml:2:9
+              2 |     report: invalid
+                |             ^
+
+              string found, object expected
+
+              Validation details:
+                config.yaml:2:9
+                2 |     report: invalid
+                  |             ^
+
+                report must be an object
+
+            1 error
+            """.trimIndent())
+        }
+    }
+
+    private fun captureOutput(block: () -> Int): Pair<String, Int> {
+        val originalOut = System.out
+        val originalErr = System.err
+        val bytes = ByteArrayOutputStream()
+        System.setOut(PrintStream(bytes))
+        System.setErr(PrintStream(bytes))
+        return try {
+            val exitCode = block()
+            String(bytes.toByteArray()).trimEnd() to exitCode
+        } finally {
+            System.setOut(originalOut)
+            System.setErr(originalErr)
+        }
+    }
+}

--- a/application/src/test/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckBaseCommandTest.kt
+++ b/application/src/test/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckBaseCommandTest.kt
@@ -22,11 +22,13 @@ class BackwardCompatibilityCheckBaseCommandTest {
           strictMode: true
         """.trimIndent())
 
-        val cmd = Flags.using(CONFIG_FILE_PATH to configFile.canonicalPath) { TestBackwardCompatibilityCommand() }
-        assertThat(cmd.repoDir()).isEqualTo(repoDir.toString())
-        assertThat(cmd.baseBranch()).isEqualTo("origin/main")
-        assertThat(cmd.targetPath()).isEqualTo("contracts")
-        assertThat(cmd.strictMode()).isTrue()
+        Flags.using(CONFIG_FILE_PATH to configFile.canonicalPath) {
+            val cmd = TestBackwardCompatibilityCommand()
+            assertThat(cmd.repoDir()).isEqualTo(repoDir.toString())
+            assertThat(cmd.baseBranch()).isEqualTo("origin/main")
+            assertThat(cmd.targetPath()).isEqualTo("contracts")
+            assertThat(cmd.strictMode()).isTrue()
+        }
     }
 
     @Test
@@ -72,11 +74,13 @@ class BackwardCompatibilityCheckBaseCommandTest {
           baseBranch: origin/develop
         """.trimIndent())
 
-        val cmd = Flags.using(CONFIG_FILE_PATH to configFile.canonicalPath) { TestBackwardCompatibilityCommand() }
-        assertThat(cmd.baseBranch()).isEqualTo("origin/develop")
-        assertThat(cmd.repoDir()).isEqualTo(".")
-        assertThat(cmd.targetPath()).isEqualTo("")
-        assertThat(cmd.strictMode()).isFalse()
+        Flags.using(CONFIG_FILE_PATH to configFile.canonicalPath) {
+            val cmd = TestBackwardCompatibilityCommand()
+            assertThat(cmd.baseBranch()).isEqualTo("origin/develop")
+            assertThat(cmd.repoDir()).isEqualTo(".")
+            assertThat(cmd.targetPath()).isEqualTo("")
+            assertThat(cmd.strictMode()).isFalse()
+        }
     }
 
     @Test
@@ -91,14 +95,13 @@ class BackwardCompatibilityCheckBaseCommandTest {
           strictMode: true
         """.trimIndent())
 
-        val cmd = Flags.using(CONFIG_FILE_PATH to configFile.canonicalPath) {
-            TestBackwardCompatibilityCommand().apply { options.targetPath = "from-cli" }
+        Flags.using(CONFIG_FILE_PATH to configFile.canonicalPath) {
+            val cmd = TestBackwardCompatibilityCommand().apply { options.targetPath = "from-cli" }
+            assertThat(cmd.repoDir()).isEqualTo(repoDirFromConfig.canonicalPath.toString())
+            assertThat(cmd.baseBranch()).isEqualTo("origin/main")
+            assertThat(cmd.targetPath()).isEqualTo("from-cli")
+            assertThat(cmd.strictMode()).isTrue()
         }
-
-        assertThat(cmd.repoDir()).isEqualTo(repoDirFromConfig.canonicalPath.toString())
-        assertThat(cmd.baseBranch()).isEqualTo("origin/main")
-        assertThat(cmd.targetPath()).isEqualTo("from-cli")
-        assertThat(cmd.strictMode()).isTrue()
     }
 
     @Test

--- a/application/src/test/kotlin/application/mcp/McpTestCommandTest.kt
+++ b/application/src/test/kotlin/application/mcp/McpTestCommandTest.kt
@@ -57,16 +57,18 @@ class McpTestCommandTest {
             """.trimIndent())
         }
 
-        val cmd = Flags.using(CONFIG_FILE_PATH to configFile.canonicalPath) { McpTestCommandMock() }
-        val exitCode = cmd.call()
-        assertThat(exitCode).isEqualTo(0)
-        assertThat(cmd.capturedBaseUrl).isEqualTo("http://config-url:8080")
-        assertThat(cmd.capturedTransport).isEqualTo(McpTransport.STREAMABLE_HTTP)
-        assertThat(cmd.capturedEnableResiliency).isTrue()
-        assertThat(cmd.capturedDictionaryFile!!.canonicalPath).isEqualTo(dictFile.canonicalPath)
-        assertThat(cmd.capturedBearerToken).isEqualTo("config-token")
-        assertThat(cmd.capturedFilterTools).containsExactlyInAnyOrder("toolX", "toolY")
-        assertThat(cmd.capturedSkipTools).containsExactly("toolZ")
+        Flags.using(CONFIG_FILE_PATH to configFile.canonicalPath) {
+            val cmd = McpTestCommandMock()
+            val exitCode = cmd.call()
+            assertThat(exitCode).isEqualTo(0)
+            assertThat(cmd.capturedBaseUrl).isEqualTo("http://config-url:8080")
+            assertThat(cmd.capturedTransport).isEqualTo(McpTransport.STREAMABLE_HTTP)
+            assertThat(cmd.capturedEnableResiliency).isTrue()
+            assertThat(cmd.capturedDictionaryFile!!.canonicalPath).isEqualTo(dictFile.canonicalPath)
+            assertThat(cmd.capturedBearerToken).isEqualTo("config-token")
+            assertThat(cmd.capturedFilterTools).containsExactlyInAnyOrder("toolX", "toolY")
+            assertThat(cmd.capturedSkipTools).containsExactly("toolZ")
+        }
     }
 
     @Test
@@ -84,18 +86,18 @@ class McpTestCommandTest {
             """.trimIndent())
         }
 
-        val cmd = Flags.using(CONFIG_FILE_PATH to configFile.canonicalPath) {
-            McpTestCommandMock().apply {
+        Flags.using(CONFIG_FILE_PATH to configFile.canonicalPath) {
+            val cmd = McpTestCommandMock().apply {
                 enableResiliencyTests = true
                 filterTools = listOf("from-cli")
             }
-        }
 
-        cmd.call()
-        assertThat(cmd.capturedBaseUrl).isEqualTo("http://config-url:8080")
-        assertThat(cmd.capturedTransport).isEqualTo(McpTransport.STREAMABLE_HTTP)
-        assertThat(cmd.capturedEnableResiliency).isTrue()
-        assertThat(cmd.capturedFilterTools).containsExactlyInAnyOrder("from-config", "from-cli")
+            cmd.call()
+            assertThat(cmd.capturedBaseUrl).isEqualTo("http://config-url:8080")
+            assertThat(cmd.capturedTransport).isEqualTo(McpTransport.STREAMABLE_HTTP)
+            assertThat(cmd.capturedEnableResiliency).isTrue()
+            assertThat(cmd.capturedFilterTools).containsExactlyInAnyOrder("from-config", "from-cli")
+        }
     }
 
     @Test

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     implementation("com.jayway.jsonpath:json-path:2.10.0")
 
     implementation("io.zenwave360:json-schema-ref-parser-jvm:0.9.12")
+    implementation("com.networknt:json-schema-validator:2.0.1")
 
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.11.0")
     implementation("org.jetbrains.kotlin:kotlin-reflect:2.3.21")
@@ -52,7 +53,6 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.14.4")
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.14.4")
     testImplementation("org.json:json:20250517")
-    testImplementation("com.networknt:json-schema-validator:2.0.1")
     testImplementation("org.springframework:spring-web:6.2.18")
     testImplementation("io.mockk:mockk-jvm:1.14.11")
     testImplementation("org.assertj:assertj-core:3.27.7")

--- a/core/src/main/kotlin/io/specmatic/core/config/VersionAwareConfigParser.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/VersionAwareConfigParser.kt
@@ -13,11 +13,11 @@ import io.specmatic.core.pattern.ContractException
 import java.io.File
 
 private const val SPECMATIC_CONFIG_VERSION = "version"
+internal val objectMapper = ObjectMapper(YAMLFactory()).registerKotlinModule()
 
-private val objectMapper = ObjectMapper(YAMLFactory()).registerKotlinModule()
-
+internal fun parseSpecmaticConfigTree(content: String): JsonNode = objectMapper.readTree(content)
 internal fun File.toResolvedSpecmaticConfigTree(): JsonNode {
-    return resolveTemplates(objectMapper.readTree(this.readText()))
+    return resolveTemplates(parseSpecmaticConfigTree(this.readText()))
 }
 
 internal fun File.toResolvedSpecmaticConfigMap(): Map<String, Any> {
@@ -161,6 +161,6 @@ private fun parseJsonStringValue(value: String): JsonNode? {
 }
 
 fun String.getVersion(): SpecmaticConfigVersion? {
-    val configTree = resolveTemplates(objectMapper.readTree(this))
+    val configTree = resolveTemplates(parseSpecmaticConfigTree(this))
     return configTree.getVersion()
 }

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/Components.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/Components.kt
@@ -5,11 +5,13 @@ import io.specmatic.core.config.ConfigPathMapper
 import java.io.File
 import io.specmatic.core.config.v3.components.Adapter
 import io.specmatic.core.config.v3.components.services.CommonServiceConfig
+import io.specmatic.core.config.v3.components.services.validate
 import io.specmatic.core.config.v3.components.Dictionary
 import io.specmatic.core.config.v3.components.Examples
 import io.specmatic.core.config.v3.components.runOptions.ContextDependentRunOptions
 import io.specmatic.core.config.v3.components.runOptions.RunOptions
 import io.specmatic.core.config.v3.components.sources.SourceV3
+import io.specmatic.core.config.validation.ConfigValidationOutput
 
 data class Components(
     val sources: Map<String, SourceV3>? = null,
@@ -21,6 +23,19 @@ data class Components(
     val certificates: Map<String, HttpsConfiguration>? = null,
     val settings: Map<String, Settings>? = null,
 ) {
+    fun validate(context: ValidationContext): List<ConfigValidationOutput> {
+        return buildList {
+            services.orEmpty().forEach { (name, service) ->
+                addAll(service.validate(context.child("services").child(name)))
+            }
+
+            examples?.let { addAll(it.validate(context.child("examples"))) }
+            runOptions.orEmpty().forEach { (name, options) ->
+                addAll(options.validate(context.child("runOptions").child(name)))
+            }
+        }
+    }
+
     fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): Components {
         val mappedSources = sources?.mapValues { (name, source) ->
             source.mapPaths(mapper.child("sources").child(name), configDirectory)

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/Data.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/Data.kt
@@ -4,6 +4,7 @@ import io.specmatic.core.config.v3.components.Adapter
 import io.specmatic.core.config.v3.components.Dictionary
 import io.specmatic.core.config.v3.components.ExampleDirectories
 import io.specmatic.core.config.ConfigPathMapper
+import io.specmatic.core.config.validation.ConfigValidationOutput
 import java.io.File
 
 data class Data(
@@ -11,6 +12,39 @@ data class Data(
     val dictionary: RefOrValue<Dictionary>? = null,
     val adapters: RefOrValue<Adapter>? = null,
 ) {
+    fun validate(context: ValidationContext): List<ConfigValidationOutput> {
+        val examplesOutput = examples?.let { reference ->
+            context.child("examples").check(
+                reference = reference,
+                resolve = { value, resolver -> value.resolveElseThrow(resolver) },
+                validate = { examples, examplesContext ->
+                    examples.flatMapIndexed { index, example ->
+                        examplesContext.child(index).check(
+                            reference = example,
+                            resolve = { value, resolver -> value.resolveElseThrow(resolver) },
+                        )
+                    }
+                },
+            )
+        }.orEmpty()
+
+        val dictionaryOutput = dictionary?.let { reference ->
+            context.child("dictionary").check(
+                reference = reference,
+                resolve = { value, resolver -> value.resolveElseThrow(resolver) },
+            )
+        }.orEmpty()
+
+        val adaptersOutput = adapters?.let { reference ->
+            context.child("adapters").check(
+                reference = reference,
+                resolve = { value, resolver -> value.resolveElseThrow(resolver) },
+            )
+        }.orEmpty()
+
+        return examplesOutput + dictionaryOutput + adaptersOutput
+    }
+
     fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): Data {
         return copy(
             adapters = adapters?.mapValue { it.mapPaths(mapper.child("adapters"), configDirectory) },

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/Proxy.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/Proxy.kt
@@ -4,9 +4,15 @@ import io.specmatic.core.ProxyConfig
 import io.specmatic.core.config.HttpsConfiguration
 import io.specmatic.core.config.ConfigPathMapper
 import io.specmatic.core.config.v3.components.Adapter
+import io.specmatic.core.config.validation.ConfigValidationOutput
 import java.io.File
 
-data class Proxy(val proxy: ProxyConfigV3)
+data class Proxy(val proxy: ProxyConfigV3) {
+    fun validate(context: ValidationContext): List<ConfigValidationOutput> {
+        return proxy.validate(context.child("proxy"))
+    }
+}
+
 data class ProxyConfigV3(
     val target: String,
     val baseUrl: String? = null,
@@ -16,6 +22,24 @@ data class ProxyConfigV3(
     val cert: RefOrValue<HttpsConfiguration>? = null,
     val recordingsDirectory: String? = null,
 ) {
+    internal fun validate(context: ValidationContext): List<ConfigValidationOutput> {
+        val adaptersOutput = adapters?.let { reference ->
+            context.child("adapters").check(
+                reference = reference,
+                resolve = { value, resolver -> value.resolveElseThrow(resolver) },
+            )
+        }.orEmpty()
+
+        val certOutput = cert?.let { reference ->
+            context.child("cert").check(
+                reference = reference,
+                resolve = { value, resolver -> value.resolveElseThrow(resolver) },
+            )
+        }.orEmpty()
+
+        return adaptersOutput + certOutput
+    }
+
     fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): ProxyConfigV3  {
         return copy(
             cert = cert?.mapValue { it.mapPaths(mapper.child("cert"), configDirectory) },

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/Specmatic.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/Specmatic.kt
@@ -3,6 +3,7 @@ package io.specmatic.core.config.v3
 import io.specmatic.core.config.v3.specmatic.Governance
 import io.specmatic.core.config.v3.specmatic.License
 import io.specmatic.core.config.ConfigPathMapper
+import io.specmatic.core.config.validation.ConfigValidationOutput
 import java.io.File
 
 data class Specmatic(
@@ -10,6 +11,15 @@ data class Specmatic(
     val governance: Governance? = null,
     val settings: RefOrValue<ConcreteSettings>? = null
 ) {
+    fun validate(context: ValidationContext): List<ConfigValidationOutput> {
+        return settings?.let { reference ->
+            context.child("settings").check(
+                reference = reference,
+                resolve = { value, resolver -> value.resolveElseThrow(resolver) },
+            )
+        }.orEmpty()
+    }
+
     fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): Specmatic {
         return copy(
             governance = governance?.mapPaths(mapper.child("governance"), configDirectory),

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3.kt
@@ -10,8 +10,10 @@ import io.specmatic.core.config.SpecmaticVersionedConfigLoader
 import io.specmatic.core.config.v3.upgrade.LegacySpecmaticConfigToV3Upgrader
 import io.specmatic.core.config.v3.components.services.MockServiceConfig
 import io.specmatic.core.config.v3.components.services.TestServiceConfig
+import io.specmatic.core.config.validation.ConfigValidationOutput
 import io.specmatic.core.pattern.ContractException
 import java.io.File
+import java.nio.file.Path
 
 data class SpecmaticConfigV3(
     val version: SpecmaticConfigVersion,
@@ -22,6 +24,20 @@ data class SpecmaticConfigV3(
     val specmatic: Specmatic? = null,
     val components: Components? = null,
 ) : SpecmaticVersionedConfig {
+    fun validate(origin: Path): List<ConfigValidationOutput> {
+        val context = ValidationContext(resolver = SpecmaticConfigV3Resolver(components ?: Components(), origin))
+        return buildList {
+            systemUnderTest?.let { addAll(it.validate(context.child("systemUnderTest"))) }
+            dependencies?.let { addAll(it.validate(context.child("dependencies"))) }
+            proxies.orEmpty().forEachIndexed { index, proxy ->
+                addAll(proxy.validate(context.child("proxies").child(index)))
+            }
+
+            specmatic?.let { addAll(it.validate(context.child("specmatic"))) }
+            components?.let { addAll(it.validate(context.child("components"))) }
+        }
+    }
+
     fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): SpecmaticConfigV3 {
         val resolver = SpecmaticConfigV3Resolver(components ?: Components(), configDirectory.toPath())
         val mappedComponents = components?.mapPaths(mapper.child("components"), configDirectory)

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/ValidationContext.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/ValidationContext.kt
@@ -1,0 +1,49 @@
+package io.specmatic.core.config.v3
+
+import io.specmatic.core.config.validation.ConfigValidationMetadata
+import io.specmatic.core.config.validation.ConfigValidationOutput
+import io.specmatic.core.config.validation.ConfigValidationSeverity
+
+data class ValidationContext(val resolver: RefOrValueResolver, private val location: String = "") {
+    fun child(segment: String): ValidationContext = copy(location = "$location/$segment")
+
+    fun child(index: Int): ValidationContext = child(index.toString())
+
+    fun error(severity: ConfigValidationSeverity, message: String, metadata: ConfigValidationMetadata? = null): ConfigValidationOutput {
+        return ConfigValidationOutput(
+            valid = false,
+            error = message,
+            severity = severity,
+            metadata = metadata,
+            keywordLocation = "",
+            instanceLocation = location,
+        )
+    }
+
+    fun <T : Any> check(
+        reference: RefOrValue<T>,
+        resolve: (RefOrValue<T>, RefOrValueResolver) -> T,
+        validate: (T, ValidationContext) -> List<ConfigValidationOutput> = { _, _ -> emptyList() },
+        metadata: ConfigValidationMetadata? = null,
+    ): List<ConfigValidationOutput> {
+        return when (reference) {
+            is RefOrValue.Value -> validate(reference.value, this)
+            is RefOrValue.Reference -> {
+                val resolved = runCatching { resolve(reference, resolver) }.getOrElse { failure ->
+                    return listOf(error(
+                        metadata = metadata,
+                        severity = ConfigValidationSeverity.ERROR,
+                        message = "Reference '${reference.ref}' could not be resolved as the expected typed value: ${failure.message ?: failure::class.simpleName}",
+                    ))
+                }
+
+                validate(resolved, contextFor(reference))
+            }
+        }
+    }
+
+    private fun contextFor(reference: RefOrValue.Reference): ValidationContext {
+        val targetLocation = reference.ref.takeIf { it.startsWith("#/") }?.removePrefix("#")
+        return targetLocation?.let { copy(location = it) } ?: this
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/Example.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/Example.kt
@@ -1,9 +1,12 @@
 package io.specmatic.core.config.v3.components
 
 import io.specmatic.core.config.v3.RefOrValue
+import io.specmatic.core.config.v3.ValidationContext
+import io.specmatic.core.config.v3.resolveElseThrow
 import io.specmatic.core.config.v3.mapValue
 import io.specmatic.core.config.ConfigPathMapper
 import java.io.File
+import io.specmatic.core.config.validation.ConfigValidationOutput
 
 class ExampleDirectories(val directories: List<String>) {
     fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): ExampleDirectories {
@@ -19,6 +22,24 @@ data class Examples(
     val mockExamples: List<RefOrValue<ExampleDirectories>>? = null,
     val commonExamples: ExampleDirectories? = null,
 ) {
+    fun validate(context: ValidationContext): List<ConfigValidationOutput> {
+        return buildList {
+            testExamples.orEmpty().forEachIndexed { index, example ->
+                addAll(context.child("testExamples").child(index).check(
+                    reference = example,
+                    resolve = { value, resolver -> value.resolveElseThrow(resolver) },
+                ))
+            }
+
+            mockExamples.orEmpty().forEachIndexed { index, example ->
+                addAll(context.child("mockExamples").child(index).check(
+                    reference = example,
+                    resolve = { value, resolver -> value.resolveElseThrow(resolver) },
+                ))
+            }
+        }
+    }
+
     fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): Examples = copy(
         commonExamples = commonExamples?.mapPaths(mapper.child("commonExamples"), configDirectory),
         testExamples = testExamples?.mapIndexed { i, value ->

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/RunOptions.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/RunOptions.kt
@@ -6,9 +6,13 @@ import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonIgnore
 import io.specmatic.core.config.SpecmaticSpecConfig
 import io.specmatic.core.config.v3.ServerOrigin
+import io.specmatic.core.config.v3.ValidationContext
+import io.specmatic.core.config.v3.resolveElseThrow
+import io.specmatic.core.config.HttpsConfiguration
 import io.specmatic.core.config.ConfigPathMapper
 import java.io.File
 import io.specmatic.reporter.model.SpecType
+import io.specmatic.core.config.validation.ConfigValidationOutput
 
 interface IRunOptions {
     val specs: List<IRunOptionSpecification>?
@@ -43,6 +47,16 @@ data class RunOptions(
     val graphqlsdl: GraphQLSdlRunOptions? = null,
     val protobuf: ProtobufRunOptions? = null,
 ) {
+    fun validate(context: ValidationContext): List<ConfigValidationOutput> {
+        return listOfNotNull(
+            openapi?.validate(context.child("openapi")),
+            wsdl?.validate(context.child("wsdl")),
+            asyncapi?.validate(context.child("asyncapi")),
+            graphqlsdl?.validate(context.child("graphqlsdl")),
+            protobuf?.validate(context.child("protobuf")),
+        ).flatten()
+    }
+
     fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): RunOptions = copy(
         wsdl = wsdl?.mapPaths(mapper.child("wsdl"), configDirectory),
         openapi = openapi?.mapPaths(mapper.child("openapi"), configDirectory),
@@ -59,6 +73,16 @@ data class TestRunOptions(
     val graphqlsdl: GraphQLSdlTestConfig? = null,
     val protobuf: ProtobufTestConfig? = null,
 ) {
+    fun validate(context: ValidationContext): List<ConfigValidationOutput> {
+        return listOfNotNull(
+            openapi?.validate(context.child("openapi")),
+            wsdl?.validate(context.child("wsdl")),
+            asyncapi?.validate(context.child("asyncapi")),
+            graphqlsdl?.validate(context.child("graphqlsdl")),
+            protobuf?.validate(context.child("protobuf")),
+        ).flatten()
+    }
+
     fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): TestRunOptions = copy(
         wsdl = wsdl?.mapPaths(mapper.child("wsdl"), configDirectory),
         openapi = openapi?.mapPaths(mapper.child("openapi"), configDirectory),
@@ -113,6 +137,16 @@ data class MockRunOptions(
     val graphqlsdl: GraphQLSdlMockConfig? = null,
     val protobuf: ProtobufMockConfig? = null,
 ) {
+    fun validate(context: ValidationContext): List<ConfigValidationOutput> {
+        return listOfNotNull(
+            openapi?.validate(context.child("openapi")),
+            wsdl?.validate(context.child("wsdl")),
+            asyncapi?.validate(context.child("asyncapi")),
+            graphqlsdl?.validate(context.child("graphqlsdl")),
+            protobuf?.validate(context.child("protobuf")),
+        ).flatten()
+    }
+
     fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): MockRunOptions = copy(
         wsdl = wsdl?.mapPaths(mapper.child("wsdl"), configDirectory),
         openapi = openapi?.mapPaths(mapper.child("openapi"), configDirectory),
@@ -174,4 +208,13 @@ private fun <T : IRunOptionSpecification> List<T>?.filterOverrides(): List<T>? {
 
 private fun <T : IRunOptionSpecification> List<T>?.collectSpecIds(): Set<String> {
     return this.orEmpty().mapNotNull(IRunOptionSpecification::getId).toSet()
+}
+
+private fun IRunOptions.validate(context: ValidationContext): List<ConfigValidationOutput> {
+    if (this !is ConfigWithCert) return emptyList()
+    val certOrReference = this.cert ?: return emptyList()
+    return context.child("cert").check(
+        reference = certOrReference,
+        resolve = { value, resolver -> value.resolveElseThrow<HttpsConfiguration>(resolver) },
+    )
 }

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/CommonServiceConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/CommonServiceConfig.kt
@@ -3,9 +3,11 @@ package io.specmatic.core.config.v3.components.services
 import io.specmatic.core.config.v3.Data
 import io.specmatic.core.config.ConfigPathMapper
 import io.specmatic.core.config.v3.RefOrValue
+import io.specmatic.core.config.v3.ValidationContext
 import io.specmatic.core.config.v3.components.sources.SourceV3
 import io.specmatic.core.config.v3.RefOrValueResolver
 import io.specmatic.core.config.v3.resolveElseThrow
+import io.specmatic.core.config.validation.ConfigValidationOutput
 import java.io.File
 
 data class CommonServiceConfig<RunOptions : Any, Settings : Any>(
@@ -46,4 +48,32 @@ data class CommonServiceConfig<RunOptions : Any, Settings : Any>(
 
         return copy(definitions = updatedDefinitions)
     }
+}
+
+inline fun <reified R : Any, reified S : Any> CommonServiceConfig<R, S>.validate(
+    context: ValidationContext,
+    crossinline validateRunOptions: (R, ValidationContext) -> List<ConfigValidationOutput> = { _, _ -> emptyList() },
+): List<ConfigValidationOutput> {
+    val definitionOutput = definitions.flatMapIndexed { index, definition ->
+        definition.validate(context.child("definitions").child(index))
+    }
+
+    val runOptionsOutput = runOptions?.let { reference ->
+        val runOptionsContext = context.child("runOptions")
+        runOptionsContext.check(
+            reference = reference,
+            resolve = { value, resolver -> value.resolveElseThrow<R>(resolver) },
+            validate = { value, valueContext -> validateRunOptions(value, valueContext) },
+        )
+    }.orEmpty()
+
+    val settingsOutput = settings?.let { reference ->
+        context.child("settings").check(
+            reference = reference,
+            resolve = { value, resolver -> value.resolveElseThrow<S>(resolver) },
+        )
+    }.orEmpty()
+
+    val dataOutput = data?.validate(context.child("data")).orEmpty()
+    return definitionOutput + runOptionsOutput + settingsOutput + dataOutput
 }

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/Definition.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/Definition.kt
@@ -2,11 +2,18 @@ package io.specmatic.core.config.v3.components.services
 
 import io.specmatic.core.config.ConfigPathMapper
 import io.specmatic.core.config.v3.RefOrValue
+import io.specmatic.core.config.v3.ValidationContext
+import io.specmatic.core.config.v3.resolveElseThrow
 import io.specmatic.core.config.v3.mapValue
 import io.specmatic.core.config.v3.components.sources.SourceV3
+import io.specmatic.core.config.validation.ConfigValidationOutput
 import java.io.File
 
 data class Definition(val definition: Value) {
+    fun validate(context: ValidationContext): List<ConfigValidationOutput> {
+        return definition.validate(context.child("definition"))
+    }
+
     fun mapPaths(
         mapper: ConfigPathMapper,
         configDirectory: File,
@@ -27,7 +34,14 @@ data class Definition(val definition: Value) {
         }))
     }
 
-    data class Value(val source: RefOrValue<SourceV3>, val specs: List<SpecificationDefinition>)
+    data class Value(val source: RefOrValue<SourceV3>, val specs: List<SpecificationDefinition>) {
+        fun validate(context: ValidationContext): List<ConfigValidationOutput> {
+            return context.child("source").check(
+                reference = source,
+                resolve = { value, resolver -> value.resolveElseThrow(resolver) },
+            )
+        }
+    }
 
     companion object {
         fun create(specificationDefinition: SpecificationDefinition): Definition {

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/MockServiceConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/MockServiceConfig.kt
@@ -6,6 +6,7 @@ import io.specmatic.core.config.HttpsConfiguration
 import io.specmatic.core.config.nonNullElse
 import io.specmatic.core.config.v3.Data
 import io.specmatic.core.config.v3.RefOrValue
+import io.specmatic.core.config.v3.ValidationContext
 import io.specmatic.core.config.ConfigPathMapper
 import io.specmatic.core.config.v3.mapValueOrReference
 import io.specmatic.core.config.v3.mapValue
@@ -23,11 +24,36 @@ import io.specmatic.core.config.v3.determineSpecTypeFor
 import io.specmatic.core.config.v3.resolveElseThrow
 import io.specmatic.core.utilities.FileAssociation
 import io.specmatic.reporter.model.SpecType
+import io.specmatic.core.config.validation.ConfigValidationOutput
 import java.io.File
 import kotlin.collections.orEmpty
 import kotlin.collections.plus
 
 data class MockServiceConfig(val services: List<Value>, val data: Data? = null, val settings: RefOrValue<MockSettings>? = null) {
+    fun validate(context: ValidationContext): List<ConfigValidationOutput> {
+        val serviceOutput = services.flatMapIndexed { index, entry ->
+            val serviceContext = context.child("services").child(index).child("service")
+            val validateRunOptions: (MockRunOptions, ValidationContext) -> List<ConfigValidationOutput> = {
+                runOptions, runOptionsContext -> runOptions.validate(runOptionsContext)
+            }
+
+            serviceContext.check(
+                reference = entry.service,
+                validate = { value, valueContext -> value.validate(valueContext, validateRunOptions) },
+                resolve = { value, resolver -> value.resolveElseThrow<MockRunOptions, MockSettings>(resolver) },
+            )
+        }
+
+        val settingsOutput = settings?.let { reference ->
+            context.child("settings").check(
+                reference = reference,
+                resolve = { value, resolver -> value.resolveElseThrow<MockSettings>(resolver) },
+            )
+        }.orEmpty()
+
+        return serviceOutput + settingsOutput + data?.validate(context.child("data")).orEmpty()
+    }
+
     data class Value(val service: RefOrValue<CommonServiceConfig<MockRunOptions, MockSettings>>)
 
     fun mapPaths(

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/TestServiceConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/TestServiceConfig.kt
@@ -7,6 +7,7 @@ import io.specmatic.core.SpecificationSourceEntry
 import io.specmatic.core.config.nonNullElse
 import io.specmatic.core.config.v3.Data
 import io.specmatic.core.config.v3.RefOrValue
+import io.specmatic.core.config.v3.ValidationContext
 import io.specmatic.core.config.ConfigPathMapper
 import io.specmatic.core.config.v3.mapValueOrReference
 import io.specmatic.core.config.v3.mapValue
@@ -23,9 +24,23 @@ import io.specmatic.core.config.v3.components.sources.SourceV3
 import io.specmatic.core.config.v3.determineSpecTypeFor
 import io.specmatic.core.config.v3.resolveElseThrow
 import io.specmatic.reporter.model.SpecType
+import io.specmatic.core.config.validation.ConfigValidationOutput
 import java.io.File
 
 data class TestServiceConfig(val service: RefOrValue<CommonServiceConfig<TestRunOptions, TestSettings>>) {
+    fun validate(context: ValidationContext): List<ConfigValidationOutput> {
+        val serviceContext = context.child("service")
+        val validateRunOptions: (TestRunOptions, ValidationContext) -> List<ConfigValidationOutput> = {
+            runOptions, runOptionsContext -> runOptions.validate(runOptionsContext)
+        }
+
+        return serviceContext.check(
+            reference = service,
+            validate = { value, valueContext -> value.validate(valueContext, validateRunOptions) },
+            resolve = { value, resolver -> value.resolveElseThrow<TestRunOptions, TestSettings>(resolver) },
+        )
+    }
+
     fun mapPaths(
         mapper: ConfigPathMapper,
         configDirectory: File,

--- a/core/src/main/kotlin/io/specmatic/core/config/validation/ConfigSchemaValidator.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/validation/ConfigSchemaValidator.kt
@@ -12,15 +12,29 @@ import com.networknt.schema.path.PathType
 import io.specmatic.core.config.SpecmaticConfigVersion
 import io.specmatic.core.config.objectMapper
 
+enum class ConfigSchemaOutputFormat {
+    LIST,
+    HIERARCHICAL,
+}
+
 class ConfigSchemaValidator {
     private val schemas = SpecmaticConfigVersion.entries
         .filter { it != SpecmaticConfigVersion.VERSION_1 }
         .associateWith { version -> loadSchema(version) }
 
-    fun validate(version: SpecmaticConfigVersion, tree: JsonNode): List<ConfigValidationOutput> {
+    fun validate(
+        version: SpecmaticConfigVersion,
+        tree: JsonNode,
+        outputFormat: ConfigSchemaOutputFormat = ConfigSchemaOutputFormat.HIERARCHICAL,
+    ): List<ConfigValidationOutput> {
         val schema = schemas.getValue(version)
-        val output = schema.validate(tree, OutputFormat.LIST)
-        return output.details.orEmpty().map { toStandardOutput(it, schema) }
+        val output = schema.validate(tree, outputFormat.networkOutputFormat)
+        val details = output.details.orEmpty()
+        return when {
+            output.isValid -> emptyList()
+            details.isNotEmpty() -> details.map { toStandardOutput(it, schema) }
+            else -> listOf(toStandardOutput(output, schema))
+        }
     }
 
     private fun loadSchema(version: SpecmaticConfigVersion): Schema {
@@ -56,6 +70,7 @@ class ConfigSchemaValidator {
             metadata = metadata(output, schema),
             keywordLocation = outputPath(output.evaluationPath),
             instanceLocation = outputPath(output.instanceLocation),
+            details = output.details.orEmpty().map { toStandardOutput(it, schema) },
             error = messages.takeIf { it.isNotEmpty() }?.joinToString("; "),
             absoluteKeywordLocation = output.schemaLocation?.takeIf { it.isNotBlank() },
         )
@@ -89,4 +104,10 @@ class ConfigSchemaValidator {
         null, "", "/", "#" -> ""
         else -> path
     }
+
+    private val ConfigSchemaOutputFormat.networkOutputFormat: OutputFormat<OutputUnit>
+        get() = when (this) {
+            ConfigSchemaOutputFormat.LIST -> OutputFormat.LIST
+            ConfigSchemaOutputFormat.HIERARCHICAL -> OutputFormat.HIERARCHICAL
+        }
 }

--- a/core/src/main/kotlin/io/specmatic/core/config/validation/ConfigSchemaValidator.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/validation/ConfigSchemaValidator.kt
@@ -1,0 +1,92 @@
+package io.specmatic.core.config.validation
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.networknt.schema.OutputFormat
+import com.networknt.schema.Schema
+import com.networknt.schema.SchemaLocation
+import com.networknt.schema.SchemaRegistry
+import com.networknt.schema.SchemaRegistryConfig
+import com.networknt.schema.SpecificationVersion
+import com.networknt.schema.output.OutputUnit
+import com.networknt.schema.path.PathType
+import io.specmatic.core.config.SpecmaticConfigVersion
+import io.specmatic.core.config.objectMapper
+
+class ConfigSchemaValidator {
+    private val schemas = SpecmaticConfigVersion.entries
+        .filter { it != SpecmaticConfigVersion.VERSION_1 }
+        .associateWith { version -> loadSchema(version) }
+
+    fun validate(version: SpecmaticConfigVersion, tree: JsonNode): List<ConfigValidationOutput> {
+        val schema = schemas.getValue(version)
+        val output = schema.validate(tree, OutputFormat.LIST)
+        return output.details.orEmpty().map { toStandardOutput(it, schema) }
+    }
+
+    private fun loadSchema(version: SpecmaticConfigVersion): Schema {
+        val resource = when (version) {
+            SpecmaticConfigVersion.VERSION_2 -> "/config-validation/config-v2-resolved.schema.json"
+            SpecmaticConfigVersion.VERSION_3 -> "/config-validation/config-v3-resolved.schema.json"
+            SpecmaticConfigVersion.VERSION_1 -> error("V1 schema is intentionally out of scope")
+        }
+
+        val schemaNode = ConfigSchemaValidator::class.java.getResourceAsStream(resource)
+            ?.use { objectMapper.readTree(it) }
+            ?: error("Unable to load internal config schema: $resource")
+
+        val registryConfig = SchemaRegistryConfig.builder()
+            .errorMessageKeyword("errorMessage")
+            .pathType(PathType.JSON_POINTER)
+            .formatAssertionsEnabled(true)
+            .cacheRefs(true)
+            .build()
+
+        val registry = SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_2020_12) { builder ->
+            builder.schemaRegistryConfig(registryConfig)
+        }
+
+        return registry.getSchema(SchemaLocation.of("urn:specmatic:config:v${version.value}"), schemaNode)
+    }
+
+    private fun toStandardOutput(output: OutputUnit, schema: Schema): ConfigValidationOutput {
+        val messages = output.errors.orEmpty().values.map(Any?::toString)
+        return ConfigValidationOutput(
+            valid = output.isValid,
+            severity = ConfigValidationSeverity.ERROR,
+            metadata = metadata(output, schema),
+            keywordLocation = outputPath(output.evaluationPath),
+            instanceLocation = outputPath(output.instanceLocation),
+            error = messages.takeIf { it.isNotEmpty() }?.joinToString("; "),
+            absoluteKeywordLocation = output.schemaLocation?.takeIf { it.isNotBlank() },
+        )
+    }
+
+    private fun metadata(output: OutputUnit, schema: Schema): ConfigValidationMetadata? {
+        val schemaNode = output.schemaLocation
+            ?.substringAfter('#', "")
+            ?.let { fragment -> schema.getSchemaNode().at(fragment) }
+            ?.takeUnless(JsonNode::isMissingNode)
+            ?: return null
+
+        return ConfigValidationMetadata(
+            title = schemaNode["title"]?.asText(),
+            keyword = output.evaluationPath?.keyword(),
+            description = schemaNode["description"]?.asText(),
+            deprecated = schemaNode["deprecated"]?.asBoolean(),
+            deprecationMessage = schemaNode["deprecationMessage"]?.asText(),
+        )
+    }
+
+    private fun String.keyword(): String? {
+        return split('/')
+            .asReversed()
+            .firstOrNull { it.isNotEmpty() && it.toIntOrNull() == null }
+            ?.decodePointerToken()
+    }
+
+    private fun String.decodePointerToken(): String = replace("~1", "/").replace("~0", "~")
+    private fun outputPath(path: String?): String = when (path) {
+        null, "", "/", "#" -> ""
+        else -> path
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/core/config/validation/ConfigValidationResult.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/validation/ConfigValidationResult.kt
@@ -1,0 +1,36 @@
+package io.specmatic.core.config.validation
+
+import io.specmatic.core.config.SpecmaticConfigVersion
+import kotlinx.serialization.Serializable
+
+sealed interface ConfigValidationResult {
+    data class Valid(val version: SpecmaticConfigVersion) : ConfigValidationResult
+    data class Invalid(val version: SpecmaticConfigVersion?, val output: List<ConfigValidationOutput>) : ConfigValidationResult
+}
+
+@Serializable
+data class ConfigValidationOutput(
+    val valid: Boolean,
+    val error: String? = null,
+    val keywordLocation: String,
+    val instanceLocation: String,
+    val absoluteKeywordLocation: String? = null,
+    val severity: ConfigValidationSeverity = ConfigValidationSeverity.ERROR,
+    @kotlinx.serialization.Transient
+    val metadata: ConfigValidationMetadata? = null,
+)
+
+@Serializable
+enum class ConfigValidationSeverity {
+    ERROR,
+    WARNING,
+}
+
+@Serializable
+data class ConfigValidationMetadata(
+    val title: String? = null,
+    val keyword: String? = null,
+    val description: String? = null,
+    val deprecated: Boolean? = null,
+    val deprecationMessage: String? = null,
+)

--- a/core/src/main/kotlin/io/specmatic/core/config/validation/ConfigValidationResult.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/validation/ConfigValidationResult.kt
@@ -1,6 +1,7 @@
 package io.specmatic.core.config.validation
 
 import io.specmatic.core.config.SpecmaticConfigVersion
+import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.Serializable
 
 sealed interface ConfigValidationResult {
@@ -16,12 +17,14 @@ data class ConfigValidationOutput(
     val instanceLocation: String,
     val absoluteKeywordLocation: String? = null,
     val severity: ConfigValidationSeverity = ConfigValidationSeverity.ERROR,
-    @kotlinx.serialization.Transient
     val metadata: ConfigValidationMetadata? = null,
+    @EncodeDefault(EncodeDefault.Mode.NEVER)
+    val details: List<ConfigValidationOutput> = emptyList(),
 )
 
 @Serializable
 enum class ConfigValidationSeverity {
+    INFO,
     ERROR,
     WARNING,
 }

--- a/core/src/main/kotlin/io/specmatic/core/config/validation/SpecmaticConfigValidator.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/validation/SpecmaticConfigValidator.kt
@@ -15,7 +15,11 @@ import java.nio.file.Path
 class SpecmaticConfigValidator(private val schemaValidator: ConfigSchemaValidator = ConfigSchemaValidator()) {
     fun validate(file: File): ConfigValidationResult = validate(file.readText(), file.toPath())
 
-    fun validate(content: String, origin: Path = Path.of("specmatic.yaml")): ConfigValidationResult {
+    fun validate(
+        content: String,
+        origin: Path = Path.of("specmatic.yaml"),
+        schemaOutputFormat: ConfigSchemaOutputFormat = ConfigSchemaOutputFormat.HIERARCHICAL,
+    ): ConfigValidationResult {
         val authoredTree = parse(content)
             ?: return invalid(null, "/", "Configuration could not be parsed as YAML or JSON.")
 
@@ -25,7 +29,7 @@ class SpecmaticConfigValidator(private val schemaValidator: ConfigSchemaValidato
         return if (version == SpecmaticConfigVersion.VERSION_1) {
             validateV1Binding(authoredTree, version)
         } else {
-            validateResolved(authoredTree, version, origin)
+            validateResolved(authoredTree, version, origin, schemaOutputFormat)
         }
     }
 
@@ -41,14 +45,14 @@ class SpecmaticConfigValidator(private val schemaValidator: ConfigSchemaValidato
         }
     }
 
-    private fun validateResolved(authoredTree: JsonNode, version: SpecmaticConfigVersion, origin: Path): ConfigValidationResult {
+    private fun validateResolved(authoredTree: JsonNode, version: SpecmaticConfigVersion, origin: Path, schemaOutputFormat: ConfigSchemaOutputFormat): ConfigValidationResult {
         val resolvedTree = try {
             resolveTemplates(authoredTree)
         } catch (_: Exception) {
             return invalid(version, "/", "Configuration expressions could not be resolved.")
         }
 
-        val schemaOutput = schemaValidator.validate(version, resolvedTree)
+        val schemaOutput = schemaValidator.validate(version, resolvedTree, schemaOutputFormat)
         if (schemaOutput.isNotEmpty()) {
             return ConfigValidationResult.Invalid(version, schemaOutput)
         }

--- a/core/src/main/kotlin/io/specmatic/core/config/validation/SpecmaticConfigValidator.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/validation/SpecmaticConfigValidator.kt
@@ -1,0 +1,123 @@
+package io.specmatic.core.config.validation
+
+import com.fasterxml.jackson.databind.JsonNode
+import io.specmatic.core.config.SpecmaticConfigVersion
+import io.specmatic.core.config.SpecmaticVersionedConfig
+import io.specmatic.core.config.objectMapper
+import io.specmatic.core.config.parseSpecmaticConfigTree
+import io.specmatic.core.config.resolveTemplates
+import io.specmatic.core.config.v1.SpecmaticConfigV1
+import io.specmatic.core.config.v2.SpecmaticConfigV2
+import io.specmatic.core.config.v3.SpecmaticConfigV3
+import java.io.File
+import java.nio.file.Path
+
+class SpecmaticConfigValidator(private val schemaValidator: ConfigSchemaValidator = ConfigSchemaValidator()) {
+    fun validate(file: File): ConfigValidationResult = validate(file.readText(), file.toPath())
+
+    fun validate(content: String, origin: Path = Path.of("specmatic.yaml")): ConfigValidationResult {
+        val authoredTree = parse(content)
+            ?: return invalid(null, "/", "Configuration could not be parsed as YAML or JSON.")
+
+        val version = detectVersion(authoredTree)
+            ?: return invalid(null, "/version", versionError(authoredTree["version"]))
+
+        return if (version == SpecmaticConfigVersion.VERSION_1) {
+            validateV1Binding(authoredTree, version)
+        } else {
+            validateResolved(authoredTree, version, origin)
+        }
+    }
+
+    private fun validateV1Binding(tree: JsonNode, version: SpecmaticConfigVersion): ConfigValidationResult {
+        return if (bind(version, tree) == null) {
+            invalid(
+                version = version,
+                instanceLocation = "/",
+                message = "The configuration could not be bound to the V1 Specmatic configuration model.",
+            )
+        } else {
+            ConfigValidationResult.Valid(version)
+        }
+    }
+
+    private fun validateResolved(authoredTree: JsonNode, version: SpecmaticConfigVersion, origin: Path): ConfigValidationResult {
+        val resolvedTree = try {
+            resolveTemplates(authoredTree)
+        } catch (_: Exception) {
+            return invalid(version, "/", "Configuration expressions could not be resolved.")
+        }
+
+        val schemaOutput = schemaValidator.validate(version, resolvedTree)
+        if (schemaOutput.isNotEmpty()) {
+            return ConfigValidationResult.Invalid(version, schemaOutput)
+        }
+
+        val bound = bind(version, resolvedTree) ?: run {
+            return invalid(
+                version = version,
+                instanceLocation = "/",
+                message = "The resolved configuration satisfies its schema but cannot be bound to the Specmatic configuration model.",
+            )
+        }
+
+        val semanticErrors = when (bound) {
+            is SpecmaticConfigV3 -> bound.validate(origin)
+            else -> emptyList()
+        }
+
+        return if (semanticErrors.isEmpty()) {
+            ConfigValidationResult.Valid(version)
+        } else {
+            ConfigValidationResult.Invalid(version, semanticErrors)
+        }
+    }
+
+    private fun parse(content: String): JsonNode? = try {
+        parseSpecmaticConfigTree(content)
+    } catch (_: Exception) {
+        null
+    }
+
+    private fun detectVersion(tree: JsonNode): SpecmaticConfigVersion? = literalVersion(tree["version"])
+    private fun versionError(versionNode: JsonNode?): String = if (versionNode == null) {
+        "Configuration validation supports V1, V2, and V3; a literal version (1, 2, or 3) is required."
+    } else {
+        "Configuration validation supports only a literal integer version 1, 2, or 3."
+    }
+
+    private fun bind(version: SpecmaticConfigVersion, tree: JsonNode): SpecmaticVersionedConfig? = try {
+        when (version) {
+            SpecmaticConfigVersion.VERSION_1 -> objectMapper.treeToValue(tree, SpecmaticConfigV1::class.java)
+            SpecmaticConfigVersion.VERSION_2 -> objectMapper.treeToValue(tree, SpecmaticConfigV2::class.java)
+            SpecmaticConfigVersion.VERSION_3 -> objectMapper.treeToValue(tree, SpecmaticConfigV3::class.java)
+        }
+    } catch (_: Exception) {
+        null
+    }
+
+    private fun invalid(version: SpecmaticConfigVersion?, instanceLocation: String, message: String): ConfigValidationResult.Invalid {
+        return ConfigValidationResult.Invalid(
+            version = version,
+            output = listOf(
+                element = ConfigValidationOutput(
+                    valid = false,
+                    error = message,
+                    keywordLocation = "",
+                    instanceLocation = instanceLocation,
+                    severity = ConfigValidationSeverity.ERROR,
+                )
+            ),
+        )
+    }
+
+    private fun literalVersion(versionNode: JsonNode?): SpecmaticConfigVersion? {
+        if (versionNode == null || !versionNode.isIntegralNumber) return null
+        return when (versionNode.intValue()) {
+            1 -> SpecmaticConfigVersion.VERSION_1
+            2 -> SpecmaticConfigVersion.VERSION_2
+            3 -> SpecmaticConfigVersion.VERSION_3
+            else -> null
+        }
+    }
+}

--- a/core/src/main/resources/config-validation/config-v2-resolved.schema.json
+++ b/core/src/main/resources/config-validation/config-v2-resolved.schema.json
@@ -360,105 +360,85 @@
           }
         }
       },
-      "oneOf": [
+      "allOf": [
         {
-          "description": "A source-less contract entry using the current directory.",
-          "not": {
-            "description": "No explicit source may be present in this branch.",
-            "anyOf": [
+          "if": {
+            "required": [
+              "git"
+            ]
+          },
+          "then": {
+            "allOf": [
               {
-                "description": "An explicit Git source is present.",
-                "required": [
-                  "git"
-                ]
+                "not": {
+                  "required": [
+                    "filesystem"
+                  ]
+                }
               },
               {
-                "description": "An explicit filesystem source is present.",
-                "required": [
-                  "filesystem"
-                ]
-              },
-              {
-                "description": "An explicit web source is present.",
-                "required": [
-                  "web"
-                ]
+                "not": {
+                  "required": [
+                    "web"
+                  ]
+                }
               }
             ]
           }
         },
         {
-          "description": "A contract entry using only a Git source.",
-          "required": [
-            "git"
-          ],
-          "not": {
-            "description": "No additional explicit source may be present in the Git branch.",
-            "anyOf": [
+          "if": {
+            "required": [
+              "filesystem"
+            ]
+          },
+          "then": {
+            "allOf": [
               {
-                "description": "An explicit filesystem source is present.",
-                "required": [
-                  "filesystem"
-                ]
+                "not": {
+                  "required": [
+                    "git"
+                  ]
+                }
               },
               {
-                "description": "An explicit web source is present.",
-                "required": [
-                  "web"
-                ]
+                "not": {
+                  "required": [
+                    "web"
+                  ]
+                }
               }
             ]
           }
         },
         {
-          "description": "A contract entry using only a filesystem source.",
-          "required": [
-            "filesystem"
-          ],
-          "not": {
-            "description": "No additional explicit source may be present in the filesystem branch.",
-            "anyOf": [
-              {
-                "description": "An explicit Git source is present.",
-                "required": [
-                  "git"
-                ]
-              },
-              {
-                "description": "An explicit web source is present.",
-                "required": [
-                  "web"
-                ]
-              }
+          "if": {
+            "required": [
+              "web"
             ]
-          }
-        },
-        {
-          "description": "A contract entry using only a web source.",
-          "required": [
-            "web"
-          ],
-          "not": {
-            "description": "No additional explicit source may be present in the web branch.",
-            "anyOf": [
+          },
+          "then": {
+            "allOf": [
               {
-                "description": "An explicit Git source is present.",
-                "required": [
-                  "git"
-                ]
+                "not": {
+                  "required": [
+                    "git"
+                  ]
+                }
               },
               {
-                "description": "An explicit filesystem source is present.",
-                "required": [
-                  "filesystem"
-                ]
+                "not": {
+                  "required": [
+                    "filesystem"
+                  ]
+                }
               }
             ]
           }
         }
       ],
       "errorMessage": {
-        "oneOf": "Specify zero or one contract source: git, filesystem, or web."
+        "not": "Specify zero or one contract source: git, filesystem, or web."
       },
       "examples": [
         {
@@ -551,46 +531,106 @@
     "ProvidesEntry": {
       "title": "Provided specification entry",
       "description": "A provided specification path, URL form, or protocol-specific configuration.",
-      "oneOf": [
-        {
-          "type": "string",
-          "description": "A resolved specification path or URL."
+      "type": [
+        "string",
+        "object"
+      ],
+      "if": {
+        "type": "string"
+      },
+      "then": {
+        "type": "string"
+      },
+      "else": {
+        "if": {
+          "required": [
+            "baseUrl"
+          ]
         },
-        {
-          "$ref": "#/definitions/FullUrlProvides",
-          "description": "A provided specification entry with a complete base URL."
+        "then": {
+          "$ref": "#/definitions/FullUrlProvides"
         },
-        {
-          "$ref": "#/definitions/PartialUrlProvides",
-          "description": "A provided specification entry with partial host or port information."
-        },
-        {
-          "$ref": "#/definitions/ConfigValue",
-          "description": "A protocol-specific provided specification configuration."
+        "else": {
+          "if": {
+            "required": [
+              "host"
+            ]
+          },
+          "then": {
+            "$ref": "#/definitions/PartialUrlProvides"
+          },
+          "else": {
+            "if": {
+              "required": [
+                "port"
+              ]
+            },
+            "then": {
+              "$ref": "#/definitions/PartialUrlProvides"
+            },
+            "else": {
+              "$ref": "#/definitions/ConfigValue"
+            }
+          }
         }
-      ]
+      }
     },
     "ConsumesEntry": {
       "title": "Consumed specification entry",
       "description": "A consumed specification path, URL form, or protocol-specific configuration.",
-      "oneOf": [
-        {
-          "type": "string",
-          "description": "A resolved specification path or URL."
+      "type": [
+        "string",
+        "object"
+      ],
+      "if": {
+        "type": "string"
+      },
+      "then": {
+        "type": "string"
+      },
+      "else": {
+        "if": {
+          "required": [
+            "baseUrl"
+          ]
         },
-        {
-          "$ref": "#/definitions/FullUrlConsumes",
-          "description": "A consumed specification entry with a complete base URL."
+        "then": {
+          "$ref": "#/definitions/FullUrlConsumes"
         },
-        {
-          "$ref": "#/definitions/PartialUrlConsumes",
-          "description": "A consumed specification entry with partial URL information."
-        },
-        {
-          "$ref": "#/definitions/ConfigValue",
-          "description": "A protocol-specific consumed specification configuration."
+        "else": {
+          "if": {
+            "required": [
+              "host"
+            ]
+          },
+          "then": {
+            "$ref": "#/definitions/PartialUrlConsumes"
+          },
+          "else": {
+            "if": {
+              "required": [
+                "port"
+              ]
+            },
+            "then": {
+              "$ref": "#/definitions/PartialUrlConsumes"
+            },
+            "else": {
+              "if": {
+                "required": [
+                  "basePath"
+                ]
+              },
+              "then": {
+                "$ref": "#/definitions/PartialUrlConsumes"
+              },
+              "else": {
+                "$ref": "#/definitions/ConfigValue"
+              }
+            }
+          }
         }
-      ]
+      }
     },
     "FullUrlProvides": {
       "title": "Full URL provides entry",
@@ -676,20 +716,17 @@
           "description": "Optional resiliency-test selection for the provided specifications."
         }
       },
-      "anyOf": [
-        {
-          "description": "A partial provider with a host.",
-          "required": [
-            "host"
-          ]
-        },
-        {
-          "description": "A partial provider with a port.",
-          "required": [
-            "port"
-          ]
-        }
-      ]
+      "if": {
+        "required": [
+          "host"
+        ]
+      },
+      "then": {},
+      "else": {
+        "required": [
+          "port"
+        ]
+      }
     },
     "PartialUrlConsumes": {
       "title": "Partial URL consumes entry",
@@ -724,26 +761,25 @@
           "description": "Specifications consumed by this partial URL entry."
         }
       },
-      "anyOf": [
-        {
-          "description": "A partial consumer with a host.",
-          "required": [
-            "host"
-          ]
-        },
-        {
-          "description": "A partial consumer with a port.",
+      "if": {
+        "required": [
+          "host"
+        ]
+      },
+      "then": {},
+      "else": {
+        "if": {
           "required": [
             "port"
           ]
         },
-        {
-          "description": "A partial consumer with a base path.",
+        "then": {},
+        "else": {
           "required": [
             "basePath"
           ]
         }
-      ],
+      },
       "examples": [
         {
           "basePath": "/orders",
@@ -796,12 +832,62 @@
           "type": "object",
           "title": "Protocol configuration",
           "description": "Protocol-specific configuration map; recognized fields are interpreted by the selected specType and extra keys are intentionally preserved.",
-      "additionalProperties": {
-        "$ref": "#/definitions/ConfigValueNode",
-        "description": "A recursively JSON-valued protocol configuration field."
+          "additionalProperties": {
+            "$ref": "#/definitions/ConfigValueNode",
+            "description": "A recursively JSON-valued protocol configuration field."
           }
         }
       },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "specType": {
+                "const": "asyncapi"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "config": {
+                "$ref": "#/definitions/AsyncConfiguration"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "specType": {
+                "const": "graphqlsdl"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "config": {
+                "$ref": "#/definitions/GraphqlConfiguration"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "specType": {
+                "const": "protobuf"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "config": {
+                "$ref": "#/definitions/GrpcConfiguration"
+              }
+            }
+          }
+        }
+      ],
       "examples": [
         {
           "specs": [
@@ -818,40 +904,242 @@
     "ConfigValueNode": {
       "title": "JSON configuration value",
       "description": "A non-null JSON scalar, array, or object used inside an extensible ConfigValue map.",
-      "anyOf": [
+      "type": [
+        "string",
+        "integer",
+        "number",
+        "boolean",
+        "array",
+        "object"
+      ],
+      "allOf": [
         {
-          "type": "string",
-          "description": "A JSON string value."
-        },
-        {
-          "type": "integer",
-          "description": "A JSON integer value."
-        },
-        {
-          "type": "number",
-          "description": "A JSON number value."
-        },
-        {
-          "type": "boolean",
-          "description": "A JSON boolean value."
-        },
-        {
-          "type": "array",
-          "description": "A JSON array whose elements are recursively JSON-valued.",
-          "items": {
-            "$ref": "#/definitions/ConfigValueNode",
-            "description": "A recursively JSON-valued array element."
+          "if": {
+            "type": "array"
+          },
+          "then": {
+            "items": {
+              "$ref": "#/definitions/ConfigValueNode",
+              "description": "A recursively JSON-valued array element."
+            }
           }
         },
         {
-          "type": "object",
-          "description": "A JSON object whose values are recursively JSON-valued.",
-          "additionalProperties": {
-            "$ref": "#/definitions/ConfigValueNode",
-            "description": "A recursively JSON-valued object member."
+          "if": {
+            "type": "object"
+          },
+          "then": {
+            "additionalProperties": {
+              "$ref": "#/definitions/ConfigValueNode",
+              "description": "A recursively JSON-valued object member."
+            }
           }
         }
       ]
+    },
+    "AsyncConfiguration": {
+      "title": "AsyncAPI configuration",
+      "description": "Known AsyncAPI test and mock options. Additional protocol-specific options remain allowed.",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "replyTimeout": {
+          "type": "integer",
+          "title": "Reply timeout",
+          "description": "Maximum time in milliseconds to wait for an asynchronous reply."
+        },
+        "subscriberReadinessWaitTime": {
+          "type": "integer",
+          "title": "Subscriber readiness wait time",
+          "description": "Time in milliseconds to wait for an asynchronous subscriber to become ready."
+        },
+        "inMemoryBroker": {
+          "$ref": "#/definitions/InMemoryBrokerConfiguration",
+          "title": "In-memory broker",
+          "description": "Optional in-memory broker settings used by asynchronous mocks."
+        },
+        "servers": {
+          "type": "array",
+          "title": "AsyncAPI servers",
+          "description": "Server connection settings used by asynchronous tests and mocks.",
+          "items": {
+            "$ref": "#/definitions/AsyncClientServerConfig",
+            "description": "One asynchronous server connection."
+          }
+        },
+        "schemaRegistry": {
+          "$ref": "#/definitions/SchemaRegistryProperties",
+          "title": "Schema registry",
+          "description": "Schema registry settings used by asynchronous tests and mocks."
+        }
+      }
+    },
+    "GraphqlConfiguration": {
+      "title": "GraphQL configuration",
+      "description": "Known GraphQL test and mock options. Additional protocol-specific options remain allowed.",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "host": {
+          "type": "string",
+          "title": "GraphQL service host",
+          "description": "Host used by the GraphQL test or mock server."
+        },
+        "port": {
+          "type": "integer",
+          "title": "GraphQL service port",
+          "description": "Port used by the GraphQL test or mock server."
+        }
+      }
+    },
+    "GrpcConfiguration": {
+      "title": "gRPC configuration",
+      "description": "Known gRPC test and mock options. Additional protocol-specific options remain allowed.",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "host": {
+          "type": "string",
+          "title": "gRPC service host",
+          "description": "Host used by the gRPC test client."
+        },
+        "port": {
+          "type": "integer",
+          "title": "gRPC service port",
+          "description": "Port used by the gRPC test client or mock server."
+        },
+        "importPaths": {
+          "type": "array",
+          "title": "Protobuf import paths",
+          "description": "Directories searched for imported Protobuf definitions.",
+          "items": {
+            "type": "string",
+            "title": "Protobuf import path",
+            "description": "One directory searched for imported Protobuf definitions."
+          }
+        },
+        "protocVersion": {
+          "type": "string",
+          "title": "protoc version",
+          "description": "Version of protoc used to compile Protobuf definitions."
+        },
+        "requestTimeout": {
+          "type": "integer",
+          "title": "gRPC request timeout",
+          "description": "Maximum time in milliseconds to wait for a gRPC request."
+        }
+      }
+    },
+    "AsyncClientServerConfig": {
+      "title": "AsyncAPI server connection",
+      "description": "Connection settings for one asynchronous server. Additional admin and client values are protocol-specific extension data.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "host",
+        "protocol"
+      ],
+      "properties": {
+        "host": {
+          "type": "string",
+          "title": "Server host",
+          "description": "Host or connection address of the asynchronous server."
+        },
+        "protocol": {
+          "type": "string",
+          "title": "Server protocol",
+          "description": "Protocol identifier used to select this asynchronous server."
+        },
+        "adminCredentials": {
+          "type": "object",
+          "title": "Admin credentials",
+          "description": "Optional administrative credentials for the asynchronous server.",
+          "additionalProperties": true
+        },
+        "client": {
+          "$ref": "#/definitions/AsyncClientProperties",
+          "title": "Client properties",
+          "description": "Optional consumer and producer client properties."
+        }
+      }
+    },
+    "AsyncClientProperties": {
+      "title": "AsyncAPI client properties",
+      "description": "Optional client properties grouped by consumer and producer.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "consumer": {
+          "type": "object",
+          "title": "Consumer properties",
+          "description": "Consumer client properties passed to the asynchronous runtime.",
+          "additionalProperties": true
+        },
+        "producer": {
+          "type": "object",
+          "title": "Producer properties",
+          "description": "Producer client properties passed to the asynchronous runtime.",
+          "additionalProperties": true
+        }
+      }
+    },
+    "SchemaRegistryProperties": {
+      "title": "Schema registry properties",
+      "description": "Schema registry connection settings for asynchronous protocols.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "title": "Schema registry kind",
+          "description": "Schema registry implementation used by the asynchronous runtime.",
+          "enum": [
+            "CONFLUENT",
+            "DEFAULT"
+          ]
+        },
+        "url": {
+          "type": "string",
+          "title": "Schema registry URL",
+          "description": "URL of the schema registry."
+        },
+        "username": {
+          "type": "string",
+          "title": "Schema registry username",
+          "description": "Username used to access the schema registry."
+        },
+        "password": {
+          "type": "string",
+          "title": "Schema registry password",
+          "description": "Password used to access the schema registry."
+        }
+      }
+    },
+    "InMemoryBrokerConfiguration": {
+      "title": "In-memory broker configuration",
+      "description": "Optional in-memory broker connection settings for asynchronous mocks.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "logDir": {
+          "type": "string",
+          "title": "Broker log directory",
+          "description": "Directory where in-memory broker logs are written."
+        },
+        "host": {
+          "type": "string",
+          "title": "Broker host",
+          "description": "Host on which the in-memory broker listens."
+        },
+        "port": {
+          "type": "integer",
+          "title": "Broker port",
+          "description": "Port on which the in-memory broker listens."
+        }
+      }
     },
     "ResiliencyTestsConfig": {
       "title": "Resiliency test mode",
@@ -1663,18 +1951,31 @@
     "KeyStoreConfiguration": {
       "title": "Key store",
       "description": "Exactly one key-store representation: a file or a directory.",
-      "oneOf": [
-        {
-          "$ref": "#/definitions/KeyStoreFileConfiguration",
-          "description": "A key store loaded from one file."
+      "if": {
+        "required": [
+          "file"
+        ]
+      },
+      "then": {
+        "$ref": "#/definitions/KeyStoreFileConfiguration"
+      },
+      "else": {
+        "if": {
+          "required": [
+            "directory"
+          ]
         },
-        {
-          "$ref": "#/definitions/KeyStoreDirectoryConfiguration",
-          "description": "A key store loaded from a directory."
+        "then": {
+          "$ref": "#/definitions/KeyStoreDirectoryConfiguration"
+        },
+        "else": {
+          "required": [
+            "file"
+          ]
         }
-      ],
+      },
       "errorMessage": {
-        "oneOf": "Specify exactly one key-store form: file or directory."
+        "required": "Specify exactly one key-store form: file or directory."
       }
     },
     "KeyStoreFileConfiguration": {

--- a/core/src/main/resources/config-validation/config-v2-resolved.schema.json
+++ b/core/src/main/resources/config-validation/config-v2-resolved.schema.json
@@ -1,0 +1,1756 @@
+{
+  "type": "object",
+  "required": [ "version" ],
+  "additionalProperties": false,
+  "title": "Specmatic V2 configuration",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://specmatic.io/internal-schema/config-v2-resolved.schema.json",
+  "description": "Concrete Specmatic V2 configuration schema after expression and template resolution.",
+  "properties": {
+    "version": {
+      "const": 2,
+      "title": "Configuration version",
+      "description": "Literal V2 configuration marker; expressions and textual coercions are not accepted at this boundary."
+    },
+    "contracts": {
+      "type": "array",
+      "title": "Contract entries",
+      "description": "An entry may be source-less, which means the current directory is used as the implicit filesystem source.",
+      "items": {
+        "$ref": "#/definitions/ContractConfig",
+        "description": "One V2 contract source and its provided or consumed specifications."
+      }
+    },
+    "auth": {
+      "$ref": "#/definitions/Auth",
+      "title": "Authentication sources",
+      "description": "Credentials and token sources used when contracts are fetched from protected locations like GitHub, GitLab, etc."
+    },
+    "pipeline": {
+      "$ref": "#/definitions/Pipeline",
+      "title": "Pipeline metadata",
+      "description": "Azure pipeline metadata used by integrations and reporting."
+    },
+    "hooks": {
+      "type": "object",
+      "title": "Global adapter hooks",
+      "description": "Named global hook commands. See https://docs.specmatic.io/features/adapters/request_response_adapters#adapters for details.",
+      "additionalProperties": false,
+      "properties": {
+        "preSpecmaticRequestProcessor": {
+          "type": "string",
+          "deprecated": true,
+          "deprecationMessage": "Replace with pre_specmatic_request_processor.",
+          "title": "Legacy pre-request processor",
+          "description": "Receives the incoming request before Specmatic validates it in mock mode or forwards it to the provider in proxy mode."
+        },
+        "postSpecmaticResponseProcessor": {
+          "type": "string",
+          "deprecated": true,
+          "deprecationMessage": "Replace with post_specmatic_response_processor.",
+          "title": "Legacy post-response processor",
+          "description": "Runs only in mock mode, after Specmatic has generated a response for the consumer."
+        },
+        "preSpecmaticResponseProcessor": {
+          "type": "string",
+          "deprecated": true,
+          "deprecationMessage": "Replace with pre_specmatic_response_processor.",
+          "title": "Legacy pre-response processor",
+          "description": "Runs in proxy mode as responses come back from the real provider."
+        },
+        "stubLoadContract": {
+          "type": "string",
+          "deprecated": true,
+          "deprecationMessage": "Replace with stub_load_contract.",
+          "title": "Legacy stub contract loader",
+          "description": "Runs when specification is being loaded for mock, receives the specification path and should return the loaded specification."
+        },
+        "testLoadContract": {
+          "type": "string",
+          "deprecated": true,
+          "deprecationMessage": "Replace with test_load_contract.",
+          "title": "Legacy test contract loader",
+          "description": "Runs when specification is being loaded for test, receives the specification path and should return the loaded specification."
+        },
+        "pre_specmatic_request_processor": {
+          "type": "string",
+          "title": "Pre-request processor",
+          "description": "Receives the incoming request before Specmatic validates it (mock) or forwards it to the provider (proxy)."
+        },
+        "post_specmatic_response_processor": {
+          "type": "string",
+          "title": "Post-response processor",
+          "description": "Runs only in mock mode, after Specmatic has generated a response for the consumer."
+        },
+        "pre_specmatic_response_processor": {
+          "type": "string",
+          "title": "Pre-response processor",
+          "description": "Runs in proxy mode as responses come back from the real provider."
+        },
+        "stub_load_contract": {
+          "type": "string",
+          "title": "Stub contract loader",
+          "description": "Runs when specification is being loaded for mock, receives the specification path and should return the loaded specification."
+        },
+        "test_load_contract": {
+          "type": "string",
+          "title": "Test contract loader",
+          "description": "Runs when specification is being loaded for test, receives the specification path and should return the loaded specification."
+        }
+      },
+      "examples": [
+        {
+          "pre_specmatic_request_processor": "python pre_request_processor.py"
+        }
+      ]
+    },
+    "proxy": {
+      "$ref": "#/definitions/ProxyConfig",
+      "title": "Proxy configuration",
+      "description": "Proxy server configuration; targetUrl identifies the upstream service being proxied."
+    },
+    "repository": {
+      "$ref": "#/definitions/RepositoryInfo",
+      "title": "Repository metadata",
+      "description": "Repository-provider metadata used by repository-aware integrations."
+    },
+    "report": {
+      "$ref": "#/definitions/ReportConfigurationDetails",
+      "title": "Reporting configuration",
+      "description": "Report and API-coverage configuration."
+    },
+    "security": {
+      "$ref": "#/definitions/SecurityConfiguration",
+      "title": "Security configuration",
+      "description": "Security scheme configuration grouped by specification format."
+    },
+    "test": {
+      "$ref": "#/definitions/TestConfiguration",
+      "title": "Test execution configuration",
+      "description": "Test execution settings such as timeouts, filters, directories, and TLS."
+    },
+    "stub": {
+      "$ref": "#/definitions/StubConfiguration",
+      "title": "Stub execution configuration",
+      "description": "Stub/Mock execution settings such as generation, reload, filtering, and TLS."
+    },
+    "backwardCompatibility": {
+      "$ref": "#/definitions/BackwardCompatibilityConfig",
+      "title": "Backward compatibility configuration",
+      "description": "Settings for comparing or validating compatibility against another repository state."
+    },
+    "virtualService": {
+      "$ref": "#/definitions/VirtualServiceConfiguration",
+      "title": "Virtual service configuration",
+      "description": "Virtual-service server and specification settings."
+    },
+    "virtual_service": {
+      "deprecated": true,
+      "$ref": "#/definitions/VirtualServiceConfiguration",
+      "title": "Virtual service configuration (legacy spelling)",
+      "description": "Legacy snake_case spelling for virtualService.",
+      "deprecationMessage": "Replace with virtualService."
+    },
+    "examples": {
+      "type": "array",
+      "title": "Shared example directories",
+      "items": {
+        "type": "string",
+        "description": "Filesystem path to a shared examples directory."
+      },
+      "description": "Paths to directories containing examples shared across specifications."
+    },
+    "workflow": {
+      "$ref": "#/definitions/WorkflowConfiguration",
+      "title": "Workflow configuration",
+      "description": "Named workflow extraction and substitution operations."
+    },
+    "ignoreInlineExamples": {
+      "type": "boolean",
+      "title": "Ignore inline examples",
+      "description": "Ignore examples embedded in the specification while loading the specification."
+    },
+    "ignoreInlineExampleWarnings": {
+      "type": "boolean",
+      "title": "Ignore inline-example warnings",
+      "description": "Suppress warnings about ignored inline examples."
+    },
+    "schemaExampleDefault": {
+      "type": "boolean",
+      "title": "Use schema examples as defaults",
+      "description": "Use schema example values as defaults where the runtime supports them."
+    },
+    "fuzzy": {
+      "type": "boolean",
+      "title": "Fuzzy payload matching",
+      "description": "Enable fuzzy payload key matching."
+    },
+    "extensibleQueryParams": {
+      "type": "boolean",
+      "title": "Extensible query parameters",
+      "description": "Allow extensible query-parameter handling where supported by the contract format."
+    },
+    "escapeSoapAction": {
+      "type": "boolean",
+      "title": "Escape SOAP actions",
+      "description": "Apply SOAP action escaping behavior."
+    },
+    "prettyPrint": {
+      "type": "boolean",
+      "title": "Pretty-print output",
+      "description": "Enable pretty-printed output where supported."
+    },
+    "additionalExampleParamsFilePath": {
+      "type": "string",
+      "title": "Additional example parameters file",
+      "description": "Path to additional parameters used while resolving examples."
+    },
+    "attributeSelectionPattern": {
+      "$ref": "#/definitions/AttributeSelectionPattern",
+      "title": "Attribute selection pattern",
+      "description": "Controls default fields and query-parameter naming when selecting generated attributes."
+    },
+    "attribute_selection_pattern": {
+      "deprecated": true,
+      "$ref": "#/definitions/AttributeSelectionPattern",
+      "title": "Attribute selection pattern (legacy spelling)",
+      "description": "Legacy snake_case spelling for attributeSelectionPattern.",
+      "deprecationMessage": "Replace with attributeSelectionPattern."
+    },
+    "allPatternsMandatory": {
+      "type": "boolean",
+      "title": "Require all pattern attributes",
+      "description": "Enables optional field checks to trigger a warning when a key is absent."
+    },
+    "all_patterns_mandatory": {
+      "type": "boolean",
+      "deprecated": true,
+      "title": "Require all pattern attributes (legacy spelling)",
+      "deprecationMessage": "Replace with allPatternsMandatory.",
+      "description": "Enables optional field checks to trigger a warning when a key is absent."
+    },
+    "defaultPatternValues": {
+      "type": "object",
+      "title": "Default pattern values",
+      "additionalProperties": true,
+      "description": "Map of default values for named pattern attributes; keys are pattern names and values are runtime-resolved JSON values used during generation."
+    },
+    "default_pattern_values": {
+      "type": "object",
+      "deprecated": true,
+      "title": "Default pattern values (legacy spelling)",
+      "additionalProperties": true,
+      "deprecationMessage": "Replace with defaultPatternValues.",
+      "description": "Legacy snake_case alias for defaultPatternValues."
+    },
+    "disableTelemetry": {
+      "type": "boolean",
+      "title": "Disable telemetry",
+      "description": "Disable telemetry reporting."
+    },
+    "disable_telemetry": {
+      "type": "boolean",
+      "deprecated": true,
+      "title": "Disable telemetry (legacy spelling)",
+      "description": "Disable telemetry reporting.",
+      "deprecationMessage": "Replace with disableTelemetry."
+    },
+    "logging": {
+      "$ref": "#/definitions/LoggingConfiguration",
+      "title": "Logging configuration",
+      "description": "Log level and JSON/text output configuration."
+    },
+    "mcp": {
+      "$ref": "#/definitions/McpConfiguration",
+      "title": "MCP configuration",
+      "description": "Model Context Protocol test configuration."
+    },
+    "licensePath": {
+      "type": "string",
+      "title": "License file path",
+      "description": "Path to the Specmatic license file."
+    },
+    "license_path": {
+      "type": "string",
+      "deprecated": true,
+      "title": "License file path (legacy spelling)",
+      "description": "Legacy snake_case spelling for licensePath.",
+      "deprecationMessage": "Replace with licensePath."
+    },
+    "reportDirPath": {
+      "type": "string",
+      "title": "Report directory path",
+      "description": "Path to the directory where reports should be written."
+    },
+    "report_dir_path": {
+      "type": "string",
+      "deprecated": true,
+      "deprecationMessage": "Replace with reportDirPath.",
+      "title": "Report directory path (legacy spelling)",
+      "description": "Legacy snake_case spelling for reportDirPath."
+    },
+    "globalSettings": {
+      "$ref": "#/definitions/SpecmaticGlobalSettings",
+      "title": "Global path settings",
+      "description": "Global path-template settings shared by specification and example resolution."
+    }
+  },
+  "examples": [
+    {
+      "version": 2
+    },
+    {
+      "version": 2,
+      "contracts": [
+        {
+          "filesystem": {
+            "directory": "contracts"
+          },
+          "provides": [
+            "orders.yaml"
+          ]
+        }
+      ]
+    }
+  ],
+  "definitions": {
+    "ContractConfig": {
+      "title": "V2 contract entry",
+      "description": "At most one explicit source is allowed. A source-less entry is valid and uses implicit filesystem/current-directory behavior.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "git": {
+          "$ref": "#/definitions/GitContractSource",
+          "title": "Git source",
+          "description": "Optional Git repository source for this contract entry."
+        },
+        "filesystem": {
+          "$ref": "#/definitions/FileSystemContractSource",
+          "title": "Filesystem source",
+          "description": "Optional local directory source for this contract entry."
+        },
+        "web": {
+          "$ref": "#/definitions/WebContractSource",
+          "title": "Web source",
+          "description": "Optional remote URL source for this contract entry."
+        },
+        "provides": {
+          "title": "Provided specifications",
+          "description": "Specifications that this service provides to consumers.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/ProvidesEntry",
+            "description": "One provided specification entry."
+          }
+        },
+        "consumes": {
+          "title": "Consumed specifications",
+          "description": "Specifications that this service consumes from providers.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/ConsumesEntry",
+            "description": "One consumed specification entry."
+          }
+        }
+      },
+      "oneOf": [
+        {
+          "description": "A source-less contract entry using the current directory.",
+          "not": {
+            "description": "No explicit source may be present in this branch.",
+            "anyOf": [
+              {
+                "description": "An explicit Git source is present.",
+                "required": [
+                  "git"
+                ]
+              },
+              {
+                "description": "An explicit filesystem source is present.",
+                "required": [
+                  "filesystem"
+                ]
+              },
+              {
+                "description": "An explicit web source is present.",
+                "required": [
+                  "web"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "description": "A contract entry using only a Git source.",
+          "required": [
+            "git"
+          ],
+          "not": {
+            "description": "No additional explicit source may be present in the Git branch.",
+            "anyOf": [
+              {
+                "description": "An explicit filesystem source is present.",
+                "required": [
+                  "filesystem"
+                ]
+              },
+              {
+                "description": "An explicit web source is present.",
+                "required": [
+                  "web"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "description": "A contract entry using only a filesystem source.",
+          "required": [
+            "filesystem"
+          ],
+          "not": {
+            "description": "No additional explicit source may be present in the filesystem branch.",
+            "anyOf": [
+              {
+                "description": "An explicit Git source is present.",
+                "required": [
+                  "git"
+                ]
+              },
+              {
+                "description": "An explicit web source is present.",
+                "required": [
+                  "web"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "description": "A contract entry using only a web source.",
+          "required": [
+            "web"
+          ],
+          "not": {
+            "description": "No additional explicit source may be present in the web branch.",
+            "anyOf": [
+              {
+                "description": "An explicit Git source is present.",
+                "required": [
+                  "git"
+                ]
+              },
+              {
+                "description": "An explicit filesystem source is present.",
+                "required": [
+                  "filesystem"
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "errorMessage": {
+        "oneOf": "Specify zero or one contract source: git, filesystem, or web."
+      },
+      "examples": [
+        {
+          "provides": [
+            "orders.spec"
+          ]
+        },
+        {
+          "filesystem": {
+            "directory": "contracts"
+          },
+          "consumes": [
+            {
+              "basePath": "/api",
+              "specs": [
+                "orders.spec"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "GitContractSource": {
+      "title": "Git contract source",
+      "description": "Optional Git source details. URL may be omitted when the repository is resolved from the current monorepo context.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "title": "Git repository URL",
+          "description": "Git repository URL. Omit for monorepo/current-repository mode.",
+          "examples": [
+            "https://github.com/acme/contracts.git"
+          ]
+        },
+        "branch": {
+          "type": "string",
+          "title": "Git branch or ref",
+          "description": "Branch or ref to use when retrieving the contract source.",
+          "examples": [
+            "main"
+          ]
+        },
+        "matchBranch": {
+          "type": "boolean",
+          "title": "Follow current repository branch",
+          "description": "Whether the source branch should follow the current repository branch."
+        }
+      }
+    },
+    "FileSystemContractSource": {
+      "title": "Filesystem contract source",
+      "description": "Filesystem source. When directory is omitted, the current directory is used.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "directory": {
+          "type": "string",
+          "title": "Contract directory",
+          "description": "Directory containing the contract files.",
+          "default": ".",
+          "examples": [
+            "contracts"
+          ]
+        }
+      }
+    },
+    "WebContractSource": {
+      "title": "Web contract source",
+      "description": "Remote web source for a contract document.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "title": "Contract URL",
+          "description": "URL from which the contract document is retrieved.",
+          "examples": [
+            "https://api.example.com/openapi.yaml"
+          ]
+        }
+      }
+    },
+    "ProvidesEntry": {
+      "title": "Provided specification entry",
+      "description": "A provided specification path, URL form, or protocol-specific configuration.",
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "A resolved specification path or URL."
+        },
+        {
+          "$ref": "#/definitions/FullUrlProvides",
+          "description": "A provided specification entry with a complete base URL."
+        },
+        {
+          "$ref": "#/definitions/PartialUrlProvides",
+          "description": "A provided specification entry with partial host or port information."
+        },
+        {
+          "$ref": "#/definitions/ConfigValue",
+          "description": "A protocol-specific provided specification configuration."
+        }
+      ]
+    },
+    "ConsumesEntry": {
+      "title": "Consumed specification entry",
+      "description": "A consumed specification path, URL form, or protocol-specific configuration.",
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "A resolved specification path or URL."
+        },
+        {
+          "$ref": "#/definitions/FullUrlConsumes",
+          "description": "A consumed specification entry with a complete base URL."
+        },
+        {
+          "$ref": "#/definitions/PartialUrlConsumes",
+          "description": "A consumed specification entry with partial URL information."
+        },
+        {
+          "$ref": "#/definitions/ConfigValue",
+          "description": "A protocol-specific consumed specification configuration."
+        }
+      ]
+    },
+    "FullUrlProvides": {
+      "title": "Full URL provides entry",
+      "description": "Provides one or more specifications at a complete service base URL.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "baseUrl",
+        "specs"
+      ],
+      "properties": {
+        "baseUrl": {
+          "type": "string",
+          "format": "uri",
+          "title": "Service base URL",
+          "description": "Complete base URL where the provided service is reachable.",
+          "examples": [
+            "http://localhost:8080"
+          ]
+        },
+        "specs": {
+          "$ref": "#/definitions/Specs",
+          "title": "Specifications",
+          "description": "Specifications provided at this service base URL."
+        },
+        "resiliencyTests": {
+          "$ref": "#/definitions/ResiliencyTestsConfig",
+          "title": "Resiliency tests",
+          "description": "Optional resiliency-test selection for the provided specifications."
+        }
+      }
+    },
+    "FullUrlConsumes": {
+      "title": "Full URL consumes entry",
+      "description": "Consumes one or more specifications from a complete service base URL.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "baseUrl",
+        "specs"
+      ],
+      "properties": {
+        "baseUrl": {
+          "type": "string",
+          "format": "uri",
+          "title": "Service base URL",
+          "description": "Complete base URL from which the consumed service is reached."
+        },
+        "specs": {
+          "$ref": "#/definitions/Specs",
+          "title": "Specifications",
+          "description": "Specifications consumed at this service base URL."
+        }
+      }
+    },
+    "PartialUrlProvides": {
+      "title": "Partial URL provides entry",
+      "description": "Provides specifications using host and/or port information instead of a complete base URL. At least host or port is required.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "specs"
+      ],
+      "properties": {
+        "host": {
+          "type": "string",
+          "title": "Service host",
+          "description": "Optional service host used with the provided port."
+        },
+        "port": {
+          "type": "integer",
+          "title": "Service port",
+          "description": "Optional service port used with the provided host."
+        },
+        "specs": {
+          "$ref": "#/definitions/Specs",
+          "title": "Specifications",
+          "description": "Specifications provided by this partial URL entry."
+        },
+        "resiliencyTests": {
+          "$ref": "#/definitions/ResiliencyTestsConfig",
+          "title": "Resiliency tests",
+          "description": "Optional resiliency-test selection for the provided specifications."
+        }
+      },
+      "anyOf": [
+        {
+          "description": "A partial provider with a host.",
+          "required": [
+            "host"
+          ]
+        },
+        {
+          "description": "A partial provider with a port.",
+          "required": [
+            "port"
+          ]
+        }
+      ]
+    },
+    "PartialUrlConsumes": {
+      "title": "Partial URL consumes entry",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "specs"
+      ],
+      "description": "A partial consume URL may contain only basePath; host and port are optional independently.",
+      "properties": {
+        "host": {
+          "type": "string",
+          "title": "Service host",
+          "description": "Optional service host; may be supplied independently of port."
+        },
+        "port": {
+          "type": "integer",
+          "title": "Service port",
+          "description": "Optional service port; may be supplied independently of host."
+        },
+        "basePath": {
+          "type": "string",
+          "title": "Base path",
+          "description": "Optional path prefix. A basePath-only consume entry is intentionally valid.",
+          "examples": [
+            "/orders"
+          ]
+        },
+        "specs": {
+          "$ref": "#/definitions/Specs",
+          "title": "Specifications",
+          "description": "Specifications consumed by this partial URL entry."
+        }
+      },
+      "anyOf": [
+        {
+          "description": "A partial consumer with a host.",
+          "required": [
+            "host"
+          ]
+        },
+        {
+          "description": "A partial consumer with a port.",
+          "required": [
+            "port"
+          ]
+        },
+        {
+          "description": "A partial consumer with a base path.",
+          "required": [
+            "basePath"
+          ]
+        }
+      ],
+      "examples": [
+        {
+          "basePath": "/orders",
+          "specs": [
+            "orders.spec"
+          ]
+        }
+      ]
+    },
+    "Specs": {
+      "title": "Specification paths",
+      "description": "One or more resolved specification paths associated with an entry.",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "title": "Specification path",
+        "description": "Resolved path or URL identifying one specification."
+      }
+    },
+    "ConfigValue": {
+      "title": "Protocol-specific V2 configuration",
+      "description": "A specification type plus a recursively JSON-valued configuration map. Extra configuration keys are intentional extension data interpreted by the selected protocol.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "specs",
+        "specType",
+        "config"
+      ],
+      "properties": {
+        "specs": {
+          "$ref": "#/definitions/Specs",
+          "title": "Specifications",
+          "description": "One or more specifications described by this configuration."
+        },
+        "specType": {
+          "type": "string",
+          "title": "Specification type",
+          "enum": [
+            "openapi",
+            "wsdl",
+            "asyncapi",
+            "protobuf",
+            "graphqlsdl"
+          ],
+          "description": "Protocol or specification format used to interpret config."
+        },
+        "config": {
+          "type": "object",
+          "title": "Protocol configuration",
+          "description": "Protocol-specific configuration map; recognized fields are interpreted by the selected specType and extra keys are intentionally preserved.",
+      "additionalProperties": {
+        "$ref": "#/definitions/ConfigValueNode",
+        "description": "A recursively JSON-valued protocol configuration field."
+          }
+        }
+      },
+      "examples": [
+        {
+          "specs": [
+            "orders.yaml"
+          ],
+          "specType": "openapi",
+          "config": {
+            "baseUrl": "http://localhost:8080",
+            "retries": 2
+          }
+        }
+      ]
+    },
+    "ConfigValueNode": {
+      "title": "JSON configuration value",
+      "description": "A non-null JSON scalar, array, or object used inside an extensible ConfigValue map.",
+      "anyOf": [
+        {
+          "type": "string",
+          "description": "A JSON string value."
+        },
+        {
+          "type": "integer",
+          "description": "A JSON integer value."
+        },
+        {
+          "type": "number",
+          "description": "A JSON number value."
+        },
+        {
+          "type": "boolean",
+          "description": "A JSON boolean value."
+        },
+        {
+          "type": "array",
+          "description": "A JSON array whose elements are recursively JSON-valued.",
+          "items": {
+            "$ref": "#/definitions/ConfigValueNode",
+            "description": "A recursively JSON-valued array element."
+          }
+        },
+        {
+          "type": "object",
+          "description": "A JSON object whose values are recursively JSON-valued.",
+          "additionalProperties": {
+            "$ref": "#/definitions/ConfigValueNode",
+            "description": "A recursively JSON-valued object member."
+          }
+        }
+      ]
+    },
+    "ResiliencyTestsConfig": {
+      "title": "Resiliency test mode",
+      "description": "Controls which resiliency tests run. This object is intentionally limited to enable.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enable": {
+          "type": "string",
+          "title": "Resiliency-test selection",
+          "description": "Select all resiliency tests, positive-only tests, or none.",
+          "enum": [
+            "all",
+            "positiveOnly",
+            "none"
+          ]
+        }
+      }
+    },
+    "Auth": {
+      "title": "Authentication sources",
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Authentication sources used for contract access. bearerFile has a runtime default when omitted.",
+      "properties": {
+        "bearer-file": {
+          "type": "string",
+          "title": "Bearer-token file",
+          "description": "Path to a file containing a bearer token."
+        },
+        "bearer-environment-variable": {
+          "type": "string",
+          "title": "Bearer-token environment variable",
+          "description": "Name of the environment variable containing a bearer token."
+        },
+        "personal-access-token": {
+          "type": "string",
+          "title": "Personal access token",
+          "description": "Personal access token used for authenticated contract retrieval."
+        },
+        "personalAccessToken": {
+          "type": "string",
+          "deprecated": true,
+          "title": "Personal access token (legacy spelling)",
+          "description": "Legacy camelCase alias for personal-access-token.",
+          "deprecationMessage": "Replace with personal-access-token."
+        }
+      }
+    },
+    "Pipeline": {
+      "title": "Pipeline metadata",
+      "description": "Azure DevOps pipeline identifiers used by pipeline-aware integrations.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "provider": {
+          "type": "string",
+          "title": "Pipeline provider",
+          "description": "Pipeline provider identifier.",
+          "enum": [
+            "azure"
+          ]
+        },
+        "organization": {
+          "type": "string",
+          "title": "Pipeline organization",
+          "description": "Azure DevOps organization containing the pipeline."
+        },
+        "project": {
+          "type": "string",
+          "title": "Pipeline project",
+          "description": "Azure DevOps project containing the pipeline."
+        },
+        "definitionId": {
+          "type": "integer",
+          "title": "Pipeline definition ID",
+          "description": "Numeric Azure DevOps pipeline definition identifier."
+        }
+      }
+    },
+    "RepositoryInfo": {
+      "title": "Repository metadata",
+      "description": "Provider and collection information for repository-aware integrations.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "provider": {
+          "type": "string",
+          "title": "Repository provider",
+          "description": "Repository hosting provider identifier."
+        },
+        "collectionName": {
+          "type": "string",
+          "title": "Repository collection",
+          "description": "Repository collection or organization name."
+        }
+      }
+    },
+    "ReportConfigurationDetails": {
+      "title": "Reporting configuration",
+      "description": "Report types and API-coverage thresholds.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "types": {
+          "$ref": "#/definitions/ReportTypes",
+          "title": "Report types",
+          "description": "Report families and API-coverage settings to generate."
+        }
+      }
+    },
+    "ReportTypes": {
+      "title": "Report types",
+      "description": "Report families enabled for this configuration.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "APICoverage": {
+          "$ref": "#/definitions/APICoverage",
+          "title": "API coverage reports",
+          "description": "API-coverage reports grouped by specification format."
+        }
+      }
+    },
+    "APICoverage": {
+      "title": "API coverage reports",
+      "description": "API-coverage reporting grouped by contract format.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "OpenAPI": {
+          "$ref": "#/definitions/APICoverageConfiguration",
+          "title": "OpenAPI coverage",
+          "description": "API-coverage settings for OpenAPI specifications."
+        }
+      }
+    },
+    "APICoverageConfiguration": {
+      "title": "API coverage configuration",
+      "description": "Coverage thresholds and endpoint exclusions for an API specification.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "successCriteria": {
+          "$ref": "#/definitions/SuccessCriteria",
+          "title": "Coverage success criteria",
+          "description": "Thresholds used to determine whether API coverage passes."
+        }
+      }
+    },
+    "SuccessCriteria": {
+      "title": "Coverage success criteria",
+      "description": "Thresholds used to decide whether API coverage meets the configured policy.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "minThresholdPercentage": {
+          "type": "integer",
+          "title": "Minimum coverage percentage",
+          "description": "Minimum percentage of covered operations required for success."
+        },
+        "maxMissedEndpointsInSpec": {
+          "type": "integer",
+          "title": "Maximum missed endpoints",
+          "description": "Maximum number of missed endpoints allowed in a specification."
+        },
+        "enforce": {
+          "type": "boolean",
+          "title": "Enforce success criteria",
+          "description": "Whether failing the configured thresholds should fail the operation."
+        }
+      }
+    },
+    "SecurityConfiguration": {
+      "title": "Security configuration",
+      "description": "Security schemes grouped by supported specification format.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "OpenAPI": {
+          "$ref": "#/definitions/OpenAPISecurityConfiguration",
+          "title": "OpenAPI security",
+          "description": "Security schemes configured for OpenAPI specifications."
+        }
+      }
+    },
+    "OpenAPISecurityConfiguration": {
+      "description": "Security schemes keyed by their names in an OpenAPI document.",
+      "title": "OpenAPI security configuration",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "securitySchemes": {
+          "type": "object",
+          "title": "Security schemes",
+          "description": "Map from security-scheme name to its resolved credentials or token settings.",
+          "additionalProperties": {
+            "$ref": "#/definitions/SecurityScheme",
+            "description": "Resolved credentials for one named security scheme."
+          }
+        }
+      }
+    },
+    "SecurityScheme": {
+      "title": "Security scheme",
+      "description": "Resolved credentials for one OpenAPI security scheme. The scheme type determines how token or value is interpreted.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "title": "Security scheme type",
+          "description": "Canonical security scheme kind.",
+          "enum": [
+            "oauth2",
+            "openIdConnect",
+            "basicAuth",
+            "bearer",
+            "apiKey"
+          ]
+        },
+        "token": {
+          "type": "string",
+          "title": "Security token",
+          "description": "Resolved token used by the security scheme."
+        },
+        "value": {
+          "type": "string",
+          "title": "Security value",
+          "description": "Resolved value used by the security scheme."
+        }
+      }
+    },
+    "TestConfiguration": {
+      "title": "Test execution configuration",
+      "description": "V2 test execution behavior, filters, limits, report output, and HTTPS settings.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resiliencyTests": {
+          "$ref": "#/definitions/ResiliencyTestsConfig",
+          "title": "Resiliency tests",
+          "description": "Selects which resiliency tests run during test execution."
+        },
+        "allowExtensibleSchema": {
+          "type": "boolean",
+          "title": "Allow extensible schemas",
+          "description": "Allow requests and responses to use schema extensions where supported."
+        },
+        "timeoutInMilliseconds": {
+          "type": "integer",
+          "title": "Request timeout",
+          "description": "Maximum request duration in milliseconds."
+        },
+        "strictMode": {
+          "type": "boolean",
+          "title": "Strict mode",
+          "description": "Enable strict validation behavior during tests."
+        },
+        "lenientMode": {
+          "type": "boolean",
+          "title": "Lenient mode",
+          "description": "Allow lenient validation behavior during tests."
+        },
+        "parallelism": {
+          "type": "string",
+          "title": "Test parallelism",
+          "description": "Parallel execution setting for generated tests."
+        },
+        "maxTestRequestCombinations": {
+          "type": "integer",
+          "title": "Maximum request combinations",
+          "description": "Maximum request combinations generated for a test."
+        },
+        "maxTestCount": {
+          "type": "integer",
+          "title": "Maximum test count",
+          "description": "Maximum number of tests to execute."
+        },
+        "testsDirectory": {
+          "type": "string",
+          "title": "Tests directory",
+          "description": "Directory containing additional test configuration or resources."
+        },
+        "swaggerUrl": {
+          "type": "string",
+          "format": "uri",
+          "title": "Swagger URL",
+          "description": "URL used to expose or locate the Swagger document."
+        },
+        "swaggerUIBaseURL": {
+          "type": "string",
+          "format": "uri",
+          "title": "Swagger UI base URL",
+          "description": "Base URL used by the Swagger UI integration."
+        },
+        "actuatorUrl": {
+          "type": "string",
+          "format": "uri",
+          "title": "Actuator URL",
+          "description": "URL of the service actuator endpoint used by test support."
+        },
+        "filter": {
+          "type": "string",
+          "title": "Test filter",
+          "description": "Expression used to select generated tests."
+        },
+        "baseUrl": {
+          "type": "string",
+          "format": "uri",
+          "title": "Service base URL",
+          "description": "Base URL used when sending test requests."
+        },
+        "filterName": {
+          "type": "string",
+          "title": "Include test names",
+          "description": "Pattern selecting tests by name."
+        },
+        "filterNotName": {
+          "type": "string",
+          "title": "Exclude test names",
+          "description": "Pattern excluding tests by name."
+        },
+        "overlayFilePath": {
+          "type": "string",
+          "title": "Overlay file path",
+          "description": "Path to an overlay applied while loading the specification."
+        },
+        "junitReportDir": {
+          "type": "string",
+          "title": "JUnit report directory",
+          "description": "Directory where JUnit reports are written."
+        },
+        "https": {
+          "$ref": "#/definitions/HttpsConfiguration",
+          "title": "HTTPS configuration",
+          "description": "TLS settings used for test requests."
+        }
+      }
+    },
+    "StubConfiguration": {
+      "title": "Stub execution configuration",
+      "description": "V2 stub behavior, reload and generation controls, filters, output, and HTTPS settings.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "generative": {
+          "type": "boolean",
+          "title": "Generative mode",
+          "description": "Generate stub responses when examples do not provide a direct response."
+        },
+        "delayInMilliseconds": {
+          "type": "integer",
+          "title": "Response delay",
+          "description": "Delay generated stub responses by this many milliseconds."
+        },
+        "dictionary": {
+          "type": "string",
+          "title": "Dictionary path",
+          "description": "Path to a dictionary used when generating stub responses."
+        },
+        "includeMandatoryAndRequestedKeysInResponse": {
+          "type": "boolean",
+          "title": "Include mandatory and requested keys",
+          "description": "Include mandatory and requested keys in generated stub responses."
+        },
+        "startTimeoutInMilliseconds": {
+          "type": "integer",
+          "title": "Stub start timeout",
+          "description": "Maximum time in milliseconds allowed for the stub to start."
+        },
+        "hotReload": {
+          "type": "string",
+          "title": "Hot reload",
+          "description": "Hot-reload behavior for changes to loaded contracts."
+        },
+        "strictMode": {
+          "type": "boolean",
+          "title": "Strict mode",
+          "description": "Enable strict validation behavior in the stub."
+        },
+        "baseUrl": {
+          "type": "string",
+          "format": "uri",
+          "title": "Stub base URL",
+          "description": "Base URL on which the stub listens."
+        },
+        "customImplicitStubBase": {
+          "type": "string",
+          "title": "Custom implicit stub base",
+          "description": "Custom base used for implicitly generated stub endpoints."
+        },
+        "filter": {
+          "type": "string",
+          "title": "Stub filter",
+          "description": "Expression used to select stubbed operations."
+        },
+        "gracefulRestartTimeoutInMilliseconds": {
+          "type": "integer",
+          "title": "Graceful restart timeout",
+          "description": "Maximum time in milliseconds allowed for a graceful stub restart."
+        },
+        "https": {
+          "$ref": "#/definitions/HttpsConfiguration",
+          "title": "HTTPS configuration",
+          "description": "TLS settings used by the stub listener."
+        },
+        "lenientMode": {
+          "type": "boolean",
+          "title": "Lenient mode",
+          "description": "Allow lenient validation behavior in the stub."
+        }
+      }
+    },
+    "ProxyConfig": {
+      "title": "Proxy configuration",
+      "description": "The local proxy listener and its required upstream target.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "targetUrl"
+      ],
+      "properties": {
+        "host": {
+          "type": "string",
+          "title": "Proxy host",
+          "description": "Local host on which the proxy listens."
+        },
+        "port": {
+          "type": "integer",
+          "title": "Proxy port",
+          "description": "Local port on which the proxy listens."
+        },
+        "targetUrl": {
+          "type": "string",
+          "format": "uri",
+          "title": "Upstream target URL",
+          "description": "Required upstream URL to which proxied traffic is sent.",
+          "examples": [
+            "http://localhost:9000"
+          ]
+        },
+        "baseUrl": {
+          "type": "string",
+          "format": "uri",
+          "title": "Proxy base URL",
+          "description": "Base URL exposed by the local proxy."
+        },
+        "timeoutInMilliseconds": {
+          "type": "integer",
+          "title": "Proxy timeout",
+          "description": "Maximum upstream request duration in milliseconds."
+        },
+        "adapters": {
+          "type": "object",
+          "title": "Proxy adapters",
+          "description": "Named adapter commands applied while proxying requests and responses.",
+          "additionalProperties": {
+            "type": "string",
+            "title": "Adapter command",
+            "description": "Command or script used for this adapter hook."
+          }
+        },
+        "consumes": {
+          "type": "array",
+          "title": "Consumed specifications",
+          "description": "Specification paths used by the proxy.",
+          "items": {
+            "type": "string",
+            "title": "Specification path",
+            "description": "Resolved path identifying a specification consumed by the proxy."
+          }
+        },
+        "https": {
+          "$ref": "#/definitions/HttpsConfiguration",
+          "title": "HTTPS configuration",
+          "description": "TLS settings used by the proxy listener."
+        },
+        "outputDirectory": {
+          "type": "string",
+          "title": "Proxy output directory",
+          "description": "Directory where proxy output is written."
+        }
+      }
+    },
+    "VirtualServiceConfiguration": {
+      "title": "Virtual service configuration",
+      "description": "Listener, specification, log, and non-patchable-key settings for a virtual service.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "host": {
+          "type": "string",
+          "title": "Virtual-service host",
+          "description": "Host on which the virtual service listens."
+        },
+        "port": {
+          "type": "integer",
+          "title": "Virtual-service port",
+          "description": "Port on which the virtual service listens."
+        },
+        "specs": {
+          "type": "array",
+          "title": "Virtual-service specifications",
+          "description": "Specification paths served by the virtual service.",
+          "items": {
+            "type": "string",
+            "title": "Specification path",
+            "description": "Resolved path identifying a served specification."
+          }
+        },
+        "specsDirPath": {
+          "type": "string",
+          "title": "Specifications directory",
+          "description": "Directory containing virtual-service specifications."
+        },
+        "logsDirPath": {
+          "type": "string",
+          "title": "Logs directory",
+          "description": "Directory where virtual-service logs are written."
+        },
+        "logMode": {
+          "type": "string",
+          "title": "Virtual-service log mode",
+          "description": "Select the virtual-service events written to logs.",
+          "enum": [
+            "ALL",
+            "REQUEST_RESPONSE"
+          ]
+        },
+        "nonPatchableKeys": {
+          "type": "array",
+          "title": "Non-patchable keys",
+          "description": "Keys that virtual-service patching must not modify.",
+          "items": {
+            "type": "string",
+            "title": "Non-patchable key",
+            "description": "Payload key excluded from patching."
+          }
+        }
+      }
+    },
+    "WorkflowConfiguration": {
+      "title": "Workflow configuration",
+      "description": "Named workflow operations used to extract values and reuse them in later requests.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "ids": {
+          "type": "object",
+          "title": "Workflow operations",
+          "description": "Named workflow operations used by the configuration.",
+          "additionalProperties": {
+            "$ref": "#/definitions/WorkflowIDOperation",
+            "description": "Workflow extraction and reuse settings for one workflow ID."
+          }
+        }
+      }
+    },
+    "WorkflowIDOperation": {
+      "title": "Workflow ID operation",
+      "description": "Extraction and reuse expressions associated with one workflow identifier.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "extract": {
+          "type": "string",
+          "title": "Extraction expression",
+          "description": "Expression that extracts a value from a workflow response."
+        },
+        "use": {
+          "type": "string",
+          "title": "Reuse expression",
+          "description": "Expression that reuses a value in a later workflow request."
+        }
+      }
+    },
+    "AttributeSelectionPattern": {
+      "title": "Attribute selection pattern",
+      "description": "Default fields and query-parameter naming used when selecting attributes from generated requests.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "defaultFields": {
+          "type": "array",
+          "title": "Default fields",
+          "description": "Fields selected by default when attributes are generated.",
+          "items": {
+            "type": "string",
+            "title": "Default field",
+            "description": "Field name selected by default."
+          }
+        },
+        "default_fields": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "Default field name selected during attribute generation."
+          },
+          "deprecated": true,
+          "title": "Default fields (legacy spelling)",
+          "description": "Legacy snake_case alias for defaultFields.",
+          "deprecationMessage": "Replace with defaultFields."
+        },
+        "queryParamKey": {
+          "type": "string",
+          "title": "Query-parameter key",
+          "description": "Name of the query parameter used for attribute selection."
+        },
+        "query_param_key": {
+          "type": "string",
+          "deprecated": true,
+          "title": "Query-parameter key (legacy spelling)",
+          "description": "Legacy snake_case alias for queryParamKey.",
+          "deprecationMessage": "Replace with queryParamKey."
+        }
+      }
+    },
+    "BackwardCompatibilityConfig": {
+      "title": "Backward compatibility configuration",
+      "description": "Repository and branch settings used for compatibility comparisons.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "baseBranch": {
+          "type": "string",
+          "title": "Base branch",
+          "description": "Branch used as the baseline for compatibility comparison."
+        },
+        "targetPath": {
+          "type": "string",
+          "title": "Compatibility target path",
+          "description": "Path whose compatibility is evaluated."
+        },
+        "repoDirectory": {
+          "type": "string",
+          "title": "Repository directory",
+          "description": "Local repository directory used for compatibility comparison."
+        },
+        "strictMode": {
+          "type": "boolean",
+          "title": "Strict compatibility mode",
+          "description": "Apply strict compatibility rules when comparing repository states."
+        }
+      }
+    },
+    "LoggingConfiguration": {
+      "title": "Logging configuration",
+      "description": "Log level and JSON/text output destinations.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "level": {
+          "type": "string",
+          "title": "Log level",
+          "description": "Minimum log level to emit.",
+          "enum": [
+            "INFO",
+            "DEBUG"
+          ]
+        },
+        "json": {
+          "$ref": "#/definitions/LogOutputConfig",
+          "title": "JSON log output",
+          "description": "Destination settings for structured JSON logs."
+        },
+        "text": {
+          "$ref": "#/definitions/LogOutputConfig",
+          "title": "Text log output",
+          "description": "Destination settings for human-readable text logs."
+        }
+      }
+    },
+    "LogOutputConfig": {
+      "title": "Log output",
+      "description": "Destination and naming options for one log output format.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "directory": {
+          "type": "string",
+          "title": "Log directory",
+          "description": "Directory where this log output is written."
+        },
+        "console": {
+          "type": "boolean",
+          "title": "Log to console",
+          "description": "Write this log output to the console."
+        },
+        "logFilePrefix": {
+          "type": "string",
+          "title": "Log-file prefix",
+          "description": "Prefix used when naming log files."
+        },
+        "logPrefix": {
+          "type": "string",
+          "deprecated": true,
+          "title": "Log-file prefix (legacy name)",
+          "description": "Legacy alias for logFilePrefix.",
+          "deprecationMessage": "Replace with logFilePrefix."
+        }
+      }
+    },
+    "McpConfiguration": {
+      "title": "MCP configuration",
+      "description": "Model Context Protocol test configuration.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "test"
+      ],
+      "properties": {
+        "test": {
+          "$ref": "#/definitions/McpTestConfiguration",
+          "title": "MCP test settings",
+          "description": "Endpoint and execution settings for MCP tests."
+        }
+      }
+    },
+    "McpTestConfiguration": {
+      "title": "MCP test configuration",
+      "description": "MCP endpoint, transport, filtering, authentication, and resiliency settings.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "baseUrl"
+      ],
+      "properties": {
+        "baseUrl": {
+          "type": "string",
+          "format": "uri",
+          "title": "MCP server base URL",
+          "description": "MCP server base URL.",
+          "examples": [
+            "http://localhost:3000"
+          ]
+        },
+        "transportKind": {
+          "type": "string",
+          "title": "MCP transport",
+          "description": "Canonical MCP transport supported by this configuration language.",
+          "enum": [
+            "STREAMABLE_HTTP"
+          ]
+        },
+        "enableResiliencyTests": {
+          "type": "boolean",
+          "title": "Enable resiliency tests",
+          "description": "Run resiliency tests against the MCP server."
+        },
+        "dictionaryFile": {
+          "type": "string",
+          "title": "Dictionary file",
+          "description": "Path to the dictionary file used by MCP tests."
+        },
+        "bearerToken": {
+          "type": "string",
+          "title": "Bearer token",
+          "description": "Bearer token used to authenticate with the MCP server."
+        },
+        "filterTools": {
+          "type": "array",
+          "title": "Included MCP tools",
+          "description": "Tool names to include in MCP tests.",
+          "items": {
+            "type": "string",
+            "title": "MCP tool name",
+            "description": "Name of an MCP tool to include."
+          }
+        },
+        "skipTools": {
+          "type": "array",
+          "title": "Excluded MCP tools",
+          "description": "Tool names to skip during MCP tests.",
+          "items": {
+            "type": "string",
+            "title": "MCP tool name",
+            "description": "Name of an MCP tool to skip."
+          }
+        }
+      }
+    },
+    "HttpsConfiguration": {
+      "title": "HTTPS configuration",
+      "description": "TLS and optional mutual-TLS settings for a test or stub listener.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "keyStore": {
+          "$ref": "#/definitions/KeyStoreConfiguration",
+          "title": "Key store",
+          "description": "Key store used for TLS credentials."
+        },
+        "keyStorePassword": {
+          "type": "string",
+          "title": "Key-store password",
+          "description": "Password used to open the key store."
+        },
+        "mtlsEnabled": {
+          "type": "boolean",
+          "title": "Enable mutual TLS",
+          "description": "Enable mutual TLS for this listener or client."
+        }
+      }
+    },
+    "KeyStoreConfiguration": {
+      "title": "Key store",
+      "description": "Exactly one key-store representation: a file or a directory.",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/KeyStoreFileConfiguration",
+          "description": "A key store loaded from one file."
+        },
+        {
+          "$ref": "#/definitions/KeyStoreDirectoryConfiguration",
+          "description": "A key store loaded from a directory."
+        }
+      ],
+      "errorMessage": {
+        "oneOf": "Specify exactly one key-store form: file or directory."
+      }
+    },
+    "KeyStoreFileConfiguration": {
+      "title": "Key-store file",
+      "description": "Key store loaded from one file path.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "file"
+      ],
+      "properties": {
+        "file": {
+          "type": "string",
+          "title": "Key-store file",
+          "description": "Path to the key-store file."
+        },
+        "password": {
+          "type": "string",
+          "title": "Key-store password",
+          "description": "Password used to open the key store."
+        },
+        "alias": {
+          "type": "string",
+          "title": "Key-store alias",
+          "description": "Optional key alias to use from the key store."
+        }
+      }
+    },
+    "KeyStoreDirectoryConfiguration": {
+      "title": "Key-store directory",
+      "description": "Key store loaded from a directory path.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "directory"
+      ],
+      "properties": {
+        "directory": {
+          "type": "string",
+          "title": "Key-store directory",
+          "description": "Path to the directory containing the key-store files."
+        },
+        "password": {
+          "type": "string",
+          "title": "Key-store password",
+          "description": "Password used to open the key store."
+        },
+        "alias": {
+          "type": "string",
+          "title": "Key-store alias",
+          "description": "Optional key alias to use from the key store."
+        }
+      }
+    },
+    "SpecmaticGlobalSettings": {
+      "title": "Global path settings",
+      "description": "Templates controlling how specification and shared-example directories are resolved.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "specExamplesDirectoryTemplate": {
+          "type": "string",
+          "title": "Specification examples directory template",
+          "description": "Template for the directory containing examples associated with a specification."
+        },
+        "sharedExamplesDirectoryTemplate": {
+          "type": "array",
+          "title": "Shared examples directory templates",
+          "description": "Templates for shared example directories searched across specifications.",
+          "items": {
+            "type": "string",
+            "title": "Directory template",
+            "description": "Template resolving to a shared examples directory."
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/src/main/resources/config-validation/config-v3-resolved.schema.json
+++ b/core/src/main/resources/config-validation/config-v3-resolved.schema.json
@@ -1,0 +1,2746 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://specmatic.io/internal-schema/config-v3-resolved.schema.json",
+  "title": "Specmatic V3 resolved configuration",
+  "description": "Concrete V3 configuration after expression and template resolution. References remain structural and are checked semantically after Jackson binding.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version"
+  ],
+  "properties": {
+    "version": {
+      "const": 3,
+      "title": "Configuration version",
+      "description": "Literal V3 configuration marker; it is not template-able at the resolved-config boundary."
+    },
+    "systemUnderTest": {
+      "$ref": "#/definitions/SystemUnderTestServiceDefinition",
+      "title": "System under test",
+      "description": "The service under test, supplied inline or by a supported reference."
+    },
+    "dependencies": {
+      "$ref": "#/definitions/DependenciesDefinition",
+      "title": "Dependencies",
+      "description": "Mocked dependency services and their optional data/settings."
+    },
+    "proxies": {
+      "type": "array",
+      "title": "Proxy definitions",
+      "description": "Proxy definitions. Multiple proxies are currently valid; target selection is runtime behavior.",
+      "items": {
+        "$ref": "#/definitions/ProxyEntry",
+        "description": "One proxy definition."
+      }
+    },
+    "mcp": {
+      "$ref": "#/definitions/McpDefinition",
+      "title": "MCP configuration",
+      "description": "Model Context Protocol test endpoint and transport settings."
+    },
+    "specmatic": {
+      "$ref": "#/definitions/SpecmaticDefinition",
+      "title": "Specmatic settings",
+      "description": "Specmatic-owned license, governance, and global settings."
+    },
+    "components": {
+      "$ref": "#/definitions/Components",
+      "title": "Reusable components",
+      "description": "Named reusable sources, services, run options, data, certificates, adapters, and settings."
+    }
+  },
+  "examples": [
+    {
+      "version": 3,
+      "systemUnderTest": {
+        "service": {
+          "definitions": []
+        }
+      },
+      "dependencies": {
+        "services": []
+      },
+      "mcp": {
+        "test": {
+          "baseUrl": "http://localhost:3000"
+        }
+      },
+      "specmatic": {
+        "license": {
+          "path": "license.txt"
+        }
+      }
+    }
+  ],
+  "definitions": {
+    "Reference": {
+      "title": "Reference",
+      "type": "object",
+      "required": [
+        "$ref"
+      ],
+      "additionalProperties": true,
+      "properties": {
+        "$ref": {
+          "type": "string",
+          "title": "Reference target",
+          "description": "Component, internal pointer, relative, or supported external reference target."
+        }
+      },
+      "description": "A structural reference. Inline sibling fields are intentional overrides and are converted after the target is resolved. Existence, type compatibility, and cycles are semantic/reference checks.",
+      "examples": [
+        {
+          "$ref": "#/components/settings/global",
+          "test": {
+            "timeoutInMilliseconds": 5000
+          }
+        }
+      ]
+    },
+    "SystemUnderTestServiceDefinition": {
+      "title": "System under test",
+      "description": "The single service Specmatic exercises as the system under test.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "service"
+      ],
+      "properties": {
+        "service": {
+          "$ref": "#/definitions/RefOrTestService",
+          "title": "Test service",
+          "description": "Inline test service or reusable service reference."
+        }
+      }
+    },
+    "DependenciesDefinition": {
+      "title": "Dependencies",
+      "description": "Dependency services are wrapped under service; each dependency is interpreted as a mock service in this context.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "services"
+      ],
+      "properties": {
+        "services": {
+          "type": "array",
+          "title": "Mock dependency services",
+          "description": "Mock dependency entries. The array may be empty; each item must contain a service wrapper.",
+          "items": {
+            "$ref": "#/definitions/MockServiceEntry",
+            "description": "One wrapped mock dependency service."
+          }
+        },
+        "data": {
+          "$ref": "#/definitions/DataDefinition",
+          "title": "Dependency data",
+          "description": "Optional examples, dictionary, and adapter data for dependencies."
+        },
+        "settings": {
+          "$ref": "#/definitions/RefOrMockSettings",
+          "title": "Dependency settings",
+          "description": "Optional mock settings or a reference to them."
+        }
+      }
+    },
+    "MockServiceEntry": {
+      "title": "Mock dependency entry",
+      "description": "Wrapper containing one inline mock service or service reference.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "service"
+      ],
+      "properties": {
+        "service": {
+          "$ref": "#/definitions/RefOrMockService",
+          "title": "Mock service",
+          "description": "Inline mock service or reusable service reference."
+        }
+      }
+    },
+    "RefOrTestService": {
+      "title": "Test service or reference",
+      "description": "Use an inline test service or a reference to a reusable service component.",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/Reference",
+          "description": "A reference to a reusable test service."
+        },
+        {
+          "$ref": "#/definitions/TestService",
+          "description": "An inline test service."
+        }
+      ]
+    },
+    "RefOrMockService": {
+      "title": "Mock service or reference",
+      "description": "Use an inline mock service or a reference to a reusable service component.",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/Reference",
+          "description": "A reference to a reusable mock service."
+        },
+        {
+          "$ref": "#/definitions/MockService",
+          "description": "An inline mock service."
+        }
+      ]
+    },
+    "RefOrContextService": {
+      "title": "Contextual service or reference",
+      "description": "Use an inline reusable service or a reference; its test/mock context is selected by the consumer.",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/Reference",
+          "description": "A reference to a reusable contextual service."
+        },
+        {
+          "$ref": "#/definitions/ContextService",
+          "description": "An inline contextual service."
+        }
+      ]
+    },
+    "TestService": {
+      "title": "Test service",
+      "description": "A service used as the system under test, with definitions and optional test run options, data, and settings.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "definitions"
+      ],
+      "properties": {
+        "description": {
+          "type": "string",
+          "title": "Service description",
+          "description": "Optional human-readable description of the service."
+        },
+        "definitions": {
+          "$ref": "#/definitions/DefinitionArray",
+          "title": "Service definitions",
+          "description": "Specifications and their sources for this service."
+        },
+        "runOptions": {
+          "$ref": "#/definitions/RefOrTestRunOptions",
+          "title": "Test run options",
+          "description": "Optional test run options or a reference to reusable options."
+        },
+        "data": {
+          "$ref": "#/definitions/DataDefinition",
+          "title": "Test data",
+          "description": "Optional examples, dictionary, and adapter data for the test service."
+        },
+        "settings": {
+          "$ref": "#/definitions/RefOrTestSettings",
+          "title": "Test settings",
+          "description": "Optional test settings or a reference to them."
+        }
+      }
+    },
+    "MockService": {
+      "title": "Mock service",
+      "description": "A dependency service used as a mock, with definitions and optional mock run options, data, and settings.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "definitions"
+      ],
+      "properties": {
+        "description": {
+          "type": "string",
+          "title": "Service description",
+          "description": "Optional human-readable description of the service."
+        },
+        "definitions": {
+          "$ref": "#/definitions/DefinitionArray",
+          "title": "Service definitions",
+          "description": "Specifications and their sources for this service."
+        },
+        "runOptions": {
+          "$ref": "#/definitions/RefOrMockRunOptions",
+          "title": "Mock run options",
+          "description": "Optional mock run options or a reference to reusable options."
+        },
+        "data": {
+          "$ref": "#/definitions/DataDefinition",
+          "title": "Mock data",
+          "description": "Optional examples, dictionary, and adapter data for the mock service."
+        },
+        "settings": {
+          "$ref": "#/definitions/RefOrMockSettings",
+          "title": "Mock settings",
+          "description": "Optional mock settings or a reference to them."
+        }
+      }
+    },
+    "ContextService": {
+      "title": "Contextual service",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "definitions"
+      ],
+      "description": "Reusable service whose concrete test or mock settings and run-option shape is selected by the consuming context. The service still requires definitions; arbitrary intermediate fields are not valid.",
+      "properties": {
+        "description": {
+          "type": "string",
+          "title": "Service description",
+          "description": "Optional human-readable description of the service."
+        },
+        "definitions": {
+          "$ref": "#/definitions/DefinitionArray",
+          "title": "Service definitions",
+          "description": "Specifications and their sources for this service."
+        },
+        "runOptions": {
+          "$ref": "#/definitions/RefOrContextRunOptions",
+          "title": "Contextual run options",
+          "description": "Optional test-or-mock run options selected by the consuming context."
+        },
+        "data": {
+          "$ref": "#/definitions/DataDefinition",
+          "title": "Service data",
+          "description": "Optional examples, dictionary, and adapter data for the service."
+        },
+        "settings": {
+          "$ref": "#/definitions/RefOrContextSettings",
+          "title": "Contextual settings",
+          "description": "Optional test-or-mock settings selected by the consuming context."
+        }
+      }
+    },
+    "DefinitionArray": {
+      "title": "Service definitions",
+      "description": "Ordered definition entries that provide the specifications for a service.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/DefinitionEntry",
+        "description": "One source-backed service definition entry."
+      }
+    },
+    "DefinitionEntry": {
+      "title": "Definition entry",
+      "description": "Wrapper containing one source-backed definition value.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "definition"
+      ],
+      "properties": {
+        "definition": {
+          "$ref": "#/definitions/DefinitionValue",
+          "title": "Definition value",
+          "description": "Named definition value containing its source and specification list."
+        }
+      }
+    },
+    "DefinitionValue": {
+      "title": "Definition value",
+      "description": "A source plus the specifications loaded from that source.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source",
+        "specs"
+      ],
+      "properties": {
+        "source": {
+          "$ref": "#/definitions/RefOrSource",
+          "title": "Definition source",
+          "description": "Inline source provider or reference to a named source component."
+        },
+        "specs": {
+          "type": "array",
+          "title": "Specifications",
+          "description": "Specifications loaded from the selected source.",
+          "items": {
+            "$ref": "#/definitions/SpecificationDefinition",
+            "description": "One specification path or per-specification override."
+          }
+        }
+      },
+      "examples": [
+        {
+          "source": {
+            "filesystem": {
+              "directory": "contracts"
+            }
+          },
+          "specs": [
+            "orders.yaml"
+          ]
+        }
+      ]
+    },
+    "SpecificationDefinition": {
+      "title": "Specification definition",
+      "description": "A specification path or an object containing that path and optional per-specification overrides.",
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "A resolved specification path."
+        },
+        {
+          "type": "object",
+          "description": "A specification path with optional per-specification overrides.",
+          "additionalProperties": false,
+          "required": [
+            "spec"
+          ],
+          "properties": {
+            "spec": {
+              "$ref": "#/definitions/SpecificationObject",
+              "title": "Specification override",
+              "description": "Inline specification path and optional per-specification overrides."
+            }
+          }
+        }
+      ]
+    },
+    "SpecificationObject": {
+      "title": "Specification object",
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "path"
+      ],
+      "description": "Specification-level options. Additional fields are intentional per-specification overrides and are applied to this specification only; they are not arbitrary fields on the surrounding service.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Specification ID",
+          "description": "Optional specification identifier used by per-spec and run-option joins.",
+          "examples": [
+            "orders"
+          ]
+        },
+        "path": {
+          "type": "string",
+          "title": "Specification path",
+          "description": "Resolved path or source-relative location of the specification.",
+          "examples": [
+            "orders.yaml"
+          ]
+        },
+        "urlPathPrefix": {
+          "type": "string",
+          "title": "URL path prefix",
+          "description": "Optional URL path prefix applied to this specification."
+        }
+      },
+      "examples": [
+        {
+          "id": "orders",
+          "path": "orders.yaml",
+          "urlPathPrefix": "/v1"
+        },
+        {
+          "path": "orders.yaml",
+          "x-team": "payments"
+        }
+      ]
+    },
+    "Components": {
+      "title": "Reusable components",
+      "description": "Named component maps. Names are referenced by $ref values and are joined semantically after structural validation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "sources": {
+          "type": "object",
+          "title": "Source components",
+          "description": "Named source components. A source is selected by exactly one of git, filesystem, or web.",
+          "additionalProperties": {
+            "$ref": "#/definitions/SourceSchema",
+            "description": "One named source component."
+          }
+        },
+        "services": {
+          "type": "object",
+          "title": "Service components",
+          "description": "Named reusable services whose test/mock context is selected by the consumer.",
+          "additionalProperties": {
+            "$ref": "#/definitions/ContextService",
+            "description": "One named reusable contextual service."
+          }
+        },
+        "runOptions": {
+          "type": "object",
+          "title": "Run-option components",
+          "description": "Named directly typed protocol run-option components. These values require their protocol branch discriminator.",
+          "additionalProperties": {
+            "$ref": "#/definitions/ComponentRunOptions",
+            "description": "One named directly typed protocol run-option component."
+          }
+        },
+        "examples": {
+          "$ref": "#/definitions/ExamplesConfiguration",
+          "title": "Example components",
+          "description": "Named example-directory collections."
+        },
+        "dictionaries": {
+          "type": "object",
+          "title": "Dictionary components",
+          "description": "Named dictionaries available to services and specifications.",
+          "additionalProperties": {
+            "$ref": "#/definitions/DictionaryConfiguration",
+            "description": "One named dictionary component."
+          }
+        },
+        "adapters": {
+          "type": "object",
+          "title": "Adapter components",
+          "description": "Named adapter hook configurations. Only the supported hook names are valid.",
+          "additionalProperties": {
+            "$ref": "#/definitions/AdapterConfiguration",
+            "description": "One named adapter-hook component."
+          }
+        },
+        "certificates": {
+          "type": "object",
+          "title": "Certificate components",
+          "description": "Named TLS/mTLS certificate configurations.",
+          "additionalProperties": {
+            "$ref": "#/definitions/CertConfiguration",
+            "description": "One named certificate component."
+          }
+        },
+        "settings": {
+          "type": "object",
+          "title": "Settings components",
+          "description": "Named settings. The concrete shape is selected from global, test, mock, proxy, or contextual settings.",
+          "additionalProperties": {
+            "$ref": "#/definitions/ContextOrConcreteSettings",
+            "description": "One named concrete or contextual settings component."
+          }
+        }
+      }
+    },
+    "SourceSchema": {
+      "title": "Source",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/GitSourceSchema",
+          "description": "A Git-backed source."
+        },
+        {
+          "$ref": "#/definitions/FileSystemSourceSchema",
+          "description": "A filesystem-backed source."
+        },
+        {
+          "$ref": "#/definitions/WebSourceSchema",
+          "description": "A web-backed source."
+        }
+      ],
+      "description": "Exactly one source provider is selected: git, filesystem, or web. The selected wrapper determines how specifications are located.",
+      "errorMessage": {
+        "oneOf": "Choose exactly one source provider: git, filesystem, or web."
+      }
+    },
+    "GitSourceSchema": {
+      "title": "Git source",
+      "description": "A source retrieved from Git or resolved from the current monorepo context.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "git"
+      ],
+      "properties": {
+        "git": {
+          "$ref": "#/definitions/GitSourceOptions",
+          "title": "Git source options",
+          "description": "Repository and branch settings for this Git source."
+        }
+      }
+    },
+    "GitSourceOptions": {
+      "title": "Git source options",
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Git source. URL may be omitted intentionally for monorepo/working-directory resolution.",
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "title": "Git repository URL",
+          "description": "Git repository URL. Omit intentionally for monorepo/current-repository mode.",
+          "examples": [
+            "https://github.com/acme/contracts.git"
+          ]
+        },
+        "branch": {
+          "type": "string",
+          "title": "Git branch or ref",
+          "description": "Branch or ref to retrieve."
+        },
+        "matchBranch": {
+          "type": "boolean",
+          "title": "Follow current repository branch",
+          "description": "Follow the current repository branch when resolving this source."
+        },
+        "auth": {
+          "$ref": "#/definitions/GitSourceAuthentication",
+          "title": "Git authentication",
+          "description": "Optional authentication method for the Git source."
+        }
+      },
+      "examples": [
+        {
+          "branch": "main"
+        },
+        {
+          "url": "https://github.com/acme/contracts.git",
+          "branch": "main"
+        }
+      ]
+    },
+    "GitSourceAuthentication": {
+      "title": "Git authentication",
+      "description": "Exactly one supported Git credential source.",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/GitBearerFileAuthentication",
+          "description": "Git authentication using a bearer-token file."
+        },
+        {
+          "$ref": "#/definitions/GitBearerEnvAuthentication",
+          "description": "Git authentication using a bearer-token environment variable."
+        },
+        {
+          "$ref": "#/definitions/GitPersonalAccessTokenAuthentication",
+          "description": "Git authentication using a personal access token."
+        }
+      ]
+    },
+    "GitBearerFileAuthentication": {
+      "title": "Git bearer-file authentication",
+      "description": "Reads the Git bearer token from a file path.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "bearerFile"
+      ],
+      "properties": {
+        "bearerFile": {
+          "type": "string",
+          "title": "Bearer-token file",
+          "description": "Path to a file containing the Git bearer token."
+        }
+      }
+    },
+    "GitBearerEnvAuthentication": {
+      "title": "Git bearer-environment authentication",
+      "description": "Reads the Git bearer token from a named environment variable.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "bearerEnvironmentVariable"
+      ],
+      "properties": {
+        "bearerEnvironmentVariable": {
+          "type": "string",
+          "title": "Bearer-token environment variable",
+          "description": "Name of the environment variable containing the Git bearer token."
+        }
+      }
+    },
+    "GitPersonalAccessTokenAuthentication": {
+      "title": "Git personal-access-token authentication",
+      "description": "Uses a resolved personal access token for Git retrieval.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "personalAccessToken"
+      ],
+      "properties": {
+        "personalAccessToken": {
+          "type": "string",
+          "title": "Personal access token",
+          "description": "Resolved personal access token used for Git retrieval."
+        }
+      }
+    },
+    "FileSystemSourceSchema": {
+      "title": "Filesystem source",
+      "description": "A source loaded from a local directory.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "filesystem"
+      ],
+      "properties": {
+        "filesystem": {
+          "$ref": "#/definitions/FileSystemSourceOptions",
+          "title": "Filesystem source options",
+          "description": "Local directory settings for this filesystem source."
+        }
+      }
+    },
+    "FileSystemSourceOptions": {
+      "title": "Filesystem source options",
+      "description": "Local directory used to resolve source specifications. Omission uses the configuration working directory.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "directory": {
+          "type": "string",
+          "title": "Source directory",
+          "description": "Directory containing specifications; omission resolves to the configuration working directory."
+        }
+      }
+    },
+    "WebSourceSchema": {
+      "title": "Web source",
+      "description": "A source loaded from a remote URL.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "web"
+      ],
+      "properties": {
+        "web": {
+          "$ref": "#/definitions/WebSourceOptions",
+          "title": "Web source options",
+          "description": "Remote URL settings for this web source."
+        }
+      }
+    },
+    "WebSourceOptions": {
+      "title": "Web source options",
+      "description": "Remote URL used to resolve source specifications.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "title": "Source URL",
+          "description": "Remote specification source URL.",
+          "examples": [
+            "https://api.example.com/openapi.yaml"
+          ]
+        }
+      }
+    },
+    "ProxyEntry": {
+      "title": "Proxy entry",
+      "description": "One named proxy wrapper. Multiple proxy entries are currently allowed.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "proxy"
+      ],
+      "properties": {
+        "proxy": {
+          "$ref": "#/definitions/ProxyDefinition",
+          "title": "Proxy definition",
+          "description": "Target, listener, adapter, certificate, and recording settings for the proxy."
+        }
+      }
+    },
+    "ProxyDefinition": {
+      "title": "Proxy definition",
+      "description": "Proxy target, listener overrides, optional mock/recording behavior, adapters, and certificate settings.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "target"
+      ],
+      "properties": {
+        "target": {
+          "type": "string",
+          "format": "uri",
+          "title": "Upstream target",
+          "description": "Required upstream target for the proxy.",
+          "examples": [
+            "http://localhost:9000"
+          ]
+        },
+        "baseUrl": {
+          "type": "string",
+          "format": "uri",
+          "title": "Proxy base URL",
+          "description": "Base URL exposed by the local proxy."
+        },
+        "timeoutInMilliseconds": {
+          "type": "integer",
+          "title": "Proxy timeout",
+          "description": "Maximum upstream request duration in milliseconds."
+        },
+        "adapters": {
+          "$ref": "#/definitions/RefOrAdapter",
+          "title": "Proxy adapters",
+          "description": "Adapter hooks applied while proxying requests and responses."
+        },
+        "mock": {
+          "type": "array",
+          "title": "Mock specifications",
+          "description": "Specification identifiers or paths to mock while proxying.",
+          "items": {
+            "type": "string",
+            "title": "Mock specification",
+            "description": "Specification identifier or path selected for mocking."
+          }
+        },
+        "cert": {
+          "$ref": "#/definitions/RefOrCert",
+          "title": "Proxy certificate",
+          "description": "TLS certificate settings or a reference to a named certificate."
+        },
+        "recordingsDirectory": {
+          "type": "string",
+          "title": "Recordings directory",
+          "description": "Directory where proxy recordings are stored."
+        }
+      }
+    },
+    "McpDefinition": {
+      "title": "MCP definition",
+      "description": "MCP test configuration. The test section is required.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "test"
+      ],
+      "properties": {
+        "test": {
+          "$ref": "#/definitions/McpTestRunOptions",
+          "title": "MCP test run options",
+          "description": "Endpoint and transport settings for MCP tests."
+        }
+      }
+    },
+    "McpTestRunOptions": {
+      "title": "MCP test run options",
+      "description": "MCP endpoint, canonical transport, tool filters, authentication, and resiliency settings.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "baseUrl"
+      ],
+      "properties": {
+        "baseUrl": {
+          "type": "string",
+          "format": "uri",
+          "title": "MCP server base URL",
+          "description": "MCP server base URL.",
+          "examples": [
+            "http://localhost:3000"
+          ]
+        },
+        "transportKind": {
+          "type": "string",
+          "title": "MCP transport",
+          "description": "Canonical MCP transport. Parser tolerance for alternate spellings is not part of the resolved language.",
+          "enum": [
+            "STREAMABLE_HTTP"
+          ]
+        },
+        "enableResiliencyTests": {
+          "type": "boolean",
+          "title": "Enable resiliency tests",
+          "description": "Run resiliency tests against the MCP server."
+        },
+        "dictionaryFile": {
+          "type": "string",
+          "title": "Dictionary file",
+          "description": "Path to the dictionary file used by MCP tests."
+        },
+        "bearerToken": {
+          "type": "string",
+          "title": "Bearer token",
+          "description": "Bearer token used to authenticate with the MCP server."
+        },
+        "filterTools": {
+          "type": "array",
+          "title": "Included MCP tools",
+          "description": "Tool names to include in MCP tests.",
+          "items": {
+            "type": "string",
+            "title": "MCP tool name",
+            "description": "Name of an MCP tool to include."
+          }
+        },
+        "skipTools": {
+          "type": "array",
+          "title": "Excluded MCP tools",
+          "description": "Tool names to skip during MCP tests.",
+          "items": {
+            "type": "string",
+            "title": "MCP tool name",
+            "description": "Name of an MCP tool to skip."
+          }
+        }
+      }
+    },
+    "SpecmaticDefinition": {
+      "title": "Specmatic settings",
+      "description": "License, governance, and named global settings for the configuration.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "license": {
+          "$ref": "#/definitions/LicenseDefinition",
+          "title": "License",
+          "description": "Path to the Specmatic license file."
+        },
+        "governance": {
+          "$ref": "#/definitions/Governance",
+          "title": "Governance",
+          "description": "Reporting and success-criteria settings."
+        },
+        "settings": {
+          "$ref": "#/definitions/RefOrConcreteSettings",
+          "title": "Global settings",
+          "description": "Global settings or a reference to a reusable settings component."
+        }
+      }
+    },
+    "LicenseDefinition": {
+      "title": "License definition",
+      "description": "Path to the Specmatic license file.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path"
+      ],
+      "properties": {
+        "path": {
+          "type": "string",
+          "title": "License file path",
+          "description": "Filesystem path to the license file.",
+          "examples": [
+            "license.txt"
+          ]
+        }
+      }
+    },
+    "Governance": {
+      "title": "Governance configuration",
+      "description": "Reporting output and success criteria for governance checks.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "report": {
+          "$ref": "#/definitions/ReportsDefinition",
+          "title": "Reports",
+          "description": "Report formats and output location."
+        },
+        "successCriteria": {
+          "$ref": "#/definitions/SuccessCriteriaDefinition",
+          "title": "Governance success criteria",
+          "description": "Coverage thresholds and enforcement behavior."
+        }
+      }
+    },
+    "ReportsDefinition": {
+      "title": "Report configuration",
+      "description": "Report formats and output location.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "formats": {
+          "type": "array",
+          "title": "Report formats",
+          "description": "Report formats to generate.",
+          "items": {
+            "type": "string",
+            "title": "Report format",
+            "description": "Supported report format name.",
+            "enum": [
+              "html",
+              "ctrf"
+            ]
+          }
+        },
+        "outputDirectory": {
+          "type": "string",
+          "title": "Report output directory",
+          "description": "Directory where generated reports are written."
+        }
+      },
+      "examples": [
+        {
+          "formats": [
+            "html",
+            "ctrf"
+          ],
+          "outputDirectory": "build/reports"
+        }
+      ]
+    },
+    "SuccessCriteriaDefinition": {
+      "title": "Governance success criteria",
+      "description": "Coverage thresholds and enforcement behavior for governance reporting.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "minCoveragePercentage": {
+          "type": "integer",
+          "title": "Minimum coverage percentage",
+          "description": "Minimum coverage percentage required for governance success."
+        },
+        "maxMissedOperationsInSpec": {
+          "type": "integer",
+          "title": "Maximum missed operations",
+          "description": "Maximum number of missed operations allowed in a specification."
+        },
+        "enforce": {
+          "type": "boolean",
+          "title": "Enforce success criteria",
+          "description": "Whether failing the configured thresholds should fail the operation."
+        }
+      }
+    },
+    "RunOptions": {
+      "title": "Run options",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/TestRunOptions",
+          "description": "Test protocol run options."
+        },
+        {
+          "$ref": "#/definitions/MockRunOptions",
+          "description": "Mock protocol run options."
+        }
+      ],
+      "description": "Protocol run options. The test/mock context is selected by the consuming service or reference target; target existence and context compatibility are semantic checks.",
+      "examples": [
+        {
+          "openapi": {
+            "baseUrl": "http://localhost:8080"
+          }
+        }
+      ]
+    },
+    "ComponentRunOptions": {
+      "title": "Direct component run options",
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Directly typed component run options. Choose a protocol property; its concrete value requires the test/mock type discriminator because this map is bound without a consuming service context.",
+      "properties": {
+        "openapi": {
+          "$ref": "#/definitions/ComponentOpenApiRunOptions",
+          "title": "OpenAPI run options",
+          "description": "Directly typed OpenAPI component options."
+        },
+        "wsdl": {
+          "$ref": "#/definitions/ComponentWsdlRunOptions",
+          "title": "WSDL run options",
+          "description": "Directly typed WSDL component options."
+        },
+        "asyncapi": {
+          "$ref": "#/definitions/ComponentAsyncApiRunOptions",
+          "title": "AsyncAPI run options",
+          "description": "Directly typed AsyncAPI component options."
+        },
+        "graphqlsdl": {
+          "$ref": "#/definitions/ComponentGraphqlSdlRunOptions",
+          "title": "GraphQL SDL run options",
+          "description": "Directly typed GraphQL SDL component options."
+        },
+        "protobuf": {
+          "$ref": "#/definitions/ComponentProtobufRunOptions",
+          "title": "Protobuf run options",
+          "description": "Directly typed Protobuf component options."
+        }
+      }
+    },
+    "ComponentOpenApiRunOptions": {
+      "title": "Direct OpenAPI component options",
+      "description": "Direct component OpenAPI options. Choose the test or mock branch and include its type discriminator.",
+      "anyOf": [
+        {
+          "description": "OpenAPI test or mock component run options.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/OpenApiTestRunOptions",
+              "description": "OpenAPI test run options."
+            },
+            {
+              "description": "The directly typed component must identify its test or mock branch.",
+              "required": [
+                "type"
+              ]
+            }
+          ]
+        },
+        {
+          "description": "OpenAPI test or mock component run options.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/OpenApiMockRunOptions",
+              "description": "OpenAPI mock run options."
+            },
+            {
+              "description": "The directly typed component must identify its test or mock branch.",
+              "required": [
+                "type"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "ComponentWsdlRunOptions": {
+      "title": "Direct WSDL component options",
+      "description": "Direct component WSDL options. Choose the test or mock branch and include its type discriminator.",
+      "anyOf": [
+        {
+          "description": "WSDL test or mock component run options.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/WsdlTestRunOptions",
+              "description": "WSDL test run options."
+            },
+            {
+              "description": "The directly typed component must identify its test or mock branch.",
+              "required": [
+                "type"
+              ]
+            }
+          ]
+        },
+        {
+          "description": "WSDL test or mock component run options.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/WsdlMockRunOptions",
+              "description": "WSDL mock run options."
+            },
+            {
+              "description": "The directly typed component must identify its test or mock branch.",
+              "required": [
+                "type"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "ComponentAsyncApiRunOptions": {
+      "title": "Direct AsyncAPI component options",
+      "description": "Direct component AsyncAPI options. Choose the test or mock branch and include its type discriminator.",
+      "anyOf": [
+        {
+          "description": "AsyncAPI test or mock component run options.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/AsyncApiTestRunOptions",
+              "description": "AsyncAPI test run options."
+            },
+            {
+              "description": "The directly typed component must identify its test or mock branch.",
+              "required": [
+                "type"
+              ]
+            }
+          ]
+        },
+        {
+          "description": "AsyncAPI test or mock component run options.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/AsyncApiMockRunOptions",
+              "description": "AsyncAPI mock run options."
+            },
+            {
+              "description": "The directly typed component must identify its test or mock branch.",
+              "required": [
+                "type"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "ComponentGraphqlSdlRunOptions": {
+      "title": "Direct GraphQL SDL component options",
+      "description": "Direct component GraphQL SDL options. Choose the test or mock branch and include its type discriminator.",
+      "anyOf": [
+        {
+          "description": "GraphQL SDL test or mock component run options.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/GraphqlSdlTestRunOptions",
+              "description": "GraphQL SDL test run options."
+            },
+            {
+              "description": "The directly typed component must identify its test or mock branch.",
+              "required": [
+                "type"
+              ]
+            }
+          ]
+        },
+        {
+          "description": "GraphQL SDL test or mock component run options.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/GraphqlSdlMockRunOptions",
+              "description": "GraphQL SDL mock run options."
+            },
+            {
+              "description": "The directly typed component must identify its test or mock branch.",
+              "required": [
+                "type"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "ComponentProtobufRunOptions": {
+      "title": "Direct Protobuf component options",
+      "description": "Direct component Protobuf options. Choose the test or mock branch and include its type discriminator.",
+      "anyOf": [
+        {
+          "description": "Protobuf test or mock component run options.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ProtobufTestRunOptions",
+              "description": "Protobuf test run options."
+            },
+            {
+              "description": "The directly typed component must identify its test or mock branch.",
+              "required": [
+                "type"
+              ]
+            }
+          ]
+        },
+        {
+          "description": "Protobuf test or mock component run options.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ProtobufMockRunOptions",
+              "description": "Protobuf mock run options."
+            },
+            {
+              "description": "The directly typed component must identify its test or mock branch.",
+              "required": [
+                "type"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "RefOrTestRunOptions": {
+      "title": "Test run options or reference",
+      "description": "Use inline test run options or a reference to a reusable option set.",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/Reference",
+          "description": "A reference to reusable test run options."
+        },
+        {
+          "$ref": "#/definitions/TestRunOptions",
+          "description": "Inline test run options."
+        }
+      ]
+    },
+    "RefOrMockRunOptions": {
+      "title": "Mock run options or reference",
+      "description": "Use inline mock run options or a reference to a reusable option set.",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/Reference",
+          "description": "A reference to reusable mock run options."
+        },
+        {
+          "$ref": "#/definitions/MockRunOptions",
+          "description": "Inline mock run options."
+        }
+      ]
+    },
+    "RefOrContextRunOptions": {
+      "title": "Contextual run options or reference",
+      "description": "Use inline context-dependent options or a reference; the consuming service selects test or mock context.",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/Reference",
+          "description": "A reference to reusable contextual run options."
+        },
+        {
+          "$ref": "#/definitions/ContextRunOptions",
+          "description": "Inline contextual run options."
+        }
+      ]
+    },
+    "ContextRunOptions": {
+      "title": "Contextual run options",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/TestRunOptions",
+          "description": "Test protocol run options."
+        },
+        {
+          "$ref": "#/definitions/MockRunOptions",
+          "description": "Mock protocol run options."
+        }
+      ],
+      "examples": [
+        {
+          "openapi": {
+            "baseUrl": "http://localhost:8080"
+          }
+        },
+        {
+          "protobuf": {
+            "type": "mock",
+            "broker": {
+              "name": "local"
+            }
+          }
+        }
+      ],
+      "description": "Context-selected protocol options. The consuming system-under-test or dependency service determines whether the concrete branch is test or mock; optional type/specs remain valid in this contextual boundary."
+    },
+    "TestRunOptions": {
+      "title": "Test run options",
+      "description": "Protocol-specific options for the system under test. Select one or more protocol branches; concrete settings are protocol-specific.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "openapi": {
+          "$ref": "#/definitions/OpenApiTestRunOptions",
+          "title": "OpenAPI test options",
+          "description": "OpenAPI options for testing the system under test."
+        },
+        "wsdl": {
+          "$ref": "#/definitions/WsdlTestRunOptions",
+          "title": "WSDL test options",
+          "description": "WSDL options for testing the system under test."
+        },
+        "asyncapi": {
+          "$ref": "#/definitions/AsyncApiTestRunOptions",
+          "title": "AsyncAPI test options",
+          "description": "AsyncAPI options for testing the system under test."
+        },
+        "graphqlsdl": {
+          "$ref": "#/definitions/GraphqlSdlTestRunOptions",
+          "title": "GraphQL SDL test options",
+          "description": "GraphQL SDL options for testing the system under test."
+        },
+        "protobuf": {
+          "$ref": "#/definitions/ProtobufTestRunOptions",
+          "title": "Protobuf test options",
+          "description": "Protobuf options for testing the system under test."
+        }
+      }
+    },
+    "MockRunOptions": {
+      "title": "Mock run options",
+      "description": "Protocol-specific options for a mocked dependency. Select one or more protocol branches; concrete settings are protocol-specific.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "openapi": {
+          "$ref": "#/definitions/OpenApiMockRunOptions",
+          "title": "OpenAPI mock options",
+          "description": "OpenAPI options for mocking a dependency."
+        },
+        "wsdl": {
+          "$ref": "#/definitions/WsdlMockRunOptions",
+          "title": "WSDL mock options",
+          "description": "WSDL options for mocking a dependency."
+        },
+        "asyncapi": {
+          "$ref": "#/definitions/AsyncApiMockRunOptions",
+          "title": "AsyncAPI mock options",
+          "description": "AsyncAPI options for mocking a dependency."
+        },
+        "graphqlsdl": {
+          "$ref": "#/definitions/GraphqlSdlMockRunOptions",
+          "title": "GraphQL SDL mock options",
+          "description": "GraphQL SDL options for mocking a dependency."
+        },
+        "protobuf": {
+          "$ref": "#/definitions/ProtobufMockRunOptions",
+          "title": "Protobuf mock options",
+          "description": "Protobuf options for mocking a dependency."
+        }
+      }
+    },
+    "OpenApiTestRunOptions": {
+      "title": "OpenAPI test run options",
+      "description": "OpenAPI options for the system under test, including endpoint selection, workflow, TLS, and per-specification overrides.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "const": "test",
+          "title": "Run mode",
+          "description": "Test branch discriminator for directly typed OpenAPI options."
+        },
+        "host": {
+          "type": "string",
+          "title": "Service host",
+          "description": "Host used when sending test requests."
+        },
+        "port": {
+          "type": "integer",
+          "title": "Service port",
+          "description": "Port used when sending test requests."
+        },
+        "baseUrl": {
+          "type": "string",
+          "format": "uri",
+          "title": "Service base URL",
+          "description": "Base URL used when sending test requests."
+        },
+        "filter": {
+          "type": "string",
+          "title": "Test filter",
+          "description": "Expression used to select generated tests."
+        },
+        "workflow": {
+          "$ref": "#/definitions/WorkflowConfiguration",
+          "title": "Workflow configuration",
+          "description": "Named workflow extraction and reuse operations."
+        },
+        "swaggerUiBaseUrl": {
+          "type": "string",
+          "format": "uri",
+          "title": "Swagger UI base URL",
+          "description": "Base URL used by the Swagger UI integration."
+        },
+        "swaggerUrl": {
+          "type": "string",
+          "format": "uri",
+          "title": "Swagger URL",
+          "description": "URL used to expose or locate the Swagger document."
+        },
+        "actuatorUrl": {
+          "type": "string",
+          "format": "uri",
+          "title": "Actuator URL",
+          "description": "URL of the service actuator endpoint used by test support."
+        },
+        "cert": {
+          "$ref": "#/definitions/RefOrCert",
+          "title": "Test certificate",
+          "description": "TLS certificate settings or a reference to a named certificate."
+        },
+        "specs": {
+          "type": "array",
+          "title": "Specification overrides",
+          "description": "Optional per-specification run-option overrides, joined by specification ID.",
+          "items": {
+            "$ref": "#/definitions/OpenApiRunOptionSpecificationEntry",
+            "description": "One OpenAPI specification override."
+          }
+        }
+      }
+    },
+    "OpenApiMockRunOptions": {
+      "title": "OpenAPI mock run options",
+      "description": "OpenAPI options for a mocked dependency, including listener, logging, TLS, and per-specification overrides.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "enum": [
+            "mock",
+            "stateful-mock"
+          ],
+          "title": "Mock mode",
+          "description": "Mock mode discriminator."
+        },
+        "host": {
+          "type": "string",
+          "title": "Mock host",
+          "description": "Host on which the mock service listens."
+        },
+        "port": {
+          "type": "integer",
+          "title": "Mock port",
+          "description": "Port on which the mock service listens."
+        },
+        "baseUrl": {
+          "type": "string",
+          "format": "uri",
+          "title": "Mock base URL",
+          "description": "Base URL on which the mock service listens."
+        },
+        "filter": {
+          "type": "string",
+          "title": "Mock filter",
+          "description": "Expression used to select mocked operations."
+        },
+        "logMode": {
+          "type": "string",
+          "title": "Mock log mode",
+          "description": "Select the mock-service events written to logs.",
+          "enum": [
+            "ALL",
+            "REQUEST_RESPONSE"
+          ]
+        },
+        "logsDirPath": {
+          "type": "string",
+          "title": "Logs directory",
+          "description": "Directory where mock-service logs are written."
+        },
+        "cert": {
+          "$ref": "#/definitions/RefOrCert",
+          "title": "Mock certificate",
+          "description": "TLS certificate settings or a reference to a named certificate."
+        },
+        "specs": {
+          "type": "array",
+          "title": "Specification overrides",
+          "description": "Optional per-specification run-option overrides, joined by specification ID.",
+          "items": {
+            "$ref": "#/definitions/OpenApiRunOptionSpecificationEntry",
+            "description": "One OpenAPI specification override."
+          }
+        }
+      }
+    },
+    "WsdlTestRunOptions": {
+      "title": "WSDL test run options",
+      "description": "WSDL test options. Additional keys are protocol-specific resolved options supported by the WSDL runtime boundary.",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "type": {
+          "const": "test",
+          "title": "Run mode",
+          "description": "Test branch discriminator when this object is directly typed."
+        },
+        "host": {
+          "type": "string",
+          "title": "Service host",
+          "description": "Host used when sending test requests."
+        },
+        "port": {
+          "type": "integer",
+          "title": "Service port",
+          "description": "Port used when sending test requests."
+        },
+        "baseUrl": {
+          "type": "string",
+          "format": "uri",
+          "title": "Service base URL",
+          "description": "Base URL used when sending test requests."
+        },
+        "cert": {
+          "$ref": "#/definitions/RefOrCert",
+          "title": "Test certificate",
+          "description": "TLS certificate settings or a reference to a named certificate."
+        },
+        "specs": {
+          "type": "array",
+          "title": "Specification overrides",
+          "description": "Optional WSDL per-specification overrides.",
+          "items": {
+            "$ref": "#/definitions/WsdlRunOptionSpecificationEntry",
+            "description": "One WSDL specification override."
+          }
+        }
+      }
+    },
+    "WsdlMockRunOptions": {
+      "title": "WSDL mock run options",
+      "description": "WSDL mock options. Additional keys are protocol-specific resolved options supported by the WSDL runtime boundary.",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "type": {
+          "const": "mock",
+          "title": "Mock mode",
+          "description": "Mock branch discriminator when this object is directly typed."
+        },
+        "host": {
+          "type": "string",
+          "title": "Mock host",
+          "description": "Host on which the mock service listens."
+        },
+        "port": {
+          "type": "integer",
+          "title": "Mock port",
+          "description": "Port on which the mock service listens."
+        },
+        "baseUrl": {
+          "type": "string",
+          "format": "uri",
+          "title": "Mock base URL",
+          "description": "Base URL on which the mock service listens."
+        },
+        "cert": {
+          "$ref": "#/definitions/RefOrCert",
+          "title": "Mock certificate",
+          "description": "TLS certificate settings or a reference to a named certificate."
+        },
+        "specs": {
+          "type": "array",
+          "title": "Specification overrides",
+          "description": "Optional WSDL per-specification overrides.",
+          "items": {
+            "$ref": "#/definitions/WsdlRunOptionSpecificationEntry",
+            "description": "One WSDL specification override."
+          }
+        }
+      }
+    },
+    "AsyncApiTestRunOptions": {
+      "title": "AsyncAPI test run options",
+      "description": "AsyncAPI test options with protocol-specific resolved option keys; the dynamic keys are the supported AsyncAPI runtime options.",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "type": {
+          "const": "test",
+          "title": "Run mode",
+          "description": "Test branch discriminator."
+        },
+        "specs": {
+          "type": "array",
+          "title": "Specification overrides",
+          "description": "Optional per-specification AsyncAPI overrides.",
+          "items": {
+            "$ref": "#/definitions/RunOptionSpecificationEntry",
+            "description": "One protocol-neutral specification override."
+          }
+        }
+      }
+    },
+    "AsyncApiMockRunOptions": {
+      "title": "AsyncAPI mock run options",
+      "description": "AsyncAPI mock options with protocol-specific resolved option keys; the dynamic keys are the supported AsyncAPI runtime options.",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "type": {
+          "const": "mock",
+          "title": "Mock mode",
+          "description": "Mock branch discriminator."
+        },
+        "specs": {
+          "type": "array",
+          "title": "Specification overrides",
+          "description": "Optional per-specification AsyncAPI overrides.",
+          "items": {
+            "$ref": "#/definitions/RunOptionSpecificationEntry",
+            "description": "One protocol-neutral specification override."
+          }
+        }
+      }
+    },
+    "GraphqlSdlTestRunOptions": {
+      "title": "GraphQL SDL test run options",
+      "description": "GraphQL SDL test options with protocol-specific resolved option keys at the intentional extension boundary.",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "type": {
+          "const": "test",
+          "title": "Run mode",
+          "description": "Test branch discriminator."
+        },
+        "specs": {
+          "type": "array",
+          "title": "Specification overrides",
+          "description": "Optional per-specification GraphQL SDL overrides.",
+          "items": {
+            "$ref": "#/definitions/RunOptionSpecificationEntry",
+            "description": "One protocol-neutral specification override."
+          }
+        }
+      }
+    },
+    "GraphqlSdlMockRunOptions": {
+      "title": "GraphQL SDL mock run options",
+      "description": "GraphQL SDL mock options with protocol-specific resolved option keys at the intentional extension boundary.",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "type": {
+          "const": "mock",
+          "title": "Mock mode",
+          "description": "Mock branch discriminator."
+        },
+        "specs": {
+          "type": "array",
+          "title": "Specification overrides",
+          "description": "Optional per-specification GraphQL SDL overrides.",
+          "items": {
+            "$ref": "#/definitions/RunOptionSpecificationEntry",
+            "description": "One protocol-neutral specification override."
+          }
+        }
+      }
+    },
+    "ProtobufTestRunOptions": {
+      "title": "Protobuf test run options",
+      "description": "Protobuf test options with protocol-specific resolved option keys at the intentional extension boundary.",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "type": {
+          "const": "test",
+          "title": "Run mode",
+          "description": "Test branch discriminator."
+        },
+        "specs": {
+          "type": "array",
+          "title": "Specification overrides",
+          "description": "Optional per-specification Protobuf overrides.",
+          "items": {
+            "$ref": "#/definitions/RunOptionSpecificationEntry",
+            "description": "One protocol-neutral specification override."
+          }
+        }
+      }
+    },
+    "ProtobufMockRunOptions": {
+      "title": "Protobuf mock run options",
+      "description": "Protobuf mock options with protocol-specific resolved option keys at the intentional extension boundary.",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "type": {
+          "const": "mock",
+          "title": "Mock mode",
+          "description": "Mock branch discriminator."
+        },
+        "specs": {
+          "type": "array",
+          "title": "Specification overrides",
+          "description": "Optional per-specification Protobuf overrides.",
+          "items": {
+            "$ref": "#/definitions/RunOptionSpecificationEntry",
+            "description": "One protocol-neutral specification override."
+          }
+        }
+      }
+    },
+    "RunOptionSpecificationEntry": {
+      "title": "Run-option specification entry",
+      "description": "Wrapper containing one generic per-specification run-option override.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "spec"
+      ],
+      "properties": {
+        "spec": {
+          "$ref": "#/definitions/RunOptionSpecification",
+          "title": "Run-option override",
+          "description": "Per-specification run-option values."
+        }
+      }
+    },
+    "OpenApiRunOptionSpecificationEntry": {
+      "title": "OpenAPI run-option specification entry",
+      "description": "Wrapper containing one OpenAPI per-specification run-option override.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "spec"
+      ],
+      "properties": {
+        "spec": {
+          "$ref": "#/definitions/OpenApiRunOptionSpecification",
+          "title": "OpenAPI run-option override",
+          "description": "Per-specification OpenAPI run-option values."
+        }
+      }
+    },
+    "WsdlRunOptionSpecificationEntry": {
+      "title": "WSDL run-option specification entry",
+      "description": "Wrapper containing one WSDL per-specification run-option override.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "spec"
+      ],
+      "properties": {
+        "spec": {
+          "$ref": "#/definitions/WsdlRunOptionSpecification",
+          "title": "WSDL run-option override",
+          "description": "Per-specification WSDL run-option values."
+        }
+      }
+    },
+    "RunOptionSpecification": {
+      "title": "Generic run-option specification override",
+      "description": "Optional per-specification override keyed by the specification identifier. Additional keys are protocol-specific run-option values.",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Specification ID",
+          "description": "Specification identifier this override targets. A non-matching identifier is handled as fallback behavior during semantic processing.",
+          "examples": [
+            "orders"
+          ]
+        },
+        "overlayFilePath": {
+          "type": "string",
+          "title": "Overlay file path",
+          "description": "Path to an overlay applied to this specification."
+        },
+        "host": {
+          "type": "string",
+          "title": "Service host",
+          "description": "Host override for this specification."
+        },
+        "port": {
+          "type": "integer",
+          "title": "Service port",
+          "description": "Port override for this specification."
+        }
+      }
+    },
+    "OpenApiRunOptionSpecification": {
+      "title": "OpenAPI run-option specification override",
+      "description": "OpenAPI per-specification endpoint, security, overlay, and URL overrides.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Specification ID",
+          "description": "Specification identifier this override targets.",
+          "examples": [
+            "orders"
+          ]
+        },
+        "overlayFilePath": {
+          "type": "string",
+          "title": "Overlay file path",
+          "description": "Path to an overlay applied to this specification."
+        },
+        "host": {
+          "type": "string",
+          "title": "Service host",
+          "description": "Host override for this specification."
+        },
+        "port": {
+          "type": "integer",
+          "title": "Service port",
+          "description": "Port override for this specification."
+        },
+        "baseUrl": {
+          "type": "string",
+          "format": "uri",
+          "title": "Service base URL",
+          "description": "Base URL override for this specification."
+        },
+        "securitySchemes": {
+          "type": "object",
+          "title": "Security schemes",
+          "description": "Security scheme credentials keyed by their OpenAPI scheme names.",
+          "additionalProperties": {
+            "$ref": "#/definitions/SecuritySchemeConfigurationV3",
+            "description": "Resolved credentials for one named OpenAPI security scheme."
+          }
+        },
+        "swaggerUrl": {
+          "type": "string",
+          "format": "uri",
+          "title": "Swagger URL",
+          "description": "Swagger document URL override for this specification."
+        },
+        "swaggerUiBaseUrl": {
+          "type": "string",
+          "format": "uri",
+          "title": "Swagger UI base URL",
+          "description": "Swagger UI base URL override for this specification."
+        },
+        "actuatorUrl": {
+          "type": "string",
+          "format": "uri",
+          "title": "Actuator URL",
+          "description": "Actuator endpoint URL override for this specification."
+        }
+      }
+    },
+    "WsdlRunOptionSpecification": {
+      "title": "WSDL run-option specification override",
+      "description": "WSDL per-specification endpoint and base-URL overrides.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Specification ID",
+          "description": "Specification identifier this override targets."
+        },
+        "baseUrl": {
+          "type": "string",
+          "format": "uri",
+          "title": "Service base URL",
+          "description": "Base URL override for this specification."
+        },
+        "host": {
+          "type": "string",
+          "title": "Service host",
+          "description": "Host override for this specification."
+        },
+        "port": {
+          "type": "integer",
+          "title": "Service port",
+          "description": "Port override for this specification."
+        }
+      }
+    },
+    "WorkflowConfiguration": {
+      "title": "Workflow configuration",
+      "description": "Named workflow extraction and reuse operations available to test run options.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "ids": {
+          "type": "object",
+          "title": "Workflow operations",
+          "description": "Named workflow operations used by the configuration.",
+          "additionalProperties": {
+            "$ref": "#/definitions/WorkflowIDOperation",
+            "description": "Workflow extraction and reuse settings for one workflow ID."
+          }
+        }
+      }
+    },
+    "WorkflowIDOperation": {
+      "title": "Workflow ID operation",
+      "description": "An extraction expression and a reuse expression associated with one workflow identifier.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "extract": {
+          "type": "string",
+          "title": "Extraction expression",
+          "description": "Expression that extracts a value from a workflow response."
+        },
+        "use": {
+          "type": "string",
+          "title": "Reuse expression",
+          "description": "Expression that reuses a value in a later workflow request."
+        }
+      }
+    },
+    "SecuritySchemeConfigurationV3": {
+      "title": "V3 security scheme",
+      "description": "Canonical security type and resolved token used by an OpenAPI run-option override.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "token"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "title": "Security scheme type",
+          "description": "Security scheme kind.",
+          "enum": [
+            "oauth2",
+            "openIdConnect",
+            "basicAuth",
+            "bearer",
+            "apiKey"
+          ]
+        },
+        "token": {
+          "type": "string",
+          "title": "Security token",
+          "description": "Resolved token or credential value for the security scheme."
+        }
+      }
+    },
+    "DataDefinition": {
+      "title": "Service data",
+      "description": "Optional examples, dictionary, and adapter data associated with a service.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "examples": {
+          "$ref": "#/definitions/RefOrExampleList",
+          "title": "Service examples",
+          "description": "Examples used by this service, inline or through a named reference."
+        },
+        "dictionary": {
+          "$ref": "#/definitions/RefOrDictionary",
+          "title": "Service dictionary",
+          "description": "Dictionary used by this service, inline or through a named reference."
+        },
+        "adapters": {
+          "$ref": "#/definitions/RefOrAdapter",
+          "title": "Service adapters",
+          "description": "Adapter hooks used by this service, inline or through a named reference."
+        }
+      }
+    },
+    "ExamplesConfiguration": {
+      "title": "Example directories",
+      "description": "Test, mock, and common example-directory collections.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "testExamples": {
+          "type": "array",
+          "title": "Test example directories",
+          "description": "Example-directory entries used during tests.",
+          "items": {
+            "$ref": "#/definitions/RefOrExampleDirectories",
+            "description": "One test example-directory entry or reference."
+          }
+        },
+        "mockExamples": {
+          "type": "array",
+          "title": "Mock example directories",
+          "description": "Example-directory entries used by mocks.",
+          "items": {
+            "$ref": "#/definitions/RefOrExampleDirectories",
+            "description": "One mock example-directory entry or reference."
+          }
+        },
+        "commonExamples": {
+          "$ref": "#/definitions/ExampleDirectories",
+          "title": "Common example directories",
+          "description": "Example directories shared by test and mock execution."
+        }
+      },
+      "examples": [
+        {
+          "commonExamples": {
+            "directories": [
+              "examples"
+            ]
+          }
+        }
+      ]
+    },
+    "ExampleDirectories": {
+      "title": "Example directory list",
+      "description": "One or more filesystem directories containing examples.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "directories"
+      ],
+      "properties": {
+        "directories": {
+          "type": "array",
+          "title": "Example directories",
+          "description": "Directories searched for example payloads.",
+          "items": {
+            "type": "string",
+            "title": "Example directory",
+            "description": "Filesystem directory searched for example payloads."
+          }
+        }
+      }
+    },
+    "DictionaryConfiguration": {
+      "title": "Dictionary",
+      "description": "A named dictionary loaded from a filesystem path.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path"
+      ],
+      "properties": {
+        "path": {
+          "type": "string",
+          "title": "Dictionary file path",
+          "description": "Filesystem path to the dictionary file.",
+          "examples": [
+            "data/dictionary.json"
+          ]
+        }
+      }
+    },
+    "AdapterConfiguration": {
+      "title": "Adapter hooks",
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Closed set of supported adapter hook names; arbitrary map keys are not part of the V3 configuration language.",
+      "properties": {
+        "preSpecmaticRequestProcessor": {
+          "type": "string",
+          "title": "Pre-request processor",
+          "description": "Hook command run before Specmatic processes an incoming request."
+        },
+        "postSpecmaticResponseProcessor": {
+          "type": "string",
+          "title": "Post-response processor",
+          "description": "Hook command run after Specmatic creates a response."
+        },
+        "preSpecmaticResponseProcessor": {
+          "type": "string",
+          "title": "Pre-response processor",
+          "description": "Hook command run before Specmatic returns a provider response."
+        },
+        "stubLoadContract": {
+          "type": "string",
+          "title": "Stub contract loader",
+          "description": "Hook command used when a contract is loaded for mocking."
+        },
+        "testLoadContract": {
+          "type": "string",
+          "title": "Test contract loader",
+          "description": "Hook command used when a contract is loaded for testing."
+        },
+        "pre_specmatic_request_processor": {
+          "type": "string",
+          "deprecated": true,
+          "title": "Pre-request processor (legacy spelling)",
+          "description": "Legacy snake_case alias for preSpecmaticRequestProcessor.",
+          "deprecationMessage": "Replace with preSpecmaticRequestProcessor."
+        },
+        "post_specmatic_response_processor": {
+          "type": "string",
+          "deprecated": true,
+          "title": "Post-response processor (legacy spelling)",
+          "description": "Legacy snake_case alias for postSpecmaticResponseProcessor.",
+          "deprecationMessage": "Replace with postSpecmaticResponseProcessor."
+        },
+        "pre_specmatic_response_processor": {
+          "type": "string",
+          "deprecated": true,
+          "title": "Pre-response processor (legacy spelling)",
+          "description": "Legacy snake_case alias for preSpecmaticResponseProcessor.",
+          "deprecationMessage": "Replace with preSpecmaticResponseProcessor."
+        },
+        "stub_load_contract": {
+          "type": "string",
+          "deprecated": true,
+          "title": "Stub contract loader (legacy spelling)",
+          "description": "Legacy snake_case alias for stubLoadContract.",
+          "deprecationMessage": "Replace with stubLoadContract."
+        },
+        "test_load_contract": {
+          "type": "string",
+          "deprecated": true,
+          "title": "Test contract loader (legacy spelling)",
+          "description": "Legacy snake_case alias for testLoadContract.",
+          "deprecationMessage": "Replace with testLoadContract."
+        }
+      },
+      "examples": [
+        {
+          "preSpecmaticRequestProcessor": "hooks/pre-request.kts"
+        }
+      ]
+    },
+    "KeyStoreConfiguration": {
+      "title": "Key store",
+      "description": "Exactly one key-store representation: a file or a directory.",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/KeyStoreFileConfiguration",
+          "description": "A key store loaded from one file."
+        },
+        {
+          "$ref": "#/definitions/KeyStoreDirectoryConfiguration",
+          "description": "A key store loaded from a directory."
+        }
+      ],
+      "errorMessage": {
+        "oneOf": "Specify exactly one key-store form: file or directory."
+      }
+    },
+    "KeyStoreFileConfiguration": {
+      "title": "Key-store file",
+      "description": "Key store loaded from one file path.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "file"
+      ],
+      "properties": {
+        "file": {
+          "type": "string",
+          "title": "Key-store file",
+          "description": "Path to the key-store file."
+        },
+        "password": {
+          "type": "string",
+          "title": "Key-store password",
+          "description": "Password used to open the key store."
+        },
+        "alias": {
+          "type": "string",
+          "title": "Key-store alias",
+          "description": "Optional key alias to use from the key store."
+        }
+      }
+    },
+    "KeyStoreDirectoryConfiguration": {
+      "title": "Key-store directory",
+      "description": "Key store loaded from a directory path.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "directory"
+      ],
+      "properties": {
+        "directory": {
+          "type": "string",
+          "title": "Key-store directory",
+          "description": "Path to the directory containing key-store files."
+        },
+        "password": {
+          "type": "string",
+          "title": "Key-store password",
+          "description": "Password used to open the key store."
+        },
+        "alias": {
+          "type": "string",
+          "title": "Key-store alias",
+          "description": "Optional key alias to use from the key store."
+        }
+      }
+    },
+    "CertConfiguration": {
+      "title": "Certificate configuration",
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Certificate settings. keyStore is optional so mTLS-only or inherited certificate forms remain valid.",
+      "properties": {
+        "keyStore": {
+          "$ref": "#/definitions/KeyStoreConfiguration",
+          "title": "Key store",
+          "description": "Key store used for TLS credentials."
+        },
+        "keyStorePassword": {
+          "type": "string",
+          "title": "Key-store password",
+          "description": "Password used to open the key store."
+        },
+        "mtlsEnabled": {
+          "type": "boolean",
+          "title": "Enable mutual TLS",
+          "description": "Enable mutual TLS for this certificate configuration."
+        }
+      },
+      "examples": [
+        {
+          "mtlsEnabled": true
+        },
+        {
+          "keyStore": {
+            "file": "server.jks",
+            "password": "change-it"
+          },
+          "mtlsEnabled": true
+        }
+      ]
+    },
+    "RefOrSource": {
+      "title": "Source or reference",
+      "description": "Use an inline source provider or a reference to a named source component.",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/Reference",
+          "description": "A reference to a named source component."
+        },
+        {
+          "$ref": "#/definitions/SourceSchema",
+          "description": "An inline source provider."
+        }
+      ]
+    },
+    "RefOrAdapter": {
+      "title": "Adapter or reference",
+      "description": "Use inline supported adapter hooks or a reference to a named adapter component.",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/Reference",
+          "description": "A reference to a named adapter component."
+        },
+        {
+          "$ref": "#/definitions/AdapterConfiguration",
+          "description": "Inline adapter hooks."
+        }
+      ]
+    },
+    "RefOrDictionary": {
+      "title": "Dictionary or reference",
+      "description": "Use an inline dictionary path or a reference to a named dictionary component.",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/Reference",
+          "description": "A reference to a named dictionary component."
+        },
+        {
+          "$ref": "#/definitions/DictionaryConfiguration",
+          "description": "An inline dictionary path."
+        }
+      ]
+    },
+    "RefOrExampleDirectories": {
+      "title": "Example directories or reference",
+      "description": "Use inline example directories or a reference to a named example-directory component.",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/Reference",
+          "description": "A reference to a named example-directory component."
+        },
+        {
+          "$ref": "#/definitions/ExampleDirectories",
+          "description": "Inline example directories."
+        }
+      ]
+    },
+    "RefOrExampleList": {
+      "title": "Example list or reference",
+      "description": "Use a list of inline/reference example-directory entries or reference a named example list.",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/Reference",
+          "description": "A reference to a named example list."
+        },
+        {
+          "type": "array",
+          "description": "Inline example-directory entries.",
+          "items": {
+            "$ref": "#/definitions/RefOrExampleDirectories",
+            "description": "One inline or referenced example-directory entry."
+          }
+        }
+      ]
+    },
+    "RefOrCert": {
+      "title": "Certificate or reference",
+      "description": "Use inline certificate settings or a reference to a named certificate component.",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/Reference",
+          "description": "A reference to a named certificate component."
+        },
+        {
+          "$ref": "#/definitions/CertConfiguration",
+          "description": "Inline certificate settings."
+        }
+      ]
+    },
+    "ContextOrConcreteSettings": {
+      "title": "Contextual or concrete settings",
+      "description": "Inline general/concrete settings or context-dependent test/mock settings. The surrounding consumer determines the applicable context.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ConcreteSettings",
+          "description": "Inline concrete settings."
+        },
+        {
+          "$ref": "#/definitions/ContextSettings",
+          "description": "Inline test-or-mock contextual settings."
+        }
+      ]
+    },
+    "RefOrConcreteSettings": {
+      "title": "Concrete settings or reference",
+      "description": "Use inline global settings or a reference to a named concrete settings component.",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/Reference",
+          "description": "A reference to a named concrete settings component."
+        },
+        {
+          "$ref": "#/definitions/ConcreteSettings",
+          "description": "Inline concrete settings."
+        }
+      ]
+    },
+    "RefOrTestSettings": {
+      "title": "Test settings or reference",
+      "description": "Use inline test settings or a reference to a named settings component; target compatibility is semantic.",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/Reference",
+          "description": "A reference to reusable test settings."
+        },
+        {
+          "$ref": "#/definitions/TestSettings",
+          "description": "Inline test settings."
+        }
+      ]
+    },
+    "RefOrMockSettings": {
+      "title": "Mock settings or reference",
+      "description": "Use inline mock settings or a reference to a named settings component; target compatibility is semantic.",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/Reference",
+          "description": "A reference to reusable mock settings."
+        },
+        {
+          "$ref": "#/definitions/MockSettings",
+          "description": "Inline mock settings."
+        }
+      ]
+    },
+    "RefOrContextSettings": {
+      "title": "Contextual settings or reference",
+      "description": "Use inline context-dependent settings or a reference; the service consumer selects test or mock reification.",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/Reference",
+          "description": "A reference to reusable contextual settings."
+        },
+        {
+          "$ref": "#/definitions/ContextSettings",
+          "description": "Inline contextual settings."
+        }
+      ]
+    },
+    "ContextSettings": {
+      "title": "Contextual settings",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/TestSettings",
+          "description": "Test settings selected by the consuming context."
+        },
+        {
+          "$ref": "#/definitions/MockSettings",
+          "description": "Mock settings selected by the consuming context."
+        }
+      ],
+      "description": "Context-dependent service settings. The consuming system-under-test or dependency context selects test or mock reification; only fields from those concrete settings shapes are valid.",
+      "examples": [
+        {
+          "timeoutInMilliseconds": 5000
+        },
+        {
+          "generative": true,
+          "strictMode": false
+        }
+      ]
+    },
+    "ConcreteSettings": {
+      "title": "Concrete settings",
+      "description": "Named settings grouped by general, test, mock, proxy, or backward-compatibility concern.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "general": {
+          "$ref": "#/definitions/GeneralSettings",
+          "title": "General settings",
+          "description": "Settings shared across Specmatic operations."
+        },
+        "test": {
+          "$ref": "#/definitions/TestSettings",
+          "title": "Test settings",
+          "description": "Settings for executing tests against the system under test."
+        },
+        "mock": {
+          "$ref": "#/definitions/MockSettings",
+          "title": "Mock settings",
+          "description": "Settings for running mocked dependencies."
+        },
+        "proxy": {
+          "$ref": "#/definitions/ProxySettings",
+          "title": "Proxy settings",
+          "description": "Settings controlling proxy recording and header handling."
+        },
+        "backwardCompatibility": {
+          "$ref": "#/definitions/BackwardCompatibilitySettings",
+          "title": "Backward compatibility settings",
+          "description": "Settings for compatibility comparisons."
+        }
+      }
+    },
+    "TestSettings": {
+      "title": "Test settings",
+      "description": "Execution settings for the system under test, including limits, modes, resiliency, and report output.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "schemaResiliencyTests": {
+          "type": "string",
+          "title": "Schema resiliency tests",
+          "description": "Select all, positive-only, or no schema resiliency tests.",
+          "enum": [
+            "all",
+            "none",
+            "positiveOnly"
+          ]
+        },
+        "resiliencyTests": {
+          "type": "string",
+          "title": "Schema resiliency tests (legacy name)",
+          "enum": [
+            "all",
+            "none",
+            "positiveOnly"
+          ],
+          "deprecated": true,
+          "description": "Legacy alias for schemaResiliencyTests.",
+          "deprecationMessage": "Replace with schemaResiliencyTests."
+        },
+        "timeoutInMilliseconds": {
+          "type": "integer",
+          "title": "Test timeout",
+          "description": "Maximum request duration in milliseconds."
+        },
+        "strictMode": {
+          "type": "boolean",
+          "title": "Strict mode",
+          "description": "Enable strict validation behavior during tests."
+        },
+        "lenientMode": {
+          "type": "boolean",
+          "title": "Lenient mode",
+          "description": "Allow lenient validation behavior during tests."
+        },
+        "parallelism": {
+          "type": "string",
+          "title": "Test parallelism",
+          "description": "Parallel execution setting for generated tests."
+        },
+        "maxTestRequestCombinations": {
+          "type": "integer",
+          "title": "Maximum request combinations",
+          "description": "Maximum request combinations generated for a test."
+        },
+        "junitReportDir": {
+          "type": "string",
+          "title": "JUnit report directory",
+          "description": "Directory where JUnit reports are written."
+        },
+        "maxTestCount": {
+          "type": "integer",
+          "title": "Maximum test count",
+          "description": "Maximum number of tests to execute."
+        }
+      }
+    },
+    "MockSettings": {
+      "title": "Mock settings",
+      "description": "Execution settings for mocked dependencies, including generation, reload, timing, and restart behavior.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "generative": {
+          "type": "boolean",
+          "title": "Generative mode",
+          "description": "Generate mock responses when examples do not provide a direct response."
+        },
+        "delayInMilliseconds": {
+          "type": "integer",
+          "title": "Response delay",
+          "description": "Delay generated mock responses by this many milliseconds."
+        },
+        "startTimeoutInMilliseconds": {
+          "type": "integer",
+          "title": "Mock start timeout",
+          "description": "Maximum time in milliseconds allowed for the mock to start."
+        },
+        "hotReload": {
+          "type": "boolean",
+          "title": "Hot reload",
+          "description": "Reload contracts when their source files change."
+        },
+        "strictMode": {
+          "type": "boolean",
+          "title": "Strict mode",
+          "description": "Enable strict validation behavior in the mock."
+        },
+        "gracefulRestartTimeoutInMilliseconds": {
+          "type": "integer",
+          "title": "Graceful restart timeout",
+          "description": "Maximum time in milliseconds allowed for a graceful mock restart."
+        },
+        "lenientMode": {
+          "type": "boolean",
+          "title": "Lenient mode",
+          "description": "Allow lenient validation behavior in the mock."
+        }
+      }
+    },
+    "GeneralSettings": {
+      "title": "General settings",
+      "description": "Settings shared across test, mock, and other Specmatic operations.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "disableTelemetry": {
+          "type": "boolean",
+          "title": "Disable telemetry",
+          "description": "Disable telemetry reporting."
+        },
+        "ignoreInlineExamples": {
+          "type": "boolean",
+          "title": "Ignore inline examples",
+          "description": "Ignore examples embedded in specifications."
+        },
+        "ignoreInlineExampleWarnings": {
+          "type": "boolean",
+          "title": "Ignore inline-example warnings",
+          "description": "Suppress warnings about ignored inline examples."
+        },
+        "prettyPrint": {
+          "type": "boolean",
+          "title": "Pretty-print output",
+          "description": "Enable pretty-printed output where supported."
+        },
+        "logging": {
+          "$ref": "#/definitions/LoggingConfiguration",
+          "title": "Logging configuration",
+          "description": "Log level and JSON/text output configuration."
+        },
+        "featureFlags": {
+          "$ref": "#/definitions/FeatureFlags",
+          "title": "Feature flags",
+          "description": "Optional feature switches controlling matching and output behavior."
+        },
+        "specExamplesDirectoryTemplate": {
+          "type": "string",
+          "title": "Specification examples directory template",
+          "description": "Template for the directory containing examples associated with a specification."
+        },
+        "sharedExamplesDirectoryTemplate": {
+          "type": "array",
+          "title": "Shared examples directory templates",
+          "description": "Templates for shared example directories searched across specifications.",
+          "items": {
+            "type": "string",
+            "title": "Directory template",
+            "description": "Template resolving to a shared examples directory."
+          }
+        }
+      }
+    },
+    "FeatureFlags": {
+      "title": "Feature flags",
+      "description": "Boolean switches for matching, schema examples, and SOAP behavior.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "fuzzyMatcherForPayloads": {
+          "type": "boolean",
+          "title": "Fuzzy payload matching",
+          "description": "Enable fuzzy matching of payload keys."
+        },
+        "schemaExampleDefault": {
+          "type": "boolean",
+          "title": "Use schema examples as defaults",
+          "description": "Use schema example values as defaults where supported."
+        },
+        "escapeSoapAction": {
+          "type": "boolean",
+          "title": "Escape SOAP actions",
+          "description": "Apply SOAP action escaping behavior."
+        }
+      }
+    },
+    "ProxySettings": {
+      "title": "Proxy settings",
+      "description": "Settings controlling request recording and headers ignored by proxy processing.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "recordRequests": {
+          "type": "boolean",
+          "title": "Record requests",
+          "description": "Record requests handled by the proxy."
+        },
+        "ignoreHeaders": {
+          "type": "array",
+          "title": "Ignored headers",
+          "description": "Header names excluded from proxy processing.",
+          "items": {
+            "type": "string",
+            "title": "Header name",
+            "description": "Header name ignored by proxy processing."
+          }
+        }
+      }
+    },
+    "BackwardCompatibilitySettings": {
+      "title": "Backward compatibility settings",
+      "description": "Repository, target path, and strictness settings for compatibility checks.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "baseBranch": {
+          "type": "string",
+          "title": "Base branch",
+          "description": "Branch used as the baseline for compatibility comparison."
+        },
+        "targetPath": {
+          "type": "string",
+          "title": "Compatibility target path",
+          "description": "Path whose compatibility is evaluated."
+        },
+        "repoDirectory": {
+          "type": "string",
+          "title": "Repository directory",
+          "description": "Local repository directory used for compatibility comparison."
+        },
+        "strictMode": {
+          "type": "boolean",
+          "title": "Strict compatibility mode",
+          "description": "Apply strict compatibility rules when comparing repository states."
+        }
+      }
+    },
+    "LoggingConfiguration": {
+      "title": "Logging configuration",
+      "description": "Log level and JSON/text output destinations shared by concrete settings.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "level": {
+          "type": "string",
+          "title": "Log level",
+          "description": "Minimum log level to emit.",
+          "enum": [
+            "INFO",
+            "DEBUG"
+          ]
+        },
+        "json": {
+          "$ref": "#/definitions/LogOutputConfiguration",
+          "title": "JSON log output",
+          "description": "Destination settings for structured JSON logs."
+        },
+        "text": {
+          "$ref": "#/definitions/LogOutputConfiguration",
+          "title": "Text log output",
+          "description": "Destination settings for human-readable text logs."
+        }
+      }
+    },
+    "LogOutputConfiguration": {
+      "title": "Log output",
+      "description": "Destination and naming settings for one log output format.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "directory": {
+          "type": "string",
+          "title": "Log directory",
+          "description": "Directory where this log output is written."
+        },
+        "console": {
+          "type": "boolean",
+          "title": "Log to console",
+          "description": "Write this log output to the console."
+        },
+        "logFilePrefix": {
+          "type": "string",
+          "title": "Log-file prefix",
+          "description": "Prefix used when naming log files."
+        },
+        "logPrefix": {
+          "type": "string",
+          "deprecated": true,
+          "title": "Log-file prefix (legacy name)",
+          "description": "Legacy alias for logFilePrefix.",
+          "deprecationMessage": "Replace with logFilePrefix."
+        }
+      }
+    }
+  }
+}

--- a/core/src/main/resources/config-validation/config-v3-resolved.schema.json
+++ b/core/src/main/resources/config-validation/config-v3-resolved.schema.json
@@ -162,42 +162,60 @@
     "RefOrTestService": {
       "title": "Test service or reference",
       "description": "Use an inline test service or a reference to a reusable service component.",
-      "oneOf": [
+      "type": "object",
+      "allOf": [
         {
-          "$ref": "#/definitions/Reference",
-          "description": "A reference to a reusable test service."
-        },
-        {
-          "$ref": "#/definitions/TestService",
-          "description": "An inline test service."
+          "if": {
+            "required": ["$ref"]
+          },
+          "then": {
+            "$ref": "#/definitions/Reference",
+            "description": "A reference to a reusable test service."
+          },
+          "else": {
+            "$ref": "#/definitions/TestService",
+            "description": "An inline test service."
+          }
         }
       ]
     },
     "RefOrMockService": {
       "title": "Mock service or reference",
       "description": "Use an inline mock service or a reference to a reusable service component.",
-      "oneOf": [
+      "type": "object",
+      "allOf": [
         {
-          "$ref": "#/definitions/Reference",
-          "description": "A reference to a reusable mock service."
-        },
-        {
-          "$ref": "#/definitions/MockService",
-          "description": "An inline mock service."
+          "if": {
+            "required": ["$ref"]
+          },
+          "then": {
+            "$ref": "#/definitions/Reference",
+            "description": "A reference to a reusable mock service."
+          },
+          "else": {
+            "$ref": "#/definitions/MockService",
+            "description": "An inline mock service."
+          }
         }
       ]
     },
     "RefOrContextService": {
       "title": "Contextual service or reference",
       "description": "Use an inline reusable service or a reference; its test/mock context is selected by the consumer.",
-      "oneOf": [
+      "type": "object",
+      "allOf": [
         {
-          "$ref": "#/definitions/Reference",
-          "description": "A reference to a reusable contextual service."
-        },
-        {
-          "$ref": "#/definitions/ContextService",
-          "description": "An inline contextual service."
+          "if": {
+            "required": ["$ref"]
+          },
+          "then": {
+            "$ref": "#/definitions/Reference",
+            "description": "A reference to a reusable contextual service."
+          },
+          "else": {
+            "$ref": "#/definitions/ContextService",
+            "description": "An inline contextual service."
+          }
         }
       ]
     },
@@ -375,23 +393,25 @@
     "SpecificationDefinition": {
       "title": "Specification definition",
       "description": "A specification path or an object containing that path and optional per-specification overrides.",
-      "oneOf": [
+      "type": [ "string", "object" ],
+      "allOf": [
         {
-          "type": "string",
-          "description": "A resolved specification path."
-        },
-        {
-          "type": "object",
-          "description": "A specification path with optional per-specification overrides.",
-          "additionalProperties": false,
-          "required": [
-            "spec"
-          ],
-          "properties": {
-            "spec": {
-              "$ref": "#/definitions/SpecificationObject",
-              "title": "Specification override",
-              "description": "Inline specification path and optional per-specification overrides."
+          "if": {
+            "type": "string"
+          },
+          "then": {
+            "description": "A resolved specification path."
+          },
+          "else": {
+            "description": "A specification path with optional per-specification overrides.",
+            "additionalProperties": false,
+            "required": [ "spec" ],
+            "properties": {
+              "spec": {
+                "$ref": "#/definitions/SpecificationObject",
+                "title": "Specification override",
+                "description": "Inline specification path and optional per-specification overrides."
+              }
             }
           }
         }
@@ -518,23 +538,42 @@
     },
     "SourceSchema": {
       "title": "Source",
-      "oneOf": [
+      "type": "object",
+      "allOf": [
         {
-          "$ref": "#/definitions/GitSourceSchema",
-          "description": "A Git-backed source."
+          "if": {
+            "required": [
+              "git"
+            ]
+          },
+          "then": {
+            "$ref": "#/definitions/GitSourceSchema"
+          }
         },
         {
-          "$ref": "#/definitions/FileSystemSourceSchema",
-          "description": "A filesystem-backed source."
+          "if": {
+            "required": [
+              "filesystem"
+            ]
+          },
+          "then": {
+            "$ref": "#/definitions/FileSystemSourceSchema"
+          }
         },
         {
-          "$ref": "#/definitions/WebSourceSchema",
-          "description": "A web-backed source."
+          "if": {
+            "required": [
+              "web"
+            ]
+          },
+          "then": {
+            "$ref": "#/definitions/WebSourceSchema"
+          }
         }
       ],
       "description": "Exactly one source provider is selected: git, filesystem, or web. The selected wrapper determines how specifications are located.",
       "errorMessage": {
-        "oneOf": "Choose exactly one source provider: git, filesystem, or web."
+        "required": "Choose exactly one source provider: git, filesystem, or web."
       }
     },
     "GitSourceSchema": {
@@ -597,18 +636,37 @@
     "GitSourceAuthentication": {
       "title": "Git authentication",
       "description": "Exactly one supported Git credential source.",
-      "oneOf": [
+      "type": "object",
+      "allOf": [
         {
-          "$ref": "#/definitions/GitBearerFileAuthentication",
-          "description": "Git authentication using a bearer-token file."
+          "if": {
+            "required": [
+              "bearerFile"
+            ]
+          },
+          "then": {
+            "$ref": "#/definitions/GitBearerFileAuthentication"
+          }
         },
         {
-          "$ref": "#/definitions/GitBearerEnvAuthentication",
-          "description": "Git authentication using a bearer-token environment variable."
+          "if": {
+            "required": [
+              "bearerEnvironmentVariable"
+            ]
+          },
+          "then": {
+            "$ref": "#/definitions/GitBearerEnvAuthentication"
+          }
         },
         {
-          "$ref": "#/definitions/GitPersonalAccessTokenAuthentication",
-          "description": "Git authentication using a personal access token."
+          "if": {
+            "required": [
+              "personalAccessToken"
+            ]
+          },
+          "then": {
+            "$ref": "#/definitions/GitPersonalAccessTokenAuthentication"
+          }
         }
       ]
     },
@@ -1052,222 +1110,284 @@
     "ComponentOpenApiRunOptions": {
       "title": "Direct OpenAPI component options",
       "description": "Direct component OpenAPI options. Choose the test or mock branch and include its type discriminator.",
-      "anyOf": [
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "enum": [
+            "test",
+            "mock",
+            "stateful-mock"
+          ],
+          "title": "Run mode",
+          "description": "Selects the concrete OpenAPI test or mock option branch."
+        }
+      },
+      "allOf": [
         {
-          "description": "OpenAPI test or mock component run options.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/OpenApiTestRunOptions",
-              "description": "OpenAPI test run options."
-            },
-            {
-              "description": "The directly typed component must identify its test or mock branch.",
-              "required": [
-                "type"
-              ]
+          "if": {
+            "properties": {
+              "type": {
+                "const": "test"
+              }
             }
-          ]
+          },
+          "then": {
+            "$ref": "#/definitions/OpenApiTestRunOptions"
+          }
         },
         {
-          "description": "OpenAPI test or mock component run options.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/OpenApiMockRunOptions",
-              "description": "OpenAPI mock run options."
-            },
-            {
-              "description": "The directly typed component must identify its test or mock branch.",
-              "required": [
-                "type"
-              ]
+          "if": {
+            "properties": {
+              "type": {
+                "enum": [
+                  "mock",
+                  "stateful-mock"
+                ]
+              }
             }
-          ]
+          },
+          "then": {
+            "$ref": "#/definitions/OpenApiMockRunOptions"
+          }
         }
       ]
     },
     "ComponentWsdlRunOptions": {
       "title": "Direct WSDL component options",
       "description": "Direct component WSDL options. Choose the test or mock branch and include its type discriminator.",
-      "anyOf": [
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "enum": [
+            "test",
+            "mock"
+          ],
+          "title": "Run mode",
+          "description": "Selects the concrete WSDL test or mock option branch."
+        }
+      },
+      "allOf": [
         {
-          "description": "WSDL test or mock component run options.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/WsdlTestRunOptions",
-              "description": "WSDL test run options."
-            },
-            {
-              "description": "The directly typed component must identify its test or mock branch.",
-              "required": [
-                "type"
-              ]
+          "if": {
+            "properties": {
+              "type": {
+                "const": "test"
+              }
             }
-          ]
+          },
+          "then": {
+            "$ref": "#/definitions/WsdlTestRunOptions"
+          }
         },
         {
-          "description": "WSDL test or mock component run options.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/WsdlMockRunOptions",
-              "description": "WSDL mock run options."
-            },
-            {
-              "description": "The directly typed component must identify its test or mock branch.",
-              "required": [
-                "type"
-              ]
+          "if": {
+            "properties": {
+              "type": {
+                "const": "mock"
+              }
             }
-          ]
+          },
+          "then": {
+            "$ref": "#/definitions/WsdlMockRunOptions"
+          }
         }
       ]
     },
     "ComponentAsyncApiRunOptions": {
       "title": "Direct AsyncAPI component options",
       "description": "Direct component AsyncAPI options. Choose the test or mock branch and include its type discriminator.",
-      "anyOf": [
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "enum": [
+            "test",
+            "mock"
+          ],
+          "title": "Run mode",
+          "description": "Selects the concrete AsyncAPI test or mock option branch."
+        }
+      },
+      "allOf": [
         {
-          "description": "AsyncAPI test or mock component run options.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/AsyncApiTestRunOptions",
-              "description": "AsyncAPI test run options."
-            },
-            {
-              "description": "The directly typed component must identify its test or mock branch.",
-              "required": [
-                "type"
-              ]
+          "if": {
+            "properties": {
+              "type": {
+                "const": "test"
+              }
             }
-          ]
+          },
+          "then": {
+            "$ref": "#/definitions/AsyncApiTestRunOptions"
+          }
         },
         {
-          "description": "AsyncAPI test or mock component run options.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/AsyncApiMockRunOptions",
-              "description": "AsyncAPI mock run options."
-            },
-            {
-              "description": "The directly typed component must identify its test or mock branch.",
-              "required": [
-                "type"
-              ]
+          "if": {
+            "properties": {
+              "type": {
+                "const": "mock"
+              }
             }
-          ]
+          },
+          "then": {
+            "$ref": "#/definitions/AsyncApiMockRunOptions"
+          }
         }
       ]
     },
     "ComponentGraphqlSdlRunOptions": {
       "title": "Direct GraphQL SDL component options",
       "description": "Direct component GraphQL SDL options. Choose the test or mock branch and include its type discriminator.",
-      "anyOf": [
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "enum": [
+            "test",
+            "mock"
+          ],
+          "title": "Run mode",
+          "description": "Selects the concrete GraphQL SDL test or mock option branch."
+        }
+      },
+      "allOf": [
         {
-          "description": "GraphQL SDL test or mock component run options.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/GraphqlSdlTestRunOptions",
-              "description": "GraphQL SDL test run options."
-            },
-            {
-              "description": "The directly typed component must identify its test or mock branch.",
-              "required": [
-                "type"
-              ]
+          "if": {
+            "properties": {
+              "type": {
+                "const": "test"
+              }
             }
-          ]
+          },
+          "then": {
+            "$ref": "#/definitions/GraphqlSdlTestRunOptions"
+          }
         },
         {
-          "description": "GraphQL SDL test or mock component run options.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/GraphqlSdlMockRunOptions",
-              "description": "GraphQL SDL mock run options."
-            },
-            {
-              "description": "The directly typed component must identify its test or mock branch.",
-              "required": [
-                "type"
-              ]
+          "if": {
+            "properties": {
+              "type": {
+                "const": "mock"
+              }
             }
-          ]
+          },
+          "then": {
+            "$ref": "#/definitions/GraphqlSdlMockRunOptions"
+          }
         }
       ]
     },
     "ComponentProtobufRunOptions": {
       "title": "Direct Protobuf component options",
       "description": "Direct component Protobuf options. Choose the test or mock branch and include its type discriminator.",
-      "anyOf": [
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "enum": [
+            "test",
+            "mock"
+          ],
+          "title": "Run mode",
+          "description": "Selects the concrete Protobuf test or mock option branch."
+        }
+      },
+      "allOf": [
         {
-          "description": "Protobuf test or mock component run options.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/ProtobufTestRunOptions",
-              "description": "Protobuf test run options."
-            },
-            {
-              "description": "The directly typed component must identify its test or mock branch.",
-              "required": [
-                "type"
-              ]
+          "if": {
+            "properties": {
+              "type": {
+                "const": "test"
+              }
             }
-          ]
+          },
+          "then": {
+            "$ref": "#/definitions/ProtobufTestRunOptions"
+          }
         },
         {
-          "description": "Protobuf test or mock component run options.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/ProtobufMockRunOptions",
-              "description": "Protobuf mock run options."
-            },
-            {
-              "description": "The directly typed component must identify its test or mock branch.",
-              "required": [
-                "type"
-              ]
+          "if": {
+            "properties": {
+              "type": {
+                "const": "mock"
+              }
             }
-          ]
+          },
+          "then": {
+            "$ref": "#/definitions/ProtobufMockRunOptions"
+          }
         }
       ]
     },
     "RefOrTestRunOptions": {
       "title": "Test run options or reference",
       "description": "Use inline test run options or a reference to a reusable option set.",
-      "oneOf": [
+      "type": "object",
+      "allOf": [
         {
-          "$ref": "#/definitions/Reference",
-          "description": "A reference to reusable test run options."
-        },
-        {
-          "$ref": "#/definitions/TestRunOptions",
-          "description": "Inline test run options."
+          "if": {
+            "required": ["$ref"]
+          },
+          "then": {
+            "$ref": "#/definitions/Reference",
+            "description": "A reference to reusable test run options."
+          },
+          "else": {
+            "$ref": "#/definitions/TestRunOptions",
+            "description": "Inline test run options."
+          }
         }
       ]
     },
     "RefOrMockRunOptions": {
       "title": "Mock run options or reference",
       "description": "Use inline mock run options or a reference to a reusable option set.",
-      "oneOf": [
+      "type": "object",
+      "allOf": [
         {
-          "$ref": "#/definitions/Reference",
-          "description": "A reference to reusable mock run options."
-        },
-        {
-          "$ref": "#/definitions/MockRunOptions",
-          "description": "Inline mock run options."
+          "if": {
+            "required": ["$ref"]
+          },
+          "then": {
+            "$ref": "#/definitions/Reference",
+            "description": "A reference to reusable mock run options."
+          },
+          "else": {
+            "$ref": "#/definitions/MockRunOptions",
+            "description": "Inline mock run options."
+          }
         }
       ]
     },
     "RefOrContextRunOptions": {
       "title": "Contextual run options or reference",
       "description": "Use inline context-dependent options or a reference; the consuming service selects test or mock context.",
-      "oneOf": [
+      "type": "object",
+      "allOf": [
         {
-          "$ref": "#/definitions/Reference",
-          "description": "A reference to reusable contextual run options."
-        },
-        {
-          "$ref": "#/definitions/ContextRunOptions",
-          "description": "Inline contextual run options."
+          "if": {
+            "required": ["$ref"]
+          },
+          "then": {
+            "$ref": "#/definitions/Reference",
+            "description": "A reference to reusable contextual run options."
+          },
+          "else": {
+            "$ref": "#/definitions/ContextRunOptions",
+            "description": "Inline contextual run options."
+          }
         }
       ]
     },
@@ -1599,6 +1719,30 @@
           "title": "Run mode",
           "description": "Test branch discriminator."
         },
+        "replyTimeout": {
+          "type": "integer",
+          "title": "Reply timeout",
+          "description": "Maximum time in milliseconds to wait for an asynchronous reply."
+        },
+        "subscriberReadinessWaitTime": {
+          "type": "integer",
+          "title": "Subscriber readiness wait time",
+          "description": "Time in milliseconds to wait for an asynchronous subscriber to become ready."
+        },
+        "servers": {
+          "type": "array",
+          "title": "AsyncAPI servers",
+          "description": "Server connection settings used by asynchronous tests.",
+          "items": {
+            "$ref": "#/definitions/AsyncClientServerConfig",
+            "description": "One asynchronous server connection."
+          }
+        },
+        "schemaRegistry": {
+          "$ref": "#/definitions/SchemaRegistryProperties",
+          "title": "Schema registry",
+          "description": "Schema registry settings used by asynchronous tests."
+        },
         "specs": {
           "type": "array",
           "title": "Specification overrides",
@@ -1620,6 +1764,25 @@
           "const": "mock",
           "title": "Mock mode",
           "description": "Mock branch discriminator."
+        },
+        "inMemoryBroker": {
+          "$ref": "#/definitions/InMemoryBrokerConfiguration",
+          "title": "In-memory broker",
+          "description": "Optional in-memory broker settings used by asynchronous mocks."
+        },
+        "servers": {
+          "type": "array",
+          "title": "AsyncAPI servers",
+          "description": "Server connection settings used by asynchronous mocks.",
+          "items": {
+            "$ref": "#/definitions/AsyncClientServerConfig",
+            "description": "One asynchronous server connection."
+          }
+        },
+        "schemaRegistry": {
+          "$ref": "#/definitions/SchemaRegistryProperties",
+          "title": "Schema registry",
+          "description": "Schema registry settings used by asynchronous mocks."
         },
         "specs": {
           "type": "array",
@@ -1643,6 +1806,16 @@
           "title": "Run mode",
           "description": "Test branch discriminator."
         },
+        "host": {
+          "type": "string",
+          "title": "GraphQL service host",
+          "description": "Host used by the GraphQL test server."
+        },
+        "port": {
+          "type": "integer",
+          "title": "GraphQL service port",
+          "description": "Port used by the GraphQL test server."
+        },
         "specs": {
           "type": "array",
           "title": "Specification overrides",
@@ -1664,6 +1837,16 @@
           "const": "mock",
           "title": "Mock mode",
           "description": "Mock branch discriminator."
+        },
+        "host": {
+          "type": "string",
+          "title": "GraphQL mock host",
+          "description": "Host on which the GraphQL mock listens."
+        },
+        "port": {
+          "type": "integer",
+          "title": "GraphQL mock port",
+          "description": "Port on which the GraphQL mock listens."
         },
         "specs": {
           "type": "array",
@@ -1687,6 +1870,36 @@
           "title": "Run mode",
           "description": "Test branch discriminator."
         },
+        "host": {
+          "type": "string",
+          "title": "gRPC service host",
+          "description": "Host used by the gRPC test client."
+        },
+        "port": {
+          "type": "integer",
+          "title": "gRPC service port",
+          "description": "Port used by the gRPC test client."
+        },
+        "importPaths": {
+          "type": "array",
+          "title": "Protobuf import paths",
+          "description": "Directories searched for imported Protobuf definitions.",
+          "items": {
+            "type": "string",
+            "title": "Protobuf import path",
+            "description": "One directory searched for imported Protobuf definitions."
+          }
+        },
+        "protocVersion": {
+          "type": "string",
+          "title": "protoc version",
+          "description": "Version of protoc used to compile Protobuf definitions."
+        },
+        "requestTimeout": {
+          "type": "integer",
+          "title": "gRPC request timeout",
+          "description": "Maximum time in milliseconds to wait for a gRPC request."
+        },
         "specs": {
           "type": "array",
           "title": "Specification overrides",
@@ -1709,6 +1922,26 @@
           "title": "Mock mode",
           "description": "Mock branch discriminator."
         },
+        "port": {
+          "type": "integer",
+          "title": "gRPC mock port",
+          "description": "Port on which the gRPC mock listens."
+        },
+        "importPaths": {
+          "type": "array",
+          "title": "Protobuf import paths",
+          "description": "Directories searched for imported Protobuf definitions.",
+          "items": {
+            "type": "string",
+            "title": "Protobuf import path",
+            "description": "One directory searched for imported Protobuf definitions."
+          }
+        },
+        "protocVersion": {
+          "type": "string",
+          "title": "protoc version",
+          "description": "Version of protoc used to compile Protobuf definitions."
+        },
         "specs": {
           "type": "array",
           "title": "Specification overrides",
@@ -1717,6 +1950,117 @@
             "$ref": "#/definitions/RunOptionSpecificationEntry",
             "description": "One protocol-neutral specification override."
           }
+        }
+      }
+    },
+    "AsyncClientServerConfig": {
+      "title": "AsyncAPI server connection",
+      "description": "Connection settings for one asynchronous server. Additional admin and client values are protocol-specific extension data.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "host",
+        "protocol"
+      ],
+      "properties": {
+        "host": {
+          "type": "string",
+          "title": "Server host",
+          "description": "Host or connection address of the asynchronous server."
+        },
+        "protocol": {
+          "type": "string",
+          "title": "Server protocol",
+          "description": "Protocol identifier used to select this asynchronous server."
+        },
+        "adminCredentials": {
+          "type": "object",
+          "title": "Admin credentials",
+          "description": "Optional administrative credentials for the asynchronous server.",
+          "additionalProperties": true
+        },
+        "client": {
+          "$ref": "#/definitions/AsyncClientProperties",
+          "title": "Client properties",
+          "description": "Optional consumer and producer client properties."
+        }
+      }
+    },
+    "AsyncClientProperties": {
+      "title": "AsyncAPI client properties",
+      "description": "Optional client properties grouped by consumer and producer.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "consumer": {
+          "type": "object",
+          "title": "Consumer properties",
+          "description": "Consumer client properties passed to the asynchronous runtime.",
+          "additionalProperties": true
+        },
+        "producer": {
+          "type": "object",
+          "title": "Producer properties",
+          "description": "Producer client properties passed to the asynchronous runtime.",
+          "additionalProperties": true
+        }
+      }
+    },
+    "SchemaRegistryProperties": {
+      "title": "Schema registry properties",
+      "description": "Schema registry connection settings for asynchronous protocols.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "title": "Schema registry kind",
+          "description": "Schema registry implementation used by the asynchronous runtime.",
+          "enum": [
+            "CONFLUENT",
+            "DEFAULT"
+          ]
+        },
+        "url": {
+          "type": "string",
+          "title": "Schema registry URL",
+          "description": "URL of the schema registry."
+        },
+        "username": {
+          "type": "string",
+          "title": "Schema registry username",
+          "description": "Username used to access the schema registry."
+        },
+        "password": {
+          "type": "string",
+          "title": "Schema registry password",
+          "description": "Password used to access the schema registry."
+        }
+      }
+    },
+    "InMemoryBrokerConfiguration": {
+      "title": "In-memory broker configuration",
+      "description": "Optional in-memory broker connection settings for asynchronous mocks.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "logDir": {
+          "type": "string",
+          "title": "Broker log directory",
+          "description": "Directory where in-memory broker logs are written."
+        },
+        "host": {
+          "type": "string",
+          "title": "Broker host",
+          "description": "Host on which the in-memory broker listens."
+        },
+        "port": {
+          "type": "integer",
+          "title": "Broker port",
+          "description": "Port on which the in-memory broker listens."
         }
       }
     },
@@ -2135,18 +2479,26 @@
     "KeyStoreConfiguration": {
       "title": "Key store",
       "description": "Exactly one key-store representation: a file or a directory.",
-      "oneOf": [
+      "type": "object",
+      "allOf": [
         {
-          "$ref": "#/definitions/KeyStoreFileConfiguration",
-          "description": "A key store loaded from one file."
-        },
-        {
-          "$ref": "#/definitions/KeyStoreDirectoryConfiguration",
-          "description": "A key store loaded from a directory."
+          "if": {
+            "required": [
+              "file"
+            ]
+          },
+          "then": {
+            "$ref": "#/definitions/KeyStoreFileConfiguration",
+            "description": "A key store loaded from one file."
+          },
+          "else": {
+            "$ref": "#/definitions/KeyStoreDirectoryConfiguration",
+            "description": "A key store loaded from a directory."
+          }
         }
       ],
       "errorMessage": {
-        "oneOf": "Specify exactly one key-store form: file or directory."
+        "required": "Specify a key-store file or directory."
       }
     },
     "KeyStoreFileConfiguration": {
@@ -2239,88 +2591,121 @@
     "RefOrSource": {
       "title": "Source or reference",
       "description": "Use an inline source provider or a reference to a named source component.",
-      "oneOf": [
+      "type": "object",
+      "allOf": [
         {
-          "$ref": "#/definitions/Reference",
-          "description": "A reference to a named source component."
-        },
-        {
-          "$ref": "#/definitions/SourceSchema",
-          "description": "An inline source provider."
+          "if": {
+            "required": ["$ref"]
+          },
+          "then": {
+            "$ref": "#/definitions/Reference",
+            "description": "A reference to a named source component."
+          },
+          "else": {
+            "$ref": "#/definitions/SourceSchema",
+            "description": "An inline source provider."
+          }
         }
       ]
     },
     "RefOrAdapter": {
       "title": "Adapter or reference",
       "description": "Use inline supported adapter hooks or a reference to a named adapter component.",
-      "oneOf": [
+      "type": "object",
+      "allOf": [
         {
-          "$ref": "#/definitions/Reference",
-          "description": "A reference to a named adapter component."
-        },
-        {
-          "$ref": "#/definitions/AdapterConfiguration",
-          "description": "Inline adapter hooks."
+          "if": {
+            "required": ["$ref"]
+          },
+          "then": {
+            "$ref": "#/definitions/Reference",
+            "description": "A reference to a named adapter component."
+          },
+          "else": {
+            "$ref": "#/definitions/AdapterConfiguration",
+            "description": "Inline adapter hooks."
+          }
         }
       ]
     },
     "RefOrDictionary": {
       "title": "Dictionary or reference",
       "description": "Use an inline dictionary path or a reference to a named dictionary component.",
-      "oneOf": [
+      "type": "object",
+      "allOf": [
         {
-          "$ref": "#/definitions/Reference",
-          "description": "A reference to a named dictionary component."
-        },
-        {
-          "$ref": "#/definitions/DictionaryConfiguration",
-          "description": "An inline dictionary path."
+          "if": {
+            "required": ["$ref"]
+          },
+          "then": {
+            "$ref": "#/definitions/Reference",
+            "description": "A reference to a named dictionary component."
+          },
+          "else": {
+            "$ref": "#/definitions/DictionaryConfiguration",
+            "description": "An inline dictionary path."
+          }
         }
       ]
     },
     "RefOrExampleDirectories": {
       "title": "Example directories or reference",
       "description": "Use inline example directories or a reference to a named example-directory component.",
-      "oneOf": [
+      "type": "object",
+      "allOf": [
         {
-          "$ref": "#/definitions/Reference",
-          "description": "A reference to a named example-directory component."
-        },
-        {
-          "$ref": "#/definitions/ExampleDirectories",
-          "description": "Inline example directories."
+          "if": {
+            "required": ["$ref"]
+          },
+          "then": {
+            "$ref": "#/definitions/Reference",
+            "description": "A reference to a named example-directory component."
+          },
+          "else": {
+            "$ref": "#/definitions/ExampleDirectories",
+            "description": "Inline example directories."
+          }
         }
       ]
     },
     "RefOrExampleList": {
       "title": "Example list or reference",
       "description": "Use a list of inline/reference example-directory entries or reference a named example list.",
-      "oneOf": [
-        {
-          "$ref": "#/definitions/Reference",
-          "description": "A reference to a named example list."
-        },
-        {
-          "type": "array",
-          "description": "Inline example-directory entries.",
-          "items": {
-            "$ref": "#/definitions/RefOrExampleDirectories",
-            "description": "One inline or referenced example-directory entry."
-          }
+      "type": ["object", "array"],
+      "if": {
+        "type": "object",
+        "required": ["$ref"]
+      },
+      "then": {
+        "$ref": "#/definitions/Reference",
+        "description": "A reference to a named example list."
+      },
+      "else": {
+        "type": "array",
+        "description": "Inline example-directory entries.",
+        "items": {
+          "$ref": "#/definitions/RefOrExampleDirectories",
+          "description": "One inline or referenced example-directory entry."
         }
-      ]
+      }
     },
     "RefOrCert": {
       "title": "Certificate or reference",
       "description": "Use inline certificate settings or a reference to a named certificate component.",
-      "oneOf": [
+      "type": "object",
+      "allOf": [
         {
-          "$ref": "#/definitions/Reference",
-          "description": "A reference to a named certificate component."
-        },
-        {
-          "$ref": "#/definitions/CertConfiguration",
-          "description": "Inline certificate settings."
+          "if": {
+            "required": ["$ref"]
+          },
+          "then": {
+            "$ref": "#/definitions/Reference",
+            "description": "A reference to a named certificate component."
+          },
+          "else": {
+            "$ref": "#/definitions/CertConfiguration",
+            "description": "Inline certificate settings."
+          }
         }
       ]
     },
@@ -2341,56 +2726,80 @@
     "RefOrConcreteSettings": {
       "title": "Concrete settings or reference",
       "description": "Use inline global settings or a reference to a named concrete settings component.",
-      "oneOf": [
+      "type": "object",
+      "allOf": [
         {
-          "$ref": "#/definitions/Reference",
-          "description": "A reference to a named concrete settings component."
-        },
-        {
-          "$ref": "#/definitions/ConcreteSettings",
-          "description": "Inline concrete settings."
+          "if": {
+            "required": ["$ref"]
+          },
+          "then": {
+            "$ref": "#/definitions/Reference",
+            "description": "A reference to a named concrete settings component."
+          },
+          "else": {
+            "$ref": "#/definitions/ConcreteSettings",
+            "description": "Inline concrete settings."
+          }
         }
       ]
     },
     "RefOrTestSettings": {
       "title": "Test settings or reference",
       "description": "Use inline test settings or a reference to a named settings component; target compatibility is semantic.",
-      "oneOf": [
+      "type": "object",
+      "allOf": [
         {
-          "$ref": "#/definitions/Reference",
-          "description": "A reference to reusable test settings."
-        },
-        {
-          "$ref": "#/definitions/TestSettings",
-          "description": "Inline test settings."
+          "if": {
+            "required": ["$ref"]
+          },
+          "then": {
+            "$ref": "#/definitions/Reference",
+            "description": "A reference to reusable test settings."
+          },
+          "else": {
+            "$ref": "#/definitions/TestSettings",
+            "description": "Inline test settings."
+          }
         }
       ]
     },
     "RefOrMockSettings": {
       "title": "Mock settings or reference",
       "description": "Use inline mock settings or a reference to a named settings component; target compatibility is semantic.",
-      "oneOf": [
+      "type": "object",
+      "allOf": [
         {
-          "$ref": "#/definitions/Reference",
-          "description": "A reference to reusable mock settings."
-        },
-        {
-          "$ref": "#/definitions/MockSettings",
-          "description": "Inline mock settings."
+          "if": {
+            "required": ["$ref"]
+          },
+          "then": {
+            "$ref": "#/definitions/Reference",
+            "description": "A reference to reusable mock settings."
+          },
+          "else": {
+            "$ref": "#/definitions/MockSettings",
+            "description": "Inline mock settings."
+          }
         }
       ]
     },
     "RefOrContextSettings": {
       "title": "Contextual settings or reference",
       "description": "Use inline context-dependent settings or a reference; the service consumer selects test or mock reification.",
-      "oneOf": [
+      "type": "object",
+      "allOf": [
         {
-          "$ref": "#/definitions/Reference",
-          "description": "A reference to reusable contextual settings."
-        },
-        {
-          "$ref": "#/definitions/ContextSettings",
-          "description": "Inline contextual settings."
+          "if": {
+            "required": ["$ref"]
+          },
+          "then": {
+            "$ref": "#/definitions/Reference",
+            "description": "A reference to reusable contextual settings."
+          },
+          "else": {
+            "$ref": "#/definitions/ContextSettings",
+            "description": "Inline contextual settings."
+          }
         }
       ]
     },

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3ReferenceValidationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3ReferenceValidationTest.kt
@@ -1,0 +1,372 @@
+package io.specmatic.core.config.v3
+
+import io.specmatic.core.config.SpecmaticConfigVersion
+import io.specmatic.core.config.validation.ConfigValidationResult
+import io.specmatic.core.config.validation.ConfigValidationOutput
+import io.specmatic.core.config.validation.SpecmaticConfigValidator
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+
+class SpecmaticConfigV3ReferenceValidationTest {
+    private val validator = SpecmaticConfigValidator()
+
+    @Nested
+    inner class ReferenceResolution {
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("io.specmatic.core.config.v3.SpecmaticConfigV3ReferenceValidationTest#missingTypedReferenceCases")
+        fun `reports missing typed references`(testCase: InvalidReferenceCase) {
+            assertThat(validator.validate(testCase.configuration))
+                .isEqualTo(invalidAt(testCase.instanceLocation, testCase.message))
+        }
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("io.specmatic.core.config.v3.SpecmaticConfigV3ReferenceValidationTest#validTypedReferenceCases")
+        fun `accepts typed references with compatible targets`(testCase: ValidReferenceCase) {
+            assertThat(validator.validate(testCase.configuration))
+                .isEqualTo(ConfigValidationResult.Valid(SpecmaticConfigVersion.VERSION_3))
+        }
+    }
+
+    @Nested
+    inner class TypeCompatibility {
+        @Test
+        fun `reports a service reference that resolves to the wrong component`() {
+            assertThat(validator.validate($$"""
+            version: 3
+            systemUnderTest:
+              service:
+                $ref: '#/components/sources/source'
+            components:
+              sources:
+                source:
+                  filesystem: {}
+            """.trimIndent())).isEqualTo(
+                invalidAt(
+                    instanceLocation = "/systemUnderTest/service",
+                    message = "Reference '#/components/sources/source' could not be resolved as the expected typed value: Failed to convert resolved value to CommonServiceConfig<TestRunOptions, TestSettings>"
+                )
+            )
+        }
+
+        @Test
+        fun `reports inline siblings that make a typed reference incompatible`() {
+            assertThat(validator.validate($$"""
+            version: 3
+            systemUnderTest:
+              service:
+                $ref: '#/components/services/sut'
+                definitions: invalid
+            components:
+              services:
+                sut:
+                  definitions: []
+            """.trimIndent())).isEqualTo(
+                invalidAt(
+                    instanceLocation = "/systemUnderTest/service",
+                    message = "Reference '#/components/services/sut' could not be resolved as the expected typed value: Failed to convert resolved value to CommonServiceConfig<TestRunOptions, TestSettings>"
+                )
+            )
+        }
+
+        @Test
+        fun `reports a certificate reference with an incompatible typed target`() {
+            assertThat(validator.validate($$"""
+            version: 3
+            components:
+              runOptions:
+                api:
+                  openapi:
+                    type: test
+                    cert:
+                      $ref: '#/components/adapters/hooks'
+              adapters:
+                hooks:
+                  preSpecmaticRequestProcessor: hooks/before.sh
+            """.trimIndent())).isEqualTo(
+                invalidAt(
+                    instanceLocation = "/components/runOptions/api/openapi/cert",
+                    message = "Reference '#/components/adapters/hooks' could not be resolved as the expected typed value: Failed to convert resolved value to HttpsConfiguration"
+                )
+            )
+        }
+    }
+
+    @Nested
+    inner class InlineAndNestedValidation {
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("io.specmatic.core.config.v3.SpecmaticConfigV3ReferenceValidationTest#nestedReferenceCases")
+        fun `validates nested references exactly once at the owning location`(testCase: InvalidReferenceCase) {
+            assertThat(validator.validate(testCase.configuration))
+                .isEqualTo(invalidAt(testCase.instanceLocation, testCase.message))
+        }
+    }
+
+    private fun invalidAt(instanceLocation: String, message: String) = ConfigValidationResult.Invalid(
+        SpecmaticConfigVersion.VERSION_3,
+        listOf(ConfigValidationOutput(
+            valid = false,
+            keywordLocation = "",
+            instanceLocation = instanceLocation,
+            error = message,
+        ))
+    )
+
+    companion object {
+        private const val MISSING_MESSAGE = "could not be resolved as the expected typed value: Component reference does not exist:"
+        data class InvalidReferenceCase(val name: String, val configuration: String, val instanceLocation: String, val message: String) {
+            override fun toString(): String = name
+        }
+
+        data class ValidReferenceCase(val name: String, val configuration: String) {
+            override fun toString(): String = name
+        }
+
+        @JvmStatic
+        fun missingTypedReferenceCases() = listOf(
+            InvalidReferenceCase(
+                name = "missing service component",
+                configuration = $$"""
+                version: 3
+                systemUnderTest:
+                  service:
+                    $ref: '#/components/services/missing'
+                components:
+                  services: {}
+                """.trimIndent(),
+                instanceLocation = "/systemUnderTest/service",
+                message = "Reference '#/components/services/missing' $MISSING_MESSAGE #/components/services/missing",
+            ),
+            InvalidReferenceCase(
+                name = "missing source beside a definition",
+                configuration = $$"""
+                version: 3
+                systemUnderTest:
+                  service:
+                    definitions:
+                      - definition:
+                          source:
+                            $ref: '#/components/sources/missing'
+                          specs: [orders.yaml]
+                components:
+                  sources: {}
+                """.trimIndent(),
+                instanceLocation = "/systemUnderTest/service/definitions/0/definition/source",
+                message = "Reference '#/components/sources/missing' $MISSING_MESSAGE #/components/sources/missing",
+            ),
+            InvalidReferenceCase(
+                name = "missing settings component",
+                configuration = $$"""
+                version: 3
+                systemUnderTest:
+                  service:
+                    definitions: []
+                    settings:
+                      $ref: '#/components/settings/missing'
+                components:
+                  settings: {}
+                """.trimIndent(),
+                instanceLocation = "/systemUnderTest/service/settings",
+                message = "Reference '#/components/settings/missing' $MISSING_MESSAGE #/components/settings/missing",
+            ),
+            InvalidReferenceCase(
+                name = "missing run options component",
+                configuration = $$"""
+                version: 3
+                systemUnderTest:
+                  service:
+                    definitions: []
+                    runOptions:
+                      $ref: '#/components/runOptions/missing'
+                components:
+                  runOptions: {}
+                """.trimIndent(),
+                instanceLocation = "/systemUnderTest/service/runOptions",
+                message = "Reference '#/components/runOptions/missing' $MISSING_MESSAGE #/components/runOptions/missing",
+            ),
+            InvalidReferenceCase(
+                name = "missing dictionary component",
+                configuration = $$"""
+                version: 3
+                systemUnderTest:
+                  service:
+                    definitions: []
+                    data:
+                      dictionary:
+                        $ref: '#/components/dictionaries/missing'
+                components:
+                  dictionaries: {}
+                """.trimIndent(),
+                instanceLocation = "/systemUnderTest/service/data/dictionary",
+                message = "Reference '#/components/dictionaries/missing' $MISSING_MESSAGE #/components/dictionaries/missing",
+            ),
+            InvalidReferenceCase(
+                name = "missing example directory component",
+                configuration = $$"""
+                version: 3
+                systemUnderTest:
+                  service:
+                    definitions: []
+                    data:
+                      examples:
+                        - $ref: '#/components/examples/missing'
+                components:
+                  examples: {}
+                """.trimIndent(),
+                instanceLocation = "/systemUnderTest/service/data/examples/0",
+                message = "Reference '#/components/examples/missing' $MISSING_MESSAGE #/components/examples/missing",
+            ),
+            InvalidReferenceCase(
+                name = "missing service data adapter component",
+                configuration = $$"""
+                version: 3
+                systemUnderTest:
+                  service:
+                    definitions: []
+                    data:
+                      adapters:
+                        $ref: '#/components/adapters/missing'
+                components:
+                  adapters: {}
+                """.trimIndent(),
+                instanceLocation = "/systemUnderTest/service/data/adapters",
+                message = "Reference '#/components/adapters/missing' $MISSING_MESSAGE #/components/adapters/missing",
+            ),
+            InvalidReferenceCase(
+                name = "missing proxy adapter component",
+                configuration = $$"""
+                version: 3
+                proxies:
+                  - proxy:
+                      target: https://one.example.test
+                      adapters:
+                        $ref: '#/components/adapters/missing'
+                components:
+                  adapters: {}
+                """.trimIndent(),
+                instanceLocation = "/proxies/0/proxy/adapters",
+                message = "Reference '#/components/adapters/missing' $MISSING_MESSAGE #/components/adapters/missing",
+            ),
+            InvalidReferenceCase(
+                name = "missing Specmatic settings component",
+                configuration = $$"""
+                version: 3
+                specmatic:
+                  settings:
+                    $ref: '#/components/settings/missing'
+                components:
+                  settings: {}
+                """.trimIndent(),
+                instanceLocation = "/specmatic/settings",
+                message = "Reference '#/components/settings/missing' $MISSING_MESSAGE #/components/settings/missing",
+            ),
+            InvalidReferenceCase(
+                name = "missing proxy certificate component",
+                configuration = $$"""
+                version: 3
+                proxies:
+                  - proxy:
+                      target: https://one.example.test
+                      cert:
+                        $ref: '#/components/certificates/missing'
+                components:
+                  certificates: {}
+                """.trimIndent(),
+                instanceLocation = "/proxies/0/proxy/cert",
+                message = "Reference '#/components/certificates/missing' $MISSING_MESSAGE #/components/certificates/missing",
+            ),
+        )
+
+        @JvmStatic
+        fun validTypedReferenceCases() = listOf(
+            ValidReferenceCase(
+                name = "service reference with compatible target",
+                configuration = $$"""
+                version: 3
+                systemUnderTest:
+                  service:
+                    $ref: '#/components/services/sut'
+                components:
+                  services:
+                    sut:
+                      definitions: []
+                """.trimIndent(),
+            ),
+            ValidReferenceCase(
+                name = "source reference with compatible target",
+                configuration = $$"""
+                version: 3
+                systemUnderTest:
+                  service:
+                    definitions:
+                      - definition:
+                          source:
+                            $ref: '#/components/sources/local'
+                          specs: [orders.yaml]
+                components:
+                  sources:
+                    local:
+                      filesystem: {}
+                """.trimIndent(),
+            ),
+        )
+
+        @JvmStatic
+        fun nestedReferenceCases() = listOf(
+            InvalidReferenceCase(
+                name = "reference nested under inline service override",
+                configuration = $$"""
+                version: 3
+                systemUnderTest:
+                  service:
+                    $ref: '#/components/services/sut'
+                    runOptions:
+                      $ref: '#/components/runOptions/missing'
+                components:
+                  services:
+                    sut:
+                      definitions: []
+                  runOptions: {}
+                """.trimIndent(),
+                instanceLocation = "/components/services/sut/runOptions",
+                message = "Reference '#/components/runOptions/missing' $MISSING_MESSAGE #/components/runOptions/missing",
+            ),
+            InvalidReferenceCase(
+                name = "reference nested inside inline service value",
+                configuration = $$"""
+                version: 3
+                systemUnderTest:
+                  service:
+                    definitions: []
+                    runOptions:
+                      openapi:
+                        type: test
+                        cert:
+                          $ref: '#/components/certificates/missing'
+                components:
+                  certificates: {}
+                """.trimIndent(),
+                instanceLocation = "/systemUnderTest/service/runOptions/openapi/cert",
+                message = "Reference '#/components/certificates/missing' $MISSING_MESSAGE #/components/certificates/missing",
+            ),
+            InvalidReferenceCase(
+                name = "reference nested inside inline examples exactly once",
+                configuration = $$"""
+                version: 3
+                systemUnderTest:
+                  service:
+                    definitions: []
+                    data:
+                      examples:
+                        - $ref: '#/components/examples/missing'
+                components:
+                  examples: {}
+                """.trimIndent(),
+                instanceLocation = "/systemUnderTest/service/data/examples/0",
+                message = "Reference '#/components/examples/missing' $MISSING_MESSAGE #/components/examples/missing",
+            ),
+        )
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/config/validation/ConfigSchemaValidationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/validation/ConfigSchemaValidationTest.kt
@@ -1,0 +1,530 @@
+package io.specmatic.core.config.validation
+
+import io.specmatic.core.config.SpecmaticConfigVersion
+import io.specmatic.core.config.objectMapper
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+
+class ConfigSchemaValidationTest {
+    private val validator = ConfigSchemaValidator()
+    private val validOutput = emptyList<ConfigValidationOutput>()
+
+    @Nested
+    inner class V2 {
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("io.specmatic.core.config.validation.ConfigSchemaValidationTest#v2ValidCases")
+        fun `accepts valid V2 shapes`(testCase: ValidSchemaCase) {
+            assertThat(schema(SpecmaticConfigVersion.VERSION_2, testCase.json))
+                .isEqualTo(validOutput)
+        }
+
+        @Test
+        fun `accepts report security test stub virtual service and workflow shapes`() {
+            assertThat(schema(SpecmaticConfigVersion.VERSION_2, $$"""
+            {
+              "version": 2,
+              "auth": {
+                "bearer-file": "token.txt",
+                "bearer-environment-variable": "TOKEN",
+                "personal-access-token": "token"
+              },
+              "report": {
+                "types": {
+                  "APICoverage": {
+                    "OpenAPI": {
+                      "successCriteria": {
+                        "minThresholdPercentage": 80,
+                        "maxMissedEndpointsInSpec": 2,
+                        "enforce": true
+                      }
+                    }
+                  }
+                }
+              },
+              "security": {
+                "OpenAPI": {
+                  "securitySchemes": {
+                    "bearer": {
+                      "type": "bearer",
+                      "token": "token"
+                    }
+                  }
+                }
+              },
+              "test": {
+                "resiliencyTests": { "enable": "all" },
+                "timeoutInMilliseconds": 5000,
+                "https": { "mtlsEnabled": true }
+              },
+              "stub": {
+                "generative": true,
+                "delayInMilliseconds": 100,
+                "hotReload": "true",
+                "https": { "mtlsEnabled": true }
+              },
+              "virtualService": {
+                "host": "localhost",
+                "port": 9000,
+                "specs": ["orders.yaml"],
+                "logMode": "ALL",
+                "nonPatchableKeys": ["id"]
+              },
+              "workflow": {
+                "ids": {
+                  "createOrder": {
+                    "extract": "$.id",
+                    "use": "$orderId"
+                  }
+                }
+              }
+            }
+            """.trimIndent())).isEqualTo(validOutput)
+        }
+
+        @Test
+        fun `rejects excludedEndpoints as a V2 property`() {
+            assertThat(schema(SpecmaticConfigVersion.VERSION_2, """
+            version: 2
+            report:
+              types:
+                APICoverage:
+                  OpenAPI:
+                    excludedEndpoints: [GET /health]
+            """.trimIndent())).isEqualTo(invalidOutput(detail(
+                $$"/properties/report/$ref/properties/types/$ref/properties/APICoverage/$ref/properties/OpenAPI/$ref",
+                "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/APICoverageConfiguration",
+                "/report/types/APICoverage/OpenAPI",
+                "property 'excludedEndpoints' is not defined in the schema and the schema does not allow additional properties",
+            )))
+        }
+
+        @Test
+        fun `rejects more than one explicit contract source`() {
+            assertThat(schema(SpecmaticConfigVersion.VERSION_2, """
+            version: 2
+            contracts:
+              - git: {}
+                filesystem: {}
+            """.trimIndent())).isEqualTo(invalidOutput(
+                detail($$"/properties/contracts/items/$ref", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ContractConfig", "/contracts/0", "Specify zero or one contract source: git, filesystem, or web."),
+                detail($$"/properties/contracts/items/$ref/oneOf/0", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ContractConfig/oneOf/0", "/contracts/0", "must not be valid to the schema {\"description\":\"No explicit source may be present in this branch.\",\"anyOf\":[{\"description\":\"An explicit Git source is present.\",\"required\":[\"git\"]},{\"description\":\"An explicit filesystem source is present.\",\"required\":[\"filesystem\"]},{\"description\":\"An explicit web source is present.\",\"required\":[\"web\"]}]}"),
+                detail($$"/properties/contracts/items/$ref/oneOf/1", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ContractConfig/oneOf/1", "/contracts/0", "must not be valid to the schema {\"description\":\"No additional explicit source may be present in the Git branch.\",\"anyOf\":[{\"description\":\"An explicit filesystem source is present.\",\"required\":[\"filesystem\"]},{\"description\":\"An explicit web source is present.\",\"required\":[\"web\"]}]}"),
+                detail($$"/properties/contracts/items/$ref/oneOf/2", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ContractConfig/oneOf/2", "/contracts/0", "must not be valid to the schema {\"description\":\"No additional explicit source may be present in the filesystem branch.\",\"anyOf\":[{\"description\":\"An explicit Git source is present.\",\"required\":[\"git\"]},{\"description\":\"An explicit web source is present.\",\"required\":[\"web\"]}]}"),
+                detail($$"/properties/contracts/items/$ref/oneOf/3", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ContractConfig/oneOf/3", "/contracts/0", "required property 'web' not found; must not be valid to the schema {\"description\":\"No additional explicit source may be present in the web branch.\",\"anyOf\":[{\"description\":\"An explicit Git source is present.\",\"required\":[\"git\"]},{\"description\":\"An explicit filesystem source is present.\",\"required\":[\"filesystem\"]}]}"),
+            ))
+        }
+
+        @Test
+        fun `rejects resiliencyTests on consumes`() {
+            assertThat(schema(SpecmaticConfigVersion.VERSION_2, """
+            version: 2
+            contracts:
+              - consumes:
+                  - baseUrl: http://localhost:8080
+                    specs: [orders.yaml]
+                    resiliencyTests:
+                      enable: all
+            """.trimIndent())).isEqualTo(invalidOutput(
+                detail($$"/properties/contracts/items/$ref/properties/consumes/items/$ref", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ConsumesEntry", "/contracts/0/consumes/0", "must be valid to one and only one schema, but 0 are valid"),
+                detail($$"/properties/contracts/items/$ref/properties/consumes/items/$ref/oneOf/0", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ConsumesEntry/oneOf/0", "/contracts/0/consumes/0", "object found, string expected"),
+                detail($$"/properties/contracts/items/$ref/properties/consumes/items/$ref/oneOf/1/$ref", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/FullUrlConsumes", "/contracts/0/consumes/0", "property 'resiliencyTests' is not defined in the schema and the schema does not allow additional properties"),
+                detail($$"/properties/contracts/items/$ref/properties/consumes/items/$ref/oneOf/2/$ref", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/PartialUrlConsumes", "/contracts/0/consumes/0", "[property 'baseUrl' is not defined in the schema and the schema does not allow additional properties, property 'resiliencyTests' is not defined in the schema and the schema does not allow additional properties]"),
+                detail($$"/properties/contracts/items/$ref/properties/consumes/items/$ref/oneOf/2/$ref/anyOf/0", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/PartialUrlConsumes/anyOf/0", "/contracts/0/consumes/0", "required property 'host' not found"),
+                detail($$"/properties/contracts/items/$ref/properties/consumes/items/$ref/oneOf/2/$ref/anyOf/1", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/PartialUrlConsumes/anyOf/1", "/contracts/0/consumes/0", "required property 'port' not found"),
+                detail($$"/properties/contracts/items/$ref/properties/consumes/items/$ref/oneOf/2/$ref/anyOf/2", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/PartialUrlConsumes/anyOf/2", "/contracts/0/consumes/0", "required property 'basePath' not found"),
+                detail($$"/properties/contracts/items/$ref/properties/consumes/items/$ref/oneOf/3/$ref", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ConfigValue", "/contracts/0/consumes/0", "[property 'baseUrl' is not defined in the schema and the schema does not allow additional properties, property 'resiliencyTests' is not defined in the schema and the schema does not allow additional properties]; [required property 'specType' not found, required property 'config' not found]"),
+            ))
+        }
+
+        @Test
+        fun `rejects basePath on provides`() {
+            assertThat(schema(SpecmaticConfigVersion.VERSION_2, """
+            version: 2
+            contracts:
+              - provides:
+                  - basePath: /orders
+                    specs: [orders.yaml]
+            """.trimIndent())).isEqualTo(invalidOutput(
+                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ProvidesEntry", "/contracts/0/provides/0", "must be valid to one and only one schema, but 0 are valid"),
+                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/oneOf/0", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ProvidesEntry/oneOf/0", "/contracts/0/provides/0", "object found, string expected"),
+                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/oneOf/1/$ref", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/FullUrlProvides", "/contracts/0/provides/0", "property 'basePath' is not defined in the schema and the schema does not allow additional properties; required property 'baseUrl' not found"),
+                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/oneOf/2/$ref", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/PartialUrlProvides", "/contracts/0/provides/0", "property 'basePath' is not defined in the schema and the schema does not allow additional properties"),
+                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/oneOf/2/$ref/anyOf/0", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/PartialUrlProvides/anyOf/0", "/contracts/0/provides/0", "required property 'host' not found"),
+                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/oneOf/2/$ref/anyOf/1", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/PartialUrlProvides/anyOf/1", "/contracts/0/provides/0", "required property 'port' not found"),
+                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/oneOf/3/$ref", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ConfigValue", "/contracts/0/provides/0", "property 'basePath' is not defined in the schema and the schema does not allow additional properties; [required property 'specType' not found, required property 'config' not found]"),
+            ))
+        }
+
+        @Test
+        fun `rejects missing ConfigValue fields`() {
+            assertThat(schema(SpecmaticConfigVersion.VERSION_2, """
+            version: 2
+            contracts:
+              - provides:
+                  - specs: [orders.yaml]
+            """.trimIndent())).isEqualTo(invalidOutput(
+                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ProvidesEntry", "/contracts/0/provides/0", "must be valid to one and only one schema, but 0 are valid"),
+                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/oneOf/0", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ProvidesEntry/oneOf/0", "/contracts/0/provides/0", "object found, string expected"),
+                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/oneOf/1/$ref", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/FullUrlProvides", "/contracts/0/provides/0", "required property 'baseUrl' not found"),
+                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/oneOf/2/$ref/anyOf/0", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/PartialUrlProvides/anyOf/0", "/contracts/0/provides/0", "required property 'host' not found"),
+                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/oneOf/2/$ref/anyOf/1", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/PartialUrlProvides/anyOf/1", "/contracts/0/provides/0", "required property 'port' not found"),
+                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/oneOf/3/$ref", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ConfigValue", "/contracts/0/provides/0", "[required property 'specType' not found, required property 'config' not found]"),
+            ))
+        }
+
+        @Test
+        fun `rejects null ConfigValue nodes`() {
+            assertThat(schema(SpecmaticConfigVersion.VERSION_2, """
+            version: 2
+            contracts:
+              - provides:
+                  - specs: [orders.yaml]
+                    specType: openapi
+                    config:
+                      token: null
+            """.trimIndent())).isEqualTo(invalidOutput(
+                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ProvidesEntry", "/contracts/0/provides/0", "must be valid to one and only one schema, but 0 are valid"),
+                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/oneOf/0", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ProvidesEntry/oneOf/0", "/contracts/0/provides/0", "object found, string expected"),
+                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/oneOf/1/$ref", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/FullUrlProvides", "/contracts/0/provides/0", "[property 'specType' is not defined in the schema and the schema does not allow additional properties, property 'config' is not defined in the schema and the schema does not allow additional properties]; required property 'baseUrl' not found"),
+                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/oneOf/2/$ref", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/PartialUrlProvides", "/contracts/0/provides/0", "[property 'specType' is not defined in the schema and the schema does not allow additional properties, property 'config' is not defined in the schema and the schema does not allow additional properties]"),
+                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/oneOf/2/$ref/anyOf/0", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/PartialUrlProvides/anyOf/0", "/contracts/0/provides/0", "required property 'host' not found"),
+                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/oneOf/2/$ref/anyOf/1", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/PartialUrlProvides/anyOf/1", "/contracts/0/provides/0", "required property 'port' not found"),
+                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/oneOf/3/$ref/properties/config/additionalProperties/$ref/anyOf/0", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ConfigValueNode/anyOf/0", "/contracts/0/provides/0/config/token", "null found, string expected"),
+                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/oneOf/3/$ref/properties/config/additionalProperties/$ref/anyOf/1", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ConfigValueNode/anyOf/1", "/contracts/0/provides/0/config/token", "null found, integer expected"),
+                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/oneOf/3/$ref/properties/config/additionalProperties/$ref/anyOf/2", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ConfigValueNode/anyOf/2", "/contracts/0/provides/0/config/token", "null found, number expected"),
+                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/oneOf/3/$ref/properties/config/additionalProperties/$ref/anyOf/3", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ConfigValueNode/anyOf/3", "/contracts/0/provides/0/config/token", "null found, boolean expected"),
+                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/oneOf/3/$ref/properties/config/additionalProperties/$ref/anyOf/4", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ConfigValueNode/anyOf/4", "/contracts/0/provides/0/config/token", "null found, array expected"),
+                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/oneOf/3/$ref/properties/config/additionalProperties/$ref/anyOf/5", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ConfigValueNode/anyOf/5", "/contracts/0/provides/0/config/token", "null found, object expected"),
+            ))
+        }
+
+        @Test
+        fun `rejects a web source without a URL`() {
+            assertThat(schema(SpecmaticConfigVersion.VERSION_2, """
+            version: 2
+            contracts:
+              - web: {}
+            """.trimIndent())).isEqualTo(invalidOutput(detail(
+                instanceLocation = "/contracts/0/web",
+                error = "required property 'url' not found",
+                keywordLocation = $$"/properties/contracts/items/$ref/properties/web/$ref",
+                absoluteKeywordLocation = "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/WebContractSource",
+            )))
+        }
+    }
+
+    @Nested
+    inner class V3 {
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("io.specmatic.core.config.validation.ConfigSchemaValidationTest#v3ValidCases")
+        fun `accepts valid V3 shapes`(testCase: ValidSchemaCase) {
+            assertThat(schema(SpecmaticConfigVersion.VERSION_3, testCase.json))
+                .isEqualTo(validOutput)
+        }
+
+        @Test
+        fun `accepts source data settings and every protocol component branch`() {
+            assertThat(schema(SpecmaticConfigVersion.VERSION_3, """
+            {
+              "version": 3,
+              "components": {
+                "sources": {
+                  "gitSource": { "git": { "branch": "main" } },
+                  "webSource": { "web": { "url": "https://contracts.example.test/openapi.yaml" } }
+                },
+                "services": {
+                  "api": {
+                    "definitions": [
+                      {
+                        "definition": {
+                          "source": { "filesystem": {} },
+                          "specs": [
+                            { "spec": { "id": "orders", "path": "orders.yaml", "x-team": "payments" } }
+                          ]
+                        }
+                      }
+                    ],
+                    "runOptions": { "openapi": { "baseUrl": "http://localhost:8080" } },
+                    "settings": { "timeoutInMilliseconds": 5000 },
+                    "data": {
+                      "examples": [{ "directories": ["examples"] }],
+                      "dictionary": { "path": "data/dictionary.json" },
+                      "adapters": { "preSpecmaticRequestProcessor": "hooks/pre.sh" }
+                    }
+                  }
+                },
+                "runOptions": {
+                  "api": { "openapi": { "type": "test", "cert": { "mtlsEnabled": true } } },
+                  "asyncapi": { "asyncapi": { "type": "test" } },
+                  "graphql": { "graphqlsdl": { "type": "mock" } },
+                  "protobuf": { "protobuf": { "type": "test" } }
+                },
+                "examples": {
+                  "testExamples": [{ "directories": ["test-examples"] }],
+                  "mockExamples": [{ "directories": ["mock-examples"] }],
+                  "commonExamples": { "directories": ["examples"] }
+                },
+                "dictionaries": {
+                  "default": { "path": "data/dictionary.json" }
+                },
+                "adapters": {
+                  "hooks": { "preSpecmaticRequestProcessor": "hooks/pre.sh" }
+                },
+                "certificates": {
+                  "mtls": { "keyStore": { "file": "server.jks" }, "mtlsEnabled": true }
+                },
+                "settings": {
+                  "global": { "general": { "disableTelemetry": true } }
+                }
+              }
+            }
+            """.trimIndent())).isEqualTo(validOutput)
+        }
+
+        @Test
+        fun `rejects an adapter hook outside the closed adapter shape`() {
+            assertThat(schema(SpecmaticConfigVersion.VERSION_3, """
+            version: 3
+            components:
+              adapters:
+                hooks:
+                  notARealHook: hooks/custom.sh
+            """.trimIndent())).isEqualTo(invalidOutput(detail(
+                instanceLocation = "/components/adapters/hooks",
+                keywordLocation = $$"/properties/components/$ref/properties/adapters/additionalProperties/$ref",
+                error = "property 'notARealHook' is not defined in the schema and the schema does not allow additional properties",
+                absoluteKeywordLocation = "https://specmatic.io/internal-schema/config-v3-resolved.schema.json#/definitions/AdapterConfiguration",
+            )))
+        }
+
+        @Test
+        fun `rejects missing root wrapper fields`() {
+            assertThat(schema(SpecmaticConfigVersion.VERSION_3, """
+            version: 3
+            systemUnderTest: {}
+            dependencies: {}
+            """.trimIndent())).isEqualTo(invalidOutput(
+                detail($$"/properties/systemUnderTest/$ref", "https://specmatic.io/internal-schema/config-v3-resolved.schema.json#/definitions/SystemUnderTestServiceDefinition", "/systemUnderTest", "required property 'service' not found"),
+                detail($$"/properties/dependencies/$ref", "https://specmatic.io/internal-schema/config-v3-resolved.schema.json#/definitions/DependenciesDefinition", "/dependencies", "required property 'services' not found"),
+            ))
+        }
+
+        @Test
+        fun `rejects source provider cardinality in components`() {
+            assertThat(schema(SpecmaticConfigVersion.VERSION_3, """
+            version: 3
+            components:
+              sources:
+                bad:
+                  git: {}
+                  filesystem: {}
+            """.trimIndent())).isEqualTo(invalidOutput(
+                detail($$"/properties/components/$ref/properties/sources/additionalProperties/$ref", "https://specmatic.io/internal-schema/config-v3-resolved.schema.json#/definitions/SourceSchema", "/components/sources/bad", "Choose exactly one source provider: git, filesystem, or web."),
+                detail($$"/properties/components/$ref/properties/sources/additionalProperties/$ref/oneOf/0/$ref", "https://specmatic.io/internal-schema/config-v3-resolved.schema.json#/definitions/GitSourceSchema", "/components/sources/bad", "property 'filesystem' is not defined in the schema and the schema does not allow additional properties"),
+                detail($$"/properties/components/$ref/properties/sources/additionalProperties/$ref/oneOf/1/$ref", "https://specmatic.io/internal-schema/config-v3-resolved.schema.json#/definitions/FileSystemSourceSchema", "/components/sources/bad", "property 'git' is not defined in the schema and the schema does not allow additional properties"),
+                detail($$"/properties/components/$ref/properties/sources/additionalProperties/$ref/oneOf/2/$ref", "https://specmatic.io/internal-schema/config-v3-resolved.schema.json#/definitions/WebSourceSchema", "/components/sources/bad", "[property 'git' is not defined in the schema and the schema does not allow additional properties, property 'filesystem' is not defined in the schema and the schema does not allow additional properties]; required property 'web' not found"),
+            ))
+        }
+
+        @Test
+        fun `rejects both key store forms`() {
+            assertThat(schema(SpecmaticConfigVersion.VERSION_3, """
+            version: 3
+            components:
+              certificates:
+                bad:
+                  keyStore:
+                    file: server.jks
+                    directory: certs
+            """.trimIndent())).isEqualTo(invalidOutput(
+                detail($$"/properties/components/$ref/properties/certificates/additionalProperties/$ref/properties/keyStore/$ref", "https://specmatic.io/internal-schema/config-v3-resolved.schema.json#/definitions/KeyStoreConfiguration", "/components/certificates/bad/keyStore", "Specify exactly one key-store form: file or directory."),
+                detail($$"/properties/components/$ref/properties/certificates/additionalProperties/$ref/properties/keyStore/$ref/oneOf/0/$ref", "https://specmatic.io/internal-schema/config-v3-resolved.schema.json#/definitions/KeyStoreFileConfiguration", "/components/certificates/bad/keyStore", "property 'directory' is not defined in the schema and the schema does not allow additional properties"),
+                detail($$"/properties/components/$ref/properties/certificates/additionalProperties/$ref/properties/keyStore/$ref/oneOf/1/$ref", "https://specmatic.io/internal-schema/config-v3-resolved.schema.json#/definitions/KeyStoreDirectoryConfiguration", "/components/certificates/bad/keyStore", "property 'file' is not defined in the schema and the schema does not allow additional properties"),
+            ))
+        }
+
+        @Test
+        fun `rejects a protocol enum outside its resolved branch`() {
+            assertThat(schema(SpecmaticConfigVersion.VERSION_3, """
+            version: 3
+            mcp:
+              test:
+                baseUrl: http://localhost:9100
+                transportKind: streamable_http
+            """.trimIndent())).isEqualTo(invalidOutput(detail(
+                instanceLocation = "/mcp/test/transportKind",
+                error = "does not have a value in the enumeration [\"STREAMABLE_HTTP\"]",
+                keywordLocation = $$"/properties/mcp/$ref/properties/test/$ref/properties/transportKind",
+                absoluteKeywordLocation = "https://specmatic.io/internal-schema/config-v3-resolved.schema.json#/definitions/McpTestRunOptions/properties/transportKind",
+            )))
+        }
+    }
+
+    companion object {
+        data class ValidSchemaCase(val name: String, val json: String) {
+            override fun toString(): String = name
+        }
+
+        @JvmStatic
+        fun v2ValidCases() = listOf(
+            ValidSchemaCase(
+                name = "source-less and each single source form",
+                json = """
+                version: 2
+                contracts:
+                  - provides: [orders.spec]
+                  - git:
+                      branch: main
+                  - filesystem: {}
+                  - web:
+                      url: https://contracts.example.test
+                """.trimIndent(),
+            ),
+            ValidSchemaCase(
+                name = "provides and consumes URL forms, including basePath-only consumes",
+                json = """
+                version: 2
+                contracts:
+                  - provides:
+                      - baseUrl: http://localhost:8080
+                        specs: [orders.yaml]
+                        resiliencyTests:
+                          enable: all
+                      - host: localhost
+                        port: 8080
+                        specs: [orders.yaml]
+                    consumes:
+                      - baseUrl: http://localhost:8081
+                        specs: [orders.yaml]
+                      - basePath: /orders
+                        specs: [orders.yaml]
+                """.trimIndent(),
+            ),
+            ValidSchemaCase(
+                name = "aliases and recursive ConfigValue JSON",
+                json = """
+                version: 2
+                auth:
+                  personalAccessToken: token
+                virtual_service:
+                  nonPatchableKeys: [id]
+                attribute_selection_pattern:
+                  default_fields: [id]
+                  query_param_key: fields
+                contracts:
+                  - filesystem:
+                      directory: contracts
+                    provides:
+                      - specs: [orders.yaml]
+                        specType: openapi
+                        config:
+                          retries: 3
+                          enabled: true
+                          extra:
+                            region: test
+                """.trimIndent(),
+            ),
+        )
+
+        @JvmStatic
+        fun v3ValidCases() = listOf(
+            ValidSchemaCase(
+                name = "contextual services and reusable protocol components",
+                json = """
+                version: 3
+                components:
+                  services:
+                    api:
+                      definitions:
+                        - definition:
+                            source:
+                              filesystem: {}
+                            specs: [orders.yaml]
+                      runOptions:
+                        openapi:
+                          baseUrl: http://localhost:8080
+                      settings:
+                        timeoutInMilliseconds: 5000
+                  sources:
+                    repo:
+                      git:
+                        branch: main
+                  runOptions:
+                    soap:
+                      wsdl:
+                        type: mock
+                        baseUrl: http://localhost:8090
+                        vendorOption:
+                          enabled: true
+                  certificates:
+                    mtls:
+                      mtlsEnabled: true
+                proxies:
+                  - proxy:
+                      target: https://one.example.test
+                  - proxy:
+                      target: https://two.example.test
+                mcp:
+                  test:
+                    baseUrl: http://localhost:9100
+                    transportKind: STREAMABLE_HTTP
+                specmatic:
+                  governance:
+                    report:
+                      formats: [html, ctrf]
+                """.trimIndent(),
+            ),
+            ValidSchemaCase(
+                name = "test and mock contextual branches",
+                json = """
+                version: 3
+                systemUnderTest:
+                  service:
+                    definitions: []
+                dependencies:
+                  services: []
+                """.trimIndent(),
+            ),
+        )
+    }
+
+    private fun invalidOutput(vararg details: ConfigValidationOutput) = details.toList()
+    private fun schema(version: SpecmaticConfigVersion, json: String) = validator.validate(version, objectMapper.readTree(json))
+    private fun detail(
+        keywordLocation: String,
+        absoluteKeywordLocation: String,
+        instanceLocation: String,
+        error: String,
+    ) = ConfigValidationOutput(
+        valid = false,
+        error = error,
+        keywordLocation = keywordLocation,
+        instanceLocation = instanceLocation,
+        absoluteKeywordLocation = absoluteKeywordLocation,
+        metadata = schemaMetadata(keywordLocation, absoluteKeywordLocation),
+    )
+
+    private fun schemaMetadata(keywordLocation: String, absoluteKeywordLocation: String): ConfigValidationMetadata {
+        val resource = if (absoluteKeywordLocation.contains("config-v2")) {
+            "/config-validation/config-v2-resolved.schema.json"
+        } else {
+            "/config-validation/config-v3-resolved.schema.json"
+        }
+
+        val schema = ConfigSchemaValidationTest::class.java.getResourceAsStream(resource)
+            ?.use(objectMapper::readTree)
+            ?: error("Unable to load schema fixture: $resource")
+
+        val schemaNode = schema.at(absoluteKeywordLocation.substringAfter('#', ""))
+        return ConfigValidationMetadata(
+            title = schemaNode["title"]?.asText(),
+            description = schemaNode["description"]?.asText(),
+            deprecated = schemaNode["deprecated"]?.asBoolean(),
+            deprecationMessage = schemaNode["deprecationMessage"]?.asText(),
+            keyword = keywordLocation.split('/').asReversed().firstOrNull { it.isNotEmpty() && it.toIntOrNull() == null }?.replace("~1", "/")?.replace("~0", "~"),
+        )
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/config/validation/ConfigSchemaValidationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/validation/ConfigSchemaValidationTest.kt
@@ -109,11 +109,8 @@ class ConfigSchemaValidationTest {
               - git: {}
                 filesystem: {}
             """.trimIndent())).isEqualTo(invalidOutput(
-                detail($$"/properties/contracts/items/$ref", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ContractConfig", "/contracts/0", "Specify zero or one contract source: git, filesystem, or web."),
-                detail($$"/properties/contracts/items/$ref/oneOf/0", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ContractConfig/oneOf/0", "/contracts/0", "must not be valid to the schema {\"description\":\"No explicit source may be present in this branch.\",\"anyOf\":[{\"description\":\"An explicit Git source is present.\",\"required\":[\"git\"]},{\"description\":\"An explicit filesystem source is present.\",\"required\":[\"filesystem\"]},{\"description\":\"An explicit web source is present.\",\"required\":[\"web\"]}]}"),
-                detail($$"/properties/contracts/items/$ref/oneOf/1", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ContractConfig/oneOf/1", "/contracts/0", "must not be valid to the schema {\"description\":\"No additional explicit source may be present in the Git branch.\",\"anyOf\":[{\"description\":\"An explicit filesystem source is present.\",\"required\":[\"filesystem\"]},{\"description\":\"An explicit web source is present.\",\"required\":[\"web\"]}]}"),
-                detail($$"/properties/contracts/items/$ref/oneOf/2", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ContractConfig/oneOf/2", "/contracts/0", "must not be valid to the schema {\"description\":\"No additional explicit source may be present in the filesystem branch.\",\"anyOf\":[{\"description\":\"An explicit Git source is present.\",\"required\":[\"git\"]},{\"description\":\"An explicit web source is present.\",\"required\":[\"web\"]}]}"),
-                detail($$"/properties/contracts/items/$ref/oneOf/3", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ContractConfig/oneOf/3", "/contracts/0", "required property 'web' not found; must not be valid to the schema {\"description\":\"No additional explicit source may be present in the web branch.\",\"anyOf\":[{\"description\":\"An explicit Git source is present.\",\"required\":[\"git\"]},{\"description\":\"An explicit filesystem source is present.\",\"required\":[\"filesystem\"]}]}"),
+                detail($$"/properties/contracts/items/$ref/allOf/0/then/allOf/0", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ContractConfig/allOf/0/then/allOf/0", "/contracts/0", "Specify zero or one contract source: git, filesystem, or web."),
+                detail($$"/properties/contracts/items/$ref/allOf/1/then/allOf/0", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ContractConfig/allOf/1/then/allOf/0", "/contracts/0", "Specify zero or one contract source: git, filesystem, or web."),
             ))
         }
 
@@ -128,14 +125,7 @@ class ConfigSchemaValidationTest {
                     resiliencyTests:
                       enable: all
             """.trimIndent())).isEqualTo(invalidOutput(
-                detail($$"/properties/contracts/items/$ref/properties/consumes/items/$ref", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ConsumesEntry", "/contracts/0/consumes/0", "must be valid to one and only one schema, but 0 are valid"),
-                detail($$"/properties/contracts/items/$ref/properties/consumes/items/$ref/oneOf/0", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ConsumesEntry/oneOf/0", "/contracts/0/consumes/0", "object found, string expected"),
-                detail($$"/properties/contracts/items/$ref/properties/consumes/items/$ref/oneOf/1/$ref", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/FullUrlConsumes", "/contracts/0/consumes/0", "property 'resiliencyTests' is not defined in the schema and the schema does not allow additional properties"),
-                detail($$"/properties/contracts/items/$ref/properties/consumes/items/$ref/oneOf/2/$ref", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/PartialUrlConsumes", "/contracts/0/consumes/0", "[property 'baseUrl' is not defined in the schema and the schema does not allow additional properties, property 'resiliencyTests' is not defined in the schema and the schema does not allow additional properties]"),
-                detail($$"/properties/contracts/items/$ref/properties/consumes/items/$ref/oneOf/2/$ref/anyOf/0", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/PartialUrlConsumes/anyOf/0", "/contracts/0/consumes/0", "required property 'host' not found"),
-                detail($$"/properties/contracts/items/$ref/properties/consumes/items/$ref/oneOf/2/$ref/anyOf/1", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/PartialUrlConsumes/anyOf/1", "/contracts/0/consumes/0", "required property 'port' not found"),
-                detail($$"/properties/contracts/items/$ref/properties/consumes/items/$ref/oneOf/2/$ref/anyOf/2", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/PartialUrlConsumes/anyOf/2", "/contracts/0/consumes/0", "required property 'basePath' not found"),
-                detail($$"/properties/contracts/items/$ref/properties/consumes/items/$ref/oneOf/3/$ref", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ConfigValue", "/contracts/0/consumes/0", "[property 'baseUrl' is not defined in the schema and the schema does not allow additional properties, property 'resiliencyTests' is not defined in the schema and the schema does not allow additional properties]; [required property 'specType' not found, required property 'config' not found]"),
+                detail($$"/properties/contracts/items/$ref/properties/consumes/items/$ref/else/then/$ref", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/FullUrlConsumes", "/contracts/0/consumes/0", "property 'resiliencyTests' is not defined in the schema and the schema does not allow additional properties"),
             ))
         }
 
@@ -148,13 +138,7 @@ class ConfigSchemaValidationTest {
                   - basePath: /orders
                     specs: [orders.yaml]
             """.trimIndent())).isEqualTo(invalidOutput(
-                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ProvidesEntry", "/contracts/0/provides/0", "must be valid to one and only one schema, but 0 are valid"),
-                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/oneOf/0", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ProvidesEntry/oneOf/0", "/contracts/0/provides/0", "object found, string expected"),
-                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/oneOf/1/$ref", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/FullUrlProvides", "/contracts/0/provides/0", "property 'basePath' is not defined in the schema and the schema does not allow additional properties; required property 'baseUrl' not found"),
-                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/oneOf/2/$ref", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/PartialUrlProvides", "/contracts/0/provides/0", "property 'basePath' is not defined in the schema and the schema does not allow additional properties"),
-                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/oneOf/2/$ref/anyOf/0", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/PartialUrlProvides/anyOf/0", "/contracts/0/provides/0", "required property 'host' not found"),
-                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/oneOf/2/$ref/anyOf/1", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/PartialUrlProvides/anyOf/1", "/contracts/0/provides/0", "required property 'port' not found"),
-                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/oneOf/3/$ref", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ConfigValue", "/contracts/0/provides/0", "property 'basePath' is not defined in the schema and the schema does not allow additional properties; [required property 'specType' not found, required property 'config' not found]"),
+                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/else/else/else/else/$ref", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ConfigValue", "/contracts/0/provides/0", "property 'basePath' is not defined in the schema and the schema does not allow additional properties; [required property 'specType' not found, required property 'config' not found]"),
             ))
         }
 
@@ -166,12 +150,7 @@ class ConfigSchemaValidationTest {
               - provides:
                   - specs: [orders.yaml]
             """.trimIndent())).isEqualTo(invalidOutput(
-                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ProvidesEntry", "/contracts/0/provides/0", "must be valid to one and only one schema, but 0 are valid"),
-                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/oneOf/0", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ProvidesEntry/oneOf/0", "/contracts/0/provides/0", "object found, string expected"),
-                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/oneOf/1/$ref", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/FullUrlProvides", "/contracts/0/provides/0", "required property 'baseUrl' not found"),
-                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/oneOf/2/$ref/anyOf/0", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/PartialUrlProvides/anyOf/0", "/contracts/0/provides/0", "required property 'host' not found"),
-                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/oneOf/2/$ref/anyOf/1", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/PartialUrlProvides/anyOf/1", "/contracts/0/provides/0", "required property 'port' not found"),
-                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/oneOf/3/$ref", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ConfigValue", "/contracts/0/provides/0", "[required property 'specType' not found, required property 'config' not found]"),
+                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/else/else/else/else/$ref", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ConfigValue", "/contracts/0/provides/0", "[required property 'specType' not found, required property 'config' not found]"),
             ))
         }
 
@@ -186,18 +165,7 @@ class ConfigSchemaValidationTest {
                     config:
                       token: null
             """.trimIndent())).isEqualTo(invalidOutput(
-                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ProvidesEntry", "/contracts/0/provides/0", "must be valid to one and only one schema, but 0 are valid"),
-                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/oneOf/0", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ProvidesEntry/oneOf/0", "/contracts/0/provides/0", "object found, string expected"),
-                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/oneOf/1/$ref", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/FullUrlProvides", "/contracts/0/provides/0", "[property 'specType' is not defined in the schema and the schema does not allow additional properties, property 'config' is not defined in the schema and the schema does not allow additional properties]; required property 'baseUrl' not found"),
-                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/oneOf/2/$ref", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/PartialUrlProvides", "/contracts/0/provides/0", "[property 'specType' is not defined in the schema and the schema does not allow additional properties, property 'config' is not defined in the schema and the schema does not allow additional properties]"),
-                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/oneOf/2/$ref/anyOf/0", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/PartialUrlProvides/anyOf/0", "/contracts/0/provides/0", "required property 'host' not found"),
-                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/oneOf/2/$ref/anyOf/1", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/PartialUrlProvides/anyOf/1", "/contracts/0/provides/0", "required property 'port' not found"),
-                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/oneOf/3/$ref/properties/config/additionalProperties/$ref/anyOf/0", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ConfigValueNode/anyOf/0", "/contracts/0/provides/0/config/token", "null found, string expected"),
-                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/oneOf/3/$ref/properties/config/additionalProperties/$ref/anyOf/1", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ConfigValueNode/anyOf/1", "/contracts/0/provides/0/config/token", "null found, integer expected"),
-                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/oneOf/3/$ref/properties/config/additionalProperties/$ref/anyOf/2", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ConfigValueNode/anyOf/2", "/contracts/0/provides/0/config/token", "null found, number expected"),
-                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/oneOf/3/$ref/properties/config/additionalProperties/$ref/anyOf/3", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ConfigValueNode/anyOf/3", "/contracts/0/provides/0/config/token", "null found, boolean expected"),
-                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/oneOf/3/$ref/properties/config/additionalProperties/$ref/anyOf/4", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ConfigValueNode/anyOf/4", "/contracts/0/provides/0/config/token", "null found, array expected"),
-                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/oneOf/3/$ref/properties/config/additionalProperties/$ref/anyOf/5", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ConfigValueNode/anyOf/5", "/contracts/0/provides/0/config/token", "null found, object expected"),
+                detail($$"/properties/contracts/items/$ref/properties/provides/items/$ref/else/else/else/else/$ref/properties/config/additionalProperties/$ref", "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ConfigValueNode", "/contracts/0/provides/0/config/token", "null found, [string, integer, number, boolean, array, object] expected"),
             ))
         }
 
@@ -213,6 +181,13 @@ class ConfigSchemaValidationTest {
                 keywordLocation = $$"/properties/contracts/items/$ref/properties/web/$ref",
                 absoluteKeywordLocation = "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/WebContractSource",
             )))
+        }
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("io.specmatic.core.config.validation.ConfigSchemaValidationTest#v2ProtocolOptionCases")
+        fun `rejects invalid known V2 protocol options`(testCase: InvalidSchemaCase) {
+            assertThat(schema(testCase.version, testCase.json))
+                .isEqualTo(invalidOutput(detail(testCase)))
         }
     }
 
@@ -322,10 +297,8 @@ class ConfigSchemaValidationTest {
                   git: {}
                   filesystem: {}
             """.trimIndent())).isEqualTo(invalidOutput(
-                detail($$"/properties/components/$ref/properties/sources/additionalProperties/$ref", "https://specmatic.io/internal-schema/config-v3-resolved.schema.json#/definitions/SourceSchema", "/components/sources/bad", "Choose exactly one source provider: git, filesystem, or web."),
-                detail($$"/properties/components/$ref/properties/sources/additionalProperties/$ref/oneOf/0/$ref", "https://specmatic.io/internal-schema/config-v3-resolved.schema.json#/definitions/GitSourceSchema", "/components/sources/bad", "property 'filesystem' is not defined in the schema and the schema does not allow additional properties"),
-                detail($$"/properties/components/$ref/properties/sources/additionalProperties/$ref/oneOf/1/$ref", "https://specmatic.io/internal-schema/config-v3-resolved.schema.json#/definitions/FileSystemSourceSchema", "/components/sources/bad", "property 'git' is not defined in the schema and the schema does not allow additional properties"),
-                detail($$"/properties/components/$ref/properties/sources/additionalProperties/$ref/oneOf/2/$ref", "https://specmatic.io/internal-schema/config-v3-resolved.schema.json#/definitions/WebSourceSchema", "/components/sources/bad", "[property 'git' is not defined in the schema and the schema does not allow additional properties, property 'filesystem' is not defined in the schema and the schema does not allow additional properties]; required property 'web' not found"),
+                detail($$"/properties/components/$ref/properties/sources/additionalProperties/$ref/allOf/0/then/$ref", "https://specmatic.io/internal-schema/config-v3-resolved.schema.json#/definitions/GitSourceSchema", "/components/sources/bad", "property 'filesystem' is not defined in the schema and the schema does not allow additional properties"),
+                detail($$"/properties/components/$ref/properties/sources/additionalProperties/$ref/allOf/1/then/$ref", "https://specmatic.io/internal-schema/config-v3-resolved.schema.json#/definitions/FileSystemSourceSchema", "/components/sources/bad", "property 'git' is not defined in the schema and the schema does not allow additional properties"),
             ))
         }
 
@@ -340,9 +313,7 @@ class ConfigSchemaValidationTest {
                     file: server.jks
                     directory: certs
             """.trimIndent())).isEqualTo(invalidOutput(
-                detail($$"/properties/components/$ref/properties/certificates/additionalProperties/$ref/properties/keyStore/$ref", "https://specmatic.io/internal-schema/config-v3-resolved.schema.json#/definitions/KeyStoreConfiguration", "/components/certificates/bad/keyStore", "Specify exactly one key-store form: file or directory."),
-                detail($$"/properties/components/$ref/properties/certificates/additionalProperties/$ref/properties/keyStore/$ref/oneOf/0/$ref", "https://specmatic.io/internal-schema/config-v3-resolved.schema.json#/definitions/KeyStoreFileConfiguration", "/components/certificates/bad/keyStore", "property 'directory' is not defined in the schema and the schema does not allow additional properties"),
-                detail($$"/properties/components/$ref/properties/certificates/additionalProperties/$ref/properties/keyStore/$ref/oneOf/1/$ref", "https://specmatic.io/internal-schema/config-v3-resolved.schema.json#/definitions/KeyStoreDirectoryConfiguration", "/components/certificates/bad/keyStore", "property 'file' is not defined in the schema and the schema does not allow additional properties"),
+                detail($$"/properties/components/$ref/properties/certificates/additionalProperties/$ref/properties/keyStore/$ref/allOf/0/then/$ref", "https://specmatic.io/internal-schema/config-v3-resolved.schema.json#/definitions/KeyStoreFileConfiguration", "/components/certificates/bad/keyStore", "property 'directory' is not defined in the schema and the schema does not allow additional properties"),
             ))
         }
 
@@ -361,11 +332,438 @@ class ConfigSchemaValidationTest {
                 absoluteKeywordLocation = "https://specmatic.io/internal-schema/config-v3-resolved.schema.json#/definitions/McpTestRunOptions/properties/transportKind",
             )))
         }
+
+        @Test
+        fun `selects the test branch before validating component run options`() {
+            assertThat(schema(SpecmaticConfigVersion.VERSION_3, """
+            version: 3
+            components:
+              runOptions:
+                api:
+                  openapi:
+                    type: test
+                    logMode: ALL
+            """.trimIndent())).isEqualTo(invalidOutput(detail(
+                instanceLocation = "/components/runOptions/api/openapi",
+                error = "property 'logMode' is not defined in the schema and the schema does not allow additional properties",
+                keywordLocation = $$"/properties/components/$ref/properties/runOptions/additionalProperties/$ref/properties/openapi/$ref/allOf/0/then/$ref",
+                absoluteKeywordLocation = "https://specmatic.io/internal-schema/config-v3-resolved.schema.json#/definitions/OpenApiTestRunOptions",
+            )))
+        }
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("io.specmatic.core.config.validation.ConfigSchemaValidationTest#v3ProtocolOptionCases")
+        fun `rejects invalid known V3 protocol options`(testCase: InvalidSchemaCase) {
+            assertThat(schema(testCase.version, testCase.json))
+                .isEqualTo(invalidOutput(detail(testCase)))
+        }
     }
 
     companion object {
+        private const val REF = $$"$ref"
         data class ValidSchemaCase(val name: String, val json: String) {
             override fun toString(): String = name
+        }
+
+        data class InvalidSchemaCase(
+            val name: String,
+            val json: String,
+            val error: String,
+            val keywordLocation: String,
+            val instanceLocation: String,
+            val version: SpecmaticConfigVersion,
+            val absoluteKeywordLocation: String,
+        ) {
+            override fun toString(): String = name
+        }
+
+        @JvmStatic
+        fun v2ProtocolOptionCases() = listOf(
+            v2OptionCase(
+                name = "AsyncAPI replyTimeout must be an integer",
+                option = "replyTimeout: slow",
+                optionPath = "replyTimeout",
+                expectedType = "integer",
+            ),
+            v2OptionCase(
+                name = "AsyncAPI subscriberReadinessWaitTime must be an integer",
+                option = "subscriberReadinessWaitTime: soon",
+                optionPath = "subscriberReadinessWaitTime",
+                expectedType = "integer",
+            ),
+            v2OptionCase(
+                name = "AsyncAPI inMemoryBroker.port must be an integer",
+                option = "inMemoryBroker: { port: nope }",
+                optionPath = "inMemoryBroker/$REF/properties/port",
+                expectedType = "integer",
+            ),
+            v2OptionCase(
+                name = "AsyncAPI servers must be an array",
+                option = "servers: invalid",
+                optionPath = "servers",
+                expectedType = "array",
+            ),
+            v2OptionCase(
+                name = "AsyncAPI server host must be a string",
+                option = "servers: [{ host: 123, protocol: kafka }]",
+                optionPath = "servers/items/$REF/properties/host",
+                instancePath = "servers/0/host",
+                expectedType = "string",
+                errorMessage = "integer found, string expected",
+            ),
+            v2OptionCase(
+                name = "AsyncAPI schema registry kind must be supported",
+                option = "schemaRegistry: { kind: unsupported }",
+                optionPath = "schemaRegistry/$REF/properties/kind",
+                errorMessage = "does not have a value in the enumeration [\"CONFLUENT\", \"DEFAULT\"]",
+            ),
+            v2OptionCase(
+                name = "GraphQL host must be a string",
+                specType = "graphqlsdl",
+                option = "host: 123",
+                optionPath = "host",
+                expectedType = "string",
+                errorMessage = "integer found, string expected",
+            ),
+            v2OptionCase(
+                name = "GraphQL port must be an integer",
+                specType = "graphqlsdl",
+                option = "port: nope",
+                optionPath = "port",
+                expectedType = "integer",
+            ),
+            v2OptionCase(
+                name = "gRPC host must be a string",
+                specType = "protobuf",
+                option = "host: 123",
+                optionPath = "host",
+                expectedType = "string",
+                errorMessage = "integer found, string expected",
+            ),
+            v2OptionCase(
+                name = "gRPC port must be an integer",
+                specType = "protobuf",
+                option = "port: nope",
+                optionPath = "port",
+                expectedType = "integer",
+            ),
+            v2OptionCase(
+                name = "gRPC importPaths must be an array",
+                specType = "protobuf",
+                option = "importPaths: invalid",
+                optionPath = "importPaths",
+                expectedType = "array",
+            ),
+            v2OptionCase(
+                name = "gRPC protocVersion must be a string",
+                specType = "protobuf",
+                option = "protocVersion: 3",
+                optionPath = "protocVersion",
+                expectedType = "string",
+                errorMessage = "integer found, string expected",
+            ),
+            v2OptionCase(
+                name = "gRPC requestTimeout must be an integer",
+                specType = "protobuf",
+                option = "requestTimeout: slow",
+                optionPath = "requestTimeout",
+                expectedType = "integer",
+            ),
+        )
+
+        @JvmStatic
+        fun v3ProtocolOptionCases() = listOf(
+            v3OptionCase(
+                name = "AsyncAPI test replyTimeout must be an integer",
+                branch = "asyncTest",
+                option = "replyTimeout: slow",
+                optionPath = "replyTimeout",
+                expectedType = "integer",
+                schema = "AsyncApiTestRunOptions",
+            ),
+            v3OptionCase(
+                name = "AsyncAPI test subscriberReadinessWaitTime must be an integer",
+                branch = "asyncTest",
+                option = "subscriberReadinessWaitTime: soon",
+                optionPath = "subscriberReadinessWaitTime",
+                expectedType = "integer",
+                schema = "AsyncApiTestRunOptions",
+            ),
+            v3OptionCase(
+                name = "AsyncAPI test servers must be an array",
+                branch = "asyncTest",
+                option = "servers: invalid",
+                optionPath = "servers",
+                expectedType = "array",
+                schema = "AsyncApiTestRunOptions",
+            ),
+            v3OptionCase(
+                name = "AsyncAPI server client consumer must be an object",
+                branch = "asyncTest",
+                option = """
+                servers:
+                  - host: localhost:9092
+                    protocol: kafka
+                    client:
+                      consumer: invalid
+                """.trimIndent(),
+                optionPath = "servers/items/$REF/properties/client/$REF/properties/consumer",
+                instancePath = "servers/0/client/consumer",
+                expectedType = "object",
+                schema = "AsyncClientProperties",
+            ),
+            v3OptionCase(
+                name = "AsyncAPI test schema registry must be an object",
+                branch = "asyncTest",
+                option = "schemaRegistry: invalid",
+                optionPath = "schemaRegistry/$REF",
+                expectedType = "object",
+                schema = "SchemaRegistryProperties",
+            ),
+            v3OptionCase(
+                name = "AsyncAPI mock inMemoryBroker.port must be an integer",
+                branch = "asyncMock",
+                option = "inMemoryBroker: { port: nope }",
+                optionPath = "inMemoryBroker/$REF/properties/port",
+                expectedType = "integer",
+                schema = "InMemoryBrokerConfiguration",
+            ),
+            v3OptionCase(
+                name = "AsyncAPI mock servers must be an array",
+                branch = "asyncMock",
+                option = "servers: invalid",
+                optionPath = "servers",
+                expectedType = "array",
+                schema = "AsyncApiMockRunOptions",
+            ),
+            v3OptionCase(
+                name = "AsyncAPI mock schema registry must be an object",
+                branch = "asyncMock",
+                option = "schemaRegistry: invalid",
+                optionPath = "schemaRegistry/$REF",
+                expectedType = "object",
+                schema = "SchemaRegistryProperties",
+            ),
+            v3OptionCase(
+                name = "GraphQL test host must be a string",
+                branch = "graphqlTest",
+                protocol = "graphqlsdl",
+                option = "host: 123",
+                optionPath = "host",
+                expectedType = "string",
+                errorMessage = "integer found, string expected",
+                schema = "GraphqlSdlTestRunOptions",
+            ),
+            v3OptionCase(
+                name = "GraphQL test port must be an integer",
+                branch = "graphqlTest",
+                protocol = "graphqlsdl",
+                option = "port: nope",
+                optionPath = "port",
+                expectedType = "integer",
+                schema = "GraphqlSdlTestRunOptions",
+            ),
+            v3OptionCase(
+                name = "GraphQL mock host must be a string",
+                branch = "graphqlMock",
+                protocol = "graphqlsdl",
+                option = "host: 123",
+                optionPath = "host",
+                expectedType = "string",
+                errorMessage = "integer found, string expected",
+                schema = "GraphqlSdlMockRunOptions",
+            ),
+            v3OptionCase(
+                name = "GraphQL mock port must be an integer",
+                branch = "graphqlMock",
+                protocol = "graphqlsdl",
+                option = "port: nope",
+                optionPath = "port",
+                expectedType = "integer",
+                schema = "GraphqlSdlMockRunOptions",
+            ),
+            v3OptionCase(
+                name = "gRPC test host must be a string",
+                branch = "grpcTest",
+                protocol = "protobuf",
+                option = "host: 123",
+                optionPath = "host",
+                expectedType = "string",
+                errorMessage = "integer found, string expected",
+                schema = "ProtobufTestRunOptions",
+            ),
+            v3OptionCase(
+                name = "gRPC test port must be an integer",
+                branch = "grpcTest",
+                protocol = "protobuf",
+                option = "port: nope",
+                optionPath = "port",
+                expectedType = "integer",
+                schema = "ProtobufTestRunOptions",
+            ),
+            v3OptionCase(
+                name = "gRPC test importPaths must be an array",
+                branch = "grpcTest",
+                protocol = "protobuf",
+                option = "importPaths: invalid",
+                optionPath = "importPaths",
+                expectedType = "array",
+                schema = "ProtobufTestRunOptions",
+            ),
+            v3OptionCase(
+                name = "gRPC test protocVersion must be a string",
+                branch = "grpcTest",
+                protocol = "protobuf",
+                option = "protocVersion: 3",
+                optionPath = "protocVersion",
+                expectedType = "string",
+                errorMessage = "integer found, string expected",
+                schema = "ProtobufTestRunOptions",
+            ),
+            v3OptionCase(
+                name = "gRPC test requestTimeout must be an integer",
+                branch = "grpcTest",
+                protocol = "protobuf",
+                option = "requestTimeout: slow",
+                optionPath = "requestTimeout",
+                expectedType = "integer",
+                schema = "ProtobufTestRunOptions",
+            ),
+            v3OptionCase(
+                name = "gRPC mock port must be an integer",
+                branch = "grpcMock",
+                protocol = "protobuf",
+                option = "port: nope",
+                optionPath = "port",
+                expectedType = "integer",
+                schema = "ProtobufMockRunOptions",
+            ),
+            v3OptionCase(
+                name = "gRPC mock importPaths must be an array",
+                branch = "grpcMock",
+                protocol = "protobuf",
+                option = "importPaths: invalid",
+                optionPath = "importPaths",
+                expectedType = "array",
+                schema = "ProtobufMockRunOptions",
+            ),
+            v3OptionCase(
+                name = "gRPC mock protocVersion must be a string",
+                branch = "grpcMock",
+                protocol = "protobuf",
+                option = "protocVersion: 3",
+                optionPath = "protocVersion",
+                expectedType = "string",
+                errorMessage = "integer found, string expected",
+                schema = "ProtobufMockRunOptions",
+            ),
+        )
+
+        private fun v2OptionCase(
+            name: String,
+            option: String,
+            optionPath: String,
+            instancePath: String? = null,
+            expectedType: String? = null,
+            errorMessage: String? = null,
+            specType: String = "asyncapi",
+        ): InvalidSchemaCase {
+            val branch = when (specType) {
+                "asyncapi" -> 0
+                "graphqlsdl" -> 1
+                "protobuf" -> 2
+                else -> error("Unsupported V2 protocol: $specType")
+            }
+
+            val schemaName = when (specType) {
+                "asyncapi" -> "AsyncConfiguration"
+                "graphqlsdl" -> "GraphqlConfiguration"
+                "protobuf" -> "GrpcConfiguration"
+                else -> error("Unsupported V2 protocol: $specType")
+            }
+
+            val schemaPath = "/properties/contracts/items/$REF/properties/provides/items/$REF/else/else/else/else/$REF"
+            val optionSchemaPath = "$schemaPath/allOf/$branch/then/properties/config/$REF/properties/$optionPath"
+            val config = buildList {
+                add("version: 2")
+                add("contracts:")
+                add("  - provides:")
+                add("      - specs: [events.yaml]")
+                add("        specType: $specType")
+                add("        config:")
+                option.lines().forEach { add("          $it") }
+            }.joinToString("\n")
+
+            return InvalidSchemaCase(
+                name = name,
+                version = SpecmaticConfigVersion.VERSION_2,
+                json = config,
+                keywordLocation = optionSchemaPath,
+                absoluteKeywordLocation = absoluteSchemaLocation(
+                    schema = when {
+                        optionPath.startsWith("inMemoryBroker/") -> "InMemoryBrokerConfiguration"
+                        optionPath.startsWith("schemaRegistry/") -> "SchemaRegistryProperties"
+                        optionPath.startsWith("servers/") -> "AsyncClientServerConfig"
+                        else -> schemaName
+                    },
+                    optionPath = optionPath,
+                    version = 2,
+                ),
+                instanceLocation = "/contracts/0/provides/0/config/${instancePath ?: instanceOptionPath(optionPath)}",
+                error = errorMessage ?: "string found, $expectedType expected",
+            )
+        }
+
+        private fun v3OptionCase(
+            name: String,
+            branch: String,
+            option: String,
+            optionPath: String,
+            instancePath: String? = null,
+            expectedType: String? = null,
+            errorMessage: String? = null,
+            schema: String,
+            protocol: String = "asyncapi",
+        ): InvalidSchemaCase {
+            val mode = if (branch.endsWith("Mock")) "mock" else "test"
+            val branchIndex = if (mode == "test") 0 else 1
+            val schemaPath = "/properties/components/$REF/properties/runOptions/additionalProperties/$REF/properties/$protocol/$REF/allOf/$branchIndex/then/$REF"
+            val optionSchemaPath = "$schemaPath/properties/$optionPath"
+            val config = buildList {
+                add("version: 3")
+                add("components:")
+                add("  runOptions:")
+                add("    $branch:")
+                add("      $protocol:")
+                add("        type: $mode")
+                option.lines().forEach { add("        $it") }
+            }.joinToString("\n")
+
+            return InvalidSchemaCase(
+                name = name,
+                version = SpecmaticConfigVersion.VERSION_3,
+                json = config,
+                keywordLocation = optionSchemaPath,
+                absoluteKeywordLocation = absoluteSchemaLocation(schema, optionPath, version = 3),
+                instanceLocation = "/components/runOptions/$branch/$protocol/${instancePath ?: instanceOptionPath(optionPath)}",
+                error = errorMessage ?: if (optionPath.endsWith("/$REF")) "string found, object expected" else "string found, $expectedType expected",
+            )
+        }
+
+        private fun absoluteSchemaLocation(schema: String, optionPath: String, version: Int): String {
+            val path = when {
+                optionPath.endsWith("/$REF") -> ""
+                optionPath.contains("/$REF/properties/") -> "/properties/${optionPath.substringAfterLast("/properties/")}"
+                else -> "/properties/$optionPath"
+            }
+
+            return "https://specmatic.io/internal-schema/config-v$version-resolved.schema.json#/definitions/$schema$path"
+        }
+
+        private fun instanceOptionPath(optionPath: String): String = when {
+            optionPath.endsWith("/$REF") -> optionPath.removeSuffix("/$REF")
+            optionPath.contains("/$REF/properties/") -> optionPath.substringBefore("/$REF") + "/" + optionPath.substringAfterLast("/properties/")
+            else -> optionPath
         }
 
         @JvmStatic
@@ -425,6 +823,54 @@ class ConfigSchemaValidationTest {
                           enabled: true
                           extra:
                             region: test
+                """.trimIndent(),
+            ),
+            ValidSchemaCase(
+                name = "known AsyncAPI, GraphQL and gRPC options with extensions",
+                json = """
+                version: 2
+                contracts:
+                  - provides:
+                      - specs: [events.yaml]
+                        specType: asyncapi
+                        config:
+                          replyTimeout: 10000
+                          subscriberReadinessWaitTime: 100
+                          inMemoryBroker:
+                            logDir: broker-logs
+                            host: localhost
+                            port: 9092
+                          servers:
+                            - host: localhost:9092
+                              protocol: kafka
+                              adminCredentials:
+                                username: admin
+                              client:
+                                consumer:
+                                  group: tests
+                                producer:
+                                  acks: all
+                          schemaRegistry:
+                            kind: DEFAULT
+                          extension:
+                            enabled: true
+                  - provides:
+                      - specs: [schema.graphql]
+                        specType: graphqlsdl
+                        config:
+                          host: localhost
+                          port: 9001
+                          extension: enabled
+                  - provides:
+                      - specs: [service.proto]
+                        specType: protobuf
+                        config:
+                          host: localhost
+                          port: 9002
+                          importPaths: [proto]
+                          protocVersion: 3.25.0
+                          requestTimeout: 5000
+                          extension: enabled
                 """.trimIndent(),
             ),
         )
@@ -488,11 +934,81 @@ class ConfigSchemaValidationTest {
                   services: []
                 """.trimIndent(),
             ),
+            ValidSchemaCase(
+                name = "known AsyncAPI, GraphQL and gRPC run options with extensions",
+                json = """
+                version: 3
+                components:
+                  runOptions:
+                    asyncTest:
+                      asyncapi:
+                        type: test
+                        replyTimeout: 10000
+                        subscriberReadinessWaitTime: 100
+                        servers:
+                          - host: localhost:9092
+                            protocol: kafka
+                            adminCredentials:
+                              username: admin
+                            client:
+                              consumer:
+                                group: tests
+                              producer:
+                                acks: all
+                        schemaRegistry:
+                          kind: DEFAULT
+                        extension:
+                          enabled: true
+                    asyncMock:
+                      asyncapi:
+                        type: mock
+                        inMemoryBroker:
+                          logDir: broker-logs
+                          host: localhost
+                          port: 9093
+                        servers:
+                          - host: localhost:9093
+                            protocol: kafka
+                        schemaRegistry:
+                          kind: DEFAULT
+                    graphqlTest:
+                      graphqlsdl:
+                        type: test
+                        host: localhost
+                        port: 9001
+                    graphqlMock:
+                      graphqlsdl:
+                        type: mock
+                        host: localhost
+                        port: 9002
+                    grpcTest:
+                      protobuf:
+                        type: test
+                        host: localhost
+                        port: 9003
+                        importPaths: [proto]
+                        protocVersion: 3.25.0
+                        requestTimeout: 5000
+                    grpcMock:
+                      protobuf:
+                        type: mock
+                        port: 9004
+                        importPaths: [proto]
+                        protocVersion: 3.25.0
+                """.trimIndent(),
+            ),
         )
     }
 
     private fun invalidOutput(vararg details: ConfigValidationOutput) = details.toList()
     private fun schema(version: SpecmaticConfigVersion, json: String) = validator.validate(version, objectMapper.readTree(json))
+    private fun detail(testCase: InvalidSchemaCase) = detail(
+        error = testCase.error,
+        keywordLocation = testCase.keywordLocation,
+        instanceLocation = testCase.instanceLocation,
+        absoluteKeywordLocation = testCase.absoluteKeywordLocation,
+    )
+
     private fun detail(
         keywordLocation: String,
         absoluteKeywordLocation: String,

--- a/core/src/test/kotlin/io/specmatic/core/config/validation/SpecmaticConfigValidatorTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/validation/SpecmaticConfigValidatorTest.kt
@@ -125,7 +125,7 @@ class SpecmaticConfigValidatorTest {
 
             assertThat(output.single().metadata).isEqualTo(metadata)
             assertThat(outputJson.encodeToString(output)).isEqualTo(
-                """[{"valid":false,"error":"invalid","keywordLocation":"","instanceLocation":"/report","absoluteKeywordLocation":"urn:specmatic:config:v2","severity":"ERROR"}]"""
+                """[{"valid":false,"error":"invalid","keywordLocation":"","instanceLocation":"/report","absoluteKeywordLocation":"urn:specmatic:config:v2","severity":"ERROR","metadata":{"title":"Report","keyword":"required","description":"Report configuration","deprecated":true,"deprecationMessage":"Replace with replacement."}}]"""
             )
         }
     }

--- a/core/src/test/kotlin/io/specmatic/core/config/validation/SpecmaticConfigValidatorTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/validation/SpecmaticConfigValidatorTest.kt
@@ -1,0 +1,167 @@
+package io.specmatic.core.config.validation
+
+import io.specmatic.core.config.SpecmaticConfigVersion
+import kotlinx.serialization.json.Json
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+
+class SpecmaticConfigValidatorTest {
+    private val validator = SpecmaticConfigValidator()
+    private val outputJson = Json { encodeDefaults = true }
+
+    @Nested
+    inner class Binding {
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("io.specmatic.core.config.validation.SpecmaticConfigValidatorTest#validConfigurationCases")
+        fun `accepts configurations that bind successfully`(testCase: ValidConfigurationCase) {
+            assertThat(validator.validate(testCase.configuration))
+                .isEqualTo(ConfigValidationResult.Valid(testCase.version))
+        }
+    }
+
+    @Nested
+    inner class InputParsing {
+        @Test
+        fun `returns standard output for a parse failure`() {
+            assertThat(validator.validate("version: [")).isEqualTo(
+                ConfigValidationResult.Invalid(
+                    version = null,
+                    output = semanticOutput("/", "Configuration could not be parsed as YAML or JSON.")
+                )
+            )
+        }
+
+        @Test
+        fun `returns standard output for a non literal version`() {
+            assertThat(validator.validate($$"version: '${VERSION:2}'")).isEqualTo(
+                ConfigValidationResult.Invalid(
+                    version = null,
+                    output = semanticOutput("/version", "Configuration validation supports only a literal integer version 1, 2, or 3.")
+                )
+            )
+        }
+    }
+
+    @Nested
+    inner class SchemaPipeline {
+        @Test
+        fun `returns standard output for a schema failure and does not bind it`() {
+            val result = validator.validate("version: 2\nreport: invalid")
+            assertThat(result).isEqualTo(
+                ConfigValidationResult.Invalid(
+                    version = SpecmaticConfigVersion.VERSION_2,
+                    output = invalidOutput(
+                        detail = ConfigValidationOutput(
+                            valid = false,
+                            instanceLocation = "/report",
+                            error = "string found, object expected",
+                            keywordLocation = $$"/properties/report/$ref",
+                            absoluteKeywordLocation = "https://specmatic.io/internal-schema/config-v2-resolved.schema.json#/definitions/ReportConfigurationDetails",
+                            metadata = ConfigValidationMetadata(
+                                keyword = $$"$ref",
+                                title = "Reporting configuration",
+                                description = "Report types and API-coverage thresholds.",
+                            ),
+                        )
+                    )
+                )
+            )
+        }
+
+        @Test
+        fun `returns schema validation before typed semantic validation`() {
+            val result = validator.validate("""
+            version: 3
+            systemUnderTest: {}
+            """.trimIndent())
+
+            assertThat(result).isEqualTo(
+                ConfigValidationResult.Invalid(
+                    version = SpecmaticConfigVersion.VERSION_3,
+                    output = invalidOutput(
+                        detail = ConfigValidationOutput(
+                            valid = false,
+                            instanceLocation = "/systemUnderTest",
+                            error = "required property 'service' not found",
+                            keywordLocation = $$"/properties/systemUnderTest/$ref",
+                            absoluteKeywordLocation = "https://specmatic.io/internal-schema/config-v3-resolved.schema.json#/definitions/SystemUnderTestServiceDefinition",
+                            metadata = ConfigValidationMetadata(
+                                keyword = $$"$ref",
+                                title = "System under test",
+                                description = "The single service Specmatic exercises as the system under test.",
+                            ),
+                        )
+                    )
+                )
+            )
+        }
+    }
+
+    @Nested
+    inner class OutputSerialization {
+        @Test
+        fun `serializes validation output with kotlinx serialization`() {
+            val metadata = ConfigValidationMetadata(
+                title = "Report",
+                keyword = "required",
+                deprecated = true,
+                description = "Report configuration",
+                deprecationMessage = "Replace with replacement.",
+            )
+
+            val output = listOf(
+                element = ConfigValidationOutput(
+                    valid = false,
+                    error = "invalid",
+                    metadata = metadata,
+                    keywordLocation = "",
+                    instanceLocation = "/report",
+                    absoluteKeywordLocation = "urn:specmatic:config:v2",
+                )
+            )
+
+            assertThat(output.single().metadata).isEqualTo(metadata)
+            assertThat(outputJson.encodeToString(output)).isEqualTo(
+                """[{"valid":false,"error":"invalid","keywordLocation":"","instanceLocation":"/report","absoluteKeywordLocation":"urn:specmatic:config:v2","severity":"ERROR"}]"""
+            )
+        }
+    }
+
+    companion object {
+        data class ValidConfigurationCase(val name: String, val version: SpecmaticConfigVersion, val configuration: String) {
+            override fun toString(): String = name
+        }
+
+        @JvmStatic
+        fun validConfigurationCases() = listOf(
+            ValidConfigurationCase(
+                configuration = "version: 1",
+                version = SpecmaticConfigVersion.VERSION_1,
+                name = "V1 binding without schema validation",
+            ),
+            ValidConfigurationCase(
+                version = SpecmaticConfigVersion.VERSION_2,
+                name = "V2 after production template resolution",
+                configuration = $$"version: 2\nhooks:\n  preSpecmaticRequestProcessor: '${HOOK:script}'",
+            ),
+            ValidConfigurationCase(
+                name = "minimal V3",
+                configuration = "version: 3",
+                version = SpecmaticConfigVersion.VERSION_3,
+            ),
+        )
+    }
+
+    private fun invalidOutput(detail: ConfigValidationOutput) = listOf(detail)
+    private fun semanticOutput(instanceLocation: String, message: String) = listOf(
+        element = ConfigValidationOutput(
+            valid = false,
+            error = message,
+            keywordLocation = "",
+            instanceLocation = instanceLocation,
+        )
+    )
+}


### PR DESCRIPTION
## What

Add the following command:

```text
specmatic config validate
```

The command supports:
- `--input <path>` for validating a specific configuration file.
- `--format text|json` for human-readable or machine-readable output.
- Exit code `0` for valid configuration.
- Exit code `1` for invalid or unreadable configuration.

## Why

Users need a direct way to validate their Specmatic configuration before running tests, mocks, or other commands.

The command provides clear source-oriented diagnostics for terminal use while preserving structured output for automation and CI.

## How

- Reuse the existing configuration-validation backend.
- Validate resolved configuration schemas using standard NetworkNT output.
- Add typed reference validation where schema validation cannot express the relationship.
- Preserve validation metadata and severity through kotlinx serialization.
- Render text diagnostics using SnakeYAML source marks.
- Defer configuration-dependent command initialization so explicit validation is not affected by unrelated command setup.

## Checklist

- [x] Unit Tests
- [ ] Build passing locally 
- [ ] Sonar Quality Gate — CI
- [ ] Security scans don't report any vulnerabilities — CI
- [ ] Documentation added/updated — N/A
- [ ] Sample Project added/updated — N/A
- [ ] Demo video — N/A
- [ ] Article on Website — N/A
- [ ] Roadmap updated — N/A
- [ ] Conference Talk — N/A