### PR TITLE
Preserve transient identity in example validation hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ Each release section should stand on its own and describe the behavior shipped i
 - When generating notes for downstream repos, this repo is consumed by:
   - `enterprise`, bumped in `enterprise/gradle.properties` via `specmaticVersion`
 
+## Unreleased
+
+### Changed
+
+- Example validation now passes the full parsed example into `AfterLoadingStaticExamples`, including transient identity from `"transient": true` or `"http-stub-id"`, so hooks can distinguish transient and persistent examples.
+
 ## 2.54.1 (2026-09-07)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,12 +30,6 @@ Each release section should stand on its own and describe the behavior shipped i
 - When generating notes for downstream repos, this repo is consumed by:
   - `enterprise`, bumped in `enterprise/gradle.properties` via `specmaticVersion`
 
-## Unreleased
-
-### Changed
-
-- Example validation now passes the full parsed example into `AfterLoadingStaticExamples`, including transient identity from `"transient": true` or `"http-stub-id"`, so hooks can distinguish transient and persistent examples.
-
 ## 2.54.1 (2026-09-07)
 
 ### Changed

--- a/core/src/main/kotlin/io/specmatic/core/examples/module/ExampleValidationModule.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/module/ExampleValidationModule.kt
@@ -193,7 +193,7 @@ class ExampleValidationModule(private val lenientMode: Boolean = false, private 
     }
 
     fun callLifecycleHook(feature: Feature, examples: List<ExampleFromFile>): Result {
-        val scenarioStubs = examples.map { ScenarioStub(request = it.request, filePath = it.file.path) }
+        val scenarioStubs = examples.map { it.scenarioStub }
         return LifecycleHooks.afterLoadingStaticExamples.call(
             ExamplesUsedFor.Validation,
             listOf(Pair(feature, scenarioStubs))

--- a/core/src/test/kotlin/io/specmatic/core/examples/module/ExampleValidationModuleTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/examples/module/ExampleValidationModuleTest.kt
@@ -3,6 +3,9 @@ package io.specmatic.core.examples.module
 import io.specmatic.conversions.ExampleFromFile
 import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.core.*
+import io.specmatic.core.examples.server.ExampleMismatchMessages
+import io.specmatic.core.lifecycle.AfterLoadingStaticExamples
+import io.specmatic.core.lifecycle.LifecycleHooks
 import io.specmatic.core.pattern.*
 import io.specmatic.core.utilities.Flags
 import io.specmatic.core.value.JSONObjectValue
@@ -10,7 +13,6 @@ import io.specmatic.core.value.NumberValue
 import io.specmatic.core.value.StringValue
 import io.specmatic.mock.ScenarioStub
 import io.specmatic.core.StandardRuleViolation
-import io.specmatic.core.examples.server.ExampleMismatchMessages
 import io.specmatic.license.core.SpecmaticProtocol
 import io.specmatic.reporter.model.SpecType
 import io.specmatic.toViolationReportString
@@ -778,6 +780,71 @@ class ExampleValidationModuleTest {
                 }
             )
         }
+    }
+
+    @Test
+    fun `callLifecycleHook preserves stubToken and filePath for transient and persistent examples`(@TempDir tempDir: File) {
+        val feature = OpenApiSpecification
+            .fromFile(XML_ONEOF_CONTRACT_WITH_INLINE_EXAMPLES.path)
+            .toFeature()
+
+        val persistentFile = tempDir.resolve("persistent.json")
+        persistentFile.writeText(
+            """
+            {
+              "http-request": { "method": "POST", "path": "/documents", "body": { "type": "document", "title": "Doc" } },
+              "http-response": { "status": 200, "body": { "id": "1" } }
+            }
+            """.trimIndent()
+        )
+        val transientFile = tempDir.resolve("transient.json")
+        transientFile.writeText(
+            """
+            {
+              "transient": true,
+              "http-request": { "method": "POST", "path": "/documents", "body": { "type": "document", "title": "Doc" } },
+              "http-response": { "status": 200, "body": { "id": "2" } }
+            }
+            """.trimIndent()
+        )
+        val stubIdFile = tempDir.resolve("stub-id.json")
+        stubIdFile.writeText(
+            """
+            {
+              "http-stub-id": "token-1",
+              "http-request": { "method": "POST", "path": "/documents", "body": { "type": "document", "title": "Doc" } },
+              "http-response": { "status": 200, "body": { "id": "3" } }
+            }
+            """.trimIndent()
+        )
+
+        val captured = mutableListOf<ScenarioStub>()
+        val hook = AfterLoadingStaticExamples { _, examples ->
+            captured += examples.flatMap { it.second }
+            Result.Success()
+        }
+        LifecycleHooks.afterLoadingStaticExamples.register(hook)
+        try {
+            val result = exampleValidationModule.callLifecycleHook(
+                feature,
+                listOf(
+                    ExampleFromFile(persistentFile, strictMode = false),
+                    ExampleFromFile(transientFile, strictMode = false),
+                    ExampleFromFile(stubIdFile, strictMode = false),
+                )
+            )
+            assertThat(result.isSuccess()).isTrue()
+        } finally {
+            LifecycleHooks.afterLoadingStaticExamples.remove(hook)
+        }
+
+        assertThat(captured).hasSize(3)
+        assertThat(captured[0].stubToken).isNull()
+        assertThat(captured[0].filePath).isEqualTo(persistentFile.path)
+        assertThat(captured[1].stubToken).isNotNull()
+        assertThat(captured[1].filePath).isEqualTo(transientFile.path)
+        assertThat(captured[2].stubToken).isEqualTo("token-1")
+        assertThat(captured[2].filePath).isEqualTo(stubIdFile.path)
     }
 
     private fun ScenarioStub.toPartialExample(tempDir: File): File {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- `ExampleValidationModule.callLifecycleHook` now passes the full parsed `ScenarioStub` into `AfterLoadingStaticExamples`, including `stubToken` from `"transient": true` or `"http-stub-id"`.
- Adds a unit test that asserts transient and persistent stubs keep their identity and file path through the hook.
- No CHANGELOG entry: this is not a customer-facing behavior change on its own.

## Why

Enterprise competing-example detection needs to know which examples are transient. The previous request-only reconstruction always dropped `stubToken`, so every validated file looked persistent.

## Test plan

- [x] `./gradlew :specmatic-core:test --tests "io.specmatic.core.examples.module.ExampleValidationModuleTest.callLifecycleHook*"`
- [x] CI green on this branch

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0b9aad8-8eb9-4c7c-a8be-9dc5511bc164?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0b9aad8-8eb9-4c7c-a8be-9dc5511bc164&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

