### PR TITLE
Add protocol-aware configuration validation

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/config/v3/ProtocolConfigValidator.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/ProtocolConfigValidator.kt
@@ -1,0 +1,17 @@
+package io.specmatic.core.config.v3
+
+import io.specmatic.core.config.validation.ConfigValidationOutput
+import io.specmatic.core.config.v3.components.runOptions.RunOptionType
+import io.specmatic.core.config.v3.components.services.SpecificationDefinition
+import io.specmatic.reporter.model.SpecType
+import java.io.File
+
+interface ProtocolConfigValidator {
+    fun supports(specType: SpecType, runOptionType: RunOptionType): Boolean
+    fun validate(
+        specification: File,
+        context: ValidationContext,
+        configuration: Map<String, Any>,
+        definition: SpecificationDefinition,
+    ): List<ConfigValidationOutput>
+}

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/ValidationContext.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/ValidationContext.kt
@@ -1,10 +1,19 @@
 package io.specmatic.core.config.v3
 
+import io.specmatic.core.config.v3.components.runOptions.RunOptionType
+import io.specmatic.core.config.v3.components.services.SpecificationDefinition
 import io.specmatic.core.config.validation.ConfigValidationMetadata
 import io.specmatic.core.config.validation.ConfigValidationOutput
 import io.specmatic.core.config.validation.ConfigValidationSeverity
+import io.specmatic.reporter.model.SpecType
+import java.io.File
+import java.util.ServiceLoader
 
-data class ValidationContext(val resolver: RefOrValueResolver, private val location: String = "") {
+data class ValidationContext(
+    val location: String = "",
+    val resolver: RefOrValueResolver,
+    val protocolConfigValidators: List<ProtocolConfigValidator> = ServiceLoader.load(ProtocolConfigValidator::class.java).toList()
+) {
     fun child(segment: String): ValidationContext = copy(location = "$location/$segment")
 
     fun child(index: Int): ValidationContext = child(index.toString())
@@ -40,6 +49,27 @@ data class ValidationContext(val resolver: RefOrValueResolver, private val locat
                 validate(resolved, contextFor(reference))
             }
         }
+    }
+
+    fun validateProtocolConfig(specType: SpecType, runOptionType: RunOptionType, specFile: File, definition: SpecificationDefinition, config: Map<String, Any>): List<ConfigValidationOutput> {
+        val validators = protocolConfigValidators.filter { it.supports(specType, runOptionType) }
+        return validators.flatMap { validator ->
+            runCatching {
+                validator.validate(context = this, configuration = config, definition = definition, specification = specFile)
+            }.getOrElse { failure ->
+                listOf(
+                    element = error(
+                        severity = ConfigValidationSeverity.ERROR,
+                        message = "Protocol validation failed for '${specFile.path}': ${failure.message ?: failure::class.simpleName}",
+                    )
+                )
+            }
+        }
+    }
+
+    fun <R: Any> updateWithRefOrValue(refOrValue: RefOrValue<R>?): ValidationContext {
+        if (refOrValue !is RefOrValue.Reference) return this
+        return contextFor(refOrValue)
     }
 
     private fun contextFor(reference: RefOrValue.Reference): ValidationContext {

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/AsyncApiRunOptions.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/AsyncApiRunOptions.kt
@@ -3,6 +3,10 @@ package io.specmatic.core.config.v3.components.runOptions
 import com.fasterxml.jackson.annotation.*
 import io.specmatic.core.config.ConfigPathMapper
 import io.specmatic.core.config.v3.ServerOrigin
+import io.specmatic.core.config.v3.ValidationContext
+import io.specmatic.core.config.v3.components.services.SpecificationDefinition
+import io.specmatic.core.config.validation.ConfigValidationOutput
+import io.specmatic.reporter.model.SpecType
 import java.io.File
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type", visible = true)
@@ -53,6 +57,16 @@ data class AsyncApiMockConfig(
     @JsonIgnore private val _config: MutableMap<String, Any> = linkedMapOf()
 ) : AsyncApiRunOptions {
     fun withConfig(newConfig: Map<String, Any>): AsyncApiMockConfig = copy(_config = LinkedHashMap(newConfig))
+    override fun validateForSpecFile(specFile: File, definition: SpecificationDefinition, validationContext: ValidationContext): List<ConfigValidationOutput> {
+        return validationContext.child("asyncapi").validateProtocolConfig(
+            config = config,
+            specFile = specFile,
+            definition = definition,
+            specType = SpecType.ASYNCAPI,
+            runOptionType = RunOptionType.MOCK,
+        )
+    }
+
     override fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): AsyncApiMockConfig = copy(
         specs = specs?.mapIndexed { index, spec ->
             spec.mapPaths(mapper.child("specs").child(index), configDirectory)

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/RunOptions.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/RunOptions.kt
@@ -10,6 +10,7 @@ import io.specmatic.core.config.v3.ValidationContext
 import io.specmatic.core.config.v3.resolveElseThrow
 import io.specmatic.core.config.HttpsConfiguration
 import io.specmatic.core.config.ConfigPathMapper
+import io.specmatic.core.config.v3.components.services.SpecificationDefinition
 import java.io.File
 import io.specmatic.reporter.model.SpecType
 import io.specmatic.core.config.validation.ConfigValidationOutput
@@ -19,6 +20,8 @@ interface IRunOptions {
     val config: Map<String, Any>
 
     fun mapPaths(mapper: ConfigPathMapper, configDirectory: File): IRunOptions
+
+    fun validateForSpecFile(specFile: File, definition: SpecificationDefinition, validationContext: ValidationContext): List<ConfigValidationOutput> = emptyList()
 
     @JsonIgnore
     fun gerServerOrigin(): ServerOrigin?

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/CommonServiceConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/CommonServiceConfig.kt
@@ -53,14 +53,17 @@ data class CommonServiceConfig<RunOptions : Any, Settings : Any>(
 inline fun <reified R : Any, reified S : Any> CommonServiceConfig<R, S>.validate(
     context: ValidationContext,
     crossinline validateRunOptions: (R, ValidationContext) -> List<ConfigValidationOutput> = { _, _ -> emptyList() },
+    crossinline validateDefinition: (Definition, R?, ValidationContext, ValidationContext) -> List<ConfigValidationOutput> = { _, _, _, _ -> emptyList() },
 ): List<ConfigValidationOutput> {
+    val resolvedRunOpts = runCatching { runOptions?.resolveElseThrow(context.resolver) }.getOrNull()
+    val runOptionsContext = context.child("runOptions").updateWithRefOrValue(runOptions)
     val definitionOutput = definitions.flatMapIndexed { index, definition ->
-        definition.validate(context.child("definitions").child(index))
+        val definitionContext = context.child("definitions").child(index)
+        validateDefinition(definition, resolvedRunOpts, definitionContext, runOptionsContext)
     }
 
     val runOptionsOutput = runOptions?.let { reference ->
-        val runOptionsContext = context.child("runOptions")
-        runOptionsContext.check(
+        context.child("runOptions").check(
             reference = reference,
             resolve = { value, resolver -> value.resolveElseThrow<R>(resolver) },
             validate = { value, valueContext -> validateRunOptions(value, valueContext) },

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/Definition.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/Definition.kt
@@ -3,15 +3,35 @@ package io.specmatic.core.config.v3.components.services
 import io.specmatic.core.config.ConfigPathMapper
 import io.specmatic.core.config.v3.RefOrValue
 import io.specmatic.core.config.v3.ValidationContext
+import io.specmatic.core.config.v3.components.runOptions.IRunOptions
+import io.specmatic.core.config.v3.components.runOptions.MockRunOptions
+import io.specmatic.core.config.v3.components.runOptions.TestRunOptions
 import io.specmatic.core.config.v3.resolveElseThrow
 import io.specmatic.core.config.v3.mapValue
 import io.specmatic.core.config.v3.components.sources.SourceV3
 import io.specmatic.core.config.validation.ConfigValidationOutput
+import io.specmatic.reporter.model.SpecType
 import java.io.File
 
 data class Definition(val definition: Value) {
-    fun validate(context: ValidationContext): List<ConfigValidationOutput> {
-        return definition.validate(context.child("definition"))
+    fun validate(
+        runOptions: MockRunOptions?,
+        context: ValidationContext,
+        runOptionsContext: ValidationContext,
+    ): List<ConfigValidationOutput> {
+        return definition.validate(context.child("definition"), runOptionsContext) { specType ->
+            runOptions?.getRunOptionsFor(specType)
+        }
+    }
+
+    fun validate(
+        runOptions: TestRunOptions?,
+        context: ValidationContext,
+        runOptionsContext: ValidationContext
+    ): List<ConfigValidationOutput> {
+        return definition.validate(context.child("definition"), runOptionsContext) { specType ->
+            runOptions?.getRunOptionsFor(specType)
+        }
     }
 
     fun mapPaths(
@@ -35,10 +55,16 @@ data class Definition(val definition: Value) {
     }
 
     data class Value(val source: RefOrValue<SourceV3>, val specs: List<SpecificationDefinition>) {
-        fun validate(context: ValidationContext): List<ConfigValidationOutput> {
+        fun validate(context: ValidationContext, runOptionsContext: ValidationContext, getRunOpts: (SpecType) -> IRunOptions?): List<ConfigValidationOutput> {
             return context.child("source").check(
                 reference = source,
                 resolve = { value, resolver -> value.resolveElseThrow(resolver) },
+                validate = { resolvedSource, _ ->
+                    specs.flatMapIndexed { index, definition ->
+                        val specValidationContext = context.child("specs").child(index)
+                        definition.validate(resolvedSource, specValidationContext, runOptionsContext, getRunOpts)
+                    }
+                },
             )
         }
     }

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/MockServiceConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/MockServiceConfig.kt
@@ -33,14 +33,19 @@ data class MockServiceConfig(val services: List<Value>, val data: Data? = null, 
     fun validate(context: ValidationContext): List<ConfigValidationOutput> {
         val serviceOutput = services.flatMapIndexed { index, entry ->
             val serviceContext = context.child("services").child(index).child("service")
+            val validateDefinition: (Definition, MockRunOptions?, ValidationContext, ValidationContext) -> List<ConfigValidationOutput> = {
+                definition, runOptions, definitionContext, runOptionsContext ->
+                    definition.validate(runOptions, definitionContext, runOptionsContext)
+            }
+
             val validateRunOptions: (MockRunOptions, ValidationContext) -> List<ConfigValidationOutput> = {
                 runOptions, runOptionsContext -> runOptions.validate(runOptionsContext)
             }
 
             serviceContext.check(
                 reference = entry.service,
-                validate = { value, valueContext -> value.validate(valueContext, validateRunOptions) },
                 resolve = { value, resolver -> value.resolveElseThrow<MockRunOptions, MockSettings>(resolver) },
+                validate = { value, valueContext -> value.validate(valueContext, validateRunOptions, validateDefinition) },
             )
         }
 

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/SpecificationDefinition.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/SpecificationDefinition.kt
@@ -13,12 +13,34 @@ import io.specmatic.core.SpecificationSourceEntry
 import io.specmatic.core.config.v3.ServerOrigin
 import io.specmatic.core.config.v3.components.sources.SourceV3
 import io.specmatic.core.config.ConfigPathMapper
+import io.specmatic.core.config.v3.ValidationContext
+import io.specmatic.core.config.v3.components.runOptions.IRunOptions
+import io.specmatic.core.config.v3.determineSpecTypeFor
+import io.specmatic.core.config.validation.ConfigValidationOutput
+import io.specmatic.core.config.validation.ConfigValidationSeverity
 import io.specmatic.core.utilities.Flags
+import io.specmatic.reporter.model.SpecType
 import java.io.File
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION, defaultImpl = SpecificationDefinition.StringValue::class)
 sealed interface SpecificationDefinition {
     fun mapPaths(mapper: ConfigPathMapper, baseDirectory: File): SpecificationDefinition
+
+    fun validate(source: SourceV3, validationContext: ValidationContext, runOptionsContext: ValidationContext, getRunOpts: (SpecType) -> IRunOptions?): List<ConfigValidationOutput> {
+        val specFile = runCatching { source.resolveSpecification(File(getSpecificationPath())) }.getOrElse { failure ->
+            return listOf(
+                element = validationContext.error(
+                    severity = ConfigValidationSeverity.ERROR,
+                    message = "Could not resolve specification '${getSpecificationPath()}': ${failure.message ?: failure::class.simpleName}",
+                )
+            )
+        }
+
+        val runOptions = determineSpecTypeFor(specFile).mapNotNull { getRunOpts(it) }
+        return runOptions.flatMap {
+            it.validateForSpecFile(specFile = specFile, definition = this, validationContext = runOptionsContext)
+        }
+    }
 
     data class Specification(
         val id: String? = null,

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/TestServiceConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/TestServiceConfig.kt
@@ -30,14 +30,19 @@ import java.io.File
 data class TestServiceConfig(val service: RefOrValue<CommonServiceConfig<TestRunOptions, TestSettings>>) {
     fun validate(context: ValidationContext): List<ConfigValidationOutput> {
         val serviceContext = context.child("service")
+        val validateDefinition: (Definition, TestRunOptions?, ValidationContext, ValidationContext) -> List<ConfigValidationOutput> = {
+            definition, runOptions, definitionContext, runOptionsContext ->
+                definition.validate(runOptions, definitionContext, runOptionsContext)
+        }
+
         val validateRunOptions: (TestRunOptions, ValidationContext) -> List<ConfigValidationOutput> = {
             runOptions, runOptionsContext -> runOptions.validate(runOptionsContext)
         }
 
         return serviceContext.check(
             reference = service,
-            validate = { value, valueContext -> value.validate(valueContext, validateRunOptions) },
             resolve = { value, resolver -> value.resolveElseThrow<TestRunOptions, TestSettings>(resolver) },
+            validate = { value, valueContext -> value.validate(valueContext, validateRunOptions, validateDefinition) },
         )
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/config/validation/SpecmaticConfigValidator.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/validation/SpecmaticConfigValidator.kt
@@ -9,6 +9,7 @@ import io.specmatic.core.config.resolveTemplates
 import io.specmatic.core.config.v1.SpecmaticConfigV1
 import io.specmatic.core.config.v2.SpecmaticConfigV2
 import io.specmatic.core.config.v3.SpecmaticConfigV3
+import io.specmatic.core.SpecmaticConfig
 import java.io.File
 import java.nio.file.Path
 
@@ -65,16 +66,45 @@ class SpecmaticConfigValidator(private val schemaValidator: ConfigSchemaValidato
             )
         }
 
+        val transformed = bound.transform(origin.toFile())
+        val loadErrors = loadContracts(transformed, origin)
         val semanticErrors = when (bound) {
             is SpecmaticConfigV3 -> bound.validate(origin)
             else -> emptyList()
         }
 
-        return if (semanticErrors.isEmpty()) {
+        val errors = loadErrors + semanticErrors
+        return if (errors.isEmpty()) {
             ConfigValidationResult.Valid(version)
         } else {
-            ConfigValidationResult.Invalid(version, semanticErrors)
+            ConfigValidationResult.Invalid(version, errors)
         }
+    }
+
+    private fun loadContracts(config: SpecmaticConfig, origin: Path): List<ConfigValidationOutput> {
+        val checkoutDirectory = origin.toFile().canonicalFile.parentFile.resolve(".specmatic").canonicalFile
+        return runCatching {
+            config.loadSources(config.getMatchBranchEnabled()).flatMap { source ->
+                source.loadContracts(
+                    configFilePath = origin.toFile().canonicalPath,
+                    selector = { it.testContracts + it.stubContracts },
+                    workingDirectory = checkoutDirectory.canonicalPath,
+                )
+            }
+        }.fold(
+            onSuccess = { emptyList() },
+            onFailure = { failure ->
+                listOf(
+                    element = ConfigValidationOutput(
+                        valid = false,
+                        keywordLocation = "",
+                        instanceLocation = "",
+                        severity = ConfigValidationSeverity.ERROR,
+                        error = "Could not load specification sources: ${failure.message ?: failure::class.simpleName}",
+                    )
+                )
+            }
+        )
     }
 
     private fun parse(content: String): JsonNode? = try {

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/ProtocolConfigValidatorTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/ProtocolConfigValidatorTest.kt
@@ -1,0 +1,74 @@
+package io.specmatic.core.config.v3
+
+import io.specmatic.core.config.validation.ConfigValidationOutput
+import io.specmatic.core.config.validation.ConfigValidationSeverity
+import io.specmatic.core.config.v3.components.runOptions.AsyncApiMockConfig
+import io.specmatic.core.config.v3.components.runOptions.RunOptionType
+import io.specmatic.reporter.model.SpecType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class ProtocolConfigValidatorTest {
+    @Test
+    fun `invokes matching validator for non-empty async mock config`(@TempDir tempDir: File) {
+        val validator = RecordingValidator()
+        val context = context(tempDir, validator)
+        val specification = tempDir.resolve("events.yaml")
+
+        val configuration = mapOf("servers" to listOf(mapOf("host" to "localhost")))
+        val output = AsyncApiMockConfig()
+            .withConfig(configuration)
+            .validateForSpecFile(specification, context)
+
+        assertThat(output).isEmpty()
+        assertThat(validator.calls).containsExactly(
+            Call(specification, configuration, "/dependencies/runOptions/asyncapi")
+        )
+    }
+
+    @Test
+    fun `invokes validator for empty async mock config so spec requirements are checked`(@TempDir tempDir: File) {
+        val validator = RecordingValidator()
+        val specification = tempDir.resolve("events.yaml")
+        AsyncApiMockConfig().validateForSpecFile(specification, context(tempDir, validator))
+        assertThat(validator.calls).containsExactly(Call(specification, emptyMap(), "/dependencies/runOptions/asyncapi"))
+    }
+
+    @Test
+    fun `reports validator failures as configuration errors`(@TempDir tempDir: File) {
+        val validator = RecordingValidator(failure = IllegalStateException("invalid broker configuration"))
+        val output = AsyncApiMockConfig()
+            .withConfig(mapOf("broker" to "localhost:9092"))
+            .validateForSpecFile(tempDir.resolve("events.yaml"), context(tempDir, validator))
+
+        assertThat(output).hasSize(1)
+        assertThat(output[0].severity).isEqualTo(ConfigValidationSeverity.ERROR)
+        assertThat(output[0].error).contains("invalid broker configuration")
+        assertThat(output[0].instanceLocation).isEqualTo("/dependencies/runOptions/asyncapi")
+    }
+
+    private fun context(tempDir: File, validator: RecordingValidator): ValidationContext {
+        return ValidationContext(
+            location = "/dependencies/runOptions",
+            protocolConfigValidators = listOf(validator),
+            resolver = SpecmaticConfigV3Resolver(Components(), tempDir.toPath()),
+        )
+    }
+
+    private data class Call(val specification: File, val configuration: Map<String, Any>, val location: String)
+    private class RecordingValidator(private val failure: Throwable? = null) : ProtocolConfigValidator {
+        val calls = mutableListOf<Call>()
+
+        override fun supports(specType: SpecType, runOptionType: RunOptionType): Boolean {
+            return specType == SpecType.ASYNCAPI && runOptionType == RunOptionType.MOCK
+        }
+
+        override fun validate(context: ValidationContext, specification: File, configuration: Map<String, Any>): List<ConfigValidationOutput> {
+            calls += Call(specification, configuration, context.location)
+            failure?.let { throw it }
+            return emptyList()
+        }
+    }
+}


### PR DESCRIPTION
**What**:
- Load all contracts before V2/V3 semantic validation
- Add ServiceLoader-backed protocol validator dispatch
- Route AsyncAPI mock validation through run options
- Preserve configuration locations for SPI errors

**Why**: Allow enterprise protocol implementations to validate resolved configuration against the loaded specification while keeping SPI dispatch inside core validation methods.

**How**:
- Discover validators through `ServiceLoader`
- Match validators by specification type and run-option type
- Pass the specification file, definition, configuration, and config context to validators
- Convert validator failures into standard validation output

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated — N/A
- [ ] Sample Project added/updated — N/A
- [ ] Demo video — N/A
- [ ] Article on Website — N/A
- [ ] Roadmap updated — N/A
- [ ] Conference Talk — N/A