### PR TITLE
Fix concurrent transient mock consumption

### DIFF
--- a/core/src/main/kotlin/io/specmatic/stub/DefaultHttpStubHandler.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/DefaultHttpStubHandler.kt
@@ -51,10 +51,6 @@ internal class DefaultHttpStubHandler(private val context: HttpStubHandlerContex
         }
     }
 
-    override fun utilizeMock(mock: HttpStubData) {
-        httpExpectations.utilizeMock(mock)
-    }
-
     override fun removeWithToken(token: String?) {
         httpExpectations.removeWithToken(token)
     }

--- a/core/src/main/kotlin/io/specmatic/stub/HttpExpectations.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpExpectations.kt
@@ -25,12 +25,6 @@ class HttpExpectations private constructor (
     val stubCount: Int get() { return static.size }
     val transientStubCount: Int get() { return transient.size }
 
-    fun utilizeMock(httpStubData: HttpStubData) {
-        val shouldBeRemovedFromTransient = httpStubData.utilize()
-        if (!shouldBeRemovedFromTransient) return
-        transient.remove(httpStubData)
-    }
-
     fun removeWithToken(token: String?) {
         transient.removeWithToken(token)
     }

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -843,10 +843,6 @@ class HttpStub(
             defaultBaseUrl = defaultBaseUrl,
         ).also {
             it.log(_logs, httpRequest)
-            if (it is FoundStubbedResponse) {
-                val mock = it.response.mock ?: return@also
-                httpStubHandlers.utilize(handler, mock)
-            }
         }
     }
 

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStubHandler.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStubHandler.kt
@@ -26,7 +26,6 @@ interface HttpStubHandler {
     interface Default : HttpStubHandler {
         val stubCount: Int
         val transientStubCount: Int
-        fun utilizeMock(mock: HttpStubData)
         fun removeWithToken(token: String?)
     }
 

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStubHandlers.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStubHandlers.kt
@@ -50,11 +50,6 @@ class HttpStubHandlers(
         mockHandler.removeWithToken(token)
     }
 
-    fun utilize(handler: HttpStubHandler, mock: HttpStubData) {
-        if (handler !is HttpStubHandler.Default) return
-        handler.utilizeMock(mock)
-    }
-
     private fun featuresForMode(candidateFeatures: List<Feature>, mode: MockMode): List<Feature> {
         if (statefulMockHandler == null) return candidateFeatures
         return candidateFeatures.filter { modeForFeature(it) == mode }

--- a/core/src/main/kotlin/io/specmatic/stub/ThreadSafeListOfStubs.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/ThreadSafeListOfStubs.kt
@@ -17,32 +17,43 @@ class ThreadSafeListOfStubs(
     private val specToBaseUrlMap: Map<String, String>,
     private val strictMode: Boolean = false,
     private val specmaticConfig: SpecmaticConfig = SpecmaticConfig(),
+    private val lock: Any = Any(),
+    private val sourceStubs: MutableList<HttpStubData>? = null,
 ) {
     val size: Int
         get() {
-            return httpStubs.size
+            synchronized(lock) { return httpStubs.size }
         }
 
     fun stubAssociatedTo(baseUrl: String, defaultBaseUrl: String, urlPath: String): ThreadSafeListOfStubs {
         val baseUrlToListOfStubsMap = baseUrlToListOfStubsMap(defaultBaseUrl).mapKeys { URI(it.key) }
         val resolvedUrls = setOf(baseUrl, defaultBaseUrl).map { it.plus(urlPath) }.map(::URI)
 
-        return resolvedUrls.firstNotNullOfOrNull { resolvedUrl ->
+        val associatedStubs = resolvedUrls.firstNotNullOfOrNull { resolvedUrl ->
             specmaticConfig.mostSpecificMatchingBaseUrl(
                 resolvedUrl,
                 baseUrlToListOfStubsMap.keys
             )?.let(baseUrlToListOfStubsMap::get)
-        } ?: emptyStubs()
+        } ?: return emptyStubs()
+
+        return ThreadSafeListOfStubs(
+            associatedStubs.httpStubs,
+            specToBaseUrlMap,
+            strictMode,
+            specmaticConfig,
+            lock,
+            sourceStubs ?: httpStubs,
+        )
     }
 
     private fun matchResults(fn: (List<HttpStubData>) -> List<Pair<Result, HttpStubData>>): List<Pair<Result, HttpStubData>> {
-        synchronized(this) {
+        synchronized(lock) {
             return fn(httpStubs.toList())
         }
     }
 
     fun addToStub(result: Pair<Result, HttpStubData?>, stub: ScenarioStub) {
-        synchronized(this) {
+        synchronized(lock) {
             result.second.let {
                 if(it != null)
                     httpStubs.add(0, it.copy(scenarioStub = stub))
@@ -51,13 +62,14 @@ class ThreadSafeListOfStubs(
     }
 
     fun remove(element: HttpStubData) {
-        synchronized(this) {
+        synchronized(lock) {
             httpStubs.remove(element)
+            sourceStubs?.remove(element)
         }
     }
 
     fun removeWithToken(token: String?) {
-        synchronized(this) {
+        synchronized(lock) {
             httpStubs.mapIndexed { index, httpStubData ->
                 if (httpStubData.stubToken == token) index else null
             }.filterNotNull().reversed().map { index ->
@@ -67,14 +79,30 @@ class ThreadSafeListOfStubs(
     }
 
     fun matchingTransientStub(httpRequest: HttpRequest): Pair<HttpStubData, List<Pair<Result, HttpStubData>>>? {
+        synchronized(lock) {
+            val availableStubs = sourceStubs?.let { source ->
+                httpStubs.filter { it in source }
+            } ?: httpStubs.toList()
+            val match = findMatchingTransientStub(httpRequest, availableStubs) ?: return null
+            val selectedStub = match.first
+            if (selectedStub.utilize()) {
+                httpStubs.remove(selectedStub)
+                sourceStubs?.remove(selectedStub)
+            }
+            return match
+        }
+    }
+
+    private fun findMatchingTransientStub(
+        httpRequest: HttpRequest,
+        stubs: List<HttpStubData>
+    ): Pair<HttpStubData, List<Pair<Result, HttpStubData>>>? {
         val expectedResponseCode = httpRequest.expectedResponseCode()
 
-        val queueMatchResults: List<Pair<Result, HttpStubData>> = matchResults { stubs ->
-            stubs.filter {
-                hasExpectedResponseCode(it, expectedResponseCode)
-            }.map {
-                Pair(it.matches(httpRequest), it)
-            }
+        val queueMatchResults = stubs.filter {
+            hasExpectedResponseCode(it, expectedResponseCode)
+        }.map {
+            Pair(it.matches(httpRequest), it)
         }
 
         val preferredMatch = queueMatchResults.findLast { (result, stubData) ->
@@ -157,7 +185,7 @@ class ThreadSafeListOfStubs(
     }
 
     private fun baseUrlToListOfStubsMap(defaultBaseUrl: String): Map<String, ThreadSafeListOfStubs> {
-        synchronized(this) {
+        synchronized(lock) {
             return httpStubs.groupBy {
                 specToBaseUrlMap[it.contractPath] ?: defaultBaseUrl
             }.mapValues { (_, stubs) ->

--- a/core/src/test/kotlin/io/specmatic/stub/HttpExpectationsTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpExpectationsTest.kt
@@ -10,6 +10,8 @@ import io.specmatic.mock.ScenarioStub
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Test
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.Executors
 
 class HttpExpectationsTest {
     private val request = HttpRequest("POST", "/products", body = parsedJSONObject("""{"name": "Specific Value"}"""))
@@ -102,5 +104,43 @@ class HttpExpectationsTest {
 
         val jsonResponse = expectedResponse.response.body as JSONObjectValue
         assertThat(jsonResponse.findFirstChildByName("id")?.toStringLiteral()).isEqualTo("20")
+    }
+
+    @Test
+    fun `a transient expectation should be selected only once by concurrent requests`() {
+        val transientStub = staticStubData.copy(
+            scenarioStub = ScenarioStub(
+                request = request,
+                response = staticStubData.response,
+                stubToken = "transient-stub"
+            )
+        )
+        val concurrentExpectations = HttpExpectations(
+            static = mutableListOf(),
+            transient = mutableListOf(transientStub),
+            specToBaseUrlMap = mapOf("test.yaml" to "http://localhost:8080")
+        )
+        val associatedExpectations = List(2) {
+            concurrentExpectations.associatedTo(
+                "http://localhost:8080",
+                "http://localhost:8080",
+                "/products"
+            )
+        }
+        val bothRequestsAreReady = CyclicBarrier(2)
+        val executor = Executors.newFixedThreadPool(2)
+
+        val selections = try {
+            associatedExpectations.map { expectationsForRequest ->
+                executor.submit<HttpStubData?> {
+                    bothRequestsAreReady.await()
+                    expectationsForRequest.matchingStub(request).first
+                }
+            }.map { it.get() }
+        } finally {
+            executor.shutdownNow()
+        }
+
+        assertThat(selections.filterNotNull()).containsExactly(transientStub)
     }
 }

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubKtTest.kt
@@ -56,6 +56,8 @@ import java.io.File
 import java.nio.file.Files
 import java.security.KeyStore
 import java.util.*
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
 import java.util.function.Consumer
 import java.util.stream.Stream
 
@@ -145,6 +147,66 @@ paths:
 
             val secondResponse = stub.client.execute(HttpRequest("GET", "/data"))
             assertThat(secondResponse.headers["X-Specmatic-Type"]).isEqualTo("random")
+        }
+    }
+
+    @Test
+    fun `only one concurrent HTTP request should receive a transient response`() {
+        val contract = OpenApiSpecification.fromYAML("""
+openapi: 3.0.0
+info:
+  title: Concurrent transient API
+  version: 1.0.0
+paths:
+  /data:
+    get:
+      responses:
+        '200':
+          description: Data
+          content:
+            text/plain:
+              schema:
+                type: string
+        """.trimIndent(), "").toFeature()
+
+        HttpStub(contract).use { stub ->
+            stub.setExpectation("""
+                {
+                    "http-request": {"method": "GET", "path": "/data"},
+                    "http-response": {"status": 200, "body": "persistent"}
+                }
+            """.trimIndent())
+            stub.setExpectation("""
+                {
+                    "http-stub-id": "one-shot",
+                    "transient": true,
+                    "http-request": {"method": "GET", "path": "/data"},
+                    "http-response": {"status": 200, "body": "transient"}
+                }
+            """.trimIndent())
+
+            val requestCount = 50
+            val ready = CountDownLatch(requestCount)
+            val start = CountDownLatch(1)
+            val executor = Executors.newFixedThreadPool(requestCount)
+
+            val responses = try {
+                List(requestCount) {
+                    executor.submit<String> {
+                        ready.countDown()
+                        start.await()
+                        stub.client.execute(HttpRequest("GET", "/data")).body.toStringLiteral()
+                    }
+                }.also {
+                    ready.await()
+                    start.countDown()
+                }.map { it.get() }
+            } finally {
+                executor.shutdownNow()
+            }
+
+            assertThat(responses.count { it == "transient" }).isOne
+            assertThat(responses.count { it == "persistent" }).isEqualTo(requestCount - 1)
         }
     }
 

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubKtTest.kt
@@ -53,6 +53,9 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import java.io.File
+import java.net.ServerSocket
+import java.net.Socket
+import java.net.URI
 import java.nio.file.Files
 import java.security.KeyStore
 import java.util.*
@@ -207,6 +210,65 @@ paths:
 
             assertThat(responses.count { it == "transient" }).isOne
             assertThat(responses.count { it == "persistent" }).isEqualTo(requestCount - 1)
+        }
+    }
+
+    @Test
+    fun `a delayed transient response should remain consumed when the client disconnects before it is written`() {
+        val contract = OpenApiSpecification.fromYAML("""
+openapi: 3.0.0
+info:
+  title: Delayed transient API
+  version: 1.0.0
+paths:
+  /data:
+    get:
+      responses:
+        '200':
+          description: Data
+          content:
+            text/plain:
+              schema:
+                type: string
+        """.trimIndent(), "").toFeature()
+
+        val port = ServerSocket(0).use { it.localPort }
+        HttpStub(contract, port = port).use { stub ->
+            stub.setExpectation("""
+                {
+                    "name": "SUCCESSFUL_RESPONSE_AFTER_TIMEOUT",
+                    "id": "successful_response_after_timeout",
+                    "http-request": {"method": "GET", "path": "/data"},
+                    "http-response": {"status": 200, "body": "persistent"}
+                }
+            """.trimIndent())
+            stub.setExpectation("""
+                {
+                    "name": "DELAYED_TRANSIENT_RESPONSE",
+                    "id": "delayed_transient_response",
+                    "transient": true,
+                    "delay-in-milliseconds": 700,
+                    "http-request": {"method": "GET", "path": "/data"},
+                    "http-response": {"status": 200, "body": "transient"}
+                }
+            """.trimIndent())
+
+            val endpoint = URI(stub.endPoint)
+            Socket(endpoint.host, endpoint.port).use { socket ->
+                socket.getOutputStream().bufferedWriter().apply {
+                    write("GET /data HTTP/1.1\r\nHost: ${endpoint.host}:${endpoint.port}\r\nConnection: close\r\n\r\n")
+                    flush()
+                }
+
+                val deadline = System.nanoTime() + 1_000_000_000
+                while (stub.transientStubCount != 0 && System.nanoTime() < deadline)
+                    Thread.sleep(10)
+                assertThat(stub.transientStubCount).isZero()
+            }
+
+            val retryResponse = stub.client.execute(HttpRequest("GET", "/data"))
+
+            assertThat(retryResponse.body.toStringLiteral()).isEqualTo("persistent")
         }
     }
 


### PR DESCRIPTION
**What**:

Make transient mock selection and consumption atomic across concurrent HTTP requests and base-URL-filtered expectation views. Add focused and HTTP-level concurrency regression tests.

**Why**:

Multiple concurrent requests could select the same transient mock before it was removed, causing a one-shot response to be served more than once.

**How**:

Share synchronization and source-list state across filtered stub views, revalidate filtered candidates against the live source list under the lock, and consume the selected transient mock in the same critical section. Remove the obsolete delayed utilization path.

**Checklist**:

- [x] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (N/A)
- [ ] Sample Project added/updated (N/A)
- [ ] Demo video (N/A)
- [ ] Article on Website (N/A)
- [ ] Roadmpap updated (N/A)
- [ ] Conference Talk (N/A)

**Issue ID**:

No linked issue.