### PR TITLE
Align protocol run-option schemas with DTOs

### DIFF
--- a/core/src/main/resources/config-validation/config-v2-resolved.schema.json
+++ b/core/src/main/resources/config-validation/config-v2-resolved.schema.json
@@ -1040,6 +1040,16 @@
         "protocol"
       ],
       "properties": {
+        "type": {
+          "type": "string",
+          "default": "external",
+          "enum": [
+            "external",
+            "in-memory"
+          ],
+          "title": "Server type",
+          "description": "Specifies whether the asynchronous server is external or in-memory."
+        },
         "host": {
           "type": "string",
           "title": "Server host",

--- a/core/src/main/resources/config-validation/config-v3-resolved.schema.json
+++ b/core/src/main/resources/config-validation/config-v3-resolved.schema.json
@@ -1729,30 +1729,21 @@
           "title": "Subscriber readiness wait time",
           "description": "Time in milliseconds to wait for an asynchronous subscriber to become ready."
         },
-        "servers": {
-          "type": "array",
-          "title": "AsyncAPI servers",
-          "description": "Server connection settings used by asynchronous tests.",
-          "items": {
-            "$ref": "#/definitions/AsyncClientServerConfig",
-            "description": "One asynchronous server connection."
-          }
-        },
-        "schemaRegistry": {
-          "$ref": "#/definitions/SchemaRegistryProperties",
-          "title": "Schema registry",
-          "description": "Schema registry settings used by asynchronous tests."
-        },
         "specs": {
           "type": "array",
           "title": "Specification overrides",
           "description": "Optional per-specification AsyncAPI overrides.",
           "items": {
-            "$ref": "#/definitions/RunOptionSpecificationEntry",
-            "description": "One protocol-neutral specification override."
+            "$ref": "#/definitions/AsyncApiTestRunOptionSpecificationEntry",
+            "description": "One AsyncAPI specification override."
           }
         }
-      }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AsyncApiCommonRunOptions"
+        }
+      ]
     },
     "AsyncApiMockRunOptions": {
       "title": "AsyncAPI mock run options",
@@ -1766,34 +1757,27 @@
           "description": "Mock branch discriminator."
         },
         "inMemoryBroker": {
+          "deprecated": true,
           "$ref": "#/definitions/InMemoryBrokerConfiguration",
           "title": "In-memory broker",
-          "description": "Optional in-memory broker settings used by asynchronous mocks."
-        },
-        "servers": {
-          "type": "array",
-          "title": "AsyncAPI servers",
-          "description": "Server connection settings used by asynchronous mocks.",
-          "items": {
-            "$ref": "#/definitions/AsyncClientServerConfig",
-            "description": "One asynchronous server connection."
-          }
-        },
-        "schemaRegistry": {
-          "$ref": "#/definitions/SchemaRegistryProperties",
-          "title": "Schema registry",
-          "description": "Schema registry settings used by asynchronous mocks."
+          "description": "Deprecated optional in-memory broker settings used by asynchronous mocks.",
+          "deprecationMessage": "Replace inMemoryBroker with a server entry within servers with 'type' set to 'in-memory'."
         },
         "specs": {
           "type": "array",
           "title": "Specification overrides",
           "description": "Optional per-specification AsyncAPI overrides.",
           "items": {
-            "$ref": "#/definitions/RunOptionSpecificationEntry",
-            "description": "One protocol-neutral specification override."
+            "$ref": "#/definitions/AsyncApiMockRunOptionSpecificationEntry",
+            "description": "One AsyncAPI specification override."
           }
         }
-      }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AsyncApiCommonRunOptions"
+        }
+      ]
     },
     "GraphqlSdlTestRunOptions": {
       "title": "GraphQL SDL test run options",
@@ -1806,26 +1790,21 @@
           "title": "Run mode",
           "description": "Test branch discriminator."
         },
-        "host": {
-          "type": "string",
-          "title": "GraphQL service host",
-          "description": "Host used by the GraphQL test server."
-        },
-        "port": {
-          "type": "integer",
-          "title": "GraphQL service port",
-          "description": "Port used by the GraphQL test server."
-        },
         "specs": {
           "type": "array",
           "title": "Specification overrides",
           "description": "Optional per-specification GraphQL SDL overrides.",
           "items": {
-            "$ref": "#/definitions/RunOptionSpecificationEntry",
-            "description": "One protocol-neutral specification override."
+            "$ref": "#/definitions/GraphqlSdlTestRunOptionSpecificationEntry",
+            "description": "One GraphQL SDL specification override."
           }
         }
-      }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/GraphqlSdlCommonRunOptions"
+        }
+      ]
     },
     "GraphqlSdlMockRunOptions": {
       "title": "GraphQL SDL mock run options",
@@ -1838,32 +1817,31 @@
           "title": "Mock mode",
           "description": "Mock branch discriminator."
         },
-        "host": {
-          "type": "string",
-          "title": "GraphQL mock host",
-          "description": "Host on which the GraphQL mock listens."
-        },
-        "port": {
-          "type": "integer",
-          "title": "GraphQL mock port",
-          "description": "Port on which the GraphQL mock listens."
-        },
         "specs": {
           "type": "array",
           "title": "Specification overrides",
           "description": "Optional per-specification GraphQL SDL overrides.",
           "items": {
-            "$ref": "#/definitions/RunOptionSpecificationEntry",
-            "description": "One protocol-neutral specification override."
+            "$ref": "#/definitions/GraphqlSdlMockRunOptionSpecificationEntry",
+            "description": "One GraphQL SDL specification override."
           }
         }
-      }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/GraphqlSdlCommonRunOptions"
+        }
+      ]
     },
     "ProtobufTestRunOptions": {
       "title": "Protobuf test run options",
       "description": "Protobuf test options with protocol-specific resolved option keys at the intentional extension boundary.",
       "type": "object",
       "additionalProperties": true,
+      "required": [
+        "host",
+        "port"
+      ],
       "properties": {
         "type": {
           "const": "test",
@@ -1875,26 +1853,6 @@
           "title": "gRPC service host",
           "description": "Host used by the gRPC test client."
         },
-        "port": {
-          "type": "integer",
-          "title": "gRPC service port",
-          "description": "Port used by the gRPC test client."
-        },
-        "importPaths": {
-          "type": "array",
-          "title": "Protobuf import paths",
-          "description": "Directories searched for imported Protobuf definitions.",
-          "items": {
-            "type": "string",
-            "title": "Protobuf import path",
-            "description": "One directory searched for imported Protobuf definitions."
-          }
-        },
-        "protocVersion": {
-          "type": "string",
-          "title": "protoc version",
-          "description": "Version of protoc used to compile Protobuf definitions."
-        },
         "requestTimeout": {
           "type": "integer",
           "title": "gRPC request timeout",
@@ -1905,11 +1863,16 @@
           "title": "Specification overrides",
           "description": "Optional per-specification Protobuf overrides.",
           "items": {
-            "$ref": "#/definitions/RunOptionSpecificationEntry",
-            "description": "One protocol-neutral specification override."
+            "$ref": "#/definitions/ProtobufTestRunOptionSpecificationEntry",
+            "description": "One Protobuf specification override."
           }
         }
-      }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProtobufCommonRunOptions"
+        }
+      ]
     },
     "ProtobufMockRunOptions": {
       "title": "Protobuf mock run options",
@@ -1922,10 +1885,69 @@
           "title": "Mock mode",
           "description": "Mock branch discriminator."
         },
+        "specs": {
+          "type": "array",
+          "title": "Specification overrides",
+          "description": "Optional per-specification Protobuf overrides.",
+          "items": {
+            "$ref": "#/definitions/ProtobufMockRunOptionSpecificationEntry",
+            "description": "One Protobuf specification override."
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProtobufCommonRunOptions"
+        }
+      ]
+    },
+    "AsyncApiCommonRunOptions": {
+      "title": "Common AsyncAPI run options",
+      "description": "AsyncAPI run-option properties shared by test and mock modes.",
+      "type": "object",
+      "properties": {
+        "servers": {
+          "type": "array",
+          "title": "AsyncAPI servers",
+          "description": "Server connection settings used by asynchronous tests and mocks.",
+          "items": {
+            "$ref": "#/definitions/AsyncClientServerConfig",
+            "description": "One asynchronous server connection."
+          }
+        },
+        "schemaRegistry": {
+          "$ref": "#/definitions/SchemaRegistryProperties",
+          "title": "Schema registry",
+          "description": "Schema registry settings used by asynchronous tests and mocks."
+        }
+      }
+    },
+    "GraphqlSdlCommonRunOptions": {
+      "title": "Common GraphQL SDL run options",
+      "description": "GraphQL SDL run-option properties shared by test and mock modes.",
+      "type": "object",
+      "properties": {
+        "host": {
+          "type": "string",
+          "title": "GraphQL service host",
+          "description": "Host used by the GraphQL service."
+        },
         "port": {
           "type": "integer",
-          "title": "gRPC mock port",
-          "description": "Port on which the gRPC mock listens."
+          "title": "GraphQL service port",
+          "description": "Port used by the GraphQL service."
+        }
+      }
+    },
+    "ProtobufCommonRunOptions": {
+      "title": "Common Protobuf run options",
+      "description": "Protobuf run-option properties shared by test and mock modes.",
+      "type": "object",
+      "properties": {
+        "port": {
+          "type": "integer",
+          "title": "gRPC service port",
+          "description": "Port used by the gRPC service."
         },
         "importPaths": {
           "type": "array",
@@ -1941,15 +1963,6 @@
           "type": "string",
           "title": "protoc version",
           "description": "Version of protoc used to compile Protobuf definitions."
-        },
-        "specs": {
-          "type": "array",
-          "title": "Specification overrides",
-          "description": "Optional per-specification Protobuf overrides.",
-          "items": {
-            "$ref": "#/definitions/RunOptionSpecificationEntry",
-            "description": "One protocol-neutral specification override."
-          }
         }
       }
     },
@@ -1963,6 +1976,16 @@
         "protocol"
       ],
       "properties": {
+        "type": {
+          "type": "string",
+          "default": "external",
+          "enum": [
+            "external",
+            "in-memory"
+          ],
+          "title": "Server type",
+          "description": "Specifies whether the asynchronous server is external or in-memory."
+        },
         "host": {
           "type": "string",
           "title": "Server host",
@@ -2064,9 +2087,9 @@
         }
       }
     },
-    "RunOptionSpecificationEntry": {
-      "title": "Run-option specification entry",
-      "description": "Wrapper containing one generic per-specification run-option override.",
+    "AsyncApiTestRunOptionSpecificationEntry": {
+      "title": "AsyncAPI test run-option specification entry",
+      "description": "Wrapper containing one AsyncAPI test per-specification run-option override.",
       "type": "object",
       "additionalProperties": false,
       "required": [
@@ -2074,9 +2097,89 @@
       ],
       "properties": {
         "spec": {
-          "$ref": "#/definitions/RunOptionSpecification",
-          "title": "Run-option override",
-          "description": "Per-specification run-option values."
+          "$ref": "#/definitions/AsyncApiTestRunOptionSpecification",
+          "title": "AsyncAPI test run-option override",
+          "description": "Per-specification AsyncAPI test run-option values."
+        }
+      }
+    },
+    "AsyncApiMockRunOptionSpecificationEntry": {
+      "title": "AsyncAPI mock run-option specification entry",
+      "description": "Wrapper containing one AsyncAPI mock per-specification run-option override.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "spec"
+      ],
+      "properties": {
+        "spec": {
+          "$ref": "#/definitions/AsyncApiMockRunOptionSpecification",
+          "title": "AsyncAPI mock run-option override",
+          "description": "Per-specification AsyncAPI mock run-option values."
+        }
+      }
+    },
+    "GraphqlSdlTestRunOptionSpecificationEntry": {
+      "title": "GraphQL SDL test run-option specification entry",
+      "description": "Wrapper containing one GraphQL SDL test per-specification run-option override.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "spec"
+      ],
+      "properties": {
+        "spec": {
+          "$ref": "#/definitions/GraphqlSdlTestRunOptionSpecification",
+          "title": "GraphQL SDL test run-option override",
+          "description": "Per-specification GraphQL SDL test run-option values."
+        }
+      }
+    },
+    "GraphqlSdlMockRunOptionSpecificationEntry": {
+      "title": "GraphQL SDL mock run-option specification entry",
+      "description": "Wrapper containing one GraphQL SDL mock per-specification run-option override.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "spec"
+      ],
+      "properties": {
+        "spec": {
+          "$ref": "#/definitions/GraphqlSdlMockRunOptionSpecification",
+          "title": "GraphQL SDL mock run-option override",
+          "description": "Per-specification GraphQL SDL mock run-option values."
+        }
+      }
+    },
+    "ProtobufTestRunOptionSpecificationEntry": {
+      "title": "Protobuf test run-option specification entry",
+      "description": "Wrapper containing one Protobuf test per-specification run-option override.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "spec"
+      ],
+      "properties": {
+        "spec": {
+          "$ref": "#/definitions/ProtobufTestRunOptionSpecification",
+          "title": "Protobuf test run-option override",
+          "description": "Per-specification Protobuf test run-option values."
+        }
+      }
+    },
+    "ProtobufMockRunOptionSpecificationEntry": {
+      "title": "Protobuf mock run-option specification entry",
+      "description": "Wrapper containing one Protobuf mock per-specification run-option override.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "spec"
+      ],
+      "properties": {
+        "spec": {
+          "$ref": "#/definitions/ProtobufMockRunOptionSpecification",
+          "title": "Protobuf mock run-option override",
+          "description": "Per-specification Protobuf mock run-option values."
         }
       }
     },
@@ -2112,16 +2215,16 @@
         }
       }
     },
-    "RunOptionSpecification": {
-      "title": "Generic run-option specification override",
-      "description": "Optional per-specification override keyed by the specification identifier. Additional keys are protocol-specific run-option values.",
+    "AsyncApiRunOptionSpecificationCommon": {
+      "title": "Common AsyncAPI run-option specification values",
+      "description": "AsyncAPI run-option specification values shared by test and mock modes.",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "id": {
           "type": "string",
           "title": "Specification ID",
-          "description": "Specification identifier this override targets. A non-matching identifier is handled as fallback behavior during semantic processing.",
+          "description": "Specification identifier this override targets.",
           "examples": [
             "orders"
           ]
@@ -2130,6 +2233,94 @@
           "type": "string",
           "title": "Overlay file path",
           "description": "Path to an overlay applied to this specification."
+        },
+        "replyTimeout": {
+          "type": "integer",
+          "title": "Reply timeout",
+          "description": "Maximum time in milliseconds to wait for an asynchronous reply."
+        },
+        "subscriberReadinessWaitTime": {
+          "type": "integer",
+          "title": "Subscriber readiness wait time",
+          "description": "Time in milliseconds to wait for an asynchronous subscriber to become ready."
+        },
+        "inMemoryBroker": {
+          "deprecated": true,
+          "$ref": "#/definitions/InMemoryBrokerConfiguration",
+          "title": "In-memory broker",
+          "description": "Deprecated optional in-memory broker settings used by asynchronous mocks.",
+          "deprecationMessage": "Replace inMemoryBroker with a server entry within servers with 'type' set to 'in-memory'."
+        },
+        "servers": {
+          "type": "array",
+          "title": "AsyncAPI servers",
+          "description": "Server connection settings used by asynchronous tests and mocks.",
+          "items": {
+            "$ref": "#/definitions/AsyncClientServerConfig",
+            "description": "One asynchronous server connection."
+          }
+        },
+        "schemaRegistry": {
+          "$ref": "#/definitions/SchemaRegistryProperties",
+          "title": "Schema registry",
+          "description": "Schema registry settings used by asynchronous tests and mocks."
+        }
+      }
+    },
+    "AsyncApiTestRunOptionSpecification": {
+      "title": "AsyncAPI test run-option specification override",
+      "description": "AsyncAPI test per-specification run-option override.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/AsyncApiRunOptionSpecificationCommon"
+        },
+        {
+          "not": {
+            "required": [
+              "inMemoryBroker"
+            ]
+          }
+        }
+      ]
+    },
+    "AsyncApiMockRunOptionSpecification": {
+      "title": "AsyncAPI mock run-option specification override",
+      "description": "AsyncAPI mock per-specification run-option override.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/AsyncApiRunOptionSpecificationCommon"
+        },
+        {
+          "not": {
+            "anyOf": [
+              {
+                "required": [
+                  "replyTimeout"
+                ]
+              },
+              {
+                "required": [
+                  "subscriberReadinessWaitTime"
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "GraphqlSdlRunOptionSpecificationCommon": {
+      "title": "Common GraphQL SDL run-option specification values",
+      "description": "GraphQL SDL run-option specification values shared by test and mock modes.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Specification ID",
+          "description": "Specification identifier this override targets.",
+          "examples": [
+            "orders"
+          ]
         },
         "host": {
           "type": "string",
@@ -2142,6 +2333,99 @@
           "description": "Port override for this specification."
         }
       }
+    },
+    "GraphqlSdlTestRunOptionSpecification": {
+      "title": "GraphQL SDL test run-option specification override",
+      "description": "GraphQL SDL test per-specification run-option override.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/GraphqlSdlRunOptionSpecificationCommon"
+        }
+      ]
+    },
+    "GraphqlSdlMockRunOptionSpecification": {
+      "title": "GraphQL SDL mock run-option specification override",
+      "description": "GraphQL SDL mock per-specification run-option override.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/GraphqlSdlRunOptionSpecificationCommon"
+        }
+      ]
+    },
+    "ProtobufRunOptionSpecificationCommon": {
+      "title": "Common Protobuf run-option specification values",
+      "description": "Protobuf run-option specification values shared by test and mock modes.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Specification ID",
+          "description": "Specification identifier this override targets.",
+          "examples": [
+            "orders"
+          ]
+        },
+        "host": {
+          "type": "string",
+          "title": "Service host",
+          "description": "Host override for this specification."
+        },
+        "port": {
+          "type": "integer",
+          "title": "Service port",
+          "description": "Port override for this specification."
+        },
+        "importPaths": {
+          "type": "array",
+          "title": "Protobuf import paths",
+          "description": "Directories searched for imported Protobuf definitions.",
+          "items": {
+            "type": "string",
+            "title": "Protobuf import path",
+            "description": "One directory searched for imported Protobuf definitions."
+          }
+        },
+        "protocVersion": {
+          "type": "string",
+          "title": "protoc version",
+          "description": "Version of protoc used to compile Protobuf definitions."
+        },
+        "requestTimeout": {
+          "type": "integer",
+          "title": "gRPC request timeout",
+          "description": "Maximum time in milliseconds to wait for a gRPC request."
+        }
+      }
+    },
+    "ProtobufTestRunOptionSpecification": {
+      "title": "Protobuf test run-option specification override",
+      "description": "Protobuf test per-specification run-option override.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProtobufRunOptionSpecificationCommon"
+        }
+      ]
+    },
+    "ProtobufMockRunOptionSpecification": {
+      "title": "Protobuf mock run-option specification override",
+      "description": "Protobuf mock per-specification run-option override.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProtobufRunOptionSpecificationCommon"
+        },
+        {
+          "not": {
+            "anyOf": [
+              {
+                "required": [
+                  "requestTimeout"
+                ]
+              }
+            ]
+          }
+        }
+      ]
     },
     "OpenApiRunOptionSpecification": {
       "title": "OpenAPI run-option specification override",

--- a/core/src/test/kotlin/io/specmatic/core/config/validation/ConfigSchemaValidationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/validation/ConfigSchemaValidationTest.kt
@@ -235,7 +235,7 @@ class ConfigSchemaValidationTest {
                   "api": { "openapi": { "type": "test", "cert": { "mtlsEnabled": true } } },
                   "asyncapi": { "asyncapi": { "type": "test" } },
                   "graphql": { "graphqlsdl": { "type": "mock" } },
-                  "protobuf": { "protobuf": { "type": "test" } }
+                  "protobuf": { "protobuf": { "type": "test", "host": "localhost", "port": 9000 } }
                 },
                 "examples": {
                   "testExamples": [{ "directories": ["test-examples"] }],
@@ -351,6 +351,56 @@ class ConfigSchemaValidationTest {
             )))
         }
 
+        @Test
+        fun `requires host and port for gRPC test run options`() {
+            assertThat(schema(SpecmaticConfigVersion.VERSION_3, """
+            version: 3
+            components:
+              runOptions:
+                grpcTest:
+                  protobuf:
+                    type: test
+            """.trimIndent())).isEqualTo(invalidOutput(detail(
+                instanceLocation = "/components/runOptions/grpcTest/protobuf",
+                error = "[required property 'host' not found, required property 'port' not found]",
+                keywordLocation = $$"/properties/components/$ref/properties/runOptions/additionalProperties/$ref/properties/protobuf/$ref/allOf/0/then/$ref",
+                absoluteKeywordLocation = "https://specmatic.io/internal-schema/config-v3-resolved.schema.json#/definitions/ProtobufTestRunOptions",
+            )))
+        }
+
+        @Nested
+        inner class ProtocolRunOptionsDataClasses {
+            @Nested
+            inner class AsyncApi {
+                @ParameterizedTest(name = "{0}")
+                @MethodSource("io.specmatic.core.config.validation.ConfigSchemaValidationTest#asyncApiDataClassCases")
+                fun `accepts the AsyncAPI test and mock data class shapes`(testCase: ValidSchemaCase) {
+                    assertThat(schema(SpecmaticConfigVersion.VERSION_3, testCase.json))
+                        .isEqualTo(validOutput)
+                }
+            }
+
+            @Nested
+            inner class GraphQL {
+                @ParameterizedTest(name = "{0}")
+                @MethodSource("io.specmatic.core.config.validation.ConfigSchemaValidationTest#graphQlDataClassCases")
+                fun `accepts the GraphQL test and mock data class shapes`(testCase: ValidSchemaCase) {
+                    assertThat(schema(SpecmaticConfigVersion.VERSION_3, testCase.json))
+                        .isEqualTo(validOutput)
+                }
+            }
+
+            @Nested
+            inner class Grpc {
+                @ParameterizedTest(name = "{0}")
+                @MethodSource("io.specmatic.core.config.validation.ConfigSchemaValidationTest#grpcDataClassCases")
+                fun `accepts the gRPC test and mock data class shapes`(testCase: ValidSchemaCase) {
+                    assertThat(schema(SpecmaticConfigVersion.VERSION_3, testCase.json))
+                        .isEqualTo(validOutput)
+                }
+            }
+        }
+
         @ParameterizedTest(name = "{0}")
         @MethodSource("io.specmatic.core.config.validation.ConfigSchemaValidationTest#v3ProtocolOptionCases")
         fun `rejects invalid known V3 protocol options`(testCase: InvalidSchemaCase) {
@@ -410,6 +460,14 @@ class ConfigSchemaValidationTest {
                 instancePath = "servers/0/host",
                 expectedType = "string",
                 errorMessage = "integer found, string expected",
+            ),
+            v2OptionCase(
+                expectedType = "string",
+                instancePath = "servers/0/type",
+                name = "AsyncAPI server type must be supported",
+                optionPath = "servers/items/$REF/properties/type",
+                option = "servers: [{ host: localhost:9092, protocol: kafka, type: invalid }]",
+                errorMessage = "does not have a value in the enumeration [\"external\", \"in-memory\"]",
             ),
             v2OptionCase(
                 name = "AsyncAPI schema registry kind must be supported",
@@ -472,6 +530,165 @@ class ConfigSchemaValidationTest {
         )
 
         @JvmStatic
+        fun asyncApiDataClassCases() = listOf(
+            ValidSchemaCase(
+                name = "AsyncAPI test configuration",
+                json = """
+                version: 3
+                components:
+                  runOptions:
+                    asyncTest:
+                      asyncapi:
+                        type: test
+                        replyTimeout: 10000
+                        subscriberReadinessWaitTime: 100
+                        servers:
+                          - host: localhost:9092
+                            protocol: kafka
+                            type: external
+                        schemaRegistry:
+                          kind: DEFAULT
+                        specs:
+                          - spec:
+                              id: events
+                              overlayFilePath: overlays/events.yaml
+                              replyTimeout: 10000
+                              subscriberReadinessWaitTime: 100
+                              servers:
+                                - host: localhost:9092
+                                  protocol: kafka
+                                  type: external
+                              schemaRegistry:
+                                kind: DEFAULT
+                """.trimIndent(),
+            ),
+            ValidSchemaCase(
+                name = "AsyncAPI mock configuration",
+                json = """
+                version: 3
+                components:
+                  runOptions:
+                    asyncMock:
+                      asyncapi:
+                        type: mock
+                        inMemoryBroker:
+                          logDir: broker-logs
+                          host: localhost
+                          port: 9093
+                        servers:
+                          - host: localhost:9093
+                            protocol: kafka
+                            type: in-memory
+                        schemaRegistry:
+                          kind: DEFAULT
+                        specs:
+                          - spec:
+                              id: events
+                              overlayFilePath: overlays/events-mock.yaml
+                              inMemoryBroker:
+                                logDir: broker-logs
+                                host: localhost
+                                port: 9093
+                              servers:
+                                - host: localhost:9093
+                                  protocol: kafka
+                                  type: in-memory
+                              schemaRegistry:
+                                kind: DEFAULT
+                """.trimIndent(),
+            ),
+        )
+
+        @JvmStatic
+        fun graphQlDataClassCases() = listOf(
+            ValidSchemaCase(
+                name = "GraphQL test configuration",
+                json = """
+                version: 3
+                components:
+                  runOptions:
+                    graphqlTest:
+                      graphqlsdl:
+                        type: test
+                        host: localhost
+                        port: 9001
+                        specs:
+                          - spec:
+                              id: schema
+                              host: localhost
+                              port: 9005
+                """.trimIndent(),
+            ),
+            ValidSchemaCase(
+                name = "GraphQL mock configuration",
+                json = """
+                version: 3
+                components:
+                  runOptions:
+                    graphqlMock:
+                      graphqlsdl:
+                        type: mock
+                        host: localhost
+                        port: 9002
+                        specs:
+                          - spec:
+                              id: schema
+                              host: localhost
+                              port: 9007
+                """.trimIndent(),
+            ),
+        )
+
+        @JvmStatic
+        fun grpcDataClassCases() = listOf(
+            ValidSchemaCase(
+                name = "gRPC test configuration",
+                json = """
+                version: 3
+                components:
+                  runOptions:
+                    grpcTest:
+                      protobuf:
+                        type: test
+                        host: localhost
+                        port: 9003
+                        importPaths: [proto]
+                        protocVersion: 3.25.0
+                        requestTimeout: 5000
+                        specs:
+                          - spec:
+                              id: service
+                              host: localhost
+                              port: 9006
+                              importPaths: [proto]
+                              protocVersion: 3.25.0
+                              requestTimeout: 5000
+                """.trimIndent(),
+            ),
+            ValidSchemaCase(
+                name = "gRPC mock configuration",
+                json = """
+                version: 3
+                components:
+                  runOptions:
+                    grpcMock:
+                      protobuf:
+                        type: mock
+                        port: 9004
+                        importPaths: [proto]
+                        protocVersion: 3.25.0
+                        specs:
+                          - spec:
+                              id: service
+                              host: localhost
+                              port: 9008
+                              importPaths: [proto]
+                              protocVersion: 3.25.0
+                """.trimIndent(),
+            ),
+        )
+
+        @JvmStatic
         fun v3ProtocolOptionCases() = listOf(
             v3OptionCase(
                 name = "AsyncAPI test replyTimeout must be an integer",
@@ -496,6 +713,16 @@ class ConfigSchemaValidationTest {
                 optionPath = "servers",
                 expectedType = "array",
                 schema = "AsyncApiTestRunOptions",
+            ),
+            v3OptionCase(
+                branch = "asyncTest",
+                expectedType = "string",
+                instancePath = "servers/0/type",
+                schema = "AsyncClientServerConfig",
+                name = "AsyncAPI server type must be supported",
+                optionPath = "servers/items/$REF/properties/type",
+                option = "servers: [{ host: localhost:9092, protocol: kafka, type: invalid }]",
+                errorMessage = "does not have a value in the enumeration [\"external\", \"in-memory\"]",
             ),
             v3OptionCase(
                 name = "AsyncAPI server client consumer must be an object",
@@ -728,7 +955,25 @@ class ConfigSchemaValidationTest {
             val mode = if (branch.endsWith("Mock")) "mock" else "test"
             val branchIndex = if (mode == "test") 0 else 1
             val schemaPath = "/properties/components/$REF/properties/runOptions/additionalProperties/$REF/properties/$protocol/$REF/allOf/$branchIndex/then/$REF"
-            val optionSchemaPath = "$schemaPath/properties/$optionPath"
+            val commonSchema = when (protocol) {
+                "asyncapi" -> "AsyncApiCommonRunOptions"
+                "graphqlsdl" -> "GraphqlSdlCommonRunOptions"
+                "protobuf" -> "ProtobufCommonRunOptions"
+                else -> null
+            }
+            val commonOptions = when (protocol) {
+                "asyncapi" -> setOf("servers", "schemaRegistry")
+                "graphqlsdl" -> setOf("host", "port")
+                "protobuf" -> setOf("port", "importPaths", "protocVersion")
+                else -> emptySet()
+            }
+            val optionRoot = optionPath.substringBefore('/')
+            val isCommonOption = optionRoot in commonOptions
+            val optionSchemaPath = if (isCommonOption) {
+                "$schemaPath/allOf/0/$REF/properties/$optionPath"
+            } else {
+                "$schemaPath/properties/$optionPath"
+            }
             val config = buildList {
                 add("version: 3")
                 add("components:")
@@ -736,6 +981,10 @@ class ConfigSchemaValidationTest {
                 add("    $branch:")
                 add("      $protocol:")
                 add("        type: $mode")
+                if (branch == "grpcTest") {
+                    if (optionRoot != "host") add("        host: localhost")
+                    if (optionRoot != "port") add("        port: 9000")
+                }
                 option.lines().forEach { add("        $it") }
             }.joinToString("\n")
 
@@ -744,7 +993,11 @@ class ConfigSchemaValidationTest {
                 version = SpecmaticConfigVersion.VERSION_3,
                 json = config,
                 keywordLocation = optionSchemaPath,
-                absoluteKeywordLocation = absoluteSchemaLocation(schema, optionPath, version = 3),
+                absoluteKeywordLocation = absoluteSchemaLocation(
+                    schema = if (isCommonOption && optionPath == optionRoot) commonSchema ?: schema else schema,
+                    optionPath = optionPath,
+                    version = 3,
+                ),
                 instanceLocation = "/components/runOptions/$branch/$protocol/${instancePath ?: instanceOptionPath(optionPath)}",
                 error = errorMessage ?: if (optionPath.endsWith("/$REF")) "string found, object expected" else "string found, $expectedType expected",
             )
@@ -843,6 +1096,7 @@ class ConfigSchemaValidationTest {
                           servers:
                             - host: localhost:9092
                               protocol: kafka
+                              type: in-memory
                               adminCredentials:
                                 username: admin
                               client:
@@ -948,6 +1202,7 @@ class ConfigSchemaValidationTest {
                         servers:
                           - host: localhost:9092
                             protocol: kafka
+                            type: external
                             adminCredentials:
                               username: admin
                             client:
@@ -957,6 +1212,18 @@ class ConfigSchemaValidationTest {
                                 acks: all
                         schemaRegistry:
                           kind: DEFAULT
+                        specs:
+                          - spec:
+                              id: events
+                              overlayFilePath: overlays/events.yaml
+                              replyTimeout: 10000
+                              subscriberReadinessWaitTime: 100
+                              servers:
+                                - host: localhost:9092
+                                  protocol: kafka
+                                  type: external
+                              schemaRegistry:
+                                kind: DEFAULT
                         extension:
                           enabled: true
                     asyncMock:
@@ -967,20 +1234,45 @@ class ConfigSchemaValidationTest {
                           host: localhost
                           port: 9093
                         servers:
-                          - host: localhost:9093
-                            protocol: kafka
+                            - host: localhost:9093
+                              protocol: kafka
+                              type: in-memory
                         schemaRegistry:
                           kind: DEFAULT
+                        specs:
+                          - spec:
+                              id: events
+                              overlayFilePath: overlays/events-mock.yaml
+                              inMemoryBroker:
+                                logDir: broker-logs
+                                host: localhost
+                                port: 9093
+                              servers:
+                                - host: localhost:9093
+                                  protocol: kafka
+                                  type: in-memory
+                              schemaRegistry:
+                                kind: DEFAULT
                     graphqlTest:
                       graphqlsdl:
                         type: test
                         host: localhost
                         port: 9001
+                        specs:
+                          - spec:
+                              id: schema
+                              host: localhost
+                              port: 9005
                     graphqlMock:
                       graphqlsdl:
                         type: mock
                         host: localhost
                         port: 9002
+                        specs:
+                          - spec:
+                              id: schema
+                              host: localhost
+                              port: 9007
                     grpcTest:
                       protobuf:
                         type: test
@@ -989,12 +1281,26 @@ class ConfigSchemaValidationTest {
                         importPaths: [proto]
                         protocVersion: 3.25.0
                         requestTimeout: 5000
+                        specs:
+                          - spec:
+                              id: service
+                              host: localhost
+                              port: 9006
+                              importPaths: [proto]
+                              protocVersion: 3.25.0
+                              requestTimeout: 5000
                     grpcMock:
                       protobuf:
                         type: mock
                         port: 9004
                         importPaths: [proto]
                         protocVersion: 3.25.0
+                        specs:
+                          - spec:
+                              id: service
+                              port: 9008
+                              importPaths: [proto]
+                              protocVersion: 3.25.0
                 """.trimIndent(),
             ),
         )


### PR DESCRIPTION
**What**: Replace generic AsyncAPI, GraphQL, and Protobuf run-option schemas with protocol- and mode-specific schemas. Add support for AsyncAPI server `type`, including `in-memory`.

**Why**:
Ensure configuration validation matches the DTOs and correctly accepts or rejects protocol-specific options.

**How**:
- Added shared schemas using `allOf`.
- Added separate test/mock schemas and entries.
- Preserved strict per-spec validation.
- Allowed protobuf mock per-spec `host` overrides.
- Enforced required gRPC test `host` and `port`.
- Updated V2 and V3 AsyncAPI server schemas.
- Added regression coverage.

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities — N/A
- [ ] Documentation added/updated — N/A
- [ ] Sample Project added/updated — N/A
- [ ] Demo video — N/A
- [ ] Article on Website — N/A
- [ ] Roadmap updated — N/A
- [ ] Conference Talk — N/A