### PR TITLE
Consume transient mocks atomically at match time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ Each release section should stand on its own and describe the behavior shipped i
 
 ## Unreleased
 
+### Changed
+
+- Transient (one-shot) mocks are now consumed when they are selected, so concurrent requests and retries after a delayed disconnect cannot receive the same one-shot response more than once.
+
 ### Added
 
 - Added the `specmatic config validate` command for validating configuration files, and performing protocol-aware semantic checks. The command supports text or JSON diagnostics, source locations, and validation-specific exit codes for CLI and CI use.

--- a/core/src/main/kotlin/io/specmatic/stub/DefaultHttpStubHandler.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/DefaultHttpStubHandler.kt
@@ -51,10 +51,6 @@ internal class DefaultHttpStubHandler(private val context: HttpStubHandlerContex
         }
     }
 
-    override fun utilizeMock(mock: HttpStubData) {
-        httpExpectations.utilizeMock(mock)
-    }
-
     override fun removeWithToken(token: String?) {
         httpExpectations.removeWithToken(token)
     }

--- a/core/src/main/kotlin/io/specmatic/stub/HttpExpectations.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpExpectations.kt
@@ -8,7 +8,8 @@ import io.specmatic.mock.ScenarioStub
 class HttpExpectations private constructor (
     private val static: ThreadSafeListOfStubs,
     private val transient: ThreadSafeListOfStubs,
-    private val dynamic: ThreadSafeListOfStubs
+    private val dynamic: ThreadSafeListOfStubs,
+    private val transientAssociation: StubBaseUrlAssociation? = null,
 ) {
     constructor(
         static: MutableList<HttpStubData>,
@@ -25,12 +26,6 @@ class HttpExpectations private constructor (
     val stubCount: Int get() { return static.size }
     val transientStubCount: Int get() { return transient.size }
 
-    fun utilizeMock(httpStubData: HttpStubData) {
-        val shouldBeRemovedFromTransient = httpStubData.utilize()
-        if (!shouldBeRemovedFromTransient) return
-        transient.remove(httpStubData)
-    }
-
     fun removeWithToken(token: String?) {
         transient.removeWithToken(token)
     }
@@ -46,12 +41,14 @@ class HttpExpectations private constructor (
     fun associatedTo(baseUrl: String, defaultBaseUrl: String, urlPath: String): HttpExpectations {
         return HttpExpectations(
             static.stubAssociatedTo(baseUrl, defaultBaseUrl, urlPath),
-            transient.stubAssociatedTo(baseUrl, defaultBaseUrl, urlPath),
-            dynamic.stubAssociatedTo(baseUrl, defaultBaseUrl, urlPath))
+            transient,
+            dynamic.stubAssociatedTo(baseUrl, defaultBaseUrl, urlPath),
+            StubBaseUrlAssociation(baseUrl, defaultBaseUrl, urlPath),
+        )
     }
 
     fun matchingStub(httpRequest: HttpRequest): Pair<HttpStubData?, List<Pair<Result, HttpStubData>>> {
-        val transientMatch = transient.matchingTransientStub(httpRequest)
+        val transientMatch = transient.matchingTransientStub(httpRequest, transientAssociation)
         if(transientMatch != null)
             return transientMatch
 

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -843,10 +843,6 @@ class HttpStub(
             defaultBaseUrl = defaultBaseUrl,
         ).also {
             it.log(_logs, httpRequest)
-            if (it is FoundStubbedResponse) {
-                val mock = it.response.mock ?: return@also
-                httpStubHandlers.utilize(handler, mock)
-            }
         }
     }
 

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStubHandler.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStubHandler.kt
@@ -26,7 +26,6 @@ interface HttpStubHandler {
     interface Default : HttpStubHandler {
         val stubCount: Int
         val transientStubCount: Int
-        fun utilizeMock(mock: HttpStubData)
         fun removeWithToken(token: String?)
     }
 

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStubHandlers.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStubHandlers.kt
@@ -50,11 +50,6 @@ class HttpStubHandlers(
         mockHandler.removeWithToken(token)
     }
 
-    fun utilize(handler: HttpStubHandler, mock: HttpStubData) {
-        if (handler !is HttpStubHandler.Default) return
-        handler.utilizeMock(mock)
-    }
-
     private fun featuresForMode(candidateFeatures: List<Feature>, mode: MockMode): List<Feature> {
         if (statefulMockHandler == null) return candidateFeatures
         return candidateFeatures.filter { modeForFeature(it) == mode }

--- a/core/src/main/kotlin/io/specmatic/stub/ThreadSafeListOfStubs.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/ThreadSafeListOfStubs.kt
@@ -12,6 +12,12 @@ import io.specmatic.mock.ScenarioStub
 import java.io.File
 import java.net.URI
 
+internal data class StubBaseUrlAssociation(
+    val baseUrl: String,
+    val defaultBaseUrl: String,
+    val urlPath: String,
+)
+
 class ThreadSafeListOfStubs(
     private val httpStubs: MutableList<HttpStubData>,
     private val specToBaseUrlMap: Map<String, String>,
@@ -20,19 +26,17 @@ class ThreadSafeListOfStubs(
 ) {
     val size: Int
         get() {
-            return httpStubs.size
+            synchronized(this) {
+                return httpStubs.size
+            }
         }
 
     fun stubAssociatedTo(baseUrl: String, defaultBaseUrl: String, urlPath: String): ThreadSafeListOfStubs {
-        val baseUrlToListOfStubsMap = baseUrlToListOfStubsMap(defaultBaseUrl).mapKeys { URI(it.key) }
-        val resolvedUrls = setOf(baseUrl, defaultBaseUrl).map { it.plus(urlPath) }.map(::URI)
-
-        return resolvedUrls.firstNotNullOfOrNull { resolvedUrl ->
-            specmaticConfig.mostSpecificMatchingBaseUrl(
-                resolvedUrl,
-                baseUrlToListOfStubsMap.keys
-            )?.let(baseUrlToListOfStubsMap::get)
-        } ?: emptyStubs()
+        synchronized(this) {
+            val associatedStubs = stubsAssociatedTo(baseUrl, defaultBaseUrl, urlPath)
+            if (associatedStubs.isEmpty()) return emptyStubs()
+            return ThreadSafeListOfStubs(associatedStubs.toMutableList(), specToBaseUrlMap, strictMode, specmaticConfig)
+        }
     }
 
     private fun matchResults(fn: (List<HttpStubData>) -> List<Pair<Result, HttpStubData>>): List<Pair<Result, HttpStubData>> {
@@ -50,12 +54,6 @@ class ThreadSafeListOfStubs(
         }
     }
 
-    fun remove(element: HttpStubData) {
-        synchronized(this) {
-            httpStubs.remove(element)
-        }
-    }
-
     fun removeWithToken(token: String?) {
         synchronized(this) {
             httpStubs.mapIndexed { index, httpStubData ->
@@ -66,15 +64,34 @@ class ThreadSafeListOfStubs(
         }
     }
 
-    fun matchingTransientStub(httpRequest: HttpRequest): Pair<HttpStubData, List<Pair<Result, HttpStubData>>>? {
+    fun matchingTransientStub(
+        httpRequest: HttpRequest,
+        association: StubBaseUrlAssociation? = null,
+    ): Pair<HttpStubData, List<Pair<Result, HttpStubData>>>? {
+        synchronized(this) {
+            val candidates = if (association == null) {
+                httpStubs.toList()
+            } else {
+                stubsAssociatedTo(association.baseUrl, association.defaultBaseUrl, association.urlPath)
+            }
+            val match = findMatchingTransientStub(httpRequest, candidates) ?: return null
+            if (match.first.utilize()) {
+                httpStubs.remove(match.first)
+            }
+            return match
+        }
+    }
+
+    private fun findMatchingTransientStub(
+        httpRequest: HttpRequest,
+        stubs: List<HttpStubData>,
+    ): Pair<HttpStubData, List<Pair<Result, HttpStubData>>>? {
         val expectedResponseCode = httpRequest.expectedResponseCode()
 
-        val queueMatchResults: List<Pair<Result, HttpStubData>> = matchResults { stubs ->
-            stubs.filter {
-                hasExpectedResponseCode(it, expectedResponseCode)
-            }.map {
-                Pair(it.matches(httpRequest), it)
-            }
+        val queueMatchResults = stubs.filter {
+            hasExpectedResponseCode(it, expectedResponseCode)
+        }.map {
+            Pair(it.matches(httpRequest), it)
         }
 
         val preferredMatch = queueMatchResults.findLast { (result, stubData) ->
@@ -156,14 +173,18 @@ class ThreadSafeListOfStubs(
         return Pair(mock?.second, listMatchResults)
     }
 
-    private fun baseUrlToListOfStubsMap(defaultBaseUrl: String): Map<String, ThreadSafeListOfStubs> {
-        synchronized(this) {
-            return httpStubs.groupBy {
-                specToBaseUrlMap[it.contractPath] ?: defaultBaseUrl
-            }.mapValues { (_, stubs) ->
-                ThreadSafeListOfStubs(stubs as MutableList<HttpStubData>, specToBaseUrlMap, strictMode, specmaticConfig)
-            }
-        }
+    private fun stubsAssociatedTo(baseUrl: String, defaultBaseUrl: String, urlPath: String): List<HttpStubData> {
+        val groupedByBaseUrl = httpStubs.groupBy {
+            specToBaseUrlMap[it.contractPath] ?: defaultBaseUrl
+        }.mapKeys { URI(it.key) }
+        val resolvedUrls = setOf(baseUrl, defaultBaseUrl).map { it.plus(urlPath) }.map(::URI)
+
+        return resolvedUrls.firstNotNullOfOrNull { resolvedUrl ->
+            specmaticConfig.mostSpecificMatchingBaseUrl(
+                resolvedUrl,
+                groupedByBaseUrl.keys
+            )?.let(groupedByBaseUrl::get)
+        } ?: emptyList()
     }
 
     private fun substituteThenFillIn(httpRequest: HttpRequest, stubData: HttpStubData): Pair<Result, HttpStubData> {

--- a/core/src/main/kotlin/io/specmatic/stub/ThreadSafeListOfStubs.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/ThreadSafeListOfStubs.kt
@@ -64,9 +64,13 @@ class ThreadSafeListOfStubs(
         }
     }
 
-    fun matchingTransientStub(
+    fun matchingTransientStub(httpRequest: HttpRequest): Pair<HttpStubData, List<Pair<Result, HttpStubData>>>? {
+        return matchingTransientStub(httpRequest, null)
+    }
+
+    internal fun matchingTransientStub(
         httpRequest: HttpRequest,
-        association: StubBaseUrlAssociation? = null,
+        association: StubBaseUrlAssociation?,
     ): Pair<HttpStubData, List<Pair<Result, HttpStubData>>>? {
         synchronized(this) {
             val candidates = if (association == null) {

--- a/core/src/test/kotlin/io/specmatic/stub/HttpExpectationsTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpExpectationsTest.kt
@@ -10,6 +10,8 @@ import io.specmatic.mock.ScenarioStub
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Test
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.Executors
 
 class HttpExpectationsTest {
     private val request = HttpRequest("POST", "/products", body = parsedJSONObject("""{"name": "Specific Value"}"""))
@@ -102,5 +104,44 @@ class HttpExpectationsTest {
 
         val jsonResponse = expectedResponse.response.body as JSONObjectValue
         assertThat(jsonResponse.findFirstChildByName("id")?.toStringLiteral()).isEqualTo("20")
+    }
+
+    @Test
+    fun `a transient expectation should be selected only once by concurrent requests through associated views`() {
+        val transientStub = staticStubData.copy(
+            scenarioStub = ScenarioStub(
+                request = request,
+                response = staticStubData.response,
+                stubToken = "transient-stub"
+            )
+        )
+        val concurrentExpectations = HttpExpectations(
+            static = mutableListOf(),
+            transient = mutableListOf(transientStub),
+            specToBaseUrlMap = mapOf("test.yaml" to "http://localhost:8080")
+        )
+        val associatedExpectations = List(2) {
+            concurrentExpectations.associatedTo(
+                "http://localhost:8080",
+                "http://localhost:8080",
+                "/products"
+            )
+        }
+        val bothRequestsAreReady = CyclicBarrier(2)
+        val executor = Executors.newFixedThreadPool(2)
+
+        val selections = try {
+            associatedExpectations.map { expectationsForRequest ->
+                executor.submit<HttpStubData?> {
+                    bothRequestsAreReady.await()
+                    expectationsForRequest.matchingStub(request).first
+                }
+            }.map { it.get() }
+        } finally {
+            executor.shutdownNow()
+        }
+
+        assertThat(selections.filterNotNull()).containsExactly(transientStub)
+        assertThat(concurrentExpectations.transientStubCount).isZero()
     }
 }

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubKtTest.kt
@@ -53,9 +53,14 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import java.io.File
+import java.net.ServerSocket
+import java.net.Socket
+import java.net.URI
 import java.nio.file.Files
 import java.security.KeyStore
 import java.util.*
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
 import java.util.function.Consumer
 import java.util.stream.Stream
 
@@ -145,6 +150,125 @@ paths:
 
             val secondResponse = stub.client.execute(HttpRequest("GET", "/data"))
             assertThat(secondResponse.headers["X-Specmatic-Type"]).isEqualTo("random")
+        }
+    }
+
+    @Test
+    fun `only one concurrent HTTP request should receive a transient response`() {
+        val contract = OpenApiSpecification.fromYAML("""
+openapi: 3.0.0
+info:
+  title: Concurrent transient API
+  version: 1.0.0
+paths:
+  /data:
+    get:
+      responses:
+        '200':
+          description: Data
+          content:
+            text/plain:
+              schema:
+                type: string
+        """.trimIndent(), "").toFeature()
+
+        HttpStub(contract).use { stub ->
+            stub.setExpectation("""
+                {
+                    "http-request": {"method": "GET", "path": "/data"},
+                    "http-response": {"status": 200, "body": "persistent"}
+                }
+            """.trimIndent())
+            stub.setExpectation("""
+                {
+                    "http-stub-id": "one-shot",
+                    "transient": true,
+                    "http-request": {"method": "GET", "path": "/data"},
+                    "http-response": {"status": 200, "body": "transient"}
+                }
+            """.trimIndent())
+
+            val requestCount = 50
+            val ready = CountDownLatch(requestCount)
+            val start = CountDownLatch(1)
+            val executor = Executors.newFixedThreadPool(requestCount)
+
+            val responses = try {
+                List(requestCount) {
+                    executor.submit<String> {
+                        ready.countDown()
+                        start.await()
+                        stub.client.execute(HttpRequest("GET", "/data")).body.toStringLiteral()
+                    }
+                }.also {
+                    ready.await()
+                    start.countDown()
+                }.map { it.get() }
+            } finally {
+                executor.shutdownNow()
+            }
+
+            assertThat(responses.count { it == "transient" }).isOne
+            assertThat(responses.count { it == "persistent" }).isEqualTo(requestCount - 1)
+        }
+    }
+
+    @Test
+    fun `a delayed transient response should remain consumed when the client disconnects before it is written`() {
+        val contract = OpenApiSpecification.fromYAML("""
+openapi: 3.0.0
+info:
+  title: Delayed transient API
+  version: 1.0.0
+paths:
+  /data:
+    get:
+      responses:
+        '200':
+          description: Data
+          content:
+            text/plain:
+              schema:
+                type: string
+        """.trimIndent(), "").toFeature()
+
+        val port = ServerSocket(0).use { it.localPort }
+        HttpStub(contract, port = port).use { stub ->
+            stub.setExpectation("""
+                {
+                    "name": "SUCCESSFUL_RESPONSE_AFTER_TIMEOUT",
+                    "id": "successful_response_after_timeout",
+                    "http-request": {"method": "GET", "path": "/data"},
+                    "http-response": {"status": 200, "body": "persistent"}
+                }
+            """.trimIndent())
+            stub.setExpectation("""
+                {
+                    "name": "DELAYED_TRANSIENT_RESPONSE",
+                    "id": "delayed_transient_response",
+                    "transient": true,
+                    "delay-in-milliseconds": 700,
+                    "http-request": {"method": "GET", "path": "/data"},
+                    "http-response": {"status": 200, "body": "transient"}
+                }
+            """.trimIndent())
+
+            val endpoint = URI(stub.endPoint)
+            Socket(endpoint.host, endpoint.port).use { socket ->
+                socket.getOutputStream().bufferedWriter().apply {
+                    write("GET /data HTTP/1.1\r\nHost: ${endpoint.host}:${endpoint.port}\r\nConnection: close\r\n\r\n")
+                    flush()
+                }
+
+                val deadline = System.nanoTime() + 1_000_000_000
+                while (stub.transientStubCount != 0 && System.nanoTime() < deadline)
+                    Thread.sleep(10)
+                assertThat(stub.transientStubCount).isZero()
+            }
+
+            val retryResponse = stub.client.execute(HttpRequest("GET", "/data"))
+
+            assertThat(retryResponse.body.toStringLiteral()).isEqualTo("persistent")
         }
     }
 


### PR DESCRIPTION
**What**:

Consume transient (one-shot) mocks atomically when they are selected, using a single canonical transient list across base-URL-filtered expectation views.

**Why**:

Concurrent HTTP requests could both match the same transient mock before it was removed. Filtered `associatedTo` views each had their own list and monitor, so match and consume could disagree about what was still available. Delayed responses plus client disconnect made a one-shot stub stay available for a retry.

**How**:

`associatedTo` keeps the original transient `ThreadSafeListOfStubs` and records the request base URL. Matching filters that canonical list inside the same lock that calls `utilize()` and removes the stub when utilization says it is spent. Post-match `utilizeMock` is removed because consumption now happens at match time. Static and dynamic stub lists are unchanged.

This is an alternative to #2728: no shared-lock constructor args, no `sourceStubs` dual-remove, and no sibling transient lists.

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (N/A)
- [ ] Sample Project added/updated (N/A)
- [ ] Demo video (N/A)
- [ ] Article on Website (N/A)
- [ ] Roadmpap updated (N/A)
- [ ] Conference Talk (N/A)

**Issue ID**:

No linked issue.
